### PR TITLE
fix(manager): the window manager reads screenLeft/Top as the frame origin (#18058)

### DIFF
--- a/apps/workstation/view/Workspace.mjs
+++ b/apps/workstation/view/Workspace.mjs
@@ -3033,11 +3033,14 @@ class Workspace extends DockWorkspace {
             targetWindow = Neo.manager?.Window?.get(me.vesselConversionTargetWindowId),
             targetRoute  = targetWindow?.nativeRoute,
             targetIsMain = me.vesselConversionTargetWindowId === me.windowId,
-            // The cover geometry and the authority check both speak published inner-window
-            // geometry; a child omitting outerRect never rejects an authorized live vessel.
+            // The size check and the authority check speak published inner-window geometry (a child
+            // omitting outerRect never rejects an authorized live vessel); the park POSITION is a
+            // frame: `moveTo` places the source frame on the target's frame origin, so the parked
+            // window lies behind the target's chrome and content alike.
             sourceRect   = sourceWindow?.innerRect,
             sourceOuter  = sourceWindow?.outerRect ?? sourceRect,
             targetRect   = targetWindow?.innerRect,
+            targetOuter  = targetWindow?.outerRect ?? targetRect,
             needsResize  = !nativeTitlebar && Boolean(sourceOuter && targetRect && (
                 sourceOuter.width > targetRect.width || sourceOuter.height > targetRect.height
             )),
@@ -3052,7 +3055,7 @@ class Workspace extends DockWorkspace {
                 y     : sourceOuter.y
             } : null,
             parkGeometry  = needsResize ? {
-                park   : {...parkSize, x: targetRect?.x, y: targetRect?.y},
+                park   : {...parkSize, x: targetOuter?.x, y: targetOuter?.y},
                 restore: restoreRect
             } : null;
 
@@ -3079,6 +3082,9 @@ class Workspace extends DockWorkspace {
             },
             targetInner: targetRect && {
                 height: targetRect.height, width: targetRect.width, x: targetRect.x, y: targetRect.y
+            },
+            targetOuter: targetOuter && {
+                height: targetOuter.height, width: targetOuter.width, x: targetOuter.x, y: targetOuter.y
             }
         };
         me.lastVesselRestoreReceipt = null;
@@ -3129,8 +3135,8 @@ class Workspace extends DockWorkspace {
                 targetWindowId : route.targetWindowId,
                 windowId       : me.windowId,
                 windowName,
-                x              : targetRect.x,
-                y              : targetRect.y
+                x              : targetOuter.x,
+                y              : targetOuter.y
             };
 
             if (!nativeTitlebar) {
@@ -3206,9 +3212,19 @@ class Workspace extends DockWorkspace {
         let me       = this,
             entry    = me.resolveTearOutVessel(itemId),
             route    = entry?.nativeRoute,
-            geometry = me.tearOutParkGeometries[itemId] ?? null;
+            geometry = me.tearOutParkGeometries[itemId] ?? null,
+            // `rect` is where the pane's CONTENT re-shows — the proxy's logical rect, or the
+            // viewport rect captured at conversion-in. `moveTo` places the FRAME, so the window's
+            // own chrome comes off the content origin; a window that never published chrome
+            // re-shows content-on-frame, the pre-chrome behaviour.
+            chrome   = Neo.manager?.Window?.get(entry?.windowId)?.chrome,
+            frame    = Number.isFinite(rect?.x) && Number.isFinite(rect?.y) ? {
+                x: rect.x - (chrome?.left ?? 0),
+                y: rect.y - (chrome?.top  ?? 0)
+            } : null;
 
         me.lastVesselRestoreReceipt = {
+            frame,
             geometry,
             rect: rect && {height: rect.height, width: rect.width, x: rect.x, y: rect.y},
             terminal
@@ -3230,8 +3246,8 @@ class Workspace extends DockWorkspace {
             targetWindowId : route.targetWindowId,
             windowId       : me.windowId,
             windowName,
-            x              : rect.x,
-            y              : rect.y
+            x              : frame.x,
+            y              : frame.y
         };
 
         try {

--- a/src/manager/Window.mjs
+++ b/src/manager/Window.mjs
@@ -23,11 +23,6 @@ class Window extends Manager {
          */
         className: 'Neo.manager.Window',
         /**
-         * @member {Boolean} isSafari
-         * @protected
-         */
-        isSafari: /^((?!chrome|android).)*safari/i.test(navigator.userAgent),
-        /**
          * @member {Boolean} singleton=true
          * @protected
          */
@@ -63,7 +58,17 @@ class Window extends Manager {
     }
 
     /**
-     * @param {Object} data
+     * Interprets one raw window report into the manager's two rectangles and the chrome between them.
+     *
+     * `screenLeft` / `screenTop` name the window FRAME's origin — the top-left of the OS window
+     * including its title bar — in every engine except Firefox, which publishes the viewport origin
+     * itself (`mozInnerScreenX/Y`). Measured, not assumed: a Chromium frame placed at `top: 120`
+     * reports `screenY 120` with 87 px of chrome, and a Chrome window filling a display under the
+     * macOS menu bar reports `screenTop 33` — a viewport reading would put its frame at y = −54,
+     * above the screen. `outerRect` is therefore the frame itself and `innerRect` the frame shifted
+     * by the chrome. The chrome split assumes symmetric side borders and a bottom border equal to a
+     * side border, so the remaining height difference is the title bar.
+     * @param {Object} data The raw report: `innerHeight`, `innerWidth`, `outerHeight`, `outerWidth`, `screenLeft`, `screenTop`, and Firefox's `mozInnerScreenX/Y`
      * @returns {Object} {chrome, innerRect, outerRect}
      */
     calculateGeometry(data) {
@@ -92,17 +97,13 @@ class Window extends Manager {
         let viewportLeft, viewportTop;
 
         if (typeof mozInnerScreenX === 'number') {
-            // Firefox: explicit viewport coordinates
+            // Firefox publishes the viewport origin directly
             viewportLeft = mozInnerScreenX;
             viewportTop  = mozInnerScreenY
-        } else if (this.isSafari) {
-            // Safari: screenLeft/Top is Frame position. Add chrome to get Viewport.
+        } else {
+            // Chrome, Edge and Safari report the frame origin: the viewport sits inside the chrome
             viewportLeft = screenLeft + sideBorder;
             viewportTop  = screenTop  + topChrome
-        } else {
-            // Chrome/Edge: screenLeft/Top is Viewport position.
-            viewportLeft = screenLeft;
-            viewportTop  = screenTop
         }
 
         const innerRect = new Rectangle(viewportLeft, viewportTop, innerWidth, innerHeight);

--- a/test/playwright/e2e/workstation/WindowGeometryRealChromeNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WindowGeometryRealChromeNL.spec.mjs
@@ -1,0 +1,70 @@
+import {expect, test} from '../../fixtures.mjs';
+
+/**
+ * @summary `Neo.manager.Window`'s published rects against the real window frame.
+ *
+ * Every emulated-viewport rig has `outerHeight === innerHeight` (no chrome), so `innerRect` and
+ * `outerRect` coincide there and no witness can tell a frame origin from a viewport origin. This arm
+ * runs with `viewport: null` — the real display, real window chrome — moves the main window to a known
+ * frame position through CDP BEFORE the app boots, and reads the manager's rects through the Neural
+ * Link: `outerRect` must be the frame CDP placed, `innerRect` the frame shifted by the chrome the
+ * window itself reports. A rig without chrome (headless) cannot see this class and says so.
+ */
+
+test.use({viewport: null});
+
+const
+    FRAME_LEFT = 200,
+    FRAME_TOP  = 120,
+    asArray    = value => Array.isArray(value) ? value : value ? [value] : [];
+
+test.describe('manager.Window — published rects on real window chrome', () => {
+    test('outerRect is the frame CDP placed; innerRect is that frame shifted by the reported chrome', async ({page, neuralLink}) => {
+        test.setTimeout(90000);
+
+        const
+            cdp        = await page.context().newCDPSession(page),
+            {windowId} = await cdp.send('Browser.getWindowForTarget');
+
+        // Place the frame before boot: the manager takes the main window's geometry at connect time.
+        await page.goto('about:blank');
+        await cdp.send('Browser.setWindowBounds', {windowId, bounds: {left: FRAME_LEFT, top: FRAME_TOP, width: 1100, height: 760, windowState: 'normal'}});
+
+        await page.goto('/apps/workstation/index.html');
+        await page.waitForSelector('.workstation-workspace', {timeout: 30000});
+
+        const
+            bounds = (await cdp.send('Browser.getWindowBounds', {windowId})).bounds,
+            report = await page.evaluate(() => ({
+                chromeSide: (window.outerWidth - window.innerWidth) / 2,
+                chromeTop : window.outerHeight - window.innerHeight,
+                screenLeft: window.screenLeft,
+                screenTop : window.screenTop
+            }));
+
+        // The rig itself: the frame is where CDP put it, and `screenTop` reports that frame.
+        expect(bounds.top,  'CDP placed the frame').toBe(FRAME_TOP);
+        expect(report.screenTop, 'screenTop reports the frame origin').toBe(FRAME_TOP);
+
+        test.skip(report.chromeTop === 0, 'this rig renders no window chrome, so frame and viewport coincide — the class is invisible here');
+
+        const
+            app       = await neuralLink.connectToApp('Workstation'),
+            managerId = asArray(await app.findInstances({className: 'Neo.manager.Window'}, ['id']))[0]?.id;
+
+        expect(managerId, 'manager.Window is live').toBeTruthy();
+
+        const
+            state = await app.callMethod(managerId, 'toJSON'),
+            main  = state.windows.find(win => win.appName === 'Workstation') ?? state.windows[0];
+
+        expect(main, 'the main window is registered').toBeTruthy();
+
+        // The manager's frame is CDP's frame; its viewport is the frame plus the chrome the window reports.
+        expect(main.outerRect.y).toBe(bounds.top);
+        expect(main.outerRect.x).toBe(bounds.left);
+        expect(main.innerRect.y).toBe(bounds.top  + report.chromeTop  - report.chromeSide);
+        expect(main.innerRect.x).toBe(bounds.left + report.chromeSide);
+        expect(main.chrome.top).toBe(report.chromeTop - report.chromeSide)
+    });
+});

--- a/test/playwright/e2e/workstation/WorkstationNativePopupOverPopupNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationNativePopupOverPopupNL.spec.mjs
@@ -100,16 +100,33 @@ async function setBounds(handle, bounds) {
 }
 
 /**
- * @summary Reads one window's manager-owned inner rect from the App Worker.
+ * @summary Reads one window's manager-owned rect from the App Worker — the FRAME (`outerRect`) by
+ * default, which is the basis `window.screenX/Y` and CDP window bounds share; `innerRect` is the
+ * viewport inside the chrome, for size comparisons against `innerWidth/Height`.
  * @param {Object} app
  * @param {String} managerId
  * @param {String} windowId
+ * @param {String} [key='outerRect']
  * @returns {Promise<Object|null>}
  */
-async function readManagerRect(app, managerId, windowId) {
+async function readManagerRect(app, managerId, windowId, key='outerRect') {
     const state = await app.callMethod(managerId, 'toJSON');
 
-    return state.windows.find(win => win.id === windowId)?.innerRect ?? null
+    return state.windows.find(win => win.id === windowId)?.[key] ?? null
+}
+
+/**
+ * @summary Reads one window's manager-owned chrome (`{top, left, right, bottom}`) — the offset between
+ * its frame and its viewport, so a frame move can be aimed at a viewport target.
+ * @param {Object} app
+ * @param {String} managerId
+ * @param {String} windowId
+ * @returns {Promise<Object>}
+ */
+async function readManagerChrome(app, managerId, windowId) {
+    const state = await app.callMethod(managerId, 'toJSON');
+
+    return state.windows.find(win => win.id === windowId)?.chrome ?? {bottom: 0, left: 0, right: 0, top: 0}
 }
 
 /**
@@ -288,7 +305,7 @@ test.describe('Workstation — native titlebar drag popup onto popup (#18047)', 
             // manager.Window to publish the new extents (observeResize on the main render target).
             const shrunk = await setBounds(mainHandle, {height: 300});
 
-            await expect.poll(async () => (await readManagerRect(app, managerId, mainWinId))?.height ?? Infinity, {
+            await expect.poll(async () => (await readManagerRect(app, managerId, mainWinId, 'innerRect'))?.height ?? Infinity, {
                 message  : 'manager.Window follows the main window resize',
                 timeout  : 5000,
                 intervals: [25, 50, 100]
@@ -308,7 +325,11 @@ test.describe('Workstation — native titlebar drag popup onto popup (#18047)', 
             await awaitOriginParity(app, managerId, target.windowId, targetScreen, 'manager.Window follows the target vessel');
 
             const
-                targetRect   = await readManagerRect(app, managerId, target.windowId),
+                // the drop anchor is the source's VIEWPORT centre and the claim tests the target's
+                // VIEWPORT, so the aim is viewport-on-viewport; the frame move subtracts the source's
+                // own chrome to put its viewport there
+                targetInner  = await readManagerRect(app, managerId, target.windowId, 'innerRect'),
+                sourceChrome = await readManagerChrome(app, managerId, source.windowId),
                 sourceScreen = await readScreen(source.popup),
                 armed        = await source.popup.evaluate(() => ({
                     intervalArmed  : Boolean(globalThis.Neo.main.addon.WindowPosition.intervalId),
@@ -326,8 +347,8 @@ test.describe('Workstation — native titlebar drag popup onto popup (#18047)', 
             // window — the first update over an unmeasured target only starts the preview
             // measurement, the following updates render it, and each update re-arms the commit.
             const
-                goalLeft = Math.round(targetRect.x + targetRect.width  / 2 - sourceScreen.innerWidth  / 2),
-                goalTop  = Math.round(targetRect.y + targetRect.height / 2 - sourceScreen.innerHeight / 2);
+                goalLeft = Math.round(targetInner.x + targetInner.width  / 2 - sourceScreen.innerWidth  / 2 - sourceChrome.left),
+                goalTop  = Math.round(targetInner.y + targetInner.height / 2 - sourceScreen.innerHeight / 2 - sourceChrome.top);
 
             for (const [dx, dy] of [[0, 0], [3, 2], [6, 4]]) {
                 const moved = await setBounds(sourceHandle, {left: goalLeft + dx, top: goalTop + dy});

--- a/test/playwright/e2e/workstation/WorkstationNativeTitlebarDragNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationNativeTitlebarDragNL.spec.mjs
@@ -88,7 +88,8 @@ async function readMainParticipationId(app) {
 }
 
 /**
- * @summary Reads one window's manager-owned inner rect from the App Worker.
+ * @summary Reads one window's manager-owned FRAME rect (`outerRect`) from the App Worker — the basis
+ * `window.screenX/Y` and CDP window bounds share, so parity with a screen read is exact.
  * @param {Object} app
  * @param {String} managerId
  * @param {String} windowId
@@ -97,7 +98,7 @@ async function readMainParticipationId(app) {
 async function readManagerRect(app, managerId, windowId) {
     const state = await app.callMethod(managerId, 'toJSON');
 
-    return state.windows.find(win => win.id === windowId)?.innerRect ?? null
+    return state.windows.find(win => win.id === windowId)?.outerRect ?? null
 }
 
 test.describe('Workstation — native titlebar popup drag (#18029)', () => {

--- a/test/playwright/unit/ai/client/InteractionService.spec.mjs
+++ b/test/playwright/unit/ai/client/InteractionService.spec.mjs
@@ -98,7 +98,10 @@ test.describe('Neo.ai.client.InteractionService', () => {
         const resolved = await InteractionService.prototype.resolveWindow('source-window');
 
         expect(resolved.id).toBe('source-window');
-        expect(resolved.innerRect).toMatchObject({height: 500, width: 800, x: 300, y: 400})
+        // `screenLeft/Top` is the frame origin; the viewport sits inside the 10 px side border and
+        // the 30 px title bar this report carries (820−800 → 10 each side; 540−500−10 → 30 on top)
+        expect(resolved.innerRect).toMatchObject({height: 500, width: 800, x: 310, y: 430});
+        expect(resolved.outerRect).toMatchObject({height: 540, width: 820, x: 300, y: 400})
     });
 
     test('driveDrag resolves target-local geometry into one source-window atomic plan', async () => {

--- a/test/playwright/unit/apps/workstation/Workspace.spec.mjs
+++ b/test/playwright/unit/apps/workstation/Workspace.spec.mjs
@@ -564,14 +564,19 @@ test.describe.serial('Workstation.view.Workspace', () => {
                 ownerWindowId  : workspace.windowId,
                 targetWindowId : 'target-window'
             },
+            // Real-chrome shapes: each window's viewport sits below its frame by the published chrome.
+            // The park lands the source FRAME on the target's frame origin; a re-show takes the
+            // source's own chrome off the content rect it is handed.
             records = new Map([
                 ['source-window', {
-                    innerRect  : {height: 479, width: 640, x: 44, y: 128},
+                    chrome     : {bottom: 0, left: 0, right: 0, top: 67},
+                    innerRect  : {height: 479, width: 640, x: 40, y: 127},
                     nativeRoute: sourceRoute,
                     outerRect  : {height: 546, width: 640, x: 40, y: 60}
                 }],
                 ['target-window', {
-                    innerRect  : {height: 260, width: 360, x: 800, y: 120},
+                    chrome     : {bottom: 0, left: 0, right: 0, top: 67},
+                    innerRect  : {height: 260, width: 360, x: 800, y: 187},
                     nativeRoute: targetRoute,
                     outerRect  : {height: 327, width: 360, x: 800, y: 120}
                 }]
@@ -640,14 +645,19 @@ test.describe.serial('Workstation.view.Workspace', () => {
                 rect      : {height: 120, width: 200, x: 420, y: 240},
                 windowName: 'tearout-audit'
             })).resolves.toBe(true);
+            // the content re-shows at (420, 240): the frame goes 67 px higher, under the title bar
             expect(resumeCalls).toEqual([{
                 nativeHandleKey: 'handle-source',
                 targetWindowId : 'source-window',
                 windowId       : workspace.windowId,
                 windowName     : 'tearout-audit',
                 x              : 420,
-                y              : 240
+                y              : 173
             }]);
+            expect(workspace.lastVesselRestoreReceipt).toMatchObject({
+                frame: {x: 420, y: 173},
+                rect : {height: 120, width: 200, x: 420, y: 240}
+            });
             expect(workspace.tearOutParkGeometries.audit).toBeUndefined();
 
             sourceRoute.capabilities.resize = false;
@@ -808,14 +818,19 @@ test.describe.serial('Workstation.view.Workspace', () => {
                 ownerWindowId  : workspace.windowId,
                 targetWindowId : 'target-window'
             },
+            // Real-chrome shapes: each window's viewport sits below its frame by the published chrome.
+            // The park lands the source FRAME on the target's frame origin; a re-show takes the
+            // source's own chrome off the content rect it is handed.
             records = new Map([
                 ['source-window', {
-                    innerRect  : {height: 479, width: 640, x: 44, y: 128},
+                    chrome     : {bottom: 0, left: 0, right: 0, top: 67},
+                    innerRect  : {height: 479, width: 640, x: 40, y: 127},
                     nativeRoute: sourceRoute,
                     outerRect  : {height: 546, width: 640, x: 40, y: 60}
                 }],
                 ['target-window', {
-                    innerRect  : {height: 260, width: 360, x: 800, y: 120},
+                    chrome     : {bottom: 0, left: 0, right: 0, top: 67},
+                    innerRect  : {height: 260, width: 360, x: 800, y: 187},
                     nativeRoute: targetRoute,
                     outerRect  : {height: 327, width: 360, x: 800, y: 120}
                 }]

--- a/test/playwright/unit/manager/Window.spec.mjs
+++ b/test/playwright/unit/manager/Window.spec.mjs
@@ -113,8 +113,12 @@ test.describe.serial('Neo.manager.Window connection ordering (#15396)', () => {
         expect(WindowManager.items).toHaveLength(1);
         expect(connected.nativeRoute).toBe(nativeRoute);
         expect(connected.capabilities).toBe(nativeRoute.capabilities);
-        expect(connected.innerRect.x).toBe(420);
-        expect(connected.innerRect.y).toBe(240)
+        // `screenLeft/Top` is the frame origin; the viewport sits inside the 10 px side border and
+        // the 30 px title bar this geometry reports (620−600 → 10 each side; 540−500−10 → 30 on top)
+        expect(connected.outerRect.x).toBe(420);
+        expect(connected.outerRect.y).toBe(240);
+        expect(connected.innerRect.x).toBe(430);
+        expect(connected.innerRect.y).toBe(270)
     });
 
     test('a route-less reconnect revokes authority instead of inheriting the previous document route', () => {

--- a/test/playwright/unit/manager/WindowGeometry.spec.mjs
+++ b/test/playwright/unit/manager/WindowGeometry.spec.mjs
@@ -1,0 +1,92 @@
+import {setup} from '../../setup.mjs';
+
+setup({
+    appConfig: {
+        name: 'ManagerWindowGeometryTest'
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../src/Neo.mjs';
+import * as core      from '../../../../src/core/_export.mjs';
+
+/**
+ * @summary `Neo.manager.Window#calculateGeometry` reads `screenLeft` / `screenTop` as the window
+ * FRAME's origin on every engine that does not publish a viewport origin of its own.
+ *
+ * Three measurements settled it: headed Chromium moved by CDP to `top: 120` reports `screenY 120`
+ * with 87 px of chrome; a live Chrome window filling a 1728×1117 display under the menu bar reports
+ * `screenTop 33` with the same 87 px; a second headed Chromium on another host repeats the first.
+ * Reading those values as the viewport origin puts the frame ABOVE the screen (y = −54 in the second
+ * case), which the OS does not allow. Firefox is the one engine with an explicit viewport origin
+ * (`mozInnerScreenX/Y`) and keeps its own branch.
+ */
+test.describe('Neo.manager.Window#calculateGeometry — the frame origin', () => {
+    let WindowManager;
+
+    test.beforeAll(async () => {
+        WindowManager = (await import('../../../../src/manager/Window.mjs')).default
+    });
+
+    test('Chromium moved to top 120 by CDP: the frame is at 120, the viewport at 207', () => {
+        const {chrome, innerRect, outerRect} = WindowManager.calculateGeometry({
+            innerHeight: 613,
+            innerWidth : 900,
+            outerHeight: 700,
+            outerWidth : 900,
+            screenLeft : 200,
+            screenTop  : 120
+        });
+
+        expect(chrome).toEqual({bottom: 0, left: 0, right: 0, top: 87});
+        expect([outerRect.x, outerRect.y, outerRect.width, outerRect.height]).toEqual([200, 120, 900, 700]);
+        expect([innerRect.x, innerRect.y, innerRect.width, innerRect.height]).toEqual([200, 207, 900, 613])
+    });
+
+    test('a live Chrome filling the display under the menu bar: frame top 33, viewport top 120', () => {
+        const {innerRect, outerRect} = WindowManager.calculateGeometry({
+            innerHeight: 997,
+            innerWidth : 1728,
+            outerHeight: 1084,
+            outerWidth : 1728,
+            screenLeft : 0,
+            screenTop  : 33
+        });
+
+        expect(outerRect.y).toBe(33);
+        expect(innerRect.y).toBe(120);
+        // the viewport reading would have put the frame above the screen
+        expect(outerRect.y).not.toBe(-54)
+    });
+
+    test('side borders split symmetrically, so the viewport shifts on both axes', () => {
+        const {chrome, innerRect, outerRect} = WindowManager.calculateGeometry({
+            innerHeight: 500,
+            innerWidth : 600,
+            outerHeight: 540,
+            outerWidth : 620,
+            screenLeft : 100,
+            screenTop  : 80
+        });
+
+        expect(chrome).toEqual({bottom: 10, left: 10, right: 10, top: 30});
+        expect([outerRect.x, outerRect.y]).toEqual([100, 80]);
+        expect([innerRect.x, innerRect.y]).toEqual([110, 110])
+    });
+
+    test('Firefox keeps its explicit viewport origin', () => {
+        const {innerRect, outerRect} = WindowManager.calculateGeometry({
+            innerHeight    : 613,
+            innerWidth     : 900,
+            mozInnerScreenX: 200,
+            mozInnerScreenY: 207,
+            outerHeight    : 700,
+            outerWidth     : 900,
+            screenLeft     : 200,
+            screenTop      : 120
+        });
+
+        expect([innerRect.x, innerRect.y]).toEqual([200, 207]);
+        expect([outerRect.x, outerRect.y]).toEqual([200, 120])
+    });
+});


### PR DESCRIPTION
Resolves #18058

Related: #18056 / PR #18059 (the corner anchor that surfaced this; its correction step is AC-4's residual), #15239 (the multi-window epic), #8164 (where the viewport reading was chosen, unmeasured)

`Neo.manager.Window#calculateGeometry` labelled Chrome's `screenLeft/Top` as the viewport origin. Three measurements say it is the FRAME origin — Vega's CDP probe, the operator's live Chrome read through the Neural Link, and a headed Chromium on this seat (frame placed at `top: 120` → `screenY 120`, 87 px of chrome) — so every published `innerRect` sat on the frame with the content's size, and every `outerRect` floated a chrome-height above the real frame. The manager now treats `screenLeft/Top` as the frame for Chrome, Edge and Safari alike (one branch, the Safari one, was already right) and keeps Firefox's explicit `mozInnerScreenX/Y`; `isSafari` had no other reader and is gone. Every rect consumer was audited: the coordinator's conversions and claim tests keep their code and get correct inputs; the Workstation's two native `moveTo` producers convert explicitly — the park lands the source FRAME on the target's frame origin, and a re-show takes the popup's own chrome off the content rect it is handed. Two real-chrome witnesses that had encoded the mislabel (frame parity read through `innerRect`) now read the frame through `outerRect` and aim viewport-on-viewport.

Evidence: L3 (unit-project execution at the head; three headed `viewport: null` witnesses on this seat's real window chrome — the new geometry receipt, the popup → main titlebar drag, the popup → popup titlebar drag) → L3 required (AC-2 names a real-chrome receipt; AC-5 names the operator's hand). Residual: AC-4 (the corner-correction residual step is PR #18059's code, not on this head), Residual-Owner: #18056; AC-5 is the post-merge hand check.

## AC Evidence

| AC | Evidence |
|---|---|
| AC-1 — unit witness with the two measured payloads; Firefox unchanged | CI-covered: `test/playwright/unit/manager/WindowGeometry.spec.mjs` — CDP payload → `outerRect.y 120` / `innerRect.y 207`; the operator's payload (`screenTop 33`, chrome 87) → `33` / `120`; a side-border payload splits both axes; Firefox keeps `mozInnerScreenX/Y`. Outside-CI: red-first on the unmodified source → **3 failed / 1 passed** (the three frame arms; `Received: -54` for the live-Chrome frame) |
| AC-2 — `viewport: null` receipt: `outerRect.y` = the CDP frame top, `innerRect.y` = frame + chrome | Outside-CI (real chrome only): `test/playwright/e2e/workstation/WindowGeometryRealChromeNL.spec.mjs`, headed under the Brain root → **1 passed**: frame placed by CDP before boot, `outerRect` = CDP bounds, `innerRect` = bounds + the chrome the window reports; the arm skips itself, stating why, on a rig without chrome |
| AC-3 — consumer audit table, each row unaffected or converted, with its witness | The table below |
| AC-4 — `WorkstationNativeTitlebarDragNL`: the corner-anchor correction step reports a zero residual | Residual: that step is PR #18059's (not on this head). On this head the pre-#18059 arm runs headed → **1 passed** (popup → main previews and reintegrates under dwell with frame parity); the zero-residual read lands when #18059 and this PR meet on `dev` |
| AC-5 — post-merge operator hand check on a real Chrome | Post-Merge Validation |

### Consumer audit (AC-3)

| Consumer | Disposition | Witness |
|---|---|---|
| `DragCoordinator#getWindowAtExcept` — `outerRect.intersects` | unaffected code; the frame is now the real frame | popup → main and popup → popup, headed |
| `DragCoordinator` pointer conversions (`screenY − innerRect.y`) | unaffected code; corrected inputs (were `chrome.top` too low into the target) | `unit/manager/DragCoordinator` (rect fixtures built directly) |
| `DragCoordinator#getNativeWindowDropCandidate` — the popup's `innerRect` centre as the anchor | unaffected code; the anchor is now the true viewport centre (PR #18059 moves it to the corner) | popup → popup, headed |
| `DragCoordinator#resolveClaimedTarget` — window `innerRect` contains + window-local hit-test | unaffected code; corrected inputs (popup → main error was `chrome.top(main) − chrome.top(popup)`) | popup → main, headed |
| Workstation `hitTestCrossWindowTarget`, `ensureCrossWindowPreviewGeometry` | unaffected code; corrected inputs | the two headed arms |
| Workstation `parkTearOutVessel` | **converted**: the park position is the target's frame origin (`targetOuter`); size checks stay inner-based; the receipt carries `targetOuter` | `unit/apps/workstation/Workspace.spec.mjs` with real-chrome fixtures (CI — see Deltas) |
| Workstation `reshowTearOutVessel` | **converted**: the content rect it is handed (the proxy's logical rect or the conversion-in viewport rect) minus the popup's own chrome is the frame `moveTo` places; the receipt carries `frame` | same spec: rect `{420, 240}` + chrome 67 → frame `{420, 173}` (CI) |
| Workstation `resolveVesselConversionSourceRect` — `innerRect` | unaffected: a content rect for the DOM proxy | — |
| `main/addon/DragDrop` park / resume `moveTo(rect)` | unaffected: receives frame coordinates from the Workspace | the two headed arms |
| `ai/Client` `window_connected` notifications | unaffected: publishes the corrected rects | — |
| `ai/client/InteractionService#resolveWindow` and its screen conversions | unaffected code; corrected inputs | `unit/ai/client/InteractionService` (expectation moved from the frame to the viewport inside the chrome) |
| `main/addon/WindowPosition#getPosition` (dock-popup placement offsets) | out of scope: the sensor's own heuristics, not a manager consumer | — |

## Deltas from ticket

- **Safari branch:** not re-measured (no Safari automation on this seat); it already read the frame, so the unified branch keeps its behaviour unchanged.
- **Two real-chrome witnesses encoded the mislabel:** `WorkstationNativePopupOverPopupNL` and `WorkstationNativeTitlebarDragNL` read frame parity through `innerRect`; with correct rects that reads 67 px off by construction. Their helper now reads `outerRect` (the basis `screenX/Y` and CDP bounds share), and the popup → popup aim is viewport-on-viewport (target `innerRect` centre, source chrome subtracted) — a rig correction, verified green against the untouched `dev` rig too. Both files are also touched by PR #18059; the overlap is the helper's four lines.
- **The Workstation unit spec does not load on this seat** (pre-existing on `dev`: `Neo.currentWorker` undefined at the manager's module-scope singleton, "No tests found"; defect-noted). Its real-chrome park/re-show fixtures ride CI for their receipt.
- **Neighbour observed, not chased:** Vega saw a window connect with a degenerate 0×0 birth rect (`screenLeft/Top` 0) after a page reload while `observeMovement` was off; a guard for `outerWidth === 0` at connect is a separate leaf if it recurs.

## Test Evidence

- Red-first: `unit/manager/WindowGeometry` on the unmodified source → 3 failed / 1 passed; the pre-existing `unit/manager/Window.spec` arm that asserted `innerRect.x 420` for `screenLeft 420` moved to `430 / 270` (frame + border / frame + title bar) with the reason inline.
- Headed, real chrome, Brain root on this seat (macOS, 87 px of chrome): `WindowGeometryRealChromeNL` 1 passed; `WorkstationNativeTitlebarDragNL` 1 passed; `WorkstationNativePopupOverPopupNL` 1 passed (3.9 s, the same as on the untouched `dev` rig; the first run at this head was red at the transfer step until the aim was corrected).
- Unit folders `manager/ dashboard/ draggable/ ai/ main/ vdom/` → 1420 passed at the head.

## Post-Merge Validation

- [ ] Operator hand check on a real Chrome: a cross-window pointer drag into the main window previews the zone under the pointer; the native corner anchor's region overlay paints beside the popup's physical corner (with PR #18059 on `dev`).
- [ ] AC-4's zero-residual read on `WorkstationNativeTitlebarDragNL` once #18059 and this PR meet on `dev`.

## Commits

- `9edaf66ddb` — the frame-origin geometry, the two Workstation `moveTo` conversions, the unit witnesses, the real-chrome receipt, and the two rig corrections.

Authored by Clio (Claude Fable 5.1, Claude Code). Session 91f83b9c-df95-4f72-a68f-d33f470792ac.

Cross-family note: the GPT seats are at 0% weekly quota (operator, 2026-09-01 22:20Z); an Opus 5 review is the sanctioned exception.

📜 Clio
