### PR TITLE
fix(test): the unit setup installs the worker mock before the hoisted imports evaluate (#18092)

### DIFF
--- a/test/playwright/setup.mjs
+++ b/test/playwright/setup.mjs
@@ -45,6 +45,40 @@ let priorNeoConfigOverrides = null;
  * @param {Boolean} options.mockMain=true True installs a minimal `Neo.Main.setRoute()` method.
  * @param {Object} options.neoConfig={} Neo.config overrides.
  */
+// The worker mock lives at module top level, not inside `setup()`: a spec's static imports are hoisted
+// and evaluate before its `setup()` call runs, and an engine module that constructs a singleton at
+// import — `manager/Window` registers `Neo.currentWorker.on(...)` in its constructor — needs the
+// worker to exist by then. This file is every spec's first import, so its top level is the one place
+// that runs before any engine module. `??=` keeps a spec's own later assignment authoritative.
+Neo.currentWorker ??= {
+    getAddon: async () => ({
+        register  : () => {},
+        unregister: () => {}
+    }),
+    insertThemeFiles: () => {},
+    isSharedWorker  : false,
+    on              : () => {},
+    un              : () => {},
+    promiseMessage  : async (dest, msg) => {
+        if (msg?.action === 'readDom') {
+            if (msg.attributes?.includes('offsetHeight')) {
+                 return { attributes: { offsetHeight: 600, offsetWidth: 800 } };
+            }
+            if (msg.functions?.[0]?.returnFnName === 'transform') {
+                 return { functions: { transform: 'matrix3d(1,0,0,0,0,1,0,0,0,0,1,0,0,0,0,1)' } };
+            }
+            // Fallback for general bounding client rect reads
+            return {
+                attributes: {},
+                functions : {},
+                rects     : [{width: 1000, height: 1000, x: 0, y: 0}]
+            };
+        }
+        return {};
+    },
+    sendMessage     : () => {}
+};
+
 export function setup(options = {}) {
     const {
         appConfig        = {},
@@ -166,35 +200,6 @@ export function setup(options = {}) {
         });
         localStorage.updateLocalStorageItem  ??= async () => {};
     }
-
-    Neo.currentWorker ??= {
-        getAddon: async () => ({
-            register  : () => {},
-            unregister: () => {}
-        }),
-        insertThemeFiles: () => {},
-        isSharedWorker  : false,
-        on              : () => {},
-        un              : () => {},
-        promiseMessage  : async (dest, msg) => {
-            if (msg?.action === 'readDom') {
-                if (msg.attributes?.includes('offsetHeight')) {
-                     return { attributes: { offsetHeight: 600, offsetWidth: 800 } };
-                }
-                if (msg.functions?.[0]?.returnFnName === 'transform') {
-                     return { functions: { transform: 'matrix3d(1,0,0,0,0,1,0,0,0,0,1,0,0,0,0,1)' } };
-                }
-                // Fallback for general bounding client rect reads
-                return {
-                    attributes: {},
-                    functions : {},
-                    rects     : [{width: 1000, height: 1000, x: 0, y: 0}]
-                };
-            }
-            return {};
-        },
-        sendMessage     : () => {}
-    };
 
     Neo.worker ??= {
         App: {


### PR DESCRIPTION
Resolves #18092

`test/playwright/setup.mjs` installed the `Neo.currentWorker` mock inside `setup()`, which a spec calls in its module body — after every static import has evaluated, because ES imports are hoisted. `src/manager/Window.mjs` constructs its singleton at import and registers `Neo.currentWorker.on(...)` in its constructor, so any spec whose static chain reached it threw at load and Playwright reported the file as having no tests. `DemoBWorkspace.spec.mjs` has been in that state since 08-30, when `ai/client/InteractionService.mjs` gained a static import of the window manager (#17862). CI never saw it: Playwright reuses a worker's Node process across files and `globalThis.Neo` survives that reuse, so the file loads whenever another spec ran first in its worker — nearly always with four workers and sixty files. Alone, or first in its worker, it was dead.

Evidence: alone at `dev` → `TypeError: Cannot read properties of undefined (reading 'on')` at `manager/Window.mjs:40`, "No tests found", exit 1 (same under CI's `NEO_TEST_SKIP_CI=true npm run test-unit -- <file>`); after another spec with `--workers=1` → loads. With this change, alone → 59 passed; first in a one-worker pair → passes.

## The change

The block moves to the module top level of `setup.mjs`, beside `globalThis.Neo ??= {}`: this file is every spec's first import, so its top level runs before any engine module evaluates. `??=` keeps a spec's own later assignment authoritative (`PipelineRemoteExecution.spec.mjs` assigns and restores its own worker seam; unaffected). The comment states why it lives there. No change to the window manager: constructing its singleton at import is its production shape.

## AC Evidence

- **AC-1 (the example spec runs alone and first in a pair):** alone 59 passed (3.6 s); `--workers=1` with it first, then `DockActionTooltips.spec.mjs`: both pass.
- **AC-2 (full unit suite green, the pipeline spec keeps its seam):** `npm run test-unit` → 2991 passed (16.7 s).
- **AC-3 (comment):** at the moved block.

## Deltas

None.

## Test Evidence

See AC-1 and AC-2; the red-first receipt is the "No tests found" run at `dev` quoted above.

## Post-Merge Validation

Any unit spec can be run alone by path; a spec importing an engine module that touches `Neo.currentWorker` at import no longer depends on which file its worker ran before it. #18088 (stacked on this branch) carries the first arm added to the example spec since it became runnable again.

Authored by Mnemosyne (@neo-fable, Claude Fable 5.1, Claude Code) · session 37bbc610-f0cd-4abb-95c2-eb70336a86f3
