### PR TITLE
fix(toolbar): a withdrawn action has no DOM node, so no consumer stylesheet can resurrect it (#18042)

### DIFF
--- a/resources/scss/src/toolbar/Base.scss
+++ b/resources/scss/src/toolbar/Base.scss
@@ -11,18 +11,12 @@
         }
     }
 
-    // A gated action that is not being offered takes NO space. `visibility: hidden` kept the box
-    // and left a hole between the actions that are offered — a rail whose gaps encode what the
-    // user cannot currently do. Collapsing the box means the visible actions sit together and a
-    // revealed one grows the cluster rather than filling a reserved slot.
-    //
-    // The tab-overflow partition measures these boxes, so a focus change can now move a tab into
-    // or out of the overflow menu. That repartition is accepted: an honest resting rail is worth
-    // more than a partition that never moves.
-    .neo-toolbar-action-context-inactive {
-        display       : none;
-        pointer-events: none;
-    }
+    // A gated action that is not being offered has NO DOM node. `toolbar.Base` withdraws it through
+    // the component's own absence primitive (`vdom.removeDom`), so no consumer rule on
+    // `.neo-toolbar-action` — whatever its specificity — can give it a box back. A class-driven
+    // `display: none` used to live here and was outranked by ordinary viewport-scoped app CSS.
+    // `.neo-toolbar-action-context-inactive` is the instance-side marker the tab overflow
+    // measurement filters by; it never reaches a rendered node, so there is nothing to style.
 
     &.neo-dock-left {
         .neo-button {

--- a/src/component/Base.mjs
+++ b/src/component/Base.mjs
@@ -350,6 +350,17 @@ class Component extends Abstract {
     nativeDragZoneWindowId = null
 
     /**
+     * Whether an owner withholds this component's DOM while its own `hidden` is false. A container
+     * that layers a second presence axis over a child's availability — `Neo.toolbar.Base` withdrawing
+     * a focus-gated action, see `applyContextualActionState` — stamps `vdom.removeDom` and raises this
+     * flag together; {@link #show} then leaves the marker in place on every path that un-hides the
+     * child, including the second `show()` a batched `set()` runs after its silent pass. The owner
+     * drops the flag and restores the marker to what `hidden` says.
+     * @member {Boolean} domWithheld=false
+     */
+    domWithheld = false
+
+    /**
      * @param {Object} config
      */
     construct(config) {
@@ -1787,12 +1798,16 @@ class Component extends Abstract {
      * Show the component.
      * hideMode: 'removeDom'  uses vdom removeDom.
      * hideMode: 'visibility' uses css visibility.
+     * While {@link #domWithheld} is set, the `removeDom` marker stays: the owner holding the DOM back
+     * decides presence, and this call only records the consumer's `hidden: false`.
      */
     show() {
         let me = this;
 
         if (me.hideMode !== 'visibility') {
-            delete me.vdom.removeDom;
+            if (!me.domWithheld) {
+                delete me.vdom.removeDom
+            }
 
             if (me.silentVdomUpdate) {
                 me.needsVdomUpdate = true

--- a/src/tab/plugin/Overflow.mjs
+++ b/src/tab/plugin/Overflow.mjs
@@ -297,10 +297,10 @@ class Overflow extends Plugin {
     /**
      * Actions which actually reduce the tab strip's main-axis extent.
      *
-     * A contextually inactive action is collapsed out of the layout, so it must be excluded here
-     * rather than measured: a collapsed node reports an all-zero rect, and this measurement reads
-     * the rect's POSITION as well as its size. Measuring one would place the action cluster at
-     * offset 0 and consume the entire strip, collapsing every tab into the overflow menu.
+     * A contextually inactive action has no DOM node (`toolbar.Base#applyContextualActionState`
+     * withholds it), so it must be excluded here rather than measured: this measurement reads each
+     * rect's POSITION as well as its size, and a missing or all-zero rect would place the action
+     * cluster at offset 0 and consume the entire strip, collapsing every tab into the overflow menu.
      * @returns {Neo.component.Base[]}
      */
     getActionItems() {

--- a/src/toolbar/Base.mjs
+++ b/src/toolbar/Base.mjs
@@ -57,8 +57,10 @@ class Toolbar extends Container {
          */
         baseCls: ['neo-toolbar'],
         /**
-         * Whether focus-gated actions are currently exposed. Inactive actions keep their layout
-         * extent but leave pointer, keyboard, and accessibility navigation.
+         * Whether focus-gated actions are currently exposed. An inactive action keeps its instance,
+         * its listeners and its place in the actions array, but has no DOM node: it occupies no
+         * layout, and no consumer stylesheet can give it a box back. See
+         * {@link #applyContextualActionState} for the invariant and its mechanism.
          *
          * Driven by {@link #focusSubjectId}; a composition may still set it directly when its
          * exposing signal is not a focus event.
@@ -213,13 +215,34 @@ class Toolbar extends Container {
     }
 
     /**
-     * Offers or withdraws the contextual actions. A withdrawn action is removed from the layout,
-     * not merely made invisible — the rail must not encode absent affordances as empty space.
-     * @param {Boolean} [silent=false]
+     * Offers or withdraws the contextual actions. A withdrawn action is removed from the DOM, not
+     * merely made invisible: the rail must not encode absent affordances as empty space, and the
+     * removal has to hold against consumer CSS of any weight.
+     *
+     * The invariant: a context-inactive action occupies no layout, and consumer CSS cannot make it
+     * occupy layout again. A class-driven `display: none` cannot promise that — any viewport-scoped
+     * consumer rule on `.neo-toolbar-action` outranks it silently, and escalating specificity only
+     * moves the tie to the next consumer. So the collapse is expressed through the component's own
+     * absence primitive, the `vdom.removeDom` marker that `hidden` uses under
+     * `hideMode: 'removeDom'`, on the retained instance: same instance, same listeners, same place
+     * in the actions array, no node. A consumer may style `.neo-toolbar-action` freely — hit areas,
+     * rest and hover paint — without knowing the collapse exists. The
+     * `neo-toolbar-action-context-inactive` class stays on the instance as the measurement marker
+     * `Neo.tab.plugin.Overflow` filters by; it never reaches a rendered node.
+     *
+     * DOM presence is layered, never shared. The toolbar owns the presence of a WITHDRAWN action
+     * and hands it back to the consumer's own `hidden` on reveal, so a `hidden: true` action stays
+     * absent when focus arrives and a `hidden: false` one returns. The hold is the component's own
+     * `domWithheld`: `show()` leaves the marker in place while it is raised, on every un-hide path —
+     * including the second `show()` a batched `set()` runs after its silent pass, which fires past
+     * any `hiddenChange` listener and is why a re-stamp from the toolbar could never be the last
+     * writer.
+     * @param {Boolean} [silent=false] Stamp the vdom only; the caller owns the update.
      */
     applyContextualActionState(silent=false) {
         let me      = this,
-            visible = me.contextualActionsVisible;
+            visible = me.contextualActionsVisible,
+            touched = false;
 
         me.getActionItems().forEach(item => {
             let focusGated      = me.isFocusGatedAction(item),
@@ -247,7 +270,9 @@ class Toolbar extends Container {
 
                 vdom['aria-hidden'] = 'true';
                 vdom.inert         = true;
-                vdom.tabIndex      = -1
+                vdom.tabIndex      = -1;
+                item.domWithheld   = true;
+                vdom.removeDom     = true
             } else {
                 delete vdom['aria-hidden'];
                 delete vdom.inert;
@@ -261,10 +286,34 @@ class Toolbar extends Container {
 
                     delete item._toolbarActionTabIndex
                 }
+
+                item.domWithheld = false;
+                me.syncActionDomPresence(item)
             }
 
-            !silent && item.update()
-        })
+            touched = true
+        });
+
+        // One update at the owner: a child cannot re-insert its own removed node, and the parent
+        // diff is what carries the removals and the returns alike.
+        if (touched && !silent) {
+            me.updateDepth = -1;
+            me.update()
+        }
+    }
+
+    /**
+     * Restores a revealed action's DOM presence to what its consumer decided: `hidden` under
+     * `hideMode: 'removeDom'` keeps the node out, anything else brings it back.
+     * @param {Neo.component.Base} item
+     * @protected
+     */
+    syncActionDomPresence(item) {
+        if (item.hidden && item.hideMode !== 'visibility') {
+            item.vdom.removeDom = true
+        } else {
+            delete item.vdom.removeDom
+        }
     }
 
     /**

--- a/test/playwright/component/dashboard/DockBootSweep.spec.mjs
+++ b/test/playwright/component/dashboard/DockBootSweep.spec.mjs
@@ -44,6 +44,21 @@ const tabsNodeWith = (page, tabText) => page.locator('.neo-dashboard-dock-tabs',
 
 const actionButton = (node, glyph) => node.locator(`.neo-tab-header-toolbar .neo-button:has([class*="${glyph}"])`);
 
+/**
+ * Opens one header's focus gate through the same reactive config the focus wiring writes. A
+ * withdrawn action has no DOM node at all, so the sweep's reveal — `hidden` flipped on the
+ * retained instance — is observable on rendered chrome only once the gate is open. Driving the
+ * config keeps this a boot witness: no pane is activated and no focus moves.
+ * @param {Object} page
+ * @param {Object} node The tabs-node locator.
+ * @returns {Promise<void>}
+ */
+const openActionGate = async (page, node) => {
+    const toolbarId = await node.locator('.neo-tab-header-toolbar').first().getAttribute('id');
+
+    await page.evaluate(id => Neo.worker.App.setConfigs({id, contextualActionsVisible: true}), toolbarId)
+};
+
 test.describe('dock boot sweep — rendered chrome after a static first projection', () => {
     test.beforeEach(async ({page}) => {
         await page.goto('test/playwright/component/apps/dock-static-boot/index.html');
@@ -53,6 +68,8 @@ test.describe('dock boot sweep — rendered chrome after a static first projecti
 
     test('the sweep reaches live chrome and REVEALS an action the projection defaulted hidden', async ({page}) => {
         const header = tabsNodeWith(page, 'Contract');
+
+        await openActionGate(page, header);
 
         // The projection hardcodes reload to `hidden: true`, so its ABSENCE proves nothing — that is
         // the default, and an arm asserting it stays green with the sweep deleted. The discriminating
@@ -79,6 +96,8 @@ test.describe('dock boot sweep — rendered chrome after a static first projecti
 
         const header = tabsNodeWith(page, 'Contract'),
               reload = actionButton(header, 'fa-rotate-right');
+
+        await openActionGate(page, header);
 
         // Poll the observable rather than a clock: `tailReplaced` flips the instant the sweep consumes
         // its sampled tail, which is precisely when the contested state exists. No fixed sleep.

--- a/test/playwright/component/dashboard/DockLock.spec.mjs
+++ b/test/playwright/component/dashboard/DockLock.spec.mjs
@@ -129,16 +129,9 @@ test.describe('dock lock — committed boundary plus reversible presentation', (
         await outside.focus();
         const relock = actionButton(main, 'fa-lock');
 
-        await expect(relock).toHaveClass(/neo-toolbar-action-context-inactive/);
-        await expect(relock).toHaveAttribute('aria-label', 'lock');
-        // Focus state crosses the App/Main render boundary. The class can become observable before
-        // the sibling accessibility deltas settle, so poll the semantic state itself rather than
-        // treating one DOM class as a settlement acknowledgement for unrelated VDOM properties.
-        await expect.poll(() => relock.evaluate(node => ({
-            ariaHidden: node.getAttribute('aria-hidden'),
-            inert     : node.inert,
-            tabIndex  : node.tabIndex
-        }))).toEqual({ariaHidden: 'true', inert: true, tabIndex: -1});
+        // Back under the focus gate, a withdrawn action has no node at all — the collapse is DOM
+        // absence on the retained instance, so there is no class or attribute left to observe.
+        await expect(relock, 'lock is withdrawn again once the protective state ends').toHaveCount(0);
 
         await tabButton(main, 'Beta').focus();
         await tabButton(main, 'Beta').click();

--- a/test/playwright/component/dashboard/DockMaximize.spec.mjs
+++ b/test/playwright/component/dashboard/DockMaximize.spec.mjs
@@ -99,10 +99,10 @@ test.describe('dock maximize — presentation, never topology', () => {
     test('the toggle is focus-gated beside an always-visible close, in the frozen order', async ({page}) => {
         const main = tabsNodeWith(page, 'Alpha');
 
-        // Focus-gated: the maximize control is collapsed out of the layout until the container
-        // holds focus, so it costs no rail space while withdrawn; the close action's
-        // `contextual: false` exemption is the visible contrast.
-        await expect(actionButton(main, 'fa-window-maximize')).toHaveClass(/neo-toolbar-action-context-inactive/);
+        // Focus-gated: the maximize control is absent from the DOM until the container holds
+        // focus, so it costs no rail space while withdrawn; the close action's `contextual: false`
+        // exemption is the visible contrast.
+        await expect(actionButton(main, 'fa-window-maximize')).toHaveCount(0);
         await expect(actionButton(main, 'fa-times')).not.toHaveClass(/neo-toolbar-action-context-inactive/);
 
         await tabButton(main, 'Alpha').click();

--- a/test/playwright/component/dashboard/DockPopOut.spec.mjs
+++ b/test/playwright/component/dashboard/DockPopOut.spec.mjs
@@ -77,10 +77,10 @@ test.describe('dock pop-out — the click is the drag terminal', () => {
     test('pop-out holds the frozen family slot, focus-gated beside an always-visible close', async ({page}) => {
         const main = tabsNodeWith(page, 'Alpha');
 
-        // Focus-gated: collapsed out of the layout entirely until the container holds focus, so a
-        // withdrawn action costs no rail space. Close's `contextual: false` exemption is the
-        // visible contrast — it is the one action that is always on offer.
-        await expect(actionButton(main, 'fa-window-restore')).toHaveClass(/neo-toolbar-action-context-inactive/);
+        // Focus-gated: absent from the DOM entirely until the container holds focus, so a withdrawn
+        // action costs no rail space and no consumer rule can give it one. Close's
+        // `contextual: false` exemption is the visible contrast — the one action always on offer.
+        await expect(actionButton(main, 'fa-window-restore')).toHaveCount(0);
         await expect(actionButton(main, 'fa-times')).not.toHaveClass(/neo-toolbar-action-context-inactive/);
 
         await tabButton(main, 'Alpha').click();

--- a/test/playwright/component/dashboard/DockRailPartition.spec.mjs
+++ b/test/playwright/component/dashboard/DockRailPartition.spec.mjs
@@ -3,32 +3,29 @@ import {test, expect} from '@playwright/test';
 /**
  * A collapsed header action must not reach `Neo.tab.plugin.Overflow`'s measurement.
  *
- * A context-inactive action is removed from layout, so it reports an all-zero DOM rect. The plugin
- * reads each action rect's POSITION as well as its size, so measuring one places the action cluster
- * at offset 0 and the strip reads as fully consumed — every tab but the active one is driven into
- * the overflow menu. `Overflow#getActionItems()` therefore excludes collapsed actions rather than
- * measuring them.
+ * A context-inactive action has no DOM node at all, so there is nothing for `getDomRect`
+ * to measure. The plugin reads each action rect's POSITION as well as its size, so measuring a
+ * missing or all-zero rect places the action cluster at offset 0 and the strip reads as fully
+ * consumed — every tab but the active one is driven into the overflow menu.
+ * `Overflow#getActionItems()` therefore excludes withdrawn actions rather than measuring them.
  *
- * This lives on the dock fixture and not beside the other Overflow arms on purpose: a standalone
- * `tab.Container` has no focus subject, so its gated actions never withdraw, and an arm written
- * there passes whether or not the exclusion exists. The dock header is where a real gated action
- * and a real overflow control coexist on a wide strip, which is the only place the zero-rect
- * collapse is observable.
+ * This lives on the dock fixture and not beside the other Overflow arms on purpose: the dock header
+ * is where a real gated action and a real overflow control coexist on a wide strip at rest, which
+ * is where a mis-measured withdrawal is observable.
  */
 
 const tabsNodeWith = (page, tabText) => page.locator('.neo-dashboard-dock-tabs', {
     has: page.locator(`.neo-tab-header-button:has-text("${tabText}")`)
 });
 
-/** Rail geometry for one dock header: strip width, direct tabs, and the collapsed action count. */
+/** Rail geometry for one dock header: strip width, direct tabs, and the rendered action count. */
 const readRail = node => node.locator(':scope > .neo-tab-header-toolbar').evaluate(bar => {
-    const children = [...bar.children],
-          actions  = children.filter(child => child.classList.contains('neo-toolbar-action'));
+    const children = [...bar.children];
 
     return {
+        actions   : children.filter(child => child.classList.contains('neo-toolbar-action')).length,
         barWidth  : Math.round(bar.getBoundingClientRect().width),
         directTabs: children.filter(child => child.classList.contains('neo-tab-header-button')).length,
-        collapsed : actions.filter(action => getComputedStyle(action).display === 'none').length,
         hasControl: !!bar.querySelector('.fa-ellipsis')
     }
 });
@@ -45,19 +42,27 @@ test.describe('dock rail — a collapsed action contributes no extent', () => {
 
         await expect(main).toHaveCount(1);
 
-        const rail = await readRail(main);
+        const rest = await readRail(main);
 
-        // Non-vacuity, both halves. Without a genuinely collapsed action there is no zero rect to
-        // mis-measure, and without a wide strip a one-tab partition is indistinguishable from the
-        // defect's output. Either precondition failing must red here rather than pass quietly.
-        expect(rail.collapsed, `at least one action must actually be collapsed — ${JSON.stringify(rail)}`)
-            .toBeGreaterThan(0);
-        expect(rail.barWidth, `the strip must be wide enough to hold several tabs — ${JSON.stringify(rail)}`)
+        // Non-vacuity, first half: without a wide strip a one-tab partition is indistinguishable
+        // from the defect's output, so this precondition must red here rather than pass quietly.
+        expect(rest.barWidth, `the strip must be wide enough to hold several tabs — ${JSON.stringify(rest)}`)
             .toBeGreaterThan(400);
 
-        // The subject. Measuring a collapsed action's all-zero rect places the cluster at offset 0
-        // and consumes the whole strip, leaving exactly the active tab.
-        expect(rail.directTabs, `tabs must stay directly reachable — ${JSON.stringify(rail)}`)
-            .toBeGreaterThan(1)
+        // The subject, read at rest. Measuring a withdrawn action's missing rect places the cluster
+        // at offset 0 and consumes the whole strip, leaving exactly the active tab.
+        expect(rest.directTabs, `tabs must stay directly reachable — ${JSON.stringify(rest)}`)
+            .toBeGreaterThan(1);
+
+        // Non-vacuity, second half, read AFTER the subject so it cannot disturb it: a withdrawn action
+        // has no node, so "genuinely withdrawn" is proven by opening the gate through the same reactive
+        // config the focus wiring writes and watching the rendered action cluster grow. No growth
+        // means nothing was withdrawn during the measurement above, and the arm must red.
+        const toolbarId = await main.locator(':scope > .neo-tab-header-toolbar').getAttribute('id');
+
+        await page.evaluate(id => Neo.worker.App.setConfigs({id, contextualActionsVisible: true}), toolbarId);
+        await expect.poll(async () => (await readRail(main)).actions,
+            {message: `at least one action must actually have been withdrawn at rest — ${JSON.stringify(rest)}`})
+            .toBeGreaterThan(rest.actions)
     })
 });

--- a/test/playwright/component/dashboard/DockReload.spec.mjs
+++ b/test/playwright/component/dashboard/DockReload.spec.mjs
@@ -82,8 +82,8 @@ test.describe('dock reload — delegation-only, settled, single-flight', () => {
               maximize = actionButton(main, 'fa-window-maximize'),
               close    = actionButton(main, 'fa-times');
 
-        await soleAction(reload, 'reload');
-        await expect(reload).toHaveClass(/neo-toolbar-action-context-inactive/);
+        // Withdrawn = absent: a focus-gated action has no node until the container holds focus.
+        await expect(reload, 'reload is withdrawn until focus arrives').toHaveCount(0);
 
         await tabButton(main, 'Alpha').click();
         await soleAction(reload, 'reload');
@@ -105,9 +105,11 @@ test.describe('dock reload — delegation-only, settled, single-flight', () => {
         const edge   = tabsNodeWith(page, 'Pinned'),
               reload = actionButton(edge, 'fa-rotate-right');
 
-        // The edge node's carrier offers reload from the first projection on.
-        await soleAction(reload, 'reload');
+        // Withdrawn until the container holds focus — no node. The edge node's carrier offers reload
+        // from the first projection on, so focus reveals it at once.
+        await expect(reload).toHaveCount(0);
         await tabButton(edge, 'Pinned').click();
+        await soleAction(reload, 'reload');
         await expect(reload).not.toHaveClass(/neo-toolbar-action-context-inactive/);
 
         // The one-way unpin rails the pane. `railed` is committed auto-hidden already, so the
@@ -132,10 +134,12 @@ test.describe('dock reload — delegation-only, settled, single-flight', () => {
         // The action is projected `hidden: true` by the stable-instance rule and only the
         // post-settle sweep reveals it — a sweep that never reaches the fresh node leaves the
         // returned pane without the one action the round trip owes it.
-        await soleAction(reloadBack, 'reload');
-        await expect(reloadBack).toHaveClass(/neo-toolbar-action-context-inactive/);
+        // Absent while withdrawn — whether by the projection's `hidden: true` or by the focus gate,
+        // so the discriminating read is the one after focus: a node only exists if the sweep un-hid it.
+        await expect(reloadBack).toHaveCount(0);
 
         await tabButton(returned, 'Pinned').click();
+        await soleAction(reloadBack, 'reload');
         await expect(reloadBack).not.toHaveClass(/neo-toolbar-action-context-inactive/)
     });
 

--- a/test/playwright/component/tab/ContainerUi.spec.mjs
+++ b/test/playwright/component/tab/ContainerUi.spec.mjs
@@ -265,9 +265,11 @@ test.describe('Neo.tab.Container — ui variants', () => {
                 closeAction   = inlineToolbar.locator('.neo-toolbar-action[aria-label="close"]'),
                 ordinary     = page.locator('#tab-ui-ordinary-toolbar .neo-toolbar-action');
 
-            await expect(gatedAction).toHaveClass(/neo-toolbar-action-context-inactive/);
-
-            const gatedBox = await gatedAction.boundingBox();
+            // A gated action is collapsed OUT of the DOM while quiet, so there is no node and no
+            // box. The superseded contract preserved the box and left a hole in the rail between
+            // the actions actually on offer; revealing an action now grows the cluster instead of
+            // filling a slot that was already paid for.
+            await expect(gatedAction, 'a gated action occupies no space: it has no node').toHaveCount(0);
 
             await inlineToolbar.locator('.neo-tab-header-button').first().focus();
             await expect(gatedAction).not.toHaveClass(/neo-toolbar-action-context-inactive/);
@@ -276,11 +278,6 @@ test.describe('Neo.tab.Container — ui variants', () => {
 
             const exposedBox = await gatedAction.boundingBox();
 
-            // A gated action is collapsed OUT of the layout, so while quiet it has no box at all.
-            // The superseded contract preserved the box and left a hole in the rail between the
-            // actions actually on offer; revealing an action now grows the cluster instead of
-            // filling a slot that was already paid for.
-            expect(gatedBox,   'a gated action occupies no space').toBeNull();
             expect(exposedBox, 'revealing it gives it a box').not.toBeNull();
 
             const measured = {

--- a/test/playwright/component/tab/OverflowAction.spec.mjs
+++ b/test/playwright/component/tab/OverflowAction.spec.mjs
@@ -52,6 +52,50 @@ async function createTabContainer(page) {
     return result.id
 }
 
+/**
+ * Creates a TabContainer whose rail carries one focus-gated action between two persistent ones.
+ * @param {Object} page
+ * @returns {Promise<String>}
+ */
+async function createGatedTabContainer(page) {
+    return page.evaluate(async id => {
+        const result = await Neo.worker.App.createNeoInstance({
+            activeIndex  : 0,
+            height       : 240,
+            headerActions: [{
+                action     : 'host-action',
+                iconCls    : 'fa fa-star',
+                showOnFocus: false
+            }, {
+                // Focus-gated: the subject of the arms using this fixture.
+                action : 'gated-action',
+                iconCls: 'fa fa-thumbtack'
+            }, {
+                action     : 'close',
+                iconCls    : 'fa fa-times',
+                showOnFocus: false
+            }],
+            headerToolbar: {plugins: [{ntype: 'plugin-tab-overflow', projectAsAction: true}]},
+            id,
+            importPath   : '../tab/Container.mjs',
+            items        : Array.from({length: 8}, (_, index) => ({
+                header: {text: `Tab ${index + 1}`},
+                ntype : 'component',
+                text  : `Content ${index + 1}`
+            })),
+            ntype   : 'tab-container',
+            parentId: 'component-test-viewport',
+            width   : 380
+        });
+
+        if (!result.success) {
+            throw new Error(`gated TabContainer creation failed: ${result.error.message}`)
+        }
+
+        return result.id
+    }, TAB_ID)
+}
+
 /** Returns the action-root ids in rendered toolbar order. */
 const actionIds = toolbar => toolbar.locator(':scope > .neo-toolbar-action')
     .evaluateAll(nodes => nodes.map(node => node.id));
@@ -232,11 +276,11 @@ test.describe('Neo.tab.plugin.Overflow — toolbar action projection', () => {
 
     test('a withdrawn focus-gated action contributes no extent to the partition', async ({page}) => {
         // The other arms in this file use `showOnFocus: false` throughout, so none of them exercise
-        // the plugin against a collapsed action. This one does: a gated action is removed from the
-        // layout while withdrawn, and the plugin must therefore EXCLUDE it from measurement rather
-        // than measure it. A collapsed node reports an all-zero rect, and this measurement reads the
-        // rect's POSITION as well as its size — measuring one places the action cluster at offset 0
-        // and consumes the whole strip, collapsing every tab into the overflow menu.
+        // the plugin against a withdrawn action. This one does: a gated action has no DOM node while
+        // withdrawn, and the plugin must therefore EXCLUDE it from measurement rather than measure
+        // it. This measurement reads each rect's POSITION as well as its size — a missing or all-zero
+        // rect places the action cluster at offset 0 and consumes the whole strip, collapsing every
+        // tab into the overflow menu.
         await page.evaluate(id => Neo.worker.App.destroyNeoInstance(id), componentId);
 
         // This arm is the only one that replaces the shared `beforeEach` container, and it reuses the
@@ -247,67 +291,34 @@ test.describe('Neo.tab.plugin.Overflow — toolbar action projection', () => {
         // the casualty surfaces in whatever spec runs next. Await the detach; it is the actual barrier.
         await page.waitForSelector(`#${TAB_ID}`, {state: 'detached'});
 
-        componentId = await page.evaluate(async id => {
-            const result = await Neo.worker.App.createNeoInstance({
-                activeIndex  : 0,
-                height       : 240,
-                headerActions: [{
-                    action     : 'host-action',
-                    iconCls    : 'fa fa-star',
-                    showOnFocus: false
-                }, {
-                    // Focus-gated: the subject of this arm.
-                    action : 'gated-action',
-                    iconCls: 'fa fa-thumbtack'
-                }, {
-                    action     : 'close',
-                    iconCls    : 'fa fa-times',
-                    showOnFocus: false
-                }],
-                headerToolbar: {plugins: [{ntype: 'plugin-tab-overflow', projectAsAction: true}]},
-                id,
-                importPath   : '../tab/Container.mjs',
-                items        : Array.from({length: 8}, (_, index) => ({
-                    header: {text: `Tab ${index + 1}`},
-                    ntype : 'component',
-                    text  : `Content ${index + 1}`
-                })),
-                ntype   : 'tab-container',
-                parentId: 'component-test-viewport',
-                width   : 380
-            });
-
-            if (!result.success) {
-                throw new Error(`gated TabContainer creation failed: ${result.error.message}`)
-            }
-
-            return result.id
-        }, TAB_ID);
+        componentId = await createGatedTabContainer(page);
 
         await page.waitForSelector(`#${componentId}`, {state: 'attached'});
 
-        const root    = page.locator(`#${TAB_ID}`),
-              toolbar = root.locator(':scope > .neo-tab-header-toolbar'),
-              control = toolbar.getByRole('button', {name: 'More tabs', exact: true}),
-              gated   = toolbar.locator(':scope > .neo-toolbar-action:has(.fa-thumbtack)'),
-              tabs    = toolbar.locator(':scope > .neo-tab-header-button');
-
-        await expect(gated, 'the gated action is projected').toHaveCount(1);
-        await expect(control, 'precondition: the strip overflows, so a partition exists to lose')
-            .toBeVisible({timeout: 10000});
-
-        const toolbarId = await toolbar.getAttribute('id'),
+        const root      = page.locator(`#${TAB_ID}`),
+              toolbar   = root.locator(':scope > .neo-tab-header-toolbar'),
+              control   = toolbar.getByRole('button', {name: 'More tabs', exact: true}),
+              gated     = toolbar.locator(':scope > .neo-toolbar-action:has(.fa-thumbtack)'),
+              tabs      = toolbar.locator(':scope > .neo-tab-header-button'),
+              toolbarId = await toolbar.getAttribute('id'),
               setGate   = visible => page.evaluate(
                   ({id, visible}) => Neo.worker.App.setConfigs({id, contextualActionsVisible: visible}),
                   {id: toolbarId, visible}
               );
+
+        // A standalone container holds no focus, so a gated action is absent from the first paint.
+        // Revealing it once is the read that proves the fixture projected it at all.
+        await setGate(true);
+        await expect(gated, 'the gated action is projected').toHaveCount(1);
+        await expect(control, 'precondition: the strip overflows, so a partition exists to lose')
+            .toBeVisible({timeout: 10000});
 
         // The withdrawn state is pinned through the SAME reactive config the focus wiring writes
         // (`toolbar.Base#contextualActionsVisible`), rather than by moving real focus. A standalone
         // container has no focus subject holding focus, so driving the config is what makes the
         // state deterministic here — and it is the identical state, not a proxy for it.
         await setGate(false);
-        await expect(gated, 'the action is withdrawn').toHaveClass(/neo-toolbar-action-context-inactive/);
+        await expect(gated, 'the action is withdrawn: no node at all').toHaveCount(0);
 
         // Force a re-partition WHILE the action is collapsed. Toggling the gate alone does not
         // re-measure, and the all-zero-rect defect only surfaces on a measurement pass: without
@@ -318,8 +329,9 @@ test.describe('Neo.tab.plugin.Overflow — toolbar action projection', () => {
             .toHaveCount(0, {timeout: 10000});
         await page.evaluate(id => Neo.worker.App.setConfigs({id, width: 380}), TAB_ID);
 
-        // Withdrawn: no box at all, so it cannot be measured into the strip extent.
-        expect(await gated.boundingBox(), 'a withdrawn action occupies no space').toBeNull();
+        // Withdrawn: no node at all, so it cannot be measured into the strip extent. (`boundingBox()`
+        // auto-waits for an element and would time out here; the count is the honest read.)
+        await expect(gated, 'a withdrawn action occupies no space: it has no node').toHaveCount(0);
 
         // The partition stays usable. This is the assertion that reds when the plugin measures the
         // collapsed action's all-zero rect: the cluster is then placed at offset 0, the strip reads
@@ -342,5 +354,71 @@ test.describe('Neo.tab.plugin.Overflow — toolbar action projection', () => {
             .toBeGreaterThan(0);
         expect(directTabs, 'precondition sanity: the withdrawn state had a real partition to lose')
             .toBeGreaterThan(1)
+    });
+
+    /**
+     * The collapse used to be one (0,2,0) engine rule, `display: none` on the inactive class, and
+     * any viewport-scoped consumer rule on `.neo-toolbar-action` outranked it silently — ghost
+     * verbs reserving space on every resting rail. The invariant is now DOM absence on the retained
+     * instance, so the falsifier is consumer CSS at the weights that actually shipped: the second
+     * occurrence's (0,5,0) hit-area rule, the minimal viewport-scoped (0,3,0) shape, and the
+     * `!important` a consumer reaches for next.
+     */
+    test('consumer CSS of any weight cannot resurrect a withdrawn action', async ({page}) => {
+        await page.evaluate(id => Neo.worker.App.destroyNeoInstance(id), componentId);
+        await page.waitForSelector(`#${TAB_ID}`, {state: 'detached'});
+
+        componentId = await createGatedTabContainer(page);
+        await page.waitForSelector(`#${componentId}`, {state: 'attached'});
+
+        const root      = page.locator(`#${TAB_ID}`),
+              toolbar   = root.locator(':scope > .neo-tab-header-toolbar'),
+              host      = toolbar.locator(':scope > .neo-toolbar-action:has(.fa-star)'),
+              gated     = toolbar.locator(':scope > .neo-toolbar-action:has(.fa-thumbtack)'),
+              control   = toolbar.getByRole('button', {name: 'More tabs', exact: true}),
+              tabs      = toolbar.locator(':scope > .neo-tab-header-button'),
+              toolbarId = await toolbar.getAttribute('id'),
+              setGate   = visible => page.evaluate(
+                  ({id, visible}) => Neo.worker.App.setConfigs({id, contextualActionsVisible: visible}),
+                  {id: toolbarId, visible}
+              ),
+              display   = locator => locator.evaluate(node => getComputedStyle(node).display);
+
+        // Author-origin and last in source order: every tie a class rule could enter, these win.
+        await page.addStyleTag({content: `
+            .neo-viewport .neo-tab-container .neo-tab-header-toolbar .neo-button.neo-toolbar-action { display: inline-flex; min-width: 24px; }
+            .neo-viewport .neo-toolbar .neo-toolbar-action { display: inline-flex; }
+            .neo-toolbar-action { display: flex !important; }
+        `});
+
+        // Positive control: the consumer stylesheet is live on the actions that ARE offered.
+        expect(await display(host), 'the consumer rule paints the persistent action').toBe('flex');
+
+        await setGate(true);
+        await expect(gated).toHaveCount(1);
+
+        const revealedId = await gated.getAttribute('id');
+
+        expect(await display(gated), 'and the revealed gated action alike').toBe('flex');
+
+        await setGate(false);
+
+        // The invariant: no node, so no rule can give it a box. `toBeHidden` would also pass for a
+        // node the stylesheet had resurrected but pushed off-screen; count is the honest read.
+        await expect(gated, 'withdrawn under (0,5,0), (0,3,0) and !important consumer rules').toHaveCount(0);
+
+        // The partition keeps its direct tabs while the strip is re-measured against the resting rail.
+        await page.evaluate(id => Neo.worker.App.setConfigs({id, width: 1200}), TAB_ID);
+        await expect(toolbar.locator('.neo-tab-overflow-control')).toHaveCount(0, {timeout: 10000});
+        await page.evaluate(id => Neo.worker.App.setConfigs({id, width: 380}), TAB_ID);
+        await expect(control, 'the overflow control is contributed').toHaveCount(1);
+        expect(await tabs.count(), 'direct tabs remain reachable').toBeGreaterThan(1);
+
+        // Reveal restores the same instance: same node id, same accessible name, consumer paint applied.
+        await setGate(true);
+        await expect(gated).toHaveCount(1);
+        expect(await gated.getAttribute('id'), 'the retained instance came back, not a replacement').toBe(revealedId);
+        await expect(gated).toHaveAttribute('aria-label', 'gated action');
+        expect(await display(gated)).toBe('flex')
     })
 });

--- a/test/playwright/unit/tab/HeaderActions.spec.mjs
+++ b/test/playwright/unit/tab/HeaderActions.spec.mjs
@@ -182,6 +182,7 @@ test.describe.serial('Neo tab header actions', () => {
         expect(action.vdom['aria-hidden']).toBe('true');
         expect(action.vdom['aria-label']).toBe('contextual');
         expect(action.vdom.tabIndex).toBe(-1);
+        expect(action.vdom.removeDom, 'withdrawn = no DOM node, not a styled one').toBe(true);
 
         toolbar.contextualActionsVisible = true;
 
@@ -191,6 +192,7 @@ test.describe.serial('Neo tab header actions', () => {
         expect(action.vdom.inert).toBeUndefined();
         expect(action.vdom['aria-hidden']).toBeUndefined();
         expect(action.vdom.tabIndex).toBeUndefined();
+        expect(action.vdom.removeDom, 'revealed = the node returns').toBeUndefined();
 
         action.vdom.tabIndex = 4;
         toolbar.contextualActionsVisible = false;
@@ -214,7 +216,58 @@ test.describe.serial('Neo tab header actions', () => {
         toolbar.contextualActionsVisible = true;
 
         expect(action.hidden, 'focus context cannot overwrite consumer-owned availability').toBe(true);
-        expect(removeDomAtVisibilitySignal, 'geometry invalidation follows the hidden DOM-state commit').toBe(true)
+        expect(removeDomAtVisibilitySignal, 'geometry invalidation follows the hidden DOM-state commit').toBe(true);
+        expect(action.vdom.removeDom, 'reveal hands presence back to the consumer: hidden keeps the node out').toBe(true);
+
+        action.hidden = false;
+        expect(action.vdom.removeDom, 'un-hiding while revealed brings the node back').toBeUndefined();
+
+        // The consumer un-hides while the action is WITHDRAWN. Availability stays the consumer's;
+        // presence stays the toolbar's until the gate opens: the toolbar holds the DOM through the
+        // component's own `domWithheld`, so `show()` leaves the marker in place.
+        toolbar.contextualActionsVisible = false;
+        action.hidden = true;
+        action.hidden = false;
+
+        expect(action.hidden).toBe(false);
+        expect(action.domWithheld, 'the toolbar holds the DOM of a withdrawn action').toBe(true);
+        expect(action.vdom.removeDom, 'a withdrawn action stays absent through a consumer un-hide').toBe(true);
+
+        // The batched path is the one no listener can win: `component.Abstract#set()` runs a second
+        // `show()` after its silent pass, past every `hiddenChange` listener. This is the dock's own
+        // shape — `Workspace#syncDockReloadAction` un-hides through `set({disabled, hidden})`.
+        action.hidden = true;
+        action.set({disabled: false, hidden: false});
+
+        expect(action.hidden).toBe(false);
+        expect(action.vdom.removeDom, 'a batched un-hide cannot re-insert a withdrawn action').toBe(true);
+
+        toolbar.contextualActionsVisible = true;
+
+        expect(action.domWithheld, 'reveal releases the hold').toBe(false);
+        expect(action.vdom.removeDom).toBeUndefined()
+    });
+
+    test('actions arriving while withdrawn are absent before their first render', () => {
+        const toolbar = own(Neo.create(Toolbar, {
+                  actions: [{action: 'first', contextual: true, iconCls: 'fa fa-eye'}]
+              })),
+              late    = toolbar.addActionContribution({action: 'late', iconCls: 'fa fa-clock', showOnFocus: true});
+
+        expect(late.cls).toContain('neo-toolbar-action-context-inactive');
+        expect(late.vdom.removeDom, 'a contributed gated action is withdrawn before it renders').toBe(true);
+
+        toolbar.actions = [{action: 'replaced', contextual: true, iconCls: 'fa fa-x'}];
+
+        const replaced = toolbar.getActionItem('replaced');
+
+        expect(replaced.vdom.removeDom, 'a replaced gated action is withdrawn before it renders').toBe(true);
+        expect(late.vdom.removeDom, 'the contribution survives the replacement, still withdrawn').toBe(true);
+
+        toolbar.contextualActionsVisible = true;
+
+        expect(late.vdom.removeDom).toBeUndefined();
+        expect(replaced.vdom.removeDom).toBeUndefined()
     });
 
     test('Dialog header order and headerAction payload stay compatible', () => {


### PR DESCRIPTION
Resolves #18042

A context-inactive toolbar action now has no DOM node at all. `toolbar.Base#applyContextualActionState` stamps the component's own absence marker, `vdom.removeDom`, on the retained instance (same instance, same listeners, same place in the actions array) and hands presence back to the consumer's `hidden` on reveal, with one update at the owner; the `(0,2,0)` SCSS rule that a viewport-scoped consumer rule outranked silently is gone. A consumer may style `.neo-toolbar-action` at any weight — hit areas, rest and hover paint — without knowing the collapse exists, because there is nothing left to style. The hold itself is a new `component.Base#domWithheld` flag that `show()` honours: a consumer un-hiding a withdrawn action cannot re-insert it on any path, including the second `show()` that `component.Abstract#set()` runs after its silent pass — the path the dock's `syncDockReloadAction` takes through `set({disabled, hidden})`, and the one the rail-return witness caught. The `neo-toolbar-action-context-inactive` class stays on the instance as the measurement marker `tab.plugin.Overflow` filters by; it never reaches a rendered node.

Evidence: L3 (unit and rendered component witnesses in CI cover AC-1…AC-4 and AC-6; AC-5 is a mutation control, run locally and receipted below) → L3 required (AC-1…AC-6). Residual: none.

Micro-review eligible: no — `show()` gains a presence layer on `component.Base`.

## AC Evidence
| AC-1 | CI-covered: `test/playwright/component/tab/OverflowAction.spec.mjs` › "consumer CSS of any weight cannot resurrect a withdrawn action" — author-origin rules at `(0,5,0)` (the Institution's shape), `(0,3,0)` and `display: flex !important` on `.neo-toolbar-action`; the withdrawn action has no node (`toHaveCount(0)`, stronger than a zero rect and honest where `toBeHidden` is not), with a positive control that the same stylesheet paints the persistent action and the revealed gated action `display: flex` |
| AC-2 | CI-covered: same arm — a 1200px → 380px re-partition under the consumer stylesheet keeps the overflow control contributed and more than one direct tab reachable; › "a withdrawn focus-gated action contributes no extent to the partition" re-measures with the action absent (the file's 380px strip; see Deltas on the 843px figure) |
| AC-3 | CI-covered: same arm reads the revealed node's id before and after a withdraw/reveal cycle (identical) and its `aria-label`; `test/playwright/unit/tab/HeaderActions.spec.mjs` › "contextual inactivity reserves the instance while leaving consumer availability intact" (instance and handler identity, consumer `hidden` untouched) and › "contributed actions stay first and preserve identity across consumer replacements" (membership) |
| AC-4 | CI-covered, unchanged in intent and green: `test/playwright/component/tab/ContainerUi.spec.mjs` › "…null stays current while inline and standalone are intentional" in all four engine themes (the quiet gated action reads absence, the revealed box and geometry as before), OverflowAction's repartition arm, `DockPopOut.spec.mjs` › "pop-out holds the frozen family slot…" and the sibling dock specs (`DockLock`, `DockMaximize`, `DockReload`, `DockBootSweep`, `DockRailPartition`) reading absence instead of the class — the last two open the gate through `contextualActionsVisible` so the sweep's reveal and the partition's non-vacuity stay observable on rendered chrome |
| AC-5 | outside-CI mutation control, receipts in Test Evidence: the class-only collapse restored (`src/toolbar/Base.mjs`, `src/component/Base.mjs` and the SCSS reverted, tests kept) turns the consumer-CSS arm red; and the engine hold reverted alone (`src/component/Base.mjs`) turns the batched un-hide unit arm red |
| AC-6 | diff: `toolbar.Base` — `contextualActionsVisible` and `applyContextualActionState` state the invariant, the consumer styling boundary and the layered presence; `component.Base` — `domWithheld` and `show()` document the hold |

## Deltas from ticket
- **The engine grew one primitive.** A `hiddenChange` re-stamp from the toolbar was the first shape and it is not in the diff: `component.Abstract#set()` runs a second `show()` after its silent pass, past every listener, so a listener can never be the last writer. `DockReload.spec.mjs` › "a pane pinned back from the rail returns with its reload action" caught it — the returned pane's reload action, un-hidden by `syncDockReloadAction` through `set({disabled, hidden})`, came back as a node while withdrawn. The hold moved to where the un-hide happens: `component.Base#domWithheld`, one flag and one condition in `show()`, raised and dropped by the toolbar together with the marker.
- The SCSS rule is deleted rather than kept for "consumers that want to style the transition": nothing renders while withdrawn, so there is nothing to style; the class remains as the Overflow measurement marker only.
- AC-2's "843px dock fixture" does not exist as a fixture in the repository; the repartition witness is OverflowAction's 380px strip, re-partitioned under the consumer stylesheet.
- Assertions on an absent node use `toHaveCount(0)`: `locator.boundingBox()` auto-waits for an element and times out on absence.
- Two boot-scoped witnesses (`DockBootSweep`, `DockRailPartition`) read rendered chrome without focus and went red in CI at the first head; they now open the header's gate through the reactive config the focus wiring writes — no pane activated, no focus moved — and the partition arm proves withdrawal after the subject is measured (the action cluster must grow once the gate opens).
- `tab.plugin.Overflow#getActionItems`: comment refresh only, the filter is unchanged.
- The Institution's local restatement (`neo-agent-institution` PR #65, `Viewport.scss`) becomes removable once its engine pin moves past this commit — a follow-up in that repository, not this PR. The DockLayouts styling-guide slot named in the ticket stays with #18036.

## Test Evidence
Mutation controls, local, Chromium component config and the unit config on this head:
- AC-5, class-only collapse restored (`git stash push -- src/toolbar/Base.mjs resources/scss/src/toolbar/Base.scss src/component/Base.mjs`, tests kept): OverflowAction › "consumer CSS of any weight cannot resurrect a withdrawn action" → **red** at `withdrawn under (0,5,0), (0,3,0) and !important consumer rules — Expected: 0, Received: 1`. Restored → green.
- Engine hold reverted alone (`git stash push -- src/component/Base.mjs`): HeaderActions › "contextual inactivity reserves the instance…" → **red** at the first un-hide-while-withdrawn read, `a withdrawn action stays absent through a consumer un-hide — Expected: true, Received: undefined` (the batched read behind it is the same hold; without it the assignment path already loses). Restored → 15/15 green.

## Post-Merge Validation
- [ ] the next theme build drops `.neo-toolbar .neo-toolbar-action-context-inactive {display: none}` from the compiled CSS; no consumer depends on the rule
- [ ] Institution: retire the local restatement in `Viewport.scss` when its engine pin includes this commit

Authored by Mnemosyne (Claude Fable 5.1, Claude Code). Session 37bbc610-f0cd-4abb-95c2-eb70336a86f3. 🪢

