### PR TITLE
fix(grid): a grid click keeps its mousedown default so focus reaches the View (#18065)

### DIFF
--- a/src/main/addon/GridDragScroll.mjs
+++ b/src/main/addon/GridDragScroll.mjs
@@ -250,9 +250,12 @@ class GridDragScroll extends Base {
             return
         }
 
-        if (event.type === 'mousedown') {
-            event.preventDefault() // Prevent text selection
-        }
+        // The mousedown default MUST survive here: it is the browser's focus move to the nearest
+        // focusable ancestor — the grid View, the single focus anchor (`tabIndex: '-1'`) that the
+        // focus-gated dock header actions, the rail reveal's focus-leave dismissal and the cell
+        // editing key registry all depend on. Cancelling it "to prevent text selection" kept DOM
+        // focus wherever it was before every grid click. Selection suppression belongs to CSS and
+        // already lives there: `.neo-grid-body.neo-mouse-drag-scroll {user-select: none}`.
 
         let {x, y} = me.getEventCoordinates(event);
 

--- a/test/playwright/component/apps/grid-focus/app.mjs
+++ b/test/playwright/component/apps/grid-focus/app.mjs
@@ -1,0 +1,86 @@
+import GridContainer from '../../../../../src/grid/Container.mjs';
+import Model         from '../../../../../src/data/Model.mjs';
+import Store         from '../../../../../src/data/Store.mjs';
+import Viewport      from '../../../../../src/container/Viewport.mjs';
+
+/**
+ * @summary Fixture for the grid click-focus contract.
+ *
+ * Two grids with the default drag-to-scroll, so a real pointer can prove both halves of the
+ * contract on one page: a click anywhere in a grid — a cell, or the empty body below a short
+ * store's last row — must land DOM focus on the grid View (the single focus anchor), and a real
+ * drag inside a body tall enough to scroll must still scroll it without selecting any text.
+ * `#grid-focus-outside` in index.html is the focusable target the leave arm moves focus to.
+ * @class Neo.test.playwright.GridFocusModel
+ * @extends Neo.data.Model
+ */
+class GridFocusModel extends Model {
+    static config = {
+        className: 'Neo.test.playwright.GridFocusModel',
+        fields   : [
+            {name: 'id',    type: 'Integer'},
+            {name: 'name',  type: 'String'},
+            {name: 'city',  type: 'String'},
+            {name: 'score', type: 'Integer'}
+        ]
+    }
+}
+
+GridFocusModel = Neo.setupClass(GridFocusModel);
+
+/**
+ * @param {Number} length
+ * @returns {Object[]}
+ */
+const rows = length => Array.from({length}, (_, i) => ({
+    id   : i + 1,
+    name : `Row ${i + 1} with enough words to select across cells`,
+    city : ['Berlin', 'Hamburg', 'Munich', 'Cologne'][i % 4],
+    score: (i * 37) % 100
+}));
+
+const columns = [
+    {dataField: 'id',    text: '#',     width: 60},
+    {dataField: 'name',  text: 'Name',  flex : 1},
+    {dataField: 'city',  text: 'City',  width: 140},
+    {dataField: 'score', text: 'Score', width: 90}
+];
+
+/**
+ * @param {String} className
+ * @param {Number} length
+ * @returns {Function}
+ */
+const storeClass = (className, length) => Neo.setupClass(class extends Store {
+    static config = {
+        className,
+        keyProperty: 'id',
+        model      : GridFocusModel,
+        data       : rows(length)
+    }
+});
+
+const
+    ShortStore = storeClass('Neo.test.playwright.GridFocusShortStore', 6),
+    LongStore  = storeClass('Neo.test.playwright.GridFocusLongStore', 400);
+
+export const onStart = () => Neo.app({
+    mainView: {
+        module: Viewport,
+        layout: {ntype: 'vbox', align: 'stretch'},
+        items : [{
+            module: GridContainer,
+            id    : 'grid-focus-short',
+            flex  : 1,
+            store : ShortStore,
+            columns
+        }, {
+            module: GridContainer,
+            id    : 'grid-focus-long',
+            flex  : 1,
+            store : LongStore,
+            columns
+        }]
+    },
+    name: 'Test.Playwright.GridFocus'
+});

--- a/test/playwright/component/apps/grid-focus/index.html
+++ b/test/playwright/component/apps/grid-focus/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Neo.mjs Grid Focus Test App</title>
+</head>
+<body>
+    <button id="grid-focus-outside" type="button">Outside grid focus</button>
+    <script src="../../../../../src/MicroLoader.mjs" type="module"></script>
+</body>
+</html>

--- a/test/playwright/component/apps/grid-focus/neo-config.json
+++ b/test/playwright/component/apps/grid-focus/neo-config.json
@@ -1,0 +1,9 @@
+{
+    "appPath"         : "test/playwright/component/apps/grid-focus/app.mjs",
+    "basePath"        : "../../../../../",
+    "environment"     : "development",
+    "mainPath"        : "./Main.mjs",
+    "mainThreadAddons": ["DragDrop", "Navigator", "ResizeObserver", "Stylesheet"],
+    "themes"          : ["neo-theme-neo-dark", "neo-theme-neo-light"],
+    "useSharedWorkers": false
+}

--- a/test/playwright/component/grid/ClickFocus.spec.mjs
+++ b/test/playwright/component/grid/ClickFocus.spec.mjs
@@ -1,0 +1,118 @@
+import {test, expect} from '@playwright/test';
+
+/**
+ * A click on a grid must land DOM focus on the grid View — the single focus anchor (`tabIndex -1`)
+ * behind focus-gated dock header actions, the rail reveal's focus-leave dismissal and the cell
+ * editing key registry. `Neo.main.addon.GridDragScroll` cancelled the mousedown default on every
+ * registered grid body "to prevent text selection", which also cancels the browser's focus move:
+ * after a click, focus stayed wherever it was before. Selection suppression is owned by
+ * `.neo-grid-body.neo-mouse-drag-scroll {user-select: none}`, so the positive control here proves a
+ * real drag still scrolls and still selects nothing once the cancel is gone.
+ *
+ * The fixture (`apps/grid-focus`) mounts a short grid, whose viewport has empty space below its last
+ * row, and a long one, whose viewport scrolls. Every arm waits for the addon to have registered both
+ * bodies, so the red on the unfixed engine is the addon's doing and not a race with its import.
+ *
+ * Which arm is the witness matters: a click ON A ROW is focused programmatically by the grid's own
+ * row-click handler, so the cell arms pass even with the cancel in place — they are the controls that
+ * pin the programmatic path. The empty-viewport arm has no row under the pointer, so only the
+ * browser's mousedown default can focus the View; that arm is red on the unfixed engine.
+ */
+const readConfigs = async (page, id, keys) => {
+    const reply = await page.evaluate(data => Neo.worker.App.getConfigs(data), {id, keys});
+
+    return reply?.data ?? reply
+};
+
+const activeElementId = page => page.evaluate(() => document.activeElement?.id || document.activeElement?.tagName);
+
+const viewIdOf = (page, gridId) => page.locator(`#${gridId} .neo-grid-view`).first().getAttribute('id');
+
+const maxScrollTop = (page, gridId) => page.evaluate(id =>
+    Math.max(0, ...Array.from(document.querySelectorAll(`#${id}, #${id} *`)).map(el => el.scrollTop || 0)), gridId);
+
+/**
+ * A real pointer drag in steps, held past the addon's activation delay before the first move.
+ * @param {import('@playwright/test').Page} page
+ * @param {{x: Number, y: Number}} from
+ * @param {{x: Number, y: Number}} to
+ * @returns {Promise<void>}
+ */
+const drag = async (page, from, to) => {
+    await page.mouse.move(from.x, from.y);
+    await page.mouse.down();
+    await page.waitForTimeout(150);
+
+    for (let i = 1; i <= 12; i++) {
+        await page.mouse.move(from.x + (to.x - from.x) * i / 12, from.y + (to.y - from.y) * i / 12);
+        await page.waitForTimeout(25)
+    }
+
+    await page.mouse.up()
+};
+
+test.beforeEach(async ({page}) => {
+    await page.goto('test/playwright/component/apps/grid-focus/index.html');
+    await page.waitForSelector('#grid-focus-long .neo-grid-row', {state: 'visible'});
+    await page.waitForSelector('#grid-focus-short .neo-grid-row', {state: 'visible'});
+    // both bodies registered with the drag-scroll addon — the subject of the contract is in place
+    await expect.poll(() => page.evaluate(() => Neo.main?.addon?.GridDragScroll?.registrations?.size ?? 0), {timeout: 15000})
+        .toBeGreaterThanOrEqual(2)
+});
+
+test.describe('grid click focus — the mousedown default reaches the View anchor (#18065)', () => {
+    test('a click on a cell focuses the grid view and the view reports containsFocus', async ({page}) => {
+        const viewId = await viewIdOf(page, 'grid-focus-short');
+
+        expect(viewId, 'the short grid projects a view').toBeTruthy();
+
+        await page.locator('#grid-focus-short .neo-grid-cell').first().click();
+
+        await expect.poll(() => activeElementId(page), {message: 'DOM focus lands on the grid view'}).toBe(viewId);
+        await expect.poll(async () => (await readConfigs(page, viewId, ['containsFocus']))[0],
+            {message: 'the App Worker sees the focus enter'}).toBe(true)
+    });
+
+    test('a click on the empty body below the last row focuses the grid view', async ({page}) => {
+        // the View is the scroll viewport; the body element is as tall as its data, so viewport
+        // geometry has to be read from the View, never from the body
+        const viewId = await viewIdOf(page, 'grid-focus-short'),
+              view   = page.locator(`#${viewId}`),
+              box    = await view.boundingBox(),
+              rows   = page.locator('#grid-focus-short .neo-grid-row:visible'),
+              last   = await rows.last().boundingBox();
+
+        // park focus outside first, so this arm does not inherit the cell arm's focus
+        await page.locator('#grid-focus-outside').click();
+        await expect.poll(() => activeElementId(page)).toBe('grid-focus-outside');
+
+        expect(last.y + last.height + 20, 'the short store leaves empty viewport below its last row').toBeLessThan(box.y + box.height);
+        await page.mouse.click(box.x + box.width / 2, box.y + box.height - 10);
+
+        await expect.poll(() => activeElementId(page), {message: 'a click on the empty body focuses the view'}).toBe(viewId);
+        await expect.poll(async () => (await readConfigs(page, viewId, ['containsFocus']))[0]).toBe(true)
+    });
+
+    test('positive control: a real drag still scrolls the body and selects no text', async ({page}) => {
+        // drag inside the View's viewport (the body element is 400 rows tall — its centre is off-screen)
+        const viewId = await viewIdOf(page, 'grid-focus-long'),
+              box    = await page.locator(`#${viewId}`).boundingBox(),
+              before = await maxScrollTop(page, 'grid-focus-long'),
+              from   = {x: box.x + box.width / 2, y: box.y + box.height * 0.75};
+
+        await drag(page, from, {x: from.x, y: from.y - 160});
+
+        await expect.poll(() => maxScrollTop(page, 'grid-focus-long'), {message: 'the drag scrolled the long grid'}).toBeGreaterThan(before);
+        expect(await page.evaluate(() => window.getSelection().toString()), 'the drag selected no text').toBe('')
+    });
+
+    test('focus leaving to an outside control clears containsFocus again', async ({page}) => {
+        const viewId = await viewIdOf(page, 'grid-focus-short');
+
+        await page.locator('#grid-focus-short .neo-grid-cell').first().click();
+        await expect.poll(async () => (await readConfigs(page, viewId, ['containsFocus']))[0]).toBe(true);
+
+        await page.locator('#grid-focus-outside').click();
+        await expect.poll(async () => (await readConfigs(page, viewId, ['containsFocus']))[0], {message: 'the leave path is untouched'}).toBe(false)
+    })
+});


### PR DESCRIPTION
Resolves #18065

> 🌿 *A grid click asked the browser for focus and the drag-scroll addon cancelled the request before the View could take it — after this change, a grid click that leaves focus where it was is unsayable.*

The drag-to-scroll addon no longer cancels the `mousedown` default over a grid body. That default carries the browser's focus move to the grid View, the single focus anchor, so a click into a grid's empty viewport now focuses the grid the way a click on a row always did: focus-gated dock header actions reveal, a click-born rail reveal dismisses, and keyboard navigation starts from the clicked grid. Selection suppression stays with the existing `user-select: none` rule on `.neo-mouse-drag-scroll`; the drag itself still arms through the addon's monitor phase.

Evidence: L3 (real Chromium, pointer-driven component fixture and Workstation e2e) → L3 required (every AC is an in-repo observable). Residual: none.

## AC Evidence
| AC-1 | `src/main/addon/GridDragScroll.mjs` — the `mousedown` cancel in `onDragStart` is removed; the `touchmove` cancel is untouched (diff) |
| AC-2 | `test/playwright/component/grid/ClickFocus.spec.mjs` + `test/playwright/component/apps/grid-focus/` — the empty-viewport arm is red with the addon change stashed at `dev` (1 failed / 3 passed) and green at head (4/4); the cell-click arm is the control that stays green on both, because `grid.Body`'s row-click handler focuses the View itself |
| AC-3 | same spec, positive-control arm: a 160 px pointer drag inside the long grid's View scrolls it and `window.getSelection().toString()` stays `''` — green before and after |
| AC-4 | components suite in CI; the two Workstation e2e arms run locally (receipt under Test Evidence — e2e is not in a workflow) |
| AC-5 | JSDoc on `onDragStart` names the contract: the mousedown default carries focus, selection suppression is the CSS rule's (diff) |

## Deltas from ticket
The ticket's first draft listed "Enter after a cell click mounts no editor" as a third symptom. The witness falsified that attribution: a click on a ROW is focused programmatically by the grid, so the View holds focus, the editing plugin's `Enter`/`Space` registry is reachable, and `Enter` on the editable cell mounts the editor in the consumer's grid too — the report was a gesture mismatch (that grid maps double-click to opening the record). The ticket body is corrected in place; the spec pins the empty-viewport click as the red-first arm and keeps the cell click as a control.

## Test Evidence
- Red-first: `git stash push -- src/main/addon/GridDragScroll.mjs` → `grid/ClickFocus` 1 failed (the empty-viewport arm) / 3 passed; `git stash pop` → 4/4 in 3.6 s.
- Consumer side (a workspace whose dock panes host grids, real Chrome): its e2e arm "a click on the empty grid body of another pane dismisses the reveal" was red against the engine at `dev` and is green with this commit cherry-picked (3 arms: control green, grid-body green, iframe arm red — a different mechanism, filed separately).
- Workstation e2e (AC-4, e2e runs in no workflow): `WorkstationGridRepaintNL` + `WorkstationDragTextSelectionNL` at head, `NEO_AGENTOS_RUNTIME_ROOT` set — 5/5 in 18.1 s (three text-selection-suppression arms, two grid-repaint arms).

## Post-Merge Validation
- [ ] Consumer workspaces that pin the engine re-run their dock reveal and header-action journeys after the bump.

Authored by Vega (Fable 5.1, Claude Code). Session 87c91db1-7fcd-4987-9932-2bf78d3dda25.
