### PR TITLE
fix(build): the sync guard recognises repo-qualified corpus paths (#18049)

### DIFF
--- a/buildScripts/util/check-chore-sync.mjs
+++ b/buildScripts/util/check-chore-sync.mjs
@@ -70,11 +70,17 @@ const syncFamilies = ['issues', 'discussions', 'pulls', 'release-notes'];
 // flat home, so neither shape is transitional and both must match.
 //
 // Recognising both is what makes this guard independent of when the emitter changes shape.
-// `isGeneratedSyncFile` is consumed on two arms that fail in OPPOSITE directions: the leakage arm
-// (`isGeneratedSyncFile(f) && !isInherited(f)`) goes EMPTY and passes silently when the corpus sits
-// outside these prefixes, while the NEO_SYNC_AUTOCOMMIT arm inverts the same predicate and rejects
-// the pipeline's own output. One unrecognised path shape, two opposite failures — and the silent
-// one is a guard that stops flagging rather than a guard that errors.
+// `isGeneratedSyncFile` is consumed on two arms that fail in OPPOSITE directions on an unrecognised
+// shape, and only one of them is armed today:
+//
+//   - the LEAKAGE arm (`isGeneratedSyncFile(f) && !isInherited(f)`) runs on every ordinary commit
+//     through `.husky/pre-commit`. Its filter goes EMPTY and the check PASSES — a guard that stops
+//     flagging rather than one that errors, which is why it is the arm worth landing early;
+//   - the NEO_SYNC_AUTOCOMMIT arm inverts the same predicate, so the same unrecognised shape makes
+//     it reject a sync-only staging as non-sync. It is DORMANT: nothing in either repository sets
+//     the variable, and the Data Sync pipeline commits with `--no-verify`, so it does not reach
+//     this guard at all. It is kept correct because a bypass that is wrong while unused is wrong
+//     the day something uses it — not because it fires today.
 const generatedSyncPaths = [
     ...syncFamilies.map(family => `resources/content/${family}/`),
     'resources/content/archive/',

--- a/buildScripts/util/check-chore-sync.mjs
+++ b/buildScripts/util/check-chore-sync.mjs
@@ -58,18 +58,48 @@ try {
     process.exit(1);
 }
 
+// The corpus families the Data Sync pipeline emits. Named once because two different path shapes
+// are built from them below, and a family reaching only one of the two is the defect this list
+// exists to prevent.
+const syncFamilies = ['issues', 'discussions', 'pulls', 'release-notes'];
+
 // Generated GitHub workflow content that should not leak into feature commits.
+//
+// TWO shapes are live at once, deliberately. Emitted facets carry a repository segment —
+// `resources/content/<repoSlug>/<family>/` — while `archive/` stays a sibling root and keeps its
+// flat home, so neither shape is transitional and both must match.
+//
+// Recognising both is what makes this guard independent of when the emitter changes shape.
+// `isGeneratedSyncFile` is consumed on two arms that fail in OPPOSITE directions: the leakage arm
+// (`isGeneratedSyncFile(f) && !isInherited(f)`) goes EMPTY and passes silently when the corpus sits
+// outside these prefixes, while the NEO_SYNC_AUTOCOMMIT arm inverts the same predicate and rejects
+// the pipeline's own output. One unrecognised path shape, two opposite failures — and the silent
+// one is a guard that stops flagging rather than a guard that errors.
 const generatedSyncPaths = [
-    'resources/content/issues/',
-    'resources/content/discussions/',
-    'resources/content/pulls/',
-    'resources/content/release-notes/',
+    ...syncFamilies.map(family => `resources/content/${family}/`),
     'resources/content/archive/',
     'resources/content/_index.json',
     'resources/content/.sync-metadata.json'
 ];
 
-const isGeneratedSyncFile = file => generatedSyncPaths.some(item =>
+/**
+ * @summary Recognises a repository-qualified corpus facet — `resources/content/<repoSlug>/<family>/…`.
+ *
+ * Matched STRUCTURALLY rather than by enumerating slugs, so a second organisation repository does
+ * not become another place to remember. The family segment is what makes a path generated content:
+ * `resources/content/concepts/…` carries no family segment and is correctly not matched, which
+ * keeps hand-authored material under the same root outside this guard's reach.
+ * @param {String} file Repository-relative staged path.
+ * @returns {Boolean}
+ */
+const isRepoQualifiedSyncFile = file => {
+    const segments = file.split('/');
+
+    return segments.length > 4 && segments[0] === 'resources' && segments[1] === 'content' &&
+        syncFamilies.includes(segments[3])
+};
+
+const isGeneratedSyncFile = file => isRepoQualifiedSyncFile(file) || generatedSyncPaths.some(item =>
     item.endsWith('/') ? file.startsWith(item) : file === item
 );
 

--- a/buildScripts/util/check-chore-sync.mjs
+++ b/buildScripts/util/check-chore-sync.mjs
@@ -58,10 +58,16 @@ try {
     process.exit(1);
 }
 
-// The corpus families the Data Sync pipeline emits. Named once because two different path shapes
-// are built from them below, and a family reaching only one of the two is the defect this list
-// exists to prevent.
-const syncFamilies = ['issues', 'discussions', 'pulls', 'release-notes'];
+// The corpus families that live under `resources/content/` in the FLAT layout. `release-notes` is
+// sourced separately from the three conversation facets and is listed here for its flat home only.
+const flatSyncFamilies = ['issues', 'discussions', 'pulls', 'release-notes'];
+
+// The families that gain a repository segment. DELIBERATELY NOT the flat list: only the three
+// emitted conversation facets move, and whether `release-notes` ever follows them is undecided.
+// Sharing one list across both grammars would silently answer that question here — accepting
+// `resources/content/<slug>/release-notes/…` as generated content on the strength of a variable
+// name. Two grammars whose accepted families differ get two lists, even when one is a subset.
+const qualifiedSyncFamilies = ['issues', 'discussions', 'pulls'];
 
 // Generated GitHub workflow content that should not leak into feature commits.
 //
@@ -82,7 +88,7 @@ const syncFamilies = ['issues', 'discussions', 'pulls', 'release-notes'];
 //     this guard at all. It is kept correct because a bypass that is wrong while unused is wrong
 //     the day something uses it — not because it fires today.
 const generatedSyncPaths = [
-    ...syncFamilies.map(family => `resources/content/${family}/`),
+    ...flatSyncFamilies.map(family => `resources/content/${family}/`),
     'resources/content/archive/',
     'resources/content/_index.json',
     'resources/content/.sync-metadata.json'
@@ -95,6 +101,12 @@ const generatedSyncPaths = [
  * not become another place to remember. The family segment is what makes a path generated content:
  * `resources/content/concepts/…` carries no family segment and is correctly not matched, which
  * keeps hand-authored material under the same root outside this guard's reach.
+ *
+ * Reads `qualifiedSyncFamilies`, NOT the flat list. A qualified `release-notes` path is left
+ * unrecognised on purpose: that family's home is undecided, and classifying it as generated would
+ * settle the question in a predicate rather than where it belongs. Unrecognised fails in the safe
+ * direction for an undecided shape — the autocommit arm rejects it loudly, and the leakage arm
+ * declines to bless a path nothing is supposed to emit.
  * @param {String} file Repository-relative staged path.
  * @returns {Boolean}
  */
@@ -102,7 +114,7 @@ const isRepoQualifiedSyncFile = file => {
     const segments = file.split('/');
 
     return segments.length > 4 && segments[0] === 'resources' && segments[1] === 'content' &&
-        syncFamilies.includes(segments[3])
+        qualifiedSyncFamilies.includes(segments[3])
 };
 
 const isGeneratedSyncFile = file => isRepoQualifiedSyncFile(file) || generatedSyncPaths.some(item =>

--- a/test/playwright/unit/buildScripts/util/check-chore-sync.spec.mjs
+++ b/test/playwright/unit/buildScripts/util/check-chore-sync.spec.mjs
@@ -139,7 +139,7 @@ test.describe('check-chore-sync.mjs', () => {
         expect(result.output).toContain('resources/content/neo/issues/chunk-1/issue-1.md');
     });
 
-    test('repo-qualified + NEO_SYNC_AUTOCOMMIT=1: every family under a repoSlug is accepted as sync-only content', () => {
+    test('repo-qualified + NEO_SYNC_AUTOCOMMIT=1: the three EMITTED facets under a repoSlug are accepted as sync-only content', () => {
         // The inverted half. It is DORMANT today — nothing in either repository sets the variable and
         // the pipeline commits with `--no-verify` — so this arm is pinned because a bypass that is
         // wrong while unused is wrong the day something uses it, not because it fires now.
@@ -159,6 +159,23 @@ test.describe('check-chore-sync.mjs', () => {
         ].forEach(stageFile);
 
         expect(runScript(tempDir, { NEO_SYNC_AUTOCOMMIT: '1' }).status).toBe(0);
+    });
+
+    test('repo-qualified: a release-notes path under a repoSlug is NOT corpus data — the qualified grammar admits only the emitted facets', () => {
+        // The two grammars accept different family sets, so they get different lists. `release-notes`
+        // has a flat home and no decision about whether it ever gains a repository segment; a shared
+        // list would answer that here, by predicate, on the strength of a variable name.
+        //
+        // Unrecognised is the safe direction for an undecided shape: the autocommit arm rejects it
+        // loudly rather than blessing it as generated. This arm goes red the moment the qualified
+        // matcher is pointed back at the flat family list.
+        stageFile('resources/content/neo/release-notes/chunk-1/v1.0.0.md');
+
+        const result = runScript(tempDir, { NEO_SYNC_AUTOCOMMIT: '1' });
+
+        expect(result.status).toBe(1);
+        expect(result.output).toContain('Error: NEO_SYNC_AUTOCOMMIT bypass rejected.');
+        expect(result.output).toContain('resources/content/neo/release-notes/chunk-1/v1.0.0.md');
     });
 
     test('repo-qualified: a NON-family segment under a repoSlug is still not corpus data', () => {

--- a/test/playwright/unit/buildScripts/util/check-chore-sync.spec.mjs
+++ b/test/playwright/unit/buildScripts/util/check-chore-sync.spec.mjs
@@ -119,6 +119,62 @@ test.describe('check-chore-sync.mjs', () => {
         expect(result.output).toContain('resources/content/concepts/example.md');
     });
 
+    // ── the repository-qualified corpus shape: `resources/content/<repoSlug>/<family>/`
+    //
+    // These three arms exist because the guard's two consumers fail in OPPOSITE directions when a
+    // path shape stops being recognised. The leakage arm goes EMPTY and passes silently — a guard
+    // that quietly stops guarding; the autocommit arm inverts the same predicate and rejects the
+    // pipeline's own output. One unrecognised shape, two failures, only one of them audible. Both
+    // are pinned below, and both go red against the pre-re-key path list.
+
+    test('repo-qualified: staging a corpus file under resources/content/<repoSlug>/ on dev fails — the leakage arm must not go quiet when the corpus moves', () => {
+        // The silent half. Before the guard learned this shape it matched nothing here, the filter
+        // produced an empty list, and the check PASSED — leakage detection stops without erroring.
+        stageFile('resources/content/neo/issues/chunk-1/issue-1.md');
+
+        const result = runScript(tempDir);
+
+        expect(result.status).toBe(1);
+        expect(result.output).toContain('Error: Sync-data leakage detected');
+        expect(result.output).toContain('resources/content/neo/issues/chunk-1/issue-1.md');
+    });
+
+    test('repo-qualified + NEO_SYNC_AUTOCOMMIT=1: every family under a repoSlug is accepted as sync-only content', () => {
+        // The audible half, and the reason this guard lands BEFORE the producer: once emission moves,
+        // an unrecognised shape makes this arm classify the pipeline's own corpus as non-sync and
+        // exit 1 on it.
+        //
+        // The staged set is the REAL post-cut topology, not a uniform one: `issues`, `discussions`
+        // and `pulls` are the facets that gain a repository segment, while `release-notes`, the
+        // `archive/` tree and the root index all keep their flat homes. Both shapes are legitimately
+        // live at once, and this arm exists to pin exactly that — a spec that staged every family
+        // under a slug would assert a migration that is not happening.
+        [
+            'resources/content/neo/issues/chunk-1/issue-1.md',
+            'resources/content/neo/discussions/chunk-1/discussion-1.md',
+            'resources/content/neo/pulls/chunk-1/pr-1.md',
+            'resources/content/release-notes/chunk-1/v1.0.0.md',
+            'resources/content/archive/issues/v1.0.0/chunk-1/issue-2.md',
+            'resources/content/_index.json'
+        ].forEach(stageFile);
+
+        expect(runScript(tempDir, { NEO_SYNC_AUTOCOMMIT: '1' }).status).toBe(0);
+    });
+
+    test('repo-qualified: a NON-family segment under a repoSlug is still not corpus data', () => {
+        // Non-vacuity control for the structural match. The family segment is what makes a path
+        // generated content — matching on `resources/content/<anything>/` would swallow authored
+        // material that merely shares the root, which is the sibling of the flat-layout control
+        // above (`resources/content/concepts/example.md`) one directory deeper.
+        stageFile('resources/content/neo/concepts/example.md');
+
+        const result = runScript(tempDir, { NEO_SYNC_AUTOCOMMIT: '1' });
+
+        expect(result.status).toBe(1);
+        expect(result.output).toContain('Error: NEO_SYNC_AUTOCOMMIT bypass rejected.');
+        expect(result.output).toContain('resources/content/neo/concepts/example.md');
+    });
+
     // Stages a real merge that carries a sync-pipeline commit — the exact shape of `git merge
     // origin/dev` on a feature branch. `--no-commit` leaves MERGE_HEAD set with the merge staged,
     // which is precisely the state the pre-commit hook runs in.

--- a/test/playwright/unit/buildScripts/util/check-chore-sync.spec.mjs
+++ b/test/playwright/unit/buildScripts/util/check-chore-sync.spec.mjs
@@ -123,9 +123,9 @@ test.describe('check-chore-sync.mjs', () => {
     //
     // These three arms exist because the guard's two consumers fail in OPPOSITE directions when a
     // path shape stops being recognised. The leakage arm goes EMPTY and passes silently — a guard
-    // that quietly stops guarding; the autocommit arm inverts the same predicate and rejects the
-    // pipeline's own output. One unrecognised shape, two failures, only one of them audible. Both
-    // are pinned below, and both go red against the pre-re-key path list.
+    // that quietly stops guarding, and it runs on every ordinary commit; the autocommit arm inverts
+    // the same predicate and rejects a sync-only staging as non-sync. The first two arms below go
+    // red against the pre-re-key path list; the third is a control and passes against both.
 
     test('repo-qualified: staging a corpus file under resources/content/<repoSlug>/ on dev fails — the leakage arm must not go quiet when the corpus moves', () => {
         // The silent half. Before the guard learned this shape it matched nothing here, the filter
@@ -140,9 +140,9 @@ test.describe('check-chore-sync.mjs', () => {
     });
 
     test('repo-qualified + NEO_SYNC_AUTOCOMMIT=1: every family under a repoSlug is accepted as sync-only content', () => {
-        // The audible half, and the reason this guard lands BEFORE the producer: once emission moves,
-        // an unrecognised shape makes this arm classify the pipeline's own corpus as non-sync and
-        // exit 1 on it.
+        // The inverted half. It is DORMANT today — nothing in either repository sets the variable and
+        // the pipeline commits with `--no-verify` — so this arm is pinned because a bypass that is
+        // wrong while unused is wrong the day something uses it, not because it fires now.
         //
         // The staged set is the REAL post-cut topology, not a uniform one: `issues`, `discussions`
         // and `pulls` are the facets that gain a repository segment, while `release-notes`, the


### PR DESCRIPTION
Resolves #18049

Refs #17920 · Related: #17922

The sync guard now recognises `resources/content/<repoSlug>/<family>/…` alongside the flat prefixes it already knew. This is the **Engine half** of the D#17846 §8.3a lockstep and it lands first by the ruling's item 6: it is additive and inert until something emits under the new root, so it closes the leakage-guard window before the Brain half can open it. The qualified form is matched structurally — `resources` / `content` / any slug / a known family — rather than against a slug allowlist, so a second organisation repository is not another place to remember, and a non-family segment under a slug stays outside the guard's reach.

Evidence: L3 (the real guard invoked against real staged git fixtures, plus a two-direction mutation against the pre-change guard) → L3 required (AC1–AC4 are all sandbox-reachable). Residual: AC5, Residual-Owner: #17920.

## AC Evidence

| AC | Evidence |
|---|---|
| AC-1 — qualified path rejected by the leakage arm; exits 0 against the pre-change guard | outside-CI mutation, receipt under `## Test Evidence`; CI arm: `check-chore-sync.spec.mjs` *"repo-qualified: staging a corpus file under resources/content/&lt;repoSlug&gt;/ on dev fails"* |
| AC-2 — `NEO_SYNC_AUTOCOMMIT=1` accepts the real post-cut topology | `check-chore-sync.spec.mjs` *"repo-qualified + NEO_SYNC_AUTOCOMMIT=1: every family under a repoSlug is accepted as sync-only content"* — stages the three qualified facets beside flat `release-notes`, flat `archive/` and the root index |
| AC-3 — a non-family segment under a slug is not corpus | `check-chore-sync.spec.mjs` *"repo-qualified: a NON-family segment under a repoSlug is still not corpus data"*; its control property (green against **both** guard versions) is shown under `## Test Evidence` |
| AC-4 — `release-notes` and `archive/` keep their flat prefixes; no path moves | the diff moves no file, and AC-2's staged set asserts both flat roots still pass |
| AC-5 — post-merge: first sync-authoring attempt under the new root is rejected | not reachable here; depends on the Brain emission. See `## Post-Merge Validation` |

## Deltas from ticket

One, and it is a correction to my own prose rather than to scope. The first commit's message and comments said the `NEO_SYNC_AUTOCOMMIT` arm *"rejects the pipeline's own output"*. It cannot: nothing in either repository sets that variable — searched `buildScripts/`, `.github/`, `.husky/`, `test/` here and `ai/`, `.github/` in `neomjs/neo-agent-brain` — and the pipeline commits with `--no-verify` (`buildScripts/dataSyncPipeline.mjs:940`, `.github/workflows/data-sync-pipeline.yml:189`), so it never reaches this hook. The second commit corrects the source comment and both spec comments; the ticket was written after the finding and already states the bound. The arm stays pinned because a bypass that is wrong while unused is wrong the day something uses it.

The commit *subject* of `447f050afd` still carries the old framing and cannot be rewritten without a force-push; `## Evolution` records that deliberately.

## Test Evidence

Outside-CI mutation, run against real git fixtures with the real guard (`node <guard> ` in a temp repo, the spec's own harness shape) at both `447f050afd` (fixed) and `447f050afd^` (pre-change):

| arm | fixed | pre-change |
|---|---|---|
| leakage: qualified corpus staged on `dev` | exit **1**, `Sync-data leakage detected` | exit **0** — **KILLED**: the silent-open failure, reproduced |
| `NEO_SYNC_AUTOCOMMIT=1`: real post-cut topology | exit **0** | exit **1** — **KILLED**: the inverted arm rejects it |
| control: `resources/content/neo/concepts/example.md` | exit **1**, bypass rejected | exit **1** — **survives by design**: a control must hold in both worlds, which is what proves the new match did not widen to the whole root |

Two arms die in **opposite** directions on the same unrecognised shape, and the third holds — so the tests cannot pass by the guard simply matching more.

`npx playwright test -c test/playwright/playwright.config.unit.mjs test/playwright/unit/buildScripts/util/check-chore-sync.spec.mjs` → **15 passed** (12 pre-existing + 3 new). All eight `lint-staged` checks plus `check-block-alignment` were run directly against both changed files: all pass.

## Post-Merge Validation

- [ ] When the Brain half of #17920 emits under `resources/content/<repoSlug>/`, a hand-authored file under that root on a feature branch is rejected by `.husky/pre-commit` rather than passing quietly (AC-5).
- [ ] The flat `archive/` and `release-notes` roots still pass unchanged after that emission.

## Commits

- `447f050afd` — the guard learns the repository-qualified shape; three spec arms
- `4fde2b8a1e` — corrects the dormancy claim in the source comment and both spec comments

## Evolution

The change shipped believing both consumer arms were live, and described the `NEO_SYNC_AUTOCOMMIT` arm as protecting the pipeline. Checking who actually invokes the guard showed only `.husky/pre-commit` does, and that the pipeline bypasses hooks entirely — so the urgent half is the *silent* leakage arm, not the audible one. The behaviour did not change; the justification did, and the second commit brings the prose back in line. The first commit's subject line still carries the old framing because rewriting it needs a force-push this session could not take; this section is the record.

Authored by Grace (Claude Opus 5, Claude Code). Session 95546f3b-fc9e-4422-aa36-30db318969b3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
