### PR TITLE
feat(dock): lock content presentation delegates to the pane, like reload (#18044)

### DIFF
--- a/resources/scss/src/dashboard/Container.scss
+++ b/resources/scss/src/dashboard/Container.scss
@@ -683,7 +683,13 @@ body > .neo-dock-dragproxy.neo-tab-header-toolbar {
 // Committed pane lock is model truth; this class is its projection-only visual carrier. Outline is
 // inset from layout via a negative offset, so locking never changes geometry in any theme.
 .neo-dashboard .neo-dock-pane-locked {
-    cursor        : not-allowed;
     outline       : 1px solid color-mix(in srgb, currentColor 34%, transparent);
     outline-offset: -1px;
+}
+
+// The forbidding cursor belongs to the engine's inert default only. A pane that delegates its lock
+// presentation (`dockLock(locked)`) may stay scrollable and selectable while locked, and the DOM
+// `inert` attribute is the truthful discriminator between the two — never the class.
+.neo-dashboard .neo-dock-pane-locked[inert] {
+    cursor: not-allowed;
 }

--- a/src/dashboard/dock/Workspace.mjs
+++ b/src/dashboard/dock/Workspace.mjs
@@ -130,6 +130,15 @@ class Workspace extends Container {
          * closed in the reducer. Workspace presentation mirrors that truth by making the pane
          * inert, hiding close, and suppressing the tab drag source while preserving exact prior
          * inert and drag-token ownership for unlock. Disabled by default.
+         *
+         * The content half is delegable, exactly like reload: a pane implementing
+         * `dockLock(locked: Boolean): void` owns what locked means for its content (a form
+         * disables its fields, a grid turns cell editing off, a read-only view keeps scrolling
+         * and selecting) and receives `true` on lock and `false` on unlock, once per transition,
+         * on the in-flow card and on the revealed rail pane alike; the engine then writes no
+         * `inert` at all. The probe is a pure `typeof` on the live card, never a resolver call.
+         * The structural half — the reducer's refusals, the hidden close action, the suppressed
+         * drag source, the `neo-dock-pane-locked` frame cue — is never delegated.
          * @member {Boolean} enableDockLockAction=false
          */
         enableDockLockAction: false,
@@ -1507,6 +1516,15 @@ class Workspace extends Container {
 
     /**
      * Applies or restores one item's lock presentation without changing model state.
+     *
+     * The content half is delegable, the reload precedent: a pane implementing
+     * `dockLock(locked)` owns what locked means for its content — a form disables its fields, a
+     * grid turns cell editing off, a stream keeps scrolling — and the engine writes no `inert` for
+     * it. The probe is a pure `typeof` on the live card, never a resolver call. The hook fires
+     * once per transition, recorded in the same per-pane state as the inert snapshot, so a sweep
+     * that runs on every active-item change never re-locks a pane its author already locked.
+     * Without the hook the engine's inert default stands, byte-identical, with its exact-restore
+     * clause.
      * @param {Object} data
      * @param {Neo.tab.header.Button|null} data.button
      * @param {Boolean} data.locked
@@ -1517,35 +1535,49 @@ class Workspace extends Container {
         let me = this;
 
         if (pane && !pane.isDestroyed) {
-            let cls     = Array.isArray(pane.cls) ? [...pane.cls] : pane.cls ? [pane.cls] : [],
-                hadCls  = cls.includes('neo-dock-pane-locked'),
-                changed = false,
+            let cls       = Array.isArray(pane.cls) ? [...pane.cls] : pane.cls ? [pane.cls] : [],
+                hadCls    = cls.includes('neo-dock-pane-locked'),
+                changed   = false,
+                delegated = typeof pane.dockLock === 'function',
                 prior,
-                vdom    = pane.vdom;
+                vdom      = pane.vdom;
 
             if (locked) {
-                if (!me.dockLockPaneState.has(pane)) {
-                    me.dockLockPaneState.set(pane, {
-                        owned: Object.hasOwn(vdom, 'inert'),
-                        value: vdom.inert
-                    })
-                }
+                if (delegated) {
+                    if (!me.dockLockPaneState.has(pane)) {
+                        me.dockLockPaneState.set(pane, {delegated: true});
+                        pane.dockLock(true)
+                    }
+                } else {
+                    if (!me.dockLockPaneState.has(pane)) {
+                        me.dockLockPaneState.set(pane, {
+                            owned: Object.hasOwn(vdom, 'inert'),
+                            value: vdom.inert
+                        })
+                    }
 
-                if (vdom.inert !== true) {
-                    vdom.inert = true;
-                    changed = true
+                    if (vdom.inert !== true) {
+                        vdom.inert = true;
+                        changed = true
+                    }
                 }
             } else if (me.dockLockPaneState.has(pane)) {
                 prior = me.dockLockPaneState.get(pane);
-
-                if (prior.owned) {
-                    vdom.inert = prior.value
-                } else {
-                    delete vdom.inert
-                }
-
                 me.dockLockPaneState.delete(pane);
-                changed = true
+
+                // Reverse along the path that locked: the record decides, never the current probe,
+                // so a pane cannot be handed an unlock it never received a lock for.
+                if (prior.delegated) {
+                    pane.dockLock(false)
+                } else {
+                    if (prior.owned) {
+                        vdom.inert = prior.value
+                    } else {
+                        delete vdom.inert
+                    }
+
+                    changed = true
+                }
             }
 
             NeoArray.toggle(cls, 'neo-dock-pane-locked', locked);

--- a/test/playwright/component/apps/dock-lock/app.mjs
+++ b/test/playwright/component/apps/dock-lock/app.mjs
@@ -1,3 +1,4 @@
+import Component     from '../../../../../src/component/Base.mjs';
 import DockWorkspace from '../../../../../src/dashboard/dock/Workspace.mjs';
 import Viewport      from '../../../../../src/container/Viewport.mjs';
 import '../../../../../src/tab/Container.mjs';
@@ -6,11 +7,19 @@ const fixtureDocument = {
     schema: 'neo.dock.zone.v1',
     root  : 'root',
     items : {
-        alpha : {componentRef: 'alpha',  title: 'Alpha',  kind: 'panel'},
-        beta  : {componentRef: 'beta',   title: 'Beta',   kind: 'panel'},
-        railed: {
+        alpha    : {componentRef: 'alpha',     title: 'Alpha',     kind: 'panel'},
+        beta     : {componentRef: 'beta',      title: 'Beta',      kind: 'panel'},
+        delegated: {componentRef: 'delegated', title: 'Delegated', kind: 'panel'},
+        railed   : {
             componentRef: 'railed',
             title       : 'Railed',
+            kind        : 'panel',
+            autoHidden  : true,
+            locked      : true
+        },
+        reader: {
+            componentRef: 'reader',
+            title       : 'Reader',
             kind        : 'panel',
             autoHidden  : true,
             locked      : true
@@ -21,10 +30,70 @@ const fixtureDocument = {
             center: {nodeId: 'main-tabs'},
             right : {nodeId: 'edge-tabs', extent: 0.25}
         }},
-        'main-tabs': {type: 'tabs', items: ['alpha', 'beta'], activeItemId: 'alpha'},
-        'edge-tabs': {type: 'tabs', items: ['railed'], activeItemId: 'railed'}
+        'main-tabs': {type: 'tabs', items: ['alpha', 'beta', 'delegated'], activeItemId: 'alpha'},
+        'edge-tabs': {type: 'tabs', items: ['railed', 'reader'], activeItemId: 'railed'}
     }
 };
+
+/**
+ * @summary A pane that owns its lock presentation through `dockLock(locked)`: it disables one of its
+ * controls and leaves the other live, the read-only shape a form or grid would take.
+ */
+class DelegatingLockPane extends Component {
+    static config = {
+        /**
+         * @member {String} className='Test.Playwright.Component.DockLock.DelegatingPane'
+         * @protected
+         */
+        className: 'Test.Playwright.Component.DockLock.DelegatingPane',
+        /**
+         * @member {String[]} cls=['dock-lock-test-pane','dock-lock-delegating-pane']
+         */
+        cls: ['dock-lock-test-pane', 'dock-lock-delegating-pane']
+    }
+
+    /**
+     * Spec-readable log of every value the engine handed to the hook, in order.
+     * @member {Boolean[]} lockCalls=[]
+     */
+    lockCalls = []
+
+    /**
+     * Child ids derive from the pane id, so the in-flow and the rail-revealed instance never collide.
+     * @param {Object} config
+     */
+    construct(config) {
+        super.construct(config);
+
+        const me = this;
+
+        me.vdom.cn = [
+            {tag: 'button', id: `${me.id}-control`, text: 'Delegated control'},
+            {tag: 'button', id: `${me.id}-keep`,    text: 'Stays live'}
+        ]
+    }
+
+    /**
+     * The engine's lock delegation contract: `true` on lock, `false` on unlock, once per transition.
+     * @param {Boolean} locked
+     */
+    dockLock(locked) {
+        const me      = this,
+              control = me.vdom.cn[0];
+
+        me.lockCalls.push(locked);
+
+        if (locked) {
+            control.disabled = true
+        } else {
+            delete control.disabled
+        }
+
+        me.update()
+    }
+}
+
+DelegatingLockPane = Neo.setupClass(DelegatingLockPane);
 
 /**
  * @summary Rendered-browser fixture for committed dock lock, inert restoration, source suppression,
@@ -144,12 +213,27 @@ class LockFixtureWorkspace extends DockWorkspace {
     }
 
     /**
-     * @summary Resolves one test pane. Beta deliberately owns inert before dock lock touches it.
+     * @summary Resolves one test pane. Beta deliberately owns inert before dock lock touches it;
+     * delegated (in flow) and reader (on the rail) implement the `dockLock(locked)` hook.
      * @param {String} itemId
      * @param {Object} item
      * @returns {Object}
      */
     resolvePane(itemId, item) {
+        const style = {
+            alignItems    : 'center',
+            display       : 'flex',
+            justifyContent: 'center'
+        };
+
+        if (itemId === 'delegated' || itemId === 'reader') {
+            return {
+                module: DelegatingLockPane,
+                id    : `dock-lock-pane-${itemId}`,
+                style
+            }
+        }
+
         const vdom = {
             cn: [{
                 tag : 'button',
@@ -164,11 +248,7 @@ class LockFixtureWorkspace extends DockWorkspace {
             cls  : ['dock-lock-test-pane'],
             id   : `dock-lock-pane-${itemId}`,
             ntype: 'component',
-            style: {
-                alignItems    : 'center',
-                display       : 'flex',
-                justifyContent: 'center'
-            },
+            style,
             vdom
         }
     }

--- a/test/playwright/component/dashboard/DockLock.spec.mjs
+++ b/test/playwright/component/dashboard/DockLock.spec.mjs
@@ -231,5 +231,105 @@ test.describe('dock lock — committed boundary plus reversible presentation', (
 
         // The pane is the registered holder of its id — a zombie would have no worker instance.
         expect((await readConfigs(page, 'dock-lock-pane-railed', ['mounted']))?.[0]).toBe(true)
+    });
+
+    /**
+     * The content half of lock is delegable: a pane implementing `dockLock(locked)` decides what
+     * locked means for its content, the engine writes no `inert`, and the forbidding cursor stays
+     * with the inert default. The structural half — hidden close, suppressed drag source, the frame
+     * cue — is never delegated.
+     */
+    test('a pane implementing dockLock owns its content presentation without inert', async ({page}) => {
+        const main    = tabsNodeWith(page, 'Alpha'),
+              pane    = page.locator('#dock-lock-pane-delegated'),
+              control = page.locator('#dock-lock-pane-delegated-control'),
+              keep    = page.locator('#dock-lock-pane-delegated-keep'),
+              cursor  = locator => locator.evaluate(node => getComputedStyle(node).cursor),
+              calls   = async () => (await readConfigs(page, 'dock-lock-pane-delegated', ['lockCalls']))[0];
+
+        await tabButton(main, 'Delegated').click();
+        await awaitRefresh(page);
+        await expect(control).toBeEnabled();
+
+        await actionButton(main, 'fa-lock').click();
+        await awaitRefresh(page);
+
+        await expect(pane).toHaveClass(/neo-dock-pane-locked/);
+        await expect(pane).toHaveCSS('outline-style', 'solid');
+        await expect(control, 'the pane disabled the control it chose to').toBeDisabled();
+        expect(await pane.evaluate(node => node.inert), 'the engine wrote no inert').toBe(false);
+        expect(await readInertOwnership(page, 'dock-lock-pane-delegated')).toEqual({owned: false, value: undefined});
+        expect(await cursor(pane), 'the forbidding cursor belongs to the inert default').not.toBe('not-allowed');
+
+        await page.evaluate(() => {
+            window.__dockLockKeepClicks = 0;
+            document.getElementById('dock-lock-pane-delegated-keep')
+                .addEventListener('click', () => window.__dockLockKeepClicks++)
+        });
+        await keep.click();
+        expect(await page.evaluate(() => window.__dockLockKeepClicks), 'what the pane left live stays live').toBe(1);
+
+        await expect(tabButton(main, 'Delegated'), 'the drag source is still the engine\'s').not.toHaveClass(/neo-draggable/);
+        await expect(actionButton(main, 'fa-times'), 'and so is the hidden close').toBeHidden();
+
+        // The sweep runs on every active-item change; the hook must not.
+        await tabButton(main, 'Alpha').click();
+        await awaitRefresh(page);
+        await tabButton(main, 'Delegated').click();
+        await awaitRefresh(page);
+        expect(await calls(), 'once per transition').toEqual([true]);
+
+        await actionButton(main, 'fa-lock-open').click();
+        await awaitRefresh(page);
+
+        await expect(control).toBeEnabled();
+        await expect(pane).not.toHaveClass(/neo-dock-pane-locked/);
+        expect(await calls()).toEqual([true, false]);
+        expect(await readInertOwnership(page, 'dock-lock-pane-delegated')).toEqual({owned: false, value: undefined});
+
+        // Contrast on the same page: a pane without the hook keeps the inert default and its cursor.
+        await tabButton(main, 'Alpha').click();
+        await awaitRefresh(page);
+        await actionButton(main, 'fa-lock').click();
+        await awaitRefresh(page);
+
+        expect(await page.locator('#dock-lock-pane-alpha').evaluate(node => node.inert)).toBe(true);
+        expect(await cursor(page.locator('#dock-lock-pane-alpha'))).toBe('not-allowed')
+    });
+
+    /**
+     * The revealed rail pane resolves the hook through the same presentation seam as the in-flow
+     * card. The workspace here takes the reconciler's default full staged transaction on every
+     * commit, rails included, so a committed unlock re-materializes the reveal pane instead of
+     * restoring it: a fresh pane is never asked. The same-instance reversal on a retained overlay is
+     * the unit spec's rail-callback witness.
+     */
+    test('a delegating reveal pane receives the committed lock on the rail, never inert', async ({page}) => {
+        const railTab = page.locator('.neo-dashboard-dock-edge-rail').getByText('Reader'),
+              overlay = page.locator(
+                  '.neo-dashboard-dock-reveal-overlay:not(.neo-dashboard-dock-reveal-overlay-hidden)'
+              ),
+              pane    = page.locator('#dock-lock-pane-reader'),
+              control = page.locator('#dock-lock-pane-reader-control'),
+              calls   = async () => (await readConfigs(page, 'dock-lock-pane-reader', ['lockCalls']))[0];
+
+        await railTab.click();
+        await expect(overlay).toHaveCount(1);
+        await expect(pane).toHaveClass(/neo-dock-pane-locked/);
+        await expect(control, 'the reveal pane was asked, not made inert').toBeDisabled();
+        expect(await pane.evaluate(node => node.inert)).toBe(false);
+        expect(await calls()).toEqual([true]);
+
+        await setWorkspace(page, {
+            operationJson: JSON.stringify({operation: 'setItemLocked', itemId: 'reader', locked: false, attempt: 4})
+        });
+        await awaitRefresh(page);
+
+        await railTab.click();
+        await expect(overlay).toHaveCount(1);
+        await expect(pane).not.toHaveClass(/neo-dock-pane-locked/);
+        await expect(control).toBeEnabled();
+        expect(await calls(), 'the re-materialized pane was never locked, so it is never asked').toEqual([]);
+        expect(await readInertOwnership(page, 'dock-lock-pane-reader')).toEqual({owned: false, value: undefined})
     })
 });

--- a/test/playwright/unit/dashboard/DockLockAction.spec.mjs
+++ b/test/playwright/unit/dashboard/DockLockAction.spec.mjs
@@ -9,6 +9,7 @@ setup({
 import {test, expect} from '@playwright/test';
 import Neo            from '../../../../src/Neo.mjs';
 import * as core      from '../../../../src/core/_export.mjs';
+import Component      from '../../../../src/component/Base.mjs';
 import DockWorkspace  from '../../../../src/dashboard/dock/Workspace.mjs';
 import LayoutAdapter  from '../../../../src/dashboard/dock/projection/LayoutAdapter.mjs';
 import Reconciler     from '../../../../src/dashboard/dock/projection/Reconciler.mjs';
@@ -49,6 +50,53 @@ class LockWorkspace extends DockWorkspace {
 }
 
 LockWorkspace = Neo.setupClass(LockWorkspace);
+
+/**
+ * @summary A pane that owns its lock presentation through the `dockLock(locked)` contract.
+ */
+class DelegatingPane extends Component {
+    static config = {
+        className: 'Test.Unit.Dashboard.DockLockAction.DelegatingPane'
+    }
+
+    /**
+     * Every value the engine handed to the hook, in order.
+     * @member {Boolean[]} lockCalls=[]
+     */
+    lockCalls = []
+
+    /**
+     * @param {Boolean} locked
+     */
+    dockLock(locked) {
+        this.lockCalls.push(locked)
+    }
+}
+
+DelegatingPane = Neo.setupClass(DelegatingPane);
+
+/**
+ * @summary Workspace fixture whose alpha pane delegates its lock presentation while beta keeps the
+ * engine's inert default.
+ */
+class DelegatingLockWorkspace extends LockWorkspace {
+    static config = {
+        className: 'Test.Unit.Dashboard.DockLockAction.DelegatingWorkspace'
+    }
+
+    /**
+     * @param {String} itemId
+     * @param {Object} item
+     * @returns {Object}
+     */
+    resolvePane(itemId, item) {
+        return itemId === 'alpha' || itemId === 'reader'
+            ? {module: DelegatingPane}
+            : super.resolvePane(itemId, item)
+    }
+}
+
+DelegatingLockWorkspace = Neo.setupClass(DelegatingLockWorkspace);
 
 /**
  * @summary Returns the first projected tabs config from a projection tree.
@@ -286,5 +334,139 @@ test.describe('Neo.dashboard.dock.Workspace lock action', () => {
         workspace.handleDockLockAction({dockNodeId: 'main-tabs', tabContainer});
 
         expect(Object.hasOwn(pane.vdom, 'inert')).toBe(false)
+    });
+
+    test('a pane implementing dockLock receives each transition once and never gains inert', () => {
+        workspace = Neo.create(DelegatingLockWorkspace, {
+            dockModel            : createDocument(),
+            enableDockCloseAction: true,
+            enableDockLockAction : true
+        });
+
+        const tabContainer = Reconciler.collectProjectedTabs(workspace.items[0]).get('main-tabs'),
+              pane         = tabContainer.getActiveCard(),
+              beta         = tabContainer.getCardContainer().items[1],
+              tabButton    = tabContainer.getTabButtons()[0],
+              closeAction  = tabContainer.getActionItem('close');
+
+        expect(pane.lockCalls, 'the fixture pane carries the hook').toEqual([]);
+        expect(typeof beta.dockLock, 'and its sibling does not').toBe('undefined');
+
+        tabButton.addWrapperCls('neo-draggable');
+
+        const locked = workspace.handleDockLockAction({dockNodeId: 'main-tabs', tabContainer});
+
+        expect(locked.errors).toEqual([]);
+        expect(pane.lockCalls).toEqual([true]);
+        expect(Object.hasOwn(pane.vdom, 'inert'), 'the engine wrote no inert').toBe(false);
+        expect(pane.cls).toContain('neo-dock-pane-locked');
+        expect(tabButton.wrapperCls, 'the structural half is never delegated').not.toContain('neo-draggable');
+        expect(closeAction.hidden).toBe(true);
+
+        // The sweep runs on every active-item change and every settle; the hook must not.
+        workspace.syncDockHeaderActions();
+        workspace.syncDockHeaderActions();
+
+        expect(pane.lockCalls, 'once per transition').toEqual([true]);
+        expect(Object.hasOwn(pane.vdom, 'inert')).toBe(false);
+
+        const unlocked = workspace.handleDockLockAction({dockNodeId: 'main-tabs', tabContainer});
+
+        expect(unlocked.errors).toEqual([]);
+        expect(pane.lockCalls).toEqual([true, false]);
+        expect(Object.hasOwn(pane.vdom, 'inert')).toBe(false);
+        expect(pane.cls).not.toContain('neo-dock-pane-locked');
+        expect(tabButton.wrapperCls).toContain('neo-draggable');
+        expect(closeAction.hidden).toBe(false);
+
+        workspace.syncDockHeaderActions();
+
+        expect(pane.lockCalls, 'unlock is a transition too, once').toEqual([true, false]);
+
+        // The same sweep keeps the inert default, exact restore included, for the sibling.
+        workspace.syncDockLockItemPresentation({locked: true, pane: beta});
+
+        expect(beta.vdom.inert).toBe(true);
+        expect(beta.cls).toContain('neo-dock-pane-locked');
+
+        workspace.syncDockLockItemPresentation({locked: false, pane: beta});
+
+        expect(Object.hasOwn(beta.vdom, 'inert')).toBe(false);
+        expect(beta.cls).not.toContain('neo-dock-pane-locked')
+    });
+
+    test('a committed lock reaches a delegating pane from the fresh projected shell', () => {
+        const document = createDocument();
+
+        document.items.alpha.locked = true;
+        workspace = Neo.create(DelegatingLockWorkspace, {
+            dockModel           : document,
+            enableDockLockAction: true
+        });
+
+        const tabContainer = Reconciler.collectProjectedTabs(workspace.items[0]).get('main-tabs'),
+              pane         = tabContainer.getActiveCard();
+
+        expect(pane.lockCalls).toEqual([]);
+
+        workspace.syncDockHeaderActions();
+
+        expect(pane.lockCalls).toEqual([true]);
+        expect(Object.hasOwn(pane.vdom, 'inert')).toBe(false);
+        expect(pane.cls).toContain('neo-dock-pane-locked')
+    });
+
+    /**
+     * The rail hands its materialized reveal pane to the workspace-owned callback on first
+     * materialization and again whenever the same revealed identity is synchronized. Driving that
+     * callback directly is the reveal-side witness for both transitions on one instance.
+     */
+    test('the rail callback delivers both transitions to a delegating reveal pane', () => {
+        const document = {
+            schema: 'neo.dock.zone.v1',
+            root  : 'root',
+            items : {
+                alpha : {componentRef: 'alpha',  title: 'Alpha',  kind: 'panel'},
+                reader: {componentRef: 'reader', title: 'Reader', kind: 'panel', autoHidden: true, locked: true}
+            },
+            nodes: {
+                root       : {type: 'edge-zone', zones: {center: {nodeId: 'main-tabs'}, right: {nodeId: 'edge-tabs'}}},
+                'main-tabs': {type: 'tabs', items: ['alpha'],  activeItemId: 'alpha'},
+                'edge-tabs': {type: 'tabs', items: ['reader'], activeItemId: 'reader'}
+            }
+        };
+
+        workspace = Neo.create(DelegatingLockWorkspace, {
+            dockModel           : document,
+            enableDockLockAction: true
+        });
+
+        let rail = null;
+
+        workspace.forEachDockRail(candidate => rail = candidate);
+
+        expect(rail, 'the auto-hidden item projected its rail').toBeTruthy();
+        expect(typeof rail.syncDockLockPane).toBe('function');
+
+        const pane = Neo.create(DelegatingPane);
+
+        rail.syncDockLockPane(pane, 'reader');
+
+        expect(pane.lockCalls).toEqual([true]);
+        expect(Object.hasOwn(pane.vdom, 'inert')).toBe(false);
+        expect(pane.cls).toContain('neo-dock-pane-locked');
+
+        rail.syncDockLockPane(pane, 'reader');
+
+        expect(pane.lockCalls, 'a re-synchronized identity is not re-locked').toEqual([true]);
+
+        workspace.dockModel.items.reader.locked = false;
+        rail.syncDockLockPane(pane, 'reader');
+
+        expect(pane.lockCalls).toEqual([true, false]);
+        expect(Object.hasOwn(pane.vdom, 'inert')).toBe(false);
+        expect(pane.cls).not.toContain('neo-dock-pane-locked');
+
+        pane.destroy()
     })
 });


### PR DESCRIPTION
Resolves #18044

The content half of dock lock is now delegable, the way reload already is. A pane implementing `dockLock(locked)` owns what locked means for its content: `Workspace#syncDockLockItemPresentation` probes the hook with a pure `typeof` on the live card, calls it with `true` on lock and `false` on unlock, once per transition, and writes no `inert` at all. The transition is recorded in the same per-pane state as the inert snapshot, so the sweep that runs on every active-item change and every settle never re-locks a pane its author already locked, and unlock reverses along the path that locked. Without the hook the inert default and its exact restore stand unchanged. The forbidding cursor moves onto `.neo-dock-pane-locked[inert]`, so a delegated read-only pane keeps the frame cue with a normal cursor. Both surfaces resolve the hook through the one seam: the in-flow card and the rail's reveal pane.

Evidence: L3 (unit and rendered component witnesses in CI cover every AC; the cursor discrimination is read from computed style in Chromium) → L3 required (AC-1…AC-6). Residual: none.

Micro-review eligible: no — a new pane-facing contract on the lock seam.

## AC Evidence
| AC-1 | CI-covered: `test/playwright/unit/dashboard/DockLockAction.spec.mjs` › "a pane implementing dockLock receives each transition once and never gains inert" (the in-flow card through `handleDockLockAction`) and › "the rail callback delivers both transitions to a delegating reveal pane" (the rail's `syncDockLockPane` callback on one instance: lock, re-sync, unlock); `test/playwright/component/dashboard/DockLock.spec.mjs` › "a pane implementing dockLock owns its content presentation without inert" and › "a delegating reveal pane receives the committed lock on the rail, never inert" |
| AC-2 | CI-covered: the #17949 witnesses unchanged and green — unit › "locks and unlocks the real pane, action, close affordance, and tab drag source", › "restores absent inert ownership and fails closed for lockable false", › "an empty retained-tabs map falls back to the fresh projected shell"; component › "inert blocks pointer and keyboard, then unlock restores absent and owned inert exactly"; plus the sibling arm of the delegation unit test (beta: `inert` true while locked, ownership absent after) |
| AC-3 | CI-covered: both delegation tests assert the drag token removed and close hidden while locked; the reducer refusals live in `DockZoneModel.spec.mjs`, untouched |
| AC-4 | CI-covered: component › the delegated pane locked reads `outline-style: solid`, `inert` false and a computed cursor that is not `not-allowed`; on the same page the inert pane locked reads `inert` true and `not-allowed` |
| AC-5 | CI-covered + diff: `delegated = typeof pane.dockLock === 'function'` on the live card, no resolver call; the prototype half is dropped, see Deltas |
| AC-6 | diff: the `enableDockLockAction` JSDoc carries the `dockLock(locked: Boolean): void` contract next to the reload wording; the `syncDockLockItemPresentation` JSDoc explains the once-per-transition record |

## Deltas from ticket
- The probe reads only the live card. The ticket named the config module's prototype as well, mirroring reload; that half is dead in the lock seam and I left it out. `Container#createItems` instantiates every `module` class up front (`lazyLoadItem` is true only for a dynamic-import function, whose `prototype.dockLock` is undefined anyway), and `layout.Card`'s `removeInactiveCards` un-mounts instances rather than reverting them to configs, so `getCardContainer().items` never holds a config whose prototype could carry a hook.
- Reverse follows the record, not the current probe: unlock consults the per-pane entry (`{delegated: true}` against the inert snapshot), so a pane is never handed an unlock it never received a lock for, and the inert path's exact restore is untouched.
- The rendered rail witness covers materialization only. This fixture takes the reconciler's default full staged transaction on every commit (`getReconcileOptions` returns `{}`), rails included, so a committed unlock re-materializes the reveal pane and a fresh pane is never asked. The same-instance reversal on a retained overlay is the unit rail-callback arm: `rail.syncDockLockPane` is the function `Rail#syncRevealPane` calls on first materialization and on every re-sync of the same identity.
- The component fixture's delegating pane derives its child ids from the pane id, so the in-flow and the rail instance of the same class never collide.

## Test Evidence
All coverage runs in CI.

## Post-Merge Validation
- [ ] none beyond CI — the `[inert]` cursor rule ships with the next theme build

Authored by Mnemosyne (Claude Fable 5.1, Claude Code). Session 6197a12f-acf2-478a-b05d-4ece32474259. 🪢
