### PR TITLE
feat(dock): header actions carry tooltips that follow their toggles (#18071)

### DIFF
--- a/src/component/Base.mjs
+++ b/src/component/Base.mjs
@@ -871,16 +871,22 @@ class Component extends Abstract {
      * @protected
      */
     afterSetTooltip(value, oldValue) {
+        let me = this;
+
         oldValue?.destroy?.();
 
         if (value) {
             if (Neo.ns('Neo.tooltip.Base')) {
-                this.createTooltip(value)
+                me.createTooltip(value)
             } else {
                 import('../tooltip/Base.mjs').then(() => {
-                    this.createTooltip(value)
+                    me.createTooltip(value)
                 })
             }
+        } else if (oldValue) {
+            // Retiring a tooltip: an own instance is destroyed above; a shared-tooltip owner must
+            // also leave the singleton's delegate set, or hovering it would open an empty tooltip.
+            me.removeCls('neo-uses-shared-tooltip')
         }
     }
 

--- a/src/component/Base.mjs
+++ b/src/component/Base.mjs
@@ -1272,7 +1272,11 @@ class Component extends Abstract {
             })
         } else {
             me._tooltip = value;
-            Neo.tooltip.Base.createSingleton(me.app);
+
+            // The shared instance delegates from the app's main view. The unit harness runs without
+            // one, so the singleton is skipped there and the config stays readable on the owner —
+            // the same deliberate no-op `updateVdom()` takes in unit-test mode.
+            !Neo.config.unitTestMode && Neo.tooltip.Base.createSingleton(me.app);
             me.addCls('neo-uses-shared-tooltip');
             me.update()
         }

