### PR TITLE
fix(dock): the reveal overlay measures from the strip's own origin (#18070)

### DIFF
--- a/resources/scss/src/dashboard/Container.scss
+++ b/resources/scss/src/dashboard/Container.scss
@@ -458,6 +458,23 @@
     }
 }
 
+// The reveal overlay's containing block, and the only reason this rule exists.
+//
+// An absolutely positioned overlay resolves its insets against the nearest positioned ancestor's
+// PADDING box, which starts before that element's own padding. The rail it must clear is laid out
+// in normal flow, inside the CONTENT box, which starts after it. Leave the containing block to the
+// dashboard host and those two origins differ by exactly the host's padding: the per-edge insets
+// below land short by that much and the overlay covers the strip it is supposed to begin at. A
+// consumer padding its dock host is ordinary, so the precondition has to be established here rather
+// than assumed — on the box the rails themselves lay out in, where both readers start from the same
+// origin whether the host is padded or not.
+//
+// Scoped deliberately to this element: the drop-indicator layer and `.neo-dock-preview` are
+// siblings of the edge zone, not descendants, so their containing block is unchanged.
+.neo-dashboard-dock-edge-zone {
+    position: relative;
+}
+
 .neo-dashboard-dock-reveal-overlay {
     background   : var(--dock-reveal-background);
     border       : var(--dock-reveal-border);
@@ -476,6 +493,11 @@
     // The reserved edge is the RAIL's extent, read from the rail's own token rather than
     // restated — the overlay must start exactly where the strip ends, and a second literal
     // here is how those two silently disagree.
+    //
+    // Sharing the token's VALUE is only half of that promise: these insets also have to be
+    // measured from the same ORIGIN the rail is laid out from, which is what the edge zone's
+    // `position: relative` above establishes. Two readers agreeing on a length still disagree
+    // if they start counting from different boxes.
     &-left,
     &-right {
         min-inline-size: min(var(--dock-reveal-min-inline-size), calc(100% - var(--dock-edge-rail-size)));

--- a/test/playwright/component/apps/dock-rail-origin/app.mjs
+++ b/test/playwright/component/apps/dock-rail-origin/app.mjs
@@ -1,0 +1,113 @@
+import Component     from '../../../../../src/component/Base.mjs';
+import DockWorkspace from '../../../../../src/dashboard/dock/Workspace.mjs';
+import Viewport      from '../../../../../src/container/Viewport.mjs';
+import '../../../../../src/tab/Container.mjs';
+
+/**
+ * Every edge zone holds exactly one auto-hidden item, so all four zones render as a rail and each
+ * of the four per-edge `inset` rules gets a witness. The two axes matter independently: left/right
+ * measure from the inline start/end, top/bottom from the block start/end.
+ */
+const fixtureDocument = {
+    schema: 'neo.dock.zone.v1',
+    root  : 'root',
+    items : {
+        main  : {componentRef: 'main',   title: 'Main',   kind: 'panel'},
+        left  : {componentRef: 'left',   title: 'Left',   kind: 'panel', autoHidden: true},
+        right : {componentRef: 'right',  title: 'Right',  kind: 'panel', autoHidden: true},
+        top   : {componentRef: 'top',    title: 'Top',    kind: 'panel', autoHidden: true},
+        bottom: {componentRef: 'bottom', title: 'Bottom', kind: 'panel', autoHidden: true}
+    },
+    nodes: {
+        root: {type: 'edge-zone', zones: {
+            center: {nodeId: 'main-tabs'},
+            left  : {nodeId: 'left-tabs',   extent: 0.25},
+            right : {nodeId: 'right-tabs',  extent: 0.25},
+            top   : {nodeId: 'top-tabs',    extent: 0.25},
+            bottom: {nodeId: 'bottom-tabs', extent: 0.25}
+        }},
+        'main-tabs'  : {type: 'tabs', items: ['main'],   activeItemId: 'main'},
+        'left-tabs'  : {type: 'tabs', items: ['left'],   activeItemId: 'left'},
+        'right-tabs' : {type: 'tabs', items: ['right'],  activeItemId: 'right'},
+        'top-tabs'   : {type: 'tabs', items: ['top'],    activeItemId: 'top'},
+        'bottom-tabs': {type: 'tabs', items: ['bottom'], activeItemId: 'bottom'}
+    }
+};
+
+/**
+ * @summary The fixture workspace for the reveal overlay's containing-block origin. It carries a
+ * consumer-shaped class on its own dashboard root so a spec can pad the dock host the way an app
+ * stylesheet does, which is the precondition the engine must hold against — a padded host offsets
+ * the rail into the content box while an absolutely positioned overlay resolves against the
+ * padding box.
+ * @class Test.Playwright.Component.DockRailOrigin.Workspace
+ * @extends Neo.dashboard.dock.Workspace
+ */
+class RailOriginWorkspace extends DockWorkspace {
+    static config = {
+        /**
+         * @member {String} className='Test.Playwright.Component.DockRailOrigin.Workspace'
+         * @protected
+         */
+        className: 'Test.Playwright.Component.DockRailOrigin.Workspace',
+        /**
+         * The host handle a spec pads, standing in for a consumer's app stylesheet.
+         * @member {String[]} cls=['dock-rail-origin-host']
+         */
+        cls: ['dock-rail-origin-host'],
+        /**
+         * @member {String} id='dock-rail-origin-workspace'
+         */
+        id: 'dock-rail-origin-workspace',
+        /**
+         * @member {Object} layout={ntype:'vbox',align:'stretch'}
+         */
+        layout: {ntype: 'vbox', align: 'stretch'},
+        /**
+         * Mirrors the shape both shipping consumers give their dock host: the Workstation and the
+         * Fleet cockpit both position it. That is what makes the unpadded arm a true control — with
+         * the host positioned, the only thing separating a correct overlay from an overlapping one
+         * is the padding, so the padded arm isolates the padding and nothing else. An unpositioned
+         * host is broken further still (the overlay resolves against the viewport), but that is a
+         * different distance and it would blur what the padded arm measures.
+         * @member {Object} style={position:'relative'}
+         */
+        style: {position: 'relative'}
+    }
+
+    /**
+     * @param {Object} config
+     */
+    construct(config) {
+        super.construct(config);
+
+        this.add(this.projectDockModel());
+        this.onDockZoneDocumentChange(structuredClone(fixtureDocument))
+    }
+
+    /**
+     * @summary Resolves one test pane. The panes carry no geometry of their own — every assertion
+     * reads the overlay and the rail, never the pane.
+     * @param {String} itemId
+     * @param {Object} item
+     * @returns {Object}
+     */
+    resolvePane(itemId, item) {
+        return {
+            cls  : ['dock-rail-origin-pane', `dock-rail-origin-pane-${itemId}`],
+            id   : `dock-rail-origin-pane-${itemId}`,
+            ntype: 'component',
+            vdom : {cn: [{tag: 'span', text: `${item?.title || itemId} pane`}]}
+        }
+    }
+}
+
+RailOriginWorkspace = Neo.setupClass(RailOriginWorkspace);
+
+export const onStart = () => Neo.app({
+    mainView: {
+        module: Viewport,
+        items : [{module: RailOriginWorkspace, flex: 1}]
+    },
+    name: 'Test.Playwright.DockRailOrigin'
+});

--- a/test/playwright/component/apps/dock-rail-origin/index.html
+++ b/test/playwright/component/apps/dock-rail-origin/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Neo.mjs Dock Lock Test App</title>
+</head>
+<body>
+    <button id="dock-lock-outside-focus" type="button">Outside dock focus</button>
+    <script src="../../../../../src/MicroLoader.mjs" type="module"></script>
+</body>
+</html>

--- a/test/playwright/component/apps/dock-rail-origin/index.html
+++ b/test/playwright/component/apps/dock-rail-origin/index.html
@@ -3,10 +3,9 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Neo.mjs Dock Lock Test App</title>
+    <title>Neo.mjs Dock Rail Reveal Origin Test App</title>
 </head>
 <body>
-    <button id="dock-lock-outside-focus" type="button">Outside dock focus</button>
     <script src="../../../../../src/MicroLoader.mjs" type="module"></script>
 </body>
 </html>

--- a/test/playwright/component/apps/dock-rail-origin/neo-config.json
+++ b/test/playwright/component/apps/dock-rail-origin/neo-config.json
@@ -1,0 +1,10 @@
+{
+    "appPath"         : "test/playwright/component/apps/dock-rail-origin/app.mjs",
+    "basePath"        : "../../../../../",
+    "environment"     : "development",
+    "mainPath"        : "./Main.mjs",
+    "mainThreadAddons": ["DragDrop", "Navigator", "Stylesheet"],
+    "themes"          : ["neo-theme-neo-dark", "neo-theme-neo-light"],
+    "useAiClient"     : true,
+    "useSharedWorkers": false
+}

--- a/test/playwright/component/dashboard/DockRailRevealOrigin.spec.mjs
+++ b/test/playwright/component/dashboard/DockRailRevealOrigin.spec.mjs
@@ -1,0 +1,140 @@
+import {test, expect} from '@playwright/test';
+
+/**
+ * The reveal overlay's ORIGIN, measured on a rendered dock rather than on stylesheet text.
+ *
+ * `--dock-edge-rail-size` gives the rail's extent and the overlay's inset one shared VALUE. That is
+ * only half of "the overlay starts exactly where the strip ends": the two readers also have to
+ * measure from the same ORIGIN. The rail is laid out in normal flow, inside its ancestor's
+ * content box; an absolutely positioned overlay resolves against the nearest positioned ancestor's
+ * padding box. Leave the containing block to the dashboard host and a consumer that pads that host
+ * pushes the rail inward while the overlay stays put — the overlay then covers the strip by exactly
+ * the padding, and the rail's other tabs cannot be reached without dismissing first.
+ *
+ * **The padded arm is the regression; the unpadded arm is the control.** A gap of 0 on a padded
+ * host only means the engine holds if an unpadded host also reports 0 in the same document —
+ * otherwise a fixture whose stylesheet never applied reads as a pass. The padded arm additionally
+ * asserts the padding is live before it measures anything, because the cheapest way for this test
+ * to lie is for `addStyleTag` to have missed.
+ *
+ * @see https://github.com/neomjs/neo/issues/18070
+ */
+
+const EDGES = ['left', 'right', 'top', 'bottom'];
+
+const HOST = '.dock-rail-origin-host';
+
+/**
+ * The signed distance from the rail's trailing edge to the overlay's leading edge, along the axis
+ * the edge reserves. 0 means they touch; a negative value is the overlay lying over the strip.
+ */
+const gapFor = (edge, rail, overlay) => {
+    if (edge === 'left')   return overlay.x - (rail.x + rail.width);
+    if (edge === 'right')  return rail.x - (overlay.x + overlay.width);
+    if (edge === 'top')    return overlay.y - (rail.y + rail.height);
+    return rail.y - (overlay.y + overlay.height)
+};
+
+const measureEdge = async (page, edge) => {
+    const railSel    = `.neo-dashboard-dock-edge-rail-${edge}`,
+          overlaySel = `.neo-dashboard-dock-reveal-overlay-${edge}`;
+
+    await page.locator(`${railSel} .neo-dashboard-dock-rail-tab`).first().click();
+    await expect(page.locator(overlaySel)).toBeVisible({timeout: 10000});
+
+    const boxes = await page.evaluate(async ({railSel, overlaySel}) => {
+        const overlay = document.querySelector(overlaySel);
+
+        // The reveal plays an entry animation (`neo-dock-reveal-from-<edge>`: a nudge along the
+        // edge's axis plus an opacity ramp). Visibility flips when it STARTS, so a rect read here
+        // samples the overlay in flight and lands several pixels off its committed position — a
+        // geometry assertion that would fail or pass on timing alone.
+        await Promise.all(overlay.getAnimations({subtree: true}).map(animation =>
+            animation.finished.catch(() => {})
+        ));
+
+        const box = sel => {
+            const r = document.querySelector(sel).getBoundingClientRect();
+            return {x: r.x, y: r.y, width: r.width, height: r.height}
+        };
+
+        return {rail: box(railSel), overlay: box(overlaySel)}
+    }, {railSel, overlaySel});
+
+    // A zero-extent overlay would satisfy every containment assertion below for the wrong reason.
+    expect(boxes.overlay.width,  `[${edge}] the reveal actually opened`).toBeGreaterThan(0);
+    expect(boxes.overlay.height, `[${edge}] the reveal actually opened`).toBeGreaterThan(0);
+
+    await page.keyboard.press('Escape');
+    await expect(page.locator(overlaySel)).toBeHidden({timeout: 10000});
+
+    return gapFor(edge, boxes.rail, boxes.overlay)
+};
+
+test.beforeEach(async ({page}) => {
+    await page.goto('test/playwright/component/apps/dock-rail-origin/index.html');
+    await page.waitForSelector('#dock-rail-origin-workspace', {state: 'attached'});
+
+    for (const edge of EDGES) {
+        await expect(page.locator(`.neo-dashboard-dock-edge-rail-${edge}`)).toBeVisible({timeout: 10000})
+    }
+});
+
+test.describe('Neo.dashboard.dock.interaction.Rail — reveal overlay origin (#18070)', () => {
+    test('an unpadded dock host: the overlay begins exactly where the strip ends, on every edge', async ({page}) => {
+        const paddingLeft = await page.evaluate(sel => getComputedStyle(document.querySelector(sel)).paddingLeft, HOST);
+
+        expect(paddingLeft, 'control precondition: this arm measures an UNPADDED host').toBe('0px');
+
+        for (const edge of EDGES) {
+            expect(await measureEdge(page, edge), `[${edge}] overlay touches the rail's trailing edge`)
+                .toBeCloseTo(0, 1)
+        }
+    });
+
+    test('a padded dock host does not move the overlay onto its own strip, on every edge', async ({page}) => {
+        // Exactly what a consumer writes: an app stylesheet giving the dock host breathing room.
+        await page.addStyleTag({content: `${HOST} { padding: 12px; }`});
+
+        const paddingLeft = await page.evaluate(sel => getComputedStyle(document.querySelector(sel)).paddingLeft, HOST);
+
+        // Without this the arm passes vacuously whenever the style tag fails to land.
+        expect(paddingLeft, 'precondition: the consumer padding is live').toBe('12px');
+
+        for (const edge of EDGES) {
+            expect(await measureEdge(page, edge), `[${edge}] overlay touches the rail's trailing edge`)
+                .toBeCloseTo(0, 1)
+        }
+    });
+
+    test('the containing block moves to the edge zone without re-anchoring the drag layers', async ({page}) => {
+        await page.addStyleTag({content: `${HOST} { padding: 12px; }`});
+
+        const anchors = await page.evaluate(() => {
+            const host = document.querySelector('.dock-rail-origin-host'),
+                  zone = document.querySelector('.neo-dashboard-dock-edge-zone'),
+                  name = el => el === host ? 'host' : el === zone ? 'edge-zone' : el?.className?.split(' ')[0] ?? null,
+                  read = sel => {
+                      const el = document.querySelector(sel);
+                      return el ? {present: true, anchor: name(el.offsetParent), insideZone: zone.contains(el)} : {present: false}
+                  };
+
+            return {
+                zonePosition  : getComputedStyle(zone).position,
+                preview       : read('.neo-dock-preview'),
+                dropIndicators: read('.neo-dashboard-dock-drop-indicators')
+            }
+        });
+
+        expect(anchors.zonePosition, 'the edge zone is the overlay\'s containing block').toBe('relative');
+
+        // The drag layers are siblings of the edge zone, so a positioned edge zone must not capture
+        // them. If either ever moves inside the zone this assertion is the thing that says so.
+        for (const [name, layer] of Object.entries({preview: anchors.preview, dropIndicators: anchors.dropIndicators})) {
+            if (layer.present) {
+                expect(layer.insideZone, `${name} is not a descendant of the edge zone`).toBe(false);
+                expect(layer.anchor,     `${name} still anchors to the dock host`).not.toBe('edge-zone')
+            }
+        }
+    })
+});


### PR DESCRIPTION
Resolves #18070

Related: #13158 (parent epic — QT-parity docking polish), #17614 (tokenised the rail measure and established the two-reader coupling), #17211 (its Contract Ledger), #18028 / PR #18038 (the reveal's extent, a different property of the same element), ADR 0029 §2.7

A rail's reveal overlay is absolutely positioned, so its per-edge `inset` resolves against the nearest positioned ancestor's **padding** box. The rail it must clear is laid out in normal flow, inside the **content** box. Leave the containing block to the dashboard host and those two origins differ by exactly that host's padding: the overlay lands short and covers the strip it is supposed to begin at, and the rail's other tabs cannot be reached without dismissing the reveal first. Operator-observed on `apps/workstation`; measured there at **12 of the 14px strip covered**, under `z-index: 20` and `pointer-events: auto`.

Tokenising the rail measure gave the rail's extent and the overlay's inset one shared **value**. Sharing a length is only half of "the overlay starts where the strip ends" — the two readers also have to count from the same **origin**. This makes the edge zone, the box the rails themselves lay out in, that origin. One declaration; the four existing inset rules then hold on every edge, for a consumer that pads its dock host and for one that does not.

Evidence: L3 (component-project execution at the head in Chromium; the padded arm red at `origin/dev@5ae9358063` in a separate worktree that built its own themes; the fix additionally driven and measured on the live `apps/workstation` dev server) → L3 required (every AC on #18070 is component-reachable; the consumer symptom is a rendered-geometry contract). No residual.

## AC Evidence

| AC | Evidence |
|---|---|
| AC-1 — a padded-host fixture reveals a rail item and the overlay's leading edge is `>=` the rail's trailing edge; red on `dev` | CI-covered: `test/playwright/component/dashboard/DockRailRevealOrigin.spec.mjs`, "a padded dock host does not move the overlay onto its own strip, on every edge"; outside-CI: the same arm at `origin/dev@5ae9358063` → red, gap **−12** (exactly the host's `padding: 12px`) |
| AC-2 — all four edges, both axes | CI-covered: the same arm iterates `left`, `right`, `top`, `bottom`; `gapFor()` reads the inline axis for left/right and the block axis for top/bottom, so each of the four `inset` rules has its own witness |
| AC-3 — an unpadded dock host renders byte-identically | CI-covered: "an unpadded dock host: the overlay begins exactly where the strip ends, on every edge" — and this arm **passes on `dev` as well**, which is what makes it a control rather than a second copy of AC-1 |
| AC-4 — no other absolutely-positioned dock descendant re-anchors | CI-covered: "the containing block moves to the edge zone without re-anchoring the drag layers" asserts `.neo-dock-preview` and `.neo-dashboard-dock-drop-indicators` are not descendants of the edge zone and do not anchor to it. Corroborated on the live Workstation: of 68 absolutely-positioned descendants of the dock host, the two drag layers sit outside the edge zone and every other one already had a nearer positioned ancestor — the overlays were the only elements the change could move |
| AC-5 — the inset rules carry a comment naming the origin precondition | CI-covered by inspection: `resources/scss/src/dashboard/Container.scss`, the block above `.neo-dashboard-dock-edge-zone` and the extension to the inset comment |
| AC-6 — unit `dashboard/` and the dock component specs green | CI-covered: unit `dashboard/` **713/713** and component `dashboard/` **69/69** at the head |

## Deltas

- **The defect is worse than the ticket states, and the fix covers both halves.** #18070 says the inset "assumes a zero-padding dock host". Building the fixture showed the engine never established a containing block *at all* — it relied on the consumer happening to position its dock host. A consumer that pads a positioned host is off by the padding (the Workstation, 12px); one that does not position the host at all resolves against the viewport and is off by the host's entire offset (measured −118.8 in the fixture before its host was given the consumer's own `position: relative`). Both are the same root cause and both are closed by this change.
- **The fixture's host is positioned on purpose.** It mirrors what both shipping consumers do, which is what makes the unpadded arm a true control: with the host positioned, the only thing separating a correct overlay from an overlapping one is the padding, so the padded arm isolates the padding and nothing else.
- **No new token, and no arithmetic.** `calc(var(--dock-edge-rail-size) + <host padding>)` was rejected: it needs a token no consumer sets, re-introduces the two-values-that-agree-today coupling the tokenisation removed, and breaks again on asymmetric padding.
- **The rail itself was rejected as the containing block** even though it is the overlay's DOM parent and would also have produced a correct origin. `--dock-edge-rail-overflow` is a consumer-settable token and the Workstation sets it to `hidden`; making the rail the containing block would bring the overlay inside that clip and shrink it to the strip. The overlay escapes that clip today only because its containing block sits outside the overflow ancestor.

## Test Evidence

- Red-first, in a separate worktree at `origin/dev@5ae9358063` that **built its own themes** — the compiled CSS is the artifact under test, so borrowing a `dist` from the fixed tree would have manufactured a green. Server confirmed serving from that worktree. Result: **1 passed / 2 failed** — the unpadded control green, the padded arm red at exactly **−12** on `left`, and the containing-block arm red with `position: static`.
- At the head: **3/3**, dock component `dashboard/` **69/69**, unit `dashboard/` **713/713**.
- **One flake removed before it shipped.** The first draft measured immediately after `toBeVisible()` and read ~6px of drift on every edge, in both trees. The reveal plays an entry animation (`neo-dock-reveal-from-<edge>`: a nudge along the edge's axis plus an opacity ramp) and visibility flips when it *starts*, so the assertion was sampling the overlay in flight. `measureEdge` now awaits `getAnimations({subtree: true})` before reading a rect; the numbers became exact and the ±6 disappeared.
- Each measurement asserts the overlay actually opened (non-zero width and height) before comparing edges — a zero-extent overlay would satisfy every containment assertion for the wrong reason. The padded arm asserts its injected `padding` is live before measuring anything, because the cheapest way for that arm to lie is for `addStyleTag` to have missed.
- Live on `apps/workstation` at the head: overlap **12 → 0**, and `elementFromPoint` at the rail tab's centre returns the rail tab rather than the overlay while the reveal is open — the reported symptom ("you cannot switch rail items without dismissing first"), measured rather than eyeballed.

## Post-Merge Validation

- [ ] None. Every AC is component-reachable and green at this head; the consumer surfaces (`apps/workstation`, the Fleet cockpit) consume this through the engine's own stylesheet with no pin or adoption step.

## Commits

- `44c640fa85` — the edge zone becomes the reveal overlay's containing block, plus the four-edge padded/unpadded fixture and its arms.

Tooling note, already filed by a peer and repeated here as a second occurrence: `npm run agent-preflight` is mandated by `pull-request-workflow.md §1` but is no longer defined in `package.json` (removed with the Brain split), so the pre-open preflight could not be run for this PR.

Authored by Ada (Claude Opus 5, Claude Code). Session 7596538d-5324-419a-b043-95c585d833ea.

Cross-family note: the GPT seats are at 0% weekly quota (operator, 2026-09-01 22:20Z); a fable-family review is the sanctioned exception for an opus-authored PR.
