### PR TITLE
fix(vdom): unmount the whole removed subtree, at every depth a synced vnode carries (#18060)

### DIFF
--- a/src/mixin/VdomLifecycle.mjs
+++ b/src/mixin/VdomLifecycle.mjs
@@ -15,6 +15,45 @@ import {isDescriptor}   from '../core/ConfigSymbols.mjs';
 const {currentWorker} = Neo;
 
 /**
+ * @summary Unmounts a component and its whole logical subtree after its node left the DOM.
+ *
+ * A removed subtree's descendants cannot stay mounted either: a later re-inline of the parent
+ * references them by `componentId`, and a child that still holds a vnode is sent as a placeholder
+ * for a node the DOM no longer has. Floating children (dialogs, popups) render outside their
+ * parent's node and keep their own tree.
+ * @param {Neo.component.Base} component
+ */
+function unmountSubtree(component) {
+    if (component.floating) {
+        return
+    }
+
+    component._vnode  = null;
+    component.mounted = false;
+
+    ComponentManager.getDirectChildren(component.id).forEach(unmountSubtree)
+}
+
+/**
+ * @summary Unmounts every direct logical child of `parent` whose node is absent from a freshly synced
+ * vnode tree — the removal half of {@link Neo.mixin.VdomLifecycle#syncVnodeTree}.
+ *
+ * A child counts as present when pass 1 found it in the new tree, or when the tree's node map holds
+ * its root node (wrapper nodes included). A pruned branch is NOT a removal: the vdom worker keeps a
+ * pruned child's previous subtree in the returned vnode, so the map lacks only nodes that really left.
+ * @param {Neo.component.Base} parent
+ * @param {Map<String, Object>} vnodeMap The node map of the synced vnode tree
+ * @param {Set<Neo.component.Base>} presentSet The components pass 1 found inside the tree
+ */
+function unmountRemovedChildren(parent, vnodeMap, presentSet) {
+    ComponentManager.getDirectChildren(parent.id).forEach(child => {
+        if (!presentSet.has(child) && !vnodeMap.get(child.vdom.id)) {
+            unmountSubtree(child)
+        }
+    })
+}
+
+/**
  * @class Neo.mixin.VdomLifecycle
  * @extends Neo.core.Base
  */
@@ -895,10 +934,12 @@ class VdomLifecycle extends Base {
      * 1. **Update Visible Children:** We iterate over children found directly in the new VNode structure
      *    (via `ComponentManager.getChildren`). This preserves the baseline behavior where fully expanded
      *    VNode trees (e.g., from `Helper.create`) are synced without unnecessary "downgrading" to references.
-     * 2. **Unmount Missing Children:** We iterate over ALL logical children (via `ComponentManager.find`)
-     *    to detect any that are absent from the new VNode tree (e.g., `removeDom: true`).
-     *    Crucially, we use `VNodeUtil.find` to distinguish between a "Placeholder" (valid, do nothing)
-     *    and a "Removal" (invalid, unmount).
+     * 2. **Unmount Removed Children:** For this component AND for every component pass 1 synced, we
+     *    iterate the direct logical children (via `ComponentManager.getDirectChildren`) and unmount —
+     *    recursively through their logical subtree — any that are neither in the new VNode tree nor
+     *    in its node map (e.g., `removeDom: true`, or list rows that left). A pruned branch keeps its
+     *    previous subtree in the returned vnode, so only genuinely removed nodes are missing from the
+     *    map: that is the "Placeholder" (valid, keep) vs "Removal" (unmount) distinction.
      *
      * @param {Neo.vdom.VNode} [vnode=this.vnode]
      */
@@ -952,24 +993,16 @@ class VdomLifecycle extends Base {
             }
         }
 
-        // New logic to handle unmounting of removed children
-        let directChildren = ComponentManager.getDirectChildren(me.id);
-        for (let i = 0, len = directChildren.length; i < len; i++) {
-            let component = directChildren[i];
-            if (!childComponentsSet.has(component)) {
-                childVnode = null;
+        // Unmount pass: every component whose node left the synced tree must know — at every depth
+        // the new vnode carries in full, not only one level below `me`. Pass 1 set `_vnode` silently
+        // for the components it found, so their own syncVnodeTree never runs; and a child whose
+        // payload a covering ancestor flight absorbed never receives a vnode at all. Without this,
+        // a pooled instance re-seated by reference after its rows left renders as a placeholder for
+        // a node the DOM no longer has.
+        unmountRemovedChildren(me, vnodeMap, childComponentsSet);
 
-                // Check if it exists in the tree (as placeholder)
-                // We use vnodeMap which resolves placeholders
-                if (me.vnode) {
-                    childVnode = vnodeMap.get(component.vdom.id);
-                }
-
-                if (!childVnode && !component.floating) {
-                    component._vnode = null;
-                    component.mounted = false
-                }
-            }
+        for (let i = 0, len = childComponents.length; i < len; i++) {
+            unmountRemovedChildren(childComponents[i], vnodeMap, childComponentsSet)
         }
 
         // silent update

--- a/src/mixin/VdomLifecycle.mjs
+++ b/src/mixin/VdomLifecycle.mjs
@@ -15,45 +15,6 @@ import {isDescriptor}   from '../core/ConfigSymbols.mjs';
 const {currentWorker} = Neo;
 
 /**
- * @summary Unmounts a component and its whole logical subtree after its node left the DOM.
- *
- * A removed subtree's descendants cannot stay mounted either: a later re-inline of the parent
- * references them by `componentId`, and a child that still holds a vnode is sent as a placeholder
- * for a node the DOM no longer has. Floating children (dialogs, popups) render outside their
- * parent's node and keep their own tree.
- * @param {Neo.component.Base} component
- */
-function unmountSubtree(component) {
-    if (component.floating) {
-        return
-    }
-
-    component._vnode  = null;
-    component.mounted = false;
-
-    ComponentManager.getDirectChildren(component.id).forEach(unmountSubtree)
-}
-
-/**
- * @summary Unmounts every direct logical child of `parent` whose node is absent from a freshly synced
- * vnode tree — the removal half of {@link Neo.mixin.VdomLifecycle#syncVnodeTree}.
- *
- * A child counts as present when pass 1 found it in the new tree, or when the tree's node map holds
- * its root node (wrapper nodes included). A pruned branch is NOT a removal: the vdom worker keeps a
- * pruned child's previous subtree in the returned vnode, so the map lacks only nodes that really left.
- * @param {Neo.component.Base} parent
- * @param {Map<String, Object>} vnodeMap The node map of the synced vnode tree
- * @param {Set<Neo.component.Base>} presentSet The components pass 1 found inside the tree
- */
-function unmountRemovedChildren(parent, vnodeMap, presentSet) {
-    ComponentManager.getDirectChildren(parent.id).forEach(child => {
-        if (!presentSet.has(child) && !vnodeMap.get(child.vdom.id)) {
-            unmountSubtree(child)
-        }
-    })
-}
-
-/**
  * @class Neo.mixin.VdomLifecycle
  * @extends Neo.core.Base
  */
@@ -934,12 +895,13 @@ class VdomLifecycle extends Base {
      * 1. **Update Visible Children:** We iterate over children found directly in the new VNode structure
      *    (via `ComponentManager.getChildren`). This preserves the baseline behavior where fully expanded
      *    VNode trees (e.g., from `Helper.create`) are synced without unnecessary "downgrading" to references.
-     * 2. **Unmount Removed Children:** For this component AND for every component pass 1 synced, we
-     *    iterate the direct logical children (via `ComponentManager.getDirectChildren`) and unmount —
-     *    recursively through their logical subtree — any that are neither in the new VNode tree nor
-     *    in its node map (e.g., `removeDom: true`, or list rows that left). A pruned branch keeps its
-     *    previous subtree in the returned vnode, so only genuinely removed nodes are missing from the
-     *    map: that is the "Placeholder" (valid, keep) vs "Removal" (unmount) distinction.
+     * 2. **Unmount Removed Children:** {@link #unmountRemovedChildren} runs for this component AND
+     *    for every component pass 1 synced: each direct logical child (via
+     *    `ComponentManager.getDirectChildren`) that is neither in the new VNode tree nor in its node
+     *    map (e.g., `removeDom: true`, or list rows that left) is unmounted, and the same test runs
+     *    on its own children. A pruned branch keeps its previous subtree in the returned vnode and a
+     *    moved node stays in the map, so only genuinely removed nodes are missing: that is the
+     *    "Placeholder" (valid, keep) vs "Removal" (unmount) distinction.
      *
      * @param {Neo.vdom.VNode} [vnode=this.vnode]
      */
@@ -999,16 +961,54 @@ class VdomLifecycle extends Base {
         // payload a covering ancestor flight absorbed never receives a vnode at all. Without this,
         // a pooled instance re-seated by reference after its rows left renders as a placeholder for
         // a node the DOM no longer has.
-        unmountRemovedChildren(me, vnodeMap, childComponentsSet);
+        me.unmountRemovedChildren(vnodeMap, childComponentsSet);
 
         for (let i = 0, len = childComponents.length; i < len; i++) {
-            unmountRemovedChildren(childComponents[i], vnodeMap, childComponentsSet)
+            childComponents[i].unmountRemovedChildren(vnodeMap, childComponentsSet)
         }
 
         // silent update
         me._vnode = vnode ? ComponentManager.addVnodeComponentReferences(vnode, me.id) : null;
 
         debug && console.log('syncVnodeTree', me.id, performance.now() - start)
+    }
+
+    /**
+     * Unmounts every direct logical child whose node is absent from a freshly synced vnode tree, and
+     * runs the same test on each removed child's own children — the removal half of
+     * {@link #syncVnodeTree}, which calls it for the receiver and for every component pass 1 synced.
+     *
+     * A child counts as present when pass 1 found it inside the tree, or when the tree's node map
+     * holds its root node (wrapper nodes included). Two cases keep a node in that map on purpose:
+     * a pruned branch, whose previous subtree the vdom worker keeps inside the returned vnode, and
+     * a node MOVED out of a removed parent in the same update — the worker emits its `removeNode`
+     * deltas after every `moveNode` for exactly that reuse, and here the test runs at every depth,
+     * so a moved descendant keeps its vnode and its mounted flag. Floating children (dialogs,
+     * popups) render outside their parent's node and are never tested.
+     *
+     * `mounted` is state tracking, not a DOM operation: the node is already gone, this records it.
+     * A class whose children track their own presence can override this to narrow or skip the pass.
+     * @param {Map<String, Object>} vnodeMap The node map of the synced vnode tree
+     * @param {Set<Neo.component.Base>} presentSet The components pass 1 found inside the tree
+     * @protected
+     */
+    unmountRemovedChildren(vnodeMap, presentSet) {
+        let children = ComponentManager.getDirectChildren(this.id),
+            i        = 0,
+            len      = children.length,
+            child;
+
+        for (; i < len; i++) {
+            child = children[i];
+
+            // cheapest test first: a present child (the common case) costs one Set lookup
+            if (!presentSet.has(child) && !vnodeMap.get(child.vdom.id) && !child.floating) {
+                child._vnode  = null;
+                child.mounted = false;
+
+                child.unmountRemovedChildren(vnodeMap, presentSet)
+            }
+        }
     }
 
     /**

--- a/test/playwright/component/apps/pooled-children/app.mjs
+++ b/test/playwright/component/apps/pooled-children/app.mjs
@@ -1,0 +1,226 @@
+import Component from '../../../../../src/component/Base.mjs';
+import Container from '../../../../../src/container/Base.mjs';
+import Viewport  from '../../../../../src/container/Viewport.mjs';
+
+/**
+ * @summary One pooled row: a container with a nested component, created ONCE and seated into the
+ * pool's vdom by reference — the `list.Component` shape, never held in `items`.
+ * @class Test.Playwright.Component.PooledChildren.Card
+ * @extends Neo.container.Base
+ */
+class Card extends Container {
+    static config = {
+        /**
+         * @member {String} className='Test.Playwright.Component.PooledChildren.Card'
+         * @protected
+         */
+        className: 'Test.Playwright.Component.PooledChildren.Card',
+        /**
+         * @member {String} ntype='pooled-children-card'
+         * @protected
+         */
+        ntype: 'pooled-children-card',
+        /**
+         * @member {String[]} baseCls=['pooled-card']
+         */
+        baseCls: ['pooled-card'],
+        /**
+         * @member {Object} _vdom={tag:'li'}
+         * @protected
+         */
+        _vdom:
+        {tag: 'li'}
+    }
+}
+Card = Neo.setupClass(Card);
+
+/**
+ * @summary The pool: renders pooled instances by reference.
+ * @class Test.Playwright.Component.PooledChildren.Pool
+ * @extends Neo.container.Base
+ */
+class Pool extends Container {
+    static config = {
+        /**
+         * @member {String} className='Test.Playwright.Component.PooledChildren.Pool'
+         * @protected
+         */
+        className: 'Test.Playwright.Component.PooledChildren.Pool',
+        /**
+         * @member {String} ntype='pooled-children-pool'
+         * @protected
+         */
+        ntype: 'pooled-children-pool',
+        /**
+         * @member {String[]} baseCls=['pool']
+         */
+        baseCls: ['pool'],
+        /**
+         * @member {Object} _vdom={tag:'ul'}
+         * @protected
+         */
+        _vdom:
+        {tag: 'ul'}
+    }
+}
+Pool = Neo.setupClass(Pool);
+
+/**
+ * @summary Browser fixture for pooled children removed inside a covering ancestor flight: a host
+ * whose own update (`updateDepth: -1`) absorbs the pool's empty render, then a refill that re-seats
+ * the same instances by reference. The reactive trigger configs are the spec's cross-worker RPC;
+ * `poolStateJson` mirrors the pooled instances' lifecycle flags.
+ * @class Test.Playwright.Component.PooledChildren.Host
+ * @extends Neo.container.Base
+ */
+class Host extends Container {
+    static config = {
+        /**
+         * @member {String} className='Test.Playwright.Component.PooledChildren.Host'
+         * @protected
+         */
+        className: 'Test.Playwright.Component.PooledChildren.Host',
+        /**
+         * @member {String} ntype='pooled-children-host'
+         * @protected
+         */
+        ntype: 'pooled-children-host',
+        /**
+         * Spec trigger: each bump empties the pool by the pool's OWN update — the control.
+         * @member {Number} clearAloneCount_=0
+         * @reactive
+         */
+        clearAloneCount_: 0,
+        /**
+         * Spec trigger: each bump dirties this host silently, widens its depth to the full tree and
+         * empties the pool, so the pool's render merges into the host's covering flight.
+         * @member {Number} clearInsideFlightCount_=0
+         * @reactive
+         */
+        clearInsideFlightCount_: 0,
+        /**
+         * @member {String[]} baseCls=['pooled-host']
+         */
+        baseCls: ['pooled-host'],
+        /**
+         * @member {String} id='pooled-host'
+         */
+        id: 'pooled-host',
+        /**
+         * Spec trigger: each bump re-seats every pooled card by reference.
+         * @member {Number} refillCount_=0
+         * @reactive
+         */
+        refillCount_: 0,
+        /**
+         * @member {Object[]} items
+         */
+        items: [
+            {module: Component, cls: ['pooled-title'], text: 'Pool'},
+            {module: Pool,      reference: 'pool'}
+        ]
+    }
+
+    /**
+     * The pooled instances, created once in {@link #onConstructed}.
+     * @member {Neo.container.Base[]} cards=[]
+     */
+    cards = []
+
+    /**
+     * Spec-readable lifecycle mirror of the pooled instances and their nested components.
+     * @returns {String}
+     */
+    get poolStateJson() {
+        return JSON.stringify(this.cards.map(card => ({
+            hasVnode    : !!card.vnode,
+            innerMounted: card.getReference('inner').mounted,
+            mounted     : card.mounted
+        })))
+    }
+
+    /**
+     * @param {Number} value
+     * @param {Number} oldValue
+     * @protected
+     */
+    afterSetClearAloneCount(value, oldValue) {
+        if (oldValue === undefined) {
+            return
+        }
+
+        const pool = this.getReference('pool');
+
+        pool.vdom.cn = [];
+        pool.update()
+    }
+
+    /**
+     * @param {Number} value
+     * @param {Number} oldValue
+     * @protected
+     */
+    afterSetClearInsideFlightCount(value, oldValue) {
+        if (oldValue === undefined) {
+            return
+        }
+
+        let me   = this,
+            pool = me.getReference('pool');
+
+        // the ancestor is dirty first (a silent config change queues its own update) ...
+        me.setSilent({style: {color: value % 2 ? 'blue' : 'red'}});
+        me.updateDepth = -1;
+
+        // ... so the pool's empty render merges into the ancestor's flight instead of flying alone
+        pool.vdom.cn = [];
+        pool.update();
+
+        me.promiseUpdate()
+    }
+
+    /**
+     * @param {Number} value
+     * @param {Number} oldValue
+     * @protected
+     */
+    afterSetRefillCount(value, oldValue) {
+        if (oldValue === undefined) {
+            return
+        }
+
+        const pool = this.getReference('pool');
+
+        pool.vdom.cn = this.cards.map(card => card.createVdomReference());
+        pool.update()
+    }
+
+    /**
+     * Creates the pooled cards once the pool exists and seats them by reference.
+     */
+    onConstructed() {
+        super.onConstructed();
+
+        let me   = this,
+            pool = me.getReference('pool');
+
+        me.cards = [0, 1, 2].map(index => Neo.create(Card, {
+            appName : me.appName,
+            id      : `pooled-card-${index}`,
+            items   : [{module: Component, cls: ['pooled-card-inner'], reference: 'inner', text: `card-${index}`}],
+            parentId: pool.id,
+            windowId: me.windowId
+        }));
+
+        pool.vdom.cn = me.cards.map(card => card.createVdomReference())
+    }
+}
+Host = Neo.setupClass(Host);
+
+export const onStart = () => Neo.app({
+    mainView: {
+        module: Viewport,
+        items : [{module: Host}]
+    },
+    name: 'Test.Playwright.PooledChildren'
+});

--- a/test/playwright/component/apps/pooled-children/index.html
+++ b/test/playwright/component/apps/pooled-children/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Neo.mjs Component Test App</title>
+</head>
+<body>
+    <script src="../../../../../src/MicroLoader.mjs" type="module"></script>
+</body>
+</html>

--- a/test/playwright/component/apps/pooled-children/neo-config.json
+++ b/test/playwright/component/apps/pooled-children/neo-config.json
@@ -1,0 +1,8 @@
+{
+    "appPath"         : "test/playwright/component/apps/pooled-children/app.mjs",
+    "basePath"        : "../../../../../",
+    "environment"     : "development",
+    "mainPath"        : "./Main.mjs",
+    "themes"          : ["neo-theme-neo-light"],
+    "useSharedWorkers": false
+}

--- a/test/playwright/component/container/PooledChildUnmount.spec.mjs
+++ b/test/playwright/component/container/PooledChildUnmount.spec.mjs
@@ -1,0 +1,97 @@
+import {test, expect} from '@playwright/test';
+
+/**
+ * @file test/playwright/component/container/PooledChildUnmount.spec.mjs
+ * @summary Pooled instances whose rows leave the DOM inside a COVERING ancestor flight must end
+ * unmounted, so that the next refill inserts their nodes instead of moving nodes that no longer exist.
+ *
+ * `syncVnodeTree` runs only for the component that receives a vnode. A pool whose update merged into
+ * an ancestor's `updateDepth: -1` flight never receives one of its own, so before the fix its removed
+ * pooled children kept `mounted: true` and a stale vnode; the refill then re-seated them by reference
+ * and the tree builder sent placeholders for nodes the DOM no longer had — visibly, a list of EMPTY
+ * rows after a settled-empty state. This is the same scenario as the unit reproducer, run through the
+ * real workers and the real DOM: the pool's `<li>` rows and their nested text are the assertion.
+ *
+ * The fixture's reactive trigger configs are the spec's cross-worker RPC (`setConfigs` writes) and
+ * `poolStateJson` the `getConfigs`-readable mirror of the pooled instances' lifecycle flags.
+ */
+
+const HOST_ID = 'pooled-host';
+
+const readHost = async (page, keys) => {
+    // The main-realm remote answers with the worker-message envelope; the values ride `.data`.
+    const reply = await page.evaluate(data => Neo.worker.App.getConfigs(data), {id: HOST_ID, keys});
+
+    return reply?.data ?? reply
+};
+
+const setHost = (page, configs) => page.evaluate(
+    data => Neo.worker.App.setConfigs(data),
+    {id: HOST_ID, ...configs}
+);
+
+const cards  = page => page.locator('li.pooled-card');
+const inners = page => page.locator('li.pooled-card .pooled-card-inner');
+
+const readPoolState = async page => {
+    const [json] = await readHost(page, ['poolStateJson']);
+
+    return JSON.parse(json)
+};
+
+const expectRefillRenders = async page => {
+    await expect(cards(page)).toHaveCount(3);
+    // the row content is what an empty `<li>` lacks — a placeholder for a departed node paints nothing
+    await expect(inners(page)).toHaveCount(3);
+    await expect(inners(page).nth(1)).toHaveText('card-1');
+
+    const state = await readPoolState(page);
+
+    expect(state.every(card => card.mounted && card.hasVnode && card.innerMounted)).toBe(true)
+};
+
+test.beforeEach(async ({page}) => {
+    await page.goto('test/playwright/component/apps/pooled-children/index.html');
+    await page.waitForSelector(`#${HOST_ID}`, {state: 'attached'});
+    await expect(cards(page)).toHaveCount(3);
+    await expect(inners(page).nth(0)).toHaveText('card-0')
+});
+
+test.describe('pooled children removed inside a covering ancestor flight', () => {
+    test('the pool emptied inside the flight unmounts its pooled children, and the refill renders them again', async ({page}) => {
+        await setHost(page, {clearInsideFlightCount: 1});
+        await expect(cards(page)).toHaveCount(0);
+
+        const state = await readPoolState(page);
+
+        // the rows left the DOM through the ancestor's flight — every pooled instance must know
+        expect(state.every(card => !card.mounted && !card.hasVnode && !card.innerMounted), JSON.stringify(state)).toBe(true);
+
+        await setHost(page, {refillCount: 1});
+        await expectRefillRenders(page)
+    });
+
+    test('CONTROL: the pool emptied by its own update behaves the same', async ({page}) => {
+        await setHost(page, {clearAloneCount: 1});
+        await expect(cards(page)).toHaveCount(0);
+
+        const state = await readPoolState(page);
+
+        expect(state.every(card => !card.mounted && !card.hasVnode && !card.innerMounted), JSON.stringify(state)).toBe(true);
+
+        await setHost(page, {refillCount: 1});
+        await expectRefillRenders(page)
+    });
+
+    test('a second round trip through the covering flight renders as well', async ({page}) => {
+        await setHost(page, {clearInsideFlightCount: 1});
+        await expect(cards(page)).toHaveCount(0);
+        await setHost(page, {refillCount: 1});
+        await expectRefillRenders(page);
+
+        await setHost(page, {clearInsideFlightCount: 2});
+        await expect(cards(page)).toHaveCount(0);
+        await setHost(page, {refillCount: 2});
+        await expectRefillRenders(page)
+    });
+});

--- a/test/playwright/unit/vdom/PooledChildUnmount.spec.mjs
+++ b/test/playwright/unit/vdom/PooledChildUnmount.spec.mjs
@@ -1,0 +1,205 @@
+import {setup} from '../../setup.mjs';
+
+const appName = 'PooledChildUnmountTest';
+
+setup({
+    neoConfig: {
+        allowVdomUpdatesInTests: true,
+        useDomApiRenderer      : true,
+        useVdomWorker          : false
+    },
+    appConfig: {
+        name: appName
+    }
+});
+
+import {test, expect}     from '@playwright/test';
+import Neo                from '../../../../src/Neo.mjs';
+import * as core          from '../../../../src/core/_export.mjs';
+import Component          from '../../../../src/component/Base.mjs';
+import Container          from '../../../../src/container/Base.mjs';
+import VdomHelper         from '../../../../src/vdom/Helper.mjs';
+import DomApiVnodeCreator from '../../../../src/vdom/util/DomApiVnodeCreator.mjs';
+// Ensure Neo.get is defined: a container's `items` resolve through the instance manager
+import InstanceManager    from '../../../../src/manager/Instance.mjs';
+
+// Mock applyDeltas to prevent errors during mount
+const realApplyDeltas = Neo.applyDeltas; // patched at import; restored in afterAll below
+
+Neo.applyDeltas = async () => {};
+
+test.afterAll(() => {
+    Neo.applyDeltas = realApplyDeltas;
+});
+
+/**
+ * A pooled row: a container with one nested component, so the removal recursion has a level to reach.
+ */
+class Card extends Container {
+    static config = {
+        className: 'Test.PooledCard',
+        ntype    : 'test-pooled-card',
+        _vdom    : {tag: 'div', cls: ['pooled-card']},
+        items    : [{module: Component, cls: ['pooled-card-inner'], reference: 'inner'}]
+    }
+}
+Card = Neo.setupClass(Card);
+
+/**
+ * A container that renders pooled component instances by reference — the `list.Component`
+ * shape: the instances are created once with `parentId` pointing at the pool and re-seated
+ * into the vdom via `createVdomReference()`, never held in `items`.
+ */
+class Pool extends Container {
+    static config = {
+        className: 'Test.Pool',
+        ntype    : 'test-pool',
+        _vdom    : {tag: 'ul', cls: ['pool']}
+    }
+}
+Pool = Neo.setupClass(Pool);
+
+class Host extends Container {
+    static config = {
+        className: 'Test.PoolHost',
+        ntype    : 'test-pool-host',
+        _vdom    : {tag: 'div', cls: ['pool-host']}
+    }
+}
+Host = Neo.setupClass(Host);
+
+/**
+ * @summary A pooled child removed from its pool inside a COVERING ancestor flight must end unmounted —
+ * and so must its own children.
+ *
+ * `syncVnodeTree` runs only for the component that receives a vnode. A pool whose update merged into
+ * an ancestor flight with `updateDepth: -1` has its payload dropped by the collision filter, never
+ * receives a vnode of its own, and (before the fix) never told its removed pooled children that their
+ * nodes left. A later re-seat by reference then sends a placeholder for a node the DOM no longer has:
+ * a fleet roster's empty `li` after a settled-empty refill.
+ */
+test.describe('Pooled children removed inside a covering ancestor flight', () => {
+    let host, pool, cards, testRun = 0;
+
+    const settle = () => new Promise(resolve => setTimeout(resolve, 100));
+
+    const createTree = () => {
+        host = Neo.create(Host, {
+            appName,
+            id   : `pool-host-${testRun}`,
+            items: [
+                {module: Component, id: `pool-title-${testRun}`, text: 'title'},
+                {module: Pool,      id: `pool-${testRun}`}
+            ]
+        });
+
+        pool = host.items[1];
+
+        cards = [0, 1].map(index => Neo.create(Card, {
+            appName,
+            id      : `pool-card-${testRun}-${index}`,
+            parentId: pool.id,
+            windowId: pool.windowId
+        }));
+
+        pool.vdom.cn = cards.map(card => card.createVdomReference());
+    };
+
+    const removeRowsInsideCoveringFlight = async () => {
+        // the ancestor is dirty first (a silent config change queues its own update) ...
+        host.setSilent({style: {color: 'blue'}});
+        host.updateDepth = -1;
+
+        // ... so the pool's empty render merges into the ancestor's flight instead of flying alone
+        pool.vdom.cn = [];
+        pool.update();
+
+        await host.promiseUpdate();
+        await settle()
+    };
+
+    test.beforeEach(() => {
+        testRun++;
+    });
+
+    test.afterEach(() => {
+        cards?.forEach(card => card.destroy());
+        host?.destroy();
+        host = pool = cards = null;
+    });
+
+    test('CONTROL: the pool updating alone unmounts its removed pooled children', async () => {
+        createTree();
+
+        await host.initVnode(true);
+        host.mounted = true;
+
+        expect(cards.map(card => card.mounted)).toEqual([true, true]);
+        expect(cards.map(card => card.vnode !== null)).toEqual([true, true]);
+
+        pool.vdom.cn = [];
+        await pool.promiseUpdate();
+        await settle();
+
+        expect(cards.map(card => card.mounted)).toEqual([false, false]);
+        expect(cards.map(card => card.vnode)).toEqual([null, null]);
+    });
+
+    test('a pool update merged into an ancestor flight (updateDepth -1) unmounts the removed pooled children', async () => {
+        createTree();
+
+        await host.initVnode(true);
+        host.mounted = true;
+
+        expect(cards.map(card => card.mounted)).toEqual([true, true]);
+
+        await removeRowsInsideCoveringFlight();
+
+        // the rows are gone from the tree the ancestor synced — the pooled instances must know
+        expect(cards.map(card => card.mounted)).toEqual([false, false]);
+        expect(cards.map(card => card.vnode)).toEqual([null, null]);
+    });
+
+    test('the removal reaches the pooled child\'s own children', async () => {
+        createTree();
+
+        await host.initVnode(true);
+        host.mounted = true;
+
+        const inner = cards.map(card => card.getReference('inner'));
+
+        expect(inner.map(item => item.mounted)).toEqual([true, true]);
+
+        await removeRowsInsideCoveringFlight();
+
+        // a re-inlined card references its inner component by id: a stale vnode one level down
+        // would render the card without it
+        expect(inner.map(item => item.mounted)).toEqual([false, false]);
+        expect(inner.map(item => item.vnode)).toEqual([null, null]);
+    });
+
+    test('CONSEQUENCE: a re-seated pooled child is inserted as a node, not moved as a placeholder', async () => {
+        createTree();
+
+        await host.initVnode(true);
+        host.mounted = true;
+
+        await removeRowsInsideCoveringFlight();
+
+        // refill: the first card is re-seated by reference, exactly like a list row coming back
+        pool.vdom.cn = [cards[0].createVdomReference()];
+
+        const {deltas} = await pool.promiseUpdate();
+
+        const inserted = deltas.filter(delta =>
+            delta.action === 'insertNode' &&
+            (delta.vnode?.id === cards[0].id || delta.outerHTML?.includes(cards[0].id))
+        );
+
+        // with a stale vnode the tree builder sends a placeholder and the diff moves a node that
+        // no longer exists (zero deltas); a correctly unmounted child is inlined and INSERTED
+        expect(inserted.length, JSON.stringify(deltas)).toBe(1);
+        expect(cards[0].mounted).toBe(true);
+        expect(cards[0].getReference('inner').mounted).toBe(true);
+    });
+});

--- a/test/playwright/unit/vdom/PooledChildUnmount.spec.mjs
+++ b/test/playwright/unit/vdom/PooledChildUnmount.spec.mjs
@@ -46,6 +46,20 @@ class Card extends Container {
 Card = Neo.setupClass(Card);
 
 /**
+ * A pooled row WITHOUT a container cascade: a plain component whose nested component is a logical
+ * child by `parentId` and a reference in its vdom. The move arm needs a removed parent that does not
+ * itself flip its children's `mounted` flag, so the flag it observes is the unmount pass's own.
+ */
+class Slot extends Component {
+    static config = {
+        className: 'Test.PooledSlot',
+        ntype    : 'test-pooled-slot',
+        _vdom    : {tag: 'li', cls: ['pooled-slot']}
+    }
+}
+Slot = Neo.setupClass(Slot);
+
+/**
  * A container that renders pooled component instances by reference — the `list.Component`
  * shape: the instances are created once with `parentId` pointing at the pool and re-seated
  * into the vdom via `createVdomReference()`, never held in `items`.
@@ -201,5 +215,63 @@ test.describe('Pooled children removed inside a covering ancestor flight', () =>
         expect(inserted.length, JSON.stringify(deltas)).toBe(1);
         expect(cards[0].mounted).toBe(true);
         expect(cards[0].getReference('inner').mounted).toBe(true);
+    });
+
+    test('MOVE: a node moved out of a removed parent in the same update keeps its vnode and its mounted flag', async () => {
+        // a slot (no container cascade) holding one nested component by reference, plus a sibling
+        // node the flight moves that component into
+        host = Neo.create(Host, {
+            appName,
+            id   : `pool-host-${testRun}`,
+            items: [
+                {module: Component, id: `pool-title-${testRun}`, text: 'title'},
+                {module: Pool,      id: `pool-${testRun}`},
+                {module: Component, id: `pool-keep-${testRun}`, cls: ['keep']}
+            ]
+        });
+
+        pool = host.items[1];
+
+        let keep  = host.items[2],
+            slot  = Neo.create(Slot,      {appName, id: `pool-slot-${testRun}`,  parentId: pool.id, windowId: pool.windowId}),
+            inner = Neo.create(Component, {appName, id: `pool-inner-${testRun}`, parentId: slot.id, windowId: pool.windowId, text: 'inner'});
+
+        cards = [slot, inner];
+
+        slot.vdom.cn = [inner.createVdomReference()];
+        pool.vdom.cn = [slot.createVdomReference()];
+
+        await host.initVnode(true);
+        host.mounted = true;
+
+        expect([slot.mounted, inner.mounted]).toEqual([true, true]);
+
+        // one covering flight: the pool drops the slot while `keep` takes the slot's inner node
+        host.setSilent({style: {color: 'blue'}});
+        host.updateDepth = -1;
+
+        pool.vdom.cn = [];
+        keep.vdom.cn = [inner.createVdomReference()];
+        pool.update();
+        keep.update();
+
+        const {deltas} = await host.promiseUpdate();
+
+        await settle();
+
+        // the worker moves the reused node BEFORE it removes the node that held it
+        const moveIndex   = deltas.findIndex(delta => delta.action === 'moveNode'   && delta.id === inner.id),
+              removeIndex = deltas.findIndex(delta => delta.action === 'removeNode' && delta.id === slot.id);
+
+        expect(moveIndex,   JSON.stringify(deltas)).toBeGreaterThan(-1);
+        expect(removeIndex, JSON.stringify(deltas)).toBeGreaterThan(-1);
+        expect(moveIndex).toBeLessThan(removeIndex);
+
+        // the removed slot is unmounted; the moved node — still in the synced tree — is not
+        expect(slot.mounted).toBe(false);
+        expect(slot.vnode).toBeNull();
+        expect(inner.mounted).toBe(true);
+        expect(inner.vnode).not.toBeNull();
+        expect(inner.parentId).toBe(slot.id);
     });
 });

--- a/test/playwright/unit/vdom/SyncVnodeTreeProfile.spec.mjs
+++ b/test/playwright/unit/vdom/SyncVnodeTreeProfile.spec.mjs
@@ -1,0 +1,272 @@
+import {setup} from '../../setup.mjs';
+
+const appName = 'SyncVnodeTreeProfileTest';
+
+setup({
+    neoConfig: {
+        allowVdomUpdatesInTests: true,
+        useDomApiRenderer      : true,
+        useVdomWorker          : false
+    },
+    appConfig: {
+        name: appName
+    }
+});
+
+import {test, expect}     from '@playwright/test';
+import Neo                from '../../../../src/Neo.mjs';
+import * as core          from '../../../../src/core/_export.mjs';
+import Component          from '../../../../src/component/Base.mjs';
+import ComponentManager   from '../../../../src/manager/Component.mjs';
+import Container          from '../../../../src/container/Base.mjs';
+import TreeBuilder        from '../../../../src/util/vdom/TreeBuilder.mjs';
+import VdomHelper         from '../../../../src/vdom/Helper.mjs';
+import DomApiVnodeCreator from '../../../../src/vdom/util/DomApiVnodeCreator.mjs';
+// Ensure Neo.get is defined: a container's `items` resolve through the instance manager
+import InstanceManager    from '../../../../src/manager/Instance.mjs';
+
+// Mock applyDeltas to prevent errors during mount
+const realApplyDeltas = Neo.applyDeltas; // patched at import; restored in afterAll below
+
+Neo.applyDeltas = async () => {};
+
+test.afterAll(() => {
+    Neo.applyDeltas = realApplyDeltas;
+});
+
+const
+    ITERATIONS = 30,
+    LEAVES     = 5,
+    ROWS       = 200,
+    WARMUP     = 5;
+
+class Leaf extends Component {
+    static config = {
+        className: 'Test.ProfileLeaf',
+        ntype    : 'test-profile-leaf',
+        _vdom    : {tag: 'span'}
+    }
+}
+Leaf = Neo.setupClass(Leaf);
+
+class Row extends Container {
+    static config = {
+        className: 'Test.ProfileRow',
+        ntype    : 'test-profile-row',
+        _vdom    : {tag: 'li'}
+    }
+}
+Row = Neo.setupClass(Row);
+
+class Host extends Container {
+    static config = {
+        className: 'Test.ProfileHost',
+        ntype    : 'test-profile-host',
+        _vdom    : {tag: 'ul'}
+    }
+}
+Host = Neo.setupClass(Host);
+
+// The pass BEFORE the extension, restated as class overrides: the receiver tested one level and never
+// recursed, and no synced child ran a pass of its own. That the profile can express it this way is
+// the point of the method being a mixin method — overriding it is the extension seam.
+class LegacyLeaf extends Leaf {
+    static config = {
+        className: 'Test.ProfileLegacyLeaf',
+        ntype    : 'test-profile-legacy-leaf'
+    }
+
+    unmountRemovedChildren() {}
+}
+LegacyLeaf = Neo.setupClass(LegacyLeaf);
+
+class LegacyRow extends Row {
+    static config = {
+        className: 'Test.ProfileLegacyRow',
+        ntype    : 'test-profile-legacy-row'
+    }
+
+    unmountRemovedChildren() {}
+}
+LegacyRow = Neo.setupClass(LegacyRow);
+
+class LegacyHost extends Host {
+    static config = {
+        className: 'Test.ProfileLegacyHost',
+        ntype    : 'test-profile-legacy-host'
+    }
+
+    unmountRemovedChildren(vnodeMap, presentSet) {
+        let children = ComponentManager.getDirectChildren(this.id),
+            i        = 0,
+            len      = children.length,
+            child;
+
+        for (; i < len; i++) {
+            child = children[i];
+
+            if (!presentSet.has(child) && !vnodeMap.get(child.vdom.id) && !child.floating) {
+                child._vnode  = null;
+                child.mounted = false
+            }
+        }
+    }
+}
+LegacyHost = Neo.setupClass(LegacyHost);
+
+const createTree = (HostClass, RowClass, LeafClass, suffix) => Neo.create(HostClass, {
+    appName,
+    id   : `profile-host-${suffix}`,
+    items: Array.from({length: ROWS}, (row, r) => ({
+        module: RowClass,
+        id    : `profile-row-${suffix}-${r}`,
+        items : Array.from({length: LEAVES}, (leaf, l) => ({module: LeafClass, id: `profile-leaf-${suffix}-${r}-${l}`}))
+    }))
+});
+
+/**
+ * The vdom worker's output for a full-depth render of the host — the exact input `syncVnodeTree`
+ * receives after an update — regenerated per sample so no sample sees a tree a previous sync compressed.
+ * @param {Neo.container.Base} host
+ * @returns {Neo.vdom.VNode}
+ */
+const expand = host => VdomHelper.create({
+    appName : host.appName,
+    vdom    : TreeBuilder.getVdomTree(host.vdom, -1),
+    windowId: host.windowId
+}).vnode;
+
+const median = samples => {
+    const sorted = [...samples].sort((a, b) => a - b);
+
+    return sorted[Math.floor(sorted.length / 2)]
+};
+
+/**
+ * One timed `syncVnodeTree` on a freshly expanded vnode — the expansion stays outside the timed region.
+ * @param {Neo.container.Base} host
+ * @param {Number[]} samples
+ */
+const sample = (host, samples) => {
+    const vnode = expand(host);
+
+    host._vnode = vnode;
+
+    const start = performance.now();
+
+    host.syncVnodeTree(vnode);
+    samples.push(performance.now() - start)
+};
+
+/**
+ * Profiles both trees interleaved (so JIT warm-up and GC pauses land on neither side alone) after a
+ * warm-up, and returns the medians in ms.
+ * @param {Neo.container.Base} extended
+ * @param {Neo.container.Base} legacy
+ * @returns {Number[]} `[extendedMs, legacyMs]`
+ */
+const profilePair = (extended, legacy) => {
+    const extendedSamples = [],
+          legacySamples   = [],
+          discard         = [];
+
+    for (let i = 0; i < WARMUP; i++) {
+        sample(extended, discard);
+        sample(legacy,   discard)
+    }
+
+    for (let i = 0; i < ITERATIONS; i++) {
+        sample(extended, extendedSamples);
+        sample(legacy,   legacySamples)
+    }
+
+    return [median(extendedSamples), median(legacySamples)]
+};
+
+const report = (label, extendedMs, legacyMs) => console.log(
+    `[syncVnodeTree profile] ${label} · ${ROWS * (LEAVES + 1)} components · ` +
+    `extended ${extendedMs.toFixed(3)} ms · one-level ${legacyMs.toFixed(3)} ms · ratio ${(extendedMs / legacyMs).toFixed(2)}`
+);
+
+/**
+ * @summary The extended unmount pass (every synced component, recursing through removed subtrees)
+ * against the one-level pass it replaced, on the same tree shape, in the same process.
+ *
+ * Two shapes: every child present (the common hot path — the extension adds one `childMap` lookup
+ * per synced component and a Set + Map lookup per direct child) and half the rows removed (the
+ * extension walks the removed subtrees the one-level pass never reached, which is its purpose).
+ * The bounds are generous on purpose — a CI worker is a noisy clock — while the printed medians are
+ * the numbers to read.
+ */
+test.describe('syncVnodeTree unmount pass — extended vs one-level', () => {
+    let extended, legacy;
+
+    test.afterEach(() => {
+        extended?.destroy();
+        legacy?.destroy();
+        extended = legacy = null
+    });
+
+    test('every child present: the extended pass stays within 2× of the one-level pass', async () => {
+        extended = createTree(Host,       Row,       Leaf,       'current');
+        legacy   = createTree(LegacyHost, LegacyRow, LegacyLeaf, 'legacy');
+
+        await extended.initVnode(true);
+        await legacy.initVnode(true);
+
+        extended.mounted = legacy.mounted = true;
+
+        expect(ComponentManager.getChildComponents(extended)).toHaveLength(ROWS * (LEAVES + 1));
+
+        const [extendedMs, legacyMs] = profilePair(extended, legacy);
+
+        report('every child present', extendedMs, legacyMs);
+
+        // nothing left, so nothing may unmount on either tree
+        expect(extended.items.every(row => row.mounted && row.items.every(leaf => leaf.mounted))).toBe(true);
+        expect(legacy.items.every(row => row.mounted && row.items.every(leaf => leaf.mounted))).toBe(true);
+        expect(extendedMs).toBeLessThan(legacyMs * 2)
+    });
+
+    test('half the rows removed: the extended pass reaches the leaves the one-level pass left with stale vnodes', async () => {
+        extended = createTree(Host,       Row,       Leaf,       'current-removed');
+        legacy   = createTree(LegacyHost, LegacyRow, LegacyLeaf, 'legacy-removed');
+
+        await extended.initVnode(true);
+        await legacy.initVnode(true);
+
+        extended.mounted = legacy.mounted = true;
+
+        for (const host of [extended, legacy]) {
+            host.items.forEach((row, index) => {
+                if (index % 2 === 0) {
+                    row.vdom.removeDom = true
+                }
+            });
+
+            host.updateDepth = -1;
+
+            await host.promiseUpdate()
+        }
+
+        const removedLeaf = host => host.items[0].items[0],
+              keptLeaf    = host => host.items[1].items[0];
+
+        // the semantic gap the extension closes: both passes unmount the removed ROW (the one-level
+        // pass through its own test, the container cascade flipping the leaves' flags), but only the
+        // extended pass reaches the leaves' vnodes — the stale vnode a later re-seat would send as a
+        // placeholder for a node the DOM no longer has
+        expect(extended.items[0].mounted).toBe(false);
+        expect(legacy.items[0].mounted).toBe(false);
+        expect(removedLeaf(extended).vnode).toBeNull();
+        expect(removedLeaf(legacy).vnode).not.toBeNull();
+        expect(keptLeaf(extended).mounted).toBe(true);
+        expect(keptLeaf(extended).vnode).not.toBeNull();
+
+        const [extendedMs, legacyMs] = profilePair(extended, legacy);
+
+        report('half the rows removed', extendedMs, legacyMs);
+
+        expect(extendedMs).toBeLessThan(legacyMs * 3)
+    });
+});


### PR DESCRIPTION
Resolves #18060

Related: #8868 (the one-level unmount pass this generalizes), neomjs/neo-agent-institution#76 (the consumer: the fleet roster's empty rows after a settled-empty refill), neomjs/neo-agent-institution#74

`syncVnodeTree` told only the receiver's direct children that their nodes left. A child whose update merged into a covering ancestor flight (`updateDepth: -1`, or any depth greater than its distance) has its payload dropped by the collision filter, never receives a vnode, and never ran the unmount pass for ITS removed children — they kept `mounted: true` and a stale vnode, so every later re-seat by reference sent a placeholder for a node the DOM no longer had. The pass is now a mixin method, `unmountRemovedChildren(vnodeMap, presentSet)`: `syncVnodeTree` calls it for the receiver and for every component pass 1 synced, and a removed child runs the same test on its own children. Presence is tested at every level — pass 1 found it, or its root node is in the synced tree's node map — so a pruned branch (the worker keeps its previous subtree) and a node MOVED out of a removed parent in the same update (the worker emits `removeNode` after every `moveNode` for exactly that reuse) both keep their vnode and their `mounted` flag. `mounted` records state; the DOM operation already happened.

Evidence: L3 (unit-project execution at the head; red-first in worktrees at `origin/dev@8c86f4478f` and at this PR's previous head `36bf90cb93`; the browser fixture driven in Chromium; the consumer's journey green on a locally patched install) → L3 required (every AC on #18060 is unit- or component-reachable; the institution row is post-merge by construction). Residual: AC-5, Residual-Owner: neomjs/neo-agent-institution#76.

## AC Evidence

| AC | Evidence |
|---|---|
| AC-1 — the reproducer exists and is green; red at the pre-fix head | CI-covered: `test/playwright/unit/vdom/PooledChildUnmount.spec.mjs`, 5 arms (control, merged, recursion, re-seat, move); outside-CI: the same spec at `origin/dev@8c86f4478f` → **4 failed / 1 passed** (control green; merged, recursion, re-seat and move red — on `dev` a merged pool never unmounts its removed slot) |
| AC-2 — the recursion reaches a removed pooled child's own child | CI-covered: arm "the removal reaches the pooled child's own children"; the profile spec's second arm pins the same gap on 100 removed rows (`removedLeaf(legacy).vnode` stays set, `removedLeaf(extended).vnode` is null) |
| AC-3 — `unit/vdom/**`, `grid/Teleportation` and the full `unit` project green | CI-covered; outside-CI: `vdom/ grid/Teleportation` → 169 passed, full `npm run test-unit` → **2952 passed / 0 failed** at the head (`grid/Teleportation` is skipped under `NEO_TEST_SKIP_CI`, so the outside-CI run is its receipt) |
| AC-4 — the JSDoc names the extended pass and its guard | CI-covered by inspection: `syncVnodeTree` "Implementation Detail" item 2 links `unmountRemovedChildren`; the method's JSDoc states the presence test, the move case, the state-tracking nature of `mounted` and the override seam |
| AC-5 — post-merge, institution #76 | Verified ahead of the bump on a locally patched install at the previous head (the settled-empty refill renders both cards; `AddAgentJourneyNL` under the Brain root → 1 passed); the mechanism is unchanged by the rework and the row stays post-merge for the real bump |

## Deltas from ticket

- **A mixin method, not module-level functions** (operator review, 2026-09-02): the first head put the helpers beside the class as module functions — an unoverridable seam in an engine built for extension. `unmountRemovedChildren` is a `VdomLifecycle` method now (every component carries it through `component.Abstract`), and the profile spec exercises the seam by restating the pre-extension pass as class overrides.
- **Presence tested at every level, not a blind subtree walk** (operator review): `vdom.Helper#update` concatenates `removeNode` deltas after every other delta so a child of a removed node can be moved elsewhere in the same batch; the previous head's recursion unmounted such a moved descendant. The move arm builds exactly that update, asserts the worker's `moveNode` precedes the `removeNode`, and is red at `36bf90cb93` (1 failed / 4 passed) and green here.
- **for-loops in the hot path** (operator review): no `forEach` in the pass, and the cheapest test (`presentSet.has`) runs first, so a present child costs one Set lookup.
- **Benchmark with and without the change** (operator review): `test/playwright/unit/vdom/SyncVnodeTreeProfile.spec.mjs` — 200 rows × 5 leaves (1,200 components), the extended pass against the one-level pass on the same worker output, interleaved after a warm-up, medians of 30 samples. Three quiet-machine runs at the head, every child present: 6.11 / 6.28 / 6.25 ms vs 5.42 / 5.50 / 5.84 ms (ratios 1.13 · 1.14 · 1.07); half the rows removed: 3.94 / 4.16 / 4.15 ms vs 2.75 / 2.97 / 3.02 ms (ratios 1.43 · 1.40 · 1.37). On `dev`, where both classes run the same one-level algorithm, the ratio reads 1.03 — the measurement floor. The bounds asserted in CI are 2× and 3×.
- **Component-based test** (operator review): `test/playwright/component/container/PooledChildUnmount.spec.mjs` on a new `apps/pooled-children` fixture — the same scenario through the real workers and the real DOM, 3 arms green here; at `origin/dev` all three are red, including the pool-alone CONTROL: the nested component's stale vnode makes the refill render no row at all in a real browser, a fact the unit control (which asserts the cards, not their children) cannot see.

## Test Evidence

- Red-first, dev worktree (`origin/dev@8c86f4478f`): unit `vdom/PooledChildUnmount vdom/SyncVnodeTreeProfile` → 5 failed / 2 passed (the control arm and the all-present profile arm green); component `container/PooledChildUnmount` → 3 failed (arm 1 at the lifecycle mirror — the cards stay mounted; arms 2 and 3 at the refill — 0 rows rendered).
- Red-first, previous-head worktree (`36bf90cb93`): unit `vdom/PooledChildUnmount` → 1 failed / 4 passed — the move arm: the blind recursion unmounted the moved node.
- Profile numbers above; full unit project 2952 passed at the head.
- Live consumer receipt (previous head, same mechanism): the fleet cockpit's settled-empty refill rendered both cards on a locally patched install where the pinned engine rendered two empty `li`; `AddAgentJourneyNL` under the Brain root → 1 passed.

## Post-Merge Validation

- [ ] Institution #76: bump the pinned `neo.mjs` SHA and re-run `AddAgentJourneyNL` under the Brain root — expected green, as on the patched install.

## Commits

- `b35dc00ff9` — the extended unmount pass as module-level helpers, and the 4-arm reproducer (superseded in shape by the next commit).
- `a5d58618b6` — the pass as a mixin method with the presence test at every level, the move arm, the profile spec and the browser fixture.

## Evolution

The first head widened the pass by recursing blindly through a removed component's logical subtree. The operator's review named the case that breaks: the worker orders `removeNode` last so a node inside a removed node can be moved out in the same update, and a blind walk unmounts it. The rework tests presence at every level instead, moves the pass onto the mixin so a class can narrow or skip it, and measures the cost against the pass it replaced.

Authored by Clio (Claude Fable 5.1, Claude Code). Session 91f83b9c-df95-4f72-a68f-d33f470792ac.

Cross-family note: the GPT seats are at 0% weekly quota (operator, 2026-09-01 22:20Z); an Opus 5 review is the sanctioned exception. Grace's approval at `36bf90cb93` predates the rework; re-review requested at the new head.

📜 Clio
