### PR TITLE
fix(manager): a refused native park retries until the OS releases the popup (#18054)

### DIFF
--- a/apps/workstation/view/Workspace.mjs
+++ b/apps/workstation/view/Workspace.mjs
@@ -3117,7 +3117,12 @@ class Workspace extends DockWorkspace {
 
             me.lastVesselParkReceipt.focused = focused;
 
-            if (!focused) return false;
+            if (!focused) {
+                // Expected while a native titlebar drag still holds the source popup: the dragged
+                // window keeps focus until the OS releases it. The coordinator retries the park.
+                me.lastVesselParkReceipt.refusedAt = 'focus';
+                return false
+            }
 
             const moveData = {
                 nativeHandleKey: route.nativeHandleKey,
@@ -3139,7 +3144,10 @@ class Workspace extends DockWorkspace {
 
             me.lastVesselParkReceipt.moved = moved;
 
-            if (!moved) return false;
+            if (!moved) {
+                me.lastVesselParkReceipt.refusedAt = 'move';
+                return false
+            }
 
             parkGeometry && (me.tearOutParkGeometries[itemId] = parkGeometry);
 
@@ -3162,6 +3170,7 @@ class Workspace extends DockWorkspace {
 
                 me.lastVesselParkReceipt.compensated = compensated;
                 me.lastVesselParkReceipt.parked      = !compensated;
+                me.lastVesselParkReceipt.refusedAt   = 'refocus';
                 compensated && delete me.tearOutParkGeometries[itemId];
 
                 // Recovery ownership and visual admission are separate: if target refocus failed,

--- a/src/manager/DragCoordinator.mjs
+++ b/src/manager/DragCoordinator.mjs
@@ -44,8 +44,9 @@ class DragCoordinator extends Manager {
          * A native-titlebar drop settles while the user may still hold the popup's titlebar, and a
          * window the OS is dragging can neither hand focus to the target nor be moved, so the first
          * park attempt legitimately fails. There is no release event on this path; a park that
-         * succeeds IS the release signal. Retries use the disposition backoff (250 ms doubling,
-         * capped at 5 s), so six attempts cover roughly twelve seconds of a held popup.
+         * succeeds IS the release signal. Each retry waits the disposition backoff (250 ms doubling,
+         * capped at 5 s): the default six retries wait 250 + 500 + 1000 + 2000 + 4000 + 5000 ms, so a
+         * popup may stay held for about 12.75 s after the terminal fires before the gesture ends.
          * @member {Number} nativeWindowParkRetryLimit=6
          */
         nativeWindowParkRetryLimit: 6,
@@ -307,9 +308,11 @@ class DragCoordinator extends Manager {
             return false
         }
 
+        // parkAttempts counts refusals; the limit counts RETRIES, so the last refusal admitted still
+        // schedules one more attempt (six retries = seven park attempts).
         candidate.parkAttempts = (candidate.parkAttempts || 0) + 1;
 
-        if (candidate.parkAttempts >= me.nativeWindowParkRetryLimit) {
+        if (candidate.parkAttempts > me.nativeWindowParkRetryLimit) {
             me.clearNativeWindowDropCandidate(windowId);
             me.endNativeGesture(windowId);
             return false
@@ -317,8 +320,7 @@ class DragCoordinator extends Manager {
 
         const delay = Math.min(
             5000,
-            Math.max(1, me.nativeWindowDispositionRetryMs) *
-                2 ** Math.min(candidate.parkAttempts - 1, 4)
+            Math.max(1, me.nativeWindowDispositionRetryMs) * 2 ** (candidate.parkAttempts - 1)
         );
 
         candidate.phase = 'park-retry';
@@ -1422,7 +1424,7 @@ class DragCoordinator extends Manager {
             // produced any given retained entry. Each entry carries its own `gestureToken` for that;
             // filter by it before reading, because the ring is a session tail and spans gestures.
             claimTrace: [...me.claimTrace],
-            sortZones                 : Array.from(me.sortZones.entries()).map(([group, map]) => ({
+            sortZones : Array.from(me.sortZones.entries()).map(([group, map]) => ({
                 group,
                 windows: Array.from(map.keys())
             }))

--- a/src/manager/DragCoordinator.mjs
+++ b/src/manager/DragCoordinator.mjs
@@ -39,6 +39,17 @@ class DragCoordinator extends Manager {
          */
         nativeWindowDispositionRetryMs: 250,
         /**
+         * How many times a refused strict native park is retried before the gesture ends.
+         *
+         * A native-titlebar drop settles while the user may still hold the popup's titlebar, and a
+         * window the OS is dragging can neither hand focus to the target nor be moved, so the first
+         * park attempt legitimately fails. There is no release event on this path; a park that
+         * succeeds IS the release signal. Retries use the disposition backoff (250 ms doubling,
+         * capped at 5 s), so six attempts cover roughly twelve seconds of a held popup.
+         * @member {Number} nativeWindowParkRetryLimit=6
+         */
+        nativeWindowParkRetryLimit: 6,
+        /**
          * Quiescence delay after the last native window-position update before committing
          * a geometry-only drop. The browser has no mouseup during OS-titlebar drags.
          * @member {Number} nativeWindowDropSettleMs=250
@@ -276,6 +287,52 @@ class DragCoordinator extends Manager {
     }
 
     /**
+     * @summary Retries a refused strict native park with the disposition backoff, bounded.
+     *
+     * The candidate stays retained in phase `park-retry` while it waits. It is NOT shielded from
+     * geometry: a position update for the source means the user moved on, and the ordinary
+     * {@link #onWindowPositionChange} path then replaces this candidate and clears the pending retry
+     * with it. Only the `parking` / `embodied` / `settling-*` phases, whose geometry the app itself
+     * publishes, are shielded. Past {@link #nativeWindowParkRetryLimit} the gesture ends exactly as
+     * a refusal did before retries existed.
+     * @param {String} windowId The moving popup's window id.
+     * @param {Object} candidate The retained native candidate whose park was refused.
+     * @returns {Boolean} `true` when a retry was scheduled, `false` when the gesture ended.
+     * @protected
+     */
+    retryNativeWindowPark(windowId, candidate) {
+        let me = this;
+
+        if (me.nativeWindowDropCandidates.get(windowId) !== candidate || candidate.cancelled) {
+            return false
+        }
+
+        candidate.parkAttempts = (candidate.parkAttempts || 0) + 1;
+
+        if (candidate.parkAttempts >= me.nativeWindowParkRetryLimit) {
+            me.clearNativeWindowDropCandidate(windowId);
+            me.endNativeGesture(windowId);
+            return false
+        }
+
+        const delay = Math.min(
+            5000,
+            Math.max(1, me.nativeWindowDispositionRetryMs) *
+                2 ** Math.min(candidate.parkAttempts - 1, 4)
+        );
+
+        candidate.phase = 'park-retry';
+        clearTimeout(candidate.timeoutId);
+        candidate.timeoutId = setTimeout(() => {
+            me.commitNativeWindowDrop(windowId, candidate).catch(error => {
+                (Neo.logError || console.error)('Native window park retry failed', error)
+            })
+        }, delay);
+
+        return true
+    }
+
+    /**
      * @summary Commits an inferred native-titlebar popup drop into the remote dashboard path.
      *
      * Commits a conservative geometry-only native titlebar drop into the existing remote
@@ -339,8 +396,11 @@ class DragCoordinator extends Manager {
             }
 
             if (embodyNativeHover === true && suspended !== true) {
-                me.clearNativeWindowDropCandidate(windowId);
-                me.endNativeGesture(windowId);
+                // The strict route refused to park. During a live OS titlebar drag that is the
+                // expected first answer, not a verdict: the dragged window holds focus and the
+                // window server owns its position until the user lets go. Keep the candidate and
+                // try again; the release has no event, so a park that succeeds is how we learn of it.
+                me.retryNativeWindowPark(windowId, candidate);
                 return
             }
 

--- a/test/playwright/unit/manager/DragCoordinator.spec.mjs
+++ b/test/playwright/unit/manager/DragCoordinator.spec.mjs
@@ -925,6 +925,222 @@ test.describe('Neo.manager.DragCoordinator — the §2.8.1 claim protocol', () =
         )).toBeNull()
     });
 
+    /**
+     * A native-titlebar drop settles while the user may still hold the popup's titlebar. A window
+     * the OS is dragging can neither hand focus to the target nor be moved, so the strict park's
+     * first answer is a refusal. There is no release event on this path: a park that finally
+     * succeeds is how the coordinator learns the user let go, so a refusal must retry, not end.
+     */
+    test('a refused strict native park RETRIES with the disposition backoff and commits once the park succeeds', async () => {
+        const
+            draggedItem = {id: 'terminal'},
+            order       = [],
+            source      = {
+                getNativeWindowDrag: () => ({draggedItem, embodyNativeHover: true, sourceWindowId: 'win-popup', widgetName: 'terminal'}),
+                onRemoteDropOut() {
+                    order.push('retire');
+                    return true
+                },
+                resumeWindowDrag: () => true,
+                sortGroup       : 'dock',
+                suspendWindowDrag() {
+                    order.push('suspend');
+                    // The OS still holds the popup for the first two attempts; the third parks.
+                    return order.filter(entry => entry === 'suspend').length >= 3
+                },
+                windowId: 'win-main'
+            },
+            target = {
+                acceptsRemoteDrag        : () => true,
+                awaitRemoteDragEmbodiment: async () => true,
+                onRemoteDragLeave() {
+                    order.push('leave')
+                },
+                onRemoteDragMove(payload) {
+                    order.push(payload.embodyProxy ? 'embody' : 'preview');
+                    return {itemId: 'terminal'}
+                },
+                onRemoteDrop() {
+                    order.push('commit');
+                    return {type: 'addTab'}
+                }
+            },
+            candidate = {
+                draggedItem,
+                embodyNativeHover: true,
+                localX           : 20,
+                localY           : 30,
+                offsetX          : 10,
+                offsetY          : 10,
+                proxyRect        : {},
+                sourceSortZone   : source,
+                sourceWindowId   : 'win-popup',
+                targetSortZone   : target,
+                targetWindowId   : 'win-main',
+                widgetName       : 'terminal'
+            },
+            oldHandoff = DragCoordinator.nativeWindowDropHandoffMs,
+            oldRetry   = DragCoordinator.nativeWindowDispositionRetryMs;
+
+        DragCoordinator.nativeWindowDropHandoffMs      = 0;
+        DragCoordinator.nativeWindowDispositionRetryMs = 5;
+        DragCoordinator.nativeWindowDropCandidates.set('win-popup', candidate);
+
+        try {
+            await DragCoordinator.commitNativeWindowDrop('win-popup', candidate);
+
+            // The first refusal schedules a retry instead of ending the gesture.
+            expect(order).toEqual(['suspend']);
+            expect(candidate.phase, 'the candidate waits in park-retry').toBe('park-retry');
+            expect(candidate.parkAttempts).toBe(1);
+            expect(DragCoordinator.nativeWindowDropCandidates.get('win-popup'), 'the candidate is retained').toBe(candidate);
+
+            await expect.poll(() => order.includes('retire'), {timeout: 2000, intervals: [10, 25, 50]}).toBe(true);
+
+            expect(order).toEqual(['suspend', 'suspend', 'suspend', 'embody', 'commit', 'retire']);
+            expect(candidate.parkAttempts, 'two refusals were counted before the park succeeded').toBe(2);
+            expect(DragCoordinator.nativeWindowDropCandidates.has('win-popup'), 'the committed gesture releases its candidate').toBe(false)
+        } finally {
+            DragCoordinator.nativeWindowDropHandoffMs      = oldHandoff;
+            DragCoordinator.nativeWindowDispositionRetryMs = oldRetry
+        }
+    });
+
+    test('the park retry is BOUNDED — past the limit the gesture ends exactly as a refusal did before retries', async () => {
+        const
+            draggedItem = {id: 'terminal'},
+            order       = [],
+            source      = {
+                getNativeWindowDrag: () => ({draggedItem, embodyNativeHover: true, sourceWindowId: 'win-popup', widgetName: 'terminal'}),
+                sortGroup          : 'dock',
+                suspendWindowDrag() {
+                    order.push('suspend');
+                    return false
+                },
+                windowId: 'win-main'
+            },
+            target = {
+                acceptsRemoteDrag: () => true,
+                onRemoteDragLeave() {
+                    order.push('leave')
+                },
+                onRemoteDragMove: () => ({itemId: 'terminal'}),
+                onRemoteDrop() {
+                    order.push('commit');
+                    return {type: 'addTab'}
+                }
+            },
+            candidate = {
+                draggedItem,
+                embodyNativeHover: true,
+                localX           : 20,
+                localY           : 30,
+                offsetX          : 10,
+                offsetY          : 10,
+                proxyRect        : {},
+                sourceSortZone   : source,
+                sourceWindowId   : 'win-popup',
+                targetSortZone   : target,
+                targetWindowId   : 'win-main',
+                widgetName       : 'terminal'
+            },
+            oldLimit = DragCoordinator.nativeWindowParkRetryLimit,
+            oldRetry = DragCoordinator.nativeWindowDispositionRetryMs;
+
+        DragCoordinator.nativeWindowParkRetryLimit     = 3;
+        DragCoordinator.nativeWindowDispositionRetryMs = 5;
+        DragCoordinator.nativeWindowDropCandidates.set('win-popup', candidate);
+        DragCoordinator.nativeHoverTargets.set('win-popup', target);
+
+        try {
+            await DragCoordinator.commitNativeWindowDrop('win-popup', candidate);
+            await expect.poll(() => order.includes('leave'), {timeout: 2000, intervals: [10, 25, 50]}).toBe(true);
+
+            expect(order, 'exactly the limit\'s worth of park attempts, then the hover ends').toEqual(['suspend', 'suspend', 'suspend', 'leave']);
+            expect(order).not.toContain('commit');
+            expect(DragCoordinator.nativeWindowDropCandidates.has('win-popup'), 'the exhausted gesture releases its candidate').toBe(false);
+            expect(DragCoordinator.nativeHoverTargets.has('win-popup')).toBe(false)
+        } finally {
+            DragCoordinator.nativeWindowParkRetryLimit     = oldLimit;
+            DragCoordinator.nativeWindowDispositionRetryMs = oldRetry
+        }
+    });
+
+    test('a source geometry update during park-retry REPLACES the candidate and clears the pending retry', async () => {
+        const
+            draggedItem = {id: 'terminal'},
+            order       = [],
+            source      = {
+                getNativeWindowDrag: windowId => windowId === 'win-popup'
+                    ? {draggedItem, embodyNativeHover: true, sourceWindowId: 'win-popup', widgetName: 'terminal'}
+                    : null,
+                sortGroup: 'dock',
+                suspendWindowDrag() {
+                    order.push('suspend');
+                    return false
+                },
+                windowId: 'win-source'
+            },
+            target = {
+                acceptsRemoteDrag: () => true,
+                onRemoteDragLeave() {
+                    order.push('leave')
+                },
+                onRemoteDragMove(payload) {
+                    order.push(payload.embodyProxy ? 'embody' : 'preview');
+                    return {itemId: 'terminal'}
+                },
+                onRemoteDrop() {
+                    order.push('commit');
+                    return {type: 'addTab'}
+                },
+                sortGroup: 'dock',
+                windowId : 'win-target'
+            },
+            oldRetry = DragCoordinator.nativeWindowDispositionRetryMs;
+
+        registerWindow('win-source', 2000,   0, 400, 400);
+        registerWindow('win-popup',   500, 500, 300, 200);
+        registerWindow('win-target',  600, 550, 400, 300);
+
+        DragCoordinator.register(source);
+        DragCoordinator.register(target);
+        DragCoordinator.nativeWindowDispositionRetryMs = 40;
+
+        try {
+            // One geometry event over the target creates the candidate; force its commit now.
+            DragCoordinator.onWindowPositionChange({windowId: 'win-popup'});
+
+            const stale = DragCoordinator.nativeWindowDropCandidates.get('win-popup');
+
+            expect(stale, 'the hover produced a retained candidate').toBeTruthy();
+            clearTimeout(stale.timeoutId);
+            await DragCoordinator.commitNativeWindowDrop('win-popup', stale);
+
+            expect(stale.phase).toBe('park-retry');
+            expect(order.filter(entry => entry === 'suspend')).toHaveLength(1);
+
+            // The user moved on: a new geometry event replaces the retained candidate...
+            DragCoordinator.onWindowPositionChange({windowId: 'win-popup'});
+
+            const fresh = DragCoordinator.nativeWindowDropCandidates.get('win-popup');
+
+            expect(fresh, 'the geometry event installs a new candidate').toBeTruthy();
+            expect(fresh).not.toBe(stale);
+            expect(stale.cancelled, 'the replaced candidate is cancelled').toBe(true);
+
+            // ...and the stale retry never fires: no second park attempt within its scheduled delay.
+            await new Promise(resolve => setTimeout(resolve, 120));
+            expect(order.filter(entry => entry === 'suspend'), 'the pending retry died with its candidate').toHaveLength(1)
+        } finally {
+            DragCoordinator.clearNativeWindowDropCandidate('win-popup');
+            DragCoordinator.endNativeGesture('win-popup');
+            DragCoordinator.unregister(source);
+            DragCoordinator.unregister(target);
+            DragCoordinator.nativeWindowDispositionRetryMs = oldRetry
+        }
+    });
+
     test('native embodiment is retained before semantic commit, then target commit precedes source retirement', async () => {
         let resolveRenderer;
 

--- a/test/playwright/unit/manager/DragCoordinator.spec.mjs
+++ b/test/playwright/unit/manager/DragCoordinator.spec.mjs
@@ -1056,7 +1056,8 @@ test.describe('Neo.manager.DragCoordinator — the §2.8.1 claim protocol', () =
             await DragCoordinator.commitNativeWindowDrop('win-popup', candidate);
             await expect.poll(() => order.includes('leave'), {timeout: 2000, intervals: [10, 25, 50]}).toBe(true);
 
-            expect(order, 'exactly the limit\'s worth of park attempts, then the hover ends').toEqual(['suspend', 'suspend', 'suspend', 'leave']);
+            // the first attempt plus the limit's worth of RETRIES (three), then the hover ends
+            expect(order, 'one attempt, three retries, then the hover ends').toEqual(['suspend', 'suspend', 'suspend', 'suspend', 'leave']);
             expect(order).not.toContain('commit');
             expect(DragCoordinator.nativeWindowDropCandidates.has('win-popup'), 'the exhausted gesture releases its candidate').toBe(false);
             expect(DragCoordinator.nativeHoverTargets.has('win-popup')).toBe(false)


### PR DESCRIPTION
Resolves #18054

🌿 *A native titlebar drop no longer dies on the OS still holding the popup, so "every drop only came home through close" is unsayable.*

The operator's hand test after #18040 landed showed the last gap on the native path: previews and claims worked, yet no drop ever reintegrated. Read live through the Neural Link on that Workstation, the park receipt said `focused: false` for every attempt — the terminal asks the target window to take focus before parking the popup, and a window the OS is still dragging cannot hand focus away or be moved. The strict route treated that refusal as the end of the gesture, and the release that follows produces no event, so nothing ever re-armed. The CDP rigs never saw it because nobody holds a CDP-moved window. This PR makes a refused strict park a bounded **retry** on `DragCoordinator`: the candidate waits in a `park-retry` phase and re-enters `commitNativeWindowDrop` on the existing disposition backoff, so the park that finally succeeds is the release detector; a source geometry update replaces the waiting candidate (the user moved on) and past `nativeWindowParkRetryLimit` the gesture ends as before. The Workstation's park receipt now names the refusing step (`refusedAt`: focus / move / refocus). Diagnosis and receipts: [#18054](https://github.com/neomjs/neo/issues/18054).

Evidence: L2 (unit witnesses drive the retry, the bound and the replacement; the CDP e2e arms park on the first attempt so the retry path is dormant there) → L4 required (AC-5: only a real OS titlebar drag exercises the refusal). Residual: AC-5, Residual-Owner: #15239.

## AC Evidence
| AC-1 | `test/playwright/unit/manager/DragCoordinator.spec.mjs` › "a refused strict native park RETRIES with the disposition backoff and commits once the park succeeds": two refusals then a park, order `suspend ×3 → embody → commit → retire`, `parkAttempts === 2`, candidate released. |
| AC-2 | Same spec › "the park retry is BOUNDED": with the limit at 3, one attempt plus three retries (four `suspend`s), then `leave` with no commit and no retained candidate; › "a source geometry update during park-retry REPLACES the candidate…": the replaced candidate is cancelled and its scheduled retry never fires. The limit counts retries: the default six wait 250 + 500 + 1000 + 2000 + 4000 + 5000 ms, about 12.75 s of held popup, as the config's JSDoc states. |
| AC-3 | Same spec, third witness: a geometry event during `park-retry` installs a fresh candidate and the stale retry timer dies with the old one (no second `suspend` inside its delay). |
| AC-4 | `WorkstationNativeTitlebarDragNL` 1/1 green (11.8s) and `WorkstationNativePopupOverPopupNL` 1/1 green (7.2s) at this head (same runtime root); the park succeeds on the first attempt in the rig, so the retry path stays dormant and both keep their receipts. |
| AC-5 | Outside every rig: pop out, drag by the titlebar over the main window, hold, release — reintegration without the close path. Operator hand check on a live host; the only place a real OS drag exercises the refusal. |
| AC-6 | `apps/workstation/view/Workspace.mjs` `parkTearOutVessel` writes `lastVesselParkReceipt.refusedAt` at the focus, move and refocus refusals; `parkAttempts` lives on the coordinator candidate. |

## Deltas from ticket
- `park-retry` is deliberately not added to the `onWindowPositionChange` phase guard (the ticket's first draft said the opposite and was corrected in place): that guard shields phases whose geometry the app itself publishes; a geometry update during a retry means the user moved, and the ordinary path replacing the candidate is the right answer.
- The attempt count is not mirrored into the Workstation receipt; it lives on the coordinator candidate where the retry runs.

## Test Evidence
- Unit: `DragCoordinator.spec.mjs` 47/47 (44 before, three new witnesses; real timers with `nativeWindowDispositionRetryMs` lowered to 5–40 ms inside the tests and restored after).
- E2E (not in CI, Neural Link tier): `WorkstationNativeTitlebarDragNL` 1/1 green (11.8s), `WorkstationNativePopupOverPopupNL` 1/1 green (7.2s) at this head.
- The refusal path itself has no rig witness by construction; the unit tests own its mechanics and the operator owns the gesture (AC-5).

## Post-Merge Validation
- [ ] Live host: header-action pop-out, drag the popup by its OS titlebar over the main window, hold still, release — the pane reintegrates at its stored home without the close path, and `lastVesselParkReceipt` shows `parked: true` after one or more `refusedAt: 'focus'` attempts.

Residual-Owner: #15239

Authored by Vega (Fable 5.1, Claude Code). Session 93fd8de9-7231-4979-b906-c050bcfc25a4.
