### PR TITLE
fix(dock): contain and elevate rail previews (#18028)

### DIFF
--- a/apps/workstation/view/Workspace.mjs
+++ b/apps/workstation/view/Workspace.mjs
@@ -949,6 +949,9 @@ class Workspace extends DockWorkspace {
         let me = this;
 
         return {
+            // Dense Workstation panes need more than the engine's compact 25% reveal floor. The
+            // committed edge extent still wins whenever it is larger.
+            defaultRevealFraction      : 0.35,
             // Cross-window participation (§2.3): every projected tab zone registers as a
             // coordinator-visible drag source under one sort group; the workspace id rides the
             // payload for the receiving window's `transferItem` resolution.

--- a/resources/scss/src/apps/workstation/Workspace.scss
+++ b/resources/scss/src/apps/workstation/Workspace.scss
@@ -95,6 +95,16 @@
         }
     }
 
+    .neo-dashboard-dock-reveal-overlay {
+        --dock-reveal-background     : var(--workstation-rail);
+        --dock-reveal-border         : 1px solid color-mix(in srgb, var(--workstation-signal) 46%, var(--workstation-line));
+        --dock-reveal-min-block-size : 16rem;
+        --dock-reveal-min-inline-size: 20rem;
+        --dock-reveal-radius         : 8px;
+        --dock-reveal-shadow         : 0 14px 38px color-mix(in srgb, var(--workstation-ground) 72%, transparent),
+                                       0 0 20px color-mix(in srgb, var(--workstation-signal) 16%, transparent);
+    }
+
     // Horizontal rails read as an app-edge info line: give their labels the tourbar caption's
     // breathing room instead of the shared strip's 1px inline padding. The vertical rails keep the
     // slim shared padding — the physical 1px inline is what lets the rotated label fit the 14px

--- a/resources/scss/src/dashboard/Container.scss
+++ b/resources/scss/src/dashboard/Container.scss
@@ -121,6 +121,16 @@
     // today. Defaulting to `hidden` would have been a silent rendering change for every square
     // rail, which is a redesign wearing a promotion's clothes.
     --dock-edge-rail-overflow       : visible;
+
+    // A reveal is an overlay, so opacity and elevation are functional rather than decorative:
+    // covered pane chrome must not bleed through, and the overlap boundary must remain visible.
+    // Consumers can supply identity values without re-declaring the structure.
+    --dock-reveal-background          : var(--neo-background-color, #fff);
+    --dock-reveal-border              : 0;
+    --dock-reveal-min-block-size      : 10rem;
+    --dock-reveal-min-inline-size     : 12rem;
+    --dock-reveal-radius              : 0;
+    --dock-reveal-shadow              : 0 12px 32px rgb(0 0 0 / 28%);
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -449,8 +459,13 @@
 }
 
 .neo-dashboard-dock-reveal-overlay {
-    position: absolute;
-    z-index : 20;
+    background   : var(--dock-reveal-background);
+    border       : var(--dock-reveal-border);
+    border-radius: var(--dock-reveal-radius);
+    box-shadow   : var(--dock-reveal-shadow);
+    overflow     : hidden;
+    position     : absolute;
+    z-index      : 20;
 
     // The overlay is also a flex container. Keep the semantic visibility state above the generic
     // `.neo-flex-container {display:flex}` rule without depending on stylesheet load order.
@@ -461,6 +476,16 @@
     // The reserved edge is the RAIL's extent, read from the rail's own token rather than
     // restated — the overlay must start exactly where the strip ends, and a second literal
     // here is how those two silently disagree.
+    &-left,
+    &-right {
+        min-inline-size: min(var(--dock-reveal-min-inline-size), calc(100% - var(--dock-edge-rail-size)));
+    }
+
+    &-top,
+    &-bottom {
+        min-block-size: min(var(--dock-reveal-min-block-size), calc(100% - var(--dock-edge-rail-size)));
+    }
+
     &-left   { inset: 0 auto 0 var(--dock-edge-rail-size); }
     &-right  { inset: 0 var(--dock-edge-rail-size) 0 auto; }
     &-top    { inset: var(--dock-edge-rail-size) 0 auto 0; }

--- a/src/dashboard/dock/interaction/RevealOverlay.mjs
+++ b/src/dashboard/dock/interaction/RevealOverlay.mjs
@@ -26,7 +26,8 @@ import MotionSignal     from '../projection/MotionSignal.mjs';
  *
  * Sizing follows the auto-hide contract: the free dimension (width for left/right rails, height
  * for top/bottom) uses the extent the item's owning split last committed when one exists
- * (`revealExtent`, resolved by the rail), else the workspace-configurable `defaultRevealFraction`.
+ * (`revealExtent`, resolved by the rail), with the workspace-configurable `defaultRevealFraction`
+ * as both fallback and usability floor.
  * Left/right reveals span full height; top/bottom span full width. The overlay stays visible
  * through the dismiss grace window (`dismiss-pending`) — pointer wobble must not flicker it.
  *
@@ -66,8 +67,9 @@ class RevealOverlay extends Container {
          */
         baseCls: ['neo-dashboard-dock-reveal-overlay'],
         /**
-         * Workspace-configurable fallback for the free dimension when the document carries no
-         * committed extent for the item (fraction of the workspace extent).
+         * Workspace-configurable fallback and minimum for the free dimension (fraction of the
+         * workspace extent). A smaller committed band must not turn a transient preview into an
+         * unusable sliver; larger committed extents remain authoritative.
          * @member {Number} defaultRevealFraction_=0.25
          * @reactive
          */
@@ -162,8 +164,8 @@ class RevealOverlay extends Container {
             cls : ['neo-dashboard-dock-reveal-header', 'neo-tab-container-inline'],
             flex: 'none',
             items: [{
-                module: TabHeaderButton,
-                cls   : ['neo-dashboard-dock-reveal-title'],
+                module : TabHeaderButton,
+                cls    : ['neo-dashboard-dock-reveal-title', 'neo-tab-overflow-capped'],
                 pressed: true,
                 text   : '',
                 // A preview title is a visual active-tab identity, not another navigation stop.
@@ -451,7 +453,9 @@ class RevealOverlay extends Container {
         let me         = this,
             edge       = me.edge,
             isVertical = edge === 'left' || edge === 'right',
-            fraction   = Number.isFinite(me.revealExtent) ? me.revealExtent : me.defaultRevealFraction,
+            fraction   = Number.isFinite(me.revealExtent)
+                ? Math.max(me.revealExtent, me.defaultRevealFraction)
+                : me.defaultRevealFraction,
             item       = me.revealedItem,
             pct        = `${Math.round(fraction * 10000) / 100}%`,
             cls        = me.cls || [];

--- a/test/playwright/e2e/workstation/WorkstationNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationNL.spec.mjs
@@ -2359,6 +2359,72 @@ test.describe('Workstation — dense living-data composition', () => {
         })
     }
 
+    test('a narrow long-title reveal stays contained and reads as an elevated pane', async ({page, neuralLink}) => {
+        await bootActionAcceptance({page, neuralLink});
+
+        await page.setViewportSize({height: 900, width: 420});
+
+        const railTab = page.locator('.neo-dashboard-dock-edge-rail-left .neo-dashboard-dock-rail-tab')
+            .filter({hasText: 'Dependency Graph Explorer'});
+
+        await expect(railTab).toBeVisible({timeout: 10000});
+        await railTab.click();
+
+        const
+            overlay = page.locator(
+                '.neo-dashboard-dock-reveal-overlay-left:not(.neo-dashboard-dock-reveal-overlay-hidden)'
+            ),
+            titleText = overlay.locator('.neo-dashboard-dock-reveal-title .neo-button-text');
+
+        await expect(overlay).toBeVisible({timeout: 10000});
+        await expect(titleText).toHaveText('Dependency Graph Explorer');
+
+        const geometry = await overlay.evaluate(overlayNode => {
+            const
+                workspaceNode = overlayNode.closest('.workstation-workspace'),
+                headerNode    = overlayNode.querySelector('.neo-dashboard-dock-reveal-header'),
+                titleNode     = headerNode.querySelector('.neo-dashboard-dock-reveal-title'),
+                textNode      = titleNode.querySelector('.neo-button-text'),
+                pinNode       = headerNode.querySelector('.neo-dashboard-dock-reveal-pin'),
+                workspaceBox  = workspaceNode.getBoundingClientRect(),
+                overlayBox    = overlayNode.getBoundingClientRect(),
+                headerBox     = headerNode.getBoundingClientRect(),
+                titleBox      = titleNode.getBoundingClientRect(),
+                textBox       = textNode.getBoundingClientRect(),
+                pinBox        = pinNode.getBoundingClientRect(),
+                overlayStyle  = getComputedStyle(overlayNode),
+                textStyle     = getComputedStyle(textNode);
+
+            return {
+                backgroundColor: overlayStyle.backgroundColor,
+                boxShadow      : overlayStyle.boxShadow,
+                header         : {left: headerBox.left, right: headerBox.right},
+                overlayRatio   : overlayBox.width / workspaceBox.width,
+                overlayWidth   : overlayBox.width,
+                pin            : {left: pinBox.left, right: pinBox.right},
+                text           : {
+                    left        : textBox.left,
+                    overflow    : textStyle.overflow,
+                    right       : textBox.right,
+                    textOverflow: textStyle.textOverflow
+                },
+                title          : {left: titleBox.left, right: titleBox.right}
+            }
+        });
+
+        expect(geometry.title.left).toBeGreaterThanOrEqual(geometry.header.left);
+        expect(geometry.title.right).toBeLessThanOrEqual(geometry.pin.left);
+        expect(geometry.text.left).toBeGreaterThanOrEqual(geometry.title.left);
+        expect(geometry.text.right).toBeLessThanOrEqual(geometry.title.right);
+        expect(geometry.pin.right).toBeLessThanOrEqual(geometry.header.right);
+        expect(geometry.text.overflow).toBe('hidden');
+        expect(geometry.text.textOverflow).toBe('ellipsis');
+        expect(geometry.overlayRatio).toBeGreaterThan(0.75);
+        expect(geometry.overlayWidth).toBeCloseTo(320, 0);
+        expect(geometry.backgroundColor).not.toBe('rgba(0, 0, 0, 0)');
+        expect(geometry.boxShadow).not.toBe('none');
+    });
+
     test('reload recreates a contract-less Workstation pane and adopts the committed identity', async ({page, neuralLink}) => {
         const pageErrors = [];
 

--- a/test/playwright/unit/dashboard/DockRevealOverlay.spec.mjs
+++ b/test/playwright/unit/dashboard/DockRevealOverlay.spec.mjs
@@ -66,6 +66,8 @@ test.describe('Neo.dashboard.dock.interaction.RevealOverlay', () => {
         expect(overlay.titleTab.className).toBe('Neo.tab.header.Button');
         expect(overlay.titleTab.pressed).toBe(true);
         expect(overlay.titleTab.vdom.tabIndex).toBe(-1);
+        expect(overlay.titleTab.cls, 'long preview titles reuse the tab overflow contract')
+            .toContain('neo-tab-overflow-capped');
         expect(overlay.pinButton.disabled).toBe(false);
         expect(overlay.items[0].className).toBe('Neo.tab.header.Toolbar');
         expect(overlay.items[0].cls).toContain('neo-tab-header-toolbar');
@@ -104,6 +106,9 @@ test.describe('Neo.dashboard.dock.interaction.RevealOverlay', () => {
 
         expect(overlay.style.width).toBe('30%');
         expect(overlay.style.height).toBeNull();
+
+        overlay.revealExtent = 0.1;
+        expect(overlay.style.width, 'the configured fallback is also the usability floor').toBe('25%');
 
         overlay.revealExtent = null;
         expect(overlay.style.width).toBe('25%');


### PR DESCRIPTION
Resolves #18028

Related: #17836
Related: #18019

Rail reveals now contain long active-tab titles, preserve a usable preview size, and paint as opaque elevated panes instead of transparent overlap. The engine reuses its existing tab overflow cap and makes `defaultRevealFraction` a floor; Workstation chooses 35% plus 20rem inline / 16rem block physical floors.

Evidence: L4 (live Workstation at a 420px viewport: complete preview geometry and computed paint measured) → L4 required (operator visual acceptance). No post-merge residuals.

## AC Evidence

| AC-1 | `WorkstationNL.spec.mjs` asserts title/text rect containment before the pin plus `overflow:hidden` / `text-overflow:ellipsis`; live receipt: text right 243px ≤ title right 255px ≤ pin left 309px. |
| AC-2 | The same real-browser arm asserts the pin right edge stays inside the header; live receipt: pin right 333px = header right 333px. |
| AC-3 | `DockRevealOverlay.spec.mjs` proves a 10% committed extent resolves to the 25% floor while a 30% extent remains 30%. |
| AC-4 | Workstation projects `defaultRevealFraction: 0.35`; CSS supplies 20rem/16rem physical floors capped by available workspace. The browser arm asserts 320px at a 420px viewport. |
| AC-5 | The browser arm rejects transparent background; live receipt is `rgb(14, 19, 26)` and covered header text no longer bleeds through. |
| AC-6 | One shared reveal-root rule owns all edges; Workstation dark/light values are palette tokens, with no backdrop/dimmer or pointer-model change. Browser arm rejects `box-shadow:none`. |
| AC-7 | `DockRevealOverlay.spec.mjs` pins composition/fraction logic; `WorkstationNL.spec.mjs` pins complete title, pin, size, opacity, and elevation geometry. |
| AC-8 | Exact-head GitHub unit/components CI required before review routing. |

## Deltas from ticket

- Live verification falsified the initial fraction-only sizing proposal: 35% was 147px at a 420px viewport. Workstation therefore adds physical 20rem/16rem floors, capped by the available workspace.
- The local headless E2E runner could not establish a browser object under host exhaustion, so the committed arm's exact assertions were executed against the already-open Workstation through Neural Link/browser geometry. The arm remains automation for a resource-capable run; Engine PR CI does not execute Workstation E2E.

## Test Evidence

- `DockRevealOverlay.spec.mjs` — 8/8 green; both new assertions were red before production changes (`neo-tab-overflow-capped` absent, 10% received instead of 25%).
- Development themes compile for all five Engine themes.
- Live Workstation, 420px viewport: overlay 320px; title/text/pin fully contained; opaque `rgb(14, 19, 26)` surface; signal-aware border; two-layer shadow.
- `WorkstationNL` focused arm is discovered successfully; its exact assertion set was executed live in the existing browser. A second local Chrome was unavailable before browser creation because the host had 1–2GB free and exhausted file watchers.

## Post-Merge Validation

None.

## Evolution

The first repair addressed only the title primitive and was validated with a title-row crop. The operator's full-surface screenshots exposed the missing system contract: containment, usable extent, opacity, and elevation have to be verified together. The implementation now does that without duplicating tab CSS or turning a hover reveal into a modal.

Authored by Euclid (GPT-5.6 Sol Ultra, Codex Desktop). Session 01a0534f-a981-7560-93de-8d3d54966db6.
