### PR TITLE
feat(tab): own the title weight and trim the inline header (#18043)

### DIFF
--- a/resources/scss/src/tab/header/Button.scss
+++ b/resources/scss/src/tab/header/Button.scss
@@ -30,8 +30,11 @@
         font-size  : var(--tab-button-text-font-size);
         // The title's weight is its own token. Without one it fell through to the button family's
         // weight, so every theme with semibold buttons had semibold tab titles by accident — and
-        // the inline dock header, where width is scarce, had no way to opt out.
-        font-weight: var(--tab-button-text-font-weight);
+        // the inline dock header, where width is scarce, had no way to opt out. The fallback IS
+        // that inheritance, made explicit: a theme that declares no tab tokens at all (cyberpunk)
+        // keeps the button family's weight, because an undefined token would otherwise make this
+        // declaration invalid and hand the title the document's inherited weight instead.
+        font-weight: var(--tab-button-text-font-weight, var(--button-text-font-weight));
     }
 
     .neo-tab-button-indicator {

--- a/resources/scss/src/tab/header/Button.scss
+++ b/resources/scss/src/tab/header/Button.scss
@@ -26,8 +26,12 @@
     }
 
     .neo-button-text {
-        color    : var(--tab-button-text-color);
-        font-size: var(--tab-button-text-font-size);
+        color      : var(--tab-button-text-color);
+        font-size  : var(--tab-button-text-font-size);
+        // The title's weight is its own token. Without one it fell through to the button family's
+        // weight, so every theme with semibold buttons had semibold tab titles by accident — and
+        // the inline dock header, where width is scarce, had no way to opt out.
+        font-weight: var(--tab-button-text-font-weight);
     }
 
     .neo-tab-button-indicator {

--- a/resources/scss/theme-dark/tab/Container.scss
+++ b/resources/scss/theme-dark/tab/Container.scss
@@ -11,9 +11,11 @@
     // on the structural fallback.
     --tab-header-inline-background-image           : none;
 
-    // Inline inherits the classic theme's established 25px / square geometry and tightens only
-    // horizontal padding. Keeping inherited defaults out of this block prevents copy-drift while
-    // leaving one measured, deletion-sensitive variant effect.
+    // Inline inherits the classic theme's established 25px / square geometry and tightens only what
+    // a dock header cannot afford: horizontal padding and the title's weight — beside an action
+    // rail the title is chrome, not a button label, and the indicator bar already carries emphasis.
+    // Keeping inherited defaults out of this block prevents copy-drift while leaving measured,
+    // deletion-sensitive variant effects.
     &.neo-tab-container-inline > .neo-tab-header-toolbar,
     .neo-tab-container-inline > .neo-tab-header-toolbar,
     // Self-scoped: a drag proxy is a detached toolbar at document.body, so it has no container
@@ -27,7 +29,8 @@
     // carries the case where an ancestor holds the theme.
     &.neo-tab-header-toolbar.neo-tab-container-inline,
     .neo-tab-header-toolbar.neo-tab-container-inline {
-        --tab-button-padding: 7px 10px 6px;
+        --tab-button-padding         : 7px 8px 6px;
+        --tab-button-text-font-weight: 400;
     }
 
     // Standalone gives classic-theme consumers a coherent free-standing card treatment without

--- a/resources/scss/theme-dark/tab/header/Button.scss
+++ b/resources/scss/theme-dark/tab/header/Button.scss
@@ -27,5 +27,6 @@
     --tab-button-padding                        : 7px 12px 6px 12px;
     --tab-button-text-color                     : #bbb;
     --tab-button-text-font-size                 : var(--button-text-font-size);
+    --tab-button-text-font-weight               : var(--button-text-font-weight);
     --tab-button-text-transform                 : none;
 }

--- a/resources/scss/theme-light/tab/Container.scss
+++ b/resources/scss/theme-light/tab/Container.scss
@@ -11,9 +11,11 @@
     // on the structural fallback.
     --tab-header-inline-background-image           : none;
 
