### PR TITLE
feat(dock): the dock host opens the window geometry stream — movement, resize, and a first sample (#18077)

### DIFF
--- a/apps/workstation/view/Workspace.mjs
+++ b/apps/workstation/view/Workspace.mjs
@@ -426,13 +426,6 @@ class Workspace extends DockWorkspace {
         me.dockService       = Neo.create(DockService, {});
         me.perspectiveStore  = Neo.create(PerspectiveLibrary, {});
 
-        // Cross-window hit testing reads manager.Window as its one geometry authority. Movement
-        // snapshots alone go stale after a main-window resize, so this render target publishes
-        // live extents from construction just like every admitted vessel does on connect. The
-        // movement poll is owned by config rather than by pointer travel: a titlebar grabbed
-        // without the cursor crossing page content produces no `mouseout` to arm it.
-        Neo.main.addon.WindowPosition?.setConfigs({observeMovement: true, observeResize: true, windowId: me.windowId});
-
         me.tourRunner  = Neo.create(TourRunner, {
             componentId   : me.id,
             dockService   : me.dockService,
@@ -3559,12 +3552,9 @@ class Workspace extends DockWorkspace {
         if (params.get('hostId') !== me.id) return;
         if (!itemId || flow !== 'tear-out' || !Number.isFinite(admissionToken)) return;
 
-        // Geometry-ready is part of child admission: do not publish the connected vessel to any
-        // ownership branch until its Main realm has installed resize AND movement observation. The
-        // header-action pop-out births this vessel with its titlebar under the pointer, so the
-        // native-titlebar drag never crosses page content and never emits the `mouseout` that
-        // would otherwise arm the poll.
-        await Neo.main.addon.WindowPosition?.setConfigs({observeMovement: true, observeResize: true, windowId});
+        // Geometry-ready is part of child admission: the vessel's Main realm publishes movement and
+        // resize (the engine host's stream) before the connection reaches any ownership branch.
+        await me.observeWindowGeometry(windowId);
 
         // Retirement authority is established before any awaited close. A connect continuation
         // that resumes after that boundary is cleanup-only. Consume its exact grant and retain

--- a/learn/agentos/decisions/0029-docking-design.md
+++ b/learn/agentos/decisions/0029-docking-design.md
@@ -441,6 +441,10 @@ handles by the semantic `windowName` passed to `Main.windowOpen()`. Those identi
   `{targetWindowId, ownerWindowId, opaqueHandleKey}` route plus generic capability facts
   (`focus`, `position`, `resize`, `close`);
   no dock document, workspace, vessel, reintegration, or persistence semantics enter the manager.
+  The manager only learns what a window's Main realm publishes, so the dock host
+  (`Neo.dashboard.dock.Workspace`) opens that stream itself — movement and resize observation for
+  its own render target at construction and for each admitted vessel before ownership publication
+  (`observeWindowGeometry`); adopters inherit it rather than arming `WindowPosition` by hand.
 - `Main` remains the physical-handle owner. On open, the opener mints a short-lived one-time capability and a separate
   opaque handle key against the exact `WindowProxy`. The target consumes that capability once during the existing
   `getWindowData()` handshake; only then does the opener bind the private key to the target runtime `windowId`. URL,

--- a/src/dashboard/dock/Workspace.mjs
+++ b/src/dashboard/dock/Workspace.mjs
@@ -498,6 +498,14 @@ class Workspace extends Container {
                 scope     : this
             })
         }
+
+        // Cross-window hit testing reads manager.Window as its one geometry authority, and the
+        // manager only learns what the Main realm publishes. The host's own render target publishes
+        // live extents from construction — the same stream every admitted vessel opens on connect —
+        // so a moved or resized main window never claims with a stale frame. Not gated on the
+        // engine lifecycle flag: a host may run its own admission (the Workstation does) and still
+        // dock across windows; the app's opt-in is loading the `WindowPosition` addon at all.
+        this.observeWindowGeometry(this.windowId)
     }
 
     /**
@@ -932,6 +940,25 @@ class Workspace extends Container {
     }
 
     /**
+     * @summary Opens one render target's live geometry stream into `Neo.manager.Window`.
+     *
+     * `Neo.main.addon.WindowPosition` publishes `windowPositionChange` only behind two configs it
+     * defaults off: `observeMovement` (the config-owned poll — pointer travel alone cannot arm it
+     * for a titlebar grabbed from outside page content) and `observeResize` (a fixed-origin resize
+     * is a geometry change the poll never sees). Without both, the manager's row for that window
+     * stays the connect-time snapshot and every cross-window claim hit-tests a stale frame. The
+     * engine host arms both — for its own window at construction, for each admitted vessel before
+     * ownership publication — so no adopter has to know the addon exists. Overridable for a
+     * realm that publishes geometry another way.
+     * @param {String} windowId The render target whose Main realm publishes
+     * @returns {Promise<void>|undefined} The addon's remote settle, or `undefined` off the browser
+     * @protected
+     */
+    observeWindowGeometry(windowId) {
+        return Neo.main?.addon?.WindowPosition?.setConfigs({observeMovement: true, observeResize: true, windowId})
+    }
+
+    /**
      * Hook: optional product grant policy after engine host/flow/token admission. Fleet's zero-grant
      * consumer inherits true; rich hosts override without exporting a grant format to the engine.
      * @param {Object} context
@@ -1026,8 +1053,14 @@ class Workspace extends Container {
             throw error
         }
 
-        // The grant hook is an async boundary. Retirement, timeout or a successor admission may
-        // have replaced this exact record while policy was deciding.
+        // Geometry-ready is part of admission: the vessel's Main realm publishes movement AND
+        // resize before the connection reaches any ownership branch. A header-action pop-out births
+        // the vessel with its titlebar under the pointer, so the native-titlebar drag never crosses
+        // page content and never emits the `mouseout` that would otherwise arm the poll.
+        await me.observeWindowGeometry(windowId);
+
+        // The grant hook and the geometry arming are async boundaries. Retirement, timeout or a
+        // successor admission may have replaced this exact record while they were pending.
         if (
             me.isDestroyed || me.tearOutAdmissions.get(itemId) !== admission ||
             admission.connectingWindowId !== windowId || !Neo.apps[windowId]

--- a/src/main/addon/WindowPosition.mjs
+++ b/src/main/addon/WindowPosition.mjs
@@ -96,12 +96,22 @@ class WindowPosition extends Base {
      * While on, the config owns the poll: {@link #onMouseOut} neither arms nor clears it.
      * Switching off releases the poll back to pointer ownership; the next document-leaving
      * `mouseout` re-arms it.
+     *
+     * Arming also publishes the current snapshot once: the poll is change-driven against the
+     * origin captured at construction, so a window that never moves would otherwise stay unknown
+     * to `Neo.manager.Window` in a dedicated-worker app, where no connect handshake registers it.
+     * A stream opens with its current value.
      * @param {Boolean} value
      * @param {Boolean} oldValue
      * @protected
      */
     afterSetObserveMovement(value, oldValue) {
-        value ? this.startPolling() : this.stopPolling()
+        if (value) {
+            this.startPolling();
+            this.publishGeometry()
+        } else {
+            this.stopPolling()
+        }
     }
 
     /**

--- a/test/playwright/component/apps/dock-popout/app.mjs
+++ b/test/playwright/component/apps/dock-popout/app.mjs
@@ -1,5 +1,6 @@
 import DockWorkspace from '../../../../../src/dashboard/dock/Workspace.mjs';
 import Viewport      from '../../../../../src/container/Viewport.mjs';
+import WindowManager from '../../../../../src/manager/Window.mjs';
 import '../../../../../src/tab/Container.mjs';
 
 const fixtureDocument = {
@@ -106,6 +107,15 @@ class PopOutFixtureWorkspace extends DockWorkspace {
          */
         refuseVessel_: false,
         /**
+         * Spec trigger: any new tick mirrors this window's `Neo.manager.Window` row into
+         * {@link #windowGeometryJson} — the geometry-observation arm reads the manager through it
+         * after a viewport resize, which is the only way a component spec can witness that the
+         * host-armed stream reached the App Worker's geometry authority.
+         * @member {Number} readWindowGeometry_=0
+         * @reactive
+         */
+        readWindowGeometry_: 0,
+        /**
          * Spec trigger: an item id drives the engine's own dead-vessel compensation — release the
          * pane, retire the vessel, reintegrate. The reintegration arm asserts the item comes home
          * through THIS path, which is the drag path's path; a click-specific return branch would
@@ -145,6 +155,28 @@ class PopOutFixtureWorkspace extends DockWorkspace {
      * @member {Object[]} openedVessels=[]
      */
     openedVessels = []
+
+    /**
+     * Spec-readable mirror of this window's `Neo.manager.Window` row (`{innerRect, outerRect}`),
+     * refreshed on every {@link #readWindowGeometry} tick; `'null'` while no row exists.
+     * @member {String|null} windowGeometryJson=null
+     */
+    windowGeometryJson = null
+
+    /**
+     * @param {Number} value
+     * @param {Number} oldValue
+     * @protected
+     */
+    afterSetReadWindowGeometry(value, oldValue) {
+        if (oldValue === undefined || !value) {
+            return
+        }
+
+        const row = WindowManager.get(this.windowId);
+
+        this.windowGeometryJson = JSON.stringify(row ? {innerRect: row.innerRect, outerRect: row.outerRect} : null)
+    }
 
     /**
      * Refreshes {@link #vesselLogJson} from the two seam logs.

--- a/test/playwright/component/apps/dock-popout/neo-config.json
+++ b/test/playwright/component/apps/dock-popout/neo-config.json
@@ -3,7 +3,7 @@
     "basePath"        : "../../../../../",
     "environment"     : "development",
     "mainPath"        : "./Main.mjs",
-    "mainThreadAddons": ["DockFlip", "DragDrop", "Navigator", "ResizeObserver", "Stylesheet"],
+    "mainThreadAddons": ["DockFlip", "DragDrop", "Navigator", "ResizeObserver", "Stylesheet", "WindowPosition"],
     "themes"          : ["neo-theme-neo-dark", "neo-theme-neo-light"],
     "useSharedWorkers": false
 }

--- a/test/playwright/component/dashboard/DockGeometryObservation.spec.mjs
+++ b/test/playwright/component/dashboard/DockGeometryObservation.spec.mjs
@@ -1,0 +1,83 @@
+import {test, expect} from '@playwright/test';
+
+/**
+ * The dock host opens the geometry stream itself: a `Neo.dashboard.dock.Workspace` arms
+ * `WindowPosition` movement AND resize observation for its own render target at construction, so
+ * `Neo.manager.Window` — the one geometry authority every cross-window claim hit-tests — follows a
+ * fixed-origin resize without any pointer travel or position change.
+ *
+ * The fixture (`apps/dock-popout`) is a tear-out host that never arms observation by hand; on an
+ * engine that leaves the arming to the app its manager row stays the connect-time snapshot, which
+ * is exactly the red this arm turns green. The boot read is the control: the row exists and
+ * carries the boot viewport before anything is resized.
+ *
+ * Emulated viewports render no window chrome, so inner and outer extents coincide here; the
+ * frame-vs-viewport split is `e2e/workstation/WindowGeometryRealChromeNL`'s concern.
+ */
+
+const WORKSPACE_ID = 'dock-popout-workspace';
+
+let tick = 0;
+
+const readWorkspace = async (page, keys) => {
+    // The main-realm remote answers with the worker-message envelope; the values ride `.data`.
+    const reply = await page.evaluate(data => Neo.worker.App.getConfigs(data), {id: WORKSPACE_ID, keys});
+
+    return reply?.data ?? reply
+};
+
+const setWorkspace = (page, configs) => page.evaluate(
+    data => Neo.worker.App.setConfigs(data),
+    {id: WORKSPACE_ID, ...configs}
+);
+
+/** Ticks the fixture's probe trigger, then reads the manager row it mirrored. */
+const readGeometry = async page => {
+    await setWorkspace(page, {readWindowGeometry: ++tick});
+
+    const [json] = await readWorkspace(page, ['windowGeometryJson']);
+
+    return json ? JSON.parse(json) : null
+};
+
+test.beforeEach(async ({page}) => {
+    await page.goto('test/playwright/component/apps/dock-popout/index.html');
+    await page.waitForSelector('#dock-popout-workspace', {state: 'attached'});
+    await page.waitForSelector('.neo-tab-header-button', {state: 'visible'})
+});
+
+test.describe('dock host geometry observation (#18077)', () => {
+    test('a fixed-origin resize of the host window refreshes manager.Window without any pointer or position change', async ({page}) => {
+        const boot = page.viewportSize();
+
+        // Control on the publisher: the host armed both observations on the Main realm's addon
+        // (the addon instance lives in the page, so the page context reads it directly).
+        await expect.poll(() => page.evaluate(() => {
+            const addon = Neo.main?.addon?.WindowPosition;
+
+            return addon ? [addon.observeMovement, addon.observeResize] : null
+        }), {message: 'the host armed movement AND resize on the WindowPosition addon'}).toEqual([true, true]);
+
+        // Control on the consumer: arming published the current snapshot, so the row exists with
+        // the boot viewport before anything moves — a dedicated-worker app has no connect handshake
+        // that would register it otherwise.
+        await expect.poll(async () => (await readGeometry(page))?.outerRect?.width, {
+            message: 'the host row is registered at boot with the boot viewport'
+        }).toBe(boot.width);
+
+        await page.setViewportSize({width: boot.width - 320, height: boot.height - 160});
+
+        // The falsifier: only a published `resize` reaches the manager; the poll never sees a
+        // fixed-origin resize and the connect-time snapshot would keep the boot width forever.
+        await expect.poll(async () => (await readGeometry(page))?.outerRect?.width, {
+            message: 'the row follows the resize through the host-armed stream',
+            timeout: 5000
+        }).toBe(boot.width - 320);
+
+        const geometry = await readGeometry(page);
+
+        expect(geometry.outerRect.height, 'the outer height follows too').toBe(boot.height - 160);
+        expect(geometry.innerRect.width, 'no chrome on an emulated viewport: inner equals outer').toBe(boot.width - 320);
+        expect(geometry.innerRect.height).toBe(boot.height - 160)
+    });
+});

--- a/test/playwright/unit/dashboard/DockWorkspace.spec.mjs
+++ b/test/playwright/unit/dashboard/DockWorkspace.spec.mjs
@@ -1105,6 +1105,88 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
             expect(workspace.lifecycleEvents).toEqual(['return:true:true', 'disconnect'])
         });
 