--- a/src/dashboard/dock/Workspace.mjs
+++ b/src/dashboard/dock/Workspace.mjs
@@ -233,9 +233,11 @@ class Workspace extends Container {
          * Tooltip texts of the engine-owned header actions and the rail's reveal pin, keyed by
          * action state: `lock` / `unlock`, `reload`, `unpin`, `popOut`, `maximize` / `restore`,
          * `close`, `revealPin`. A consumer restates wording or language per key: the map deep-merges
-         * over these defaults, and a key set to `null` leaves that action without a tooltip. Toggles
-         * keep text, icon and accessible name coherent on the retained action instance
-         * ({@link #syncDockLockAction}, {@link #syncDockMaximizeActionPresentation}).
+         * over these defaults, and a key set to `null` leaves that action without a tooltip — for a
+         * toggle, in the state that key names: a `null` `unlock` clears the tooltip while the pane is
+         * locked and `lock` restores it on unlock. Toggles keep text, icon and accessible name
+         * coherent on the retained action instance ({@link #syncDockLockAction},
+         * {@link #syncDockMaximizeActionPresentation}, both through {@link #syncDockActionTooltip}).
          * @member {Object} dockActionTooltips_
          * @reactive
          */
@@ -1534,7 +1536,7 @@ class Workspace extends Container {
             hidden       = !activeItemId || activeItem?.lockable === false,
             iconCls      = activeItem?.locked === true ? me.dockUnlockIconCls : me.dockLockIconCls,
             ariaLabel    = activeItem?.locked === true ? 'unlock' : 'lock',
-            tooltip      = me.dockActionTooltips?.[activeItem?.locked === true ? 'unlock' : 'lock'] ?? null,
+            tooltipKey   = activeItem?.locked === true ? 'unlock' : 'lock',
             showOnFocus  = activeItem?.locked !== true,
             changes      = {};
 
@@ -1544,8 +1546,7 @@ class Workspace extends Container {
             action.hidden  !== hidden  && (changes.hidden  = hidden);
             action.iconCls !== iconCls && (changes.iconCls = iconCls);
             action.showOnFocus !== showOnFocus && (changes.showOnFocus = showOnFocus);
-            // An absent key leaves whatever the projection gave the action — never a null write.
-            tooltip != null && me.readDockActionTooltip(action) !== tooltip && (changes.tooltip = tooltip);
+            me.syncDockActionTooltip(action, tooltipKey, changes);
 
             if (Object.keys(changes).length || ariaLabelChanged) {
                 // `setSilent()` consumes non-config class-field keys from its input, so remember
@@ -2929,12 +2930,11 @@ class Workspace extends Container {
 
         let iconCls          = maximized ? me.dockMinimizeIconCls : me.dockMaximizeIconCls,
             ariaLabel        = maximized ? 'restore' : 'maximize',
-            tooltip          = me.dockActionTooltips?.[maximized ? 'restore' : 'maximize'] ?? null,
             ariaLabelChanged = action.vdom?.['aria-label'] !== ariaLabel,
             changes          = {};
 
         action.iconCls !== iconCls && (changes.iconCls = iconCls);
-        tooltip != null && me.readDockActionTooltip(action) !== tooltip && (changes.tooltip = tooltip);
+        me.syncDockActionTooltip(action, maximized ? 'restore' : 'maximize', changes);
 
         if (Object.keys(changes).length || ariaLabelChanged) {
             Object.keys(changes).length && action.setSilent(changes);
@@ -2955,6 +2955,28 @@ class Workspace extends Container {
         let {tooltip} = action || {};
 
         return typeof tooltip === 'string' ? tooltip : (tooltip?.text ?? null)
+    }
+
+    /**
+     * Stages the tooltip a toggle state owes its retained action into one batched change set.
+     *
+     * The map distinguishes two things the projection also keeps apart: a key that is ABSENT
+     * leaves whatever the projection gave the action, and a key set to `null` is the documented
+     * opt-out — it clears the tooltip in that state, so a toggle never keeps naming the state it
+     * just left. The opposite half of the pair restores its own text on the way back.
+     * @param {Neo.component.Base} action
+     * @param {String} key One of the map's keys (`lock`, `unlock`, `maximize`, `restore`).
+     * @param {Object} changes The batch handed to `setSilent()`.
+     * @protected
+     */
+    syncDockActionTooltip(action, key, changes) {
+        let tips = this.dockActionTooltips || {};
+
+        if (key in tips) {
+            let tooltip = tips[key] ?? null;
+
+            this.readDockActionTooltip(action) !== tooltip && (changes.tooltip = tooltip)
+        }
     }
 
     /**

--- a/src/dashboard/dock/Workspace.mjs
+++ b/src/dashboard/dock/Workspace.mjs
@@ -1,6 +1,7 @@
 import Component                   from '../../component/Base.mjs';
 import Container                   from '../../container/Base.mjs';
 import NeoArray                    from '../../util/Array.mjs';
+import {isDescriptor}              from '../../core/ConfigSymbols.mjs';
 import LayoutAdapter               from './projection/LayoutAdapter.mjs';
 import MotionSignal                from './projection/MotionSignal.mjs';
 import PreviewProducer             from './interaction/PreviewProducer.mjs';
@@ -228,6 +229,32 @@ class Workspace extends Container {
          * @member {String} dockMinimizeIconCls='far fa-window-minimize'
          */
         dockMinimizeIconCls: 'far fa-window-minimize',
+        /**
+         * Tooltip texts of the engine-owned header actions and the rail's reveal pin, keyed by
+         * action state: `lock` / `unlock`, `reload`, `unpin`, `popOut`, `maximize` / `restore`,
+         * `close`, `revealPin`. A consumer restates wording or language per key: the map deep-merges
+         * over these defaults, and a key set to `null` leaves that action without a tooltip. Toggles
+         * keep text, icon and accessible name coherent on the retained action instance
+         * ({@link #syncDockLockAction}, {@link #syncDockMaximizeActionPresentation}).
+         * @member {Object} dockActionTooltips_
+         * @reactive
+         */
+        dockActionTooltips_: {
+            [isDescriptor]: true,
+            clone         : 'deep',
+            merge         : 'deep',
+            value         : {
+                close    : 'Close',
+                lock     : 'Lock pane',
+                maximize : 'Maximize',
+                popOut   : 'Pop out into a window',
+                reload   : 'Reload pane',
+                restore  : 'Restore',
+                revealPin: 'Pin back into the layout',
+                unlock   : 'Unlock pane',
+                unpin    : 'Unpin into the rail'
+            }
+        },
         /**
          * Enables the engine-owned dock tear-out admission/document/window lifecycle. Disabled
          * by default so ordinary workspaces and hosts carrying their own legacy lifecycle remain
@@ -1507,6 +1534,7 @@ class Workspace extends Container {
             hidden       = !activeItemId || activeItem?.lockable === false,
             iconCls      = activeItem?.locked === true ? me.dockUnlockIconCls : me.dockLockIconCls,
             ariaLabel    = activeItem?.locked === true ? 'unlock' : 'lock',
+            tooltip      = me.dockActionTooltips?.[activeItem?.locked === true ? 'unlock' : 'lock'] ?? null,
             showOnFocus  = activeItem?.locked !== true,
             changes      = {};
 
@@ -1516,6 +1544,8 @@ class Workspace extends Container {
             action.hidden  !== hidden  && (changes.hidden  = hidden);
             action.iconCls !== iconCls && (changes.iconCls = iconCls);
             action.showOnFocus !== showOnFocus && (changes.showOnFocus = showOnFocus);
+            // An absent key leaves whatever the projection gave the action — never a null write.
+            tooltip != null && me.readDockActionTooltip(action) !== tooltip && (changes.tooltip = tooltip);
 
             if (Object.keys(changes).length || ariaLabelChanged) {
                 // `setSilent()` consumes non-config class-field keys from its input, so remember
@@ -2802,7 +2832,7 @@ class Workspace extends Container {
             me.playDockMaximizeFlip(host)
         }
 
-        me.syncDockMaximizeActionIcon(tabContainer, true);
+        me.syncDockMaximizeActionPresentation(tabContainer, true);
         await me.registerDockMaximizeResizeObserver(true)
     }
 
@@ -2875,24 +2905,56 @@ class Workspace extends Container {
                 })
             }
 
-            me.syncDockMaximizeActionIcon(tabContainer, false)
+            me.syncDockMaximizeActionPresentation(tabContainer, false)
         }
 
         await me.registerDockMaximizeResizeObserver(false)
     }
 
     /**
-     * Flips the node's projected maximize action between its maximize and restore icons — on
-     * the stable action instance, the same discipline every action consumer relies on.
+     * Flips the node's projected maximize action between its maximize and restore presentation —
+     * icon, accessible name and tooltip together, on the stable action instance, the same
+     * discipline every action consumer relies on. The glyph names the NEXT action, so the name and
+     * the tooltip follow it: `restore` while the node is maximized. One batched update, like
+     * {@link #syncDockLockAction}.
      * @param {Neo.tab.Container|null} tabContainer
      * @param {Boolean} maximized
      * @protected
      */
-    syncDockMaximizeActionIcon(tabContainer, maximized) {
+    syncDockMaximizeActionPresentation(tabContainer, maximized) {
         let me     = this,
             action = tabContainer?.getActionItem?.('maximize');
 
-        action && (action.iconCls = maximized ? me.dockMinimizeIconCls : me.dockMaximizeIconCls)
+        if (!action) return;
+
+        let iconCls          = maximized ? me.dockMinimizeIconCls : me.dockMaximizeIconCls,
+            ariaLabel        = maximized ? 'restore' : 'maximize',
+            tooltip          = me.dockActionTooltips?.[maximized ? 'restore' : 'maximize'] ?? null,
+            ariaLabelChanged = action.vdom?.['aria-label'] !== ariaLabel,
+            changes          = {};
+
+        action.iconCls !== iconCls && (changes.iconCls = iconCls);
+        tooltip != null && me.readDockActionTooltip(action) !== tooltip && (changes.tooltip = tooltip);
+
+        if (Object.keys(changes).length || ariaLabelChanged) {
+            Object.keys(changes).length && action.setSilent(changes);
+            ariaLabelChanged && (action.vdom['aria-label'] = ariaLabel);
+            action.update()
+        }
+    }
+
+    /**
+     * The text a projected action currently offers as its tooltip. `component.Base#tooltip` reads
+     * back the shared-instance config object once the tooltip module has loaded and the plain
+     * string before that, so a sync compares text, never the container.
+     * @param {Neo.component.Base|null} action
+     * @returns {String|null}
+     * @protected
+     */
+    readDockActionTooltip(action) {
+        let {tooltip} = action || {};
+
+        return typeof tooltip === 'string' ? tooltip : (tooltip?.text ?? null)
     }
 
     /**
@@ -3306,6 +3368,7 @@ class Workspace extends Container {
                 enableDockPinAction      : me.enableDockPinAction,
                 enableDockPopOutAction   : me.enableDockPopOutAction,
                 enableDockReloadAction   : me.enableDockReloadAction,
+                dockActionTooltips       : me.dockActionTooltips,
                 dockMaximizeIconCls      : me.dockMaximizeIconCls,
                 dockPopOutActionAvailable: me.dockPopOutActionActive,
                 dockPopOutIconCls        : me.dockPopOutIconCls,

--- a/src/dashboard/dock/interaction/Rail.mjs
+++ b/src/dashboard/dock/interaction/Rail.mjs
@@ -135,7 +135,13 @@ class Rail extends Container {
          * @member {Number|null} revealDwellMs_=null
          * @reactive
          */
-        revealDwellMs_: null
+        revealDwellMs_: null,
+        /**
+         * Tooltip text handed to the reveal overlay's pin control at construction, from the
+         * workspace's `dockActionTooltips.revealPin`. `null` leaves the control without a tooltip.
+         * @member {String|null} revealPinTooltip=null
+         */
+        revealPinTooltip: null
     }
 
     /**
@@ -172,8 +178,9 @@ class Rail extends Container {
             config.items = [
                 ...(config.railItems || []).map(railItem => this.createTabConfig(railItem, config.edge)),
                 {
-                    module: RevealOverlay,
-                    edge  : this.getValidatedEdge(config.edge)
+                    module    : RevealOverlay,
+                    edge      : this.getValidatedEdge(config.edge),
+                    pinTooltip: config.revealPinTooltip ?? null
                 }
             ]
         }

--- a/src/dashboard/dock/interaction/RevealOverlay.mjs
+++ b/src/dashboard/dock/interaction/RevealOverlay.mjs
@@ -85,6 +85,12 @@ class RevealOverlay extends Container {
          */
         layout: {ntype: 'vbox', align: 'stretch'},
         /**
+         * Tooltip text of the overlay's pin control, threaded by the rail from the workspace's
+         * `dockActionTooltips.revealPin`. `null` leaves the control without a tooltip.
+         * @member {String|null} pinTooltip=null
+         */
+        pinTooltip: null,
+        /**
          * Committed extent fraction for the free dimension, or `null` for the default fraction.
          * Resolved by the rail from the live document — never computed from DOM geometry.
          * @member {Number|null} revealExtent_=null
@@ -157,7 +163,8 @@ class RevealOverlay extends Container {
                 iconCls    : 'fa fa-thumbtack',
                 showOnFocus: false,
                 text       : null,
-                vdom       : {'aria-label': 'Pin'}
+                vdom       : {'aria-label': 'Pin'},
+                ...(config.pinTooltip != null && {tooltip: config.pinTooltip})
             }],
             // The self-scoped variant class lets every theme resolve the same compact tokens as
             // an inline TabContainer, even though this runtime-only toolbar has no container owner.

--- a/src/dashboard/dock/projection/LayoutAdapter.mjs
+++ b/src/dashboard/dock/projection/LayoutAdapter.mjs
@@ -430,6 +430,10 @@ class LayoutAdapter extends Base {
      *     capability changes its hidden state rather than node-level action membership.
      * @param {String} [options.dockPopOutIconCls='far fa-window-restore'] Icon of the projected
      *     pop-out action.
+     * @param {Object} [options.dockActionTooltips] Tooltip texts of the engine actions and the
+     *     rail's reveal pin, keyed by action state (`lock` / `unlock`, `reload`, `unpin`, `popOut`,
+     *     `maximize` / `restore`, `close`, `revealPin`); a missing key projects no tooltip for that
+     *     action. The workspace threads its `dockActionTooltips` map here.
      * @param {Function} [options.onDockActiveIndexChange] Runtime active-item signal for action policy.
      * @param {Function} [options.onDockHeaderAction] Runtime Dock action intent; never persisted.
      * @param {Function} [options.resolveDockHeaderActions] Host resolver for additional tab-header
@@ -500,6 +504,7 @@ class LayoutAdapter extends Base {
             dockTabSortBoundaryContainerId   : options.dockTearOutBoundaryContainerId
                 || options.dockWorkspaceBoundaryContainerId
                 || null,
+            dockActionTooltips               : options.dockActionTooltips || null,
             dockLockIconCls                  : options.dockLockIconCls || 'fa fa-lock',
             dockMaximizeIconCls              : options.dockMaximizeIconCls || 'far fa-window-maximize',
             dockPopOutActionAvailable        : options.dockPopOutActionAvailable === true,
@@ -647,6 +652,7 @@ class LayoutAdapter extends Base {
             onDockZoneDocumentChange: context.onDockZoneDocumentChange,
             railItems               : itemIds.map(itemId => this.createRailTab(itemId, edge, context)),
             resolveComponentRef     : context.resolveRevealComponentRef,
+            revealPinTooltip        : context.dockActionTooltips?.revealPin ?? null,
             syncDockLockPane        : context.syncDockLockPane
         }
     }
@@ -1100,6 +1106,10 @@ class LayoutAdapter extends Base {
             seen.add(name)
         }
 
+        const tips = context.dockActionTooltips || {},
+              // Only a present key becomes a config: an absent tooltip must not write `tooltip: undefined`.
+              tip  = key => tips[key] != null ? {tooltip: tips[key]} : {};
+
         const headerActions = [
             ...hostActions,
             // Lock leads the frozen engine set. The ordinary lock gesture inherits focus gating;
@@ -1114,7 +1124,8 @@ class LayoutAdapter extends Base {
                 showOnFocus: context.items[activeItemId]?.locked !== true,
                 vdom       : {
                     'aria-label': context.items[activeItemId]?.locked === true ? 'unlock' : 'lock'
-                }
+                },
+                ...tip(context.items[activeItemId]?.locked === true ? 'unlock' : 'lock')
             }] : []),
             // Reload follows lock in the frozen family order (lock · reload · pin · maximize — close
             // always last). Not a toggle, so the icon is fixed like pin's. `hidden` is a
@@ -1127,7 +1138,8 @@ class LayoutAdapter extends Base {
             ...(context.enableDockReloadAction ? [{
                 action : 'reload',
                 hidden : true,
-                iconCls: 'fa fa-rotate-right'
+                iconCls: 'fa fa-rotate-right',
+                ...tip('reload')
             }] : []),
             ...(context.enableDockPinAction ? [{
                 action    : 'pin',
@@ -1148,8 +1160,9 @@ class LayoutAdapter extends Base {
                 // Like maximize → minimize, the glyph names the NEXT action, not current state:
                 // this one-way command unpins into the rail; the reveal toolbar owns the inverse
                 // thumbtack that pins the pane back into flow.
-                iconCls   : 'fa fa-thumbtack-slash',
-                vdom      : {'aria-label': 'unpin'}
+                iconCls: 'fa fa-thumbtack-slash',
+                vdom   : {'aria-label': 'unpin'},
+                ...tip('unpin')
             }] : []),
             // Pop-out sits between pin and maximize per the family's frozen ordering. Same
             // focus-gating default as the rest of the engine set — no `contextual` key.
@@ -1161,13 +1174,15 @@ class LayoutAdapter extends Base {
             ...(context.enableDockPopOutAction ? [{
                 action : 'pop-out',
                 hidden : !activeItemId || !context.dockPopOutActionAvailable,
-                iconCls: context.dockPopOutIconCls
+                iconCls: context.dockPopOutIconCls,
+                ...tip('popOut')
             }] : []),
             // Maximize inherits the same focus-gating default; the family ordering contract keeps
             // the engine set between host actions and the always-visible, always-last `close`.
             ...(context.enableDockMaximizeAction ? [{
                 action : 'maximize',
-                iconCls: context.dockMaximizeIconCls
+                iconCls: context.dockMaximizeIconCls,
+                ...tip('maximize')
             }] : []),
             ...(context.enableDockCloseAction ? [{
                 action    : 'close',
@@ -1175,7 +1190,8 @@ class LayoutAdapter extends Base {
                 hidden    : !activeItemId
                     || context.items[activeItemId]?.closable === false
                     || context.items[activeItemId]?.locked === true,
-                iconCls   : 'fa fa-times'
+                iconCls   : 'fa fa-times',
+                ...tip('close')
             }] : [])
         ];
 

--- a/test/playwright/component/dashboard/DockActionTooltips.spec.mjs
+++ b/test/playwright/component/dashboard/DockActionTooltips.spec.mjs
@@ -1,0 +1,87 @@
+import {test, expect} from '@playwright/test';
+
+/**
+ * @summary The engine header actions and the rail's reveal pin name themselves on hover through the
+ * app's shared tooltip, and the maximize toggle renames with its glyph.
+ *
+ * Rides the dock-maximize fixture: reload, maximize and close are enabled, pin projects on the edge
+ * node, and `railed` sits auto-hidden on the right rail so the reveal overlay's pin exists. A
+ * withdrawn action has no hover target, so every read happens after the container holds focus.
+ *
+ * Run: npx playwright test dashboard/DockActionTooltips -c test/playwright/playwright.config.component.mjs --workers=1
+ */
+
+const tabsNodeWith = (page, tabText) => page.locator('.neo-dashboard-dock-tabs', {
+    has: page.locator(`.neo-tab-header-button:has-text("${tabText}")`)
+});
+
+const tabButton = (node, text) => node.locator('.neo-tab-header-button', {hasText: text});
+
+const actionButton = (node, glyph) => node.locator(`.neo-tab-header-toolbar .neo-button:has([class*="${glyph}"])`);
+
+/**
+ * Hovers one control and waits for the app's shared tooltip — one node, mounted on show — to carry
+ * the expected text. The pointer parks on a neutral spot first, so hovering the same control twice
+ * (before and after a toggle) re-enters it and the singleton reconfigures.
+ * @param {Object} page
+ * @param {Object} locator
+ * @param {String} text
+ * @returns {Promise<void>}
+ */
+const expectTooltip = async (page, locator, text) => {
+    await page.mouse.move(0, 0);
+    await locator.hover();
+    await expect(page.locator('.neo-tooltip'), `hovering shows "${text}"`).toHaveText(text)
+};
+
+test.beforeEach(async ({page}) => {
+    await page.goto('test/playwright/component/apps/dock-maximize/index.html');
+    await page.waitForSelector('#dock-maximize-workspace', {state: 'attached'});
+    await page.waitForSelector('.neo-tab-header-button',   {state: 'visible'})
+});
+
+test.describe('dock header action tooltips', () => {
+    test('every offered engine action names itself on hover, and maximize renames with its glyph', async ({page}) => {
+        const main = tabsNodeWith(page, 'Alpha');
+
+        await tabButton(main, 'Alpha').click();
+
+        await expectTooltip(page, actionButton(main, 'fa-rotate-right'), 'Reload pane');
+        await expectTooltip(page, actionButton(main, 'fa-times'),        'Close');
+
+        const maximize = actionButton(main, 'fa-window-maximize');
+
+        await expectTooltip(page, maximize, 'Maximize');
+        await expect(maximize).toHaveAttribute('aria-label', 'maximize');
+
+        await maximize.click();
+        await expect(page.locator('.neo-dock-maximized')).toHaveCount(1);
+
+        // The toggle keeps its instance: the same node now carries the restore glyph, name and text.
+        const restore = actionButton(main, 'fa-window-minimize');
+
+        await expect(restore).toHaveCount(1);
+        await expectTooltip(page, restore, 'Restore');
+        await expect(restore).toHaveAttribute('aria-label', 'restore');
+
+        await restore.click();
+        await expect(page.locator('.neo-dock-maximized')).toHaveCount(0);
+
+        await expectTooltip(page, actionButton(main, 'fa-window-maximize'), 'Maximize');
+        await expect(actionButton(main, 'fa-window-maximize')).toHaveAttribute('aria-label', 'maximize')
+    });
+
+    test('unpin and the reveal overlay pin name themselves on hover', async ({page}) => {
+        const edge = tabsNodeWith(page, 'Pinned');
+
+        await tabButton(edge, 'Pinned').click();
+        await expectTooltip(page, actionButton(edge, 'fa-thumbtack-slash'), 'Unpin into the rail');
+
+        await page.locator('.neo-dashboard-dock-edge-rail').getByText('Railed').click();
+
+        const overlay = page.locator('.neo-dashboard-dock-reveal-overlay:not(.neo-dashboard-dock-reveal-overlay-hidden)');
+
+        await expect(overlay).toHaveCount(1);
+        await expectTooltip(page, overlay.getByRole('button', {name: 'Pin'}), 'Pin back into the layout')
+    })
+});

--- a/test/playwright/unit/dashboard/DockActionTooltips.spec.mjs
+++ b/test/playwright/unit/dashboard/DockActionTooltips.spec.mjs
@@ -1,0 +1,169 @@
+import {setup} from '../../setup.mjs';
+
+setup({
+    appConfig: {
+        name: 'NeoDashboardDockActionTooltipsTest'
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../src/Neo.mjs';
+import * as core      from '../../../../src/core/_export.mjs';
+import DockWorkspace  from '../../../../src/dashboard/dock/Workspace.mjs';
+import Reconciler     from '../../../../src/dashboard/dock/projection/Reconciler.mjs';
+import '../../../../src/manager/Instance.mjs';
+import '../../../../src/tab/Container.mjs';
+
+/**
+ * @summary A committed document with a center tabs node and one auto-hidden edge item, so the
+ * projection carries every engine header action AND a rail with its reveal overlay.
+ * @returns {Object}
+ */
+function createDocument() {
+    return {
+        schema: 'neo.dock.zone.v1',
+        root  : 'root',
+        items : {
+            alpha : {componentRef: 'alpha',  title: 'Alpha',  kind: 'panel'},
+            beta  : {componentRef: 'beta',   title: 'Beta',   kind: 'panel'},
+            pinned: {componentRef: 'pinned', title: 'Pinned', kind: 'panel'},
+            railed: {componentRef: 'railed', title: 'Railed', kind: 'panel', autoHidden: true}
+        },
+        nodes: {
+            root       : {type: 'edge-zone', zones: {center: {nodeId: 'main-tabs'}, right: {nodeId: 'edge-tabs', extent: 0.25}}},
+            'main-tabs': {type: 'tabs', items: ['alpha', 'beta'],    activeItemId: 'alpha'},
+            'edge-tabs': {type: 'tabs', items: ['pinned', 'railed'], activeItemId: 'pinned'}
+        }
+    }
+}
+
+/**
+ * @summary Workspace fixture that mounts the real projected composition once.
+ */
+class TooltipWorkspace extends DockWorkspace {
+    static config = {
+        className: 'Test.Unit.Dashboard.DockActionTooltips.Workspace',
+        layout   : {ntype: 'vbox', align: 'stretch'}
+    }
+
+    construct(config) {
+        super.construct(config);
+        this.add(this.projectDockModel())
+    }
+}
+
+TooltipWorkspace = Neo.setupClass(TooltipWorkspace);
+
+/**
+ * The tooltip TEXT an action offers: the plain string until the tooltip module has loaded, the
+ * shared-instance config object after — the same read `Workspace#readDockActionTooltip` makes.
+ * @param {Neo.component.Base} action
+ * @returns {String|null}
+ */
+const tipText = action => typeof action.tooltip === 'string' ? action.tooltip : (action.tooltip?.text ?? null);
+
+test.describe('dock header action tooltips', () => {
+    let workspace = null;
+
+    test.afterEach(() => {
+        workspace?.destroy();
+        workspace = null
+    });
+
+    const create = (config={}) => (workspace = Neo.create(TooltipWorkspace, {
+        dockModel           : createDocument(),
+        enableDockLockAction: true,
+        ...config
+    }));
+
+    const tabsOf = nodeId => Reconciler.collectProjectedTabs(workspace.items[0]).get(nodeId);
+
+    test('the projection stamps the engine defaults onto every header action and the reveal pin', () => {
+        create();
+
+        const main     = tabsOf('main-tabs'),
+              expected = {
+                  close    : 'Close',
+                  lock     : 'Lock pane',
+                  maximize : 'Maximize',
+                  pin      : 'Unpin into the rail',
+                  'pop-out': 'Pop out into a window',
+                  reload   : 'Reload pane'
+              };
+
+        for (const [action, text] of Object.entries(expected)) {
+            expect(tipText(main.getActionItem(action)), `${action} names itself`).toBe(text)
+        }
+
+        const rail    = workspace.down({ntype: 'dashboard-dock-rail'}),
+              overlay = rail.items.at(-1),
+              pin     = overlay.items[0].getActionItem('pin');
+
+        expect(rail.revealPinTooltip, 'the rail carries the text for its overlay').toBe('Pin back into the layout');
+        expect(overlay.pinTooltip).toBe('Pin back into the layout');
+        expect(tipText(pin), 'the reveal pin names itself').toBe('Pin back into the layout')
+    });
+
+    test('a consumer override deep-merges over the defaults, and a null key withholds one tooltip', () => {
+        const overridden = create({dockActionTooltips: {lock: 'Sperren', reload: null}}),
+              main       = tabsOf('main-tabs');
+
+        expect(overridden.dockActionTooltips.lock,  'the overridden key').toBe('Sperren');
+        expect(overridden.dockActionTooltips.close, 'an untouched key keeps the engine default').toBe('Close');
+        expect(tipText(main.getActionItem('lock'))).toBe('Sperren');
+        expect(tipText(main.getActionItem('close'))).toBe('Close');
+        expect(main.getActionItem('reload').tooltip, 'a null key writes no tooltip at all').toBeNull();
+
+        overridden.destroy();
+
+        // The merge lands on the instance, never on the class default.
+        create();
+        expect(workspace.dockActionTooltips.lock, 'a fresh workspace keeps the engine default').toBe('Lock pane');
+        expect(tipText(tabsOf('main-tabs').getActionItem('reload'))).toBe('Reload pane')
+    });
+
+    test('lock ↔ unlock flips tooltip, icon and accessible name together on the retained instance', () => {
+        create();
+
+        const main   = tabsOf('main-tabs'),
+              action = main.getActionItem('lock');
+
+        expect(tipText(action)).toBe('Lock pane');
+
+        expect(workspace.handleDockLockAction({dockNodeId: 'main-tabs', tabContainer: main}).errors).toEqual([]);
+
+        expect(main.getActionItem('lock'), 'the same instance').toBe(action);
+        expect(action.iconCls).toBe(workspace.dockUnlockIconCls);
+        expect(action.vdom['aria-label']).toBe('unlock');
+        expect(tipText(action)).toBe('Unlock pane');
+
+        expect(workspace.handleDockLockAction({dockNodeId: 'main-tabs', tabContainer: main}).errors).toEqual([]);
+
+        expect(action.iconCls).toBe(workspace.dockLockIconCls);
+        expect(action.vdom['aria-label']).toBe('lock');
+        expect(tipText(action)).toBe('Lock pane')
+    });
+
+    test('maximize ↔ restore flips tooltip, icon and accessible name on the retained instance', () => {
+        create();
+
+        const main   = tabsOf('main-tabs'),
+              action = main.getActionItem('maximize');
+
+        expect(action.vdom['aria-label'], 'the derived name before any toggle').toBe('maximize');
+        expect(tipText(action)).toBe('Maximize');
+
+        workspace.syncDockMaximizeActionPresentation(main, true);
+
+        expect(main.getActionItem('maximize'), 'the same instance').toBe(action);
+        expect(action.iconCls).toBe(workspace.dockMinimizeIconCls);
+        expect(action.vdom['aria-label'], 'the restore glyph is announced as restore').toBe('restore');
+        expect(tipText(action)).toBe('Restore');
+
+        workspace.syncDockMaximizeActionPresentation(main, false);
+
+        expect(action.iconCls).toBe(workspace.dockMaximizeIconCls);
+        expect(action.vdom['aria-label']).toBe('maximize');
+        expect(tipText(action)).toBe('Maximize')
+    })
+});

--- a/test/playwright/unit/dashboard/DockActionTooltips.spec.mjs
+++ b/test/playwright/unit/dashboard/DockActionTooltips.spec.mjs
@@ -144,6 +144,31 @@ test.describe('dock header action tooltips', () => {
         expect(tipText(action)).toBe('Lock pane')
     });
 
+    test('a null key on one half of a toggle clears the tooltip in that state, and the other half restores it', () => {
+        create({dockActionTooltips: {restore: null, unlock: null}});
+
+        const main     = tabsOf('main-tabs'),
+              lock     = main.getActionItem('lock'),
+              maximize = main.getActionItem('maximize');
+
+        expect(tipText(lock)).toBe('Lock pane');
+        expect(workspace.handleDockLockAction({dockNodeId: 'main-tabs', tabContainer: main}).errors).toEqual([]);
+        expect(lock.iconCls, 'the icon follows the toggle').toBe(workspace.dockUnlockIconCls);
+        expect(tipText(lock), 'the opted-out state has no tooltip — not the one the button just left').toBeNull();
+        expect(lock.cls, 'and no longer joins the shared tooltip').not.toContain('neo-uses-shared-tooltip');
+
+        expect(workspace.handleDockLockAction({dockNodeId: 'main-tabs', tabContainer: main}).errors).toEqual([]);
+        expect(tipText(lock), 'the other half restores its text').toBe('Lock pane');
+
+        expect(tipText(maximize)).toBe('Maximize');
+        workspace.syncDockMaximizeActionPresentation(main, true);
+        expect(maximize.iconCls).toBe(workspace.dockMinimizeIconCls);
+        expect(tipText(maximize), 'restore opted out: no tooltip while maximized').toBeNull();
+
+        workspace.syncDockMaximizeActionPresentation(main, false);
+        expect(tipText(maximize)).toBe('Maximize')
+    });
+
     test('maximize ↔ restore flips tooltip, icon and accessible name on the retained instance', () => {
         create();
 


### PR DESCRIPTION
Resolves #18071

Every engine header action (lock, reload, pin, pop-out, maximize, close) and the rail's reveal pin now names itself on hover through the app's shared tooltip, and the two toggles keep tooltip, icon and accessible name coherent on the retained instance — maximize is announced as `restore` while the restore glyph shows, which it was not before. The texts live in one reactive `Workspace#dockActionTooltips` map with engine defaults: a consumer restates wording or language per key (deep-merged), and a `null` key withholds that one tooltip. The map travels the same seam as the icon classes — the projection context into `LayoutAdapter.project()`, documented as an option — and the rail hands `revealPin` to the overlay's pin control at construction. Focus gating is untouched: a withdrawn action has no hover target.

Evidence: L3 (unit and rendered component witnesses in CI cover AC-1…AC-5; the hover texts are read from the mounted shared tooltip in Chromium) → L3 required (AC-1…AC-5). Residual: none.

Micro-review eligible: no — a new consumer-facing config, a projection option, and a guard in `component.Base#createTooltip`.

## AC Evidence
| AC-1 | CI-covered: `test/playwright/component/dashboard/DockActionTooltips.spec.mjs` › "every offered engine action names itself on hover, and maximize renames with its glyph" (reload, close, maximize on a focused container) and › "unpin and the reveal overlay pin name themselves on hover" (unpin on the edge node, the overlay's pin after a rail reveal); lock and pop-out texts at the projection in `test/playwright/unit/dashboard/DockActionTooltips.spec.mjs` › "the projection stamps the engine defaults onto every header action and the reveal pin" |
| AC-2 | CI-covered: unit › "lock ↔ unlock flips tooltip, icon and accessible name together on the retained instance" (through `handleDockLockAction`, same instance asserted) and › "maximize ↔ restore flips tooltip, icon and accessible name on the retained instance" (`aria-label` reads `restore` under the restore glyph); component: the same node reads `aria-label` `maximize` → `restore` → `maximize` across the toggle with the tooltip following |
| AC-3 | CI-covered: unit › "a consumer override deep-merges over the defaults, and a null key withholds one tooltip" — `lock: 'Sperren'` reaches the projected action, `close` keeps the engine default, `reload: null` projects no tooltip, and a fresh workspace still carries the engine default (the merge lands on the instance, never on the class) |
| AC-4 | CI-covered: every component read happens after the container holds focus (a withdrawn action has no node — #18042's contract on `dev` once PR #18069 lands, `display: none` before it); the focus gate itself is not touched by this diff |
| AC-5 | CI-covered: `DockLock`, `DockMaximize`, `DockPopOut`, `DockReload` and the tab header unit suite unchanged and green on this head |

## Deltas from ticket
- **`component.Base#createTooltip` gains a unit-test-mode guard.** The shared tooltip singleton delegates from `app.mainView`, which the unit harness does not have; with projected actions now carrying tooltips, every workspace unit spec would have thrown asynchronously after the tooltip module's dynamic import (measured with a probe before the change: `Cannot read properties of null (reading 'name')` without an app name, `… undefined (reading 'id')` with one). The guard mirrors the deliberate `updateVdom()` no-op in unit-test mode; the config stays readable on the owner.
- **The map is a reactive config with a descriptor** (`clone: 'deep'`, `merge: 'deep'`), the `listeners_` / `remote_` precedent — a plain config stored the descriptor object verbatim and a consumer object replaced the defaults wholesale.
- **`project()` grows the option.** The adapter maps `options` into a curated context that enumerates keys, so the map had to be threaded explicitly, like the icon classes.
- **`syncDockMaximizeActionIcon` is renamed to `syncDockMaximizeActionPresentation`** (two internal call sites): it now writes icon, `aria-label` and tooltip in one batched update, the `syncDockLockAction` shape.
- **`readDockActionTooltip`** compares text: `component.Base#tooltip` reads back the shared-instance config object (`{text}`) once the tooltip module has loaded and the plain string before, so a sync comparing the container would re-create the tooltip on every active-item change.
- The reveal overlay reads the text at construction (`Rail#revealPinTooltip` → `RevealOverlay#pinTooltip`), where its pin control is built; no runtime toggle exists for that control.

## Test Evidence
All coverage runs in CI.

## Post-Merge Validation
- [ ] Workstation and WebStudio dock headers show the engine texts on hover once their engine pin includes this commit; wording overrides, if wanted, go through `dockActionTooltips` in those apps

Authored by Mnemosyne (Claude Fable 5.1, Claude Code). Session 37bbc610-f0cd-4abb-95c2-eb70336a86f3. 🪢

