### PR TITLE
fix(dock): a click into an iframe pane leaves a rail reveal, and one inside the revealed pane keeps it (#18067)

### DIFF
--- a/resources/scss/src/dashboard/Container.scss
+++ b/resources/scss/src/dashboard/Container.scss
@@ -514,6 +514,18 @@
     &-bottom { inset: auto 0 var(--dock-edge-rail-size) 0; }
 }
 
+// While a reveal is open, every iframe OUTSIDE its overlay stops taking the pointer. A nested
+// document is opaque to this one — no `mousedown`, `click` or `focusin` crosses its boundary, and a
+// document that cancels the `mousedown` default (an editor managing its own caret) takes no focus
+// either — so a click into such a frame would leave the reveal open with nothing to dismiss it.
+// Without pointer events the click lands on the parent element beneath the frame, where the rail's
+// outside-pointer listener reads it as leaving. Frames INSIDE the overlay keep their pointer events:
+// a click into the revealed pane is inside, whatever it lands on. The same boundary idiom as the
+// drag shield (`body.neo-drag-active iframe`).
+.neo-dashboard:has(.neo-dashboard-dock-reveal-overlay:not(.neo-dashboard-dock-reveal-overlay-hidden)) iframe:not(.neo-dashboard-dock-reveal-overlay iframe) {
+    pointer-events: none;
+}
+
 .neo-dashboard-dock-reveal-header {
     gap: 4px;
 }

