### PR TITLE
feat(dock): a rail loads a lazy module item on reveal, like a card layout on activation (#18062)

### DIFF
--- a/learn/agentos/decisions/0029-docking-design.md
+++ b/learn/agentos/decisions/0029-docking-design.md
@@ -342,6 +342,10 @@ The table above guarantees a resolved instance is **moved / re-parented, never d
 
 **Retirement condition.** This exception exists only because `dockReload()` is optional. When the delegation contract becomes mandatory for embedded surfaces, or a pane-level error boundary makes a wedged pane recoverable without identity loss, this subsection retires with the leaf that makes it unnecessary and the table row returns to unconditional. Whoever lands that leaf should delete this block rather than qualify it further.
 
+#### Lazy first materialization (amendment, 2026-09-02 — #18062)
+
+The table's first row governs instances that **exist**. An item whose resolved config carries a lazy `module` function (`module: () => import('...')`, the tab-card shape) has no instance until its first activation: the tab flow creates it when its card activates (`Neo.layout.Card#loadModule`), and a rail creates it on first reveal (`Neo.dashboard.dock.interaction.Rail#loadRevealPane`) — a rail is the auto-hide analog of a tab strip with no active item, and reveal is its activation. That first creation is materialization, not recreation: the row is unaffected, and from that moment on the instance is moved / re-parented like any other. The never-recreate rule governs existing views; creating a new view on demand is ordinary component lifecycle, and it is what keeps a heavy pane behind a never-opened tab or rail tab from paying class loading, construction, `initAsync` and store `autoLoad` at app boot (operator ruling, 2026-09-02).
+
 ### §2.7 Auto-Hide UI Contract
 
 Grace's #13280 implements this section; it is written to be implementation-sufficient without further design decisions. Sequencing per the leaf owner's decision (2026-07-02): the leaf follows this record.

--- a/src/dashboard/dock/interaction/Rail.mjs
+++ b/src/dashboard/dock/interaction/Rail.mjs
@@ -886,8 +886,9 @@ class Rail extends Container {
                 if (Neo.typeOf(resolved) === 'NeoInstance') {
                     slot.add(resolved)
                 } else if (resolved) {
-                    if (Neo.isFunction(resolved.module) && !resolved.module.isClass) {
-                        // the lazy shape: loaded on activation — reveal is the rail's activation
+                    if (Neo.typeOf(resolved.module) === 'Function') {
+                        // the lazy shape (a loader, never a class — typeOf reads a class as 'NeoClass'):
+                        // loaded on activation, and reveal is the rail's activation
                         me.revealPaneLoads[nextId] ??= me.loadRevealPane(nextId, resolved)
                     } else {
                         me.revealPaneCache[nextId] = slot.add({...resolved})

--- a/src/dashboard/dock/interaction/Rail.mjs
+++ b/src/dashboard/dock/interaction/Rail.mjs
@@ -148,9 +148,11 @@ class Rail extends Container {
     revealPaneCache = {}
     /**
      * In-flight lazy pane loads, keyed by dock item id: the promise {@link #loadRevealPane} returns
-     * for a resolved config whose `module` is a loader function. One load per item at a time; the
-     * entry clears when the load settles, when the item is released and on destroy — a load whose
-     * entry is gone adds nothing.
+     * for a resolved config whose `module` is a loader function. The entry is the load's lease: it
+     * clears when the load settles (resolved or rejected) and when the item is released, and a
+     * destroyed rail has no map at all (`Neo.core.Base#destroy` deletes every own property) — a load
+     * whose lease is gone adds nothing. A release followed by a re-reveal can briefly overlap two
+     * loads; only the first to settle holds the lease, so only one pane lands.
      * @member {Object} revealPaneLoads={}
      * @protected
      */
@@ -747,27 +749,61 @@ class Rail extends Container {
     }
 
     /**
+     * The recoverable placeholder for an item whose pane cannot be materialized — the adapter's own
+     * policy, so a reveal never shows a silently empty overlay.
+     * @param {String} itemId
+     * @returns {Object} A component config
+     * @protected
+     */
+    createRevealPlaceholder(itemId) {
+        const item = this.dockZoneDocument?.items?.[itemId];
+
+        return Neo.dashboard?.dock?.projection?.LayoutAdapter?.createPlaceholder?.(itemId, item)
+            ?? {cls: ['neo-dashboard-dock-placeholder'], dockItemId: itemId, ntype: 'component'}
+    }
+
+    /**
      * Loads the module of a lazy pane config — `module: () => import('...')`, the shape a tab
      * container's card layout loads when the tab activates (`Neo.layout.Card#loadModule`) — and
      * materializes the pane into the overlay's slot once the import settles. Reveal is the rail's
      * activation: a lazy item has no instance before its first reveal, and creating it there is
      * first materialization, not recreation — the never-recreate rule governs instances that exist.
-     * The item's `revealPaneLoads` entry is the load's lease: a released item or a destroyed rail
-     * clears it, and a reveal dismissed while
-     * the import is in flight adds nothing — the next reveal resolves again, immediately, from the
-     * module registry.
+     *
+     * The item's `revealPaneLoads` entry is the load's lease. It clears however the load ends: a
+     * resolved import lands the pane if the reveal still names the item; a dismissed reveal lands
+     * nothing and the next reveal resolves again, immediately, from the module registry; a REJECTED
+     * import (a chunk that fails to fetch, a pane module that throws while evaluating) clears the
+     * lease so the next reveal retries, and the reveal that is still open gets the recoverable
+     * placeholder instead of an empty overlay — uncached and transient, so a retry is a real import;
+     * a released item or a destroyed rail leaves no lease to honour, and the guard reads the map
+     * optionally because destroy removes it.
      * @param {String} itemId
      * @param {Object} config The resolved pane config; `config.module` is the loader function
-     * @returns {Promise<Neo.component.Base|null>} The materialized pane, or `null` when the reveal left
+     * @returns {Promise<Neo.component.Base|null>} The materialized pane, or `null` when the reveal left or the import failed
      * @protected
      */
     async loadRevealPane(itemId, config) {
-        let me     = this,
-            module = (await config.module()).default,
-            pane;
+        let me = this,
+            module, pane;
 
-        // released, destroyed, or superseded while the import was in flight
-        if (!me.revealPaneLoads[itemId]) {
+        try {
+            module = (await config.module()).default
+        } catch (error) {
+            console.error(`Rail: the lazy pane module of item '${itemId}' failed to load`, error);
+
+            me.revealPaneLoads && delete me.revealPaneLoads[itemId];
+
+            if (me.revealOverlay?.revealPaneItemId === itemId) {
+                pane = me.revealOverlay.paneSlot.add(me.createRevealPlaceholder(itemId));
+                // transient: dismissal destroys it rather than parking it, so the next reveal retries
+                pane.revealLoadFailed = true
+            }
+
+            return null
+        }
+
+        // released, or the rail was destroyed (its maps are gone) while the import was in flight
+        if (!me.revealPaneLoads?.[itemId]) {
             return null
         }
 
@@ -832,7 +868,8 @@ class Rail extends Container {
         }
 
         if (child) {
-            slot.remove(child, false)
+            // park everything a reveal may show again; a failed-load placeholder is transient
+            slot.remove(child, child.revealLoadFailed === true)
         }
 
         if (nextId && typeof me.resolveComponentRef === 'function') {
@@ -858,10 +895,7 @@ class Rail extends Container {
                 } else if (item) {
                     // Neither live instance nor blueprint resolves: recoverable placeholder,
                     // never a silently empty overlay — the adapter's own policy.
-                    me.revealPaneCache[nextId] = slot.add(
-                        Neo.dashboard?.dock?.projection?.LayoutAdapter?.createPlaceholder?.(nextId, item) ??
-                        {cls: ['neo-dashboard-dock-placeholder'], dockItemId: nextId, ntype: 'component'}
-                    )
+                    me.revealPaneCache[nextId] = slot.add(me.createRevealPlaceholder(nextId))
                 }
             }
         }

--- a/src/dashboard/dock/interaction/Rail.mjs
+++ b/src/dashboard/dock/interaction/Rail.mjs
@@ -147,6 +147,15 @@ class Rail extends Container {
      */
     revealPaneCache = {}
     /**
+     * In-flight lazy pane loads, keyed by dock item id: the promise {@link #loadRevealPane} returns
+     * for a resolved config whose `module` is a loader function. One load per item at a time; the
+     * entry clears when the load settles, when the item is released and on destroy — a load whose
+     * entry is gone adds nothing.
+     * @member {Object} revealPaneLoads={}
+     * @protected
+     */
+    revealPaneLoads = {}
+    /**
      * The reveal/dismiss timing brain. Runtime-only; created per instance, torn down in `destroy()`.
      * @member {RevealStateMachine|null} revealMachine=null
      * @protected
@@ -391,6 +400,9 @@ class Rail extends Container {
         let me   = this,
             pane = me.revealPaneCache[itemId];
 
+        // an import still in flight for a released item must not land a pane afterwards
+        delete me.revealPaneLoads[itemId];
+
         if (!pane) {
             return
         }
@@ -434,6 +446,7 @@ class Rail extends Container {
             pane?.isDestroyed || pane?.destroy?.()
         });
         me.revealPaneCache = {};
+        me.revealPaneLoads = {};
 
         super.destroy(...args)
     }
@@ -734,10 +747,55 @@ class Rail extends Container {
     }
 
     /**
+     * Loads the module of a lazy pane config — `module: () => import('...')`, the shape a tab
+     * container's card layout loads when the tab activates (`Neo.layout.Card#loadModule`) — and
+     * materializes the pane into the overlay's slot once the import settles. Reveal is the rail's
+     * activation: a lazy item has no instance before its first reveal, and creating it there is
+     * first materialization, not recreation — the never-recreate rule governs instances that exist.
+     * The item's `revealPaneLoads` entry is the load's lease: a released item or a destroyed rail
+     * clears it, and a reveal dismissed while
+     * the import is in flight adds nothing — the next reveal resolves again, immediately, from the
+     * module registry.
+     * @param {String} itemId
+     * @param {Object} config The resolved pane config; `config.module` is the loader function
+     * @returns {Promise<Neo.component.Base|null>} The materialized pane, or `null` when the reveal left
+     * @protected
+     */
+    async loadRevealPane(itemId, config) {
+        let me     = this,
+            module = (await config.module()).default,
+            pane;
+
+        // released, destroyed, or superseded while the import was in flight
+        if (!me.revealPaneLoads[itemId]) {
+            return null
+        }
+
+        delete me.revealPaneLoads[itemId];
+
+        // dismissed before the import settled
+        if (me.revealOverlay?.revealPaneItemId !== itemId) {
+            return null
+        }
+
+        pane = me.revealPaneCache[itemId] = me.revealOverlay.paneSlot.add({...config, module});
+
+        me.syncDockLockPane?.(pane, itemId);
+
+        return pane
+    }
+
+    /**
      * Materializes the revealed item's pane into the overlay's slot through the adapter's durable
      * reveal resolver, with the `componentRef` read from the committed document (the rail's copy
      * re-projects on every change). This resolver must outlive any transaction-only in-flow staging
      * resolver because the user can reveal the rail long after projection reconciliation settles.
+     *
+     * A resolved config whose `module` is a loader function takes the one asynchronous branch:
+     * {@link #loadRevealPane} awaits the import and adds the instance once it settles, exactly as a
+     * tab container's card layout loads a lazy card on activation — a plain slot add would park the
+     * loader as an unrendered object (`Neo.container.Base#createItem`), which nothing on the reveal
+     * path ever resolves.
      *
      * Live-instance contract: a resolver-returned Neo INSTANCE is added as-is and PARKED on
      * dismissal (removed without destroy — moved/re-parented, never destroyed), so its identity
@@ -791,7 +849,12 @@ class Rail extends Container {
                 if (Neo.typeOf(resolved) === 'NeoInstance') {
                     slot.add(resolved)
                 } else if (resolved) {
-                    me.revealPaneCache[nextId] = slot.add({...resolved})
+                    if (Neo.isFunction(resolved.module) && !resolved.module.isClass) {
+                        // the lazy shape: loaded on activation — reveal is the rail's activation
+                        me.revealPaneLoads[nextId] ??= me.loadRevealPane(nextId, resolved)
+                    } else {
+                        me.revealPaneCache[nextId] = slot.add({...resolved})
+                    }
                 } else if (item) {
                     // Neither live instance nor blueprint resolves: recoverable placeholder,
                     // never a silently empty overlay — the adapter's own policy.

--- a/test/playwright/component/apps/dock-lazy-rail/LazyPane.mjs
+++ b/test/playwright/component/apps/dock-lazy-rail/LazyPane.mjs
@@ -1,0 +1,44 @@
+import Component from '../../../../../src/component/Base.mjs';
+
+/**
+ * @summary The lazily loaded rail pane: nothing in the fixture's boot graph imports this file, so
+ * its class registration in the Neo namespace is the load witness, and its construction count is
+ * the identity witness (one instance across dismiss / re-reveal).
+ * @class Test.Playwright.Component.DockLazyRail.LazyPane
+ * @extends Neo.component.Base
+ */
+class LazyPane extends Component {
+    /**
+     * Constructions of this class — read through the fixture workspace's `lazyPaneInstances`.
+     * @member {Number} instances=0
+     * @static
+     */
+    static instances = 0
+
+    static config = {
+        /**
+         * @member {String} className='Test.Playwright.Component.DockLazyRail.LazyPane'
+         * @protected
+         */
+        className: 'Test.Playwright.Component.DockLazyRail.LazyPane',
+        /**
+         * @member {String} ntype='dock-lazy-rail-pane'
+         * @protected
+         */
+        ntype: 'dock-lazy-rail-pane',
+        /**
+         * @member {String[]} baseCls=['dock-lazy-rail-pane']
+         */
+        baseCls: ['dock-lazy-rail-pane']
+    }
+
+    /**
+     * @param {Object} config
+     */
+    construct(config) {
+        super.construct(config);
+        this.constructor.instances++
+    }
+}
+
+export default Neo.setupClass(LazyPane);

--- a/test/playwright/component/apps/dock-lazy-rail/app.mjs
+++ b/test/playwright/component/apps/dock-lazy-rail/app.mjs
@@ -1,0 +1,105 @@
+import DockWorkspace from '../../../../../src/dashboard/dock/Workspace.mjs';
+import Viewport      from '../../../../../src/container/Viewport.mjs';
+import '../../../../../src/tab/Container.mjs';
+
+const fixtureDocument = {
+    schema: 'neo.dock.zone.v1',
+    root  : 'root',
+    items : {
+        alpha : {componentRef: 'Alpha',  title: 'Alpha',  kind: 'panel'},
+        pinned: {componentRef: 'Pinned', title: 'Pinned', kind: 'panel'},
+        lazy  : {componentRef: 'Lazy',   title: 'Lazy',   kind: 'panel', autoHidden: true}
+    },
+    nodes: {
+        root       : {type: 'edge-zone', zones: {center: {nodeId: 'main-tabs'}, right: {nodeId: 'edge-tabs', extent: 0.3}}},
+        'main-tabs': {type: 'tabs', items: ['alpha'],          activeItemId: 'alpha'},
+        'edge-tabs': {type: 'tabs', items: ['pinned', 'lazy'], activeItemId: 'pinned'}
+    }
+};
+
+/**
+ * @summary Browser fixture for a lazy rail item: an edge tabs node with one visible pane and one
+ * auto-hidden item whose pane config is a lazy `module` function — the shape a tab container's
+ * card layout loads on activation. The module lives in its own file (`LazyPane.mjs`) so that its
+ * registration in the Neo namespace can witness WHEN it loaded: at boot nothing imports it.
+ * @class Test.Playwright.Component.DockLazyRail.Workspace
+ * @extends Neo.dashboard.dock.Workspace
+ */
+class LazyRailFixtureWorkspace extends DockWorkspace {
+    static config = {
+        /**
+         * @member {String} className='Test.Playwright.Component.DockLazyRail.Workspace'
+         * @protected
+         */
+        className: 'Test.Playwright.Component.DockLazyRail.Workspace',
+        /**
+         * @member {String} id='dock-lazy-rail-workspace'
+         */
+        id: 'dock-lazy-rail-workspace',
+        /**
+         * @member {Object} layout={ntype:'vbox',align:'stretch'}
+         */
+        layout: {ntype: 'vbox', align: 'stretch'}
+    }
+
+    /**
+     * Spec-readable load witness: the lazy pane class is registered only once its module evaluated.
+     * @returns {Boolean}
+     */
+    get lazyPaneModuleLoaded() {
+        return !!Neo.ns('Test.Playwright.Component.DockLazyRail.LazyPane')
+    }
+
+    /**
+     * Spec-readable identity witness: constructions of the lazy pane class — 0 before the first
+     * reveal, 1 after it, still 1 after a dismiss and re-reveal (the cached instance is re-parented).
+     * @returns {Number}
+     */
+    get lazyPaneInstances() {
+        return Neo.ns('Test.Playwright.Component.DockLazyRail.LazyPane')?.instances ?? 0
+    }
+
+    /**
+     * @param {Object} config
+     */
+    construct(config) {
+        super.construct(config);
+
+        // The proven deferred-boot dance: seed the empty shell, then commit the real document.
+        this.add(this.projectDockModel());
+        this.onDockZoneDocumentChange(structuredClone(fixtureDocument))
+    }
+
+    /**
+     * @param {String} itemId
+     * @param {Object} item
+     * @returns {Object}
+     */
+    resolvePane(itemId, item) {
+        if (itemId === 'lazy') {
+            return {
+                // the lazy shape: loaded on activation — for a rail item, on its first reveal
+                module: () => import('./LazyPane.mjs'),
+                id    : 'dock-lazy-rail-pane-lazy',
+                text  : 'Lazy pane'
+            }
+        }
+
+        return {
+            ntype: 'component',
+            id   : `dock-lazy-rail-pane-${itemId}`,
+            style: {alignItems: 'center', display: 'flex', justifyContent: 'center'},
+            text : item?.title || itemId
+        }
+    }
+}
+
+LazyRailFixtureWorkspace = Neo.setupClass(LazyRailFixtureWorkspace);
+
+export const onStart = () => Neo.app({
+    mainView: {
+        module: Viewport,
+        items : [{module: LazyRailFixtureWorkspace, flex: 1}]
+    },
+    name: 'Test.Playwright.DockLazyRail'
+});

--- a/test/playwright/component/apps/dock-lazy-rail/index.html
+++ b/test/playwright/component/apps/dock-lazy-rail/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Neo.mjs Component Test App</title>
+</head>
+<body>
+    <script src="../../../../../src/MicroLoader.mjs" type="module"></script>
+</body>
+</html>

--- a/test/playwright/component/apps/dock-lazy-rail/neo-config.json
+++ b/test/playwright/component/apps/dock-lazy-rail/neo-config.json
@@ -1,0 +1,9 @@
+{
+    "appPath"         : "test/playwright/component/apps/dock-lazy-rail/app.mjs",
+    "basePath"        : "../../../../../",
+    "environment"     : "development",
+    "mainPath"        : "./Main.mjs",
+    "mainThreadAddons": ["DockFlip", "DragDrop", "Navigator", "ResizeObserver", "Stylesheet"],
+    "themes"          : ["neo-theme-neo-dark", "neo-theme-neo-light"],
+    "useSharedWorkers": false
+}

--- a/test/playwright/component/dashboard/DockRailLazyModule.spec.mjs
+++ b/test/playwright/component/dashboard/DockRailLazyModule.spec.mjs
@@ -1,0 +1,84 @@
+import {test, expect} from '@playwright/test';
+
+/**
+ * @file test/playwright/component/dashboard/DockRailLazyModule.spec.mjs
+ * @summary An auto-hidden dock item whose pane config carries a lazy `module` function loads on its
+ * FIRST reveal — not at boot, and not never.
+ *
+ * The tab flow already has this contract: a card layout loads a lazy item's module when its tab
+ * activates, so a heavy pane behind a never-opened tab costs nothing at startup. A rail is the same
+ * strip with no active item, and reveal is its activation. Before the fix the reveal path handed
+ * the loader function to a plain container slot, which threw inside the reveal transition and left
+ * the overlay empty.
+ *
+ * Two observables, both read on the rendered workspace:
+ * - the module registry: the lazy pane class is absent from the Neo namespace at boot (a static
+ *   import anywhere in the fixture's boot graph would register it) and present after the reveal —
+ *   read through the fixture workspace's `lazyPaneModuleLoaded` getter;
+ * - the DOM: the visible reveal overlay holds the pane's node after the rail-tab click.
+ */
+
+const WORKSPACE_ID = 'dock-lazy-rail-workspace';
+
+const readWorkspace = async (page, keys) => {
+    // The main-realm remote answers with the worker-message envelope; the values ride `.data`.
+    const reply = await page.evaluate(data => Neo.worker.App.getConfigs(data), {id: WORKSPACE_ID, keys});
+
+    return reply?.data ?? reply
+};
+
+const lazyTab = page => page.locator('.neo-dashboard-dock-rail-tab', {hasText: 'Lazy'});
+
+const visibleOverlay = page => page.locator('.neo-dashboard-dock-reveal-overlay:not(.neo-dashboard-dock-reveal-overlay-hidden)');
+
+test.beforeEach(async ({page}) => {
+    await page.goto('test/playwright/component/apps/dock-lazy-rail/index.html');
+    await page.waitForSelector(`#${WORKSPACE_ID}`,       {state: 'attached'});
+    await page.waitForSelector('.neo-dashboard-dock-rail-tab', {state: 'visible'})
+});
+
+test.describe('dock rail — a lazy module item loads on its first reveal', () => {
+    test('nothing loads at boot, while the eager sibling renders', async ({page}) => {
+        // non-vacuity: the projection rendered — the visible edge pane and the rail tab both exist
+        await expect(page.locator('#dock-lazy-rail-pane-pinned')).toBeVisible();
+        await expect(lazyTab(page)).toHaveCount(1);
+
+        const [loaded, instances] = await readWorkspace(page, ['lazyPaneModuleLoaded', 'lazyPaneInstances']);
+
+        expect(loaded).toBe(false);
+        expect(instances).toBe(0);
+        await expect(page.locator('.dock-lazy-rail-pane')).toHaveCount(0)
+    });
+
+    test('the rail-tab click loads the module and renders the pane inside the reveal overlay', async ({page}) => {
+        await lazyTab(page).click();
+
+        await expect(visibleOverlay(page)).toHaveCount(1);
+        await expect(visibleOverlay(page).locator('.dock-lazy-rail-pane')).toBeVisible();
+        await expect(visibleOverlay(page).locator('.dock-lazy-rail-pane')).toHaveText('Lazy pane');
+
+        const [loaded, instances] = await readWorkspace(page, ['lazyPaneModuleLoaded', 'lazyPaneInstances']);
+
+        expect(loaded).toBe(true);
+        expect(instances).toBe(1)
+    });
+
+    test('a dismiss parks the loaded pane; the re-reveal shows the same instance, no second construction', async ({page}) => {
+        await lazyTab(page).click();
+        await expect(visibleOverlay(page).locator('.dock-lazy-rail-pane')).toBeVisible();
+
+        // A click-born reveal holds focus inside the overlay, so Escape reaches its keydown seam —
+        // the reveal contract's keyboard dismissal. A rail-tab re-click is not usable here: the
+        // pointer leaving the overlay opens the dismiss grace first, and the click re-enters the
+        // reveal before it lapses.
+        await page.keyboard.press('Escape');
+        await expect(visibleOverlay(page)).toHaveCount(0);
+
+        await lazyTab(page).click();
+        await expect(visibleOverlay(page).locator('#dock-lazy-rail-pane-lazy')).toBeVisible();
+
+        const [instances] = await readWorkspace(page, ['lazyPaneInstances']);
+
+        expect(instances).toBe(1)
+    });
+});

--- a/test/playwright/unit/dashboard/DockRail.spec.mjs
+++ b/test/playwright/unit/dashboard/DockRail.spec.mjs
@@ -563,6 +563,77 @@ test.describe('Neo.dashboard.dock.interaction.Rail', () => {
         expect(slot.items[0]).toBe(pane);
     });
 
+    test('a rejected import clears the lease, shows the recoverable placeholder, and the next reveal retries', async () => {
+        let attempts = 0;
+
+        rail = Neo.create(DockRail, {
+            dockZoneDocument   : createDocument(),
+            edge               : 'right',
+            id                 : 'dock-rail-lazy-module-rejected',
+            railItems          : createRailItems(),
+            resolveComponentRef: () => ({
+                module: () => ++attempts === 1 ? Promise.reject(new Error('chunk failed to load')) : Promise.resolve({default: Button}),
+                text  : 'Lazy'
+            })
+        });
+
+        rail.onTabClick({component: tabsOf(rail)[0]});
+
+        let slot = rail.revealOverlay.paneSlot;
+
+        // The failed load settles to null, the lease clears (a second reveal is not short-circuited),
+        // nothing is cached, and the open reveal shows the recoverable placeholder — not an empty overlay.
+        expect(await rail.revealPaneLoads.terminal).toBeNull();
+        expect(rail.revealPaneLoads.terminal).toBeUndefined();
+        expect(rail.revealPaneCache.terminal).toBeUndefined();
+        expect(slot.items).toHaveLength(1);
+        expect(slot.items[0].cls).toContain('neo-dashboard-dock-placeholder');
+        expect(slot.items[0].dockItemId).toBe('terminal');
+        expect(slot.items[0].revealLoadFailed).toBe(true);
+
+        let placeholder = slot.items[0];
+
+        // The placeholder is transient: dismissal destroys it instead of parking it.
+        rail.revealMachine.escape();
+
+        expect(slot.items).toHaveLength(0);
+        expect(placeholder.isDestroyed).toBe(true);
+
+        // The next reveal retries the import and materializes the real pane.
+        rail.onTabClick({component: tabsOf(rail)[0]});
+
+        let pane = await rail.revealPaneLoads.terminal;
+
+        expect(attempts).toBe(2);
+        expect(pane instanceof Button).toBe(true);
+        expect(slot.items[0]).toBe(pane);
+        expect(rail.revealPaneCache.terminal).toBe(pane);
+    });
+
+    test('a rail destroyed while the import is in flight settles the load to null, never a throw', async () => {
+        let release,
+            gate = new Promise(resolve => { release = resolve });
+
+        rail = Neo.create(DockRail, {
+            dockZoneDocument   : createDocument(),
+            edge               : 'right',
+            id                 : 'dock-rail-lazy-module-destroyed',
+            railItems          : createRailItems(),
+            resolveComponentRef: () => ({module: () => gate.then(() => ({default: Button})), text: 'Lazy'})
+        });
+
+        rail.onTabClick({component: tabsOf(rail)[0]});
+
+        let load = rail.revealPaneLoads.terminal;
+
+        // core.Base#destroy deletes every own property, the lease map included
+        rail.destroy();
+        rail = null;
+        release();
+
+        await expect(load).resolves.toBeNull();
+    });
+
     test('threads the workspace default reveal fraction into the bound overlay', () => {
         let overlay = createStubOverlay();
 

--- a/test/playwright/unit/dashboard/DockRail.spec.mjs
+++ b/test/playwright/unit/dashboard/DockRail.spec.mjs
@@ -491,6 +491,78 @@ test.describe('Neo.dashboard.dock.interaction.Rail', () => {
         expect(pane._data?.missingComponentRef).toBe(true);
     });
 
+    test('a lazy module config materializes on reveal — the rail loads it as a card layout loads its active tab', async () => {
+        rail = Neo.create(DockRail, {
+            dockZoneDocument   : createDocument(),
+            edge               : 'right',
+            id                 : 'dock-rail-lazy-module',
+            railItems          : createRailItems(),
+            resolveComponentRef: () => ({module: () => import('../../../../src/button/Base.mjs'), text: 'Lazy'})
+        });
+
+        rail.onTabClick({component: tabsOf(rail)[0]});
+
+        let slot = rail.revealOverlay.paneSlot;
+
+        // The import is in flight: the reveal already names the item and the slot holds nothing yet —
+        // and nothing threw (on dev the plain slot add threw `createVdomReference is not a function`).
+        expect(rail.revealOverlay.revealPaneItemId).toBe('terminal');
+        expect(slot.items).toHaveLength(0);
+        expect(rail.revealPaneLoads.terminal).toBeInstanceOf(Promise);
+
+        let pane = await rail.revealPaneLoads.terminal;
+
+        expect(pane instanceof Button).toBe(true);
+        expect(pane.text).toBe('Lazy');
+        expect(slot.items[0]).toBe(pane);
+        expect(rail.revealPaneCache.terminal).toBe(pane);
+        expect(rail.revealPaneLoads.terminal).toBeUndefined();
+
+        // Dismissal parks the loaded pane; the re-reveal re-parents the same instance — no second load.
+        rail.revealMachine.escape();
+
+        expect(slot.items).toHaveLength(0);
+        expect(pane.isDestroyed).not.toBe(true);
+
+        rail.onTabClick({component: tabsOf(rail)[0]});
+
+        expect(slot.items[0]).toBe(pane);
+        expect(rail.revealPaneLoads.terminal).toBeUndefined();
+    });
+
+    test('a reveal dismissed before the import settles adds nothing; the next reveal materializes', async () => {
+        let release,
+            gate = new Promise(resolve => { release = resolve });
+
+        rail = Neo.create(DockRail, {
+            dockZoneDocument   : createDocument(),
+            edge               : 'right',
+            id                 : 'dock-rail-lazy-module-dismissed',
+            railItems          : createRailItems(),
+            resolveComponentRef: () => ({module: () => gate.then(() => ({default: Button})), text: 'Lazy'})
+        });
+
+        rail.onTabClick({component: tabsOf(rail)[0]});
+
+        let slot = rail.revealOverlay.paneSlot,
+            load = rail.revealPaneLoads.terminal;
+
+        rail.revealMachine.escape();
+        release();
+
+        expect(await load).toBeNull();
+        expect(slot.items).toHaveLength(0);
+        expect(rail.revealPaneCache.terminal).toBeUndefined();
+        expect(rail.revealPaneLoads.terminal).toBeUndefined();
+
+        rail.onTabClick({component: tabsOf(rail)[0]});
+
+        let pane = await rail.revealPaneLoads.terminal;
+
+        expect(pane instanceof Button).toBe(true);
+        expect(slot.items[0]).toBe(pane);
+    });
+
     test('threads the workspace default reveal fraction into the bound overlay', () => {
         let overlay = createStubOverlay();
 


### PR DESCRIPTION
Resolves #18062

Related: neomjs/neo-agent-institution#74 (the consumer symptom: the define-agent zone reveals empty), neomjs/neo-agent-institution#77 (the withdrawn static-import shape, reworked into the pin bump after this lands), #13280 (the auto-hide interaction layer), #18039 (the reveal-pane cache and release paths)

A dock rail is a tab strip with no active item, and reveal is its activation — so a rail item resolving to `module: () => import('...')` now loads on its first reveal exactly as a card layout loads a lazy card when its tab activates. Before, `Rail#syncRevealPane` handed the loader function to the overlay's plain pane slot, `container.Base#insert` threw `item.createVdomReference is not a function`, and the throw escaped the reveal transition after the overlay had opened: an empty overlay, and a console error nobody read. The lazy branch is the one asynchronous path: `loadRevealPane` awaits the import, adds the instance if the reveal still names the item, and caches it per item like a blueprint pane; the `revealPaneLoads` entry is the load's lease — it clears however the load ends. A rejected import (a chunk that fails to fetch, a pane module that throws while evaluating) clears the lease so the next reveal retries and shows the adapter's recoverable placeholder in the still-open reveal — uncached and transient, destroyed on dismissal rather than parked; a rail destroyed while the import is in flight settles the load to `null` (the guard reads the lease map optionally, because `core.Base#destroy` removes it). Live instances, plain configs, blueprints and placeholders keep the synchronous path byte for byte; the placeholder literal now lives in one factory, `createRevealPlaceholder`, that both the cascade tail and the failure route call. ADR 0029 §2.6 records why this is first materialization, not the recreation its first row forbids.

Evidence: L3 (unit-project execution at the head; the two success arms red at `origin/dev@8c86f4478f` and the two failure arms red at this PR's previous head `7b79a1030b`, both in scratch worktrees; the fixture rendered and driven in Chromium) → L3 required (every AC on #18062 is unit- or component-reachable; the consumer row is post-merge by construction). Residual: AC-6, Residual-Owner: neomjs/neo-agent-institution#74.

## AC Evidence

| AC | Evidence |
|---|---|
| AC-1 — a lazy `module` config materializes on reveal; red on `dev` | CI-covered: `test/playwright/unit/dashboard/DockRail.spec.mjs`, "a lazy module config materializes on reveal — the rail loads it as a card layout loads its active tab"; outside-CI: the same arm at `origin/dev@8c86f4478f` → red, `TypeError: item.createVdomReference is not a function` at `src/container/Base.mjs:692` |
| AC-2 — a reveal dismissed before the import settles adds nothing; the next reveal materializes | CI-covered: same spec, "a reveal dismissed before the import settles adds nothing; the next reveal materializes" (red on `dev` for the same throw) |
| AC-3 — component arm: not loaded at boot, loaded and rendered inside the visible overlay after the rail-tab click | CI-covered: `test/playwright/component/dashboard/DockRailLazyModule.spec.mjs` on the new `apps/dock-lazy-rail` fixture — the lazy pane class is absent from the Neo namespace at boot while the eager sibling renders; the click registers it and paints `.dock-lazy-rail-pane` inside the visible overlay; dismiss + re-reveal keeps one construction |
| AC-4 — unit `dashboard/` and the dock component specs green; the pin path unchanged | CI-covered: unit `dashboard/` and component `dashboard/` at the head; the live / config / blueprint / placeholder branches of `syncRevealPane` are behaviour-identical (the placeholder literal moved into `createRevealPlaceholder`) and the tab flow still loads through `Neo.layout.Card#loadModule` |
| AC-5 — ADR 0029 §2.6 carries the amendment | CI-covered by inspection: "Lazy first materialization (amendment, 2026-09-02 — #18062)" under §2.6 |
| AC-6 — post-merge, institution PR #77 restores the lazy module and bumps the pin | Post-merge by construction; tracked in Post-Merge Validation, owner neomjs/neo-agent-institution#74 |
| AC-7 — the failure route: a rejected import clears the lease, shows the recoverable placeholder (destroyed on dismissal, not parked) and the next reveal retries; a destroyed rail settles the load to `null` | CI-covered: same unit spec, "a rejected import clears the lease, shows the recoverable placeholder, and the next reveal retries" and "a rail destroyed while the import is in flight settles the load to null, never a throw"; outside-CI: both arms at the previous head `7b79a1030b` → **2 failed / 20 passed**, the destroy arm with `TypeError: Cannot read properties of undefined (reading 'terminal')` |

## Deltas from ticket

- **The lease is one map, not a flag:** `revealPaneLoads` holds the load's promise per item; `releaseRevealPane` and `destroy` clear it, so an import still in flight for an item that LEFT the rail (pin, transfer, a restored perspective) cannot land a pane afterwards — one case beyond the ticket's dismissal path, and the class of stale-pane collision #18039 closed.
- **The failure route (Round 1, reproduced by the reviewer):** the first head modelled only a resolving import — a rejection skipped the lease clear after the `await`, the `??=` then short-circuited every later reveal of the item for the session, the rejection went unhandled, and a rail destroyed mid-load threw because `core.Base#destroy` deletes every own property. Now: rejection → log, lease cleared, transient placeholder in the open reveal, retry on the next reveal; destroyed rail → `null`. Ticket #18062 gained AC-7 and its Contract Ledger's Fallback column carries both semantics.
- **A third component arm:** dismiss and re-reveal re-parent the one loaded instance (construction count stays 1) — the blueprint-cache contract holds for lazily created panes too.

## Test Evidence

- Red-first, success arms: `DockRail.spec.mjs` with the two lazy arms copied into a worktree at `origin/dev@8c86f4478f` → **2 failed / 18 passed**, both failures the `createVdomReference` throw through `Rail.mjs` → `container/Base.mjs:692`.
- Red-first, failure arms: the same spec with the two failure arms in a worktree at `7b79a1030b` → **2 failed / 20 passed** (the rejection arm: the lease still a `Promise`, the slot empty; the destroy arm: the reviewer's exact `TypeError`).
- The component fixture's dismissal is `Escape` on purpose: a rail-tab re-click leaves the overlay first (dismiss grace opens) and the click re-enters the reveal before the grace lapses — a real-browser fact the unit machine does not model.

## Post-Merge Validation

- [ ] neomjs/neo-agent-institution#74 / PR #77: restore `module: () => import('../instances/AddAgentForm.mjs')` for the define-agent zone (wake routes stays lazy), bump the engine pin, re-run `AddAgentJourneyNL` under the Brain root and read the reveal from the rail tab and from the bootstrap CTA on the live cockpit.

## Commits

- `7b79a1030b` — the lazy branch, the lease, the two success arms, the component fixture, the ADR sentence.
- `6a0e2e2dd1` — the failure route (rejection → placeholder + retry; destroyed rail → `null`), the placeholder factory, the two failure arms, the JSDoc that now says what holds.

Authored by Clio (Claude Fable 5.1, Claude Code). Session 91f83b9c-df95-4f72-a68f-d33f470792ac.

Cross-family note: the GPT seats are at 0% weekly quota (operator, 2026-09-01 22:20Z); an Opus 5 review is the sanctioned exception.

📜 Clio
