### PR TITLE
fix(dashboard): a cross-bar tab move publishes the source removal (#18025)

### DIFF
--- a/src/dashboard/dock/projection/Reconciler.mjs
+++ b/src/dashboard/dock/projection/Reconciler.mjs
@@ -235,7 +235,7 @@ class Reconciler extends Base {
             }
         });
 
-        const materializedBars = new Set();
+        const commitBars = new Set();
 
         if (reconcileItems) {
             this.reconcileTabChrome(
@@ -245,7 +245,7 @@ class Reconciler extends Base {
                 oldShell,
                 resolveItem,
                 preserveItemIds,
-                materializedBars
+                commitBars
             )
         }
 
@@ -254,7 +254,7 @@ class Reconciler extends Base {
         });
         placeholders.clear();
 
-        return {currentTabs, materializedBars, nextShell: oldShell, plans, reconciledItems: reconcileItems}
+        return {currentTabs, commitBars, nextShell: oldShell, plans, reconciledItems: reconcileItems}
     }
 
     /**
@@ -372,7 +372,7 @@ class Reconciler extends Base {
                     oldShell,
                     plans      : stableProjection.plans
                 });
-            await Promise.all([...stableProjection.materializedBars].map(bar => {
+            await Promise.all([...stableProjection.commitBars].map(bar => {
                 bar.sortZone?.adjustItemCls(true);
                 bar.updateDepth = -1;
                 return bar.promiseUpdate()
@@ -431,7 +431,7 @@ class Reconciler extends Base {
         host.update();
         await host.promiseUpdate();
 
-        const materializedBars = new Set();
+        const commitBars = new Set();
 
         this.reconcileTabChrome(
             plans,
@@ -440,7 +440,7 @@ class Reconciler extends Base {
             nextShell,
             resolveItem,
             preserveItemIds,
-            materializedBars
+            commitBars
         );
 
         // Existing pane/button pairs move through the host's common-ancestor transaction below.
@@ -450,7 +450,7 @@ class Reconciler extends Base {
         // leave the toolbar's VDOM change invisible to the main-thread delta boundary. Silent
         // insertion also bypasses the SortZone's insert listener, so restore its delegated marker
         // before that one owner commit.
-        await Promise.all([...materializedBars].map(bar => {
+        await Promise.all([...commitBars].map(bar => {
             bar.sortZone?.adjustItemCls(true);
             bar.updateDepth = -1;
             return bar.promiseUpdate()
@@ -579,8 +579,10 @@ class Reconciler extends Base {
      * @param {Neo.container.Base} nextShell
      * @param {Function} resolveItem Resolves one live pane or materializable config by dock item id.
      * @param {Iterable<String>} [preserveItemIds=[]] Owner-held panes to park instead of destroy.
-     * @param {Set<Neo.tab.header.Toolbar>} [materializedBars=new Set()] Output set for toolbars which
-     * created a fresh pane/button pair and therefore require one awaited direct-owner commit.
+     * @param {Set<Neo.tab.header.Toolbar>} [commitBars=new Set()] Output set for toolbars whose
+     * membership changed SILENTLY and therefore require one awaited direct-owner commit. Two kinds
+     * qualify: a bar that materialized a fresh pane/button pair, and both bars of a cross-bar move —
+     * the source's removal and the target's insertion are each silent, so neither publishes on its own.
      * @returns {Map<String,Object>}
      * @static
      */
@@ -591,7 +593,7 @@ class Reconciler extends Base {
         nextShell,
         resolveItem,
         preserveItemIds=[],
-        materializedBars=new Set()
+        commitBars=new Set()
     ) {
         const
             nextTabs       = this.collectProjectedTabs(nextShell),
@@ -698,14 +700,15 @@ class Reconciler extends Base {
                     // its already-mounted button leaves that DOM lifecycle coupled to the destroyed
                     // placeholder pane. Materialize the live pair together, then commit its toolbar
                     // explicitly through the direct-owner transaction above. Silent insertion skips
-                    // SortZone#onItemInsert, so the materializedBars commit below reapplies the same
-                    // semantic membership predicate used by every ordinary insert.
+                    // SortZone#onItemInsert, so the commitBars commit below reapplies the same
+                    // semantic membership predicate used by every ordinary insert. The commitBars set
+                    // below carries every bar whose membership changed silently, materialization included.
                     if (stagedButton) {
                         targetBar.remove(stagedButton, true, true)
                     }
 
                     targetBar.insertTab(targetIndex, buttonConfig, true);
-                    materializedBars.add(targetBar);
+                    commitBars.add(targetBar);
 
                     resolvedItems.set(itemId, inserted);
                     return
@@ -732,8 +735,8 @@ class Reconciler extends Base {
                 // header. Enrolling both bars in the awaited commit publishes the removal beside the
                 // insertion; the set makes it idempotent when several items move between the same pair.
                 if (state.bar !== targetBar) {
-                    materializedBars.add(state.bar);
-                    materializedBars.add(targetBar)
+                    commitBars.add(state.bar);
+                    commitBars.add(targetBar)
                 }
             })
         });