--- a/src/dashboard/dock/interaction/Rail.mjs
+++ b/src/dashboard/dock/interaction/Rail.mjs
@@ -158,6 +158,20 @@ class Rail extends Container {
      * @protected
      */
     revealOverlay = null
+    /**
+     * One retained `mousedown` config on the app main view while a reveal is open — the outside
+     * pointer reading (`Neo.form.field.Picker`'s idiom). A pointer landing anywhere the reveal does
+     * not own is leaving it, whether or not that target can take focus.
+     * @member {Object|null} outsidePointerListener=null
+     * @protected
+     */
+    outsidePointerListener = null
+    /**
+     * The main view currently carrying {@link #outsidePointerListener}.
+     * @member {Neo.component.Base|null} outsidePointerListenerOwner=null
+     * @protected
+     */
+    outsidePointerListenerOwner = null
 
     /**
      * Seeds the initial button set from `railItems` before the container creates its items —
@@ -426,6 +440,7 @@ class Rail extends Container {
     destroy(...args) {
         let me = this;
 
+        me.syncOutsidePointerListener(false);
         me.revealMachine?.destroy();
         me.revealMachine = null;
         me.revealOverlay = null;
@@ -445,6 +460,57 @@ class Rail extends Container {
      */
     getValidatedEdge(edge) {
         return ['top', 'right', 'bottom', 'left'].includes(edge) ? edge : 'left'
+    }
+
+    /**
+     * Adds or removes the one retained `mousedown` config on the owning app main view. Attached for
+     * as long as a reveal is open (any machine state but `idle`), detached on dismissal and destroy.
+     * @param {Boolean} attach
+     * @protected
+     */
+    syncOutsidePointerListener(attach) {
+        let me    = this,
+            owner = me.outsidePointerListenerOwner;
+
+        if (attach && !owner) {
+            owner = me.app?.mainView;
+
+            if (owner) {
+                me.outsidePointerListener ||= {mousedown: me.onAppMouseDown, scope: me};
+                owner.addDomListeners(me.outsidePointerListener);
+                me.outsidePointerListenerOwner = owner
+            }
+        } else if (!attach && owner) {
+            owner.removeDomListeners(me.outsidePointerListener);
+            me.outsidePointerListenerOwner = null
+        }
+    }
+
+    /**
+     * A `mousedown` on the app main view while a reveal is open. Anything outside this rail's own
+     * subtree — the overlay is a child of the rail — is leaving the reveal, so the machine gets the
+     * explicit dismissal input the maximize path already uses. The reveal's own tabs and its
+     * overlay stay with their own handlers: a tab click is a retarget or a toggle, an inside click
+     * refocuses the root.
+     *
+     * This is what a nested document needs. Nothing inside an iframe reaches the parent, and a frame
+     * whose document cancels the `mousedown` default takes no focus either — so the stylesheet
+     * withdraws pointer events from every frame outside an open reveal, the click lands on the
+     * parent element beneath the frame, and it arrives here.
+     * @param {Object} data
+     * @param {Object[]} [data.path]
+     * @protected
+     */
+    onAppMouseDown(data) {
+        let me = this;
+
+        if (!me.revealMachine || me.revealMachine.state === 'idle') {
+            return
+        }
+
+        if (!(data.path || []).some(item => item.id === me.id)) {
+            me.revealMachine.outsideClick()
+        }
     }
 
     /**
@@ -569,6 +635,7 @@ class Rail extends Container {
 
         me.syncRevealOverlay();
         me.syncRevealedTabState(next.revealedItemId);
+        me.syncOutsidePointerListener(next.state !== 'idle');
 
         // Embodied focus-hold: a click-born reveal moves REAL browser focus into the overlay.
         // Focus-rescue transitions (revealed / dismiss-pending -> focused) already hold focus

--- a/src/dashboard/dock/interaction/RevealStateMachine.mjs
+++ b/src/dashboard/dock/interaction/RevealStateMachine.mjs
@@ -37,7 +37,7 @@
  * | `revealed` / `dismiss-pending` | `overlayFocusEnter()` | `revealed-focused` | Focus rescues and holds. |
  * | `revealed-focused` | `overlayPointerLeave()` | `revealed-focused` | FOCUS-HOLD: a focused reveal never auto-dismisses. |
  * | `revealed-focused` | `overlayFocusLeave()` | `idle` | Focus leaving the overlay dismisses. |
- * | `revealed*` / `dismiss-pending` | `escape()` / `outsideClick()` | `idle` | Explicit dismissal. |
+ * | `revealed*` / `dismiss-pending` | `escape()` / `outsideClick()` | `idle` | Explicit dismissal. `outsideClick()` arrives from the rail's outside-pointer listener on the app main view (a `mousedown` outside the rail's subtree, iframes included — the stylesheet withdraws their pointer events while a reveal is open) and from the maximize path. |
  * | any | `itemCleared(item)` | `idle` | Fail-closed sync: the item left auto-hidden state (pin, restore, transfer, policy) — a reveal of it cannot survive. |
  *
  * Dismissal in every form discards runtime state only; no operation descriptor exists for it.

--- a/src/main/DomEvents.mjs
+++ b/src/main/DomEvents.mjs
@@ -140,6 +140,7 @@ class DomEvents extends Base {
         document.addEventListener('visibilitychange',  me.onVisibilitychange .bind(me));
         window  .addEventListener('orientationchange', me.onOrientationChange.bind(me));
         window  .addEventListener('hashchange',        me.onHashChange       .bind(me));
+        window  .addEventListener('blur',              me.onWindowBlur       .bind(me));
 
         if (Neo.config.useSharedWorkers) {
             window.addEventListener('beforeunload', me.onBeforeUnload.bind(me))
@@ -522,6 +523,40 @@ class DomEvents extends Base {
      */
     onFocusOut(event) {
         this.sendMessageToApp(this.getEventData(event))
+    }
+
+    /**
+     * Focus crossing into a nested document is invisible to the focus events this document forwards:
+     * the element losing focus fires `focusout` with no `relatedTarget`, the `<iframe>` element that
+     * now holds it fires no `focusin`, and only the window's `blur` says anything happened. Without a
+     * `focusin` the app worker's focus manager reads the `focusout` as a leave after its gap — a
+     * click into an iframe INSIDE a focus-holding subtree looks like leaving it. This forwards the
+     * frame element as the focus target, so the worker sees a move to the component that hosts the
+     * frame. `activeElement` settles after `blur`, hence the deferral; a blur that leaves the
+     * document altogether (another window) has no iframe at the active element and forwards nothing.
+     */
+    onWindowBlur() {
+        let me = this;
+
+        setTimeout(() => {
+            let node = document.activeElement,
+                path = [];
+
+            if (node?.tagName !== 'IFRAME') {
+                return
+            }
+
+            for (let current = node; current; current = current.parentNode) {
+                path.push(current)
+            }
+
+            me.sendMessageToApp(me.getEventData({
+                composedPath: () => path,
+                target      : node,
+                timeStamp   : performance.now(),
+                type        : 'focusin'
+            }))
+        }, 0)
     }
 
     /**

--- a/test/playwright/component/apps/dock-rail-iframe/app.mjs
+++ b/test/playwright/component/apps/dock-rail-iframe/app.mjs
@@ -1,0 +1,117 @@
+import DockWorkspace from '../../../../../src/dashboard/dock/Workspace.mjs';
+import Viewport      from '../../../../../src/container/Viewport.mjs';
+import '../../../../../src/tab/Container.mjs';
+
+/**
+ * A rail beside two iframe panes, one per way a nested document can answer a click.
+ *
+ * `plain` leaves the `mousedown` default alone, so a click inside it moves focus into the frame.
+ * `cancel` cancels that default from inside its own document — what an editor managing its own
+ * caret does — so focus never leaves the parent and the parent sees no pointer event either.
+ * The rail's own revealed pane is an iframe too, so the focus-hold contract for a frame INSIDE the
+ * reveal has a witness beside the two OUTSIDE it.
+ */
+const fixtureDocument = {
+    schema: 'neo.dock.zone.v1',
+    root  : 'root',
+    items : {
+        plain : {componentRef: 'plain',  title: 'Plain',  kind: 'panel'},
+        cancel: {componentRef: 'cancel', title: 'Cancel', kind: 'panel'},
+        pinned: {componentRef: 'pinned', title: 'Pinned', kind: 'panel'},
+        railed: {componentRef: 'railed', title: 'Railed', kind: 'panel', autoHidden: true}
+    },
+    nodes: {
+        root         : {type: 'edge-zone', zones: {center: {nodeId: 'root-split'}, right: {nodeId: 'edge-tabs', extent: 0.3}}},
+        'root-split' : {type: 'split', orientation: 'horizontal', children: ['plain-tabs', 'cancel-tabs'], sizes: [0.5, 0.5]},
+        'plain-tabs' : {type: 'tabs', items: ['plain'],            activeItemId: 'plain'},
+        'cancel-tabs': {type: 'tabs', items: ['cancel'],           activeItemId: 'cancel'},
+        'edge-tabs'  : {type: 'tabs', items: ['pinned', 'railed'], activeItemId: 'pinned'}
+    }
+};
+
+/**
+ * One nested document per frame. Each carries a large, labelled button so a spec can click a real
+ * element inside the frame rather than its empty body.
+ * @param {String} id The target element's id inside the frame.
+ * @param {Boolean} cancelMousedown Whether the document cancels the `mousedown` default.
+ * @returns {String} The `srcdoc` markup.
+ */
+const frameDocument = (id, cancelMousedown) =>
+    `<!DOCTYPE html><html><head><style>body{margin:0}button{width:100%;height:120px;font:16px sans-serif}</style>` +
+    (cancelMousedown ? `<script>document.addEventListener('mousedown', event => event.preventDefault())</script>` : '') +
+    `</head><body><button id="${id}" type="button">${id}</button></body></html>`;
+
+/**
+ * @summary The fixture workspace for the reveal's frame-boundary contract: two sibling iframe panes
+ * outside the rail, and an iframe as the revealed pane itself.
+ * @class Test.Playwright.Component.DockRailIframe.Workspace
+ * @extends Neo.dashboard.dock.Workspace
+ */
+class RailIframeWorkspace extends DockWorkspace {
+    static config = {
+        /**
+         * @member {String} className='Test.Playwright.Component.DockRailIframe.Workspace'
+         * @protected
+         */
+        className: 'Test.Playwright.Component.DockRailIframe.Workspace',
+        /**
+         * @member {String} id='dock-rail-iframe-workspace'
+         */
+        id: 'dock-rail-iframe-workspace',
+        /**
+         * @member {Object} layout={ntype:'vbox',align:'stretch'}
+         */
+        layout: {ntype: 'vbox', align: 'stretch'},
+        /**
+         * Mirrors the shape both shipping consumers give their dock host.
+         * @member {Object} style={position:'relative'}
+         */
+        style: {position: 'relative'}
+    }
+
+    /**
+     * @param {Object} config
+     */
+    construct(config) {
+        super.construct(config);
+
+        this.add(this.projectDockModel());
+        this.onDockZoneDocumentChange(structuredClone(fixtureDocument))
+    }
+
+    /**
+     * @summary Resolves one pane: an iframe for the three frame items, a plain component otherwise.
+     * @param {String} itemId
+     * @param {Object} item
+     * @returns {Object}
+     */
+    resolvePane(itemId, item) {
+        if (itemId === 'pinned') {
+            return {
+                cls  : ['dock-rail-iframe-pane'],
+                id   : 'dock-rail-iframe-pane-pinned',
+                ntype: 'component',
+                vdom : {cn: [{tag: 'span', text: 'Pinned pane'}]}
+            }
+        }
+
+        return {
+            cls  : ['dock-rail-iframe-pane', `dock-rail-iframe-pane-${itemId}`],
+            id   : `dock-rail-iframe-pane-${itemId}`,
+            ntype: 'component',
+            style: {border: 0, height: '100%', width: '100%'},
+            tag  : 'iframe',
+            vdom : {tag: 'iframe', srcdoc: frameDocument(`${itemId}-target`, itemId === 'cancel')}
+        }
+    }
+}
+
+RailIframeWorkspace = Neo.setupClass(RailIframeWorkspace);
+
+export const onStart = () => Neo.app({
+    mainView: {
+        module: Viewport,
+        items : [{module: RailIframeWorkspace, flex: 1}]
+    },
+    name: 'Test.Playwright.DockRailIframe'
+});

--- a/test/playwright/component/apps/dock-rail-iframe/index.html
+++ b/test/playwright/component/apps/dock-rail-iframe/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Neo.mjs Dock Rail Iframe Test App</title>
+</head>
+<body>
+    <script src="../../../../../src/MicroLoader.mjs" type="module"></script>
+</body>
+</html>

--- a/test/playwright/component/apps/dock-rail-iframe/neo-config.json
+++ b/test/playwright/component/apps/dock-rail-iframe/neo-config.json
@@ -1,0 +1,9 @@
+{
+    "appPath"         : "test/playwright/component/apps/dock-rail-iframe/app.mjs",
+    "basePath"        : "../../../../../",
+    "environment"     : "development",
+    "mainPath"        : "./Main.mjs",
+    "mainThreadAddons": ["DragDrop", "Navigator", "Stylesheet"],
+    "themes"          : ["neo-theme-neo-dark", "neo-theme-neo-light"],
+    "useSharedWorkers": false
+}

--- a/test/playwright/component/dashboard/DockRailRevealIframe.spec.mjs
+++ b/test/playwright/component/dashboard/DockRailRevealIframe.spec.mjs
@@ -1,0 +1,145 @@
+import {test, expect} from '@playwright/test';
+
+/**
+ * A click into an iframe is "moving on" like any other outside click, and a click into the
+ * revealed pane's own iframe is not.
+ *
+ * An iframe is a second document: nothing that happens inside it reaches the parent's event
+ * surfaces — no `mousedown`, no `click`, no `focusin`. What the parent can see is at most a focus
+ * crossing (when the frame's document takes focus) and the pointer crossing the frame ELEMENT. A
+ * nested document that cancels the `mousedown` default — an editor managing its own caret — takes no
+ * focus at all, so the parent sees nothing. The two frames of this fixture are those two shapes.
+ *
+ * The first arm is a MEASUREMENT before it is an assertion: it records which parent signals a click
+ * into each frame produces, so the mechanism is chosen on evidence rather than on the event model's
+ * reputation. The dismissal arms are the regression; the inside-frame arm is the control that keeps
+ * the focus-hold contract for the revealed pane's own frame.
+ */
+
+const WORKSPACE_ID = 'dock-rail-iframe-workspace';
+
+const overlaySel = '.neo-dashboard-dock-reveal-overlay:not(.neo-dashboard-dock-reveal-overlay-hidden)';
+
+const readInstance = async (page, id, keys) => {
+    const reply = await page.evaluate(data => Neo.worker.App.getConfigs(data), {id, keys});
+
+    return reply?.data ?? reply
+};
+
+/** Reveals the rail item by a real click on its rail tab, and waits for the focused reveal. */
+const reveal = async page => {
+    await page.locator('.neo-dashboard-dock-edge-rail').getByText('Railed').click();
+
+    const overlay = page.locator(overlaySel);
+
+    await expect(overlay).toHaveCount(1);
+    await expect(overlay).toBeVisible();
+
+    const overlayId = await overlay.getAttribute('id');
+
+    await expect.poll(async () => (await readInstance(page, overlayId, ['revealState']))[0],
+        {message: 'a click-born reveal holds focus'}).toBe('revealed-focused');
+
+    return overlayId
+};
+
+/** The reveal machine's state as the overlay mirrors it. */
+const stateOf = async (page, overlayId) => (await readInstance(page, overlayId, ['revealState']))[0];
+
+/**
+ * Installs main-document listeners for every signal the parent could receive when a click lands in
+ * a frame, BEFORE the click, and returns a reader for what arrived.
+ */
+const traceParentSignals = page => page.evaluate(() => {
+    const trace = window.__railIframeTrace = {focusin: [], focusout: [], windowBlur: 0, mousedown: []};
+
+    const label = node => node === window ? 'window' : node === document ? 'document'
+        : `${node.tagName?.toLowerCase()}#${node.id || ''}.${[...(node.classList || [])].slice(0, 2).join('.')}`;
+
+    document.addEventListener('focusin',   event => trace.focusin.push(label(event.target)),  true);
+    document.addEventListener('focusout',  event => trace.focusout.push({from: label(event.target), to: event.relatedTarget ? label(event.relatedTarget) : null}), true);
+    document.addEventListener('mousedown', event => trace.mousedown.push(label(event.target)), true);
+    window.addEventListener('blur', () => trace.windowBlur++)
+});
+
+const readTrace = page => page.evaluate(() => ({
+    ...window.__railIframeTrace,
+    activeElement: document.activeElement === document.body ? 'body'
+        : `${document.activeElement?.tagName?.toLowerCase()}#${document.activeElement?.id || ''}`
+}));
+
+test.beforeEach(async ({page}) => {
+    await page.goto('test/playwright/component/apps/dock-rail-iframe/index.html');
+    await page.waitForSelector(`#${WORKSPACE_ID}`, {state: 'attached'});
+    await expect(page.locator('.neo-dashboard-dock-edge-rail')).toBeVisible({timeout: 10000});
+    await expect(page.locator('#dock-rail-iframe-pane-plain')).toBeVisible();
+    await expect(page.locator('#dock-rail-iframe-pane-cancel')).toBeVisible()
+});
+
+test.describe('Neo.dashboard.dock.interaction.Rail — a reveal and the frame boundary', () => {
+    for (const frame of ['plain', 'cancel']) {
+        test(`a click into the "${frame}" iframe pane dismisses a focused reveal`, async ({page}, testInfo) => {
+            const overlayId = await reveal(page),
+                  pane      = page.locator(`#dock-rail-iframe-pane-${frame}`),
+                  pointer   = () => pane.evaluate(node => getComputedStyle(node).pointerEvents);
+
+            // While the reveal is open, a frame outside it is shielded from the pointer, so the click
+            // below reaches the parent document; the reveal's own frame is not (see the inside arm).
+            expect(await pointer(), `[${frame}] an outside frame is shielded while the reveal is open`).toBe('none');
+
+            await traceParentSignals(page);
+
+            // The user's gesture: a click at the frame's position on screen. Not a frame-locator
+            // click — Playwright would wait for the frame to become a pointer target, which is the
+            // very thing the shield denies while the reveal is open.
+            const box = await pane.boundingBox();
+
+            await page.mouse.click(box.x + box.width / 2, box.y + box.height / 2);
+
+            // Let the focus manager's leave window elapse before reading anything, so a dismissal
+            // that arrives through the focus path is not missed by reading too early.
+            await page.waitForTimeout(400);
+
+            const trace = await readTrace(page),
+                  state = await stateOf(page, overlayId);
+
+            // AC-1: the measurement is the receipt, whatever the verdict below says.
+            testInfo.annotations.push({type: `parent-signals-${frame}`, description: JSON.stringify({...trace, revealState: state})});
+            console.log(`[#18067 ${frame}]`, JSON.stringify({...trace, revealState: state}));
+
+            await expect.poll(() => stateOf(page, overlayId), {message: `[${frame}] the reveal is dismissed`}).toBe('idle');
+            await expect(page.locator(overlaySel)).toHaveCount(0);
+
+            // The shield lifts with the reveal: the frame is a pointer target again.
+            await expect.poll(pointer, {message: `[${frame}] the shield lifts once the reveal is gone`}).toBe('auto')
+        })
+    }
+
+    test('a click into the revealed pane\'s own iframe keeps the reveal open (focus-hold)', async ({page}) => {
+        const overlayId = await reveal(page),
+              railed    = page.locator('#dock-rail-iframe-pane-railed');
+
+        // The revealed pane's own frame keeps its pointer events — the shield is for frames OUTSIDE
+        // the overlay — so a frame-locator click on a real element inside it is the honest gesture.
+        expect(await railed.evaluate(node => getComputedStyle(node).pointerEvents), 'an inside frame takes the pointer').toBe('auto');
+
+        await page.frameLocator('#dock-rail-iframe-pane-railed').locator('#railed-target').click();
+        await page.waitForTimeout(400);
+
+        // Focus moved into the nested document, and the parent's focus manager was told which
+        // element holds it — a frame inside the overlay's subtree, so nothing left.
+        expect(await page.evaluate(() => document.activeElement?.id), 'focus is in the inside frame').toBe('dock-rail-iframe-pane-railed');
+        expect(await stateOf(page, overlayId), 'an inside frame is inside').toBe('revealed-focused');
+        await expect(page.locator(overlaySel)).toHaveCount(1)
+    });
+
+    test('control: a click on another pane\'s tab header dismisses the reveal on the existing focus path', async ({page}) => {
+        const overlayId = await reveal(page);
+
+        await page.locator('.neo-dashboard-dock-tabs', {has: page.locator('.neo-tab-header-button:has-text("Plain")')})
+            .locator('.neo-tab-header-button', {hasText: 'Plain'}).click();
+
+        await expect.poll(() => stateOf(page, overlayId), {message: 'the control dismisses'}).toBe('idle');
+        await expect(page.locator(overlaySel)).toHaveCount(0)
+    })
+});


### PR DESCRIPTION
Resolves #18067

A click into an iframe pane now leaves a rail reveal, whatever the nested document does with the click, and a click into the revealed pane's own iframe keeps it. Measured first: a frame that takes focus already dismissed on `dev` (the overlay root's `focusout` plus a window `blur`), a frame whose document cancels the `mousedown` default produced no parent signal at all and left the reveal open, and the fixture surfaced a second defect the ticket did not know about — a click into the revealed pane's own iframe dismissed the reveal, because the parent never receives a `focusin` for a frame element and the focus manager read the `focusout` as leaving. Two mechanisms, one per boundary: the stylesheet withdraws pointer events from every iframe outside an open reveal (the drag shield's idiom), so the click lands on the parent element beneath the frame, where the rail's new outside-pointer listener on the app main view (the Picker's idiom) turns any `mousedown` outside the rail's subtree into `RevealStateMachine#outsideClick()`; and `Neo.main.DomEvents` forwards the active `<iframe>` element as a `focusin` when the window blurs onto it, so the worker sees focus move to the component hosting the frame — a move within the overlay's subtree holds the reveal, a move outside it is the leave the focus path already handles.

