### PR TITLE
fix(container): insert parks a lazy module config and loads it at the active card index, so a lazily resolved dock pane materializes in the tab flow (#18084)

### DIFF
--- a/src/container/Base.mjs
+++ b/src/container/Base.mjs
@@ -635,6 +635,12 @@ class Container extends Component {
      * 4. The `DeltaUpdates` system detects the existing DOM node and moves it physically, preserving
      *    DOM state such as focus, input values, and iframe content.
      *
+     * A lazy config (`{module: () => import('...')}`) PARKS, exactly as it does at construction:
+     * the config itself takes the items slot and a `removeDom` placeholder vnode holds its index
+     * in the vdom, so a card layout can replace both with the loaded instance. A card layout loads a
+     * parked item when its index activates; when the inserted index is already the active one, this
+     * method starts that load itself. The parked config is what gets returned in that case.
+     *
      * @param {Number} index
      * @param {Array|Object|Neo.component.Base} item
      * @param {Boolean} [silent=false]
@@ -645,7 +651,7 @@ class Container extends Component {
         let me      = this,
             {items} = me,
             lca     = null,
-            i, itemParent, itemType, len, oldParent, parentsA, parentsB, returnArray;
+            i, itemParent, itemType, len, oldParent, parentsA, parentsB, parked, returnArray, vdom;
 
         if (Array.isArray(item)) {
             i           = 0;
@@ -685,17 +691,39 @@ class Container extends Component {
                 }
             }
 
-            item = me.createItem(item, index, removeFromPreviousParent);
+            item   = me.createItem(item, index, removeFromPreviousParent);
+            parked = !(item instanceof Neo.core.Base);
 
-            // added the true param => for card layouts, we do not want a dynamically inserted cmp to get removed right away
-            // since it will most likely get activated right away
-            me.layout?.applyChildAttributes(item, index, true);
+            if (parked) {
+                // A lazy `module` config parks, exactly as construction parks it (see createItems()):
+                // the config takes the slot and its `removeDom` placeholder vnode keeps the indices
+                // aligned for the card layout's later loadModule() replacement.
+                vdom = item.vdom
+            } else {
+                // added the true param => for card layouts, we do not want a dynamically inserted cmp to get removed right away
+                // since it will most likely get activated right away
+                me.layout?.applyChildAttributes(item, index, true);
+                vdom = item.createVdomReference()
+            }
 
             items.splice(index, 0, item);
 
             me.items = items;
 
-            me.getVdomItemsRoot().cn.splice(index, 0, item.createVdomReference())
+            me.getVdomItemsRoot().cn.splice(index, 0, vdom);
+
+            // A card layout loads a parked item when its index ACTIVATES. An index that is already
+            // active fired that hook long before this insert, so the inserter starts the load itself;
+            // the settled instance publishes through its own update, independent of the caller's
+            // (possibly silent) transaction. A parked item at any other index loads on activation.
+            if (parked && me.layout?.loadModule && me.layout.activeIndex === index) {
+                me.layout.loadModule(item, index).then(() => {
+                    if (!me.isDestroyed) {
+                        me.updateDepth = -1;
+                        me.update()
+                    }
+                })
+            }
         }
 
         if (!silent) {

--- a/src/container/Base.mjs
+++ b/src/container/Base.mjs
@@ -722,6 +722,14 @@ class Container extends Component {
                         me.updateDepth = -1;
                         me.update()
                     }
+                }).catch(error => {
+                    // The failure route this call site owes: loadModule() flags the item `isLoading`
+                    // before its await and has no catch of its own, so a rejected import (a chunk that
+                    // fails to fetch, a module that throws while evaluating) would otherwise leave an
+                    // unhandled rejection and an item flagged loading forever. The config stays parked
+                    // behind its placeholder, unflagged, so the next activation retries the load.
+                    delete item.isLoading;
+                    console.error(`${me.id}: the lazy module inserted at index ${index} failed to load`, error)
                 })
             }
         }