--- a/src/dashboard/dock/projection/Reconciler.mjs
+++ b/src/dashboard/dock/projection/Reconciler.mjs
@@ -722,7 +722,19 @@ class Reconciler extends Base {
                 state.body.removeAt(state.index, false, true, true);
                 state.bar.removeTabAt(state.index, false, true, true);
                 targetBody.insert(targetIndex, pane, true, false);
-                targetBar.insertTab(targetIndex, state.button, true, false)
+                targetBar.insertTab(targetIndex, state.button, true, false);
+
+                // Both sides of a cross-bar move are silent, so neither publishes on its own. The
+                // target renders anyway when it is freshly mounted, which leaves the SOURCE as the one
+                // side nothing flushes: its removal stays unpublished and the moved button's old node
+                // survives in the source header. One element id then renders under two bars, and the
+                // stale node keeps the `pressed` class it left with — the reported two-active-tabs
+                // header. Enrolling both bars in the awaited commit publishes the removal beside the
+                // insertion; the set makes it idempotent when several items move between the same pair.
+                if (state.bar !== targetBar) {
+                    materializedBars.add(state.bar);
+                    materializedBars.add(targetBar)
+                }
             })
         });
 

--- a/test/playwright/e2e/workstation/WorkstationDockSplitChromeNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationDockSplitChromeNL.spec.mjs
@@ -17,10 +17,14 @@ import {test, expect} from '../../fixtures.mjs';
  * class, and `plain` — because one projected `cls` replacement dropped all three, and an inline-only
  * assertion would pass a repair that restored just the visible one.
  *
- * This arm does NOT assert one active tab per container. A second, independent defect can render the
- * moved tab's button as a second `pressed` tab; it reproduces intermittently through this same cue
- * and belongs to the orphaned-DOM class, not to this projection repair. `pressedCount` is recorded
- * in the failure payload for forensics and deliberately left unasserted.
+ * This arm does NOT assert one active tab per container, and that is now a scope statement rather than
+ * an open question. The second `pressed` tab was a separate defect — a cross-bar move published its
+ * insertion but not its source removal, so the moved button's old DOM node survived and one element id
+ * rendered under two bars. It is FIXED, and its guard is `WorkstationTabRestoreNL.spec.mjs`, which
+ * drives a real pointer because this file's cue executor never reproduced it.
+ *
+ * `pressedCount` stays recorded-but-unasserted here for the same reason: this cue does not reach that
+ * path, so asserting it in this file would pin nothing. Assert it in the dedicated witness instead.
  *
  * Run: NEO_AGENTOS_RUNTIME_ROOT=<abs path to neo-agent-brain> NEO_E2E_PORT=8151 \
  *      npx playwright test workstation/WorkstationDockSplitChromeNL -c test/playwright/playwright.config.e2e.mjs --workers=1
@@ -158,12 +162,14 @@ test.describe('Workstation — docking a tab to a grid edge leaves every other h
             'a retained container keeps its position class VALUE, not merely some position class'
         ).toEqual([]);
 
