### PR TITLE
fix(data): TreeStore resolves child membership by key, not identity (…

### DIFF
--- a/learn/guides/datahandling/TreeStore.md
+++ b/learn/guides/datahandling/TreeStore.md
@@ -212,6 +212,29 @@ The transform itself lives in `Neo.data.normalizer.Path`, the sibling of `Neo.da
 same category of reshaping, different input encoding. Use the normalizer directly through a
 `Neo.data.Pipeline` when path-addressed data arrives from a remote source in bulk.
 
+### Adding a node that already exists
+
+`add()` resolves nodes by key, not by object identity. A record whose key is already in the store
+**replaces** the node in its parent's child array rather than joining it there, so re-reading the same
+config, fixture or API response is idempotent and needs no "does this exist yet" branch of its own:
+
+```javascript readonly
+treeStore.add({id: 'Group', parentId: 'root', name: 'Group', isLeaf: false});
+treeStore.add({id: 'Group', parentId: 'root', name: 'Group', isLeaf: false});
+
+treeStore.getChildren('root');       // one entry — the second add replaced the first
+treeStore.get('Group').siblingCount; // 1
+```
+
+Both halves of the Structural Layer end up on the same record, so what `getChildren()` returns is what
+`get()` returns, and the derived ARIA fields describe the level that actually exists. What this is not
+is a **merge**: the node is replaced by the payload you pass, so a field you omit is re-derived from
+the defaults rather than inherited from the node it replaced.
+
+An auto-healed node — one whose declared parent was absent, re-parented to `'root'` as described above
+— carries `depth: 0`. The depth resolved against the missing parent describes a level the node does
+not end up on.
+
 ### Expanding and Collapsing
 
 The primary way users interact with a TreeStore is by toggling node visibility.

--- a/src/data/TreeStore.mjs
+++ b/src/data/TreeStore.mjs
@@ -85,6 +85,74 @@ class TreeStore extends Store {
     #childrenMap = new Map()
 
     /**
+     * @summary Inserts a node into a parent's child array, resolving membership by key.
+     *
+     * `#allRecordsMap` is keyed, so re-adding a node overwrites its entry. `#childrenMap` holds arrays,
+     * where membership has to be scanned for — and scanning by object identity is a membership test an
+     * equal-but-distinct literal can never satisfy, which is the ordinary shape for anything re-read
+     * from a config, a fixture or an API. Identity-scanning therefore appended the new literal beside
+     * the object it had just replaced: the child array held a stale node and a live one under the same
+     * key, `getCount()` reported one child while `getChildren()` returned two, and `updateSiblingStats()`
+     * published the array's length as `siblingCount` — a level with a single node announcing "1 of 2" to
+     * a screen reader while the rendered tree looked entirely correct.
+     *
+     * Resolving by key keeps both maps pointing at the same record: an existing key is replaced in place,
+     * so the re-added field values win and the stale object stops being reachable through `getChildren()`.
+     * Re-adding the exact same reference stays a no-op, and `affectedParents` grows only when the array
+     * actually changed, so `updateSiblingStats()` runs for a replacement and not for a no-op.
+     *
+     * **Why the caller hands over the previous record rather than letting this scan for the key.**
+     * Ingestion is already O(N) over a level, so a per-node key scan makes a bulk load O(N²) — with a
+     * record getter on every comparison rather than a reference check. Measured over 20k flat siblings,
+     * that is the difference between 0.5s and 11.6s, in the one class whose whole premise is 50k-record
+     * ingestion. A key absent from `#allRecordsMap` cannot be in any child array, so the common path —
+     * ingesting a genuinely new node — never scans at all, and only a real re-add pays for the lookup.
+     *
+     * @param {String|Number} parentId The child array to insert into. Root-level nodes live under 'root'.
+     * @param {Object|Neo.data.Record} data
+     * @param {Object|Neo.data.Record|undefined} existing What this key resolved to BEFORE the current
+     * ingestion overwrote it; `undefined` for a key the Structural Layer has never held.
+     * @param {Set} affectedParents Collects the parents whose derived stats need recalculating.
+     * @private
+     */
+    #addChild(parentId, data, existing, affectedParents) {
+        let me       = this,
+            siblings = me.#childrenMap.get(parentId),
+            index    = -1;
+
+        if (!siblings) {
+            siblings = [];
+            me.#childrenMap.set(parentId, siblings)
+        }
+
+        if (existing) {
+            index = siblings.indexOf(existing);
+
+            // `hydrateRecord()` heals both maps in step, so identity resolves the entry in practice.
+            // The key scan is the fallback for a node whose two map entries have drifted apart —
+            // without it, a drifted entry would silently duplicate exactly as it used to.
+            if (index < 0) {
+                let key = me.getKey(data);
+
+                index = siblings.findIndex(sibling => me.getKey(sibling) === key)
+            }
+        }
+
+        if (index > -1) {
+            // Same reference: the node is already parented here, so nothing derived can have changed.
+            if (siblings[index] === data) {
+                return
+            }
+
+            siblings[index] = data
+        } else {
+            siblings.push(data)
+        }
+
+        affectedParents.add(parentId)
+    }
+
+    /**
      * Triggered before the pathNormalizer config gets changed.
      * Instantiates a config object, defaulting to `Neo.data.normalizer.Path`. A falsy value stays
      * falsy on purpose: the normalizer is created on first `materializePath()` call, not eagerly for
@@ -1094,6 +1162,11 @@ class TreeStore extends Store {
                         data.collapsed = true
                     }
 
+                    // Captured before the overwrite: this is both the node a re-add replaces and the
+                    // proof that the key is in the hierarchy at all, which is what keeps `#addChild()`
+                    // from scanning a level per ingested node.
+                    let existing = me.#allRecordsMap.get(key);
+
                     me.#allRecordsMap.set(key, data);
 
                     if (!me.#childrenMap.has(parentId)) {
@@ -1108,10 +1181,7 @@ class TreeStore extends Store {
                         }
                     }
 
-                    if (!me.#childrenMap.get(parentId).includes(data)) {
-                        me.#childrenMap.get(parentId).push(data);
-                        affectedParents.add(parentId)
-                    }
+                    me.#addChild(parentId, data, existing, affectedParents);
 
                     // Identify nodes that need their flat visible descendants calculated
                     if (parentId === 'root' || !me.#allRecordsMap.has(parentId)) {
@@ -1120,6 +1190,13 @@ class TreeStore extends Store {
                         // Auto-heal disconnected branches by reparenting them to 'root'
                         if (parentId !== 'root') {
                             data.parentId = 'root';
+
+                            // The re-parenting carries its own derived invariant. `depth` was resolved
+                            // against the declared parent above — and that parent is precisely the one
+                            // that turned out to be absent, so the value it produced describes a level
+                            // this node no longer sits on. A root-level node is at depth 0.
+                            data.depth = 0;
+
                             let siblings = me.#childrenMap.get(parentId);
                             if (siblings) {
                                 let idx = siblings.indexOf(data);
@@ -1127,13 +1204,8 @@ class TreeStore extends Store {
                                     siblings.splice(idx, 1)
                                 }
                             }
-                            if (!me.#childrenMap.has('root')) {
-                                me.#childrenMap.set('root', [])
-                            }
-                            if (!me.#childrenMap.get('root').includes(data)) {
-                                me.#childrenMap.get('root').push(data);
-                                affectedParents.add('root')
-                            }
+
+                            me.#addChild('root', data, existing, affectedParents)
                         }
                     } else {
                         let parentNode = me.#allRecordsMap.get(parentId);

--- a/test/playwright/unit/data/TreeStore.spec.mjs
+++ b/test/playwright/unit/data/TreeStore.spec.mjs
@@ -1103,3 +1103,94 @@ test.describe('Neo.data.TreeStore (getChildren)', () => {
         turboStore.destroy()
     })
 });
+
+test.describe('Neo.data.TreeStore (re-adding an existing key)', () => {
+    let store;
+
+    class ReAddTreeModel extends TreeModel {
+        static config = {
+            className: 'Test.Unit.Data.TreeStore.ReAddTreeModel',
+            fields   : [
+                {name: 'id',   type: 'String'},
+                {name: 'name', type: 'String'}
+            ]
+        }
+    }
+
+    const ReAddModel = Neo.setupClass(ReAddTreeModel);
+
+    test.beforeEach(() => {
+        store = Neo.create(TreeStore, {
+            model: ReAddModel,
+            data : [
+                {id: 'Group',   name: 'Group', isLeaf: false},
+                {id: 'Group/A', name: 'A',     isLeaf: true, parentId: 'Group'}
+            ]
+        })
+    });
+
+    test.afterEach(() => {
+        store?.destroy()
+    });
+
+    const childIds = (parentId='root') => store.getChildren(parentId).map(record => record.id);
+
+    test('replaces the node in its parent child array instead of appending beside it', () => {
+        store.add({id: 'Group/A', parentId: 'Group', name: 'A (updated)', isLeaf: true});
+
+        expect(childIds('Group')).toEqual(['Group/A']);
+        expect(store.get('Group/A').siblingCount).toBe(1);
+        expect(store.get('Group').childCount).toBe(1)
+    });
+
+    test('the re-added values win and the stale object stops being reachable', () => {
+        store.add({id: 'Group/A', parentId: 'Group', name: 'A (updated)', isLeaf: true});
+
+        const [child] = store.getChildren('Group');
+
+        expect(child.name).toBe('A (updated)');
+
+        // Both halves of the Structural Layer must resolve to the same record. A child array entry
+        // that get() no longer returns is the half-fix this assertion exists to reject: it would
+        // make siblingCount correct while leaving getChildren() serving the object it replaced.
+        expect(child).toBe(store.get('Group/A'))
+    });
+
+    test('a root-level re-add leaves one root entry with one sibling', () => {
+        store.add({id: 'Group', parentId: 'root', name: 'Group', isLeaf: false});
+
+        expect(store.getCount()).toBe(1);
+        expect(childIds()).toEqual(['Group']);
+        expect(store.get('Group').siblingCount).toBe(1)
+    });
+
+    test('adding the same object reference twice still no-ops', () => {
+        store.add(store.get('Group/A'));
+
+        expect(childIds('Group')).toEqual(['Group/A']);
+        expect(store.get('Group/A').siblingCount).toBe(1)
+    });
+
+    test('an auto-healed node carries the depth of the level it lands on', () => {
+        store.add({id: 'Orphan/A', parentId: 'Orphan', name: 'A'});
+
+        const healed = store.get('Orphan/A');
+
+        expect(healed.parentId).toBe('root');
+
+        // depth is resolved from the declared parent — here, the parent that turned out to be absent.
+        // Re-parenting to 'root' has to carry that derived field with it.
+        expect(healed.depth).toBe(0)
+    });
+
+    test('a re-added orphan heals into the root level once, not twice', () => {
+        store.add({id: 'Orphan/A', parentId: 'Orphan', name: 'A'});
+        store.add({id: 'Orphan/A', parentId: 'Orphan', name: 'A (updated)'});
+
+        // The auto-heal branch resolves membership on its own, so a fix confined to the main
+        // ingestion path leaves this one duplicating.
+        expect(childIds()).toEqual(['Group', 'Orphan/A']);
+        expect(store.get('Orphan/A').name).toBe('A (updated)');
+        expect(store.get('Orphan/A').siblingCount).toBe(2)
+    })
+});

--- a/test/playwright/unit/data/TreeStorePathMaterialization.spec.mjs
+++ b/test/playwright/unit/data/TreeStorePathMaterialization.spec.mjs
@@ -137,16 +137,18 @@ test.describe('Neo.data.TreeStore (Path Materialization)', () => {
             expect(second.id).toBe(first.id)
         });
 
-        test('CONTROL: a raw add() of the same node DOES duplicate it', () => {
-            // Without this control the test above proves nothing — it would pass against any
-            // implementation, including one that simply never adds twice because nothing adds at all.
-            // The Structural Layer dedupes children by object identity, so an equal-but-distinct
-            // literal is appended a second time. materializePath() is what avoids that.
+        test('CONTROL: a raw add() of the same node does not duplicate it either', () => {
+            // This control is inverted from what it originally pinned. The Structural Layer used to
+            // test child membership by object identity, so an equal-but-distinct literal was appended
+            // beside the node it should have replaced, and materializePath()'s own key filtering was
+            // the only thing between a caller and a duplicated child. splice() now resolves child
+            // membership by key, so idempotence holds for a raw add() too: what the test above proves
+            // about materializePath() no longer rests on the store lacking the same guarantee.
             store.materializePath('Group');
             store.add({id: 'Group', parentId: 'root', name: 'Group', isLeaf: false});
 
-            expect(childIds('root')).toEqual(['Group', 'Group']);
-            expect(store.get('Group').siblingCount).toBe(2)
+            expect(childIds('root')).toEqual(['Group']);
+            expect(store.get('Group').siblingCount).toBe(1)
         })
     });
 


### PR DESCRIPTION
**Does this PR resolve an issue?** (Required)

Closes #17855

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

`add()` of an already-present key previously produced a duplicate child entry. Code relying on that duplication was relying on a defect; nothing relies on it in-tree.

**The PR fulfills this requirement:**

- [x] It's submitted to the `dev` branch, _not_ the `main` branch

**Other information:**

### The defect

`#allRecordsMap` is keyed, so re-adding a node overwrote its entry. `#childrenMap` holds arrays and tested membership with `Array#includes` — object identity, which an equal-but-distinct literal never satisfies. The literal was appended beside the object it had just replaced, so the child array held a stale node and a live one under the same key:

```javascript
store.add({id: 'Group', parentId: 'root', name: 'Group', isLeaf: false});
store.add({id: 'Group', parentId: 'root', name: 'Group', isLeaf: false});

store.getCount();                // 1  — correct
store.getChildren('root');       // ['Group', 'Group']  — WRONG
store.get('Group').siblingCount; // 2  — WRONG
```

`updateSiblingStats()` derives `siblingCount` from that array's length, so a screen reader was told "1 of 2" for a level holding one node — view-invisible, since the tree renders correctly and only reports itself incorrectly.

### The fix

Child-array membership now resolves by key, in a single `#addChild()` helper used by **both** identity tests in the "Process Additions & Moves" block — the main ingestion path and the auto-heal branch that re-parents an orphan to `'root'`. Fixing only the first leaves a re-added orphan duplicating; there is a spec for that specifically.

An existing key is replaced in place, so both maps end up pointing at the same record: what `getChildren()` returns is what `get()` returns. The same-reference fast path still no-ops, and `affectedParents` grows only when the array actually changed, so `updateSiblingStats()` runs for a replacement and not for a no-op.

`splice()` also now assigns `depth: 0` when it re-parents a node to `'root'`. `depth` was resolved against the declared parent — the one that turned out to be absent — so the value it produced described a level the node does not end up on.

### Performance

The insert takes the previous record from `#allRecordsMap` (captured before the overwrite) rather than scanning for the key. A key the Structural Layer has never held cannot be in any child array, so ingesting a genuinely new node performs no scan at all — where the old code ran an `includes()` scan per node.

| Ingesting 20k flat siblings | Time |
|---|---|
| `dev` | 526 ms |
| naive key scan (rejected) | 11,627 ms |
| this PR | 453–571 ms |

The middle row is why the helper takes `existing` as a parameter: a per-node key scan makes bulk ingestion O(N²) with a record getter on every comparison, in the one class whose premise is 50k-record ingestion.

### Tests

- Six new specs in `test/playwright/unit/data/TreeStore.spec.mjs` covering each AC: single child entry after a re-add, unchanged `siblingCount` / `childCount`, the re-added values winning with the stale object unreachable, the same-reference no-op, `depth: 0` on auto-heal, and the re-added orphan going through the second membership test.
- The CONTROL at `TreeStorePathMaterialization.spec.mjs:140` is **inverted** with its comment rewritten. It asserted the defect deliberately; left as-is it would have been a false green.
- `learn/guides/datahandling/TreeStore.md` gains an "Adding a node that already exists" section documenting the keyed semantics, that a re-add is a replace and not a merge, and the auto-heal `depth`.

Verified with `npm run test-unit` (the repo's explicit config, not bare `npx playwright test`): **2668 passed**. One failure, `apps/workstation/Workspace.spec.mjs` › "remote main previews render all four edges…", **reproduces identically on clean `dev` with this branch stashed** — pre-existing and unrelated. `npm run test-components` shows two flaky `dashboard/Dock*` specs that also fail on clean `dev` and alternate between runs.

### Out of scope — two findings for follow-up

**1. A re-add that changes `parentId` leaves a stale entry under the old parent.** `add({id: 'X', parentId: 'B'})` for an `X` currently under `A` leaves `X` reachable through `getChildren('A')` as the stale object, with `A.childCount` still 1. This is the same trap the ticket names, reached via a different route. It behaves identically on `dev` — this PR neither fixes nor worsens it — and the ACs are all same-parent, so I left it alone. Happy to open a ticket if you want it scoped.

**2. The Projection Layer keeps the stale object after a re-add.** `store.getAt(0)` still returns the replaced record while `store.get(…)` returns the new one, because `Neo.collection.Base#splice` skips an existing key on add and explicitly refuses same-key replacement in its remove branch. That is a Collection-wide contract question affecting every store, not a `TreeStore` one.