+        test.describe('#18077 the host opens the geometry stream for its window and for every admitted vessel', () => {
+            let calls, originalSetConfigs, originalWindowPosition, windowPosition;
+
+            test.beforeEach(() => {
+                originalWindowPosition = Neo.main?.addon?.WindowPosition;
+                windowPosition         = originalWindowPosition ?? Neo.ns('Neo.main.addon.WindowPosition', true);
+                originalSetConfigs     = windowPosition.setConfigs;
+                calls                  = [];
+
+                windowPosition.setConfigs = data => {
+                    calls.push(data);
+                    return Promise.resolve()
+                }
+            });
+
+            test.afterEach(() => {
+                if (originalWindowPosition) {
+                    originalSetConfigs
+                        ? windowPosition.setConfigs = originalSetConfigs
+                        : delete windowPosition.setConfigs
+                } else {
+                    delete Neo.main.addon.WindowPosition
+                }
+            });
+
+            test('construction opens movement AND resize for the host render target; a realm without the addon opens nothing and throws nothing', () => {
+                workspace = Neo.create(TearOutWorkspace, {dockModel: createDocument(), windowId: 'host-window'});
+
+                expect(calls, 'one stream, both observations, the host window').toEqual([
+                    {observeMovement: true, observeResize: true, windowId: 'host-window'}
+                ]);
+
+                // A host running its own admission (no engine lifecycle) docks across windows too:
+                // the arming is not gated on the lifecycle flag.
+                const plain = Neo.create(PlainWorkspace, {dockModel: createDocument(), windowId: 'plain-window'});
+
+                try {
+                    expect(calls.at(-1), 'every dock host opens its stream').toEqual(
+                        {observeMovement: true, observeResize: true, windowId: 'plain-window'}
+                    )
+                } finally {
+                    plain.destroy()
+                }
+
+                // The app's opt-in is the addon itself: without it the call is a no-op, never a throw.
+                const addon = Neo.main.addon.WindowPosition;
+
+                delete Neo.main.addon.WindowPosition;
+
+                try {
+                    const bare = Neo.create(PlainWorkspace, {dockModel: createDocument(), windowId: 'bare-window'});
+
+                    bare.destroy();
+                    expect(calls, 'no addon, no stream').toHaveLength(2)
+                } finally {
+                    Neo.main.addon.WindowPosition = addon
+                }
+            });
+
+            test('an admitted vessel opens its stream before the connection reaches any ownership branch', async () => {
+                workspace = Neo.create(TearOutWorkspace, {dockModel: createDocument(), windowId: 'host-window'});
+
+                const {request, zone} = await beginExit('preview');
+
+                expect(workspace.tearOutHandlers.onDockTearOutTerminal({itemId: 'preview', sortZone: zone})).toBe(true);
+                await workspace.refreshPromise;
+
+                const mainView = addWindow('vessel-window', vesselUrl(request, 'preview'));
+
+                workspace.afterTearOutWindowConnect = () => calls.push('afterTearOutWindowConnect');
+
+                await workspace.onWindowConnect({windowId: 'vessel-window'});
+
+                expect(calls, 'host at construction, vessel on admission, observers last').toEqual([
+                    {observeMovement: true, observeResize: true, windowId: 'host-window'},
+                    {observeMovement: true, observeResize: true, windowId: 'vessel-window'},
+                    'afterTearOutWindowConnect'
+                ]);
+                expect(mainView.items, 'the pane entered its vessel after the stream opened').toHaveLength(1)
+            });
+        });
+
         test('connect-first keeps exact admission identity until the detached terminal consumes it', async () => {
             workspace = Neo.create(TearOutWorkspace, {dockModel: createDocument()});
 

--- a/test/playwright/unit/main/addon/WindowPosition.spec.mjs
+++ b/test/playwright/unit/main/addon/WindowPosition.spec.mjs
@@ -131,11 +131,14 @@ test.describe('Neo.main.addon.WindowPosition — live geometry publication', () 
     });
 
     test('observeMovement owns the poll: armed without any pointer event, immune to element travel', () => {
+        let published = 0;
+
         const addon = {
             checkMovement  : () => {},
             intervalId     : null,
             intervalTime   : 20,
             observeMovement: true,
+            publishGeometry: () => published++,
             startPolling   : WindowPosition.prototype.startPolling,
             stopPolling    : WindowPosition.prototype.stopPolling
         };
@@ -145,16 +148,21 @@ test.describe('Neo.main.addon.WindowPosition — live geometry publication', () 
         const armedId = addon.intervalId;
 
         expect(armedId, 'the config arms the poll with no mouseout at all').toBeTruthy();
+        // The poll is change-driven against the origin captured at construction, so arming
+        // publishes the current snapshot once — a window that never moves is still known.
+        expect(published, 'arming opens the stream with its current value').toBe(1);
 
         WindowPosition.prototype.onMouseOut.call(addon, {toElement: {}});
         expect(addon.intervalId, 'element travel cannot clear a config-owned poll').toBe(armedId);
 
         WindowPosition.prototype.onMouseOut.call(addon, {toElement: null});
         expect(addon.intervalId, 'a document-leaving mouseout does not re-arm a second interval').toBe(armedId);
+        expect(published, 'pointer travel publishes nothing by itself').toBe(1);
 
         addon.observeMovement = false;
         WindowPosition.prototype.afterSetObserveMovement.call(addon, false, true);
-        expect(addon.intervalId, 'switching off releases the poll').toBeNull()
+        expect(addon.intervalId, 'switching off releases the poll').toBeNull();
+        expect(published, 'switching off publishes nothing').toBe(1)
     });
 
     /**


### PR DESCRIPTION
Resolves #18077

Related: #18040 (the config-owned movement poll), #18068 (frame-origin geometry — the surface this finding came from), PR #18059 (the rebase that surfaced it, @neo-opus-vega's Tier 2.5 finding), #17541 / #17546 (the engine host and the Workstation migration), #13158 (parent), neomjs/neo-agent-institution (the Fleet cockpit, which does not extend the engine host yet)

`Neo.manager.Window` is the one geometry authority every cross-window claim hit-tests, and it only learns what a window's Main realm publishes — behind two `WindowPosition` configs the addon defaults off. Until now only `apps/workstation` armed them, by hand, in two places; the dock example and the Fleet cockpit armed nothing, so their manager rows were connect-time snapshots (or, in a dedicated-worker app, nothing at all). Now the engine host opens the stream: `Neo.dashboard.dock.Workspace#observeWindowGeometry(windowId)` arms movement AND resize for the host's own render target at construction and for each admitted vessel before the connection reaches any ownership branch; the Workstation's two app-level copies retire onto that seam. The stream also opens with its current value — `WindowPosition#afterSetObserveMovement` publishes one snapshot on arming, because the poll is change-driven against the origin captured at construction and a window that never moves would otherwise stay unknown to the manager wherever no connect handshake registers it.

Evidence: L3 (unit arms red-first in a scratch worktree at `origin/dev@5ae9358063`, the component falsifier on a real Chromium viewport, the two native Workstation arms headed on real window chrome under the Brain root) → L3 required (the contract is what a Main realm publishes and what the App Worker's manager reads back). Residual: none.

## AC Evidence

| AC | Evidence |
| --- | --- |
| AC-1 — unit: construction records one `setConfigs({observeMovement: true, observeResize: true, windowId})`; a realm without the addon opens nothing and throws nothing | CI-covered: `unit/dashboard/DockWorkspace.spec.mjs`, "construction opens movement AND resize for the host render target; a realm without the addon opens nothing and throws nothing" (the addon deleted from `Neo.main.addon` for the bare construction). Red at `dev`: `unit/dashboard/DockWorkspace + unit/main/addon/WindowPosition` **3 failed / 85 passed** (the two host arms: no `setConfigs` call at all; the poll arm: `published` 0, not 1) |
| AC-2 — unit: an admitted vessel records the same call for its `windowId`, before `afterTearOutWindowConnect` | CI-covered: same spec, "an admitted vessel opens its stream before the connection reaches any ownership branch" — the recorder sees `[host, vessel, 'afterTearOutWindowConnect']` in that order and the pane entered its vessel. Red at `dev` (no call at all). |
| AC-3 — the Workstation no longer calls `setConfigs` itself; its unit spec and the two native e2e arms stay green | `apps/workstation/view/Workspace.mjs`: the construct-time call is gone (inherited), the vessel-admission call is `await me.observeWindowGeometry(windowId)` on the engine seam (its own `onWindowConnect` override keeps the app's admission; the config literal lives in one place now). `unit/apps/workstation/Workspace.spec.mjs`'s existing arm still expects exactly one call at construction — CI-covered (that spec does not load on this seat, a pre-existing `Neo.currentWorker` gap noted in PR #18068). Headed under the Brain root: `WorkstationNativePopupOverPopupNL` ✓ and `WorkstationNativeTitlebarDragNL` ✓ (2 passed, 10.7s) at the final head; `WindowGeometryRealChromeNL` ✓ (the #18068 frame/viewport witness, unchanged) |
| AC-4 — component falsifier on the `dock-popout` fixture: after a fixed-origin viewport resize the manager row follows; the boot read is the control | CI-covered: `component/dashboard/DockGeometryObservation.spec.mjs` — two controls (the Main realm's addon reports `[observeMovement, observeResize] === [true, true]`; the row exists at boot with the boot viewport, which only the initial publication can provide in a dedicated-worker fixture) and the falsifier (`outerRect`/`innerRect` follow `setViewportSize` within 5s). Red at `origin/dev` with the same files: the addon control fails (`[undefined, undefined]`). Green at head, 2.2s. |
| AC-5 — no `observeResize` / `observeMovement` literal outside `src/` | `grep -rn "observeResize\|observeMovement" apps examples` → only the Workstation's JSDoc mention of the seam; the two literals live in `src/dashboard/dock/Workspace.mjs#observeWindowGeometry`. |

## Deltas from ticket

- **The arming is not gated on `enableDockTearOutLifecycle`.** The ticket proposed gating on the engine lifecycle flag; the Workstation runs its own admission (no engine lifecycle flag, `enableDockTearOut` only on its bars) and docks across windows — the gate would have un-armed the very host the finding came from (measured: `WorkstationNativePopupOverPopupNL` red at "manager.Window follows the main window resize", 953 vs ≤ 290, on the gated head). The app's opt-in is loading the `WindowPosition` addon: without it the call is a no-op (the dock example loads no addon and pays nothing; a host that loads it runs the 20ms poll it asked for). AC-1's control changed accordingly: no addon → no call, never a throw.
- **The stream opens with its current value** (`WindowPosition#afterSetObserveMovement`): not in the ticket. Found by the component falsifier's control — in a dedicated-worker app (`useSharedWorkers: false`, the fixture) `manager.Window` has no connect-time row and the change-driven poll never publishes for a window that never moves, so arming alone left the manager empty. One snapshot on arming; the existing poll arm now asserts it and that pointer travel / switching off publish nothing more.
- **The vessel path in the Workstation stays a call, not a deletion**: its `onWindowConnect` override does not run the engine's admission, so it calls the seam itself; the ticket's "retire" is the literal, not the call.
- **AC-4 moved from a real-Chrome e2e on the example app to the component tier** (amended on the ticket 2026-09-02): the example is not a tear-out host and loads no addon, so it was never the falsifier; the frame/viewport split stays with `WindowGeometryRealChromeNL` (green, unchanged).
- **The fixture** (`component/apps/dock-popout`) gains the `WindowPosition` addon and a spec-readable probe (`readWindowGeometry_` → `windowGeometryJson`) — the only cross-worker RPC a component spec has.

## Test Evidence

- Red-first (scratch worktree at `origin/dev@5ae9358063`, the final test files copied in): `unit/dashboard/DockWorkspace + unit/main/addon/WindowPosition` **3 failed / 85 passed** (the two host arms: no `setConfigs` call at all; the poll arm: `published` 0, not 1); the component arm red at the addon control.
- Head: `unit/dashboard unit/main unit/manager` **923 passed**; `unit/dashboard/DockWorkspace + unit/main/addon/WindowPosition + unit/manager` 182 passed; `component/dashboard/DockGeometryObservation` 1 passed (2.2s); the full `component/dashboard/` suite (the pop-out fixture changed) **67 passed** (40.2s).
- Headed under the Brain root (real window chrome, `viewport: null`): `WorkstationNativePopupOverPopupNL` ✓ and `WorkstationNativeTitlebarDragNL` ✓ (2 passed, 10.7s) at the final head; `WindowGeometryRealChromeNL` ✓ (the #18068 frame/viewport witness, unchanged).
- The gated first head, for the record: `WorkstationNativePopupOverPopupNL` red at the main-window resize wait (the Workstation un-armed) — the measurement that removed the gate.

## Post-Merge Validation

- [ ] The Fleet cockpit (institution): when it adopts the engine host it inherits the arming; until then its interim one-line arming is an institution leaf under #13158's consumer rows (not filed here).
- [ ] WebStudio (Vega's clone): confirm it loads the `WindowPosition` addon; with this engine it needs no app-level arming.

## Commits

- `ddc27fa6e4` — the engine seam (`observeWindowGeometry`: construct + vessel admission), the addon's first sample on arming, the Workstation's two copies onto the seam, the ADR sentence, the three unit arms, the component falsifier and its fixture probe.

Authored by Clio (Claude Fable 5.1, Claude Code). Session 91f83b9c-df95-4f72-a68f-d33f470792ac.

Same-family review note: the GPT seats are at 0% weekly quota (operator, 2026-09-01 22:20Z); an Opus 5 review is the sanctioned exception.

📜 Clio

🤖 Generated with [Claude Code](https://claude.com/claude-code)
