### PR TITLE
fix(dock): the native drop anchors on the popup's corner and reads the full zone grammar (#18056)

### DIFF
--- a/apps/workstation/view/Workspace.mjs
+++ b/apps/workstation/view/Workspace.mjs
@@ -314,6 +314,15 @@ class Workspace extends DockWorkspace {
      * @protected
      */
     crossWindowPreviewGeometries = new Map()
+
+    /**
+     * The main window's inner-rect signature at the last remote frame. A change mid-gesture means
+     * the main window was resized under a hovering popup, so the affordance geometry is re-measured
+     * (see {@link #renderMainCrossWindowPreview}). Reset when the main preview clears.
+     * @member {String|null} mainPreviewWindowSignature=null
+     * @protected
+     */
+    mainPreviewWindowSignature = null
     /**
      * Worker-owned vessel workspace records keyed by stable workspace identity. Entries carry
      * document ownership and render-target refs, never cached geometry.
@@ -1366,8 +1375,10 @@ class Workspace extends DockWorkspace {
 
     /**
      * Resolves the render host, exact semantic target component, and preview renderer for one
-     * cross-window workspace. A bare vessel has no projected tabs component yet, so its main view
-     * is the exact landing surface; projected main-workspace nodes always resolve by `dockNodeId`.
+     * VESSEL workspace. A bare vessel has no projected tabs component yet, so its main view is the
+     * exact landing surface; a projected vessel node resolves by `dockNodeId`. The main workspace
+     * does not come through here — it rides the affordance controller's own geometry
+     * ({@link #renderMainCrossWindowPreview}).
      * @summary Keeps semantic node identity paired with its actual rendered component.
      * @param {String} workspaceId
      * @param {String} targetNodeId
@@ -1377,12 +1388,11 @@ class Workspace extends DockWorkspace {
      */
     resolveCrossWindowPreviewSurface(workspaceId, targetNodeId) {
         let me       = this,
-            isMain   = workspaceId === Workspace.MAIN_WORKSPACE_ID,
-            state    = isMain ? null : me.vesselWorkspaces.get(workspaceId),
-            windowId = isMain ? me.windowId : state?.windowId,
-            host     = isMain ? me.dragAffordances?.host : state?.host ?? state?.app?.mainView,
+            state    = me.vesselWorkspaces.get(workspaceId),
+            windowId = state?.windowId,
+            host     = state?.host ?? state?.app?.mainView,
             target   = state && !state.host ? host : host?.down({dockNodeId: targetNodeId}),
-            renderer = isMain ? me.dragAffordances?.preview : state?.preview;
+            renderer = state?.preview;
 
         return windowId != null && host && target && renderer &&
             typeof host.getDomRect === 'function' && !host.isDestroyed && !target.isDestroyed
@@ -1474,9 +1484,10 @@ class Workspace extends DockWorkspace {
     }
 
     /**
-     * Computes and renders one remote preview from an exact live target-node measurement. A vessel
-     * uses its stable lazy landing surface; the main workspace returns a stack to its captured
-     * semantic home. A missing or in-flight measurement hides the preview for that frame.
+     * Computes and renders one remote preview. The main workspace resolves it the way an in-window
+     * gesture does ({@link #renderMainCrossWindowPreview}); a vessel uses its stable lazy landing
+     * surface from an exact live measurement. A missing or in-flight measurement hides the preview
+     * for that frame.
      * @param {String} workspaceId
      * @param {Object} data
      * @returns {Object|null}
@@ -1502,8 +1513,9 @@ class Workspace extends DockWorkspace {
                 : Workspace.vesselTabsNodeId(state?.itemId),
             pointer         = {x: data?.localX, y: data?.localY},
             renderer        = isMain ? me.dragAffordances?.preview : state?.preview,
-            indicators      = isMain ? null : state?.indicators,
+            indicators      = state?.indicators,
             producer        = me.dragAffordances.producer,
+            sourceNodeId    = data?.sourceNodeId,
             preview;
 
         if (
@@ -1513,6 +1525,10 @@ class Workspace extends DockWorkspace {
             renderer && (renderer.dockPreview = null);
             indicators?.clear();
             return null
+        }
+
+        if (isMain) {
+            return me.renderMainCrossWindowPreview({groupNodeId, itemId, pointer, renderer, sourceNodeId, targetNodeId})
         }
 
         me.ensureCrossWindowPreviewGeometry(workspaceId, targetNodeId);
@@ -1526,61 +1542,107 @@ class Workspace extends DockWorkspace {
             return null
         }
 
-        const
-            zone           = {nodeId: targetNodeId, rect: geometry.targetRect},
-            previewPointer = isMain
-                ? pointer
-                : {
-                    x: geometry.targetRect.x + geometry.targetRect.width / 2,
-                    y: geometry.targetRect.y + geometry.targetRect.height / 2
-                };
+        const zone = {nodeId: targetNodeId, rect: geometry.targetRect};
 
         if (indicators) {
             indicators.hostRect = geometry.hostRect;
             indicators.candidateSet = producer.produceCandidates({
-                containerId : geometry.host.id,
+                containerId: geometry.host.id,
                 groupNodeId,
                 itemId,
                 pointer,
-                root        : zone,
-                sourceNodeId: data?.sourceNodeId,
-                zones       : [zone]
+                root       : zone,
+                sourceNodeId,
+                zones      : [zone]
             });
             preview = indicators.updatePointer(pointer)?.preview ?? null
         }
 
+        // A vessel has one landing surface — the pane joins its stack — so the pointer-inference
+        // preview binds the zone's centre (the whole-zone tab-into) wherever inside the vessel the
+        // pointer is; only a hovered indicator chip above selects anything else.
         preview ??= producer.produce({
-            containerId : geometry.host.id,
+            containerId: geometry.host.id,
             groupNodeId,
             itemId,
-            pointer     : previewPointer,
-            sourceNodeId: data?.sourceNodeId,
-            zones       : [zone]
+            pointer    : {
+                x: geometry.targetRect.x + geometry.targetRect.width  / 2,
+                y: geometry.targetRect.y + geometry.targetRect.height / 2
+            },
+            sourceNodeId,
+            zones      : [zone]
         });
-
-        // Stored-home acquisition fallback: the window hit-test above already admitted the
-        // gesture, so a pointer that lands inside the window but outside every exact zone
-        // still acquires the stored-home semantic target — the preview (and its painting)
-        // binds the exact node rect, never the pointer's empty position. Real on-zone drags
-        // keep the full placement grammar (splits included); only the off-zone position
-        // resolves to the stored-home tab-into.
-        if (!preview && isMain) {
-            preview = producer.produce({
-                containerId: geometry.host.id,
-                groupNodeId,
-                itemId,
-                pointer    : {
-                    x: geometry.targetRect.x + geometry.targetRect.width  / 2,
-                    y: geometry.targetRect.y + geometry.targetRect.height / 2
-                },
-                sourceNodeId: data?.sourceNodeId,
-                zones       : [zone]
-            });
-        }
 
         if (geometry.renderer) {
             geometry.renderer.dockPreview = preview;
             preview && geometry.renderer.applyTargetGeometry(geometry.localTargetRect)
+        }
+
+        return preview
+    }
+
+    /**
+     * The main workspace's remote frame: the SAME once-per-gesture geometry and tier order the
+     * in-window gesture uses ({@link Neo.dashboard.dock.interaction.DragAffordances#resolvePreview} —
+     * every projected tabs zone, an indicator candidate first, pointer inference second), so a
+     * popup or remote pointer reads the full placement grammar wherever it points and the drop
+     * lands there. The measurement is warmed here and read synchronously — a frame before it
+     * settles hides the preview rather than guessing — and re-measured when the main window's
+     * rect changes mid-gesture, which a remote gesture can outlive and a pointer drag cannot.
+     * @param {Object} data
+     * @param {String|null} data.groupNodeId
+     * @param {String} data.itemId
+     * @param {Object} data.pointer {x, y} in main-window client space
+     * @param {Neo.dashboard.dock.interaction.Preview|null} data.renderer
+     * @param {String} [data.sourceNodeId]
+     * @param {String} data.targetNodeId the stored-home tabs node — the off-zone fallback target
+     * @returns {Object|null}
+     * @protected
+     */
+    renderMainCrossWindowPreview({groupNodeId, itemId, pointer, renderer, sourceNodeId, targetNodeId}) {
+        let me          = this,
+            affordances = me.dragAffordances,
+            inner       = Neo.manager?.Window?.get(me.windowId)?.innerRect,
+            signature   = inner ? [inner.x ?? 0, inner.y ?? 0, inner.width, inner.height].join(':') : null,
+            preview, targetRect;
+
+        if (me.mainPreviewWindowSignature && me.mainPreviewWindowSignature !== signature) {
+            affordances.invalidateGeometry()
+        }
+
+        me.mainPreviewWindowSignature = signature;
+        affordances.ensureGeometry();
+
+        const {geometry} = affordances;
+
+        if (!geometry) {
+            renderer && (renderer.dockPreview = null);
+            return null
+        }
+
+        preview = affordances.resolvePreview({groupNodeId, itemId, pointer, sourceNodeId});
+
+        // Stored-home acquisition fallback: the window hit-test already admitted the gesture, so a
+        // pointer inside the window but outside every zone still acquires the stored-home target —
+        // the preview (and its painting) binds that exact node rect, never the pointer's empty
+        // position. On-zone positions keep the full placement grammar resolved above.
+        if (!preview) {
+            const home = geometry.zones.find(zone => zone.nodeId === targetNodeId);
+
+            preview = home ? affordances.producer.produce({
+                groupNodeId,
+                itemId,
+                pointer: {x: home.rect.x + home.rect.width / 2, y: home.rect.y + home.rect.height / 2},
+                sourceNodeId,
+                zones  : [home]
+            }) : null
+        }
+
+        targetRect = affordances.previewTargetRect(preview);
+
+        if (renderer) {
+            renderer.dockPreview = preview;
+            preview && targetRect && renderer.applyTargetGeometry(affordances.localRect(targetRect, geometry.hostRect))
         }
 
         return preview
@@ -1595,6 +1657,7 @@ class Workspace extends DockWorkspace {
         this.crossWindowPreviewGeometries.delete(workspaceId);
 
         if (workspaceId === Workspace.MAIN_WORKSPACE_ID) {
+            this.mainPreviewWindowSignature = null;
             this.dragAffordances?.clear()
         } else {
             let state   = this.vesselWorkspaces.get(workspaceId),

--- a/src/container/Base.mjs
+++ b/src/container/Base.mjs
@@ -253,7 +253,9 @@ class Container extends Component {
     }
 
     /**
-     * Triggered after the dragResortable config got changed
+     * Triggered after the dragResortable config got changed. The hook awaits the sort-zone module,
+     * so a container created and destroyed inside that await (a short-lived projection, a unit
+     * harness tearing down) resumes here with no parent left: a destroyed container creates no zone.
      * @param {Boolean} value
      * @param {Boolean} oldValue
      * @protected
@@ -272,6 +274,10 @@ class Container extends Component {
             } else {
                 module = await me.trap(me.loadSortZoneModule());
                 module = module.default
+            }
+
+            if (me.isDestroyed || me.sortZone) {
+                return
             }
 
             me.createSortZone(Neo.merge({
@@ -636,9 +642,9 @@ class Container extends Component {
      * @returns {Neo.component.Base|Neo.component.Base[]}
      */
     insert(index, item, silent=false, removeFromPreviousParent=true) {
-        let me          = this,
-            {items}     = me,
-            lca         = null,
+        let me      = this,
+            {items} = me,
+            lca     = null,
             i, itemParent, itemType, len, oldParent, parentsA, parentsB, returnArray;
 
         if (Array.isArray(item)) {

--- a/src/dashboard/dock/interaction/DragAffordances.mjs
+++ b/src/dashboard/dock/interaction/DragAffordances.mjs
@@ -49,6 +49,15 @@ class DragAffordances extends Base {
     dragGeometry = null
 
     /**
+     * The settled geometry of the live gesture — the synchronous mirror of {@link #dragGeometry},
+     * null until that promise resolves and again after {@link #invalidateGeometry}. A remote frame
+     * (the cross-window participation path) must resolve its preview on the frame it arrives and
+     * writes the renderer itself, so it reads this instead of awaiting.
+     * @member {Object|null} geometry=null
+     */
+    geometry = null
+
+    /**
      * The dock host container (the overlays' coordinate origin and the zone-measure root).
      * Assigned by the consumer after composition.
      * @member {Neo.container.Base|null} host=null
@@ -95,7 +104,7 @@ class DragAffordances extends Base {
     clear() {
         let me = this;
 
-        me.dragGeometry = null;
+        me.invalidateGeometry();
         me.indicators?.clear();
         me.preview && (me.preview.dockPreview = null)
     }
@@ -130,7 +139,7 @@ class DragAffordances extends Base {
                 ? (Document.getZoneNodeId(nodes[me.owner.dockModel.root].zones?.center) ?? me.owner.dockModel.root)
                 : me.owner.dockModel.root;
 
-        me.dragGeometry = host.getDomRect([host.id, ...zoneEntries.map(zone => zone.container.id)]).then(([hostRect, ...zoneRects]) => {
+        const promise = host.getDomRect([host.id, ...zoneEntries.map(zone => zone.container.id)]).then(([hostRect, ...zoneRects]) => {
             let geometry = hostRect?.width > 0 && hostRect?.height > 0 && {
                 hostRect,
                 root : {nodeId: rootId, rect: hostRect},
@@ -149,17 +158,31 @@ class DragAffordances extends Base {
             // A gesture's FIRST move can outrace measurability (fresh mount, mid-layout —
             // missing OR zero-area rects): a degenerate result must not latch for the whole
             // gesture — uncache so the next move frame re-measures and the session self-heals.
+            // A superseded generation (cleared or invalidated while in flight) touches nothing.
             if (!geometry || geometry.zones.length < 1) {
-                me.dragGeometry = null;
+                me.dragGeometry === promise && (me.dragGeometry = null);
                 return null
             }
 
-            me.indicators && (me.indicators.hostRect = geometry.hostRect);
+            if (me.dragGeometry === promise) {
+                me.geometry = geometry;
+                me.indicators && (me.indicators.hostRect = geometry.hostRect)
+            }
 
             return geometry
         });
 
-        return me.dragGeometry
+        return me.dragGeometry = promise
+    }
+
+    /**
+     * Drops the memoized geometry without ending the session: the next frame re-measures while the
+     * indicator menu and the renderer keep their current paint until it lands. A pointer drag cannot
+     * outlive a resize of its own window, but a remote (cross-window) gesture can — its consumer
+     * calls this when the host window's rect changes mid-gesture.
+     */
+    invalidateGeometry() {
+        this.dragGeometry = this.geometry = null
     }
 
     /**
@@ -172,6 +195,48 @@ class DragAffordances extends Base {
      */
     localRect(rect, hostRect) {
         return {x: rect.x - hostRect.x, y: rect.y - hostRect.y, width: rect.width, height: rect.height}
+    }
+
+    /**
+     * The measured rect a preview paints against: the host rect for a root-edge placement, the
+     * target zone's rect otherwise; null before the geometry settles or for an unmeasured target.
+     * @param {Object|null} preview a dockPreview
+     * @returns {Object|null} viewport-space {x, y, width, height}
+     */
+    previewTargetRect(preview) {
+        let {geometry} = this,
+            nodeId     = preview?.target?.nodeId;
+
+        if (!geometry || !nodeId) return null;
+
+        return nodeId === geometry.root.nodeId
+            ? geometry.root.rect
+            : geometry.zones.find(zone => zone.nodeId === nodeId)?.rect ?? null
+    }
+
+    /**
+     * Resolves the preview one pointer selects from the SETTLED geometry, in the §06 tier order — a
+     * hovered indicator's candidate first, pointer inference over every zone second — without
+     * touching the renderer. {@link #onDragMove} is the async, renderer-writing form of the same
+     * decision; the cross-window participation path calls this synchronously per remote frame
+     * because it owns the renderer write, and supplies its own fallback for a null.
+     * @param {Object} data
+     * @param {String} data.itemId
+     * @param {Object} data.pointer {x, y} in the host window's client space
+     * @param {String|null} [data.groupNodeId=null]
+     * @param {String} [data.sourceNodeId]
+     * @returns {Object|null} the dockPreview, or null before the geometry settles or when nothing is under the pointer
+     */
+    resolvePreview({groupNodeId = null, itemId, pointer, sourceNodeId}) {
+        let me         = this,
+            {geometry} = me,
+            candidate  = geometry ? me.indicators?.hitTest(pointer) : null;
+
+        if (!geometry) return null;
+
+        if (candidate?.preview?.itemId === itemId) return candidate.preview;
+
+        return me.producer.produce({groupNodeId, itemId, pointer, root: geometry.root, sourceNodeId, zones: geometry.zones})
     }
 
     /**
@@ -226,13 +291,9 @@ class DragAffordances extends Base {
         if (preview && writeRenderer) {
             preview.dockPreview = dockPreview;
 
-            if (dockPreview) {
-                let targetRect = dockPreview.target.nodeId === geometry.root.nodeId
-                    ? geometry.root.rect
-                    : geometry.zones.find(entry => entry.nodeId === dockPreview.target.nodeId)?.rect;
+            let targetRect = me.previewTargetRect(dockPreview);
 
-                targetRect && preview.applyTargetGeometry(me.localRect(targetRect, geometry.hostRect))
-            }
+            targetRect && preview.applyTargetGeometry(me.localRect(targetRect, geometry.hostRect))
         }
     }
 

--- a/src/manager/DragCoordinator.mjs
+++ b/src/manager/DragCoordinator.mjs
@@ -51,6 +51,18 @@ class DragCoordinator extends Manager {
          */
         nativeWindowParkRetryLimit: 6,
         /**
+         * Inset, in px, from the moving popup's outer top-left corner to the point that is
+         * hit-tested against remote targets during a native-titlebar drag.
+         *
+         * No pointer event reaches the page while the OS drags a window, so the window's geometry
+         * is the only signal. The centre of an opaque window is the one point the window itself is
+         * guaranteed to cover, which hid every drop target under the popup; a corner exposes two
+         * sides of the selected region and tracks the hand on the titlebar. The inset keeps the
+         * point inside the popup's own frame rather than on its boundary pixel.
+         * @member {Number} nativeWindowDropAnchorInset=8
+         */
+        nativeWindowDropAnchorInset: 8,
+        /**
          * Quiescence delay after the last native window-position update before committing
          * a geometry-only drop. The browser has no mouseup during OS-titlebar drags.
          * @member {Number} nativeWindowDropSettleMs=250
@@ -581,6 +593,8 @@ class DragCoordinator extends Manager {
             {sourceSortZone} = sourceDrag,
             popupWindow      = Window.get(data.windowId),
             popupRect        = popupWindow?.innerRect,
+            anchorRect       = popupWindow?.outerRect ?? popupRect,
+            inset            = me.nativeWindowDropAnchorInset,
             {sortGroup}      = sourceSortZone,
             sourceWindowId   = sourceDrag.sourceWindowId ?? sourceSortZone.windowId,
             targetWindowId, targetSortZone, targetWindow, localX, localY, width, height, arbiter, claimed, excludedWindowIds;
@@ -589,8 +603,9 @@ class DragCoordinator extends Manager {
             return null
         }
 
-        localX = popupRect.x + popupRect.width  / 2;
-        localY = popupRect.y + popupRect.height / 2;
+        // The popup's outer top-left corner (inset) is the drop anchor — see nativeWindowDropAnchorInset.
+        localX = anchorRect.x + inset;
+        localY = anchorRect.y + inset;
 
         excludedWindowIds = new Set([data.windowId, sourceWindowId]);
         arbiter           = me.nativeClaimArbiters.get(data.windowId);
@@ -644,13 +659,22 @@ class DragCoordinator extends Manager {
         width  = popupRect.width;
         height = popupRect.height;
 
+        // The proxy stands where the popup's CONTENT is, in target-local coordinates; the offsets
+        // locate the anchor inside that proxy so an embodiment keeps the popup's own placement.
+        const proxyRect = new Rectangle(
+            popupRect.x - targetWindow.innerRect.x,
+            popupRect.y - targetWindow.innerRect.y,
+            width,
+            height
+        );
+
         return {
             ...sourceDrag,
             localX,
             localY,
-            offsetX  : width  / 2,
-            offsetY  : height / 2,
-            proxyRect: new Rectangle(localX - width / 2, localY - height / 2, width, height),
+            offsetX: localX - proxyRect.x,
+            offsetY: localY - proxyRect.y,
+            proxyRect,
             targetSortZone,
             targetWindowId
         }

--- a/test/playwright/e2e/workstation/WorkstationNativePopupOverPopupNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationNativePopupOverPopupNL.spec.mjs
@@ -20,14 +20,22 @@ import {expect, test} from '../../fixtures.mjs';
  * 1. Playwright emulates `window.screen` at the viewport size; a popup outside the main window is
  *    then off the emulated screen and the app's `window.moveTo` cannot park it. `viewport: null`
  *    uses the real display.
- * 2. Chrome will not shrink the main window below roughly 500px wide, so on a small display the
- *    target vessel has to sit BELOW a 300px-tall main window, not beside it.
+ * 2. Chrome will not shrink the main window below roughly 500px wide or 375px tall. On an 800×600
+ *    display the vessels therefore sit to the RIGHT of a 500px-wide main window: the 300px beside it
+ *    hold a 146px vessel with room to spare, while nothing fits below a 375px-tall one.
  * 3. The Workstation collapses its tab headers into the overflow menu when the main window is small,
- *    so both pop-outs happen while the main window is full-size; it is shrunk afterwards.
+ *    so both pop-outs happen while the main window is full-size; it is narrowed afterwards.
  * 4. The claim arbiter keeps hover seniority across moves: a source that first claims the main window
  *    keeps main while it still intersects it, and a pause there longer than dwell + settle
  *    reintegrates into main. The source therefore moves once, directly onto the target, and only
  *    nudges afterwards.
+ * 5. The native drop anchor is the moving popup's outer top-left corner plus a small inset, read from
+ *    manager.Window — which takes `screenX/Y` as the FRAME origin, the basis a CDP bounds move
+ *    shares, so placing a frame at (left, top) puts its anchor at (left + inset, top + inset)
+ *    with no chrome arithmetic. Positioning a vessel is itself a move the native path listens to: a
+ *    vessel whose corner lands inside the main window would hand its anchor to main and be
+ *    reintegrated the moment it is placed. Side by side, the anchors' x stays clear of main whatever
+ *    their y.
  */
 
 test.use({viewport: null});
@@ -64,6 +72,8 @@ function readScreen(page) {
         availWidth : globalThis.screen.availWidth,
         innerHeight: globalThis.innerHeight,
         innerWidth : globalThis.innerWidth,
+        outerHeight: globalThis.outerHeight,
+        outerWidth : globalThis.outerWidth,
         screenX    : globalThis.screenX,
         screenY    : globalThis.screenY
     }))
@@ -113,20 +123,6 @@ async function readManagerRect(app, managerId, windowId, key='outerRect') {
     const state = await app.callMethod(managerId, 'toJSON');
 
     return state.windows.find(win => win.id === windowId)?.[key] ?? null
-}
-
-/**
- * @summary Reads one window's manager-owned chrome (`{top, left, right, bottom}`) — the offset between
- * its frame and its viewport, so a frame move can be aimed at a viewport target.
- * @param {Object} app
- * @param {String} managerId
- * @param {String} windowId
- * @returns {Promise<Object>}
- */
-async function readManagerChrome(app, managerId, windowId) {
-    const state = await app.callMethod(managerId, 'toJSON');
-
-    return state.windows.find(win => win.id === windowId)?.chrome ?? {bottom: 0, left: 0, right: 0, top: 0}
 }
 
 /**
@@ -252,8 +248,9 @@ test.describe('Workstation — native titlebar drag popup onto popup (#18047)', 
 
             const stage = await readScreen(page);
 
-            // Rig facts 1–3: a full-size main window for the pop-outs, then a 300px-tall main window
-            // with a 240px target below it — both must fit the real display.
+            // Rig facts 1–3: a full-size main window for the pop-outs, then a 500px-wide main window
+            // with the target vessel beside it and the source's corner inside that target — all of it
+            // must fit the real display.
             test.skip(
                 stage.availWidth < 760 || stage.availHeight < 560,
                 `${stage.availWidth}x${stage.availHeight} display cannot hold a 760px main window plus a target vessel below it`
@@ -283,6 +280,7 @@ test.describe('Workstation — native titlebar drag popup onto popup (#18047)', 
             const target = await popOut({app, page, workspaceId, itemId: TARGET_ITEM});
 
             popups.push(target.popup);
+            target.popup.on('close', () => console.log('[native-popup-over-popup] target popup closed at', new Date().toISOString()));
 
             const source = await popOut({app, page, workspaceId, itemId: SOURCE_ITEM});
 
@@ -301,37 +299,65 @@ test.describe('Workstation — native titlebar drag popup onto popup (#18047)', 
                 globalThis.addEventListener('mouseout', () => globalThis.__nativeTitlebarMouseouts++)
             });
 
-            // Rig fact 2: shrink the main window now that nothing needs clicking in it, and wait for
-            // manager.Window to publish the new extents (observeResize on the main render target).
-            const shrunk = await setBounds(mainHandle, {height: 300});
+            // Rig fact 2: a vessel (146 px) and its gap must fit beside the main window. A wide display
+            // holds them beside the full-size 760 px main; a small one (the 800×600 headless screen)
+            // needs the main narrowed to 500 px first — done now that nothing needs clicking in it,
+            // waiting for manager.Window to publish the new extents (observeResize on the render target).
+            if (stage.availLeft + 760 + 20 + 200 > stage.availLeft + stage.availWidth) {
+                const shrunk = await setBounds(mainHandle, {width: 500});
 
-            await expect.poll(async () => (await readManagerRect(app, managerId, mainWinId, 'innerRect'))?.height ?? Infinity, {
-                message  : 'manager.Window follows the main window resize',
-                timeout  : 5000,
-                intervals: [25, 50, 100]
-            }).toBeLessThanOrEqual(shrunk.innerHeight + 2);
+                await expect.poll(async () => (await readManagerRect(app, managerId, mainWinId, 'innerRect'))?.width ?? Infinity, {
+                    message  : 'manager.Window follows the main window resize',
+                    timeout  : 5000,
+                    intervals: [25, 50, 100]
+                }).toBeLessThanOrEqual(shrunk.innerWidth + 2);
 
+                // Environment gate: headless Chrome leaves `outerWidth/outerHeight` at the pre-resize
+                // size after a CDP bounds change while the viewport follows it. manager.Window derives
+                // the frame and the chrome from exactly those numbers, so the main window would
+                // keep a 760 px frame that swallows any vessel beside its 500 px viewport — the main
+                // claims the vessel's own anchor the moment it is placed. Only a real window measures it.
+                test.skip(
+                    shrunk.outerWidth - shrunk.innerWidth > 60,
+                    `outerWidth ${shrunk.outerWidth} vs innerWidth ${shrunk.innerWidth} after the resize: headless Chrome reports a stale frame size — run this arm headed on a wide display`
+                )
+            }
+
+            // Place the vessel from the main window's own screen read, not from its manager rects:
+            // headless Chrome keeps `outerWidth/outerHeight` at the pre-resize 760×560 after a CDP
+            // bounds change while `innerWidth/innerHeight` follow it, so the frame rect would put the
+            // vessel off-screen and the chrome split (260 px of "side border", a negative top chrome)
+            // would put the viewport rect above the screen — and a vessel parked at a negative y is a
+            // move the platform refuses. `screenX + innerWidth` is right in both worlds.
             const
                 targetHandle = await acquireNativeWindow(target.popup),
                 sourceHandle = await acquireNativeWindow(source.popup),
-                mainRect     = await readManagerRect(app, managerId, mainWinId),
+                mainScreen   = await readScreen(page),
+                mainRight    = mainScreen.screenX + mainScreen.innerWidth,
                 targetScreen = await setBounds(targetHandle, {
-                    left: Math.round(mainRect.x + 120),
-                    top : Math.round(mainRect.y + mainRect.height + 16)
-                });
+                    left: Math.round(mainRight + 20),
+                    top : Math.round(Math.max(mainScreen.screenY, mainScreen.availTop) + 40)
+                }),
+                placement    = JSON.stringify({mainScreen, targetScreen});
 
-            expect(targetScreen.screenY, 'the target vessel sits below the main window').toBeGreaterThanOrEqual(mainRect.y + mainRect.height);
-            expect(targetScreen.screenY + targetScreen.innerHeight, 'the target vessel is fully on-screen').toBeLessThanOrEqual(targetScreen.availHeight);
+            expect(targetScreen.screenX, `the target vessel sits beside the main window ${placement}`).toBeGreaterThanOrEqual(mainRight);
+            expect(targetScreen.screenX + targetScreen.innerWidth, `the target vessel is fully on-screen ${placement}`).toBeLessThanOrEqual(targetScreen.availLeft + targetScreen.availWidth);
             await awaitOriginParity(app, managerId, target.windowId, targetScreen, 'manager.Window follows the target vessel');
 
+            // Rig fact 5's hazard, named: positioning the target is itself a window move, and a move
+            // is what the native path listens to. Main must not have claimed the target's own anchor.
+            await target.popup.waitForTimeout(800);
+
+            expect((await app.getComponent(workspaceId, ['tearOutPanes'])).tearOutPanes?.[TARGET_ITEM]?.windowId,
+                'placing the target vessel did not hand it to the main window').toBe(target.windowId);
+
             const
-                // the drop anchor is the source's VIEWPORT centre and the claim tests the target's
-                // VIEWPORT, so the aim is viewport-on-viewport; the frame move subtracts the source's
-                // own chrome to put its viewport there
-                targetInner  = await readManagerRect(app, managerId, target.windowId, 'innerRect'),
-                sourceChrome = await readManagerChrome(app, managerId, source.windowId),
-                sourceScreen = await readScreen(source.popup),
-                armed        = await source.popup.evaluate(() => ({
+                // the drop anchor is the source FRAME's top-left corner plus the inset, and the claim
+                // tests the target's VIEWPORT — so the aim is frame-corner-into-viewport
+                targetInner                          = await readManagerRect(app, managerId, target.windowId, 'innerRect'),
+                sourceScreen                         = await readScreen(source.popup),
+                {nativeWindowDropAnchorInset: inset} = await app.getComponent(coordId, ['nativeWindowDropAnchorInset']),
+                armed                                = await source.popup.evaluate(() => ({
                     intervalArmed  : Boolean(globalThis.Neo.main.addon.WindowPosition.intervalId),
                     mouseouts      : globalThis.__nativeTitlebarMouseouts,
                     observeMovement: globalThis.Neo.main.addon.WindowPosition.observeMovement
@@ -343,12 +369,16 @@ test.describe('Workstation — native titlebar drag popup onto popup (#18047)', 
                 observeMovement: true
             });
 
-            // Rig fact 4: one direct move onto the target's centre, then two nudges inside the dwell
-            // window — the first update over an unmeasured target only starts the preview
-            // measurement, the following updates render it, and each update re-arms the commit.
+            // Rig facts 4 + 5: one direct move that parks the source's CORNER anchor inside the target,
+            // then two nudges inside the dwell window — the first update over an unmeasured target only
+            // starts the preview measurement, the following updates render it, and each update re-arms
+            // the commit. The anchor is the coordinator's arithmetic: the source's outer rect plus the
+            // inset, and manager.Window takes `screenX/Y` as the FRAME origin, the same basis a CDP
+            // bounds move uses — so a frame placed at (left, top) puts the anchor at (left + inset,
+            // top + inset), no chrome arithmetic. Aim it 24 px inside the target's viewport.
             const
-                goalLeft = Math.round(targetInner.x + targetInner.width  / 2 - sourceScreen.innerWidth  / 2 - sourceChrome.left),
-                goalTop  = Math.round(targetInner.y + targetInner.height / 2 - sourceScreen.innerHeight / 2 - sourceChrome.top);
+                goalLeft = Math.round(targetInner.x + 24 - inset),
+                goalTop  = Math.round(targetInner.y + 24 - inset);
 
             for (const [dx, dy] of [[0, 0], [3, 2], [6, 4]]) {
                 const moved = await setBounds(sourceHandle, {left: goalLeft + dx, top: goalTop + dy});
@@ -356,6 +386,21 @@ test.describe('Workstation — native titlebar drag popup onto popup (#18047)', 
                 await awaitOriginParity(app, managerId, source.windowId, moved, 'manager.Window follows the source popup through the poll alone');
                 await source.popup.waitForTimeout(120)
             }
+
+            // The coordinator's own arithmetic must place the anchor inside the target — the source's
+            // OUTER corner plus the inset, against the target's inner rect. It is the precondition every
+            // claim below depends on, named here so a placement mistake fails as itself.
+            const
+                sourceOuter = (await app.callMethod(managerId, 'toJSON')).windows.find(win => win.id === source.windowId)?.outerRect,
+                anchor      = sourceOuter && {x: sourceOuter.x + inset, y: sourceOuter.y + inset};
+
+            expect(anchor, 'manager.Window holds the source popup\'s outer rect').toBeTruthy();
+            expect(
+                anchor.x >= targetInner.x && anchor.x <= targetInner.x + targetInner.width &&
+                anchor.y >= targetInner.y && anchor.y <= targetInner.y + targetInner.height,
+                `the source's corner anchor ${JSON.stringify(anchor)} sits inside the target ${JSON.stringify(targetInner)} ` +
+                `(requested ${goalLeft},${goalTop}; source ${JSON.stringify(await readScreen(source.popup))}; stage ${JSON.stringify(stage)})`
+            ).toBe(true);
 
             // Every movement of the gesture is done: read the trigger witness NOW, while the source
             // realm is certainly alive. The dwell timer is already running, and the commit that retires
@@ -410,12 +455,19 @@ test.describe('Workstation — native titlebar drag popup onto popup (#18047)', 
                     target      : TARGET_WORKSPACE_ID
                 })
             } catch (error) {
-                // Bounded triage receipt: which phase the native terminal died in.
+                // Bounded triage receipt: which phase the native terminal died in, what the target saw
+                // at that instant, and where every window stood in the manager's own coordinates.
                 console.log('[native-popup-over-popup-diagnostic]', JSON.stringify({
-                    claimTail: ((await app.getComponent(coordId, ['claimTrace'])).claimTrace ?? []).slice(-3)
+                    claimTail: ((await app.getComponent(coordId, ['claimTrace'])).claimTrace ?? []).slice(-6)
                         .map(entry => ({claimedStableId: entry.claimedStableId, outcome: entry.outcome, token: entry.gestureToken})),
-                    park    : receipt?.lastVesselParkReceipt ?? null,
-                    transfer: receipt?.lastCrossWindowTransfer ?? null
+                    candidates    : await app.getComponent(coordId, ['nativeWindowDropCandidates']).catch(e => String(e)),
+                    participations: await participations(app).catch(e => String(e)),
+                    popups        : {sourceClosed: source.popup.isClosed(), targetClosed: target.popup.isClosed()},
+                    vessels       : await app.getComponent(workspaceId, ['tearOutPanes', 'lastTearOutClose', 'lastVesselRestoreReceipt', 'vesselConversionTargetWindowId']).catch(e => String(e)),
+                    park          : receipt?.lastVesselParkReceipt ?? null,
+                    snapshot      : await app.callMethod(workspaceId, 'readCrossWindowGestureSnapshot', [{parkedItemId: SOURCE_ITEM, targetWorkspaceId: TARGET_WORKSPACE_ID}]).catch(e => String(e)),
+                    transfer      : receipt?.lastCrossWindowTransfer ?? null,
+                    windows       : (await app.callMethod(managerId, 'toJSON')).windows.map(win => ({id: win.id, chrome: win.chrome, innerRect: win.innerRect, outerRect: win.outerRect}))
                 }, null, 1));
                 throw error
             }

--- a/test/playwright/e2e/workstation/WorkstationNativeTitlebarDragNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationNativeTitlebarDragNL.spec.mjs
@@ -16,7 +16,12 @@ import {expect, test} from '../../fixtures.mjs';
  * asserted at zero to prove the synthetic half stayed out of the gesture.
  */
 
-const asArray = value => Array.isArray(value) ? value : value ? [value] : [];
+const
+    asArray = value => Array.isArray(value) ? value : value ? [value] : [],
+    readId  = result => result?.properties?.id ?? result?.id ?? (Array.isArray(result) ? readId(result[0]) : null),
+    // The zone the popup's corner is parked in: NOT Commit Stream's stored home (right-bottom-tabs),
+    // and the trailing child of a horizontal split, so its left band is a sibling insertion.
+    TARGET_NODE = 'heavy-tabs';
 
 /**
  * @summary Resolves one native CDP window handle for a page.
@@ -102,7 +107,7 @@ async function readManagerRect(app, managerId, windowId) {
 }
 
 test.describe('Workstation — native titlebar popup drag (#18029)', () => {
-    test('a popup moved by its OS titlebar previews over the main window and reintegrates under dwell', async ({page, neuralLink}) => {
+    test('a popup moved by its OS titlebar previews the zone under its corner and reintegrates there under dwell', async ({page, neuralLink}) => {
         const pageErrors = [];
         let popup;
 
@@ -219,16 +224,28 @@ test.describe('Workstation — native titlebar popup drag (#18029)', () => {
             }).toEqual({armed: true, mouseouts: 0, observeMovement: true});
 
             const
-                mainParticipationAtGrab = await readMainParticipationId(app),
-                mainRect                = await readManagerRect(app, managerId, (await app.getComponent(workspaceId, ['windowId'])).windowId),
-                popupBefore             = await readScreen(popup),
-                targetLeft              = Math.round(mainRect.x + mainRect.width  / 2 - popupBefore.innerWidth  / 2),
-                targetTop               = Math.round(mainRect.y + mainRect.height / 2 - popupBefore.innerHeight / 2);
+                mainParticipationAtGrab              = await readMainParticipationId(app),
+                mainRect                             = await readManagerRect(app, managerId, (await app.getComponent(workspaceId, ['windowId'])).windowId),
+                popupBefore                          = await readScreen(popup),
+                {nativeWindowDropAnchorInset: inset} = await app.getComponent(coordId, ['nativeWindowDropAnchorInset']),
+                zoneId                               = readId(await app.queryComponent({dockNodeId: TARGET_NODE}, ['id'])),
+                zoneBox                              = zoneId && await page.locator(`#${zoneId}`).boundingBox();
 
             expect(mainRect, 'manager.Window holds the main window rect').toBeTruthy();
+            expect(zoneBox, `${TARGET_NODE} is a measurable drop zone`).toBeTruthy();
 
-            // Walk the popup onto the main window's centre. After every step the manager rect must
-            // catch up through the production poll: no publishGeometry() call, no pointer event.
+            // The drop anchor is the popup's outer top-left corner, inset — the one point an opaque
+            // popup cannot hide. Aim it at the LEFT band of a zone that is not the pane's stored home,
+            // below the header carve-out and clear of the centre indicator chips: that zone sits in a
+            // horizontal split, so the band is a sibling insertion whose region overlay paints beside
+            // the corner. CDP bounds are the frame origin, so the requested origin IS the corner.
+            const
+                anchor     = {x: zoneBox.x + 10, y: zoneBox.y + zoneBox.height * 0.6},
+                targetLeft = Math.round(mainRect.x + anchor.x - inset),
+                targetTop  = Math.round(mainRect.y + anchor.y - inset);
+
+            // Walk the popup's corner onto that band. After every step the manager rect must catch
+            // up through the production poll: no publishGeometry() call, no pointer event.
             for (const step of [0.5, 1]) {
                 const
                     left   = Math.round(popupBefore.screenX + (targetLeft - popupBefore.screenX) * step),
@@ -246,12 +263,43 @@ test.describe('Workstation — native titlebar popup drag (#18029)', () => {
                 }).toBeLessThanOrEqual(2)
             }
 
-            // The reported defect: previews must render in the target realm while the popup is over it.
-            await expect.poll(() => page.locator('.neo-dock-preview-affordance').count(), {
-                message  : 'the main window renders a drop-zone preview while the popup hovers it',
+            // Land the anchor exactly where the coordinator will read it: it anchors on the manager's
+            // OUTER rect, whose relation to the CDP frame origin is the platform's to define, so read
+            // that rect back and correct the residual once. The receipt is the coordinator's own
+            // arithmetic — outer corner + inset, in the main window's local space — at the aimed point.
+            const
+                readAnchor = async () => {
+                    const outer = (await app.callMethod(managerId, 'toJSON')).windows.find(win => win.id === popupWindowId)?.outerRect;
+
+                    return outer ? {x: outer.x + inset - mainRect.x, y: outer.y + inset - mainRect.y} : null
+                },
+                residual   = anchorNow => anchorNow ? Math.max(Math.abs(anchorNow.x - anchor.x), Math.abs(anchorNow.y - anchor.y)) : Infinity;
+
+            let anchorNow = await readAnchor();
+
+            if (residual(anchorNow) > 1) {
+                await moveNative(popupHandle, Math.round(targetLeft - (anchorNow.x - anchor.x)), Math.round(targetTop - (anchorNow.y - anchor.y)));
+
+                await expect.poll(async () => residual(anchorNow = await readAnchor()), {
+                    message  : 'the popup\'s corner anchor lands on the aimed band point',
+                    timeout  : 5000,
+                    intervals: [25, 50, 100]
+                }).toBeLessThanOrEqual(2)
+            }
+
+            // The reported defect: previews must render in the target realm while the popup is over
+            // it — and with the corner in a split band, as a REGION overlay, not only as indicator arrows.
+            await expect.poll(() => page.locator('.neo-dock-preview-region').count(), {
+                message  : 'the main window renders a region overlay while the popup\'s corner sits in a split band',
                 timeout  : 5000,
                 intervals: [50, 100, 250]
             }).toBeGreaterThan(0);
+
+            const snapshot = await app.callMethod(workspaceId, 'readCrossWindowGestureSnapshot', [{targetWorkspaceId: 'workstation-main'}]);
+
+            expect(snapshot.rendered, 'the painted preview is the band\'s sibling insertion, not the stored home')
+                .toMatchObject({placement: {kind: 'split-before'}, target: {nodeId: TARGET_NODE}});
+            expect(snapshot.preview?.previewId, 'the semantic and painted previews agree').toBe(snapshot.rendered.previewId);
 
             expect(await popup.evaluate(() => globalThis.__nativeTitlebarMouseouts),
                 'no mouseout reached the popup realm during the gesture').toBe(0);
@@ -297,6 +345,17 @@ test.describe('Workstation — native titlebar popup drag (#18029)', () => {
                 message: 'the committed reintegration retires the physical vessel',
                 timeout: 10000
             }).toBe(true);
+
+            // The drop lands where the corner pointed: a fresh tabs node inserted BEFORE the band's
+            // zone in a horizontal split — not at the pane's stored home.
+            const
+                {dockModel} = await app.getComponent(workspaceId, ['dockModel']),
+                landing     = Object.entries(dockModel.nodes).find(([, node]) => node.type === 'tabs' && node.items?.includes('commits'))?.[0],
+                split       = Object.values(dockModel.nodes).find(node => node.type === 'split' && node.children?.[0] === landing);
+
+            expect(landing, 'Commit Stream lands in a fresh tabs node, not its stored home').not.toBe('right-bottom-tabs');
+            expect(split, 'the landing node is the leading sibling of the band\'s zone')
+                .toMatchObject({orientation: 'horizontal', children: [landing, TARGET_NODE]});
 
             expect(await app.callMethod(workspaceId, 'getPaneIdentity', ['commits']),
                 'reintegration retains the exact live pane instance').toBe(paneId);

--- a/test/playwright/unit/apps/workstation/Workspace.spec.mjs
+++ b/test/playwright/unit/apps/workstation/Workspace.spec.mjs
@@ -1081,12 +1081,14 @@ test.describe.serial('Workstation.view.Workspace', () => {
         }
     });
 
-    test('remote main previews render all four edges against the exact semantic target geometry', async () => {
+    test('remote main previews resolve through the affordance geometry: the full grammar on the pointed zone, the stored-home tab-into off-zone', async () => {
         const
             workspace         = Neo.create(Workspace, {}),
             sourceWorkspaceId = Workspace.vesselWorkspaceId('queues'),
             hostRect          = {x: 100, y: 80, width: 900, height: 600},
-            targetRect        = {x: 120, y: 120, width: 260, height: 260},
+            leftRect          = {x: 160, y: 140, width: 260, height: 260},
+            heavyRect         = {x: 520, y: 140, width: 300, height: 300},
+            farRect           = {x: 2000, y: 2000, width: 100, height: 100},
             paintedRects      = [],
             measuredIds       = [];
 
@@ -1094,9 +1096,24 @@ test.describe.serial('Workstation.view.Workspace', () => {
             await workspace.crossWindowParticipationPromise;
 
             const
-                host                    = workspace.getReference('dock-host'),
-                target                  = host.down({dockNodeId: 'left-tabs'}),
-                renderer                = workspace.dragAffordances.preview,
+                host        = workspace.getReference('dock-host'),
+                affordances = workspace.dragAffordances,
+                renderer    = affordances.preview,
+                zoneId      = nodeId => host.down({dockNodeId: nodeId}).id,
+                tabsZoneIds = Object.entries(workspace.dockModel.nodes)
+                    .filter(([, node]) => node.type === 'tabs')
+                    .map(([nodeId]) => zoneId(nodeId)),
+                rects                   = {[host.id]: hostRect, [zoneId('left-tabs')]: leftRect, [zoneId('heavy-tabs')]: heavyRect},
+                local                   = rect => ({x: rect.x - hostRect.x, y: rect.y - hostRect.y, width: rect.width, height: rect.height}),
+                render                  = (point, sourceWorkspace = sourceWorkspaceId) => workspace.renderCrossWindowPreview(
+                    Workspace.MAIN_WORKSPACE_ID,
+                    {
+                        draggedItem : {dockItemId: 'queues', dockSourceWorkspaceId: sourceWorkspace},
+                        localX      : point.x,
+                        localY      : point.y,
+                        sourceNodeId: Workspace.vesselTabsNodeId('queues')
+                    }
+                ),
                 WindowManager           = Neo.manager.Window,
                 originalGet             = WindowManager.get,
                 originalGetDomRect      = host.getDomRect,
@@ -1111,99 +1128,86 @@ test.describe.serial('Workstation.view.Workspace', () => {
                 WindowManager.get = () => ({innerRect: {x: 0, y: 0, width: 1280, height: 720}});
                 host.getDomRect = async ids => {
                     measuredIds.push(ids);
-                    return [hostRect, targetRect]
+                    return ids.map(id => rects[id] ?? farRect)
                 };
                 renderer.applyTargetGeometry = rect => paintedRects.push(rect);
 
-                await workspace.ensureCrossWindowPreviewGeometry(Workspace.MAIN_WORKSPACE_ID, 'left-tabs');
+                // The first frame warms the SAME once-per-gesture measurement the indicator tier
+                // uses — the host plus EVERY projected tabs zone — and hides until it settles.
+                expect(render({x: 290, y: 180})).toBeNull();
+                expect(measuredIds).toHaveLength(1);
+                expect(measuredIds[0][0]).toBe(host.id);
+                expect([...measuredIds[0]].sort()).toEqual([host.id, ...tabsZoneIds].sort());
 
-                expect(measuredIds).toEqual([[host.id, target.id]]);
+                await affordances.ensureGeometry();
 
-                const
-                    baseData = {
-                        draggedItem: {
-                            dockItemId           : 'queues',
-                            dockSourceWorkspaceId: sourceWorkspaceId
-                        },
-                        sourceNodeId: Workspace.vesselTabsNodeId('queues')
-                    },
-                    points = {
-                        top   : {localX: 250, localY: 160},
-                        right : {localX: 379, localY: 250},
-                        bottom: {localX: 250, localY: 379},
-                        left  : {localX: 121, localY: 250}
-                    };
+                // Four edges of the stored home resolve against its exact measured rect (its parent is
+                // the edge-zone root, so every side is a node-splitting edge).
+                const points = {
+                    top   : {x: 290, y: 180},
+                    right : {x: 419, y: 270},
+                    bottom: {x: 290, y: 399},
+                    left  : {x: 161, y: 270}
+                };
 
                 Object.entries(points).forEach(([edge, point]) => {
-                    const preview = workspace.renderCrossWindowPreview(
-                        Workspace.MAIN_WORKSPACE_ID,
-                        {...baseData, ...point}
-                    );
+                    const preview = render(point);
 
                     expect(preview.target.nodeId).toBe('left-tabs');
                     expect(preview.placement.kind).toBe(`edge-${edge}`)
                 });
 
-                expect(paintedRects).toEqual(Array(4).fill({
-                    x     : targetRect.x - hostRect.x,
-                    y     : targetRect.y - hostRect.y,
-                    width : targetRect.width,
-                    height: targetRect.height
-                }));
+                expect(paintedRects).toEqual(Array(4).fill(local(leftRect)));
+                expect(measuredIds, 'one measurement serves the whole gesture').toHaveLength(1);
 
-                const
-                    nativeHomeId = 'right-top-tabs',
-                    nativeTarget = host.down({dockNodeId: nativeHomeId});
+                // The full grammar on ANY pointed zone: heavy-tabs sits in a horizontal split, so its
+                // left band is a sibling insertion — the region a native popup's corner selects.
+                const split = render({x: 530, y: 320});
 
-                workspace.tearOutPlacements.queues = {index: 1, tabsNodeId: nativeHomeId};
-                workspace.crossWindowPreviewGeometries.delete(Workspace.MAIN_WORKSPACE_ID);
+                expect(split.target.nodeId).toBe('heavy-tabs');
+                expect(split.placement.kind).toBe('split-before');
+                expect(paintedRects.at(-1)).toEqual(local(heavyRect));
+                expect(renderer.dockPreview?.previewId).toBe(split.previewId);
 
-                await workspace.ensureCrossWindowPreviewGeometry(
-                    Workspace.MAIN_WORKSPACE_ID,
-                    nativeHomeId
-                );
+                // Off every zone but inside the window: the stored home acquires the drop as a
+                // tab-into, painted on the home's exact rect — never on the pointer's empty position.
+                workspace.tearOutPlacements.queues = {index: 1, tabsNodeId: 'right-top-tabs'};
 
-                expect(measuredIds.at(-1)).toEqual([host.id, nativeTarget.id]);
+                const offZone = render({x: 450, y: 500}, Workspace.MAIN_WORKSPACE_ID);
 
-                const nativeReturnPreview = workspace.renderCrossWindowPreview(
-                    Workspace.MAIN_WORKSPACE_ID,
-                    {
-                        draggedItem: {
-                            dockItemId           : 'queues',
-                            dockSourceWorkspaceId: Workspace.MAIN_WORKSPACE_ID
-                        },
-                        localX      : 250,
-                        localY      : 160,
-                        sourceNodeId: Workspace.vesselTabsNodeId('queues')
-                    }
-                );
+                expect(offZone?.target.nodeId, 'a main-origin native popup recovers its saved semantic home off-zone')
+                    .toBe('right-top-tabs');
+                expect(offZone.placement.kind).toBe('tab-into');
+                expect(paintedRects.at(-1)).toEqual(local(farRect));
 
-                expect(nativeReturnPreview?.target.nodeId,
-                    'a main-origin native popup must recover its own saved semantic home')
-                    .toBe(nativeHomeId);
+                // …while a pointed zone still wins over the stored home.
+                expect(render({x: 290, y: 300}, Workspace.MAIN_WORKSPACE_ID)).toMatchObject({
+                    placement: {kind: 'tab-into'},
+                    target   : {nodeId: 'left-tabs'}
+                });
 
-                workspace.tearOutPlacements.queues = {index: 0, tabsNodeId: 'left-tabs'};
-
+                // A main-window resize mid-gesture re-measures: the in-flight frame hides stale
+                // pixels, the settled one paints again.
                 let settleReplacement;
 
                 WindowManager.get = () => ({innerRect: {x: 0, y: 0, width: 1279, height: 720}});
                 host.getDomRect = async ids => {
                     measuredIds.push(ids);
 
-                    return new Promise(resolve => settleReplacement = resolve)
+                    return new Promise(resolve => settleReplacement = () => resolve(ids.map(id => rects[id] ?? farRect)))
                 };
 
-                expect(workspace.renderCrossWindowPreview(
-                    Workspace.MAIN_WORKSPACE_ID,
-                    {...baseData, ...points.top}
-                )).toBeNull();
+                expect(render(points.top)).toBeNull();
                 expect(renderer.dockPreview, 'an in-flight replacement must hide stale pixels').toBeNull();
+                expect(measuredIds).toHaveLength(2);
 
-                settleReplacement([hostRect, targetRect]);
-                await workspace.ensureCrossWindowPreviewGeometry(Workspace.MAIN_WORKSPACE_ID, 'left-tabs')
+                settleReplacement();
+                await affordances.ensureGeometry();
+
+                expect(render(points.top)).toMatchObject({placement: {kind: 'edge-top'}, target: {nodeId: 'left-tabs'}})
             } finally {
-                WindowManager.get           = originalGet;
-                host.getDomRect             = originalGetDomRect;
+                WindowManager.get            = originalGet;
+                host.getDomRect              = originalGetDomRect;
                 renderer.applyTargetGeometry = originalApplyTargetRect;
                 workspace.windowId           = originalWindowId;
                 workspace.vesselWorkspaces.delete(sourceWorkspaceId);
@@ -1234,6 +1238,8 @@ test.describe.serial('Workstation.view.Workspace', () => {
 
             const
                 host               = workspace.getReference('dock-host'),
+                homeId             = host.down({dockNodeId: 'left-tabs'}).id,
+                farRect            = {x: 2000, y: 2000, width: 100, height: 100},
                 renderer           = workspace.dragAffordances.preview,
                 WindowManager      = Neo.manager.Window,
                 originalGet        = WindowManager.get,
@@ -1242,12 +1248,12 @@ test.describe.serial('Workstation.view.Workspace', () => {
 
             try {
                 WindowManager.get = () => ({innerRect: {x: 0, y: 0, width: 1280, height: 720}});
-                host.getDomRect   = async () => [hostRect, targetRect];
+                host.getDomRect   = async ids => ids.map(id => id === host.id ? hostRect : id === homeId ? targetRect : farRect);
 
-                await workspace.ensureCrossWindowPreviewGeometry(Workspace.MAIN_WORKSPACE_ID, 'left-tabs');
+                await workspace.dragAffordances.ensureGeometry();
 
-                // Off-zone but window-admitted: inside the host rect, outside the exact node
-                // rect — the stored-home fallback must paint the grouped tab-into…
+                // Off-zone but window-admitted: inside the host rect, outside every zone rect —
+                // the stored-home fallback must paint the grouped tab-into…
                 participation.target.onRemoteDragMove({
                     draggedItem: {
                         dockGroupNodeId      : 'workstation-vessel-tabs:queues',

--- a/test/playwright/unit/draggable/dashboard/SortZone.spec.mjs
+++ b/test/playwright/unit/draggable/dashboard/SortZone.spec.mjs
@@ -680,8 +680,10 @@ test.describe.serial('Neo.draggable.dashboard.SortZone Directional Logic', () =>
         const move = calls.find(call => call.type === 'move').data;
 
         expect(move.draggedItem).toBe(item);
-        expect(move.localX).toBe(100);
-        expect(move.localY).toBe(90);
+        // the anchor is the popup's OUTER top-left corner (150, 130) plus the 8px inset, in the
+        // target's local space — not the popup's centre
+        expect(move.localX).toBe(58);
+        expect(move.localY).toBe(38);
         expect(move.proxyRect.width).toBe(100);
         expect(move.proxyRect.height).toBe(80);
         expect(DragCoordinator.nativeWindowDropCandidates.size).toBe(0)

--- a/test/playwright/unit/manager/DragCoordinator.spec.mjs
+++ b/test/playwright/unit/manager/DragCoordinator.spec.mjs
@@ -857,12 +857,12 @@ test.describe('Neo.manager.DragCoordinator — the §2.8.1 claim protocol', () =
 
         registerWindow('win-source', 2000,   0, 400, 400);
         registerWindow('win-popup',   500, 500, 300, 200);
-        registerWindow('win-target',  600, 550, 400, 300);
+        registerWindow('win-target',  400, 400, 400, 300);
 
         DragCoordinator.register(source);
         DragCoordinator.register(target);
 
-        // two geometry events while the popup's center (650, 600) sits over the target
+        // two geometry events while the popup's corner anchor (508, 508) sits over the target
         DragCoordinator.onWindowPositionChange({windowId: 'win-popup'});
         DragCoordinator.onWindowPositionChange({windowId: 'win-popup'});
 
@@ -873,8 +873,11 @@ test.describe('Neo.manager.DragCoordinator — the §2.8.1 claim protocol', () =
         expect(nativePayloads.every(payload => payload.embodyProxy === false)).toBe(true);
         expect(nativePayloads.every(payload => payload.sourceSortZone === source)).toBe(true);
 
-        // the popup leaves the target: the hover ends exact-once
-        WindowManager.get('win-popup').innerRect = new Rectangle(3000, 3000, 300, 200);
+        // the popup leaves the target: the hover ends exact-once (the anchor reads the OUTER rect)
+        Object.assign(WindowManager.get('win-popup'), {
+            innerRect: new Rectangle(3000, 3000, 300, 200),
+            outerRect: new Rectangle(3000, 3000, 300, 200)
+        });
 
         DragCoordinator.onWindowPositionChange({windowId: 'win-popup'});
 
@@ -887,6 +890,71 @@ test.describe('Neo.manager.DragCoordinator — the §2.8.1 claim protocol', () =
         DragCoordinator.onWindowPositionChange({windowId: 'win-popup'});
 
         expect(DragCoordinator.nativeClaimArbiters.size).toBe(0)
+    });
+
+    test('the NATIVE drop anchor is the popup\'s outer top-left corner, inset — the centre is the one point the popup always hides', () => {
+        const
+            nativePayloads = [],
+            draggedItem    = {id: 'tab-1'},
+            source         = {
+                sortGroup: 'dock',
+                windowId : 'win-source',
+                getNativeWindowDrag(windowId) {
+                    return windowId === 'win-popup' ? {draggedItem, widgetName: 'tab-1'} : null
+                },
+                async suspendWindowDrag(widgetName) {
+                    calls.push(['suspend', widgetName])
+                }
+            },
+            // the popup's content (inner) sits 30px below and 4px right of its frame (outer)
+            popupInner = new Rectangle(504, 530, 300, 200),
+            popupOuter = new Rectangle(500, 500, 308, 234),
+            centreOnly = createZone('workspace-centre', 'win-centre'),
+            cornerOnly = createZone('workspace-corner', 'win-corner'),
+            oldInset   = DragCoordinator.nativeWindowDropAnchorInset,
+            lastMove   = () => calls.filter(([name]) => name === 'move').at(-1);
+
+        cornerOnly.onRemoteDragMove = payload => {
+            nativePayloads.push(payload);
+            calls.push(['move', 'workspace-corner', payload.localX, payload.localY])
+        };
+
+        registerWindow('win-source', 2000,   0, 400, 400);
+        registerWindow('win-popup',     0,   0,   0,   0, {innerRect: popupInner, outerRect: popupOuter});
+        registerWindow('win-centre',  600, 600, 400, 300); // covers the popup's centre (654, 630), not its corner
+        registerWindow('win-corner',  400, 400, 180, 180); // covers the corner anchor (508, 508), not the centre
+
+        DragCoordinator.register(source);
+        DragCoordinator.register(centreOnly);
+        DragCoordinator.register(cornerOnly);
+
+        try {
+            DragCoordinator.onWindowPositionChange({windowId: 'win-popup'});
+
+            // the corner's window previews, in ITS local space; the window under the centre is never asked
+            expect(calls.filter(([name]) => name === 'move')).toEqual([['move', 'workspace-corner', 108, 108]]);
+            expect(nativePayloads).toHaveLength(1);
+
+            const [payload] = nativePayloads;
+
+            // the proxy stands where the popup's CONTENT is, in the target's space, and the offsets
+            // locate the anchor inside it — 4px in from the frame, 22px above the content
+            expect(payload.proxyRect).toMatchObject({x: 104, y: 130, width: 300, height: 200});
+            expect([payload.offsetX, payload.offsetY]).toEqual([4, -22]);
+
+            // the inset is the config: at 0 the anchor is the frame's exact corner
+            DragCoordinator.nativeWindowDropAnchorInset = 0;
+            DragCoordinator.onWindowPositionChange({windowId: 'win-popup'});
+            expect(lastMove()).toEqual(['move', 'workspace-corner', 100, 100]);
+
+            // without an outer rect the content rect's corner anchors, inset again
+            DragCoordinator.nativeWindowDropAnchorInset = oldInset;
+            WindowManager.get('win-popup').outerRect = null;
+            DragCoordinator.onWindowPositionChange({windowId: 'win-popup'});
+            expect(lastMove()).toEqual(['move', 'workspace-corner', 112, 138])
+        } finally {
+            DragCoordinator.nativeWindowDropAnchorInset = oldInset
+        }
     });
 
     test('a native source may name its physical popup separately so the originating main participation can claim', () => {
@@ -1102,7 +1170,7 @@ test.describe('Neo.manager.DragCoordinator — the §2.8.1 claim protocol', () =
 
         registerWindow('win-source', 2000,   0, 400, 400);
         registerWindow('win-popup',   500, 500, 300, 200);
-        registerWindow('win-target',  600, 550, 400, 300);
+        registerWindow('win-target',  400, 400, 400, 300); // covers the popup's corner anchor (508, 508)
 
         DragCoordinator.register(source);
         DragCoordinator.register(target);


### PR DESCRIPTION
Resolves #18056

🌿 *A native drop now reads the zone under the popup's corner, so "the drop target is always hidden under the popup" is unsayable.*

The operator's hand test after #18040 showed two defects in one gesture: the native drop matched on the popup's geometric centre, the one point an opaque window always covers, and the main window's semantic preview offered a single zone (the pane's stored home), so the indicator arrows evaluated every zone while the region overlays could appear on none of them. This PR moves the anchor to the popup's **outer top-left corner** inset by a new `nativeWindowDropAnchorInset` (8 px, `innerRect` fallback when `outerRect` is absent), keeps the target-side proxy where the popup's content is (offsets locate the anchor inside it), and lets the main workspace resolve its remote preview exactly as an in-window gesture does: `DragAffordances` gains a settled-geometry mirror (`geometry`), `resolvePreview` (indicator candidate first, pointer inference over every zone second), `previewTargetRect` and `invalidateGeometry`, and `renderMainCrossWindowPreview` reads them synchronously per remote frame with the stored-home tab-into as the off-zone fallback and a re-measure when the main window is resized under a hovering popup. Diagnosis and receipts: [#18056](https://github.com/neomjs/neo/issues/18056).

Evidence: L2 (unit witnesses on the anchor, the grammar and the fallback) + L3 (both native e2e arms, CDP window bounds standing in for the OS) → L4 required (AC-5: only a real OS titlebar drag on a real Chrome shows the region beside the physical corner). Residual: AC-5, Residual-Owner: #15239.

## AC Evidence
| AC-1 | `test/playwright/unit/manager/DragCoordinator.spec.mjs` › "the NATIVE drop anchor is the popup's outer top-left corner, inset": a popup whose centre lies over one window and whose corner over another previews in the corner's window at its local anchor, `proxyRect` is the content rect in target space with `offsetX/offsetY` locating the anchor inside it, inset 0 lands on the exact frame corner, and a null `outerRect` anchors the inner rect. |
| AC-2 | `WorkstationNativeTitlebarDragNL`: the corner is parked in the left band of `heavy-tabs` (not Commit Stream's stored home); `.neo-dock-preview-region` renders in the main window, the painted and semantic previews agree on `split-before` / `heavy-tabs`, and after the dwell Commit Stream lands in a fresh tabs node as the leading sibling of `heavy-tabs` in a horizontal split — not in `right-bottom-tabs`. 1/1 green. |
| AC-3 | `WorkstationNativePopupOverPopupNL`: vessels sit beside a 500 px main window; the source is placed so the coordinator's anchor (`outerRect` + inset) lands inside the target, a named precondition; claim → target preview → park → `transferItem` → source retired. 1/1 green. |
| AC-4 | Pointer path, run locally at this head AND at the baseline (`dev` + PR #18055, `9019fd1727`) on the same host: `WorkstationFiveBeatNL` 7 passed / 1 failed / 3 skipped on both, `DemoBCrossWindowDragNL` 3 failed on both with the same error ("the exact tear-out Page must navigate and remain live during conversion"), `WorkstationHumanPopupOverlapNL` skipped on both (film gate). Identical failure sets, so nothing here changed the pointer path's outcome; the FiveBeat passes include the vessel→main return steps that ride the rewritten main-window preview. |
| AC-5 | Outside every rig: pop out, drag by the titlebar, hold the corner over a zone's band — the region overlay paints beside the corner and the drop lands there. Operator hand check on a live host. #18058 (merged as PR #18068 before this PR) corrected `manager.Window`'s frame origin, so the overlay paints at the physical corner. |

## Deltas from ticket
- `container/Base.afterSetDragResortable` gains a post-await `isDestroyed` guard: the Workspace unit spec's rewritten cross-window tests destroy a workspace while its grid header toolbars still await their sort-zone module, and the resumed hook read `me.parent.id` on a destroyed toolbar. The guard is the fix the failing test demanded; no witness was added beyond that test turning green.
- `resolveCrossWindowPreviewSurface` / `ensureCrossWindowPreviewGeometry` are vessel-only now; the main workspace rides the affordance controller's geometry instead of a second measurement of the same host (the ticket's "Avoided Traps" row).
- Follow-up filed, not folded: #18058 — `manager.Window` labels Chrome's `screenLeft/Top` as the viewport origin while Chrome reports the frame; surfaced by the popup→popup arm's real chrome. The anchor definition here was correct by construction; #18058 landed first (PR #18068) and this PR is rebased onto it.

## Test Evidence
- Unit: `DragCoordinator.spec.mjs` 47/47 (one new witness; the continuous-preview witness re-pinned to the corner), `draggable/dashboard/SortZone.spec.mjs` 20/20 (local anchor re-pinned), `dashboard/DockDragAffordances.spec.mjs` 9/9, `apps/workstation/Workspace.spec.mjs` green behind its predecessor (two cross-window tests rewritten to the full grammar; the #16309 test is the one the `container/Base` guard turned green). Full unit suite serial: 2943/2943.
- E2E (not in CI, Neural Link tier, this host): `WorkstationNativeTitlebarDragNL` 1/1 (5.7s), `WorkstationNativePopupOverPopupNL` 1/1 (7.4s); pointer battery per AC-4, identical to the baseline.
- Note for the next author: `Workspace.spec.mjs` cannot load alone — its import graph reaches `manager/Window.mjs` before its own `setup()` runs; run it behind any spec that sorts before `apps/workstation` (e.g. `apps/portal/view/content/Component.spec.mjs`), as CI's full run does.

## Post-Merge Validation
- [ ] Live host, real Chrome: header-action pop-out, drag by the OS titlebar so the popup's top-left corner sits in a zone's edge band, hold, release — a region overlay paints beside the corner and the pane lands in that placement. No chrome offset is expected: #18058 landed before this PR.

Residual-Owner: #15239

Authored by Vega (Fable 5.1, Claude Code). Session 93fd8de9-7231-4979-b906-c050bcfc25a4.