Evidence: L3 (rendered component witnesses in CI: real nested documents via `srcdoc`, the shield read from computed style, the machine state read from the overlay's mirrored config) → L3 required (AC-1…AC-5). Residual: the consumer arm in the WebStudio's own e2e suite (Vega's `RailRevealDismissal`) turns green only on that repo's engine pin, Residual-Owner: #18067's Post-Merge line below, no open ticket needed.

Micro-review eligible: no — a main-thread event surface (`window` `blur` → forwarded `focusin`) and a stylesheet rule on every iframe under a dashboard.

## AC Evidence
| AC-1 | CI-covered: `test/playwright/component/dashboard/DockRailRevealIframe.spec.mjs` › "a click into the "plain" / "cancel" iframe pane dismisses a focused reveal" — each arm records the parent signals as a test annotation and in the run log before asserting; the receipts from the unfixed tree are in Test Evidence below and on the ticket |
| AC-2 | CI-covered: the `plain` arm (the frame takes focus): raw pointer click at the frame's position → `idle`, overlay gone, shield lifted after |
| AC-3 | CI-covered: the `cancel` arm (the frame's document cancels the `mousedown` default): same gesture → `idle`; red on `dev` (the frame stayed `revealed-focused` with no parent signal) |
| AC-4 | CI-covered: › "a click into the revealed pane's own iframe keeps the reveal open (focus-hold)" — a frame-locator click on a real element inside the revealed pane's iframe; `document.activeElement` is that frame and the state stays `revealed-focused`; red on `dev` (it went `idle`) |
| AC-5 | diff + CI: the `RevealStateMachine` state table names both sources of `outsideClick()`; component `dashboard/` and unit `dashboard/` folders green at this head (counts in Test Evidence) |

## Deltas from ticket
- **Half of AC-1's premise did not survive the measurement.** The ticket expected both frame variants to leave the reveal open on `dev`; the frame that takes focus already dismissed (parent `focusout` with no `relatedTarget`, window `blur` ×1, no `focusin`, then `focusLeave` after the gap). Only the frame that cancels the default was opaque — and that is the consumer's editor.
- **A second defect, found by the fixture and fixed by the same forwarding.** The revealed pane's own iframe dismissed the reveal on `dev` — the focus-hold contract AC-4 asked to *keep* was already broken for any pane hosting a frame. Forwarding the frame element's focus as a `focusin` on window `blur` turns the parent's blind spot into a focus move; the inside case holds and the outside case leaves, with one mechanism.
- **The pointer boundary is a stylesheet shield plus the Picker idiom, not a hover reading.** The ticket sketched "pointer entering an outside `<iframe>` as an outside interaction", which is a hover signal the ticket's own Avoided Traps refuse for a focused reveal. Withdrawing pointer events from outside frames while a reveal is open (`.neo-dashboard:has(<open overlay>) iframe:not(<overlay> iframe)`, the `body.neo-drag-active iframe` precedent) makes the click a parent-document `mousedown`, so the same outside-pointer listener that now covers every non-focusable outside target covers frames too. The consequence is the ordinary popover one: the first click into a shielded frame dismisses the reveal and does not reach the frame.
- **The outside arms click with the raw pointer at the frame's position.** A frame-locator click waits for the frame to become a pointer target, which the shield denies while the reveal is open — the test would time out on the very property it proves. The inside arm keeps the frame-locator click, because that frame must accept it.
- No new state-machine input: `outsideClick()` was already the explicit dismissal the maximize path uses; the rail is its second caller.

## Test Evidence
Parent signals recorded by the measurement arms on the **unfixed** tree (`dev@8e9ff9cd31`), reveal open and click-born:
- `plain` (frame takes focus): `focusout` from the overlay root with `relatedTarget: null`, window `blur` ×1, no `focusin`, `activeElement` = the frame → state `idle` (already dismissed).
- `cancel` (frame cancels the default): no `focusin`, no `focusout`, no `blur`, no `mousedown`, `activeElement` = the overlay root → state `revealed-focused` (the red).
- inside frame: state `idle` on `dev` (the red the ticket did not predict).

On this head: the same arms 4/4; after the fix both outside clicks land as a `mousedown` on the tab body beneath the frame, focus moves to that tab container, state `idle`, and the frame's `pointer-events` reads `none` while open and `auto` after. Folder receipts at this head, local Chromium: unit `dashboard/` 713/713, component `dashboard/` 69/69 plus the new spec 4/4. Themes rebuilt before the component runs (`node buildScripts/build/themes.mjs -n -e dev`), since the shield is a compiled stylesheet rule. Neural Link e2e on this head with `NEO_AGENTOS_RUNTIME_ROOT` set: `DockAutoHideRevealNL` green and the five behavioural arms of `DockPinCollapseNL` green; that spec's four `toHaveScreenshot` arms are red on a plain `dev` worktree as well (the darwin snapshots predate the inline-header trim of #18048; defect-noted, the re-record is a separate housekeeping change).

## Post-Merge Validation
- [ ] The WebStudio e2e arm `RailRevealDismissal` (iframe half) turns green once that repo's engine pin includes this commit; a click into the editor while a reveal is open dismisses the reveal and is not delivered to the editor (first click dismisses, second edits).

Authored by Mnemosyne (Claude Fable 5.1, Claude Code). Session 37bbc610-f0cd-4abb-95c2-eb70336a86f3. 🪢