-    // Inline inherits the classic theme's established 25px / square geometry and tightens only
-    // horizontal padding. Keeping inherited defaults out of this block prevents copy-drift while
-    // leaving one measured, deletion-sensitive variant effect.
+    // Inline inherits the classic theme's established 25px / square geometry and tightens only what
+    // a dock header cannot afford: horizontal padding and the title's weight — beside an action
+    // rail the title is chrome, not a button label, and the indicator bar already carries emphasis.
+    // Keeping inherited defaults out of this block prevents copy-drift while leaving measured,
+    // deletion-sensitive variant effects.
     &.neo-tab-container-inline > .neo-tab-header-toolbar,
     .neo-tab-container-inline > .neo-tab-header-toolbar,
     // Self-scoped: a drag proxy is a detached toolbar at document.body, so it has no container
@@ -27,7 +29,8 @@
     // carries the case where an ancestor holds the theme.
     &.neo-tab-header-toolbar.neo-tab-container-inline,
     .neo-tab-header-toolbar.neo-tab-container-inline {
-        --tab-button-padding: 7px 10px 6px;
+        --tab-button-padding         : 7px 8px 6px;
+        --tab-button-text-font-weight: 400;
     }
 
     // Standalone gives classic-theme consumers a coherent free-standing card treatment without

--- a/resources/scss/theme-light/tab/header/Button.scss
+++ b/resources/scss/theme-light/tab/header/Button.scss
@@ -27,5 +27,6 @@
     --tab-button-padding                        : 7px 12px 6px 12px;
     --tab-button-text-color                     : #2b2b2b;
     --tab-button-text-font-size                 : var(--button-text-font-size);
+    --tab-button-text-font-weight               : var(--button-text-font-weight);
     --tab-button-text-transform                 : uppercase;
 }

--- a/resources/scss/theme-neo-dark/design-tokens/Core.scss
+++ b/resources/scss/theme-neo-dark/design-tokens/Core.scss
@@ -13,6 +13,7 @@
     --core-fontsize-h2             : 1.75rem;
     --core-fontsize-h3             : 1.25rem;
     --core-fontsize-label          : 1rem;
+    --core-fontsize-small          : 0.75rem;
     --core-fontweight-bold         : 700;
     --core-fontweight-medium       : 500;
     --core-fontweight-regular      : 400;

--- a/resources/scss/theme-neo-dark/design-tokens/Semantic.scss
+++ b/resources/scss/theme-neo-dark/design-tokens/Semantic.scss
@@ -86,4 +86,7 @@
     --sem-typo-label-regular-fontFamily                                      : var(--core-fontfamily-sans);
     --sem-typo-label-regular-fontSize                                        : var(--core-fontsize-body);
     --sem-typo-label-regular-fontWeight                                      : var(--core-fontweight-regular);
+    --sem-typo-label-small-fontFamily                                        : var(--core-fontfamily-sans);
+    --sem-typo-label-small-fontSize                                          : var(--core-fontsize-small);
+    --sem-typo-label-small-fontWeight                                        : var(--core-fontweight-regular);
 }

--- a/resources/scss/theme-neo-dark/tab/Container.scss
+++ b/resources/scss/theme-neo-dark/tab/Container.scss
@@ -28,10 +28,10 @@
     // carries the case where an ancestor holds the theme.
     &.neo-tab-header-toolbar.neo-tab-container-inline,
     .neo-tab-header-toolbar.neo-tab-container-inline {
-        --tab-button-border-radius : 0;
-        --tab-button-gap           : 0;
-        --tab-button-height        : var(--sem-height-large);
-        --tab-button-height-pressed: var(--sem-height-large);
+        --tab-button-border-radius   : 0;
+        --tab-button-gap             : 0;
+        --tab-button-height          : var(--sem-height-large);
+        --tab-button-height-pressed  : var(--sem-height-large);
         --tab-button-padding         : 4px var(--sem-spacing-xsmall) 3px;
         --tab-button-text-font-size  : var(--sem-typo-label-small-fontSize);
         --tab-button-text-font-weight: var(--sem-typo-label-small-fontWeight);

--- a/resources/scss/theme-neo-dark/tab/Container.scss
+++ b/resources/scss/theme-neo-dark/tab/Container.scss
@@ -32,7 +32,9 @@
         --tab-button-gap           : 0;
         --tab-button-height        : var(--sem-height-large);
         --tab-button-height-pressed: var(--sem-height-large);
-        --tab-button-padding       : 4px var(--sem-spacing-small) 3px;
+        --tab-button-padding         : 4px var(--sem-spacing-xsmall) 3px;
+        --tab-button-text-font-size  : var(--sem-typo-label-small-fontSize);
+        --tab-button-text-font-weight: var(--sem-typo-label-small-fontWeight);
     }
 
     // Standalone explicitly names the theme's existing free-standing treatment.

