### PR TITLE
feat(main): WindowPosition observeMovement owns the movement poll (#18029)

### DIFF
--- a/apps/workstation/view/Workspace.mjs
+++ b/apps/workstation/view/Workspace.mjs
@@ -428,8 +428,10 @@ class Workspace extends DockWorkspace {
 
         // Cross-window hit testing reads manager.Window as its one geometry authority. Movement
         // snapshots alone go stale after a main-window resize, so this render target publishes
-        // live extents from construction just like every admitted vessel does on connect.
-        Neo.main.addon.WindowPosition?.setConfigs({observeResize: true, windowId: me.windowId});
+        // live extents from construction just like every admitted vessel does on connect. The
+        // movement poll is owned by config rather than by pointer travel: a titlebar grabbed
+        // without the cursor crossing page content produces no `mouseout` to arm it.
+        Neo.main.addon.WindowPosition?.setConfigs({observeMovement: true, observeResize: true, windowId: me.windowId});
 
         me.tourRunner  = Neo.create(TourRunner, {
             componentId   : me.id,
@@ -3533,8 +3535,11 @@ class Workspace extends DockWorkspace {
         if (!itemId || flow !== 'tear-out' || !Number.isFinite(admissionToken)) return;
 
         // Geometry-ready is part of child admission: do not publish the connected vessel to any
-        // ownership branch until its Main realm has installed resize observation.
-        await Neo.main.addon.WindowPosition?.setConfigs({observeResize: true, windowId});
+        // ownership branch until its Main realm has installed resize AND movement observation. The
+        // header-action pop-out births this vessel with its titlebar under the pointer, so the
+        // native-titlebar drag never crosses page content and never emits the `mouseout` that
+        // would otherwise arm the poll.
+        await Neo.main.addon.WindowPosition?.setConfigs({observeMovement: true, observeResize: true, windowId});
 
         // Retirement authority is established before any awaited close. A connect continuation
         // that resumes after that boundary is cleanup-only. Consume its exact grant and retain

--- a/src/main/addon/WindowPosition.mjs
+++ b/src/main/addon/WindowPosition.mjs
@@ -24,6 +24,20 @@ class WindowPosition extends Base {
          */
         intervalTime: 20,
         /**
+         * Keeps the movement poll armed independent of pointer state.
+         *
+         * By default the poll arms only on a `mouseout` that leaves the document, the signal a
+         * pointer produces when it travels from page content onto the OS titlebar. A window whose
+         * titlebar is grabbed WITHOUT the cursor ever entering its content (the header-action
+         * pop-out places the new titlebar right under the pointer) never produces that signal, so
+         * its movement is never published and {@link Neo.manager.Window} keeps the birth rect.
+         * Render targets that take part in cross-window hit testing opt in; the poll costs two
+         * integer compares per tick and publishes only on change.
+         * @member {Boolean} observeMovement_=false
+         * @reactive
+         */
+        observeMovement_: false,
+        /**
          * @member {Boolean} observeResize_=false
          * @reactive
          */
@@ -75,6 +89,19 @@ class WindowPosition extends Base {
         me.screenTop  = screenTop;
 
         window.addEventListener('mouseout', me.onMouseOut.bind(me))
+    }
+
+    /**
+     * Triggered after the observeMovement config got changed.
+     * While on, the config owns the poll: {@link #onMouseOut} neither arms nor clears it.
+     * Switching off releases the poll back to pointer ownership; the next document-leaving
+     * `mouseout` re-arms it.
+     * @param {Boolean} value
+     * @param {Boolean} oldValue
+     * @protected
+     */
+    afterSetObserveMovement(value, oldValue) {
+        value ? this.startPolling() : this.stopPolling()
     }
 
     /**
@@ -200,13 +227,15 @@ class WindowPosition extends Base {
     onMouseOut(event) {
         let me = this;
 
+        // The config owns the poll while it observes movement; pointer travel must not clear it.
+        if (me.observeMovement) {
+            return
+        }
+
         if (!event.toElement) {
-            if (!me.intervalId) {
-                me.intervalId = setInterval(me.checkMovement.bind(me), me.intervalTime)
-            }
-        } else if (me.intervalId) {
-            clearInterval(me.intervalId);
-            me.intervalId = null
+            me.startPolling()
+        } else {
+            me.stopPolling()
         }
     }
 
@@ -254,6 +283,31 @@ class WindowPosition extends Base {
      */
     registerWindow(data) {
         this.windows[data.name] = data
+    }
+
+    /**
+     * @summary Arms the movement poll once; a running poll is left untouched.
+     * @protected
+     */
+    startPolling() {
+        let me = this;
+
+        if (!me.intervalId) {
+            me.intervalId = setInterval(me.checkMovement.bind(me), me.intervalTime)
+        }
+    }
+
+    /**
+     * @summary Clears the movement poll if it is running.
+     * @protected
+     */
+    stopPolling() {
+        let me = this;
+
+        if (me.intervalId) {
+            clearInterval(me.intervalId);
+            me.intervalId = null
+        }
     }
 
     /**

--- a/test/playwright/e2e/workstation/WorkstationNativeTitlebarDragNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationNativeTitlebarDragNL.spec.mjs
@@ -1,0 +1,309 @@
+import {expect, test} from '../../fixtures.mjs';
+
+/**
+ * @summary The native-titlebar popup drag: previews and reintegration with no pointer event at all.
+ *
+ * The header-action pop-out births its vessel with the new titlebar right under the pointer, so a
+ * human grabs the OS titlebar without the cursor ever entering popup content. That gesture emits
+ * no `mouseout` in the popup realm and no pointer stream anywhere; the only production signals are
+ * the popup's `screenX`/`screenY` changing and the `WindowPosition` poll noticing.
+ *
+ * Trigger discipline: this spec dispatches NO mouse event to the popup and never calls
+ * `publishGeometry()`. CDP `Browser.setWindowBounds` is the physical-window adapter, standing in
+ * for the OS window server; every hop from the poll onward is production code. The poll must be
+ * armed by the vessel's `observeMovement` config alone, which the spec asserts before moving —
+ * a probe whose trigger never armed cannot report green. The popup realm's `mouseout` count is
+ * asserted at zero to prove the synthetic half stayed out of the gesture.
+ */
+
+const asArray = value => Array.isArray(value) ? value : value ? [value] : [];
+
+/**
+ * @summary Resolves one native CDP window handle for a page.
+ * @param {import('@playwright/test').Page} page
+ * @returns {Promise<{cdp: Object, page: Object, windowId: Number}>}
+ */
+async function acquireNativeWindow(page) {
+    const
+        cdp        = await page.context().newCDPSession(page),
+        {windowId} = await cdp.send('Browser.getWindowForTarget');
+
+    return {cdp, page, windowId}
+}
+
+/**
+ * @summary Reads the browser-observed viewport origin and size.
+ * @param {import('@playwright/test').Page} page
+ * @returns {Promise<Object>}
+ */
+function readScreen(page) {
+    return page.evaluate(() => ({
+        innerHeight: globalThis.innerHeight,
+        innerWidth : globalThis.innerWidth,
+        screenX    : globalThis.screenX,
+        screenY    : globalThis.screenY
+    }))
+}
+
+/**
+ * @summary Moves a native window and waits until the browser reports the new origin.
+ * @param {Object} handle
+ * @param {Number} left
+ * @param {Number} top
+ * @returns {Promise<Object>}
+ */
+async function moveNative(handle, left, top) {
+    const {bounds} = await handle.cdp.send('Browser.getWindowBounds', {windowId: handle.windowId});
+
+    await handle.cdp.send('Browser.setWindowBounds', {
+        bounds  : {...bounds, left, top, windowState: 'normal'},
+        windowId: handle.windowId
+    });
+
+    await expect.poll(async () => {
+        const screen = await readScreen(handle.page);
+
+        return Math.max(Math.abs(screen.screenX - left), Math.abs(screen.screenY - top))
+    }, {
+        message  : `native window ${handle.windowId} reaches ${left},${top}`,
+        timeout  : 5000,
+        intervals: [25, 50, 100]
+    }).toBeLessThanOrEqual(80);
+
+    return readScreen(handle.page)
+}
+
+/**
+ * @summary Reads the instance id of the main window's stable cross-window participation.
+ * A dock projection refresh destroys and recreates it, so a changed id is the refresh's receipt.
+ * @param {Object} app
+ * @returns {Promise<String|null>}
+ */
+async function readMainParticipationId(app) {
+    const participations = asArray(await app.findInstances(
+        {className: 'Neo.dashboard.dock.window.Participation'}, ['id', 'workspaceId']
+    ));
+
+    return participations.find(entry => entry.properties?.workspaceId === 'workstation-main')?.id ?? null
+}
+
+/**
+ * @summary Reads one window's manager-owned inner rect from the App Worker.
+ * @param {Object} app
+ * @param {String} managerId
+ * @param {String} windowId
+ * @returns {Promise<Object|null>}
+ */
+async function readManagerRect(app, managerId, windowId) {
+    const state = await app.callMethod(managerId, 'toJSON');
+
+    return state.windows.find(win => win.id === windowId)?.innerRect ?? null
+}
+
+test.describe('Workstation — native titlebar popup drag (#18029)', () => {
+    test('a popup moved by its OS titlebar previews over the main window and reintegrates under dwell', async ({page, neuralLink}) => {
+        const pageErrors = [];
+        let popup;
+
+        page.on('pageerror', error => pageErrors.push(String(error.stack || error.message || error)));
+
+        try {
+            await page.goto('/apps/workstation/index.html');
+            await page.waitForSelector('.workstation-workspace', {timeout: 30000});
+
+            const
+                app         = await neuralLink.connectToApp('Workstation'),
+                workspaceId = asArray(await app.findInstances({className: 'Workstation.view.Workspace'}, ['id']))[0]?.id,
+                managerId   = asArray(await app.findInstances({className: 'Neo.manager.Window'}, ['id']))[0]?.id,
+                coordId     = asArray(await app.findInstances({className: 'Neo.manager.DragCoordinator'}, ['id']))[0]?.id,
+                paneId      = await app.callMethod(workspaceId, 'getPaneIdentity', ['commits']);
+
+            expect(workspaceId, 'one live Workspace').toBeTruthy();
+            expect(managerId, 'manager.Window is live').toBeTruthy();
+            expect(coordId, 'manager.DragCoordinator is live').toBeTruthy();
+            expect(paneId, 'Commit Stream owns a live pane before pop-out').toBeTruthy();
+
+            // The main window's stable target is re-registered by every dock projection refresh
+            // (`afterRefreshDockWorkspace` → `refreshCrossWindowParticipation`). Capture its identity
+            // before the pop-out so the detach projection's refresh can be observed landing below.
+            const mainParticipationBeforePopOut = await readMainParticipationId(app);
+
+            expect(mainParticipationBeforePopOut, 'the main window registers a stable cross-window target').toBeTruthy();
+
+            // Pop-out through the real header action, exactly the reported gesture's first half.
+            let chrome;
+
+            await expect.poll(async () => {
+                chrome = await app.callMethod(workspaceId, 'getTabChromeIdentity', ['right-bottom-tabs']);
+
+                return chrome?.buttons?.commits ?? null
+            }, {
+                message  : 'right-bottom-tabs projects commits into live tab chrome',
+                timeout  : 10000,
+                intervals: [25, 50, 100]
+            }).toBeTruthy();
+
+            await page.locator(`#${chrome.buttons.commits}`).click();
+
+            const action = await app.callMethod(chrome.containerId, 'getActionItem', ['pop-out']);
+
+            expect(action?.id, 'pop-out resolves on the live tab owner').toBeTruthy();
+            await expect(page.locator(`#${action.id}`), 'pop-out is user-reachable').toBeVisible({timeout: 10000});
+
+            const popupPromise = page.waitForEvent('popup', {timeout: 30000});
+
+            await page.locator(`#${action.id}`).click();
+            popup = await popupPromise;
+            await popup.waitForSelector('.workstation-viewport', {timeout: 30000});
+
+            // The realm-side witness for the trigger discipline: installed before anything else
+            // touches the popup, it must stay empty for the whole gesture.
+            await popup.evaluate(() => {
+                globalThis.__nativeTitlebarMouseouts = 0;
+                globalThis.addEventListener('mouseout', () => globalThis.__nativeTitlebarMouseouts++)
+            });
+
+            let popupWindowId;
+
+            await expect.poll(async () => {
+                const state = await app.getComponent(workspaceId, ['lastVesselOpen', 'tearOutPanes']);
+
+                popupWindowId = state.tearOutPanes?.commits?.windowId ?? null;
+
+                return {stage: state.lastVesselOpen?.stage, windowId: popupWindowId}
+            }, {
+                message  : 'the header action reaches vessel admission and adoption',
+                timeout  : 30000,
+                intervals: [50, 100, 250]
+            }).toEqual({stage: 'granted', windowId: expect.any(String)});
+
+            // Adoption settles before the titlebar is grabbed, as it does for a human: the live pane
+            // has left the main window, the popup shows it, and the detach projection's refresh has
+            // re-registered the main target. A native candidate claimed BEFORE that refresh dies with
+            // the zone it claimed (the coordinator tolerates refreshes only while settling a drop), so
+            // moving earlier would test the projection race rather than the reported gesture.
+            await expect(page.locator(`#${paneId}`), 'the main window releases the live pane').toHaveCount(0);
+            await expect(popup.locator(`#${paneId}`), 'the popup adopts the exact live pane').toBeVisible();
+            await expect.poll(() => readMainParticipationId(app), {
+                message  : 'the detach projection refresh re-registers the main cross-window target',
+                timeout  : 15000,
+                intervals: [50, 100, 250]
+            }).not.toBe(mainParticipationBeforePopOut);
+
+            const
+                mainHandle  = await acquireNativeWindow(page),
+                popupHandle = await acquireNativeWindow(popup);
+
+            expect(popupHandle.windowId, 'the popup is a distinct native window').not.toBe(mainHandle.windowId);
+
+            // Positive control for the drag-source branch: the coordinator resolves the moving popup
+            // to a live native drag before any movement happens.
+            const dragSource = await app.callMethod(coordId, 'getNativeWindowDragSource', [popupWindowId]);
+
+            expect(dragSource?.widgetName, 'the popup resolves to a live native drag source').toBe('commits');
+
+            // The poll must be armed by config, with no pointer event having reached the realm.
+            await expect.poll(() => popup.evaluate(() => {
+                const addon = globalThis.Neo.main.addon.WindowPosition;
+
+                return {
+                    armed          : Boolean(addon.intervalId),
+                    mouseouts      : globalThis.__nativeTitlebarMouseouts,
+                    observeMovement: addon.observeMovement
+                }
+            }), {
+                message  : 'the vessel realm owns an armed movement poll without any pointer event',
+                timeout  : 10000,
+                intervals: [25, 50, 100]
+            }).toEqual({armed: true, mouseouts: 0, observeMovement: true});
+
+            const
+                mainParticipationAtGrab = await readMainParticipationId(app),
+                mainRect                = await readManagerRect(app, managerId, (await app.getComponent(workspaceId, ['windowId'])).windowId),
+                popupBefore             = await readScreen(popup),
+                targetLeft              = Math.round(mainRect.x + mainRect.width  / 2 - popupBefore.innerWidth  / 2),
+                targetTop               = Math.round(mainRect.y + mainRect.height / 2 - popupBefore.innerHeight / 2);
+
+            expect(mainRect, 'manager.Window holds the main window rect').toBeTruthy();
+
+            // Walk the popup onto the main window's centre. After every step the manager rect must
+            // catch up through the production poll: no publishGeometry() call, no pointer event.
+            for (const step of [0.5, 1]) {
+                const
+                    left   = Math.round(popupBefore.screenX + (targetLeft - popupBefore.screenX) * step),
+                    top    = Math.round(popupBefore.screenY + (targetTop  - popupBefore.screenY) * step),
+                    screen = await moveNative(popupHandle, left, top);
+
+                await expect.poll(async () => {
+                    const managed = await readManagerRect(app, managerId, popupWindowId);
+
+                    return managed ? Math.max(Math.abs(managed.x - screen.screenX), Math.abs(managed.y - screen.screenY)) : Infinity
+                }, {
+                    message  : `manager.Window follows the popup to step ${step} through the poll alone`,
+                    timeout  : 5000,
+                    intervals: [25, 50, 100]
+                }).toBeLessThanOrEqual(2)
+            }
+
+            // The reported defect: previews must render in the target realm while the popup is over it.
+            await expect.poll(() => page.locator('.neo-dock-preview-affordance').count(), {
+                message  : 'the main window renders a drop-zone preview while the popup hovers it',
+                timeout  : 5000,
+                intervals: [50, 100, 250]
+            }).toBeGreaterThan(0);
+
+            expect(await popup.evaluate(() => globalThis.__nativeTitlebarMouseouts),
+                'no mouseout reached the popup realm during the gesture').toBe(0);
+            expect(await readMainParticipationId(app),
+                'the claimed target keeps its registration through the hover').toBe(mainParticipationAtGrab);
+
+            // Reintegration under the settle/dwell contract, while the popup stays over the target.
+            // The spec never closes the popup; the coordinator's commit retires the vessel.
+            try {
+                await expect.poll(async () => {
+                    const state = await app.getComponent(workspaceId, ['dockModel', 'tearOutPanes']);
+
+                    return {
+                        inTree: Object.values(state.dockModel.nodes)
+                            .some(node => node.type === 'tabs' && node.items?.includes('commits')),
+                        pane  : state.tearOutPanes?.commits ?? null
+                    }
+                }, {
+                    message  : 'dwelling over the main window reintegrates Commit Stream without a close',
+                    timeout  : 15000,
+                    intervals: [50, 100, 250]
+                }).toEqual({inTree: true, pane: null})
+            } catch (error) {
+                // Bounded triage receipt: which phase the native terminal died in, and whether the
+                // target registration survived the hover.
+                const diagnostic = {
+                    coordinator      : await app.getComponent(coordId, ['nativeWindowDropCandidates', 'nativeHoverTargets', 'claimTrace']).catch(e => String(e)),
+                    mainParticipation: {atGrab: mainParticipationAtGrab, now: await readMainParticipationId(app).catch(e => String(e))},
+                    popupClosed      : popup.isClosed(),
+                    popupScreen      : popup.isClosed() ? null : await readScreen(popup).catch(e => String(e)),
+                    previews         : await page.locator('.neo-dock-preview-affordance').count(),
+                    workspace        : await app.getComponent(workspaceId, [
+                        'lastTearOutClose', 'lastVesselParkReceipt', 'lastVesselRestoreReceipt',
+                        'tearOutPanes', 'tearOutParkGeometries', 'tearOutRetirements'
+                    ]).catch(e => String(e))
+                };
+
+                console.log('[native-titlebar-diagnostic]', JSON.stringify(diagnostic, null, 1));
+                throw error
+            }
+
+            await expect.poll(() => popup.isClosed(), {
+                message: 'the committed reintegration retires the physical vessel',
+                timeout: 10000
+            }).toBe(true);
+
+            expect(await app.callMethod(workspaceId, 'getPaneIdentity', ['commits']),
+                'reintegration retains the exact live pane instance').toBe(paneId);
+            await expect(page.locator(`#${paneId}`), 'the live pane is back in the main window').toBeVisible();
+            expect(await page.locator('.neo-dock-preview-affordance').count(), 'previews clear after the commit').toBe(0);
+            expect(pageErrors, 'no page errors during the native drag').toEqual([])
+        } finally {
+            popup && !popup.isClosed() && await popup.close()
+        }
+    })
+});

--- a/test/playwright/unit/apps/workstation/Workspace.spec.mjs
+++ b/test/playwright/unit/apps/workstation/Workspace.spec.mjs
@@ -450,9 +450,12 @@ test.describe.serial('Workstation.view.Workspace', () => {
                 targetId: targetWorkspaceId
             });
 
+            // Movement observation rides the same call: the main render target's poll is owned by
+            // config, so a titlebar grabbed from outside page content still publishes.
             expect(resizeCalls).toEqual([{
-                observeResize: true,
-                windowId     : workspace.windowId
+                observeMovement: true,
+                observeResize  : true,
+                windowId       : workspace.windowId
             }]);
             expect(workspace.workspaceSet.ids()).toEqual([Workspace.MAIN_WORKSPACE_ID]);
             expect(workspace.workspaceSet.getDocument(Workspace.MAIN_WORKSPACE_ID)).toBe(workspace.dockModel);

--- a/test/playwright/unit/main/addon/WindowPosition.spec.mjs
+++ b/test/playwright/unit/main/addon/WindowPosition.spec.mjs
@@ -157,6 +157,24 @@ test.describe('Neo.main.addon.WindowPosition — live geometry publication', () 
         expect(addon.intervalId, 'switching off releases the poll').toBeNull()
     });
 
+    /**
+     * The two witnesses above call the hook directly, so they cannot see whether the config is wired
+     * to it. Reactivity rides on the trailing underscore alone: without it `afterSetObserveMovement`
+     * never fires and the poll is silently never armed by config — the same silent non-arming this
+     * feature exists to end, one layer up. The class-level accessor is the witness that survives the
+     * mock's missing `addEventListener`, and the non-reactive sibling is the control that proves the
+     * assertion discriminates.
+     */
+    test('observeMovement is wired as a reactive config on the class, not a plain field', () => {
+        const
+            reactive = Object.getOwnPropertyDescriptor(WindowPosition.prototype, 'observeMovement'),
+            plain    = Object.getOwnPropertyDescriptor(WindowPosition.prototype, 'intervalTime');
+
+        expect(typeof reactive?.set, 'observeMovement_ installs a prototype setter').toBe('function');
+        expect(typeof reactive?.get, 'observeMovement_ installs a prototype getter').toBe('function');
+        expect(typeof plain?.set, 'the non-reactive intervalTime config installs no setter (control)').not.toBe('function')
+    });
+
     test('remote routing metadata is stripped before configs reach the addon', () => {
         let configs;
         const data  = {appName: 'WindowPositionTest', observeResize: true, windowId: 'popup-a'};

--- a/test/playwright/unit/main/addon/WindowPosition.spec.mjs
+++ b/test/playwright/unit/main/addon/WindowPosition.spec.mjs
@@ -105,6 +105,58 @@ test.describe('Neo.main.addon.WindowPosition — live geometry publication', () 
         expect(addon.screenTop).toBe(window.screenTop)
     });
 
+    /**
+     * A pointer that leaves page content arms the poll and a pointer moving between elements clears
+     * it. That is the whole trigger contract without `observeMovement`, and it is why a titlebar
+     * grabbed from outside the content never publishes.
+     */
+    test('pointer-owned polling arms on a document-leaving mouseout and clears on element travel', () => {
+        const addon = {
+            checkMovement  : () => {},
+            intervalId     : null,
+            intervalTime   : 20,
+            observeMovement: false,
+            startPolling   : WindowPosition.prototype.startPolling,
+            stopPolling    : WindowPosition.prototype.stopPolling
+        };
+
+        WindowPosition.prototype.onMouseOut.call(addon, {toElement: {}});
+        expect(addon.intervalId, 'element travel never arms').toBeNull();
+
+        WindowPosition.prototype.onMouseOut.call(addon, {toElement: null});
+        expect(addon.intervalId, 'leaving the document arms').toBeTruthy();
+
+        WindowPosition.prototype.onMouseOut.call(addon, {toElement: {}});
+        expect(addon.intervalId, 'element travel clears').toBeNull()
+    });
+
+    test('observeMovement owns the poll: armed without any pointer event, immune to element travel', () => {
+        const addon = {
+            checkMovement  : () => {},
+            intervalId     : null,
+            intervalTime   : 20,
+            observeMovement: true,
+            startPolling   : WindowPosition.prototype.startPolling,
+            stopPolling    : WindowPosition.prototype.stopPolling
+        };
+
+        WindowPosition.prototype.afterSetObserveMovement.call(addon, true, false);
+
+        const armedId = addon.intervalId;
+
+        expect(armedId, 'the config arms the poll with no mouseout at all').toBeTruthy();
+
+        WindowPosition.prototype.onMouseOut.call(addon, {toElement: {}});
+        expect(addon.intervalId, 'element travel cannot clear a config-owned poll').toBe(armedId);
+
+        WindowPosition.prototype.onMouseOut.call(addon, {toElement: null});
+        expect(addon.intervalId, 'a document-leaving mouseout does not re-arm a second interval').toBe(armedId);
+
+        addon.observeMovement = false;
+        WindowPosition.prototype.afterSetObserveMovement.call(addon, false, true);
+        expect(addon.intervalId, 'switching off releases the poll').toBeNull()
+    });
+
     test('remote routing metadata is stripped before configs reach the addon', () => {
         let configs;
         const data  = {appName: 'WindowPositionTest', observeResize: true, windowId: 'popup-a'};


### PR DESCRIPTION
Resolves #18029

🌿 *A Workstation popup grabbed by its titlebar can no longer move without the App Worker knowing, so for the two render targets that opt in, "the poll never armed" is unsayable.*

`Neo.main.addon.WindowPosition` armed its movement poll on one signal only: a `mouseout` with no `toElement`, the event a pointer produces when it travels from page content onto the OS titlebar. The header-action pop-out births the vessel with its titlebar under the pointer, so a human grabs it without ever entering popup content; no `mouseout`, no poll, no geometry, no previews, reintegration only through close. The addon gains a reactive `observeMovement_` config that owns the poll independent of pointer travel (two integer compares per 20ms tick, publishes on change only); the Workstation opts both render targets in on the calls that already set `observeResize`. Every other consumer keeps pointer-only arming: the config defaults to `false`. Root-cause measurement and the three-arm trigger comparison: [#18029 comment](https://github.com/neomjs/neo/issues/18029#issuecomment-5499643927).

Evidence: L3 (Playwright e2e with CDP `Browser.setWindowBounds` as the physical-window adapter; real OS titlebar drag is not reproducible in Playwright) → L4 required (AC-1/AC-4: a human titlebar drag on a live host). Residual: AC-1, AC-4 human confirmation, Residual-Owner: #17844.

## AC Evidence
| AC-1 | `test/playwright/e2e/workstation/WorkstationNativeTitlebarDragNL.spec.mjs` drives the gesture with zero pointer events in the popup realm and asserts a `.neo-dock-preview-affordance` renders in the target realm while the popup hovers it. Red on `dev@0659b0e42d` at the arming assertion (`armed: false`), green on this branch. |
| AC-2 | Reactive wiring of the config is witnessed at class level in `WindowPosition.spec.mjs` (post-approval test commit). Spec header states the trigger split (CDP = physical-window adapter only; every hop from the poll onward is production). It asserts `{armed: true, mouseouts: 0, observeMovement: true}` in the popup realm before moving, so an unarmed probe cannot report green. |
| AC-3 | None of branches 1–3 bails: `onWindowPositionChange` is never called on `dev`. Measured with poll/publish/send counters in the popup realm and the manager rect in the worker (0/0/0 and a frozen rect with no pointer event; a direct `publishGeometry()` control moved the rect). Ticket body + comment carry the table. |
| AC-4 | Same spec: after the preview, `tearOutPanes.commits` clears and Commit Stream returns to a tabs node while the popup is still over the target; the spec never closes the popup, and asserts the vessel retires and `getPaneIdentity` is unchanged. |
| AC-5 | Neither pointer-path spec runs in CI: the matrix runs `unit` + `components` only, and every `neuralLink` spec is gated on the external Brain runtime (the #17844 lane). `DemoBCrossWindowDragNL`: see Test Evidence. `WorkstationHumanPopupOverlapNL`: skips on this host (`screen.width` below the cell's stage minimum) and cannot be reached by this diff, since it calls `publishGeometry()` itself and never depends on the poll; #17844 owns its next battery run. |
| AC-6 | No new gesture system: the only product change is when the existing poll runs. Previews still flow through `updateNativeHover → onRemoteDragMove → previewFor`, drops through `onRemoteDrop → previewToOperation → commitOperation`. |

## Deltas from ticket
- Both Workstation render targets opt in, not only the vessel: the main window's poll had the same pointer-only arming, so a main window moved by its titlebar from outside content would go stale in `manager.Window` the same way.
- Adjacent hazard evidenced while building the arm, out of scope: the detach projection's `refreshCrossWindowParticipation` re-registers the main target a few hundred ms after the pop-out commit, and a native candidate claimed before that refresh dies with the zone it claimed (`DragCoordinator.unregister` tolerates refreshes only in `settling-target`). A human grabs the titlebar long after; the arm waits for the refresh receipt (main `Participation` id changes) before moving and asserts the target keeps its registration through the hover.

## Test Evidence
- New arm, this branch: 3 consecutive runs, 3 passed. `dev@0659b0e42d` with the spec alone: 1 failed at `the vessel realm owns an armed movement poll without any pointer event` (`armed: false`).
- `WorkstationHumanPopupOverlapNL` (default cell): skipped on this host, `screen.width` below the stage minimum the spec computes; unchanged by this PR (it calls `publishGeometry()` directly, so the poll change cannot reach it). Not in CI; next run belongs to the #17844 battery.
- `DemoBCrossWindowDragNL`: 3/3 fail on this host at `the exact tear-out Page must navigate and remain live during conversion` on BOTH arms, `dev@0659b0e42d` (1 run) and this branch (2 runs), same assertion each time. These are the three known #17578 reds already dispositioned in the #17844 battery receipts (same spec lines 246/458/704 on `dev@68efc42bb2`), so they are not attributable to this diff. Not in CI (Neural Link specs are runtime-gated); tracked under #17578.
- Unit: `WindowPosition.spec.mjs` 6/6 (three new witnesses: pointer-owned arming/clearing; config-owned poll immune to element travel and released on switch-off; and, from the review's Depth Floor, a class-level accessor witness that `observeMovement_` is wired reactive, with the non-reactive `intervalTime` as the discriminating control, so dropping the trailing underscore now fails in CI). `apps/workstation/Workspace.spec.mjs` expectation updated for the new payload; that spec does not load on this host (on `dev` either: `Neo.currentWorker` undefined at `manager/Window.mjs:45` import), and the CI `unit` job on this head ran it green.

## Post-Merge Validation
- [ ] Live host: pop out a pane via the header action, grab the popup's OS titlebar without entering its content, move it over the main window: previews render and the pane reintegrates after dwell (the L4 half of AC-1/AC-4).
- [ ] #17844 battery at or after the merged head: `WorkstationNativeTitlebarDragNL` plus `WorkstationHumanPopupOverlapNL` on a stage wide enough to run it (CI runs neither: Neural Link specs are gated on the external Brain runtime).

Residual-Owner: #17844

Authored by Vega (Fable 5.1, Claude Code). Session 93fd8de9-7231-4979-b906-c050bcfc25a4.
