### PR TITLE
fix(dock): a native drag lifts the rail reveal's frame shield for its lifetime (#18087)

### DIFF
--- a/resources/scss/src/Global.scss
+++ b/resources/scss/src/Global.scss
@@ -72,7 +72,10 @@ html, .neo-body-viewport {
 // `pointer-events: none` also removes an element as a NATIVE drag-and-drop target, because the same
 // hit-testing governs dragover/drop. This class is stamped only inside sensor-driven synthetic
 // gestures and never for a native drag, so the shield can never suppress a real HTML5 drop. A drag
-// whose legitimate target IS the iframe opts out per element.
+// whose legitimate target IS the iframe opts out per element. The rail reveal's frame shield in
+// `dashboard/Container.scss` rests on this same side effect with the opposite scope (an open reveal,
+// not a gesture), so it lifts while `body.neo-native-drag-active` marks a native drag in flight; the
+// rail-iframe component arms witness both — a change to either scope is a change to both.
 //
 // This covers a window nothing else does. Once a DragZone session is live,
 // `draggable/DragProxyComponent.scss` shields the whole page with

--- a/resources/scss/src/dashboard/Container.scss
+++ b/resources/scss/src/dashboard/Container.scss
@@ -520,9 +520,18 @@
 // either — so a click into such a frame would leave the reveal open with nothing to dismiss it.
 // Without pointer events the click lands on the parent element beneath the frame, where the rail's
 // outside-pointer listener reads it as leaving. Frames INSIDE the overlay keep their pointer events:
-// a click into the revealed pane is inside, whatever it lands on. The same boundary idiom as the
-// drag shield (`body.neo-drag-active iframe`).
-.neo-dashboard:has(.neo-dashboard-dock-reveal-overlay:not(.neo-dashboard-dock-reveal-overlay-hidden)) iframe:not(.neo-dashboard-dock-reveal-overlay iframe) {
+// a click into the revealed pane is inside, whatever it lands on.
+//
+// The same boundary idiom as the drag shield in `Global.scss` (`body.neo-drag-active iframe`), and
+// the same side effect that shield's comment calls load-bearing: `pointer-events: none` also removes
+// a frame as a NATIVE drop target, because one hit test governs pointer, dragover and drop. That
+// shield is scoped to sensor gestures, which never carry a native drag. An open reveal says nothing
+// about a drag in flight, so this one lifts for the lifetime of any native drag the document starts:
+// the `NativeDragSource` addon stamps `neo-native-drag-active` on `body` at `dragstart` and clears it
+// at `dragend`. Measured before it was written — the press that starts a drag outside the reveal does
+// dismiss it, but the overlay hides one vdom round trip later, and by then the drop had been hit-tested
+// onto the parent beneath the frame. The rail-iframe component arms keep the two shields in step.
+body:not(.neo-native-drag-active) .neo-dashboard:has(.neo-dashboard-dock-reveal-overlay:not(.neo-dashboard-dock-reveal-overlay-hidden)) iframe:not(.neo-dashboard-dock-reveal-overlay iframe) {
     pointer-events: none;
 }
 

--- a/src/main/addon/NativeDragSource.mjs
+++ b/src/main/addon/NativeDragSource.mjs
@@ -8,6 +8,14 @@ import Base from './Base.mjs';
 const templateToken = /\{([\w-]+)\}/g;
 
 /**
+ * The `body` class marking a native drag in flight, from `dragstart` to `dragend`. Frame shields
+ * that key on other state — the dock rail reveal's in `dashboard/Container.scss` — lift while it is
+ * present, so the drop can be hit-tested onto the frame it is aimed at.
+ * @type {String}
+ */
+const nativeDragCls = 'neo-native-drag-active';
+
+/**
  * @summary Declarative native HTML5 drag sources: `DataTransfer` filled from worker-declared config.
  *
  * The synthetic drag pipeline (DragDrop addon + the sensors) is right for the Neo world — records,
@@ -55,7 +63,10 @@ const templateToken = /\{([\w-]+)\}/g;
  * decline it. Declined-by-sensor also means the synthetic pipeline's `dragstart` suppression is
  * never installed and `neo-drag-active` (the iframe shield's hook) is never stamped for a native
  * drag — load-bearing, since the shield makes iframes hit-test-inert and a native drag's whole
- * purpose is to LAND on one.
+ * purpose is to LAND on one. What a native drag does stamp is `neo-native-drag-active` on `body`,
+ * from `dragstart` to `dragend`: a frame shield keyed on something other than the gesture — the
+ * dock rail reveal's — would otherwise hit-test the drop away from a frame that is not inside the
+ * reveal, and the reveal's dismissal (a worker round trip) cannot win a race against `dragover`.
  *
  * @class Neo.main.addon.NativeDragSource
  * @extends Neo.main.addon.Base
@@ -155,6 +166,12 @@ class NativeDragSource extends Base {
             {dataTransfer} = event,
             node, types;
 
+        // Every native drag this document starts lifts the frame shields for its lifetime, armed by
+        // this addon or not: `pointer-events: none` removes a frame as a drop target, and a drop has
+        // to be able to land in an editor frame whichever node carried the payload. The rail reveal's
+        // shield (`dashboard/Container.scss`) keys on this class; cleared in {@link #onGestureEnd}.
+        document.body.classList.add(nativeDragCls);
+
         if (!armed || event.target !== armed.node || !dataTransfer) {
             return
         }
@@ -177,6 +194,8 @@ class NativeDragSource extends Base {
     onGestureEnd() {
         let {armed} = this;
 
+        document.body.classList.remove(nativeDragCls);
+
         if (armed) {
             // restore only addon-owned DOM state: a node that was draggable before stays draggable
             armed.addedAttribute && armed.node.removeAttribute('draggable');
@@ -195,6 +214,10 @@ class NativeDragSource extends Base {
         if (event.button !== 0 || event.ctrlKey || event.metaKey) {
             return
         }
+
+        // A new press means any earlier drag is over. `dragend` never fires for a source node removed
+        // from the DOM mid-drag, and a lift that outlived its drag would keep the reveal shield down.
+        document.body.classList.remove(nativeDragCls);
 
         const source = this.sourceOf(event);
 

--- a/test/playwright/component/apps/dock-rail-iframe/app.mjs
+++ b/test/playwright/component/apps/dock-rail-iframe/app.mjs
@@ -10,19 +10,26 @@ import '../../../../../src/tab/Container.mjs';
  * caret does — so focus never leaves the parent and the parent sees no pointer event either.
  * The rail's own revealed pane is an iframe too, so the focus-hold contract for a frame INSIDE the
  * reveal has a witness beside the two OUTSIDE it.
+ *
+ * The left zone holds `source`, a plain pane carrying a native drag source — the row a consumer's
+ * grid would drag into an editor frame. It sits on the far side from the rail so an open reveal on
+ * the right never covers it, and every frame document is a native drop target, so the drop's
+ * arrival can be read from inside the frame the drag was aimed at.
  */
 const fixtureDocument = {
     schema: 'neo.dock.zone.v1',
     root  : 'root',
     items : {
+        source: {componentRef: 'source', title: 'Source', kind: 'panel'},
         plain : {componentRef: 'plain',  title: 'Plain',  kind: 'panel'},
         cancel: {componentRef: 'cancel', title: 'Cancel', kind: 'panel'},
         pinned: {componentRef: 'pinned', title: 'Pinned', kind: 'panel'},
         railed: {componentRef: 'railed', title: 'Railed', kind: 'panel', autoHidden: true}
     },
     nodes: {
-        root         : {type: 'edge-zone', zones: {center: {nodeId: 'root-split'}, right: {nodeId: 'edge-tabs', extent: 0.3}}},
+        root         : {type: 'edge-zone', zones: {left: {nodeId: 'source-tabs', extent: 0.2}, center: {nodeId: 'root-split'}, right: {nodeId: 'edge-tabs', extent: 0.3}}},
         'root-split' : {type: 'split', orientation: 'horizontal', children: ['plain-tabs', 'cancel-tabs'], sizes: [0.5, 0.5]},
+        'source-tabs': {type: 'tabs', items: ['source'],           activeItemId: 'source'},
         'plain-tabs' : {type: 'tabs', items: ['plain'],            activeItemId: 'plain'},
         'cancel-tabs': {type: 'tabs', items: ['cancel'],           activeItemId: 'cancel'},
         'edge-tabs'  : {type: 'tabs', items: ['pinned', 'railed'], activeItemId: 'pinned'}
@@ -31,7 +38,10 @@ const fixtureDocument = {
 
 /**
  * One nested document per frame. Each carries a large, labelled button so a spec can click a real
- * element inside the frame rather than its empty body.
+ * element inside the frame rather than its empty body, and each is a native drop target that
+ * records what arrived on its own window (`__nativeDrop`) — the live drag store read from a real
+ * `drop`, never a constructed event — so a spec can tell whether a drag aimed at the frame reached
+ * its document or was hit-tested onto the parent beneath it.
  * @param {String} id The target element's id inside the frame.
  * @param {Boolean} cancelMousedown Whether the document cancels the `mousedown` default.
  * @returns {String} The `srcdoc` markup.
@@ -39,6 +49,10 @@ const fixtureDocument = {
 const frameDocument = (id, cancelMousedown) =>
     `<!DOCTYPE html><html><head><style>body{margin:0}button{width:100%;height:120px;font:16px sans-serif}</style>` +
     (cancelMousedown ? `<script>document.addEventListener('mousedown', event => event.preventDefault())</script>` : '') +
+    `<script>` +
+    `document.addEventListener('dragover', event => {event.preventDefault(); (window.__nativeDrop ||= {}).dragoverAt ??= Date.now()});` +
+    `document.addEventListener('drop', event => {event.preventDefault(); Object.assign(window.__nativeDrop ||= {}, {droppedAt: Date.now(), plain: event.dataTransfer.getData('text/plain')})})` +
+    `</script>` +
     `</head><body><button id="${id}" type="button">${id}</button></body></html>`;
 
 /**
@@ -80,7 +94,8 @@ class RailIframeWorkspace extends DockWorkspace {
     }
 
     /**
-     * @summary Resolves one pane: an iframe for the three frame items, a plain component otherwise.
+     * @summary Resolves one pane: an iframe for the three frame items, the native drag source for
+     * `source`, a plain component otherwise.
      * @param {String} itemId
      * @param {Object} item
      * @returns {Object}
@@ -92,6 +107,24 @@ class RailIframeWorkspace extends DockWorkspace {
                 id   : 'dock-rail-iframe-pane-pinned',
                 ntype: 'component',
                 vdom : {cn: [{tag: 'span', text: 'Pinned pane'}]}
+            }
+        }
+
+        if (itemId === 'source') {
+            return {
+                cls  : ['dock-rail-iframe-pane'],
+                id   : 'dock-rail-iframe-pane-source',
+                ntype: 'component',
+                // The declared shape a consumer grid uses: the row's id rides the drag store.
+                nativeDragZone: {
+                    delegate     : '.dock-rail-iframe-entity',
+                    effectAllowed: 'copy',
+                    types        : {'text/plain': 'entity:{data-record-id}'}
+                },
+                vdom: {cn: [
+                    {tag: 'span', text: 'Source pane'},
+                    {tag: 'span', cls: ['dock-rail-iframe-entity'], 'data-record-id': 'row-7', style: {display: 'block', padding: '20px'}, text: 'row 7'}
+                ]}
             }
         }
 

--- a/test/playwright/component/apps/dock-rail-iframe/neo-config.json
+++ b/test/playwright/component/apps/dock-rail-iframe/neo-config.json
@@ -3,7 +3,7 @@
     "basePath"        : "../../../../../",
     "environment"     : "development",
     "mainPath"        : "./Main.mjs",
-    "mainThreadAddons": ["DragDrop", "Navigator", "Stylesheet"],
+    "mainThreadAddons": ["DragDrop", "NativeDragSource", "Navigator", "Stylesheet"],
     "themes"          : ["neo-theme-neo-dark", "neo-theme-neo-light"],
     "useSharedWorkers": false
 }

--- a/test/playwright/component/dashboard/DockRailRevealIframe.spec.mjs
+++ b/test/playwright/component/dashboard/DockRailRevealIframe.spec.mjs
@@ -143,3 +143,116 @@ test.describe('Neo.dashboard.dock.interaction.Rail — a reveal and the frame bo
         await expect(page.locator(overlaySel)).toHaveCount(0)
     })
 });
+
+/**
+ * The shield that routes an outside click to the dismissal also removes an outside frame as a
+ * NATIVE drop target: one hit test governs pointer, dragover and drop, which is the side effect the
+ * drag shield's comment in `Global.scss` calls load-bearing. A row native-dragged from the main
+ * document into an outside editor frame while a reveal is open therefore races the dismissal: the
+ * press fires the rail's outside listener, but the overlay hides one vdom round trip later, and
+ * `dragstart` / `dragover` do not wait for that.
+ *
+ * The control proves the instrument with no reveal open. The reveal arm records the ORDER of the
+ * parent's signals — press, drag start, the frame's pointer state at that instant, the overlay
+ * hiding — beside what the frame document received, so the verdict below rests on a measured
+ * sequence rather than on the event model's reputation. Measured at the shield as first written,
+ * the overlay hid AFTER `dragend`, with the frame still shielded at `dragstart` and the drop lost to
+ * the parent; the shield now lifts for a native drag's lifetime (`body.neo-native-drag-active`,
+ * stamped by the `NativeDragSource` addon), which the receipt's `framePointer` at `dragstart` shows.
+ */
+test.describe('Neo.dashboard.dock.interaction.Rail — a native drag across the frame boundary', () => {
+    const
+        SOURCE_SEL = '#dock-rail-iframe-pane-source .dock-rail-iframe-entity',
+        TARGET_SEL = '#dock-rail-iframe-pane-plain',
+        HIDDEN_CLS = 'neo-dashboard-dock-reveal-overlay-hidden';
+
+    /**
+     * Installs the parent-side clocks BEFORE the gesture: the capture-phase drag lifecycle with the
+     * outside frame's computed pointer state at each event, a `drop` reaching the parent (the sign a
+     * shielded frame was hit-tested away), and the overlay's hidden class landing in the DOM.
+     */
+    const traceDrag = (page, overlayId) => page.evaluate(({overlayId, targetSel, hiddenCls}) => {
+        const trace  = window.__railDragTrace = {events: []},
+              target = document.querySelector(targetSel),
+              stamp  = (type, extra={}) => trace.events.push({type, at: Date.now(), framePointer: getComputedStyle(target).pointerEvents, ...extra}),
+              label  = node => `${node.tagName?.toLowerCase()}#${node.id || ''}`;
+
+        ['mousedown', 'dragstart', 'dragend', 'drop'].forEach(type =>
+            document.addEventListener(type, event => stamp(type, {target: label(event.target)}), true));
+
+        const overlay = overlayId && document.getElementById(overlayId);
+
+        if (overlay) {
+            const observer = new MutationObserver(() => {
+                if (!document.contains(overlay) || overlay.classList.contains(hiddenCls)) {
+                    stamp('overlay-hidden');
+                    observer.disconnect()
+                }
+            });
+
+            observer.observe(overlay, {attributes: true, attributeFilter: ['class']});
+            observer.observe(overlay.parentNode, {childList: true})
+        }
+    }, {overlayId, targetSel: TARGET_SEL, hiddenCls: HIDDEN_CLS});
+
+    /**
+     * A real browser drag from the source row to the centre of the plain frame, driven as raw pointer
+     * input: Chromium starts the native drag on the first move after the press and delivers
+     * dragover / drop by hit-testing the target point, exactly as a user's gesture would. A locator
+     * drag would first wait for the frame to become a pointer target, which is the very thing the
+     * shield denies while a reveal is open.
+     */
+    const dragRowIntoPlainFrame = async page => {
+        const source = await page.locator(SOURCE_SEL).boundingBox(),
+              target = await page.locator(TARGET_SEL).boundingBox();
+
+        await page.mouse.move(source.x + source.width / 2, source.y + source.height / 2);
+        await page.mouse.down();
+        await page.mouse.move(target.x + target.width / 2, target.y + target.height / 2, {steps: 4});
+        await page.mouse.up()
+    };
+
+    /** What the plain frame's own document recorded from the live drag store. */
+    const readFrameDrop = page => page.frameLocator(TARGET_SEL).locator('body').evaluate(() => window.__nativeDrop || null);
+
+    /** The lift is a body class for the drag's lifetime; a stuck one would keep the reveal shield down. */
+    const liftResidue = page => page.evaluate(() => document.body.classList.contains('neo-native-drag-active'));
+
+    test('control: with no reveal open, the row drops into the plain frame', async ({page}) => {
+        await traceDrag(page, null);
+        await dragRowIntoPlainFrame(page);
+
+        await expect.poll(() => readFrameDrop(page), {message: 'the frame document received the drop'}).toMatchObject({plain: 'entity:row-7'});
+        expect(await liftResidue(page), 'the drag lift leaves no residue').toBe(false)
+    });
+
+    test('a native drag into an outside frame while a reveal is open: the drop lands, and the press still dismisses', async ({page}, testInfo) => {
+        const overlayId = await reveal(page);
+
+        expect(await page.locator(TARGET_SEL).evaluate(node => getComputedStyle(node).pointerEvents), 'the outside frame is shielded before the press').toBe('none');
+
+        await traceDrag(page, overlayId);
+        await dragRowIntoPlainFrame(page);
+        await page.waitForTimeout(400);
+
+        const trace = await page.evaluate(() => window.__railDragTrace),
+              drop  = await readFrameDrop(page),
+              state = await stateOf(page, overlayId),
+              order = {...trace, frameDrop: drop, revealState: state};
+
+        // The measurement is the receipt, whatever the verdict below says.
+        testInfo.annotations.push({type: 'native-drag-order', description: JSON.stringify(order)});
+        console.log('[#18087 native drag]', JSON.stringify(order));
+
+        expect(drop, 'the frame document received the drop').toMatchObject({plain: 'entity:row-7'});
+        expect(trace.events.find(event => event.type === 'dragstart')?.framePointer, 'the shield had lifted by dragstart').toBe('auto');
+        expect(await liftResidue(page), 'the drag lift leaves no residue').toBe(false);
+
+        await expect.poll(() => stateOf(page, overlayId), {message: 'the press outside the reveal still dismisses it'}).toBe('idle');
+        await expect(page.locator(overlaySel)).toHaveCount(0);
+
+        // The shield is back once the drag is over and the reveal gone: a fresh reveal shields again.
+        await reveal(page);
+        expect(await page.locator(TARGET_SEL).evaluate(node => getComputedStyle(node).pointerEvents), 'the next reveal shields the frame again').toBe('none')
+    })
+});

--- a/test/playwright/unit/main/addon/NativeDragSource.spec.mjs
+++ b/test/playwright/unit/main/addon/NativeDragSource.spec.mjs
@@ -16,7 +16,15 @@ const
     documentRef      = new EventTarget(),
     owners           = {};
 
-documentRef.body           = {};
+// `body` carries the class list the addon stamps for a native drag's lifetime.
+documentRef.body = {
+    classList: {
+        list: new Set(),
+        add(cls)      { this.list.add(cls) },
+        remove(cls)   { this.list.delete(cls) },
+        contains(cls) { return this.list.has(cls) }
+    }
+};
 documentRef.getElementById = id => owners[id] ?? null;
 documentRef.querySelector  = () => null;
 globalThis.document        = documentRef;
@@ -105,6 +113,28 @@ test.describe('Neo.main.addon.NativeDragSource', () => {
         addon.onGestureEnd();
         expect(node.draggable).toBe(false);
         expect(addon.armed).toBe(null)
+    });
+
+    test('a native drag lifts the frame shields for its lifetime: stamped at dragstart, cleared at dragend and by the next press', () => {
+        const node   = registerGrid(),
+              lifted = () => document.body.classList.contains('neo-native-drag-active');
+
+        addon.onMouseDown(press(node));
+        expect(lifted(), 'a press alone lifts nothing').toBe(false);
+
+        addon.onDragStart({target: node, dataTransfer: fakeDataTransfer()});
+        expect(lifted(), 'a drag in flight lifts').toBe(true);
+
+        addon.onGestureEnd();
+        expect(lifted(), 'dragend clears').toBe(false);
+
+        // Any native drag the document starts lifts, armed by this addon or not: a link, an image.
+        addon.onDragStart({target: fakeNode(), dataTransfer: fakeDataTransfer()});
+        expect(lifted(), 'a drag this addon did not arm lifts too').toBe(true);
+
+        // dragend never fires for a source removed mid-drag, so the next press ends a lift instead.
+        addon.onMouseDown(press(fakeNode()));
+        expect(lifted(), 'the next press clears a lift its dragend never ended').toBe(false)
     });
 
     test('secondary presses never arm: context menus and macOS secondary clicks stay menus', () => {


### PR DESCRIPTION
Resolves #18087

While a rail reveal is open, every iframe outside it is `pointer-events: none` so the first outside click reaches the rail's dismissal (#18081) — and one hit test governs pointer, dragover and drop, so the frame is no native drop target either. Grace named the interaction in her review of #18081 without measuring it; measured here on the rail-iframe fixture, it is a defect: the press that starts a drag from a `nativeDragZone` row does dismiss the reveal, but the overlay hides one vdom round trip later, the frame is still shielded at `dragstart`, and the drop is hit-tested onto the parent beneath it, where nothing accepts it. The payload is lost while the reveal closes as intended.

Evidence: the reveal arm's receipt at the shield as first written — `mousedown` t+0 (frame `none`), `dragstart` t+6 ms (frame `none`), `dragend` t+9 ms, overlay hidden t+14 ms, `frameDrop: null`, reveal `idle`. With the fix — `dragstart` t+6 ms (frame `auto`), frame `dragover` t+8 ms, drop t+10 ms with `entity:row-7`, shield back at `dragend`, overlay hidden t+13 ms, the next reveal shields again.

## The change

- `src/main/addon/NativeDragSource.mjs` stamps `neo-native-drag-active` on `body` at `dragstart` — for any native drag the document starts, armed by the addon or not — and clears it at `dragend` and on the next press (a source node removed mid-drag never fires `dragend`; a lift that outlived its drag would keep the shield down).
- `resources/scss/src/dashboard/Container.scss`: the reveal shield's selector excludes that class, so hit-testing at `dragover` time sees the frame with no round trip in the path. The shield returns the instant the drag ends.
- Both shield comments (`Global.scss`, `Container.scss`) now name each other and the invariant they share — Grace's `[TOOLING_GAP]`, in its smallest form.
- Fixture: a left-zone `source` pane carrying the native drag source, on the far side from the rail so a reveal never covers it; every frame document is a drop witness recording the live drag store on its own window. Config adds the `NativeDragSource` addon.
- Spec: the no-reveal control and the measured reveal arm (order of parent signals, frame pointer state per event, what the frame received), a stuck-lift check on both, the re-shield after the drag.
- Unit: the addon's fake `body` gains a class list; one arm covers the stamp's lifetime including the next-press clear.

## AC Evidence

- **AC-1 (arm + control on the fixture, control green at the start):** `DockRailRevealIframe.spec.mjs` — control green before the fix; the reveal arm red-first at the shield as written (receipt above), green with the fix.
- **AC-2 (reveal-open arm green, red-first documented):** 6/6 on the spec after the fix; the pre-fix run's receipt is quoted above.
- **AC-3 (both shield comments name each other and the invariant):** `Global.scss` drag shield + `Container.scss` reveal shield.
- **AC-4 (existing suites green; the outside click still routes to the dismissal):** the four existing arms of the spec pass unchanged on the widened fixture; component/dashboard + component NativeDragZone + unit addon specs below.

## Deltas

- The lift is stamped for every native `dragstart` in the document, not only for drags this addon armed: a link or an image dragged into an editor frame hits the same shield. The ticket named the armed path; the wider scope is the honest one for a document-level fact and costs one class flip.
- Foreign drags (desktop files, another window) never fire `dragstart` here and stay shielded while a reveal is open — the ticket's non-goal, unchanged.

## Test Evidence

- `component/dashboard/DockRailRevealIframe.spec.mjs`: 6 passed (7.9 s) — receipts as above.
- `unit/main/addon/NativeDragSource.spec.mjs` + `unit/component/NativeDragZone.spec.mjs`: 18 passed.
- `component/component/NativeDragZone.spec.mjs` + `component/dashboard/**`: 83 passed (54.1 s).

## Post-Merge Validation

On the Workstation with a rail reveal open, native-drag a row into an editor frame outside the reveal: the drop lands and the reveal closes. A click into an outside frame while a reveal is open still dismisses it (the shield is back the instant a drag ends and is never down without one).

Authored by Mnemosyne (@neo-fable, Claude Fable 5.1, Claude Code) · session 37bbc610-f0cd-4abb-95c2-eb70336a86f3