--- a/resources/scss/theme-neo-dark/tab/header/Button.scss
+++ b/resources/scss/theme-neo-dark/tab/header/Button.scss
@@ -27,6 +27,7 @@
     --tab-button-padding                        : 7px var(--cmp-tab-spacinghorizontal) 6px;
     --tab-button-text-color                     : var(--sem-color-fg-neutral-subdued);
     --tab-button-text-font-size                 : var(--sem-typo-label-regular-fontSize);
+    --tab-button-text-font-weight               : var(--button-text-font-weight);
     --tab-button-text-transform                 : uppercase;
 
     // custom overrides

--- a/resources/scss/theme-neo-light/design-tokens/Core.scss
+++ b/resources/scss/theme-neo-light/design-tokens/Core.scss
@@ -13,6 +13,7 @@
     --core-fontsize-h2             : 1.75rem;
     --core-fontsize-h3             : 1.25rem;
     --core-fontsize-label          : 1rem;
+    --core-fontsize-small          : 0.75rem;
     --core-fontweight-bold         : 700;
     --core-fontweight-medium       : 500;
     --core-fontweight-regular      : 400;

--- a/resources/scss/theme-neo-light/design-tokens/Semantic.scss
+++ b/resources/scss/theme-neo-light/design-tokens/Semantic.scss
@@ -86,4 +86,7 @@
     --sem-typo-label-regular-fontFamily                                      : var(--core-fontfamily-sans);
     --sem-typo-label-regular-fontSize                                        : var(--core-fontsize-body);
     --sem-typo-label-regular-fontWeight                                      : var(--core-fontweight-regular);
+    --sem-typo-label-small-fontFamily                                        : var(--core-fontfamily-sans);
+    --sem-typo-label-small-fontSize                                          : var(--core-fontsize-small);
+    --sem-typo-label-small-fontWeight                                        : var(--core-fontweight-regular);
 }

--- a/resources/scss/theme-neo-light/tab/Container.scss
+++ b/resources/scss/theme-neo-light/tab/Container.scss
@@ -28,10 +28,10 @@
     // carries the case where an ancestor holds the theme.
     &.neo-tab-header-toolbar.neo-tab-container-inline,
     .neo-tab-header-toolbar.neo-tab-container-inline {
-        --tab-button-border-radius : 0;
-        --tab-button-gap           : 0;
-        --tab-button-height        : var(--sem-height-large);
-        --tab-button-height-pressed: var(--sem-height-large);
+        --tab-button-border-radius   : 0;
+        --tab-button-gap             : 0;
+        --tab-button-height          : var(--sem-height-large);
+        --tab-button-height-pressed  : var(--sem-height-large);
         --tab-button-padding         : 4px var(--sem-spacing-xsmall) 3px;
         --tab-button-text-font-size  : var(--sem-typo-label-small-fontSize);
         --tab-button-text-font-weight: var(--sem-typo-label-small-fontWeight);

--- a/resources/scss/theme-neo-light/tab/Container.scss
+++ b/resources/scss/theme-neo-light/tab/Container.scss
@@ -32,7 +32,9 @@
         --tab-button-gap           : 0;
         --tab-button-height        : var(--sem-height-large);
         --tab-button-height-pressed: var(--sem-height-large);
-        --tab-button-padding       : 4px var(--sem-spacing-small) 3px;
+        --tab-button-padding         : 4px var(--sem-spacing-xsmall) 3px;
+        --tab-button-text-font-size  : var(--sem-typo-label-small-fontSize);
+        --tab-button-text-font-weight: var(--sem-typo-label-small-fontWeight);
     }
 
     // Standalone explicitly names the theme's existing free-standing treatment.

