### PR TITLE
fix(dock): a pane returns from the rail with its reload action (#18039)

### DIFF
--- a/src/dashboard/dock/Workspace.mjs
+++ b/src/dashboard/dock/Workspace.mjs
@@ -1590,25 +1590,56 @@ class Workspace extends Container {
 
         if (!me.enableDockLockAction) return;
 
+        me.forEachDockRail(rail => {
+            let itemId = rail.revealOverlay?.revealPaneItemId,
+                pane   = rail.revealOverlay?.paneSlot?.items?.[0];
+
+            if (itemId && pane) {
+                me.syncDockLockItemPresentation({
+                    locked: me.dockModel?.items?.[itemId]?.locked === true,
+                    pane
+                })
+            }
+        })
+    }
+
+    /**
+     * Visits every projected edge rail below the dock shell. Rails are leaves of the walk: their
+     * reveal overlays host application content, never dock nodes.
+     * @param {Function} callback Receives one {@link Neo.dashboard.dock.interaction.Rail}.
+     * @protected
+     */
+    forEachDockRail(callback) {
         const visit = component => {
             if (!component || component.isDestroyed) return;
 
             if (component.dockNodeType === 'edge-rail') {
-                let itemId = component.revealOverlay?.revealPaneItemId,
-                    pane   = component.revealOverlay?.paneSlot?.items?.[0];
-
-                if (itemId && pane) {
-                    me.syncDockLockItemPresentation({
-                        locked: me.dockModel?.items?.[itemId]?.locked === true,
-                        pane
-                    })
-                }
+                callback(component);
+                return
             }
 
             component.items?.forEach(visit)
         };
 
-        visit(me.getDockHost()?.items?.[me.dockShellIndex])
+        visit(this.getDockHost()?.items?.[this.dockShellIndex])
+    }
+
+    /**
+     * Releases every rail-cached reveal pane whose item leaves auto-hidden state with the incoming
+     * document — BEFORE the projection materializes that item's flow pane. The rail releases on its
+     * own leave paths (pin escape, reconciled leaver); this sweep covers the ones that never pass
+     * through it — a restored perspective, a transfer — which take the staged path that tears the
+     * old rail down only AFTER the new shell minted the flow pane. Silent: this refresh owns the
+     * next update train. See {@link Neo.dashboard.dock.interaction.Rail#releaseRevealPane}.
+     * @param {Object|null} document The committed document this refresh projects.
+     * @protected
+     */
+    releaseStaleRevealPanes(document) {
+        this.forEachDockRail(rail => {
+            Object.keys(rail.revealPaneCache || {}).forEach(itemId => {
+                document?.items?.[itemId]?.autoHidden === true || rail.releaseRevealPane(itemId, true)
+            })
+        })
     }
 
     /**
@@ -1715,34 +1746,29 @@ class Workspace extends Container {
      * Synchronizes every projected engine header action after reconciliation, including retained tabs
      * whose action instance outlived a model-policy or active-item change.
      *
+     * Walks the SETTLED shell, never a map handed in from the reconciler: that map is the OLD shell's
+     * tabs (`Reconciler.collectProjectedTabs(oldShell)`), so a node the projection just CREATED — a
+     * railed item pinned back into flow, a fresh boot's placeholders — is not in it, and `reload`'s
+     * availability, projected as a constant `hidden: true` by the stable-instance rule, is revealed
+     * by nothing else. Every write below is change-guarded, so re-walking retained nodes is idempotent.
+     *
      * Each action's own sync guards on its own opt-in and is a no-op when the action was never
      * projected — the opt-in guard is load-bearing, not redundant: a host may legally own an
      * engine action NAME while that engine flag is off (the reserved-name guard fires only for
      * enabled actions), and `getActionItem` finds the host's action by name. Without the guard,
      * this sweep would rewrite consumer-owned action state.
-     * @param {Map<String,Neo.tab.Container>|null} [tabs=null]
      * @protected
      */
-    syncDockHeaderActions(tabs=null) {
-        let me            = this,
-            projectedTabs = tabs;
+    syncDockHeaderActions() {
+        let me    = this,
+            shell = me.getDockHost()?.items?.[me.dockShellIndex];
 
-        // A fresh boot reconciles with nothing retained, so the reconciler's map arrives EMPTY —
-        // yet the staged projection resolved PLACEHOLDERS, whose pane-dependent action states
-        // (reload's contract probe) are wrong until this sync reaches the live chrome. Walk the
-        // shell whenever the handed map cannot.
-        if (!projectedTabs?.size) {
-            let shell = me.getDockHost()?.items?.[me.dockShellIndex];
-
-            projectedTabs = shell ? Reconciler.collectProjectedTabs(shell) : new Map()
-        }
-
-        projectedTabs?.forEach?.(tab => {
+        shell && Reconciler.collectProjectedTabs(shell).forEach(tab => {
             me.syncDockCloseAction(tab);
             me.syncDockLockAction(tab);
             me.syncDockPinAction(tab);
             me.syncDockReloadAction(tab)
-        })
+        });
 
         me.enableDockLockAction && me.syncDockLockRails()
     }
@@ -3292,6 +3318,7 @@ class Workspace extends Container {
         }
 
         me.beforeRefreshDockWorkspace(document, refreshOptions);
+        me.releaseStaleRevealPanes(document);
 
         const nextConfig = me.projectDockModel(tabInsertDescriptor, (componentRef, item, itemId) => {
             const placeholder = me.createProjectionPlaceholder(itemId, item, componentRef);
@@ -3369,14 +3396,14 @@ class Workspace extends Container {
             // application: a bar write with the refresh's own update train still open is the
             // collision that duplicated retained chrome on slow rigs. Every write is
             // change-guarded, so post-settle is both the safe and the idempotent slot.
-            me.syncDockHeaderActions(result?.currentTabs);
+            me.syncDockHeaderActions();
 
             // Once more on SETTLED chrome: the pre-settle sync above can run while projected
             // header actions are still instantiating (a fresh boot's first refresh), and a
             // pane-dependent action state (reload's contract probe) corrected on chrome that
             // does not exist yet is a correction nobody received. Every write in the sync is
             // change-guarded, so re-running it on settled chrome is idempotent.
-            me.syncDockHeaderActions(result?.currentTabs)
+            me.syncDockHeaderActions()
         }
     }
 

--- a/src/dashboard/dock/Workspace.mjs
+++ b/src/dashboard/dock/Workspace.mjs
@@ -1629,17 +1629,31 @@ class Workspace extends Container {
      * document — BEFORE the projection materializes that item's flow pane. The rail releases on its
      * own leave paths (pin escape, reconciled leaver); this sweep covers the ones that never pass
      * through it — a restored perspective, a transfer — which take the staged path that tears the
-     * old rail down only AFTER the new shell minted the flow pane. Silent: this refresh owns the
-     * next update train. See {@link Neo.dashboard.dock.interaction.Rail#releaseRevealPane}.
+     * old rail down only AFTER the new shell minted the flow pane. Awaited: the releases have to
+     * LAND before the projection stages a node under a released id.
+     * See {@link Neo.dashboard.dock.interaction.Rail#releaseRevealPane}.
+     *
+     * The reveal STATE retires with the pane, exactly as on the rail's own leave paths: the state
+     * machine's contract names restore and transfer as `itemCleared` transitions, and an overlay
+     * whose `revealPaneItemId` still names a departed item would take `syncRevealPane`'s
+     * same-id early return onto an empty slot the next time that item is revealed.
      * @param {Object|null} document The committed document this refresh projects.
+     * @returns {Promise<void>}
      * @protected
      */
-    releaseStaleRevealPanes(document) {
+    async releaseStaleRevealPanes(document) {
+        const pending = [];
+
         this.forEachDockRail(rail => {
             Object.keys(rail.revealPaneCache || {}).forEach(itemId => {
-                document?.items?.[itemId]?.autoHidden === true || rail.releaseRevealPane(itemId, true)
+                if (document?.items?.[itemId]?.autoHidden !== true) {
+                    pending.push(rail.releaseRevealPane(itemId));
+                    rail.revealMachine?.itemCleared(itemId)
+                }
             })
-        })
+        });
+
+        await Promise.all(pending)
     }
 
     /**
@@ -3318,7 +3332,12 @@ class Workspace extends Container {
         }
 
         me.beforeRefreshDockWorkspace(document, refreshOptions);
-        me.releaseStaleRevealPanes(document);
+
+        await me.releaseStaleRevealPanes(document);
+
+        if (me.isDestroyed) {
+            return
+        }
 
         const nextConfig = me.projectDockModel(tabInsertDescriptor, (componentRef, item, itemId) => {
             const placeholder = me.createProjectionPlaceholder(itemId, item, componentRef);

--- a/src/dashboard/dock/interaction/Rail.mjs
+++ b/src/dashboard/dock/interaction/Rail.mjs
@@ -363,6 +363,47 @@ class Rail extends Container {
     }
 
     /**
+     * Releases the blueprint- or placeholder-created reveal pane of an item that LEFT auto-hidden
+     * state (pin, transfer, a restored perspective). The cache parks panes across dismissals so a
+     * re-reveal keeps its instance, but an item returning to the tab flow gets its flow pane from
+     * the projection — and a consumer resolving both from one config mints the same id twice. A
+     * cached reveal pane that outlives the flow pane's creation unregisters that id when the rail
+     * tears down, leaving a live pane nobody can address and a refresh that throws mid-teardown.
+     * Destroying it here, while it is still the id's only holder, keeps the registry honest.
+     *
+     * Live instances are never cached (parked, never owned — see {@link #syncRevealPane}), so a
+     * consumer's own pane cannot be destroyed through this path.
+     *
+     * The rail releases on its own leave paths (the pin escape, a reconciled leaver) BEFORE the
+     * dismissal parks the pane, so a revealed pane leaves through its slot in the one update the
+     * dismissal would otherwise spend on parking it — its DOM node and its registration retire
+     * together, ahead of the refresh that mints the flow pane. The workspace's pre-projection sweep
+     * ({@link Neo.dashboard.dock.Workspace#releaseStaleRevealPanes}) covers the leave paths that
+     * never pass through this rail (a restored perspective, a transfer), silently.
+     * @param {String} itemId
+     * @param {Boolean} [silent=false] `true` when the caller owns the next update train.
+     * @protected
+     */
+    releaseRevealPane(itemId, silent=false) {
+        let me   = this,
+            pane = me.revealPaneCache[itemId];
+
+        if (!pane) {
+            return
+        }
+
+        delete me.revealPaneCache[itemId];
+
+        if (!pane.isDestroyed) {
+            const parent = pane.parent;
+
+            // A parked pane keeps its `parentId` after `removeAt(index, false)`, so `parent` can
+            // resolve a slot that no longer lists it — go through the parent only while it does.
+            parent?.items?.includes(pane) ? parent.remove(pane, true, silent) : pane.destroy(false, silent)
+        }
+    }
+
+    /**
      * Tears down the reveal machinery before container destruction — pending dwell/grace timers
      * must never outlive the rail.
      * @param {...*} args
@@ -461,6 +502,9 @@ class Rail extends Container {
         result     = me.commitOperation(descriptor);
 
         if (!result.errors?.length) {
+            // The item leaves the rail: its reveal pane goes first, through the slot, so the flow
+            // pane the scheduled refresh mints never meets it (id, DOM node, registration).
+            me.releaseRevealPane(itemId);
             me.revealMachine?.itemCleared(itemId)
         }
 
@@ -604,6 +648,7 @@ class Rail extends Container {
             }
 
             if (!target.some(railItem => railItem.dockItemId === existing[index].dockItemId)) {
+                me.releaseRevealPane(existing[index].dockItemId);
                 me.revealMachine?.itemCleared(existing[index].dockItemId);
                 me.removeAt(index)
             }

--- a/src/dashboard/dock/interaction/Rail.mjs
+++ b/src/dashboard/dock/interaction/Rail.mjs
@@ -379,12 +379,15 @@ class Rail extends Container {
      * dismissal would otherwise spend on parking it — its DOM node and its registration retire
      * together, ahead of the refresh that mints the flow pane. The workspace's pre-projection sweep
      * ({@link Neo.dashboard.dock.Workspace#releaseStaleRevealPanes}) covers the leave paths that
-     * never pass through this rail (a restored perspective, a transfer), silently.
+     * never pass through this rail (a restored perspective, a transfer) and AWAITS the result: the
+     * slot's removal has to land before a staged projection inserts a node under the same id, and a
+     * destroy must never race an in-flight update that still diffs the pane's vnode — either one
+     * wedges the refresh (measured: a reconcile whose `promiseUpdate` never settles).
      * @param {String} itemId
-     * @param {Boolean} [silent=false] `true` when the caller owns the next update train.
+     * @returns {Promise<void>} Settles once the pane is gone from the DOM and the registry.
      * @protected
      */
-    releaseRevealPane(itemId, silent=false) {
+    async releaseRevealPane(itemId) {
         let me   = this,
             pane = me.revealPaneCache[itemId];
 
@@ -394,12 +397,24 @@ class Rail extends Container {
 
         delete me.revealPaneCache[itemId];
 
-        if (!pane.isDestroyed) {
-            const parent = pane.parent;
+        if (pane.isDestroyed) {
+            return
+        }
 
-            // A parked pane keeps its `parentId` after `removeAt(index, false)`, so `parent` can
-            // resolve a slot that no longer lists it — go through the parent only while it does.
-            parent?.items?.includes(pane) ? parent.remove(pane, true, silent) : pane.destroy(false, silent)
+        const parent = pane.parent;
+
+        // A parked pane keeps its `parentId` after `removeAt(index, false)`, so `parent` can
+        // resolve a slot that no longer lists it — go through the parent only while it does.
+        if (parent?.items?.includes(pane)) {
+            // `removeAt` splices the vdom BEFORE the payload is built and destroys the pane, so the
+            // removal it publishes never references the instance; hand its landing back.
+            parent.remove(pane, true);
+            await parent.promiseUpdate()
+        } else {
+            // Parked: the dismissal already spliced it out, but that update may still be in flight
+            // with the pane's vnode in its diff — let it land before the instance goes.
+            await parent?.promiseUpdate?.();
+            pane.isDestroyed || pane.destroy()
         }
     }
 

--- a/test/playwright/component/apps/dock-maximize/app.mjs
+++ b/test/playwright/component/apps/dock-maximize/app.mjs
@@ -721,9 +721,11 @@ class MaximizeFixtureWorkspace extends DockWorkspace {
         }
 
         // alpha and beta both own the reload contract — two contract carriers in ONE node is
-        // what witnesses per-item single-flight across active-item switches; gamma's contract
-        // throws (containment witness); frame stays contract-free — the hidden witness.
-        const module = itemId === 'alpha' || itemId === 'beta' ? ReloadProbe
+        // what witnesses per-item single-flight across active-item switches; pinned owns it too,
+        // as the EDGE node's carrier for the rail round-trip arm (the action has to come back
+        // with the pane); gamma's contract throws (containment witness); frame stays
+        // contract-free — the hidden witness.
+        const module = itemId === 'alpha' || itemId === 'beta' || itemId === 'pinned' ? ReloadProbe
             : itemId === 'gamma' ? ThrowingReloadProbe
             : null;
 

--- a/test/playwright/component/apps/dock-static-boot/app.mjs
+++ b/test/playwright/component/apps/dock-static-boot/app.mjs
@@ -118,12 +118,11 @@ class StaticBootFixtureWorkspace extends DockWorkspace {
     /**
      * Counts real sweeps so the spec can assert the absence of a write, not merely the absence of
      * a rendered symptom — a hidden action and an un-run sweep look identical in the DOM.
-     * @param {Map|null} [tabs=null]
      * @returns {*}
      */
-    syncDockHeaderActions(tabs=null) {
+    syncDockHeaderActions() {
         this.sweepCount++;
-        return super.syncDockHeaderActions(tabs)
+        return super.syncDockHeaderActions()
     }
 
     /**

--- a/test/playwright/component/dashboard/DockLock.spec.mjs
+++ b/test/playwright/component/dashboard/DockLock.spec.mjs
@@ -189,5 +189,47 @@ test.describe('dock lock — committed boundary plus reversible presentation', (
             owned: false,
             value: undefined
         })
+    });
+
+    /**
+     * An item can leave auto-hidden state without the rail ever being asked — a restored perspective,
+     * a transfer, or as here a `setItemPinned` committed straight through the reducer. Only the
+     * workspace's pre-projection sweep sees it leave. With the overlay OPEN on that item, the sweep
+     * has to retire the reveal state with the pane, and the refresh has to settle: this fixture mints
+     * pane ids from a config, so a reveal pane that outlives the flow pane's creation is exactly the
+     * id collision that rejected the refresh silently.
+     */
+    test('a reducer-committed pin-back with an open reveal returns the pane to flow and settles', async ({page}) => {
+        const railTab = page.locator('.neo-dashboard-dock-edge-rail').getByText('Railed'),
+              overlay = page.locator(
+                  '.neo-dashboard-dock-reveal-overlay:not(.neo-dashboard-dock-reveal-overlay-hidden)'
+              );
+
+        // Unlock first: the arm is about the leave path, not the lock boundary.
+        await setWorkspace(page, {
+            operationJson: JSON.stringify({operation: 'setItemLocked', itemId: 'railed', locked: false, attempt: 2})
+        });
+        await awaitRefresh(page);
+
+        await railTab.click();
+        await expect(overlay).toHaveCount(1);
+        await expect(overlay.locator('#dock-lock-pane-railed')).toBeVisible();
+
+        // The leave path the rail never sees: the reducer un-rails the revealed item directly.
+        await setWorkspace(page, {
+            operationJson: JSON.stringify({operation: 'setItemPinned', itemId: 'railed', pinned: true, attempt: 3})
+        });
+        await awaitRefresh(page);
+
+        const returned = tabsNodeWith(page, 'Railed');
+
+        await expect(returned, 'the band is back with a tabs node').toHaveCount(1);
+        await expect(returned.locator('#dock-lock-pane-railed'), 'the flow pane took the consumer id').toBeVisible();
+        await expect(overlay, 'the reveal is gone with the rail').toHaveCount(0);
+        await expect(page.locator('.neo-dashboard-dock-edge-rail').getByText('Railed'), 'and so is its rail tab')
+            .toHaveCount(0);
+
+        // The pane is the registered holder of its id — a zombie would have no worker instance.
+        expect((await readConfigs(page, 'dock-lock-pane-railed', ['mounted']))?.[0]).toBe(true)
     })
 });

--- a/test/playwright/component/dashboard/DockReload.spec.mjs
+++ b/test/playwright/component/dashboard/DockReload.spec.mjs
@@ -101,6 +101,44 @@ test.describe('dock reload — delegation-only, settled, single-flight', () => {
         expect(maxBox.x).toBeLessThan(closeBox.x)
     });
 
+    test('a pane pinned back from the rail returns with its reload action', async ({page}) => {
+        const edge   = tabsNodeWith(page, 'Pinned'),
+              reload = actionButton(edge, 'fa-rotate-right');
+
+        // The edge node's carrier offers reload from the first projection on.
+        await soleAction(reload, 'reload');
+        await tabButton(edge, 'Pinned').click();
+        await expect(reload).not.toHaveClass(/neo-toolbar-action-context-inactive/);
+
+        // The one-way unpin rails the pane. `railed` is committed auto-hidden already, so the
+        // band's live flow empties and its tabs node leaves the projection entirely.
+        await actionButton(edge, 'fa-thumbtack-slash').click();
+        await expect(edge).toHaveCount(0);
+
+        // Reveal from the rail tab, then the overlay's pin control restores the pane into flow.
+        // The band comes back as a FRESH tabs node — the reconciler retained nothing of it.
+        await page.locator('.neo-dashboard-dock-edge-rail').getByText('Pinned').click();
+
+        const overlay = page.locator('.neo-dashboard-dock-reveal-overlay:not(.neo-dashboard-dock-reveal-overlay-hidden)');
+
+        await expect(overlay).toHaveCount(1);
+        await overlay.getByRole('button', {name: 'Pin'}).click();
+
+        const returned   = tabsNodeWith(page, 'Pinned'),
+              reloadBack = actionButton(returned, 'fa-rotate-right');
+
+        await expect(returned).toHaveCount(1);
+
+        // The action is projected `hidden: true` by the stable-instance rule and only the
+        // post-settle sweep reveals it — a sweep that never reaches the fresh node leaves the
+        // returned pane without the one action the round trip owes it.
+        await soleAction(reloadBack, 'reload');
+        await expect(reloadBack).toHaveClass(/neo-toolbar-action-context-inactive/);
+
+        await tabButton(returned, 'Pinned').click();
+        await expect(reloadBack).not.toHaveClass(/neo-toolbar-action-context-inactive/)
+    });
+
     test('sync delegation settles clean: asked once, identity kept, document untouched', async ({page}) => {
         const main = tabsNodeWith(page, 'Alpha');
 

--- a/test/playwright/unit/dashboard/DockLockAction.spec.mjs
+++ b/test/playwright/unit/dashboard/DockLockAction.spec.mjs
@@ -207,7 +207,7 @@ test.describe('Neo.dashboard.dock.Workspace lock action', () => {
 
         expect(Object.hasOwn(pane.vdom, 'inert')).toBe(false);
 
-        workspace.syncDockHeaderActions(new Map());
+        workspace.syncDockHeaderActions();
 
         expect(pane.vdom.inert).toBe(true);
         expect(pane.cls).toContain('neo-dock-pane-locked')

--- a/test/playwright/unit/dashboard/DockRail.spec.mjs
+++ b/test/playwright/unit/dashboard/DockRail.spec.mjs
@@ -300,7 +300,7 @@ test.describe('Neo.dashboard.dock.interaction.Rail', () => {
      * resolves reveal and flow from ONE config mints the same id twice, so the cached reveal pane has
      * to go first — while it is the id's only holder — or its later teardown unregisters the flow pane.
      */
-    test('releaseRevealPane destroys a cached blueprint pane and forgets it; a live instance is never cached', () => {
+    test('releaseRevealPane destroys a cached blueprint pane and forgets it; a live instance is never cached', async () => {
         rail = Neo.create(DockRail, {
             dockZoneDocument   : createDocument(),
             edge               : 'right',
@@ -317,7 +317,8 @@ test.describe('Neo.dashboard.dock.interaction.Rail', () => {
         expect(cached, 'a blueprint-created reveal pane is cached').toBeTruthy();
         expect(Neo.get('dock-rail-release-pane'), 'and holds the consumer-minted id').toBe(cached);
 
-        rail.releaseRevealPane('terminal');
+        // Parked: the release lets the dismissal's update land, then destroys.
+        await rail.releaseRevealPane('terminal');
 
         expect(rail.revealPaneCache.terminal, 'the cache forgets it').toBeUndefined();
         expect(cached.isDestroyed, 'the instance is destroyed').toBe(true);
@@ -325,8 +326,8 @@ test.describe('Neo.dashboard.dock.interaction.Rail', () => {
         expect(Neo.get('dock-rail-release-pane'), 'so the id is free for the flow pane').toBeNull();
 
         // Idempotent: releasing a released or never-cached item is a no-op.
-        rail.releaseRevealPane('terminal');
-        rail.releaseRevealPane('editor');
+        await rail.releaseRevealPane('terminal');
+        await rail.releaseRevealPane('editor');
 
         // The pin escape releases on its own, while the pane is still IN the slot: one update
         // retires the DOM node and the registration together, ahead of the refresh it scheduled.
@@ -355,7 +356,7 @@ test.describe('Neo.dashboard.dock.interaction.Rail', () => {
 
         rail.onTabClick({component: rail.items[0]});
         rail.revealMachine.escape();
-        rail.releaseRevealPane('terminal');
+        await rail.releaseRevealPane('terminal');
 
         expect(rail.revealPaneCache.terminal, 'never cached').toBeUndefined();
         expect(livePane.isDestroyed, 'the consumer still owns its pane').toBeFalsy();

--- a/test/playwright/unit/dashboard/DockRail.spec.mjs
+++ b/test/playwright/unit/dashboard/DockRail.spec.mjs
@@ -9,6 +9,7 @@ setup({
 import {test, expect}    from '@playwright/test';
 import Neo               from '../../../../src/Neo.mjs';
 import * as core         from '../../../../src/core/_export.mjs';
+import '../../../../src/manager/Instance.mjs'; // defines Neo.get — the registry the release witness reads
 import Button            from '../../../../src/button/Base.mjs';
 import DockLayoutAdapter from '../../../../src/dashboard/dock/projection/LayoutAdapter.mjs';
 import DockRail          from '../../../../src/dashboard/dock/interaction/Rail.mjs';
@@ -292,6 +293,74 @@ test.describe('Neo.dashboard.dock.interaction.Rail', () => {
         rail.onTabClick({component: rail.items[0]});
         overlay.fire('revealEscape', {});
         expect(rail.revealMachine.state).toBe('idle');
+    });
+
+    /**
+     * An item that leaves auto-hidden state gets its flow pane from the projection. A consumer that
+     * resolves reveal and flow from ONE config mints the same id twice, so the cached reveal pane has
+     * to go first — while it is the id's only holder — or its later teardown unregisters the flow pane.
+     */
+    test('releaseRevealPane destroys a cached blueprint pane and forgets it; a live instance is never cached', () => {
+        rail = Neo.create(DockRail, {
+            dockZoneDocument   : createDocument(),
+            edge               : 'right',
+            id                 : 'dock-rail-release',
+            railItems          : createRailItems(),
+            resolveComponentRef: componentRef => ({ntype: 'component', id: 'dock-rail-release-pane', html: componentRef})
+        });
+
+        rail.onTabClick({component: rail.items[0]});
+        rail.revealMachine.escape();
+
+        const cached = rail.revealPaneCache.terminal;
+
+        expect(cached, 'a blueprint-created reveal pane is cached').toBeTruthy();
+        expect(Neo.get('dock-rail-release-pane'), 'and holds the consumer-minted id').toBe(cached);
+
+        rail.releaseRevealPane('terminal');
+
+        expect(rail.revealPaneCache.terminal, 'the cache forgets it').toBeUndefined();
+        expect(cached.isDestroyed, 'the instance is destroyed').toBe(true);
+        expect(rail.revealOverlay.paneSlot.items.includes(cached), 'and left the slot').toBe(false);
+        expect(Neo.get('dock-rail-release-pane'), 'so the id is free for the flow pane').toBeNull();
+
+        // Idempotent: releasing a released or never-cached item is a no-op.
+        rail.releaseRevealPane('terminal');
+        rail.releaseRevealPane('editor');
+
+        // The pin escape releases on its own, while the pane is still IN the slot: one update
+        // retires the DOM node and the registration together, ahead of the refresh it scheduled.
+        rail.onTabClick({component: rail.items[0]});
+
+        const revealed = rail.revealPaneCache.terminal;
+
+        expect(rail.revealOverlay.paneSlot.items.includes(revealed), 'revealed: the pane sits in the slot').toBe(true);
+        expect(rail.onRevealPinRequested({itemId: 'terminal'}).errors).toEqual([]);
+        expect(rail.revealPaneCache.terminal, 'pinned back: forgotten').toBeUndefined();
+        expect(revealed.isDestroyed, 'destroyed').toBe(true);
+        expect(rail.revealOverlay.paneSlot.items, 'and the slot is empty').toHaveLength(0);
+        expect(Neo.get('dock-rail-release-pane'), 'the id is free again').toBeNull();
+
+        // A live instance is added as-is and parked, never cached — release cannot reach it.
+        const livePane = Neo.create(Button, {id: 'dock-rail-release-live', text: 'live'});
+
+        rail.destroy();
+        rail = Neo.create(DockRail, {
+            dockZoneDocument   : createDocument(),
+            edge               : 'right',
+            id                 : 'dock-rail-release-live-rail',
+            railItems          : createRailItems(),
+            resolveComponentRef: () => livePane
+        });
+
+        rail.onTabClick({component: rail.items[0]});
+        rail.revealMachine.escape();
+        rail.releaseRevealPane('terminal');
+
+        expect(rail.revealPaneCache.terminal, 'never cached').toBeUndefined();
+        expect(livePane.isDestroyed, 'the consumer still owns its pane').toBeFalsy();
+
+        livePane.destroy()
     });
 
     test('self-hosts a composed reveal overlay child and materializes the pane through resolveComponentRef', () => {

--- a/test/playwright/unit/dashboard/DockWorkspace.spec.mjs
+++ b/test/playwright/unit/dashboard/DockWorkspace.spec.mjs
@@ -313,17 +313,69 @@ class SweepWitnessWorkspace extends PlainWorkspace {
 
     sweepLog = []
 
-    syncDockHeaderActions(tabs=null) {
+    syncDockHeaderActions() {
         this.sweepLog.push('sweep');
-        return super.syncDockHeaderActions(tabs)
+        return super.syncDockHeaderActions()
     }
 }
 
 Neo.setupClass(SweepWitnessWorkspace);
 
+/**
+ * The recreate fallback wired (`resolveFreshPane` overridden), so `reload` is offered on every node
+ * with an active item while no pane carries `dockReload()` — the Workstation's shape. Which nodes the
+ * post-settle sweep REACHES is then the only thing deciding whether the action shows.
+ */
+class RecreateFallbackWorkspace extends PlainWorkspace {
+    static config = {
+        className: 'Test.Unit.Dashboard.DockWorkspace.RecreateFallbackWorkspace'
+    }
+
+    resolveFreshPane(itemId, item) {
+        return this.resolvePane(itemId, item)
+    }
+}
+
+Neo.setupClass(RecreateFallbackWorkspace);
+
+/**
+ * A consumer minting deterministic pane ids from a config — the shape every dock component fixture
+ * uses. Reveal and flow resolve from the same config, so the reveal pane and the flow pane compete
+ * for one id across the pin escape.
+ */
+class FixedIdWorkspace extends RecreateFallbackWorkspace {
+    static config = {
+        className: 'Test.Unit.Dashboard.DockWorkspace.FixedIdWorkspace'
+    }
+
+    resolvePane(itemId, item) {
+        return {ntype: 'component', id: `fixed-id-pane-${itemId}`, text: item?.title || itemId}
+    }
+}
+
+Neo.setupClass(FixedIdWorkspace);
+
 
 const
-    tabsOf  = shell => DockProjectionReconciler.collectProjectedTabs(shell),
+    tabsOf = shell => DockProjectionReconciler.collectProjectedTabs(shell),
+    railOf = shell => {
+        let found = null;
+
+        const visit = component => {
+            if (!component || found) return;
+
+            if (component.dockNodeType === 'edge-rail') {
+                found = component;
+                return
+            }
+
+            component.items?.forEach(visit)
+        };
+
+        visit(shell);
+
+        return found
+    },
     collect = (config, predicate, out=[]) => {
         if (config && typeof config === 'object') {
             predicate(config) && out.push(config);
@@ -1473,6 +1525,87 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
 
         expect(commits.map(descriptor => descriptor.operation)).toEqual(['setItemAutoHidden']);
         expect(workspace.getDockZoneDocument().items.inspector.autoHidden).toBe(true)
+    });
+
+    /**
+     * `reload` is projected `hidden: true` by the stable-instance rule and revealed only by the
+     * post-settle sweep. A railed item projects no tabs node; pinning it back CREATES one beside the
+     * retained center — a node the reconciler's map (the OLD shell's tabs) never held. The sweep has
+     * to reach it anyway, or the returned pane comes back without the one action the round trip owes it.
+     */
+    test('a pane pinned back from the rail returns with its reload action — the sweep reaches the FRESH node', async () => {
+        const document = createEdgeDocument();
+
+        // Committed auto-hidden: the right band projects a rail and no `inspector-tabs` node.
+        document.items.inspector.autoHidden = true;
+
+        workspace = Neo.create(RecreateFallbackWorkspace, {dockModel: document});
+
+        expect(tabsOf(workspace.items[0]).get('inspector-tabs'), 'an all-railed band keeps no tab flow')
+            .toBeUndefined();
+
+        // The reveal overlay's pin control commits exactly this; the model clears `autoHidden` itself.
+        const descriptor = {operation: 'setItemPinned', itemId: 'inspector', pinned: true},
+              result     = workspace.applyDockZoneOperation(descriptor);
+
+        expect(result.errors, 'the restore is a clean commit').toEqual([]);
+        expect(result.document.items.inspector.autoHidden, 'and it un-hides the item').not.toBe(true);
+
+        workspace.onDockZoneDocumentChange(result.document, descriptor);
+        await workspace.refreshPromise;
+
+        const tabs     = tabsOf(workspace.items[0]),
+              returned = tabs.get('inspector-tabs');
+
+        expect(returned, 'the band is back with a tabs node').toBeTruthy();
+
+        // ONE post-settle sweep ran. It reached the retained node — that is the control — and it
+        // has to reach the node the projection just created.
+        expect(tabs.get('center-tabs').getActionItem('reload').hidden,
+            'the post-settle sweep reached the retained node').toBe(false);
+        expect(returned.getActionItem('reload')?.hidden,
+            'the returned node offers reload exactly like a never-railed one').toBe(false)
+    });
+
+    /**
+     * The reveal pane is a SEPARATE materialization of the item: a consumer resolving reveal and flow
+     * from one config mints the same id for both. The refresh that returns the item to flow releases
+     * the cached reveal pane BEFORE it mints the flow pane — otherwise the old rail's teardown
+     * unregisters the id under the live flow pane, the refresh throws mid-teardown, and the post-settle
+     * sweep never runs.
+     */
+    test('the pin escape returns a consumer-fixed-id pane to flow without an id collision, and the refresh settles', async () => {
+        const document = createEdgeDocument();
+
+        document.items.inspector.autoHidden = true;
+
+        workspace = Neo.create(FixedIdWorkspace, {dockModel: document});
+
+        const rail = railOf(workspace.items[0]);
+
+        expect(rail, 'the right band projects a rail').toBeTruthy();
+
+        // Reveal from the rail tab: the overlay materializes the pane from the consumer's config.
+        rail.onTabClick({component: rail.items[0]});
+
+        const revealPane = rail.revealPaneCache.inspector;
+
+        expect(revealPane?.id, 'the reveal pane carries the consumer-minted id').toBe('fixed-id-pane-inspector');
+
+        // The overlay's pin control: commits through the workspace reducer and dismisses the reveal.
+        expect(rail.onRevealPinRequested({itemId: 'inspector'}).errors).toEqual([]);
+
+        await workspace.refreshPromise;
+
+        const tabs     = tabsOf(workspace.items[0]),
+              returned = tabs.get('inspector-tabs'),
+              flowPane = returned?.getCard(0);
+
+        expect(flowPane?.id, 'the flow pane took the id').toBe('fixed-id-pane-inspector');
+        expect(flowPane.isDestroyed, 'and it is alive').toBeFalsy();
+        expect(Neo.get('fixed-id-pane-inspector'), 'registered under it — the only holder').toBe(flowPane);
+        expect(revealPane.isDestroyed, 'the reveal pane was released before the flow pane was minted').toBe(true);
+        expect(returned.getActionItem('reload')?.hidden, 'and the post-settle sweep ran on the returned node').toBe(false)
     });
 
     test('the pin action refuses fail-closed where the collapse cannot complete, and moves by hidden on ONE instance', async () => {

--- a/test/playwright/unit/dashboard/DockWorkspace.spec.mjs
+++ b/test/playwright/unit/dashboard/DockWorkspace.spec.mjs
@@ -1608,6 +1608,52 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
         expect(returned.getActionItem('reload')?.hidden, 'and the post-settle sweep ran on the returned node').toBe(false)
     });
 
+    /**
+     * The leave paths that bypass the rail (a restored perspective, a transfer) reach the reveal pane
+     * only through the workspace's pre-projection sweep. The state machine's contract names those
+     * transitions `itemCleared`, so the sweep retires the reveal STATE with the pane: an overlay whose
+     * `revealPaneItemId` still named the departed item would short-circuit onto an empty slot the
+     * next time that item is revealed.
+     */
+    test('the pre-projection sweep retires an open reveal with its pane — state, pointer and slot', async () => {
+        const document = createEdgeDocument();
+
+        document.items.inspector.autoHidden = true;
+
+        workspace = Neo.create(FixedIdWorkspace, {dockModel: document});
+
+        const rail = railOf(workspace.items[0]);
+
+        rail.onTabClick({component: rail.items[0]});
+
+        const revealPane = rail.revealPaneCache.inspector,
+              overlay    = rail.revealOverlay;
+
+        expect(rail.revealMachine.state, 'revealed').toBe('revealed-focused');
+        expect(overlay.revealPaneItemId, 'the overlay names the revealed item').toBe('inspector');
+        expect(overlay.paneSlot.items.includes(revealPane), 'and hosts its pane').toBe(true);
+
+        // A restore that un-rails the item: the rail is never asked, only the sweep sees it leave.
+        const restored = structuredClone(workspace.getDockZoneDocument());
+
+        delete restored.items.inspector.autoHidden;
+
+        await workspace.releaseStaleRevealPanes(restored);
+
+        expect(rail.revealPaneCache.inspector, 'the cache forgot the pane').toBeUndefined();
+        expect(revealPane.isDestroyed, 'the pane is destroyed').toBe(true);
+        expect(rail.revealMachine.state, 'the reveal state is idle for the departed item').toBe('idle');
+        expect(overlay.revealPaneItemId, 'the overlay no longer names it').toBeNull();
+        expect(overlay.paneSlot.items, 'and its slot is empty').toHaveLength(0);
+
+        // An item that stays railed is untouched by the same sweep.
+        rail.onTabClick({component: rail.items[0]});
+        await workspace.releaseStaleRevealPanes(workspace.getDockZoneDocument());
+
+        expect(rail.revealPaneCache.inspector, 'a still-railed item keeps its reveal pane').toBeTruthy();
+        expect(rail.revealMachine.state, 'and its reveal').toBe('revealed-focused')
+    });
+
     test('the pin action refuses fail-closed where the collapse cannot complete, and moves by hidden on ONE instance', async () => {
         const document = createEdgeDocument();
 


### PR DESCRIPTION
Resolves #18039

A pane that goes unpin → rail reveal → Pin now comes back with its `reload` action, on the Workstation and on every consumer that mints pane ids from a config. Two mechanisms sat behind the one gesture, both fixed here: the post-settle header-action sweep only ever saw the OLD shell's tabs (so a node the projection just created was never synced), and a rail-cached reveal pane collided with the flow pane on one id (so the restore refresh rejected silently and no sweep ran at all). Detail, receipts and the trace that separated the two are on the ticket body.

Evidence: L3 (rendered browser round trip on the `dock-maximize` fixture plus unit witnesses, all in CI) → L3 required (AC-1…AC-5). Residual: none — AC-7 is a live Workstation receipt recorded below, not a sandbox gap.

## AC Evidence
| AC-1 | CI-covered: `test/playwright/component/dashboard/DockReload.spec.mjs` › "a pane pinned back from the rail returns with its reload action" (red on `dev`: 0 reload nodes on the returned node; green at head, 2× repeat) |
| AC-2 | CI-covered: `test/playwright/unit/dashboard/DockWorkspace.spec.mjs` › "a pane pinned back from the rail returns with its reload action — the sweep reaches the FRESH node" (red on `dev`: retained node synced, fresh node `hidden: true`) |
| AC-3 | CI-covered: `DockWorkspace.spec.mjs` › "the pin escape returns a consumer-fixed-id pane to flow without an id collision, and the refresh settles" (red on `dev`: duplicate-id registration, reveal pane the registered holder) |
| AC-4 | CI-covered: `test/playwright/unit/dashboard/DockRail.spec.mjs` › "releaseRevealPane destroys a cached blueprint pane and forgets it; a live instance is never cached" |
| AC-5 | CI-covered: the six dock component specs (40/40 at head) and `test/playwright/unit/dashboard` (709/709); full unit suite 2934/2934 |
| AC-6 | Outside-CI, structural: `reload` keeps its constant `hidden: true` in `LayoutAdapter.mjs` (untouched); both sweep calls stay in the post-settle slot of `refreshDockWorkspace` (`Workspace.mjs`, the two `syncDockHeaderActions()` calls after `afterRefreshDockWorkspace`); the reveal release inside the refresh is silent and runs before `projectDockModel` |
| AC-7 | Outside-CI: Workstation at this tree, Chromium, the ticket's reproducer — before: `reload · unpin · pop out · maximize · close`; after unpin → rail → reveal → Pin → focus: `reload · unpin · pop out · maximize · close`, returned pane `neo-component-37` registered and mounted |

Micro-review eligible: no — concept-bearing (a lifecycle rule for rail-cached reveal panes and a changed sweep contract).

## Deltas from ticket
- Mechanism 2 (the reveal/flow id collision) was found during implementation and folded into the ticket body by its author before this PR opened; the ACs above are the ticket's current seven.
- `syncDockHeaderActions()` drops its `tabs` parameter: its only truthful meaning was "old shell", the wrong set by construction. Every caller and override follows: the two engine call sites, the `DockWorkspace.spec` and `dock-static-boot` fixture overrides, and the `DockLockAction.spec` call that passed an empty map (round-2 fixup; the first head had left the fixture override and the spec call behind).
- The pre-projection sweep retires the reveal STATE with the pane (`revealMachine.itemCleared`), matching the rail's own leave paths — Ada's round-1 finding: the state machine's contract names restore and transfer as `itemCleared` transitions, and an overlay still naming a departed item would short-circuit onto an empty slot on that item's next reveal. Unit witness: state idle, overlay pointer null, slot empty after the sweep; component arm on the `dock-lock` fixture: a reducer-committed pin-back with an open reveal returns the pane to flow and the refresh settles.
- `syncDockLockRails` shares the new `forEachDockRail` walker instead of carrying its own.
- A follow-up worth its own leaf, not filed here: a rejected `refreshPromise` is swallowed by design (`.catch(() => {})` tails keep the chain alive), which is why mechanism 2 was invisible until traced.

## Test Evidence
- Live Workstation receipt (AC-7) taken in the authoring session on this tree with Playwright-driven clicks and DOM/worker reads; the same run before the fix lost `reload` and, on the fixture, left the restore refresh rejected with `util.VDom.getVdom: Component not found for id: dock-maximize-pane-pinned` (registry unregistered under the live flow pane) — the trace that separated mechanism 2 from mechanism 1.
- Ordering falsifier: releasing the parked reveal pane *inside* the refresh (first attempt) hung the reconcile — the dismissal's own slot update was still in flight; that is why the rail releases on its leave paths and the in-refresh sweep is the silent backstop only.
- Repeat runs: the new component arm 3× red on `dev` before the fix, 2× green at head; sibling dock component specs 40/40 twice.

## Post-Merge Validation
- none — AC-7's hand receipt on the Workstation at head discharges the reproducer; nothing remains that only a merge can verify.

## Commits
- `f4f8fcb86f` — the two mechanisms: settled-shell sweep; reveal-pane release on the rail's leave paths + the silent pre-projection sweep
- `70ab2b9fdc` — round 2: the pre-projection sweep retires the reveal state with the pane (state machine `itemCleared`, overlay pointer cleared) and AWAITS each release so the slot's removal lands before the staged projection mints the id again (the open-reveal arm hung the reconcile without it); the `dock-static-boot` fixture override drops the removed `tabs` parameter; a `DockLock` component arm drives the rail-bypassing leave path with an open reveal

## Evolution
The shell-walk alone cured the Workstation (its `resolvePane` returns cached live instances, so no id collision) but not the fixture arm. A temporary refresh trace showed the restore refresh rejecting mid-teardown on a duplicate pane id; releasing the reveal pane inside the refresh then hung the reconcile, which moved the release to the rail's own leave paths with the in-refresh sweep kept silent as the backstop for restores and transfers.

Review topology: GPT seats are at 1% weekly quota for 1–2 days; the operator declared opus↔fable reviews the exception for this window (2026-09-01), so the primary seat is requested on the Claude/Opus roster.

Authored by Mnemosyne (Claude Fable 5.1, Claude Code). Session 6197a12f-acf2-478a-b05d-4ece32474259.
