### PR TITLE
fix(test): the preview/zone oracle asserts placement, not thickness (#18082)

### DIFF
--- a/test/playwright/e2e/utils/dockGeometry.mjs
+++ b/test/playwright/e2e/utils/dockGeometry.mjs
@@ -143,15 +143,22 @@ export async function assertAffordanceContainment(app, {dockHostId, indicatorIds
 
 /**
  * Family 3 — preview/zone alignment: the painted preview equals its target zone rect within
- * tolerance for `tab-into`, or forms a band at the named zone edge for edge previews. The
- * band height must not exceed `edgeBandMax` (the skin's 24px default at authoring time) and
- * must hug the zone's own edge — never float free and never extend past it.
+ * tolerance for `tab-into`, or occupies the named edge of the zone for edge previews — hugging
+ * that edge, spanning the zone across it, and never floating free or extending past it.
+ *
+ * These are the relationships that hold whatever the preview LANGUAGE is. How thick a directional
+ * placement paints is affordance policy: `Preview#resultRegionPreviews` paints the region the pane
+ * would occupy, its predecessor painted a fixed insertion band, and the exact rect for either is
+ * pinned per edge in `unit/dashboard/DockPreview.spec.mjs` against `affordanceGeometry`. This
+ * helper asserted a thickness too, and that copy is the one that rotted: it kept the band budget
+ * after the default became region mode, so the demo's own witness reported a red that named no
+ * defect. A size contract belongs in one place, and this is not it.
  *
  * @param {Object} app the connected neuralLink app wrapper
- * @param {Object} geometry {zoneId, previewRect, kind: 'tab-into' | 'edge-top' | 'edge-right' | 'edge-bottom' | 'edge-left', edgeBandMax?}
+ * @param {Object} geometry {zoneId, previewRect, kind: 'tab-into' | 'edge-top' | 'edge-right' | 'edge-bottom' | 'edge-left'}
  * @param {Number} [tolerance=2]
  */
-export async function assertPreviewZoneAlignment(app, {zoneId, previewRect, kind, edgeBandMax = 24}, tolerance = 2) {
+export async function assertPreviewZoneAlignment(app, {zoneId, previewRect, kind}, tolerance = 2) {
     const rects = await readComponentRects(app, [zoneId]),
           zone  = rects[zoneId];
 
@@ -168,21 +175,25 @@ export async function assertPreviewZoneAlignment(app, {zoneId, previewRect, kind
         expect(withinRect(previewRect, zone, tolerance),
             'an edge preview never extends past its zone').toBe(true);
 
-        if (edge === 'top' || edge === 'bottom') {
-            expect(previewRect.height, 'edge band height stays within the skin budget')
-                .toBeLessThanOrEqual(edgeBandMax + tolerance);
+        const vertical = edge === 'top' || edge === 'bottom',
+              // the axis the placement extends along, and the one it spans
+              along    = vertical ? 'height' : 'width',
+              across   = vertical ? 'width'  : 'height',
+              anchor   = edge;
 
-            const anchor = edge === 'top' ? 'top' : 'bottom';
-            expect(Math.abs(previewRect[anchor] - zone[anchor]),
-                `the ${edge} band hugs the zone's ${edge} edge`).toBeLessThanOrEqual(tolerance)
-        } else {
-            expect(previewRect.width, 'edge band width stays within the skin budget')
-                .toBeLessThanOrEqual(edgeBandMax + tolerance);
+        // Spanning the zone across the edge is what makes it an EDGE placement rather than a box
+        // that happens to sit near one. Neither preview language has ever painted less.
+        expect(Math.abs(previewRect[across] - zone[across]),
+            `the ${edge} placement spans the zone's ${across}`).toBeLessThanOrEqual(tolerance);
 
-            const anchor = edge;
-            expect(Math.abs(previewRect[anchor] - zone[anchor]),
-                `the ${edge} band hugs the zone's ${edge} edge`).toBeLessThanOrEqual(tolerance)
-        }
+        // A placement, not the whole zone: `tab-into` is the affordance that claims everything, and
+        // an edge preview that grew to fill its zone would be indistinguishable from it.
+        expect(previewRect[along], `the ${edge} placement has a visible ${along}`).toBeGreaterThan(tolerance);
+        expect(previewRect[along], `the ${edge} placement stays a sub-region of its zone`)
+            .toBeLessThan(zone[along] - tolerance);
+
+        expect(Math.abs(previewRect[anchor] - zone[anchor]),
+            `the ${edge} placement hugs the zone's ${edge} edge`).toBeLessThanOrEqual(tolerance)
     }
 
     return rects

--- a/test/playwright/e2e/utils/dockGeometry.mjs
+++ b/test/playwright/e2e/utils/dockGeometry.mjs
@@ -154,6 +154,13 @@ export async function assertAffordanceContainment(app, {dockHostId, indicatorIds
  * after the default became region mode, so the demo's own witness reported a red that named no
  * defect. A size contract belongs in one place, and this is not it.
  *
+ * Known bound of the instrument: "a sub-region, not the whole zone" is expressed against the same
+ * `tolerance` as every other comparison, so a placement occupying more than `1 - tolerance/extent`
+ * of its zone reads as the whole thing — above roughly 0.993 on a 300px zone. `Preview` derives
+ * that share from the affordance's own `ratio`, so a legitimate region near the extreme would be
+ * refused here. Widening it means asserting the share, which is the size contract this helper
+ * deliberately does not hold a copy of; raise the caller's `tolerance` for such a case instead.
+ *
  * @param {Object} app the connected neuralLink app wrapper
  * @param {Object} geometry {zoneId, previewRect, kind: 'tab-into' | 'edge-top' | 'edge-right' | 'edge-bottom' | 'edge-left'}
  * @param {Number} [tolerance=2]

--- a/test/playwright/unit/e2e/dockGeometry.spec.mjs
+++ b/test/playwright/unit/e2e/dockGeometry.spec.mjs
@@ -1,0 +1,81 @@
+import {test, expect}               from '@playwright/test';
+import {assertPreviewZoneAlignment} from '../../e2e/utils/dockGeometry.mjs';
+
+/**
+ * The preview/zone oracle, tested as the instrument it is.
+ *
+ * `assertPreviewZoneAlignment` used to assert a band thickness for edge placements. That is
+ * affordance policy — `Preview#resultRegionPreviews` paints the region the pane would occupy, its
+ * predecessor painted a fixed insertion band — and when the default moved to region mode the
+ * budget stayed behind, so the five-beat journey reported a red that named no defect. The repair
+ * drops the thickness and keeps the relationships that hold under EITHER language.
+ *
+ * A weakening and a repair look identical from the outside, so every relationship the helper still
+ * claims gets a mutation that must make it throw. Without those, "the demo spec is green again"
+ * would be indistinguishable from "the oracle stopped looking".
+ *
+ * @see https://github.com/neomjs/neo/issues/18082
+ */
+
+const ZONE = {left: 100, top: 200, right: 500, bottom: 500, width: 400, height: 300},
+      // the affordance's own key; the helper never reads it, it reads the painted rect
+      appFor = zone => ({getDomRect: async ids => Object.fromEntries(ids.map(id => [id, zone]))}),
+      app    = appFor(ZONE),
+
+      assert = (previewRect, kind) => assertPreviewZoneAlignment(app, {kind, previewRect, zoneId: 'zone'});
+
+/** A rect from left/top/width/height, carrying the right/bottom the helper reads. */
+const rect = (left, top, width, height) => ({left, top, width, height, right: left + width, bottom: top + height});
+
+test.describe('assertPreviewZoneAlignment — the edge placement oracle', () => {
+    test.describe('accepts both preview languages, because thickness is not its contract', () => {
+        test('region mode: half the zone, hugging the named edge', async () => {
+            // what `resultRegionPreviews: true` paints today
+            await assert(rect(100, 200, 400, 150), 'edge-top');
+            await assert(rect(100, 350, 400, 150), 'edge-bottom');
+            await assert(rect(100, 200, 200, 300), 'edge-left');
+            await assert(rect(300, 200, 200, 300), 'edge-right')
+        });
+
+        test('line mode: a 24px insertion band, hugging the named edge', async () => {
+            // what the predecessor painted — the helper must not have become region-only
+            await assert(rect(100, 200, 400, 24), 'edge-top');
+            await assert(rect(100, 476, 400, 24), 'edge-bottom');
+            await assert(rect(100, 200, 24, 300), 'edge-left');
+            await assert(rect(476, 200, 24, 300), 'edge-right')
+        });
+
+        test('tab-into still equals the whole zone', async () => {
+            await assert(rect(100, 200, 400, 300), 'tab-into')
+        })
+    });
+
+    test.describe('mutations — each relationship it still claims must fail when broken', () => {
+        test('a placement that extends past its zone', async () => {
+            await expect(assert(rect(100, 200, 400, 340), 'edge-top')).rejects.toThrow()
+        });
+
+        test('a placement that floats free of the named edge', async () => {
+            // right size, right span, but 40px below the zone's top
+            await expect(assert(rect(100, 240, 400, 150), 'edge-top')).rejects.toThrow()
+        });
+
+        test('a placement that does not span the zone across the edge', async () => {
+            // half-width band on a top edge: an edge placement never paints less than the span
+            await expect(assert(rect(100, 200, 200, 150), 'edge-top')).rejects.toThrow()
+        });
+
+        test('a placement collapsed to nothing', async () => {
+            await expect(assert(rect(100, 200, 400, 0), 'edge-top')).rejects.toThrow()
+        });
+
+        test('a placement that has grown to cover its whole zone', async () => {
+            // indistinguishable from `tab-into` — the failure the removed budget used to catch
+            await expect(assert(rect(100, 200, 400, 300), 'edge-top')).rejects.toThrow()
+        });
+
+        test('a tab-into that is not the whole zone', async () => {
+            await expect(assert(rect(100, 200, 400, 150), 'tab-into')).rejects.toThrow()
+        })
+    })
+});


### PR DESCRIPTION
Resolves #18082

Related: #17873 / `60592e6a85` (the commit that changed the meaning), #15252 (the five-beat journey), #17853 (e2e runs in no CI job — why this went unseen), #17890 (same surface, closed, colour rather than geometry), #13158

`assertPreviewZoneAlignment` asserted a 24 px band budget for edge previews. That is affordance policy, not this helper's contract: `Preview#resultRegionPreviews` paints the region a pane would occupy, its predecessor painted a fixed insertion band, and the exact rect for either is already pinned per edge in `unit/dashboard/DockPreview.spec.mjs:353-356`. When the default became region mode on 2026-08-30 the budget stayed behind, so `WorkstationFiveBeatNL` — the executable authority the demo recording derives from — reported `Expected <= 26, Received 248.5`, a red that named no defect. A size contract belongs in one place, and the copy is what rotted.

The edge branch now asserts the relationships that hold under **either** preview language: the placement spans its zone across the named edge, stays a strict sub-region along it, hugs that edge, and never extends past the zone. The span was not asserted before, so this is net stronger rather than a relaxation — a preview floating free of its edge at the right thickness used to pass.

Evidence: L3 (the demo journey executed end to end against a real Chromium and the Brain root at the rebased head; the oracle exercised directly against both preview languages and six mutations) → L3 required (the ACs are the helper's own behaviour plus the journey it gates). No residual.

## AC Evidence

| AC | Evidence |
|---|---|
| AC-1 — no band-thickness assertion for `edge-*`; `WorkstationFiveBeatNL` passes the `edge-bottom` dwell at `:1503` on current `dev` with `resultRegionPreviews` at its shipped default | CI-covered by inspection of `test/playwright/e2e/utils/dockGeometry.mjs`; outside-CI: the journey run below (e2e executes in no CI job, #17853) |
| AC-2 — the helper asserts the full cross-axis extent, an invariant it did not carry | CI-covered: `test/playwright/unit/e2e/dockGeometry.spec.mjs`, "a placement that does not span the zone across the edge" — a half-width band on a top edge now throws where it previously passed |
| AC-3 — still fails a preview that is uncontained, floats free, collapses, or covers the whole zone; each exercised by a mutation | CI-covered: same spec, six mutation arms — past the zone, floating free, not spanning, collapsed to nothing, grown to the whole zone, and a partial `tab-into`. Both preview languages pass as positive controls, so the arms discriminate rather than merely accept |
| AC-4 — `WorkstationFiveBeatNL` reaches 8 passed / 0 failed / 3 skipped on current `dev` | Outside-CI: **8 passed / 0 failed / 3 skipped** at the rebased head `c246f4ab73` (was 7/1/3). The three skips are the pre-existing capture-display gates, untouched |
| AC-5 — `DockPreview.spec.mjs` stays green and keeps owning the exact per-edge geometry; no size literal moves into the helper | CI-covered: `unit/dashboard/DockPreview.spec.mjs` **52/52**; the helper contains no rect literal — the only numbers left are the caller's `tolerance` |

## Deltas

- **The repair removes an assertion, so the helper gets its own spec.** A weakening and a repair are indistinguishable from the outside — "the demo spec is green again" reads identically to "the oracle stopped looking". `unit/e2e/dockGeometry.spec.mjs` (precedent: `unit/e2e/glState.spec.mjs`) pins both directions: region mode *and* line mode pass, and every relationship still claimed has a mutation that must throw. That file is the reason this PR can be trusted to be a fix.
- **Line mode is asserted even though nothing ships it.** `resultRegionPreviews` is a live config a consumer can turn off, and an oracle that silently became region-only would strand them. Cheap to state, and it is the arm that would catch a future "simplification" of the helper.
- **`edgeBandMax` is retired rather than kept as an option.** Keeping it would leave the rotted contract expressible, and no caller passed it.

## Test Evidence

- **The journey, before and after, on the same tree:** 7 passed / 1 failed / 3 skipped on `dev` → **8 passed / 0 failed / 3 skipped** at this head. The film-cue receipt is byte-identical across both (`sha256=80920fc4b95482f112fdafa4283cc3def20071c5d799e17aa0f97b4b757913b4`, `journeys=2 beats=5,5`), which is the evidence that the *journey* did not change — only the oracle did.
- **The red was controlled before it was diagnosed.** Identical assertion and identical `248.5` at three heads (`8e9ff9cd31`, `fff4dd94f5`, `8c86f4478f`), which established "not this diff, not that day's merges" but could never establish "not a defect at all" — that needed the assertion's provenance, which @neo-opus-vega supplied (`60592e6a85`) and then yielded the repair.
- Oracle spec 9/9; `DockPreview` 52/52; both re-run at the rebased head after `check-block-alignment --fix` mutated the tree inside the commit hook, since a green taken before that describes a different tree.

## Post-Merge Validation

- [ ] None. Both ACs that need a runtime are executed at this head; the helper has no consumer outside the two call sites in `WorkstationFiveBeatNL`.

## Commits

- `c246f4ab73` — the edge branch asserts placement rather than thickness, plus the helper's own spec.

Authored by Ada (Claude Opus 5, Claude Code). Session 7596538d-5324-419a-b043-95c585d833ea.

Cross-family note: the GPT seats are at 0% weekly quota (operator, 2026-09-01 22:20Z); a fable-family review is the sanctioned exception for an opus-authored PR.
