### PR TITLE
chore(deps): consume neo-agent-skills 0.1.3 (#18045)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
                 "marked": "^18.0.5",
                 "mermaid": "^11.16.0",
                 "monaco-editor": "0.50.0",
-                "neo-agent-skills": "^0.1.1",
+                "neo-agent-skills": "^0.1.3",
                 "parse5": "^8.0.1",
                 "postcss": "^8.5.16",
                 "sass": "^1.101.0",
@@ -2692,9 +2692,9 @@
             }
         },
         "node_modules/acorn": {
-            "version": "8.17.0",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
-            "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
+            "version": "8.18.0",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+            "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
             "dev": true,
             "license": "MIT",
             "bin": {
@@ -6455,13 +6455,19 @@
             }
         },
         "node_modules/neo-agent-skills": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/neo-agent-skills/-/neo-agent-skills-0.1.1.tgz",
-            "integrity": "sha512-y6cgogGzPwdhxj32FyjLae3Ld/qeiX48UZeIgEazLGSH2YQLwS6YoZV236Wu9hWhPrcAFP9AmA+rB4YMKBummA==",
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/neo-agent-skills/-/neo-agent-skills-0.1.3.tgz",
+            "integrity": "sha512-RQsVHa7uhw6T5DVmhpR66/Kicige5TmqdMpiKr4unKDcDMQT/AOvGSn/wnsbIA/PlhE0oS/5IdxascVsJsTx0g==",
             "dev": true,
             "license": "MIT",
+            "dependencies": {
+                "acorn": "^8.18.0"
+            },
             "bin": {
-                "neo-agent-skills-materialize": "scripts/materialize-harness-skills.mjs"
+                "neo-agent-skills-materialize": "scripts/materialize-harness-skills.mjs",
+                "neo-agent-skills-pr-body": "scripts/check-pr-body.mjs",
+                "neo-agent-skills-substrate-size": "scripts/check-substrate-size.mjs",
+                "neo-agent-skills-ticket-archaeology": "scripts/check-ticket-archaeology.mjs"
             },
             "engines": {
                 "node": ">=24.0.0"

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
         "marked"                       : "^18.0.5",
         "mermaid"                      : "^11.16.0",
         "monaco-editor"                : "0.50.0",
-        "neo-agent-skills"             : "^0.1.1",
+        "neo-agent-skills"             : "^0.1.3",
         "parse5"                       : "^8.0.1",
         "postcss"                      : "^8.5.16",
         "sass"                         : "^1.101.0",


### PR DESCRIPTION
Resolves #18045

The declared floor moves to `^0.1.3` and the lockfile resolves it, so the two governance rules published in `neo-agent-skills@0.1.3` — `ticket-create` §1a's decision-substrate sweep arms and §10's exhaustive ownership disposition — actually reach an agent working in this repository. The range was never the binding constraint: `^0.1.1` already admitted `0.1.3` under npm's `0.x` caret semantics, so the lockfile was what pinned the old tarball while everything stayed green.

Evidence: L2 (install-time receipts: the resolved lock entry, the materializer's `--check` against the real install, and a `grep` of the projected payload) → L2 required (the close-target ACs are install-time assertions; there is no runtime surface to reach). No residuals.

## AC Evidence

| AC-1 | `package.json:120` — `"neo-agent-skills"             : "^0.1.3",`. Hand-edited to one line; the repo's aligned-colon formatting is preserved. |
| AC-2 | `package-lock.json` — `node_modules/neo-agent-skills` now reads `"version": "0.1.3"` with `resolved` pointing at `neo-agent-skills-0.1.3.tgz`. Verified by the tarball URL, not by the range. |
| AC-3 | `npx --no-install neo-agent-skills-materialize --check` → exit 0: *"37 skill link(s) materialized from node_modules, none tracked, none shadowed (v0.1.3)"*. Reachability, not resolution. |
| AC-4 | `git check-ignore -q .claude/skills` → ignored; `git status --porcelain` clean after the re-projection. No skill bytes enter the tree. |
| AC-5 | `grep -c "unowned-rationale" .claude/skills/ticket-create/references/ticket-create-workflow.md` → 1, and `.claude/skills/ticket-create/references/` now lists `decision-substrate-sweeps.md` — the payload `#33` added. The version number alone would not have shown this. |

## Deltas from ticket

- **The manifest is hand-edited rather than `npm install`-edited.** A plain `npm install neo-agent-skills@^0.1.3` rewrites the entire `package.json` in npm's own formatting, discarding this repo's aligned-colon style and producing a ~100-line diff around a one-token change. The lock is still npm-generated (`npm install --package-lock-only`) — hand-editing integrity hashes is not on the table.
- **The lock also refreshes `acorn` 8.17.0 → 8.18.0.** npm resolved it while regenerating, and it is in-range for the `^8.17.0` this repository already declares. Disclosed rather than reverted: pinning it back would mean hand-editing the lock, which is the trap the ticket names.
- **`npm run agent-preflight` does not exist in this repository.** `pull-request-workflow.md` §1 mandates it before the first commit; `npm error Missing script: "agent-preflight"`. Not repaired here — it is a substrate gap with no relation to this bump, and worth its own ticket by whoever owns that workflow's callers.

## Test Evidence

All coverage runs in CI. The `substrate-sync` workflow performs the same `neo-agent-skills-materialize --check` assertion this PR's AC-3 receipt ran locally, so the projection claim is re-proven on the exact head rather than resting on an author receipt.

## Post-Merge Validation

- [ ] A fresh clone + `npm ci` resolves `0.1.3` and materializes 37 links — the clean-checkout path this PR's floor raise exists to protect.
- [ ] Sibling consumer bumps land: neomjs/neo-agent-brain#294 and neomjs/neo-agent-institution#67. All three repositories should read the same skill corpus; a lagging sibling means agents in that repo file work against different rules.

## Commits

- `d7fec97c0c` — manifest floor + lock refresh

Authored by Grace (Anthropic Claude Opus 5, Claude Code). Session 5e4492c2-ace7-47e8-83bf-98ccca3a684b.
