### PR TITLE
fix(test): the data-sync run-path arms measure an age, not a frozen date (#18075)

### DIFF
--- a/test/playwright/unit/buildScripts/dataSyncPipeline.spec.mjs
+++ b/test/playwright/unit/buildScripts/dataSyncPipeline.spec.mjs
@@ -280,6 +280,27 @@ test.describe('dataSyncPipeline guards (#17920)', () => {
     });
 
     test.describe('the refusal reaches the RUN path, not only the pure function', () => {
+        /**
+         * These arms reach the guard through `emitGeneratedData`, which calls
+         * `assertCorpusFreshness({facetCommitDates})` with no `now` — so the subject reads the REAL
+         * clock. The pinned `NOW` above is safe for the pure-function arms only because they hand
+         * that same constant to the subject; here there is nothing to hand it to.
+         *
+         * A fixture built from `hours()` therefore does not express an AGE, it expresses a fixed
+         * DATE that ages against wall time. `corpusAgeHours: 1` measured 48.4h on 2026-09-02 and
+         * turned the unit job red on every branch — the arm had not tested a fresh corpus since it
+         * was written, and passed only while the wall clock happened to sit inside the threshold of
+         * its own constant. The refusal arm degraded the same way in the other
+         * direction: still green, no longer discriminating, because by then it got a refusal
+         * whatever it injected.
+         *
+         * Live-relative by construction, so an injected age IS the measured age and no future date
+         * can re-arm this.
+         * @param {Number} n Hours before the real now.
+         * @returns {String} ISO date the guard will measure as exactly `n` hours old.
+         */
+        const liveHours = n => new Date(Date.now() - n * 3_600_000).toISOString();
+
         // A guard that only exists as an exported function nothing calls is the same silence this
         // ticket is about. These two witness the wiring inside `emitGeneratedData`.
         const runWith = ({corpusAgeHours}) => {
@@ -292,7 +313,7 @@ test.describe('dataSyncPipeline guards (#17920)', () => {
                     cwd    : '/repo',
                     execute: (command, args) => {
                         if (command === 'git') {
-                            return Promise.resolve({stderr: '', stdout: `${hours(corpusAgeHours)}\n`})
+                            return Promise.resolve({stderr: '', stdout: `${liveHours(corpusAgeHours)}\n`})
                         }
 
                         executed.push(args.join(' '));


### PR DESCRIPTION
Resolves #18075

`Engine Tests` is red on `dev` at `5ae9358063`, so the `unit` job fails on every branch and every PR is gated — including the demo chain. The guard that tripped is not wrong; the spec is.

Evidence: L3 (unit-project execution at the head; both run-path arms mutation-verified red-capable in the two directions that matter) → L3 required (every AC is unit-reachable; this is a test-only change). Residual: none.

## AC Evidence

| AC | Evidence |
|---|---|
| AC-1 — the fresh-corpus arm passes regardless of wall-clock date | Fixtures are now derived from `Date.now()` rather than the file's pinned `NOW`, so an injected age IS the measured age and the arm has no date dependence left to rot. Date-independence is structural rather than sampled: there is no longer any constant for the clock to drift away from. Falsified in the other direction — restoring the frozen `NOW` reds this arm **today** (1 failed / 18 passed). |
| AC-2 — the refusal arm is discriminating again | Mutated `assertCorpusFreshness` to never throw: **6 failed / 13 passed**, the refusal arms among them. Before this change that arm passed on a refusal it would have received whatever it injected, so it could not have gone red for the right reason. |
| AC-3 — no change to `buildScripts/dataSyncPipeline.mjs` | The diff is one file, `test/playwright/unit/buildScripts/dataSyncPipeline.spec.mjs`. The production guard and the `Data Sync Pipeline` workflow's failure are untouched. |
| AC-4 — `npm run test-unit` green | **2977 passed**, 0 failed, at this head. |
| AC-5 — a note so the next author does not re-freeze it | The `liveHours` JSDoc states why the run-path arms cannot share the pinned `NOW`: they reach the guard through `emitGeneratedData`, which passes no `now`, so the subject reads the real clock and there is nothing to hand the constant to. |

## Deltas from ticket

None. The ticket proposed the live-relative harness and rejected threading a `now` seam through `emitGeneratedData`; that judgement held on implementation — the subject already exposes `now` one level down, and the harness was the thing that was wrong.

## Test Evidence

The arithmetic that identified this, for the record:

```
NOW   = new Date('2026-08-31T12:00:00Z')      // pinned in the spec
hours = n => new Date(NOW.getTime() - n * 3_600_000)

runWith({corpusAgeHours: 1})  ->  fixture date 2026-08-31T11:00Z
measured by the guard at 11:21Z on 2026-09-02:
  realNow - 2026-08-31T11:00Z = 48.35h   vs   threshold 48h
```

which is the `48.4h` in the CI failure, to the decimal. The pure-function arms are unaffected because they pass `now: NOW` to the subject; only the arms reaching it through `emitGeneratedData` read the real clock.

- `dataSyncPipeline.spec.mjs` — **19 passed**
- full unit project — **2977 passed**
- mutation A (frozen `NOW` restored): 1 failed — the fresh-corpus arm, today
- mutation B (guard never refuses): 6 failed — the refusal arms

## Post-Merge Validation

- [ ] `Engine Tests` green on `dev` after merge, unblocking the queued PRs.
- [ ] The `Data Sync Pipeline` workflow **still fails** on the stale corpus. That is the intended outcome, not a regression: it is the finding #17920 tracks and #17834 alarms on. A green Data Sync run after this merge would mean something else changed and is worth investigating.

## Commits

- `20b205ee16` fix(test): the data-sync run-path arms measure an age, not a frozen date (#18075)

## Evolution

The durable shape is a test that decays into two different lies. This one froze a clock on the day it was written, and both of its arms rotted in opposite directions from that single cause: the positive arm stopped testing what it named the moment wall time left the threshold window, and the negative arm kept passing while it stopped discriminating. Neither failure announced itself — the positive arm went red two days later looking like a product regression on someone else's merge, and the negative arm is still green today.

Worth carrying: when a subject reads a clock the test does not control, a fixture DATE is not a fixture AGE, and the gap between them grows on its own. The pure-function arms in this same file get it right by handing the subject the constant they built from — the seam existed, the run-path arms just could not reach it.

---

Authored by Grace (Opus 5, Claude Code). Session fb58e855-74b2-4367-9f83-5877f151f024.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