--- a/test/playwright/component/apps/dock-lazy-rail/app.mjs
+++ b/test/playwright/component/apps/dock-lazy-rail/app.mjs
@@ -39,7 +39,31 @@ class LazyRailFixtureWorkspace extends DockWorkspace {
         /**
          * @member {Object} layout={ntype:'vbox',align:'stretch'}
          */
-        layout: {ntype: 'vbox', align: 'stretch'}
+        layout: {ntype: 'vbox', align: 'stretch'},
+        /**
+         * Spec trigger: a JSON operation descriptor commits through the REAL reducer + refresh loop
+         * (`applyDockZoneOperation` → `onDockZoneDocumentChange`), the way a consumer's own
+         * controls commit — the tab-flow arm un-hides the lazy item with it, so the projection has
+         * to materialize the lazily resolved pane through the card layout, not the reveal overlay.
+         * @member {String|null} applyOperationJson_=null
+         * @reactive
+         */
+        applyOperationJson_: null
+    }
+
+    /**
+     * @param {String|null} value
+     * @param {String|null} oldValue
+     * @protected
+     */
+    afterSetApplyOperationJson(value, oldValue) {
+        if (oldValue === undefined || !value) {
+            return
+        }
+
+        const result = this.applyDockZoneOperation(JSON.parse(value));
+
+        result && !result.errors?.length && this.onDockZoneDocumentChange(result.document)
     }
 
     /**

--- a/test/playwright/component/dashboard/DockRailLazyModule.spec.mjs
+++ b/test/playwright/component/dashboard/DockRailLazyModule.spec.mjs
@@ -27,6 +27,11 @@ const readWorkspace = async (page, keys) => {
     return reply?.data ?? reply
 };
 
+const setWorkspace = (page, configs) => page.evaluate(
+    data => Neo.worker.App.setConfigs(data),
+    {id: WORKSPACE_ID, ...configs}
+);
+
 const lazyTab = page => page.locator('.neo-dashboard-dock-rail-tab', {hasText: 'Lazy'});
 
 const visibleOverlay = page => page.locator('.neo-dashboard-dock-reveal-overlay:not(.neo-dashboard-dock-reveal-overlay-hidden)');
@@ -80,5 +85,59 @@ test.describe('dock rail — a lazy module item loads on its first reveal', () =
         const [instances] = await readWorkspace(page, ['lazyPaneInstances']);
 
         expect(instances).toBe(1)
+    });
+
+    test('un-hidden into a tabs node behind an active sibling, the lazy item parks in the tab flow and loads when its tab activates', async ({page}) => {
+        // The commit a consumer's own control makes: the item leaves the rail and the projection
+        // places it into its tabs node. The reconciler swaps the staged placeholder through
+        // container.insert(), which has to PARK a lazy config — and, this tab not being the active
+        // one, must not load it: the header is there, the module is not, until the tab activates.
+        await setWorkspace(page, {applyOperationJson: JSON.stringify({operation: 'setItemAutoHidden', itemId: 'lazy', autoHidden: false})});
+
+        const
+            tabsNode   = page.locator('.neo-dashboard-dock-tabs', {has: page.locator('.neo-tab-header-button', {hasText: 'Lazy'})}),
+            lazyHeader = tabsNode.locator('.neo-tab-header-button', {hasText: 'Lazy'});
+
+        await expect(tabsNode, 'the item is projected as a tab').toHaveCount(1);
+        await expect(lazyTab(page), 'it left the rail').toHaveCount(0);
+        await expect(visibleOverlay(page), 'no reveal overlay was involved').toHaveCount(0);
+        await expect(tabsNode.locator('#dock-lazy-rail-pane-pinned'), 'the eager sibling stays the active card').toBeVisible();
+
+        let [loaded] = await readWorkspace(page, ['lazyPaneModuleLoaded']);
+
+        expect(loaded, 'parked: an inactive tab loads nothing').toBe(false);
+
+        await lazyHeader.click();
+
+        await expect(tabsNode.locator('.dock-lazy-rail-pane'), 'activation loads the module and the pane is the tab\'s card').toBeVisible();
+        await expect(tabsNode.locator('.dock-lazy-rail-pane')).toHaveText('Lazy pane');
+
+        const [loadedAfter, instances] = await readWorkspace(page, ['lazyPaneModuleLoaded', 'lazyPaneInstances']);
+
+        expect(loadedAfter).toBe(true);
+        expect(instances, 'one construction').toBe(1)
+    });
+
+    test('un-hidden as the only visible item of its tabs node, the lazy item is the active card and loads at once', async ({page}) => {
+        // The Fleet cockpit's shape: a node whose every item is railed, then one un-hidden by the
+        // bootstrap CTA — the projected tab is active from the first frame, and the reconciler's
+        // insert lands on the layout's active index, where nothing else would ever trigger the load.
+        await setWorkspace(page, {applyOperationJson: JSON.stringify({operation: 'setItemAutoHidden', itemId: 'pinned', autoHidden: true})});
+        await expect(page.locator('.neo-dashboard-dock-rail-tab', {hasText: 'Pinned'})).toHaveCount(1);
+
+        await setWorkspace(page, {applyOperationJson: JSON.stringify({operation: 'setItemAutoHidden', itemId: 'lazy', autoHidden: false})});
+
+        const tabsNode = page.locator('.neo-dashboard-dock-tabs', {has: page.locator('.neo-tab-header-button', {hasText: 'Lazy'})});
+
+        await expect(tabsNode, 'the item is projected as a tab').toHaveCount(1);
+        await expect(tabsNode.locator('.dock-lazy-rail-pane'), 'the active index loads on insert; the pane is the card').toBeVisible();
+        await expect(tabsNode.locator('.dock-lazy-rail-pane')).toHaveText('Lazy pane');
+        await expect(lazyTab(page), 'it left the rail').toHaveCount(0);
+        await expect(visibleOverlay(page), 'no reveal overlay was involved').toHaveCount(0);
+
+        const [loaded, instances] = await readWorkspace(page, ['lazyPaneModuleLoaded', 'lazyPaneInstances']);
+
+        expect(loaded).toBe(true);
+        expect(instances, 'one construction').toBe(1)
     });
 });

--- a/test/playwright/unit/container/InsertLazyModule.spec.mjs
+++ b/test/playwright/unit/container/InsertLazyModule.spec.mjs
@@ -1,0 +1,129 @@
+import {setup} from '../../setup.mjs';
+
+const appName = 'ContainerInsertLazyModuleTest';
+
+setup({
+    appConfig: {
+        name: appName
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../src/Neo.mjs';
+import * as core      from '../../../../src/core/_export.mjs';
+import Button         from '../../../../src/button/Base.mjs';
+import Container      from '../../../../src/container/Base.mjs';
+import CardLayout     from '../../../../src/layout/Card.mjs';
+
+/**
+ * `container.Base#insert` with a lazy `module` config — the shape a card layout loads on
+ * activation. Construction parks such a config (`createItem` stamps a `removeDom` placeholder
+ * vnode, `createItems` pushes it into the items root); `insert` mirrors that instead of treating the
+ * config as an instance. The dock projection materializes panes through `insert`, so this is the
+ * contract a lazily resolved dock pane rides.
+ *
+ * Every arm uses a loader that resolves in a microtask (no real import): what is under test is the
+ * parking and the load trigger, not module fetching. Every card container starts with one eager
+ * card at the active index, because a card layout activating an index with no item is its own
+ * error, not this contract's.
+ */
+
+const lazyButton = text => ({module: () => Promise.resolve({default: Button}), text});
+
+const cardContainer = () => Neo.create(Container, {
+    appName,
+    layout: {ntype: 'card', activeIndex: 0},
+    items : [{module: Button, text: 'eager'}]
+});
+
+/** Resolves once the container's card layout has replaced the parked config at `index`. */
+const untilLoaded = (container, index) => new Promise(resolve => {
+    const check = () => container.items[index] instanceof Neo.core.Base ? resolve(container.items[index]) : setTimeout(check, 5);
+
+    check()
+});
+
+test.describe('Neo.container.Base#insert — a lazy module config parks, then loads on the active card index', () => {
+    let container;
+
+    test.afterEach(() => {
+        container?.destroy();
+        container = null
+    });
+
+    test('inserted at the active index: parked first, the placeholder vnode holds the slot, then the loaded instance takes both', async () => {
+        container = cardContainer();
+
+        const
+            eager    = container.items[0],
+            returned = container.insert(0, lazyButton('lazy'));
+
+        // Parked, not thrown: the config is the item, its placeholder vnode is the slot.
+        expect(returned, 'insert returns the parked config').not.toBeInstanceOf(Neo.core.Base);
+        expect(returned.module, 'the loader survives parking').toEqual(expect.any(Function));
+        expect(container.items[0], 'the config takes the items slot').toBe(returned);
+        expect(container.items[1], 'the eager card shifted').toBe(eager);
+        expect(container.vdom.cn, 'one vnode per item').toHaveLength(2);
+        expect(container.vdom.cn[0].removeDom, 'the placeholder vnode keeps the index aligned').toBe(true);
+        expect(container.vdom.cn[1].componentId, 'the eager reference followed its item').toBe(eager.id);
+
+        const loaded = await untilLoaded(container, 0);
+
+        expect(loaded, 'the active index loads the module').toBeInstanceOf(Button);
+        expect(loaded.text).toBe('lazy');
+        expect(container.items, 'the instance replaced the config in place').toHaveLength(2);
+        expect(container.vdom.cn[0].componentId, 'and its reference replaced the placeholder').toBe(loaded.id)
+    });
+
+    test('inserted at a non-active index it stays parked, and loads when that index activates', async () => {
+        container = cardContainer();
+
+        const returned = container.insert(1, lazyButton('later'));
+
+        expect(returned).not.toBeInstanceOf(Neo.core.Base);
+        expect(container.items[1]).toBe(returned);
+        expect(container.vdom.cn[1].removeDom).toBe(true);
+
+        // Give a would-be load every chance to run: nothing may load an inactive card.
+        await new Promise(resolve => setTimeout(resolve, 20));
+
+        expect(container.items[1], 'a non-active parked item does not load on insert').toBe(returned);
+        expect(container.items[0], 'the active eager card is untouched').toBeInstanceOf(Button);
+
+        container.layout.activeIndex = 1;
+
+        const loaded = await untilLoaded(container, 1);
+
+        expect(loaded, 'activation loads it, as at construction').toBeInstanceOf(Button);
+        expect(loaded.text).toBe('later');
+        expect(container.vdom.cn[1].componentId).toBe(loaded.id)
+    });
+
+    test('add() rides the same branch: parked at the end, loaded when that index activates', async () => {
+        container = cardContainer();
+
+        const returned = container.add(lazyButton('added'));
+
+        expect(returned).not.toBeInstanceOf(Neo.core.Base);
+        expect(container.items[1]).toBe(returned);
+        expect(container.vdom.cn[1].removeDom).toBe(true);
+
+        container.layout.activeIndex = 1;
+
+        const loaded = await untilLoaded(container, 1);
+
+        expect(loaded).toBeInstanceOf(Button);
+        expect(loaded.text).toBe('added')
+    });
+
+    test('a plain container without a card layout parks the config and leaves it parked (construction parity)', () => {
+        container = Neo.create(Container, {appName, items: [{module: Button, text: 'eager'}]});
+
+        const returned = container.insert(0, lazyButton('plain'));
+
+        expect(returned).not.toBeInstanceOf(Neo.core.Base);
+        expect(container.items[0]).toBe(returned);
+        expect(container.vdom.cn[0].removeDom).toBe(true);
+        expect(container.vdom.cn).toHaveLength(2)
+    });
+});