--- a/resources/scss/theme-neo-light/tab/header/Button.scss
+++ b/resources/scss/theme-neo-light/tab/header/Button.scss
@@ -27,6 +27,7 @@
     --tab-button-padding                        : 7px var(--cmp-tab-spacinghorizontal) 6px;
     --tab-button-text-color                     : var(--sem-color-fg-neutral-subdued);
     --tab-button-text-font-size                 : var(--sem-typo-label-regular-fontSize);
+    --tab-button-text-font-weight               : var(--button-text-font-weight);
     --tab-button-text-transform                 : uppercase;
 
     // custom overrides

--- a/test/playwright/component/tab/ContainerUi.spec.mjs
+++ b/test/playwright/component/tab/ContainerUi.spec.mjs
@@ -7,37 +7,41 @@ const THEMES = [
     'neo-theme-neo-dark'
 ];
 
+// Title typography is measured per variant: `null` and `standalone` keep the button family's size
+// and weight (the weight token exists so a title can OPT OUT, never to change what inherits by
+// default), while `inline` — the dock header, where a five-action rail leaves a 180px title 36px —
+// drops to regular weight, one size step down in the neo themes, and 8px horizontal padding.
 const EXPECTED = {
     'neo-theme-light': {
         actionSize: '20px',
         gradient  : false,
-        inline    : {height: '25px', padding: '7px 10px 6px', radius: '0px'},
-        null      : {height: '25px', padding: '7px 12px 6px', radius: '0px'},
-        standalone: {height: '40px', padding: '7px 16px 6px', radius: '8px'},
+        inline    : {fontSize: '11px', fontWeight: '400', height: '25px', padding: '7px 8px 6px',  radius: '0px'},
+        null      : {fontSize: '11px', fontWeight: '600', height: '25px', padding: '7px 12px 6px', radius: '0px'},
+        standalone: {fontSize: '11px', fontWeight: '600', height: '40px', padding: '7px 16px 6px', radius: '8px'},
         textColor : 'rgb(43, 43, 43)'
     },
     'neo-theme-dark': {
         actionSize: '20px',
         gradient  : false,
-        inline    : {height: '25px', padding: '7px 10px 6px', radius: '0px'},
-        null      : {height: '25px', padding: '7px 12px 6px', radius: '0px'},
-        standalone: {height: '40px', padding: '7px 16px 6px', radius: '8px'},
+        inline    : {fontSize: '11px', fontWeight: '400', height: '25px', padding: '7px 8px 6px',  radius: '0px'},
+        null      : {fontSize: '11px', fontWeight: '600', height: '25px', padding: '7px 12px 6px', radius: '0px'},
+        standalone: {fontSize: '11px', fontWeight: '600', height: '40px', padding: '7px 16px 6px', radius: '8px'},
         textColor : 'rgb(187, 187, 187)'
     },
     'neo-theme-neo-light': {
         actionSize: '24px',
         gradient  : true,
-        inline    : {height: '32px', padding: '4px 12px 3px', radius: '0px'},
-        null      : {height: '48px', padding: '7px 16px 6px', radius: '8px'},
-        standalone: {height: '48px', padding: '7px 16px 6px', radius: '8px'},
+        inline    : {fontSize: '12px', fontWeight: '400', height: '32px', padding: '4px 8px 3px',  radius: '0px'},
+        null      : {fontSize: '16px', fontWeight: '600', height: '48px', padding: '7px 16px 6px', radius: '8px'},
+        standalone: {fontSize: '16px', fontWeight: '600', height: '48px', padding: '7px 16px 6px', radius: '8px'},
         textColor : 'rgb(69, 75, 66)'
     },
     'neo-theme-neo-dark': {
         actionSize: '24px',
         gradient  : true,
-        inline    : {height: '32px', padding: '4px 12px 3px', radius: '0px'},
-        null      : {height: '48px', padding: '7px 16px 6px', radius: '8px'},
-        standalone: {height: '48px', padding: '7px 16px 6px', radius: '8px'},
+        inline    : {fontSize: '12px', fontWeight: '400', height: '32px', padding: '4px 8px 3px',  radius: '0px'},
+        null      : {fontSize: '16px', fontWeight: '600', height: '48px', padding: '7px 16px 6px', radius: '8px'},
+        standalone: {fontSize: '16px', fontWeight: '600', height: '48px', padding: '7px 16px 6px', radius: '8px'},
         textColor : 'rgb(153, 162, 149)'
     }
 };