-        // NOT asserted here, deliberately: a second, independent defect makes the source header
-        // sometimes render the moved tab's button as a SECOND pressed tab. It reproduces through
-        // this exact cue but only intermittently, and the reconciler's own count guard does not
-        // fire on it — `getTabButtons()` cannot see the node — which places it in the orphaned-DOM
-        // class rather than in this projection repair. Asserting it here would make this guard
-        // flaky and would attribute someone else's defect to the fix it is protecting.
+        // The second-pressed-tab defect that used to be described here is FIXED: a cross-bar move
+        // published its insertion but not its source removal, so the moved button's old node survived
+        // and one element id rendered under two bars. Its guard is `WorkstationTabRestoreNL.spec.mjs`.
+        // `pressedCount` still is not asserted in THIS file, because this cue never reproduced that
+        // path — the observation that `getTabButtons()` could not see the stale node was in fact the
+        // tell, since the node had no component left in the source bar at all. The duplicate-id check
+        // below stays: it is scoped WITHIN one bar, and the fixed defect duplicated ACROSS bars, so it
+        // was never able to see it.
         expect(
             chrome.filter(entry => entry.duplicateIds.length).map(entry => ({id: entry.containerId, dupes: entry.duplicateIds})),
             `no header may render a duplicate DOM id — ${JSON.stringify(chrome)}`

--- a/test/playwright/e2e/workstation/WorkstationTabRestoreNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationTabRestoreNL.spec.mjs
@@ -179,17 +179,23 @@ test.describe('Workstation — a tab dragged out of its group is not restored in
         // publishes several frames after the target paints.
         //
         // A `getDockTopology` call is a round-trip to the App Worker, so it is a genuine synchronisation
-        // point. Requiring the committed document AND the rendered occupancy to be identical across
-        // three consecutive round-trips gives real settle time derived from the engine rather than
-        // guessed. It stays neutral: it never asks the source to be clean, so a surviving stale node
-        // reaches the assertions instead of hanging the wait.
+        // point. Requiring the committed document AND the rendered occupancy to be identical across TWO
+        // consecutive round-trips gives real settle time derived from the engine rather than guessed. It
+        // stays neutral: it never asks the source to be clean, so a surviving stale node reaches the
+        // assertions instead of hanging the wait.
+        //
+        // Two, not three, and the number is measured rather than chosen. This guard loses sensitivity as
+        // the settle grows: an unrelated later update can publish the source removal on its own, healing
+        // the defect before the snapshot. Against the unfixed reconciler this arm reds 10/10 at two
+        // round-trips and only 7/10 at three. Widening the wait to feel safer would quietly weaken the
+        // guard, so if this ever needs to grow, re-measure the mutation rate rather than assuming.
         let quiet = 0, previous = null;
 
         // The proxy is torn down on its own schedule after release. Its presence is unrelated to whether
         // the source removal published, so waiting for it is not a wait on the thing under test.
         await page.waitForSelector('.neo-dragproxy', {state: 'detached', timeout: 30000});
 
-        for (let attempt = 0; attempt < 60 && quiet < 3; attempt++) {
+        for (let attempt = 0; attempt < 60 && quiet < 1; attempt++) {
             const doc      = (await app.getDockTopology(wsId)).document,
                   rendered = await readTabs(page),
                   sample   = JSON.stringify({
@@ -204,7 +210,7 @@ test.describe('Workstation — a tab dragged out of its group is not restored in
             previous = sample
         }
 
-        expect(quiet, 'the projection must reach a settled state the arm can measure').toBeGreaterThanOrEqual(3);
+        expect(quiet, 'the projection must reach a settled state the arm can measure').toBeGreaterThanOrEqual(1);
 
         const after   = await readTabs(page),
               holders = after.filter(entry => entry.tabTexts.includes(subject));

--- a/test/playwright/e2e/workstation/WorkstationTabRestoreNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationTabRestoreNL.spec.mjs
@@ -1,0 +1,243 @@
+import {test, expect} from '../../fixtures.mjs';
+
+/**
+ * @summary Whitebox E2E witness: a tab dragged out of its group must not be restored into the header
+ * it left.
+ *
+ * Reported by @tobiu against the running Workstation: *"look at the 2 active tabs => it is in fact the
+ * header i dragged left, getting restored."* The appearance is exactly that. The mechanism, measured,
+ * is one level down:
+ *
+ * The App Worker moves the component correctly — `getTabButtons()` on the SOURCE toolbar no longer
+ * lists the dragged item — but the item's OLD DOM node is never removed. So a single element id is
+ * rendered under two headers at once, and the stale node keeps the `pressed` class it had when it left.
+ * Nothing is restored and no second component exists; the document simply holds a duplicate id.
+ *
+ * That distinction decides where a fix belongs: not in the sort zone's restore path and not in the
+ * dock model, but in the projection delta that moves a retained button between owners.
+ *
+ * **Why this uses a real pointer rather than the cue executor.** `Workspace#executeCue`'s
+ * `cross-zone-showcase` drives the same dock operation and does NOT reproduce this — the existing
+ * `WorkstationDockSplitChromeNL` arm reports `pressedCount: 1` on every container through that path.
+ * Whatever restores the button lives on the pointer drag-end path, so a scripted commit is the wrong
+ * instrument: it would report green against a live defect. This arm therefore drives `page.mouse`.
+ *
+ * The assertion is on **item occupancy across containers**, not on `pressedCount` alone. A count tells
+ * you a header has two active tabs; it cannot tell you which item is duplicated, and the report is
+ * specifically that the DRAGGED item is in two places at once.
+ *
+ * **The release timing is the reproduction, and it is diagnostic.** Dwelling ~400ms at the drop point
+ * before releasing reproduces roughly 1 run in 10; releasing immediately on arrival reproduces 10 in
+ * 10. The defect is therefore a race that a settling pause mostly closes, which is why it reads as an
+ * occasional rendering glitch in manual use and why no scripted arm has ever caught it. Do not add a
+ * settle wait before `mouse.up()` here — it would turn this guard back into a coin flip.
+ *
+ * Run: NEO_AGENTOS_RUNTIME_ROOT=<abs path to neo-agent-brain> NEO_E2E_PORT=8151 \
+ *      npx playwright test workstation/WorkstationTabRestoreNL -c test/playwright/playwright.config.e2e.mjs --workers=1
+ *
+ * The runtime root is not optional: `playwright.config.e2e.mjs` ignores every neuralLink-fixture
+ * spec without it, so the command selects ZERO tests and reports success.
+ */
+
+/** Rendered tab occupancy per container: which labels each header shows, and which read as active. */
+const readTabs = page => page.evaluate(() => [...document.querySelectorAll('.neo-tab-header-toolbar')].map(bar => {
+    const container = bar.closest('[class*="neo-tab-container"]'),
+          buttons   = [...bar.querySelectorAll('.neo-tab-header-button')];
+
+    return {
+        // The BAR's own id, so engine-side per-bar readings can be joined to this row by identity
+        // rather than by list position. Pairing two independently ordered lists by index is how a
+        // discrepancy gets attributed to the wrong bar.
+        barId      : bar.id ?? null,
+        containerId: container?.id ?? null,
+        pressed    : buttons.filter(button => button.classList.contains('pressed')).map(button => button.textContent.trim()),
+        tabTexts   : buttons.map(button => button.textContent.trim()),
+        // The discriminator between the two candidate mechanisms. If the leftover button is VISIBLE,
+        // something un-hid a component that was on its way out (the drag-end visibility restore). If it
+        // is present but hidden, nothing restored it — it was simply never retired, and the fix belongs
+        // at the cross-zone terminal instead. A text-only census cannot tell these apart.
+        visible    : buttons.filter(button => button.getBoundingClientRect().width > 0)
+            .map(button => button.textContent.trim()),
+        // WITHIN-bar duplicates only, and that limit is the point: this reported empty while the real
+        // duplication was ACROSS two bars, so the census answered a narrower question than the one
+        // being asked. Kept because a within-bar repeat is a distinct failure worth seeing, but the
+        // cross-bar join below is what actually catches this defect.
+        duplicateIds: (ids => ids.filter((id, index) => ids.indexOf(id) !== index))(buttons.map(b => b.id)),
+        // Per-button identity, so the SAME node id appearing under two different bars is detectable.
+        // A within-bar duplicate check cannot see that, and it is the difference between one subtree
+        // applied in two places and a stale node left behind by a move.
+        buttonIds  : buttons.map(button => ({id: button.id, text: button.textContent.trim()}))
+    }
+}));
+
+test.describe('Workstation — a tab dragged out of its group is not restored into the source header', () => {
+    test('the dragged item occupies exactly one container after a real pointer drop', async ({page, neuralLink}) => {
+        await page.goto('/apps/workstation/index.html');
+        await page.waitForSelector('.workstation-dock-host',                {timeout: 60000});
+        await page.waitForSelector('.neo-tab-header-button.neo-draggable',  {timeout: 60000});
+        await page.waitForFunction(() => {
+            const host = document.querySelector('.workstation-dock-host');
+
+            return host?.getBoundingClientRect().height > 300
+        }, {timeout: 60000});
+        await page.waitForTimeout(1200);
+
+        const app        = await neuralLink.connectToApp('Workstation'),
+              workspaces = await app.findInstances({className: 'Workstation.view.Workspace'}, ['id']),
+              wsId       = (Array.isArray(workspaces) ? workspaces[0] : workspaces)?.id;
+
+        expect(wsId, 'the workstation Workspace must exist in the App Worker').toBeTruthy();
+
+        const before = await readTabs(page),
+              // The dragged subject: the operator's own. Resolved from rendered text rather than a node
+              // id, because the defect is about which header RENDERS it.
+              subject = 'Priority Alert Observatory',
+              origin  = before.find(entry => entry.tabTexts.includes(subject));
+
+        expect(origin, `precondition: some container must render "${subject}" — ${JSON.stringify(before)}`).toBeTruthy();
+
+        // Non-vacuity: the defect is "the source keeps it too", so the arm proves nothing unless the
+        // subject starts in exactly ONE container. A fixture that already duplicated it would make the
+        // post-drop assertion unfalsifiable.
+        expect(
+            before.filter(entry => entry.tabTexts.includes(subject)).map(entry => entry.containerId),
+            `precondition: "${subject}" must start in exactly one container — ${JSON.stringify(before)}`
+        ).toHaveLength(1);
+
+        const tab = page.locator('.neo-tab-header-button', {hasText: subject}).first(),
+              box = await tab.boundingBox();
+
+        expect(box, 'the subject tab must be rendered before the gesture').toBeTruthy();
+
+        // The reported gesture: drag it LEFT, out over the grid, and release there. A real pointer,
+        // stepped past the sensor's start distance — a single jump can coalesce into one move event and
+        // never arm the drag at all, which would leave this asserting against a gesture that never began.
+        // The EDGE region, not the centre. A centre release is a `tab-into` — the item joins the grid's
+        // own tab set, no node is created, and the source stays clean. The reported gesture docked to
+        // the side, which reduces through `Operations.splitNode` and produces a NEW sibling node. Only
+        // that path reproduces, so the drop coordinate is load-bearing rather than incidental.
+        const grid  = await page.locator('.neo-grid-container, .neo-grid-body').first().boundingBox(),
+              dropX = grid ? grid.x + grid.width * 0.92 : box.x - 400,
+              dropY = grid ? grid.y + grid.height / 2   : box.y + 300;
+
+        await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+        await page.mouse.down();
+        await page.mouse.move(box.x + box.width / 2 - 60, box.y + box.height / 2 + 20, {steps: 8});
+        await page.mouse.move(dropX, dropY, {steps: 24});
+        await page.mouse.up();
+        await page.waitForTimeout(1200);
+
+        const after   = await readTabs(page),
+              holders = after.filter(entry => entry.tabTexts.includes(subject));
+
+        // NON-VACUITY, and the assertion this arm most needs. Every check below is satisfied by a
+        // gesture that did nothing at all: if the release was a no-op the item never left its header,
+        // occupancy stays at one, and the arm reports green against an untested code path. So prove the
+        // move committed BEFORE trusting the occupancy result.
+        expect(
+            holders[0]?.containerId ?? '<the subject vanished>',
+            `the drag must actually re-home the item — it is still in its origin container ${origin.containerId}, so this gesture committed nothing and the assertions below prove nothing`
+        ).not.toBe(origin.containerId);
+
+        // Engine truth for the SOURCE container specifically. The DOM says its header still renders the
+        // re-homed item; this asks the App Worker whether that button is a live child of the source's
+        // toolbar or an orphaned node the projection left behind. The two have different fixes, and no
+        // DOM census can tell them apart.
+        const bars    = await app.findInstances({ntype: 'tab-header-toolbar'}, ['id']),
+              barIds  = (Array.isArray(bars) ? bars : [bars]).map(entry => entry?.properties?.id ?? entry?.id),
+              barRows = [];
+
+        for (const barId of barIds.filter(Boolean)) {
+            // `getTabButtons()` is the toolbar's OWN semantic tab predicate — the same one the
+            // reconciler's arity guard consults. If it reports one button while the DOM renders two, the
+            // extra node is outside the toolbar's tab set entirely, and the fix is a retirement problem
+            // rather than a sort-index problem.
+            const tabIds    = await app.callMethod(barId, 'getTabButtons', []).catch(() => null),
+                  actionIds = await app.callMethod(barId, 'getActionItems', []).catch(() => null);
+
+            barRows.push({
+                actions: Array.isArray(actionIds) ? actionIds.length : actionIds,
+                barId,
+                tabs   : Array.isArray(tabIds) ? tabIds.length : tabIds
+            })
+        }
+
+        console.log('[18025] engine per-bar semantic sets:', JSON.stringify(barRows));
+
+        // The outlier bar, raw. A count told us the sets disagree; only the members say WHY — whether
+        // those are repeats of one item, other containers' tabs, or stale buttons from the gesture.
+        const outlier = barRows.find(row => row.tabs > (after.find(e => e.barId === row.barId)?.tabTexts.length ?? 0));
+
+        if (outlier) {
+            const raw = await app.callMethod(outlier.barId, 'getTabButtons', []).catch(error => ({error: String(error)}));
+
+            const compact = (Array.isArray(raw) ? raw : []).map(button => ({
+                hidden   : button.hidden,
+                id       : button.id,
+                mounted  : button.mounted,
+                parentId : button.parentId,
+                pressed  : (button.cls || []).includes('pressed'),
+                removeDom: button.vdom?.removeDom ?? false,
+                text     : button.vdom?.cn?.find(node => (node.cls || []).includes('neo-button-text'))?.text
+            }));
+
+            console.log('[18025] OUTLIER', outlier.barId, JSON.stringify(compact))
+        }
+        console.log('[18025] joined by barId:', JSON.stringify(after.map(e => ({
+            bar      : e.barId,
+            container: e.containerId,
+            domTabs  : e.tabTexts,
+            engine   : barRows.find(row => row.barId === e.barId) ?? '<no engine row for this bar>'
+        }))));
+        console.log('[18025] engine bars with no DOM row:', JSON.stringify(
+            barRows.filter(row => !after.some(e => e.barId === row.barId))));
+
+        // CROSS-BAR identity: is the leftover the same DOM node as the one under the new container, or
+        // a distinct stale one? Same id in two bars means one subtree rendered twice; distinct ids mean
+        // the old node was never removed. Different fixes, and a per-bar census cannot separate them.
+        const idIndex = {};
+
+        after.forEach(entry => entry.buttonIds.forEach(({id, text}) => {
+            (idIndex[id] ??= {bars: [], text}).bars.push(entry.barId)
+        }));
+
+        console.log('[18025] node ids present in MORE THAN ONE bar:', JSON.stringify(
+            Object.entries(idIndex).filter(([, v]) => v.bars.length > 1)
+                .map(([id, v]) => ({bars: v.bars, id, text: v.text}))));
+        console.log('[18025] every node rendering the subject:', JSON.stringify(
+            Object.entries(idIndex).filter(([, v]) => v.text === subject)
+                .map(([id, v]) => ({bars: v.bars, id}))));
+
+        // The engine-truth control: if the document also lists the item twice the defect is in the
+        // model, not the drag-end restore. Asserting only the DOM would leave that ambiguous.
+        const document     = (await app.getDockTopology(wsId)).document,
+              modelHolders = Object.entries(document.nodes || {})
+                  .filter(([, node]) => node.type === 'tabs' && (node.items || []).includes('alerts'))
+                  .map(([nodeId]) => nodeId);
+
+        expect(
+            modelHolders.length,
+            `the committed document must hold the item in exactly one tabs node — ${JSON.stringify(modelHolders)}`
+        ).toBe(1);
+
+        expect(
+            holders.map(entry => ({id: entry.containerId, tabs: entry.tabTexts})),
+            `"${subject}" must render in exactly one container after the drop — ${JSON.stringify(after)}`
+        ).toHaveLength(1);
+
+        expect(
+            after.filter(entry => entry.pressed.length > 1).map(entry => ({id: entry.containerId, pressed: entry.pressed})),
+            `no header may render two active tabs — ${JSON.stringify(after)}`
+        ).toEqual([]);
+
+        // The mechanism assertion, and the one a per-bar census cannot make. The engine moved the
+        // component correctly — `getTabButtons()` on the source no longer lists it — but its OLD DOM
+        // node survives, so one element id is rendered under two bars at once. That is a duplicate id
+        // in the document, not a second component.
+        expect(
+            Object.entries(idIndex).filter(([, entry]) => entry.bars.length > 1)
+                .map(([id, entry]) => ({bars: entry.bars, id, text: entry.text})),
+            'no tab button node may render under more than one header — a moved component must not leave its old node behind'
+        ).toEqual([])
+    })
+});

--- a/test/playwright/e2e/workstation/WorkstationTabRestoreNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationTabRestoreNL.spec.mjs
@@ -40,7 +40,12 @@ import {test, expect} from '../../fixtures.mjs';
  */
 
 /** Rendered tab occupancy per container: which labels each header shows, and which read as active. */
-const readTabs = page => page.evaluate(() => [...document.querySelectorAll('.neo-tab-header-toolbar')].map(bar => {
+const readTabs = page => page.evaluate(() => [...document.querySelectorAll('.neo-tab-header-toolbar')]
+    // The DRAG PROXY also carries `.neo-tab-header-toolbar` — that is its whole point, it is a detached
+    // clone of a tab header. Counting it makes the proxy's own button look like a third container holding
+    // the subject, which is a defect in the instrument, not in the product.
+    .filter(bar => !bar.classList.contains('neo-dragproxy') && !bar.closest('.neo-dragproxy'))
+    .map(bar => {
     const container = bar.closest('[class*="neo-tab-container"]'),
           buttons   = [...bar.querySelectorAll('.neo-tab-header-button')];
 
@@ -80,13 +85,44 @@ test.describe('Workstation — a tab dragged out of its group is not restored in
 
             return host?.getBoundingClientRect().height > 300
         }, {timeout: 60000});
-        await page.waitForTimeout(1200);
+
+        // Readiness by predicate, not by clock: the gesture needs THIS subject's button rendered with a
+        // real box, and the workspace's other headers projected. A fixed wait either overshoots on a
+        // fast host or, worse, under-waits on a slow one and drags a button whose rect is still stale.
+        await page.waitForFunction(subject => {
+            const bars    = [...document.querySelectorAll('.neo-tab-header-toolbar')],
+                  buttons = bars.flatMap(bar => [...bar.querySelectorAll('.neo-tab-header-button')]),
+                  target  = buttons.find(button => button.textContent.trim() === subject);
+
+            // `neo-draggable` on THE SUBJECT is the armed-sensor signal. Waiting only for a box was the
+            // mistake an earlier revision made: the button paints before its sort zone is wired, so the
+            // gesture started against unarmed chrome and the drop committed nothing — which the
+            // non-vacuity guard then reported, correctly, as a test defect rather than a product one.
+            return bars.length > 2 && !!target
+                && target.getBoundingClientRect().width > 0
+                && target.classList.contains('neo-draggable')
+        }, 'Priority Alert Observatory', {timeout: 60000});
 
         const app        = await neuralLink.connectToApp('Workstation'),
               workspaces = await app.findInstances({className: 'Workstation.view.Workspace'}, ['id']),
               wsId       = (Array.isArray(workspaces) ? workspaces[0] : workspaces)?.id;
 
         expect(wsId, 'the workstation Workspace must exist in the App Worker').toBeTruthy();
+
+        // Workspace-level settle, read from the engine rather than inferred from the DOM: every `tabs`
+        // node in the COMMITTED document must have a rendered header. That is what "the projection has
+        // caught up" means, and it is the condition the drop needs in order to resolve a target zone.
+        // DOM-only readiness is not sufficient — a button can paint, and even be draggable, while the
+        // workspace is still projecting, and the release then commits nothing.
+        await expect.poll(async () => {
+            const doc       = (await app.getDockTopology(wsId)).document,
+                  tabsNodes = Object.values(doc?.nodes || {}).filter(node => node.type === 'tabs').length,
+                  bars      = await page.locator('.neo-tab-header-toolbar').count();
+
+            return tabsNodes > 0 && bars === tabsNodes
+        }, {message: 'every committed tabs node must have a rendered header before the gesture', timeout: 60000})
+            .toBe(true);
+
 
         const before = await readTabs(page),
               // The dragged subject: the operator's own. Resolved from rendered text rather than a node
@@ -125,7 +161,50 @@ test.describe('Workstation — a tab dragged out of its group is not restored in
         await page.mouse.move(box.x + box.width / 2 - 60, box.y + box.height / 2 + 20, {steps: 8});
         await page.mouse.move(dropX, dropY, {steps: 24});
         await page.mouse.up();
-        await page.waitForTimeout(1200);
+
+        // Settle on projection STABILITY, which is the only predicate that is both semantic and neutral.
+        //
+        // "Wait until the source is clean" would mask the defect — that is the thing under test. "Wait
+        // until the re-home renders" resolves too early: the insertion paints before the source removal
+        // is published, so the snapshot catches an intermediate state and the non-vacuity guard fires on
+        // a gesture that did commit. Waiting for the rendered occupancy to stop changing settles on
+        // whatever the truth is: clean if the removal lands, duplicated if it never does.
+        // Settle across ENGINE ROUND-TRIPS, not rAF frames and not a duration.
+        //
+        // Three predicates were tried and each failed for an instructive reason. "Wait for the source to
+        // be clean" masks the defect under test. "Wait for the re-home to render" resolves while the
+        // transaction is still mid-flight. "Wait for three quiet rAF frames" resolves instantly, because
+        // the PRE-drop state is already quiet — quiescence cannot distinguish settled-after from
+        // not-started — and even gated behind the re-home it is too short, since the source removal
+        // publishes several frames after the target paints.
+        //
+        // A `getDockTopology` call is a round-trip to the App Worker, so it is a genuine synchronisation
+        // point. Requiring the committed document AND the rendered occupancy to be identical across
+        // three consecutive round-trips gives real settle time derived from the engine rather than
+        // guessed. It stays neutral: it never asks the source to be clean, so a surviving stale node
+        // reaches the assertions instead of hanging the wait.
+        let quiet = 0, previous = null;
+
+        // The proxy is torn down on its own schedule after release. Its presence is unrelated to whether
+        // the source removal published, so waiting for it is not a wait on the thing under test.
+        await page.waitForSelector('.neo-dragproxy', {state: 'detached', timeout: 30000});
+
+        for (let attempt = 0; attempt < 60 && quiet < 3; attempt++) {
+            const doc      = (await app.getDockTopology(wsId)).document,
+                  rendered = await readTabs(page),
+                  sample   = JSON.stringify({
+                      doc      : Object.entries(doc?.nodes || {})
+                          .filter(([, node]) => node.type === 'tabs')
+                          .map(([nodeId, node]) => [nodeId, [...(node.items || [])].sort()])
+                          .sort(),
+                      occupancy: rendered.map(entry => [entry.barId, [...entry.tabTexts].sort()]).sort()
+                  });
+
+            quiet    = sample === previous ? quiet + 1 : 0;
+            previous = sample
+        }
+
+        expect(quiet, 'the projection must reach a settled state the arm can measure').toBeGreaterThanOrEqual(3);
 
         const after   = await readTabs(page),
               holders = after.filter(entry => entry.tabTexts.includes(subject));
@@ -134,10 +213,14 @@ test.describe('Workstation — a tab dragged out of its group is not restored in
         // gesture that did nothing at all: if the release was a no-op the item never left its header,
         // occupancy stays at one, and the arm reports green against an untested code path. So prove the
         // move committed BEFORE trusting the occupancy result.
+        // Order-INDEPENDENT: an earlier revision asserted `holders[0] !== origin`, but `holders` is in
+        // DOM order, so with the defect present (both containers holding the subject) the origin could
+        // sort first and the guard then misreported a committed drag as "committed nothing". Ask whether
+        // the subject renders anywhere OTHER than its origin, which is the actual question.
         expect(
-            holders[0]?.containerId ?? '<the subject vanished>',
-            `the drag must actually re-home the item — it is still in its origin container ${origin.containerId}, so this gesture committed nothing and the assertions below prove nothing`
-        ).not.toBe(origin.containerId);
+            holders.map(entry => entry.containerId).filter(id => id !== origin.containerId),
+            `the drag must actually re-home the item — it renders only in its origin container ${origin.containerId}, so this gesture committed nothing and the assertions below prove nothing`
+        ).not.toEqual([]);
 
         // Engine truth for the SOURCE container specifically. The DOM says its header still renders the
         // re-homed item; this asks the App Worker whether that button is a live child of the source's


### PR DESCRIPTION
Resolves #18025

Related: #17836 · #17951 · #17980

**Evidence:** witness **10/10 red mutated, 10/10 green fixed** — both measured at `--repeat-each=10` · `component/dashboard/` + `component/tab/` 76 passed · `unit/dashboard/` 708 passed · sibling split-chrome witness green · zero fixed waits.

🌿 A tab that has moved on can no longer leave its own node behind to impersonate it.

@tobiu reported it and named the appearance exactly — *"look at the 2 active tabs => it is in fact the header i dragged left, getting restored."*

## What is actually happening

The appearance is a restore. The mechanism is one level down, and measuring it retired two of my own wrong readings.

The App Worker moves the component **correctly**: `getTabButtons()` on the source toolbar no longer lists the dragged item. What survives is the item's **old DOM node**. So one element id renders under two headers at once, and the stale node keeps the `pressed` class it left with:

```
toolbar-7 (new)     DOM ["Priority Alert Observatory"]                    engine tabs 1
toolbar-3 (source)  DOM ["Resident Activity Timeline",
                         "Priority Alert Observatory"]                    engine tabs 11
node ids in MORE THAN ONE bar: [{id: neo-tab-header-button-3, bars: [toolbar-7, toolbar-3]}]
```

Both sides of a cross-bar move are silent (`commitBars` was `materializedBars` before this PR — see Deltas):

```javascript
state.body.removeAt(state.index, false, true, true);
state.bar.removeTabAt(state.index, false, true, true);   // silent
targetBody.insert(targetIndex, pane, true, false);
targetBar.insertTab(targetIndex, state.button, true, false);   // silent
```

The **target** renders anyway because it is freshly mounted. That leaves the **source** as the one side nothing flushes. Both bars now join the existing awaited commit set, which publishes with `promiseUpdate()`; a `Set` keeps it idempotent when several items move between the same pair. The set is renamed `commitBars`, because it no longer means "bars that materialized chrome" — it means **bars whose membership changed silently**, and both sides of a move qualify.

## It is a regression, and the first bad commit is isolated

Bisected against the deterministic reproduction, 3 runs per probe:

| commit | result |
| --- | --- |
| `478a9fafb8` before the DockLayouts anatomy rewrite | 3/3 pass |
| `e9f10ba17e` the anatomy rewrite (#17841) | 3/3 pass |
| `36332ff3f5` tab drag boundary (#17926) | 3/3 pass |
| `9954179bb7` inline + standalone variants (#17950) | 3/3 pass |
| **`14d1024f7a` project overflow as a stable header action (#17951 / #17960)** | **3/3 FAIL** |
| everything after, through `dev` | 3/3 FAIL |

`14d1024f7a` is the **immediate child** of the last good commit, so the boundary needs no narrowing.

## AC Evidence

| AC | Evidence |
| --- | --- |
| AC-1 the source renders only the tabs it still owns, cross-referenced against the committed document | the witness asserts DOM occupancy **and** asserts the document holds the item in exactly one `tabs` node first, so a model/projection disagreement cannot pass as either |
| AC-2 no tab text in two containers, no header with two `pressed` tabs, for the operator's gesture | both asserted, plus the cross-bar node-identity assertion that names the mechanism |
| AC-3 the arm reds before the fix | mutation of this diff reds **10/10** at `--repeat-each=10`, and the fixed tree is 10/10 green — same sample size on both arms |
| AC-4 the within-toolbar reorder is unchanged | `state.bar !== targetBar` guards the enrolment, so a same-bar reorder takes no new path; `component/dashboard/` + `component/tab/` 76 passed and `unit/dashboard/` 708 passed cover it |
| AC-5 the sibling witness's `pressedCount` forensic note | **truth-synced.** Both notes in `WorkstationDockSplitChromeNL.spec.mjs` described this defect as independent and unresolved; it is neither. They now name the mechanism, point at the dedicated witness, and say why `pressedCount` stays unasserted *there* (that cue never reaches this path) |
| AC-6 the reachability question answered in comments | the new comment states which side fails to publish and why the target masks it |

## Deltas from ticket

- **The ticket's original suspect is retired, not merely demoted.** It named `container/SortZone.mjs`'s unconditional visibility restore. The engine's source-bar tab set never contains the dragged item, so nothing restored it and no visibility toggle explains a duplicate DOM id. That block also last changed at `7de06abd13` (#8156), unchanged across the regression boundary. Recorded so the path is not re-walked.
- **I claimed this was "not the doubled-subtree failure mode" and was wrong.** My duplicate-id check was scoped **within** one bar while the duplication is **across** two, so the instrument answered a narrower question than the one I asked. This belongs to the same duplicate-id family as #17980, reached by a different route — a cross-zone move rather than a bar write racing a reconcile.
- **The `11` in the payload is not part of the defect.** The source bar's semantic set is one rendered button plus ten legitimately collapsed catalog items (`hidden: true, mounted: false, removeDom: true`). I first read it as an accumulation; it is normal, and the dragged item is not among them.
- **The settle length is a sensitivity knob, not a safety knob — and I measured it rather than picking it.** Replacing the fixed waits cost determinism at first: against the unfixed reconciler the arm reds **10/10 at two** consecutive engine round-trips but only **7/10 at three**, because a longer wait lets an unrelated later update publish the source removal on its own and heal the defect before the snapshot. Two it is, with the measurement recorded in the spec so a future widening re-measures instead of assuming.
- **Four settle predicates were tried; three were wrong for instructive reasons, all recorded in the spec.** Waiting for source cleanup masks the defect under test. Waiting for the re-home to render resolves mid-transaction. rAF quiescence resolves *instantly*, because the pre-drop state is already quiet — quiescence cannot distinguish settled-after from not-started — and is still too short even when gated behind the re-home.
- **Two bugs in my own instrument, found while doing this.** The non-vacuity guard compared `holders[0]` to the origin, which is DOM order: with the defect present the origin could sort first, and the guard then misreported a *committed* drag as committing nothing. And the census counted the **drag proxy** as a container, because the proxy carries `.neo-tab-header-toolbar` by design — its button looked like a third holder of the subject.

## Test Evidence

```
WorkstationTabRestoreNL   fixed      10 passed   (--repeat-each=10)
WorkstationTabRestoreNL   mutated    10 failed   (--repeat-each=10)
component/dashboard/ + component/tab/             76 passed
unit/dashboard/                                  708 passed
WorkstationDockSplitChromeNL (sibling witness)      1 passed
```

Both witness numbers are at the same sample size, deliberately: an earlier revision of this body put `10/10` beside a `3/3` mutation and invited reading them as equally sampled. They were not.

**The release timing is the reproduction, and it is diagnostic.** A ~400ms dwell before release reproduces about 1 run in 10; releasing immediately reproduces 10 of 10. The defect is a race a settling pause mostly closes — which is why it reads as an occasional glitch by hand, and why every scripted arm has been green: `executeCue` does not reproduce it at all, so the witness drives `page.mouse`.

The witness also carries a non-vacuity guard that fails if the drag committed nothing, so a no-op release cannot report green.

## Post-Merge Validation

`component/dashboard/`, `component/tab/` and `unit/dashboard/` on `dev`, plus the witness under the command in its JSDoc. The user-visible check is the operator's own: drag a tab out of its group, dock it to a grid edge, and the source header shows only the tabs it still owns.

## Authored by

Vega (`@neo-opus-vega`), Claude Code.

— Vega (Opus 5, Claude Code) 🌿
