### PR TITLE
fix(examples): the crossWindow host arms movement beside resize for its window and each vessel (#18088)

### DIFF
--- a/examples/dashboard/crossWindow/DemoBWorkspace.mjs
+++ b/examples/dashboard/crossWindow/DemoBWorkspace.mjs
@@ -506,10 +506,13 @@ class DemoBWorkspace extends Container {
         me.popupDocument    = DemoBWorkspace.createPopupDocument();
         me.popup2Document   = DemoBWorkspace.createPopupDocument();
 
-        // Live-rect authority: every Demo-B render target publishes resize geometry into
-        // manager.Window. Movement-only snapshots make a post-resize conversion compare against
-        // stale extents, violating the metric before threshold calibration even begins.
-        Neo.main.addon.WindowPosition?.setConfigs({observeResize: true, windowId: me.windowId});
+        // Live-rect authority: every Demo-B render target publishes movement AND resize geometry
+        // into manager.Window. Resize alone left the row where the window was born: the pointer path
+        // arms the movement poll only on a document-leaving `mouseout`, which a titlebar placed under
+        // the pointer never produces, so a native titlebar drag ran its claims against a stale rect.
+        // A host that EXTENDS the engine's dock host inherits this pair; one composed from the dock
+        // pieces, as this one is, arms it itself.
+        Neo.main.addon.WindowPosition?.setConfigs({observeMovement: true, observeResize: true, windowId: me.windowId});
 
         // Both workspaces register under their STABLE semantic ids — the seams read/write the
         // live owner fields, so registry resolution always answers with committed truth.
@@ -2984,8 +2987,9 @@ class DemoBWorkspace extends Container {
         if (params.get('hostId') !== me.id) return;
 
         // Geometry-ready is part of child admission: do not publish the connected vessel to any
-        // ownership branch until its Main realm has installed resize observation.
-        await Neo.main.addon.WindowPosition?.setConfigs({observeResize: true, windowId});
+        // ownership branch until its Main realm has installed movement and resize observation — the
+        // same pair the host window armed at construction, for the same reason.
+        await Neo.main.addon.WindowPosition?.setConfigs({observeMovement: true, observeResize: true, windowId});
 
         if (workspaceId === DemoBWorkspace.POPUP_WORKSPACE_ID || workspaceId === DemoBWorkspace.POPUP2_WORKSPACE_ID) {
             if (flow !== 'workspace-target') return;

--- a/src/dashboard/dock/Workspace.mjs
+++ b/src/dashboard/dock/Workspace.mjs
@@ -977,7 +977,10 @@ class Workspace extends Container {
      * is a geometry change the poll never sees). Without both, the manager's row for that window
      * stays the connect-time snapshot and every cross-window claim hit-tests a stale frame. The
      * engine host arms both — for its own window at construction, for each admitted vessel before
-     * ownership publication — so no adopter has to know the addon exists. Overridable for a
+     * ownership publication — so an adopter that EXTENDS this host never has to know the addon
+     * exists. A host COMPOSED from the dock pieces onto a plain container never runs this
+     * constructor and must arm the same pair itself; half of it (resize only) leaves the row blind
+     * to a titlebar drag, which is the defect the composition example carried. Overridable for a
      * realm that publishes geometry another way.
      * @param {String} windowId The render target whose Main realm publishes
      * @returns {Promise<void>|undefined} The addon's remote settle, or `undefined` off the browser

--- a/test/playwright/unit/examples/dashboard/crossWindow/DemoBWorkspace.spec.mjs
+++ b/test/playwright/unit/examples/dashboard/crossWindow/DemoBWorkspace.spec.mjs
@@ -427,6 +427,46 @@ test.describe.serial('Neo.examples.dashboard.crossWindow.DemoBWorkspace', () => 
         }
     });
 
+    test('the composition host arms BOTH geometry streams: its own window at construction, each admitted vessel before publication', async () => {
+        // A host composed from the dock pieces never runs the engine host's constructor, so it does
+        // not inherit `observeWindowGeometry` and has to arm the addon itself — and half of the pair
+        // is the defect: resize alone leaves manager.Window's row where the vessel was born, so a
+        // native titlebar drag of a popup runs its claim against a rect that never follows it. The
+        // pointer path cannot stand in: a titlebar placed under the pointer never produces the
+        // document-leaving `mouseout` that arms the poll.
+        const previous = Neo.main.addon.WindowPosition,
+              calls    = [];
+
+        Neo.main.addon.WindowPosition = {setConfigs: async data => { calls.push(data) }};
+
+        // The stub has to be in place before construction, which is where the host arms its own window.
+        workspace.destroy();
+        workspace = Neo.create(DemoBWorkspace, {});
+
+        const harness = installWindowConnectHarness(workspace);
+        let clickUrl;
+
+        Neo.Main.windowOpen = async data => {
+            clickUrl = data.url;
+            await harness.connect('geometry-child', clickUrl);
+            return true
+        };
+
+        try {
+            expect(calls, 'construction arms the host window for movement and resize')
+                .toContainEqual({observeMovement: true, observeResize: true, windowId: workspace.windowId});
+
+            expect(await workspace.popOutPane('workbench')).toEqual({detached: true, errors: []});
+
+            expect(calls, 'admission arms the vessel for movement and resize')
+                .toContainEqual({observeMovement: true, observeResize: true, windowId: 'geometry-child'});
+            expect(calls.filter(call => call.observeMovement !== true), 'never half of the pair').toEqual([])
+        } finally {
+            harness.restore();
+            Neo.main.addon.WindowPosition = previous
+        }
+    });
+
     test('tear-out connect-before-terminal consumes its grant and a replay stays inert', async () => {
         const harness      = installWindowConnectHarness(workspace),
               pane         = workspace.resolvePane('timeline', initialDocument.items.timeline),


### PR DESCRIPTION
Resolves #18088

**Stacked on #18092's branch** (the example's unit spec could not load alone until that setup fix; this PR's base is `agent/18092-unit-setup-current-worker` and retargets to `dev` when #18092 merges). The diff here is the example, one JSDoc, and the arm.

`DemoBWorkspace` composes the dock pieces onto a plain container, so it never runs the engine host's constructor and does not inherit `observeWindowGeometry` (#18078). It armed `WindowPosition` by hand, and only half of it: `observeResize` at construction and at vessel admission, never `observeMovement`. The pointer path cannot stand in — a titlebar placed under the pointer never produces the document-leaving `mouseout` that arms the poll (#18040) — so a native titlebar drag of a popup ran its claims against the rect the vessel was born with. Grace's non-blocking finding on #18078, V-B-A'd by Clio in the ticket.

Evidence: the unit falsifier at `dev` — `Expected {observeMovement: true, observeResize: true, windowId: null}`, `Received [{observeResize: true, windowId: null}]`; green with the fix, 59 passed on the spec alone.

## The change

- `examples/dashboard/crossWindow/DemoBWorkspace.mjs`: both arming sites pass the pair the host arms for its own adopters — `{observeMovement: true, observeResize: true, windowId}`; the comments say why movement is part of live-rect authority and that a composition host arms it itself.
- `src/dashboard/dock/Workspace.mjs#observeWindowGeometry` JSDoc: names who inherits the arming (extension) and who must call it (composition), and what half of the pair costs — the sentence Grace found narrower than it read.
- `test/playwright/unit/examples/dashboard/crossWindow/DemoBWorkspace.spec.mjs`: one arm stubs the addon before constructing the host, drives a click pop-out through the existing connect harness, and asserts both configs for the host window and for the admitted vessel, and that no call ever carries half of the pair.

**Shape chosen: the ticket's option 1 (example-local pair).** Option 2 (the addon arms itself when loaded) would flip #18040's opt-in contract to default-on and restate `WindowPosition.spec.mjs`'s pointer-owned arm the night before the demo, for four apps that already arm explicitly. The precedent the engine's own adopters teach is the explicit pair, so the example now teaches the same.

## AC Evidence

- **AC-1 (movement and resize recorded for the host window at construction and for a vessel at admission; red on dev):** the arm above — red-first receipt quoted, green now (59/59 alone).
- **AC-2 (shape 2 only):** not applicable — shape 1 chosen.
- **AC-3 (host JSDoc states extension vs composition):** `Workspace.mjs#observeWindowGeometry`.

## Deltas

None beyond the shape choice the ticket delegated.

## Test Evidence

- `unit/examples/dashboard/crossWindow/DemoBWorkspace.spec.mjs` alone: 59 passed (3.6 s) — the first arm added since the spec became runnable alone again (#18092).
- Full unit suite with both commits in the tree: 2991 passed (16.7 s).

## Post-Merge Validation

Open the crossWindow example, pop a pane out, drag the popup by its native titlebar onto the main window: the manager's row follows the popup, so the drop claim hit-tests where the popup is. The example's `DemoBCrossWindowDragNL` stays red for the unrelated `barItemCount` guard the ticket keeps out of scope.

Authored by Mnemosyne (@neo-fable, Claude Fable 5.1, Claude Code) · session 37bbc610-f0cd-4abb-95c2-eb70336a86f3