@@ -183,15 +187,18 @@ const readVariant = (page, id) => page.evaluate(componentId => {
     const root    = document.getElementById(componentId),
           button  = root.querySelector('.neo-tab-header-button'),
           toolbar = root.querySelector('.neo-tab-header-toolbar'),
-          style   = getComputedStyle(button);
+          style   = getComputedStyle(button),
+          text    = getComputedStyle(button.querySelector('.neo-button-text'));
 
     return {
         backgroundImage: getComputedStyle(toolbar).backgroundImage,
         cls            : [...root.classList],
+        fontSize       : text.fontSize,
+        fontWeight     : text.fontWeight,
         height         : style.height,
         padding        : style.padding,
         radius         : style.borderRadius,
-        textColor      : getComputedStyle(button.querySelector('.neo-button-text')).color
+        textColor      : text.color
     }
 }, id);
 

--- a/test/playwright/component/tab/ContainerUi.spec.mjs
+++ b/test/playwright/component/tab/ContainerUi.spec.mjs
@@ -360,6 +360,57 @@ test.describe('Neo.tab.Container — ui variants', () => {
         })
     }
 
+    /**
+     * A fifth engine theme builds with no `tab/` directory at all: `theme-cyberpunk` declares none of
+     * the `--tab-button-*` tokens. The tab title's weight rule outranks the button rule by
+     * specificity, so an undefined weight token would make that declaration invalid and hand the
+     * title the document's inherited weight — a regression no four-theme matrix can see. The
+     * consumption-site fallback is what keeps such a theme at the button family's weight, for every
+     * variant, exactly as before the token existed.
+     */
+    test('a theme without tab tokens keeps the button family\'s title weight through the fallback', async ({page}) => {
+        await page.evaluate(async hrefs => {
+            for (const href of hrefs) {
+                const link = document.createElement('link');
+
+                link.rel  = 'stylesheet';
+                link.href = href;
+
+                await new Promise((resolve, reject) => {
+                    link.onload  = resolve;
+                    link.onerror = () => reject(new Error(`stylesheet did not load: ${href}`));
+                    document.head.appendChild(link)
+                })
+            }
+        }, [
+            '/dist/development/css/theme-cyberpunk/button/Base.css',
+            '/dist/development/css/theme-cyberpunk/toolbar/Base.css'
+        ]);
+
+        await applyTheme(page, 'neo-theme-cyberpunk');
+
+        const tokens = await page.evaluate(() => {
+            const text  = document.querySelector('#tab-ui-null .neo-tab-header-button .neo-button-text'),
+                  style = getComputedStyle(text);
+
+            return {
+                buttonWeight: style.getPropertyValue('--button-text-font-weight').trim(),
+                tabWeight   : style.getPropertyValue('--tab-button-text-font-weight').trim()
+            }
+        });
+
+        // The precondition that makes this arm mean anything: the theme really declares no tab
+        // weight token, while it does declare the button family's.
+        expect(tokens.tabWeight, 'cyberpunk declares no tab title weight token').toBe('');
+        expect(tokens.buttonWeight, 'and does declare the button weight').toBe('600');
+
+        for (const variant of ['null', 'inline', 'standalone']) {
+            const measured = await readVariant(page, `tab-ui-${variant}`);
+
+            expect(measured.fontWeight, `${variant}: the title keeps the button family's weight`).toBe('600')
+        }
+    });
+
     test('the inline gradient hook is theme-valued, overridable and cannot leak to ui:null', async ({page}) => {
         await applyTheme(page, 'neo-theme-neo-light');
 


### PR DESCRIPTION
Resolves #18043

The inline tab header stops borrowing the button family's semibold: the tab title gets its own weight token in all four engine themes, declared with the value that inherited before, so `ui: null` and `standalone` render byte-identical. The inline variant then trims what a dock header cannot afford — regular weight, 8px horizontal padding, and one size step down in the neo themes through a new label-small typography step. On the Workstation's 180px "Queues" header with the full engine rail revealed the title went from "Q…" (16px/600/12px) to the whole word, uncapped, with the bar exactly filled (12px/400/8px). Numbers and the rejected alternatives are on the ticket.

Evidence: L3 (the variant paint matrix reads title size, weight and padding per variant across the four themes in CI; live Workstation measurement at the ticket's header) → L3 required (AC-1…AC-4). Residual: none — AC-5 is the operator's visual acceptance, which this hand-off requests.

## AC Evidence
| AC-1 | CI-covered: `test/playwright/component/tab/ContainerUi.spec.mjs` › the per-theme variant matrix now asserts `fontSize`/`fontWeight` for `null` and `standalone` at their pre-change values (11px/600 classic, 16px/600 neo) — the weight token exists in all four theme `tab/header/Button.scss` files and `src/tab/header/Button.scss` is the only consumer |
| AC-2 | CI-covered: same spec, `inline` rows: 400 weight in all four themes, 8px horizontal padding (`7px 8px 6px` classic, `4px 8px 3px` neo), 12px in the neo themes |
| AC-3 | Outside-CI: Workstation at this tree, Chromium 1280×720 @2x, "Queues" header focused with reload · unpin · pop-out · maximize · close revealed — button 58px, title box 42px = text width, `neo-tab-overflow-capped` absent, bar children sum 180/180; the 13px step was measured first and still lost 2px to the ellipsis, which is why the small step is 0.75rem |
| AC-4 | CI-covered: `test/playwright/component/tab/DragProxyDensity.spec.mjs` green at head — the proxy resolves the same inline tokens through the self-scoped selector forms |
| AC-5 | Outside-CI: the high-resolution crop of the focused header was handed to the operator with this PR; merge is the acceptance |

Micro-review eligible: no — a token contract change across four themes plus a new typography step.

## Deltas from ticket
- Round 2 (Grace): the consumption site now carries the fallback — `font-weight: var(--tab-button-text-font-weight, var(--button-text-font-weight))`. A theme that declares no tab tokens at all (`theme-cyberpunk`, a first-class build target with no `tab/` directory) would otherwise have had the new (0,3,0) rule outrank the button rule with an undefined token, i.e. an invalid declaration, and its titles would have inherited the document weight instead of keeping the button family's 600. The four theme declarations stay as explicit-by-reference opt-outs; the fallback is what makes the ledger's "absent → the button family's weight" true by construction. A cyberpunk arm in the paint spec pins the no-tab-tokens theme at the button weight for every variant.
- The neo size step is 12px (`--core-fontsize-small: 0.75rem`), not 13px: at 13px the 180px header still clipped "Queues" by 2px. 12px also matches the 12px action glyphs beside it.
- The step lands as a semantic typography token pair (`--sem-typo-label-small-fontSize` / `-fontWeight`, plus `-fontFamily` for symmetry with the existing label steps) in both neo themes, so consumers retune one token rather than the tab block.
- The classic themes keep their 11px title size (already small) and take only the weight and padding trim.

## Test Evidence
- Workstation measurement (AC-3) at head, both steps, with the tab overflow plugin's cap state read from the DOM: 13px → capped, text box 44 < 46 needed; 12px → uncapped, 42 = 42.
- Tab component folder 14/14; the six dock component specs green at head (header geometry feeds the overflow partition and the pop-out ordering arm).

## Post-Merge Validation
- none — the paint matrix runs in CI and the Workstation receipt is at head.

## Commits
- `838b08b0df` — `feat(tab): own the title weight and trim the inline header (#18043)`
- `96dabba28d` — round 2: the consumption-site fallback to the button family's weight, the cyberpunk no-tab-tokens arm in the paint matrix, and the neo inline blocks aligned on one column

Authored by Mnemosyne (Claude Fable 5.1, Claude Code). Session 6197a12f-acf2-478a-b05d-4ece32474259. 🪢