--- a/test/playwright/unit/container/InsertLazyModule.spec.mjs
+++ b/test/playwright/unit/container/InsertLazyModule.spec.mjs
@@ -116,6 +116,45 @@ test.describe('Neo.container.Base#insert — a lazy module config parks, then lo
         expect(loaded.text).toBe('added')
     });
 
+    test('a rejected import at the active index logs with the container identity, clears the loading flag, and leaves the item parked so the next activation retries', async () => {
+        const
+            errors        = [],
+            originalError = console.error;
+
+        console.error = (...args) => errors.push(args);
+
+        try {
+            container = cardContainer();
+
+            const broken = container.insert(0, {module: () => Promise.reject(new Error('chunk failed to load')), text: 'broken'});
+
+            expect(broken.isLoading, 'the load started').toBe(true);
+
+            // Let the rejection reach the call site's failure route.
+            await new Promise(resolve => setTimeout(resolve, 20));
+
+            expect(container.items[0], 'the config stays parked').toBe(broken);
+            expect(container.vdom.cn[0].removeDom, 'behind its placeholder').toBe(true);
+            expect(broken.isLoading, 'and is not flagged loading forever').toBeUndefined();
+            expect(errors, 'one diagnosable line').toHaveLength(1);
+            expect(errors[0][0]).toContain(container.id);
+            expect(errors[0][0]).toContain('index 0');
+            expect(errors[0][1]).toBeInstanceOf(Error);
+
+            // The retry: a repaired loader loads on the next activation of that index.
+            broken.module = () => Promise.resolve({default: Button});
+            container.layout.activeIndex = 1;
+            container.layout.activeIndex = 0;
+
+            const loaded = await untilLoaded(container, 0);
+
+            expect(loaded).toBeInstanceOf(Button);
+            expect(loaded.text).toBe('broken')
+        } finally {
+            console.error = originalError
+        }
+    });
+
     test('a plain container without a card layout parks the config and leaves it parked (construction parity)', () => {
         container = Neo.create(Container, {appName, items: [{module: Button, text: 'eager'}]});
 


### PR DESCRIPTION
Resolves #18084

Related: #18062 / PR #18063 (the rail-path twin: a rail loads a lazy module item on reveal), #13158 (parent), neomjs/neo-agent-institution#74 / PR #77 (the consumer: the Fleet cockpit's bootstrap CTA un-hides its define-agent zone into the tab flow), neomjs/neo-agent-institution#76 / PR #79 (the previous pin)

A tab container accepts a lazy card — `{module: () => import('...')}` — and loads it when the card becomes active. Construction honours that end to end: `createItem` parks the config with a `removeDom` placeholder vnode, `createItems` pushes that vnode into the items root, and the card layout's `loadModule` later replaces both the parked config and its vnode with the created instance. `container.Base#insert` did not: after `createItem` it applied layout attributes to the config and called `createVdomReference()` on it, so a lazy config thrown into `insert` (and `add`) threw. The dock projection materializes every pane through `insert` — `Reconciler.reconcileProjection` swaps its staged placeholders that way — so a lazily resolved dock pane on the tab path rejected the whole refresh silently and left an orphaned placeholder body where the pane should have been. The rail path had been fixed in #18063 by loading before adding; the tab path could not be fixed there, because the tab container's card layout is the right owner of the load. Now `insert` parks a lazy config exactly as construction does, and when the inserted index is the card layout's active one — the projection's case, where the activation hook fired long before the swap — it starts the load itself; a parked card at any other index loads on activation, unchanged.

Evidence: L3 (unit arms on `container.Base` red-first at `origin/dev`; the `dock-lazy-rail` fixture driven through the real reducer + refresh loop in Chromium, red-first at `origin/dev`; the defect reproduced live on the Fleet cockpit through the Neural Link before the fix) → L3 required (the contract is what a parked config becomes in `items` and in the vdom, and whether a projected tab renders its lazily resolved pane). Residual: none.

## AC Evidence

| AC | Evidence |
| --- | --- |
| AC-1 — unit: a lazy config inserted at the active card index parks (config in `items`, `removeDom` placeholder in the vdom), throws nothing, and resolves to the created instance; at a non-active index it stays parked until activation | CI-covered: `test/playwright/unit/container/InsertLazyModule.spec.mjs` — five arms: active index (parked → loaded, the eager sibling's reference follows its shifted item), non-active index (stays parked through a 20ms grace, loads on `layout.activeIndex = 1`), `add()` (same branch), a plain container (parks and leaves parked — construction parity), and the failure route (Round 1): a rejected import logs one line carrying the container id and the index, clears `isLoading`, leaves the config parked behind its placeholder, and a repaired loader loads on the next activation of that index. Red at `origin/dev@961ac9cd11`: **4 failed / 0 passed**, every arm at `TypeError: item.createVdomReference is not a function` — the throw the reconciler met. |
| AC-2 — component: un-hiding the lazy item projects it into the tab flow and renders the pane, one construction; the rail arms stay green | CI-covered: `test/playwright/component/dashboard/DockRailLazyModule.spec.mjs` gains two arms on the `dock-lazy-rail` fixture, driven through a new `applyOperationJson_` trigger that commits through the REAL reducer + refresh loop (`applyDockZoneOperation` → `onDockZoneDocumentChange`): (a) un-hidden behind an active sibling, the item parks in the tab flow — header present, module NOT loaded (`lazyPaneModuleLoaded` false) — and loads on the header click; (b) un-hidden as the only visible item of its node (the cockpit's shape), the projected tab is active from the first frame and the reconciler's insert lands on the layout's active index — the pane renders at once, one construction, no overlay. The three rail arms unchanged, 5/5 at the head. Red at `origin/dev@961ac9cd11` with the fixture trigger and the spec copied in: **2 failed / 3 passed** — (a) at `the item is projected as a tab · Expected 1 · Received 0` (the throw inside the swap rejects the whole refresh, so not even the tab node projects) and (b) at `the active index loads on insert; the pane is the card · element(s) not found`; the three rail arms green there (they landed with #18063). |
| AC-3 — `unit/container`, `unit/layout`, `unit/dashboard`, `component/dashboard` green | `unit/container unit/layout unit/tab unit/dashboard unit/form` **848 passed** at the head; the full `component/dashboard/` suite **81 passed** (53.8s) — every dock witness that materializes panes through the reconciler's swap runs on the new `insert`. |
| AC-4 — post-merge: institution PR #77 bumps to the pin that carries this; `AddAgentJourneyNL` green under the Brain root | Post-merge by construction: PR #77 is rebased and pinned to `dev@961ac9cd11` today and stays draft until this lands; its journey witness is the consumer receipt. |

## Deltas from ticket

- **The load trigger is the inserter's, not the layout's.** The ticket's fix step 2 as written; stated here because it is the one line that makes the projection case work: `layout.Card#afterSetActiveIndex` loads on CHANGE, and a projected tabs node whose only visible item is the lazy one has been at index 0 since its construction with a placeholder — nothing would ever load the swapped-in config without `insert` asking. The settled instance publishes through the container's own update, independent of the caller's (the reconciler's silent) transaction.
- **One arm more than the ticket asked for** (component (a), the non-active un-hide): it pins the half of the contract that must NOT load — a heavy pane behind a non-active tab still costs nothing until its tab activates, the startup cost the lazy shape exists to avoid.
- **The fixture** gains the `applyOperationJson_` trigger (the pop-out fixture's precedent); its document is unchanged.
- **Round 1 (Grace): the load the inserter starts has a failure route.** `layout.Card#loadModule` flags the item `isLoading` before its await and has no catch of its own, so a rejected import at the new call site would have left an unhandled rejection and an item flagged loading forever — a parked placeholder body that reads like the very defect this PR removes. The call site now catches: it logs with the container id and the index (as the rail's `loadRevealPane` logs the item id), clears the flag, and leaves the config parked so the next activation retries. Hardening `loadModule` itself is deliberately not this PR's (every tab container rides it; one place, its own leaf).
- **Not unified:** the three lazy-detection spellings (`createItem`'s `!module.isClass && Neo.isFunction`, `toJSON`'s twin, `layout.Card`'s `Neo.typeOf(module) === 'Function'`) stay as they are — a polish leaf, named in the ticket's Out of Scope. This diff uses the instance test (`instanceof Neo.core.Base`) that `createItems` already uses to tell a parked config from an instance.

## Test Evidence

- Red-first, unit (scratch worktree at `origin/dev@961ac9cd11`, the spec copied in): Red at `origin/dev@961ac9cd11`: **4 failed / 0 passed**, every arm at `TypeError: item.createVdomReference is not a function` — the throw the reconciler met.
- Red-first, component (same worktree, fixture + spec copied in): Red at `origin/dev@961ac9cd11` with the fixture trigger and the spec copied in: **2 failed / 3 passed** — (a) at `the item is projected as a tab · Expected 1 · Received 0` (the throw inside the swap rejects the whole refresh, so not even the tab node projects) and (b) at `the active index loads on insert; the pane is the card · element(s) not found`; the three rail arms green there (they landed with #18063).
- Red-first, the failure route (scratch worktree at this PR's first head `702eb5175a`, the spec copied in): **1 failed / 4 passed** — the rejected-import arm surfaces the unhandled `Error: chunk failed to load` and the item keeps its `isLoading` flag; green at `8dd35978a4` (5/5).
- Head: `unit/container/InsertLazyModule` **5 passed**; `component/dashboard/DockRailLazyModule` **5 passed** (4.0s); `unit/container unit/layout unit/tab unit/dashboard unit/form` **848 passed** at the first head (the failure route touches the call site only); the full `component/dashboard/` suite **81 passed** (53.8s) — every dock witness that materializes panes through the reconciler's swap runs on the new `insert`..
- Live, before the fix (Fleet cockpit at engine `961ac9cd11`, Neural Link): the CTA handler projected `Add agent` as the active tab with one card — a bare `neo-component-184`, 0 children, invisible, already gone worker-side; `.fm-add-agent-form` never appeared. The rail tab rendered the form (the #18063 path).

## Post-Merge Validation

- [ ] neomjs/neo-agent-institution PR #77: pin to the `dev` that carries this, `AddAgentJourneyNL` under the Brain root (bootstrap CTA → S5 zone → readback → graduation), the CTA path read on the live cockpit.

## Commits

- `702eb5175a` — the parked branch in `container.Base#insert` (+ the active-index load and the JSDoc contract), the four unit arms, the fixture's `applyOperationJson_` trigger, the two tab-flow component arms.
- `8dd35978a4` — Round 1: the failure route on the load the inserter starts (log with identity, clear `isLoading`, stay parked for the retry) and its unit arm.

Same-family review note: the GPT seats are at 0% weekly quota (operator, 2026-09-01 22:20Z); an Opus 5 review is the sanctioned exception.

📜 Clio · @neo-fable-clio · Claude Fable 5.1 · Claude Code · session 91f83b9c-df95-4f72-a68f-d33f470792ac
