### PR TITLE
feat(dock): the reveal overlay carries a discoverability floor on any ground (#18080)

### DIFF
--- a/resources/scss/src/dashboard/Container.scss
+++ b/resources/scss/src/dashboard/Container.scss
@@ -125,12 +125,31 @@
     // A reveal is an overlay, so opacity and elevation are functional rather than decorative:
     // covered pane chrome must not bleed through, and the overlap boundary must remain visible.
     // Consumers can supply identity values without re-declaring the structure.
+    //
+    // ── Reveal chrome floor ──────────────────────────────────────────────────────────────
+    // The surface deliberately stays the host's, so the overlay and the pane it covers are the
+    // same colour BY DESIGN and the boundary above can only come from the chrome. A `0` border
+    // plus a black drop shadow supplied that boundary on a light ground and nothing at all on a
+    // dark one, where 28%-black over a near-black surface is not an edge — the revealed pane read
+    // as the pane beneath it with a title line floating in it. Both flagship hosts had already
+    // written their own border and shadow to escape that, which is the tell: a default every
+    // serious consumer overrides is a gap wearing a default's clothes.
+    //
+    // Same resolution strategy as the splitter floor above, and for the same reason: values go
+    // through `currentColor` because the engine cannot know a host's palette, and a literal grey
+    // would read wrong on half of them. Mixing against inherited ink gives a hairline on any
+    // ground. The halo layer carries the elevation where a black shadow cannot — it brightens on
+    // dark skins and stays subordinate to the drop shadow on light ones.
+    //
+    // This is a FLOOR: both values are plain token defaults, so a consumer that sets either one
+    // wins on the cascade exactly as before. Identity remains theirs; discoverability is ours.
     --dock-reveal-background          : var(--neo-background-color, #fff);
-    --dock-reveal-border              : 0;
+    --dock-reveal-border              : 1px solid color-mix(in srgb, currentColor 22%, transparent);
     --dock-reveal-min-block-size      : 10rem;
     --dock-reveal-min-inline-size     : 12rem;
     --dock-reveal-radius              : 0;
-    --dock-reveal-shadow              : 0 12px 32px rgb(0 0 0 / 28%);
+    --dock-reveal-shadow              : 0 0 0 1px color-mix(in srgb, currentColor 8%, transparent),
+                                        0 12px 32px rgb(0 0 0 / 28%);
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/test/playwright/component/dashboard/DockRevealChromeFloor.spec.mjs
+++ b/test/playwright/component/dashboard/DockRevealChromeFloor.spec.mjs
@@ -1,0 +1,204 @@
+import {test, expect} from '@playwright/test';
+
+/**
+ * The reveal overlay's discoverability floor, measured on a rendered overlay in both neo themes.
+ *
+ * A revealed pane is an overlay over the workspace, and the engine keeps its SURFACE the host's —
+ * `--dock-reveal-background` resolves to `--neo-background-color`, deliberately. That means the
+ * overlay and the pane it covers are the same colour by design, and the only thing separating them
+ * is the chrome: a border and an elevation shadow.
+ *
+ * On a dark ground the shipped default supplied neither. `--dock-reveal-border` was `0` and the
+ * shadow was `0 12px 32px rgb(0 0 0 / 28%)` — 28%-black over a near-black surface, which is not an
+ * edge. The revealed pane read as the pane beneath it with a title line floating in it. Both
+ * flagship hosts had already written their own border and shadow to escape it, which is the tell:
+ * a default every serious consumer overrides is not a default, it is a gap.
+ *
+ * **The delta cannot come from the background, so it must come from the border.** This is why the
+ * arms below measure the border colour against the overlay's OWN surface rather than the overlay
+ * against the pane. Comparing surfaces would report ~0 on a correct implementation — the surfaces
+ * are supposed to match — so an arm written that way would fail on the fix and pass on the defect.
+ *
+ * **The theme control is the point.** A hairline that resolves through `currentColor` reads on any
+ * ground, but only if a theme is actually live in the document. Every arm therefore asserts the two
+ * skins resolve DIFFERENT ink first: if the theme stylesheet never applied, both themes report the
+ * same colour and every measurement below is about nothing.
+ *
+ * @see https://github.com/neomjs/neo/issues/18080
+ */
+
+const
+    THEMES = ['neo-theme-neo-dark', 'neo-theme-neo-light'],
+
+    /**
+     * Colour maths for the arms below, injected as source because it runs in the page.
+     *
+     * Two things here are load-bearing and both were learned by getting them wrong:
+     *
+     * 1. **Two channel scales.** A `color-mix()` result comes back from Chrome as
+     *    `color(srgb 0.94 0.95 0.94 / 0.22)` — channels in 0..1 — while a plain colour is
+     *    `rgb(14, 15, 13)` in 0..255. Parsing both with one `/255` divisor turns a near-WHITE
+     *    border into near-black, which reported an invisible edge on a correct implementation.
+     * 2. **Alpha must be composited, not dropped.** The floor is a 22%-alpha hairline; what a
+     *    viewer sees is that colour laid OVER the surface, not the colour itself. Comparing the
+     *    raw border against the surface would credit the edge with contrast it does not have.
+     */
+    COLOR_MATHS = `{
+        parse: value => {
+            const nums = value.match(/[\\d.]+/g).map(Number);
+            // \`color(srgb …)\` carries 0..1 channels; rgb()/rgba() carry 0..255.
+            const scale = value.startsWith('color(') ? 1 : 255;
+            return {
+                r: nums[0] / scale,
+                g: nums[1] / scale,
+                b: nums[2] / scale,
+                a: nums.length > 3 ? nums[3] : 1
+            }
+        },
+        luminance: c => {
+            const lin = v => v <= 0.03928 ? v / 12.92 : Math.pow((v + 0.055) / 1.055, 2.4);
+            return 0.2126 * lin(c.r) + 0.7152 * lin(c.g) + 0.0722 * lin(c.b)
+        },
+        over: (fg, bg) => ({
+            r: fg.a * fg.r + (1 - fg.a) * bg.r,
+            g: fg.a * fg.g + (1 - fg.a) * bg.g,
+            b: fg.a * fg.b + (1 - fg.a) * bg.b,
+            a: 1
+        })
+    }`;
+
+let dashboardId;
+
+test.beforeEach(async ({page}) => {
+    await page.goto('test/playwright/component/apps/dock-rail-origin/index.html');
+    await page.waitForSelector('.neo-dashboard', {state: 'attached'})
+});
+
+/** Swap the active theme class on the document element and read back what took effect. */
+const applyTheme = (page, theme) => page.evaluate(name => {
+    for (const el of [document.body, document.documentElement]) {
+        el.classList.forEach(c => c.startsWith('neo-theme-') && el.classList.remove(c))
+    }
+
+    document.body.classList.add(name);
+
+    return document.body.className
+}, theme);
+
+/**
+ * Opens the left rail's reveal by a real click and waits for the entry animation to settle.
+ * Visibility flips when the animation STARTS, so a paint read taken then samples the overlay
+ * mid-ramp — its opacity is still climbing and every colour comes back blended.
+ */
+const revealLeft = async page => {
+    await page.locator('.neo-dashboard-dock-edge-rail-left .neo-dashboard-dock-rail-tab').first().click();
+
+    const overlay = page.locator('.neo-dashboard-dock-reveal-overlay-left');
+
+    await expect(overlay).toBeVisible({timeout: 10000});
+
+    await expect.poll(
+        () => page.evaluate(() => {
+            const el = document.querySelector('.neo-dashboard-dock-reveal-overlay-left');
+            return el ? getComputedStyle(el).opacity : '0'
+        }),
+        {message: 'the reveal must settle before its paint is read', timeout: 10000}
+    ).toBe('1');
+
+    return overlay
+};
+
+test.describe('the dock reveal overlay carries a discoverability floor in both skins', () => {
+    for (const theme of THEMES) {
+        test(`${theme}: the overlay's edge is visible against its own surface`, async ({page}) => {
+            await applyTheme(page, theme);
+            await revealLeft(page);
+
+            const measured = await page.evaluate(mathsSource => {
+                const maths   = eval('(' + mathsSource + ')'),
+                      overlay = document.querySelector('.neo-dashboard-dock-reveal-overlay-left'),
+                      style   = getComputedStyle(overlay),
+                      surface = maths.parse(style.backgroundColor),
+                      // What the eye gets: the hairline composited over the surface it sits on.
+                      edge    = maths.over(maths.parse(style.borderTopColor), surface);
+
+                return {
+                    background : style.backgroundColor,
+                    borderColor: style.borderTopColor,
+                    borderStyle: style.borderTopStyle,
+                    borderWidth: style.borderTopWidth,
+                    boxShadow  : style.boxShadow,
+                    delta      : Math.abs(maths.luminance(edge) - maths.luminance(surface)),
+                    ink        : style.color
+                }
+            }, COLOR_MATHS);
+
+            // The floor itself.
+            expect(measured.borderStyle,
+                `[${theme}] the overlay must carry a border style, not \`none\``).not.toBe('none');
+            expect(parseFloat(measured.borderWidth),
+                `[${theme}] the border must be a visible hairline, not 0`).toBeGreaterThan(0);
+            expect(measured.boxShadow,
+                `[${theme}] elevation must survive this ground`).not.toBe('none');
+
+            // The measurement that makes the border meaningful rather than merely present: a
+            // 1px border the same colour as the surface it sits on is a border nobody can see.
+            expect(measured.delta,
+                `[${theme}] the edge must separate from the overlay's own surface ` +
+                `(border ${measured.borderColor} on ${measured.background})`).toBeGreaterThan(0.02)
+        })
+    }
+
+    test('CONTROL: the two skins resolve different ink, so the arms above measure something', async ({page}) => {
+        // Without this, a document whose theme stylesheet never loaded reports one palette for both
+        // names and every luminance assertion above becomes a statement about the default UA style.
+        const read = async theme => {
+            await applyTheme(page, theme);
+            await revealLeft(page);
+
+            return page.evaluate(() => {
+                const style = getComputedStyle(document.querySelector('.neo-dashboard-dock-reveal-overlay-left'));
+                return {background: style.backgroundColor, ink: style.color}
+            })
+        };
+
+        const dark = await read('neo-theme-neo-dark');
+        await page.reload();
+        await page.waitForSelector('.neo-dashboard', {state: 'attached'});
+        const light = await read('neo-theme-neo-light');
+
+        expect(dark.background,
+            'the two skins must paint different surfaces — otherwise no theme is live')
+            .not.toBe(light.background)
+    });
+
+    test('a consumer override still wins: the floor is a floor, not a ceiling', async ({page}) => {
+        // The two flagship hosts set their own border and shadow. The floor must not outrank them,
+        // or this change silently restyles every app that already solved the problem.
+        await applyTheme(page, 'neo-theme-neo-dark');
+        await revealLeft(page);
+
+        const measured = await page.evaluate(() => {
+            const style = document.createElement('style');
+
+            style.textContent =
+                '.neo-dashboard .neo-dashboard-dock-reveal-overlay {' +
+                '  --dock-reveal-border: 3px dashed rgb(255 0 0);' +
+                '}';
+            document.head.appendChild(style);
+
+            const overlay  = document.querySelector('.neo-dashboard-dock-reveal-overlay-left'),
+                  computed = getComputedStyle(overlay);
+
+            return {
+                borderColor: computed.borderTopColor,
+                borderStyle: computed.borderTopStyle,
+                borderWidth: computed.borderTopWidth
+            }
+        });
+
+        expect(measured.borderWidth, 'a consumer border width must survive the floor').toBe('3px');
+        expect(measured.borderStyle, 'and its style').toBe('dashed');
+        expect(measured.borderColor, 'and its colour').toBe('rgb(255, 0, 0)')
+    })
+});


### PR DESCRIPTION
Resolves #18080

Related: #13158 (parent), #18074 / PR #18079 (the reveal's motion — untouched), #18070 (its start geometry — untouched), the splitter affordance floor in the same file (the house pattern this follows)

The overlay's surface is deliberately the host's, so it and the pane it covers are the same colour **by design** — which means the boundary can only ever come from the chrome. The shipped default gave that boundary `--dock-reveal-border: 0` and a 28%-black drop shadow: an edge on a light ground, and nothing at all on a dark one, where black over near-black is not an edge. The revealed pane read as the pane beneath it with a title line floating in it.

Both flagship hosts had already written their own border and shadow to escape that. That is the tell this ticket is built on: a default every serious consumer overrides is a gap wearing a default's clothes.

Evidence: L3 (component-tier measured paint on a rendered overlay in both neo skins, red-first verified in both directions) → L3 required (every AC is a computed-style contract on a mounted overlay). Residual: the design-read half of AC-2, Residual-Owner: #13158.

## AC Evidence

| AC | Evidence |
|---|---|
| AC-1 — computed border is a visible hairline, box-shadow is not `none`, and a luminance delta at the edge exceeds a floor, in BOTH skins; red on `dev` in neo-dark | `DockRevealChromeFloor.spec.mjs`, two parameterized arms. Green at this head; with the floor reverted **both** arms red on `the overlay must carry a border style, not 'none'`. One refinement to the ticket's prediction: the *border* is absent in both skins, not only dark — `border: 0` is theme-agnostic. Only the *shadow's* inadequacy was dark-specific. The witness catches both. |
| AC-2 — the app overrides render unchanged; where a host does not override, the floor shows | Mechanically: both values stay plain token defaults, so a consumer declaration still wins on the cascade. The arm `a consumer override still wins: the floor is a floor, not a ceiling` injects `3px dashed rgb(255 0 0)` at the selector shape `Workspace.scss` uses and asserts all three computed values survive. `apps/workstation` and the Fleet cockpit SCSS are untouched. **Residual:** the "byte-identically … screenshots, design-read" half is a human read; the cascade half is what is mechanised here. |
| AC-3 — lint green, no consumer SCSS change | Pre-commit gates green; the diff is one engine SCSS block plus one new spec. No consumer file touched. |

## Deltas from ticket

- **The shadow is a two-layer value, not a replacement.** The ticket offered `0 0 0 1px color-mix(currentColor 8%)` *or* a glow; this keeps the original drop shadow and prepends the halo, so light grounds are unchanged in appearance and dark grounds gain the ring. Replacing the drop would have altered every light-ground consumer for no reason.
- **No radius, no background change**, exactly as scoped.

## Test Evidence

Four arms in `test/playwright/component/dashboard/DockRevealChromeFloor.spec.mjs`, on the `dock-rail-origin` fixture:

- `neo-theme-neo-dark` / `neo-theme-neo-light`: the floor, measured on a rendered, settled overlay
- `CONTROL: the two skins resolve different ink` — a document whose theme never loaded reports one palette for both names, and every luminance assertion above would then be a statement about the UA default
- `a consumer override still wins` — the floor must not outrank a host that already solved this

Red-first, with the floor reverted at this head: **2 failed / 2 passed** — both theme arms red, control and override arms green. Full components suite at this head: **198 passed**.

Two details in the witness are load-bearing, and I got both wrong first:

1. **It compares the border against the overlay's OWN surface, not against the pane beneath.** Comparing surfaces reports ~0 on a *correct* implementation — they are meant to match — so that arm would have failed on the fix and passed on the defect.
2. **It composites the hairline's alpha over the surface.** My first version parsed every colour with a `/255` divisor; Chrome returns `color-mix()` as `color(srgb 0.94 0.95 0.94 / 0.22)` with 0..1 channels, which turned a near-**white** border into near-black and reported an invisible edge on a correct implementation. The light arm passed anyway — for the wrong reason — which is exactly the masked green the control discipline exists to catch. Both scales are now handled and the alpha is composited, because a 22% border is not what a viewer sees.

## Post-Merge Validation

- [ ] Design read on a dark-ground host that does **not** override (the dock example, a fresh adopter): the revealed pane is distinguishable from the pane it covers.
- [ ] `apps/workstation` reveal unchanged to the eye — the cascade guarantees it, a glance confirms it.

## Commits

- `180110e477` feat(dock): the reveal overlay carries a discoverability floor on any ground (#18080)

## Evolution

The reusable shape is the tell, not the fix: **every serious consumer had already written the same two lines.** Two independent hosts overriding one default in the same direction is not two consumers exercising taste, it is a default that does not work — and it stayed invisible because each override looked like app identity rather than a workaround. The splitter floor directly above this block exists for the identical reason and says so in its own comment; this is the second instance of the same pattern in one file, which suggests the question worth asking of any engine default is not "is it reasonable?" but "does anyone ship it?"

---

Authored by Grace (Opus 5, Claude Code). Session fb58e855-74b2-4367-9f83-5877f151f024.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
