### PR TITLE
feat(tab): the inline header paints a flat surface with a hairline in the neo themes (#18095)

### DIFF
--- a/resources/scss/src/apps/workstation/Viewport.scss
+++ b/resources/scss/src/apps/workstation/Viewport.scss
@@ -71,8 +71,8 @@
     --tab-header-action-glyph-color            : var(--workstation-ink-dim);
     --tab-header-action-glyph-color-active     : var(--workstation-signal);
     --tab-header-action-glyph-color-hover      : var(--workstation-signal);
-    // The inline variant's band. The neo themes value this hook with a neutral olive ramp; painted
-    // over this instrument's blue-slate panel it read as a foreign surface, because
+    // The inline variant's band. The neo themes paint a flat semantic surface with a hairline; this
+    // instrument keeps its own two-panel ramp so the header stays inside its blue-slate palette —
     // `background-image` covers the `background-color` the header rule sets below.
     --tab-header-inline-background-image       : linear-gradient(
         180deg,

--- a/resources/scss/src/tab/Container.scss
+++ b/resources/scss/src/tab/Container.scss
@@ -1,9 +1,19 @@
 .neo-tab-container {
-    // The public inline-header hook belongs to the variant selector, not the generic toolbar. A
-    // consumer may set the token on any ancestor; ui:null and standalone containers never match
-    // this rule and therefore keep their established flat paint.
+    // The public inline-header hooks belong to the variant selector, not the generic toolbar. A
+    // consumer may set the tokens on any ancestor; ui:null and standalone containers never match
+    // this rule and therefore keep their established paint. Every fallback is transparent / none,
+    // so a theme that values nothing (the legacy themes) paints exactly what it painted before.
+    //
+    // Longhands only: a `background` shorthand carries an implicit `background-image: none` that
+    // fights any consumer valuing the image hook. The hairline is an INSET shadow rather than a
+    // `border-bottom`: it paints the same line at zero layout cost, so the header's box does not
+    // grow by a pixel under the zero-gap focus geometry and no height-asserting spec moves. The
+    // shadow is one whole-value token (not a colour inside a fixed shadow), so a theme that values
+    // nothing computes exactly `none` rather than a transparent shadow string.
     &.neo-tab-container-inline > .neo-tab-header-toolbar {
+        background-color: var(--tab-header-inline-background-color, transparent);
         background-image: var(--tab-header-inline-background-image, none);
+        box-shadow      : var(--tab-header-inline-box-shadow, none);
     }
 
     &.neo-bottom {

--- a/resources/scss/theme-neo-dark/tab/Container.scss
+++ b/resources/scss/theme-neo-dark/tab/Container.scss
@@ -7,11 +7,12 @@
     --tab-header-action-glyph-color-active         : var(--sem-color-icon-neutral-contrast);
     --tab-header-action-glyph-color-hover          : var(--sem-color-icon-neutral-contrast);
     --tab-header-action-size                       : 24px;
-    --tab-header-inline-background-image           : linear-gradient(
-        180deg,
-        var(--sem-color-surface-neutral-highlighted),
-        var(--sem-color-surface-neutral-default)
-    );
+    // The inline header is a flat panel surface with a hairline under it — the chrome a dock pane
+    // header shares with its neighbours, not a gradient band that reads as its own object. The
+    // image hook stays public and defaults to none; a consumer that wants a ramp values it.
+    --tab-header-inline-background-color           : var(--sem-color-surface-neutral-highlighted);
+    --tab-header-inline-background-image           : none;
+    --tab-header-inline-box-shadow                 : inset 0 -1px 0 var(--sem-color-border-default);
 
     // Embedded pane chrome uses the semantic 32px density tier and releases the free-standing
     // radius. The theme's ui:null contract remains the established 48px / 8px treatment.

--- a/resources/scss/theme-neo-light/tab/Container.scss
+++ b/resources/scss/theme-neo-light/tab/Container.scss
@@ -7,11 +7,12 @@
     --tab-header-action-glyph-color-active         : var(--sem-color-icon-neutral-contrast);
     --tab-header-action-glyph-color-hover          : var(--sem-color-icon-neutral-contrast);
     --tab-header-action-size                       : 24px;
-    --tab-header-inline-background-image           : linear-gradient(
-        180deg,
-        var(--sem-color-surface-neutral-highlighted),
-        var(--sem-color-surface-neutral-default)
-    );
+    // The inline header is a flat panel surface with a hairline under it — the chrome a dock pane
+    // header shares with its neighbours, not a gradient band that reads as its own object. The
+    // image hook stays public and defaults to none; a consumer that wants a ramp values it.
+    --tab-header-inline-background-color           : var(--sem-color-surface-neutral-highlighted);
+    --tab-header-inline-background-image           : none;
+    --tab-header-inline-box-shadow                 : inset 0 -1px 0 var(--sem-color-border-default);
 
     // Embedded pane chrome uses the semantic 32px density tier and releases the free-standing
     // radius. The theme's ui:null contract remains the established 48px / 8px treatment.

--- a/test/playwright/component/dashboard/DockInlineHeaderPaint.spec.mjs
+++ b/test/playwright/component/dashboard/DockInlineHeaderPaint.spec.mjs
@@ -1,0 +1,144 @@
+import {test, expect} from '@playwright/test';
+
+/**
+ * The inline tab header's paint, measured on a rendered dock pane header rather than on stylesheet
+ * text: in both neo themes the header is a flat semantic surface with a hairline under it, and the
+ * public image hook resolves to `none`. Before this contract the themes valued the hook with a
+ * gradient from the highlighted to the default neutral surface — a band that read as its own object
+ * over any host surface, and that the Workstation had to re-value for itself.
+ *
+ * **The control is the point.** A standalone (`ui: null`) tab container in the same document, same
+ * theme, must keep its established paint — no surface colour, no image, no hairline — so a pass
+ * here means the variant selector scoped the tokens, not that a stylesheet leaked them everywhere.
+ * Token values are resolved through probe elements, never by string-matching hex literals, so the
+ * assertion follows the theme's semantic tokens if their core values move.
+ */
+const THEMES = ['neo-theme-neo-dark', 'neo-theme-neo-light'];
+
+const INLINE_HEADER = '.neo-tab-container-inline > .neo-tab-header-toolbar';
+
+let controlId;
+
+test.beforeEach(async ({page}) => {
+    await page.goto('test/playwright/component/apps/dock-lock/index.html');
+    await page.waitForSelector('#dock-lock-workspace', {state: 'attached'});
+    await page.waitForSelector(INLINE_HEADER, {state: 'visible'});
+
+    // The control: a free-standing tab container beside the dock, created through the real class
+    // system so its stylesheet loads and its header renders exactly as a consumer's would.
+    controlId = await page.evaluate(async () => {
+        const viewportId = document.querySelector('.neo-viewport').id,
+              reply      = await Neo.worker.App.createNeoInstance({
+                  importPath: '../tab/Container.mjs',
+                  ntype     : 'tab-container',
+                  parentId  : viewportId,
+                  height    : 120,
+                  items     : [
+                      {ntype: 'component', header: {text: 'Control A'}, html: 'a'},
+                      {ntype: 'component', header: {text: 'Control B'}, html: 'b'}
+                  ]
+              });
+
+        if (!reply.success) throw new Error(`control tab container: ${reply.error.message}`);
+
+        return reply.id
+    });
+
+    await page.waitForSelector(`#${controlId} > .neo-tab-header-toolbar`, {state: 'visible'})
+});
+
+test.afterEach(async ({page}) => {
+    controlId && await page.evaluate(id => Neo.worker.App.destroyNeoInstance(id), controlId)
+});
+
+/** Swap the active theme class on the document element and read back what took effect. */
+const applyTheme = (page, theme) => page.evaluate(name => {
+    for (const el of [document.body, document.documentElement]) {
+        el.classList.forEach(c => c.startsWith('neo-theme-') && el.classList.remove(c))
+    }
+    document.body.classList.add(name);
+    return document.body.className
+}, theme);
+
+/**
+ * Reads the inline header, the control header, and the two semantic tokens the contract names —
+ * each token resolved to the rgb() string a browser computes for it, via a probe element.
+ */
+const measure = (page, controlId) => page.evaluate(id => {
+    const
+        inline  = document.querySelector('.neo-tab-container-inline > .neo-tab-header-toolbar'),
+        control = document.querySelector(`#${id} > .neo-tab-header-toolbar`),
+        resolve = token => {
+            const probe = document.createElement('div');
+
+            probe.style.backgroundColor = `var(${token})`;
+            document.body.appendChild(probe);
+
+            const value = getComputedStyle(probe).backgroundColor;
+
+            probe.remove();
+            return value
+        },
+        paint = el => el && {
+            backgroundColor: getComputedStyle(el).backgroundColor,
+            backgroundImage: getComputedStyle(el).backgroundImage,
+            boxShadow      : getComputedStyle(el).boxShadow,
+            height         : el.getBoundingClientRect().height
+        };
+
+    return {
+        control     : paint(control),
+        inline      : paint(inline),
+        surfaceToken: resolve('--sem-color-surface-neutral-highlighted'),
+        borderToken : resolve('--sem-color-border-default')
+    }
+}, controlId);
+
+test.describe('Neo.tab.Container — the inline header paints a flat surface with a hairline', () => {
+    for (const theme of THEMES) {
+        test(`${theme}: flat semantic surface, hairline, no gradient — and the standalone control keeps its paint`, async ({page}) => {
+            await applyTheme(page, theme);
+
+            const measured = await measure(page, controlId);
+
+            expect(measured.inline, 'an inline dock header must be rendered').toBeTruthy();
+            expect(measured.control, 'the standalone control header must be rendered').toBeTruthy();
+
+            // The tokens must resolve to real colours in this theme, or the arm below is vacuous.
+            expect(measured.surfaceToken, `${theme} values the highlighted neutral surface`).toMatch(/^rgb/);
+            expect(measured.borderToken, `${theme} values the default border`).toMatch(/^rgb/);
+
+            // The measurement: no band, the theme's surface, the theme's hairline.
+            expect(measured.inline.backgroundImage, 'the inline header paints no gradient band').toBe('none');
+            expect(measured.inline.backgroundColor, 'the inline header is the highlighted neutral surface').toBe(measured.surfaceToken);
+            expect(measured.inline.boxShadow, 'the hairline is an inset shadow in the border colour').toContain('inset');
+            expect(measured.inline.boxShadow).toContain(measured.borderToken);
+
+            // The control: same theme, same document, none of it — the variant selector scoped the tokens.
+            expect(measured.control.backgroundImage, 'a standalone header paints no image').toBe('none');
+            expect(measured.control.backgroundColor, 'a standalone header stays transparent').toBe('rgba(0, 0, 0, 0)');
+            expect(measured.control.boxShadow, 'a standalone header carries no hairline').toBe('none')
+        })
+    }
+
+    test('the hairline costs no layout: the inline header keeps its density-tier height', async ({page}) => {
+        await applyTheme(page, 'neo-theme-neo-dark');
+
+        const measured = await measure(page, controlId),
+              tier     = await page.evaluate(() => {
+                  const probe = document.createElement('div');
+
+                  probe.style.height = 'var(--sem-height-large)';
+                  document.body.appendChild(probe);
+
+                  const value = probe.getBoundingClientRect().height;
+
+                  probe.remove();
+                  return value
+              });
+
+        expect(tier, 'the semantic large height must resolve').toBeGreaterThan(0);
+        // An inset shadow paints inside the box; a border-bottom would have added a pixel here.
+        expect(Math.abs(measured.inline.height - tier), 'the inline header is exactly the density tier tall').toBeLessThanOrEqual(1)
+    })
+});

--- a/test/playwright/component/tab/ContainerUi.spec.mjs
+++ b/test/playwright/component/tab/ContainerUi.spec.mjs
@@ -14,7 +14,7 @@ const THEMES = [
 const EXPECTED = {
     'neo-theme-light': {
         actionSize: '20px',
-        gradient  : false,
+        band      : 'none',
         inline    : {fontSize: '11px', fontWeight: '400', height: '25px', padding: '7px 8px 6px',  radius: '0px'},
         null      : {fontSize: '11px', fontWeight: '600', height: '25px', padding: '7px 12px 6px', radius: '0px'},
         standalone: {fontSize: '11px', fontWeight: '600', height: '40px', padding: '7px 16px 6px', radius: '8px'},
@@ -22,7 +22,7 @@ const EXPECTED = {
     },
     'neo-theme-dark': {
         actionSize: '20px',
-        gradient  : false,
+        band      : 'none',
         inline    : {fontSize: '11px', fontWeight: '400', height: '25px', padding: '7px 8px 6px',  radius: '0px'},
         null      : {fontSize: '11px', fontWeight: '600', height: '25px', padding: '7px 12px 6px', radius: '0px'},
         standalone: {fontSize: '11px', fontWeight: '600', height: '40px', padding: '7px 16px 6px', radius: '8px'},
@@ -30,7 +30,7 @@ const EXPECTED = {
     },
     'neo-theme-neo-light': {
         actionSize: '24px',
-        gradient  : true,
+        band      : 'surface',
         inline    : {fontSize: '12px', fontWeight: '400', height: '32px', padding: '4px 8px 3px',  radius: '0px'},
         null      : {fontSize: '16px', fontWeight: '600', height: '48px', padding: '7px 16px 6px', radius: '8px'},
         standalone: {fontSize: '16px', fontWeight: '600', height: '48px', padding: '7px 16px 6px', radius: '8px'},
@@ -38,7 +38,7 @@ const EXPECTED = {
     },
     'neo-theme-neo-dark': {
         actionSize: '24px',
-        gradient  : true,
+        band      : 'surface',
         inline    : {fontSize: '12px', fontWeight: '400', height: '32px', padding: '4px 8px 3px',  radius: '0px'},
         null      : {fontSize: '16px', fontWeight: '600', height: '48px', padding: '7px 16px 6px', radius: '8px'},
         standalone: {fontSize: '16px', fontWeight: '600', height: '48px', padding: '7px 16px 6px', radius: '8px'},
@@ -191,7 +191,9 @@ const readVariant = (page, id) => page.evaluate(componentId => {
           text    = getComputedStyle(button.querySelector('.neo-button-text'));
 
     return {
+        backgroundColor: getComputedStyle(toolbar).backgroundColor,
         backgroundImage: getComputedStyle(toolbar).backgroundImage,
+        boxShadow      : getComputedStyle(toolbar).boxShadow,
         cls            : [...root.classList],
         fontSize       : text.fontSize,
         fontWeight     : text.fontWeight,
@@ -338,9 +340,20 @@ test.describe('Neo.tab.Container — ui variants', () => {
             expect(ordinaryChrome.padding, 'ordinary toolbar actions keep stock button chrome')
                 .not.toBe('0px');
 
-            EXPECTED[theme].gradient
-                ? expect(measured.inline.backgroundImage).toContain('linear-gradient')
-                : expect(measured.inline.backgroundImage).toBe('none');
+            // The inline header's band. The neo themes paint a flat semantic surface with an inset
+            // hairline and value the public image hook `none`; the legacy themes value none of the
+            // inline hooks and keep a transparent header. Neither paints a gradient any more.
+            expect(measured.inline.backgroundImage, 'no theme paints the inline header as a gradient').toBe('none');
+
+            if (EXPECTED[theme].band === 'surface') {
+                expect(measured.inline.backgroundColor, 'the inline header is a theme surface').not.toBe('rgba(0, 0, 0, 0)');
+                expect(measured.inline.boxShadow, 'with a hairline under it').toContain('inset')
+            } else {
+                expect(measured.inline.backgroundColor, 'a theme without inline hooks keeps the header transparent').toBe('rgba(0, 0, 0, 0)');
+                expect(measured.inline.boxShadow).toBe('none')
+            }
+
+            expect(measured.null.boxShadow, 'the hairline belongs to the inline variant alone').toBe('none');
 
             await closeAction.hover();
             expect((await readActionChrome(closeAction)).backgroundColor)
@@ -408,7 +421,7 @@ test.describe('Neo.tab.Container — ui variants', () => {
         }
     });
 
-    test('the inline gradient hook is theme-valued, overridable and cannot leak to ui:null', async ({page}) => {
+    test('the inline header hooks are theme-valued, the image hook overridable, and none of it leaks to ui:null', async ({page}) => {
         await applyTheme(page, 'neo-theme-neo-light');
 
         const before = {
@@ -418,14 +431,21 @@ test.describe('Neo.tab.Container — ui variants', () => {
             null   : await readVariant(page, 'tab-ui-null')
         };
 
+        // Theme-valued: the inline header is a flat surface with a hairline and no gradient …
         expect(before.default.backgroundImage).toBe('none');
-        expect(before.inline.backgroundImage).toContain('linear-gradient');
+        expect(before.inline.backgroundImage, 'the theme values the image hook none').toBe('none');
+        expect(before.inline.backgroundColor, 'the theme values the surface hook').not.toBe('rgba(0, 0, 0, 0)');
+        expect(before.inline.boxShadow, 'the theme values the hairline hook').toContain('inset');
+        // … and a nested ui:null header inside the inline container inherits the tokens as CSS
+        // variables but not the paint: the direct-child variant selector is the only consumer.
         expect(before.nested).toMatchObject({
             backgroundImage: 'none',
+            boxShadow      : 'none',
             height         : '48px',
             radius         : '8px'
         });
         expect(before.null.backgroundImage).toBe('none');
+        expect(before.null.boxShadow).toBe('none');
 
         const after = await page.evaluate(() => {
             const gradient = 'linear-gradient(rgb(1, 2, 3), rgb(4, 5, 6))';


### PR DESCRIPTION
Resolves #18095

> 🌿 *The inline header wore a gradient no host had asked for, and the one app that minded painted over it — after this change, a dock pane header that reads as its own band is unsayable in the neo themes.*

Both neo themes now value the inline tab header as a flat semantic surface with a hairline: `--tab-header-inline-background-image` defaults to `none` (the hook stays public), and two new tokens carry the paint — `--tab-header-inline-background-color` (the highlighted neutral surface) and `--tab-header-inline-box-shadow` (an inset hairline in the default border colour, one whole-value token so a theme that values nothing computes exactly `none`). `src/tab/Container.scss` paints them on the inline variant selector with transparent fallbacks, the hairline as an inset shadow so the header's box does not grow under the zero-gap geometry. Legacy themes and every non-inline header are byte-identical; the Workstation's own two-panel ramp keeps winning on its palette, its comment corrected.

Evidence: L3 (rendered computed-style witness in real Chromium, both neo themes, standalone control) → L3 required (every AC is an in-repo observable; the reveal-pin baselines are a sequenced follow-on, see Post-Merge). Residual: AC-5, Residual-Owner: #18089.

## AC Evidence
| AC-1 | `resources/scss/theme-neo-dark/tab/Container.scss` + `theme-neo-light/tab/Container.scss` — three tokens each (diff); `node buildScripts/util/check-theme-coverage.mjs` ✓ |
| AC-2 | `resources/scss/src/tab/Container.scss` — longhands with `transparent` / `none` fallbacks on the inline variant selector only (diff); the paint witness's standalone control proves nothing leaks to `ui: null` |
| AC-3 | `test/playwright/component/dashboard/DockInlineHeaderPaint.spec.mjs` — red on dev (`background-image` resolves to the gradient) / green at head, both themes + a layout-cost arm; receipts below |
| AC-4 | `resources/scss/src/apps/workstation/Viewport.scss` — the override is untouched, only its comment (diff); the Workstation's inline headers paint from its own tokens before and after |
| AC-5 | `DockPinCollapseNL` reveal-pin baselines show the inline header; recorded once against the final band in the order stated under Post-Merge Validation — Residual-Owner #18089 (PR #18090) |
| AC-6 | `components` in CI; `component/dashboard` 88/88 + `component/tab` 25/25 at head locally — receipts below |

## Deltas from ticket
One, in the hairline token's shape. The ticket named a colour token (`--tab-header-inline-border-color`) inside a fixed inset shadow; the PR ships a whole-value token, `--tab-header-inline-box-shadow`, because a `transparent` colour fallback still computes to a shadow STRING on the legacy themes (`rgba(0, 0, 0, 0) 0px -1px 0px 0px inset`), which the `tab/ContainerUi` spec correctly refused as not byte-identical. With the whole-value token a theme that values nothing computes exactly `none`. The ticket body is corrected in place. The witness also carries the layout-cost arm the ticket implied (the header stays the density tier tall), and `tab/ContainerUi.spec.mjs` — which encoded the gradient as the contract — now asserts the new one per theme (`band: 'surface'` for the neo themes, `'none'` for the legacy ones) while keeping its override-and-no-leak arm.

## Test Evidence
- Red-first: with the four sheets stashed and themes rebuilt at dev's values, `dashboard/DockInlineHeaderPaint` → 2 failed / 1 passed — both theme arms red on `background-image` resolving to `linear-gradient(rgb(41, 45, 40), rgb(14, 15, 13))` (neo-dark) and `linear-gradient(rgb(255, 255, 255), rgb(250, 250, 250))` (neo-light); the layout-cost arm passes on both states, which is what makes it a control. Restored and rebuilt → 3/3.
- `component/dashboard` at head: 88/88 on the first run (includes the three new arms), 87/88 on the second with `DockRailLazyModule.spec.mjs:71` red once and 5/5 alone right after — the first-run flake its author recorded on PR #18063, unrelated to header paint; `component/tab` at head: 25/25 — its `ContainerUi` arms were red on the first push (three arms still asserted the gradient as the contract) and now assert the flat surface + hairline per theme, keeping the override-and-no-leak arm; the CI `OverflowAction.spec.mjs:134` timeout on that run is the known empty-viewport flake (green locally on every run today).
- Before/after paint of the dock-lock fixture's inline header, read off the rendered node on the engine dev server — neo-dark: `rgba(0, 0, 0, 0)` + gradient + no shadow → `rgb(41, 45, 40)` + `none` + `rgb(69, 75, 66) 0px -1px 0px 0px inset`; neo-light: `rgba(0, 0, 0, 0)` + gradient → `rgb(255, 255, 255)` + `none` + `rgb(211, 215, 210) 0px -1px 0px 0px inset`. Crops shared with the operator.
- `PreviewLanguageVisual` frames the Workstation's specimen board (drop previews, no tab header) — unaffected; `WorkstationNL` snapshots paint from the Workstation's own tokens — unaffected.

## Post-Merge Validation
- [ ] `DockPinCollapseNL` reveal-pin baselines: four of the eight (the neo-dark / neo-light pairs) change with the flat band; the legacy-theme pairs do not. PR #18090 (open, re-records all eight after the inline-header trim) merges FIRST, then this PR re-records the four neo ones against the final band before its own merge; if the order flips, #18090 re-records once more on its rebase. One recording against the final band either way.
- [ ] A consumer workspace on the next engine bump shows flat inline headers without any app-level override.

Authored by Vega (Fable 5.1, Claude Code). Session 87c91db1-7fcd-4987-9932-2bf78d3dda25.
