### PR TITLE
fix(workstation): tooltips join the app's floating chrome instead of arriving stock blue (#18096)

### DIFF
--- a/resources/scss/src/apps/workstation/Workspace.scss
+++ b/resources/scss/src/apps/workstation/Workspace.scss
@@ -312,6 +312,27 @@ body:has(.workstation-viewport) .neo-menu-list.neo-tab-overflow-menu {
     }
 }
 
+// The third floating direct-body embodiment, and the newest: the dock header actions gained
+// tooltips, so the shared singleton now paints here — in the stock theme blue, the one piece of
+// chrome not speaking this palette. Same bridge as the overflow menu above, and deliberately the
+// same values: a tooltip and that menu are both transient label chrome and should not disagree
+// about what floating chrome looks like here.
+//
+// The `body:has()` scope is doing real work, not decoration. The theme ships its own
+// `:root .neo-theme-neo-* { --tooltip-bg: … }` at (0,2,0), so a projection written at that same
+// weight — the shape the `--agent-dock-preview-*` block above uses — LOSES the tie on load order,
+// because `theme-neo-*/tooltip/Base.css` is appended after this app's sheets. Those projections
+// work only because nothing else declares them. Naming the floating element directly reaches
+// (0,2,1) and sets the tokens on the node that reads them, so no ancestor has to be guessed —
+// the tooltip is one lazily created instance bound to the main view, not a workspace descendant.
+body:has(.workstation-viewport) .neo-tooltip {
+    --tooltip-bg       : var(--workstation-panel-2);
+    --tooltip-border   : 1px solid color-mix(in srgb, var(--workstation-signal) 42%, var(--workstation-line));
+    --tooltip-boxshadow: 0 12px 28px color-mix(in srgb, var(--workstation-ground) 58%, transparent);
+    --tooltip-color    : var(--workstation-ink);
+    --tooltip-fontsize : 12px;
+}
+
 // Pane skin — `.workstation-placeholder`, `.workstation-resident-*`, `.workstation-data-pane` and
 // `.workstation-heat-*` — moved to `Viewport.scss`. They are what the reported `?popout=` vessel
 // actually hosts, and this file's generated sheet never loads there.

--- a/resources/scss/src/apps/workstation/Workspace.scss
+++ b/resources/scss/src/apps/workstation/Workspace.scss
@@ -318,13 +318,18 @@ body:has(.workstation-viewport) .neo-menu-list.neo-tab-overflow-menu {
 // same values: a tooltip and that menu are both transient label chrome and should not disagree
 // about what floating chrome looks like here.
 //
-// The `body:has()` scope is doing real work, not decoration. The theme ships its own
-// `:root .neo-theme-neo-* { --tooltip-bg: … }` at (0,2,0), so a projection written at that same
-// weight — the shape the `--agent-dock-preview-*` block above uses — LOSES the tie on load order,
-// because `theme-neo-*/tooltip/Base.css` is appended after this app's sheets. Those projections
-// work only because nothing else declares them. Naming the floating element directly reaches
-// (0,2,1) and sets the tokens on the node that reads them, so no ancestor has to be guessed —
-// the tooltip is one lazily created instance bound to the main view, not a workspace descendant.
+// The `body:has()` scope is doing real work, not decoration, and the reason is a weight the two
+// engine sheets do not share. The dock values layer declares its defaults at `:where(.neo-theme-*)`
+// — zero specificity by design — so the `--agent-dock-preview-*` projections in this app's theme
+// files win outright at `:root .neo-theme-*` (0,2,0). The tooltip theme sheet declares at that SAME
+// (0,2,0), so a projection written the same way only ties, and `theme-neo-*/tooltip/Base.css` is
+// appended after this app's sheets, so the tie goes to the theme. Naming the floating element
+// reaches (0,2,1) and wins on weight rather than on order.
+//
+// It also has to be the element rather than an ancestor: the shared singleton stamps the hovered
+// target's theme onto ITSELF, so after this app's runtime light/dark toggle the tooltip carries
+// `neo-theme-neo-light` while `body` still carries `neo-theme-neo-dark`. A body-inherited
+// projection could not follow that; an own-element declaration does.
 body:has(.workstation-viewport) .neo-tooltip {
     --tooltip-bg       : var(--workstation-panel-2);
     --tooltip-border   : 1px solid color-mix(in srgb, var(--workstation-signal) 42%, var(--workstation-line));


### PR DESCRIPTION
Resolves #18096

Related: #18071 / PR #18072 (which made tooltips visible here), #17633 (rail paint tokens — the same promote-then-project pattern), #18036 (the DockLayouts styling guide slot)

The dock header actions gained tooltips, so `apps/workstation` renders the shared tooltip for the first time — in the stock theme blue, the one piece of chrome not speaking its palette. It now joins the overflow menu's bridge, deliberately reusing that block's values: a tooltip and that menu are both transient label chrome and should not disagree about what floating chrome looks like here. The palette tokens differ per theme, so one block serves both.

Evidence: L3 (the rule rendered against live tokens in a real Chromium, both themes, before and after; the dark result read by eye on the running app) → L3 required (the ACs are rendered appearance). Residual: none, with one bound stated under Test Evidence.

## AC Evidence

| AC | Evidence |
|---|---|
| AC-1 — neo-dark computes app-derived paint, not `rgb(62,99,221)` | outside-CI: a `.neo-tooltip` rendered against live tokens computes `background rgb(26,33,44)` (= `--workstation-panel-2` `#1a212c`), `color rgb(214,220,230)` (= `--workstation-ink`), a signal-tinted border and a ground-based elevation. Before the change, the same probe computed `rgb(62,99,221)` |
| AC-2 — neo-light derives independently from its own palette | outside-CI: `background rgb(247,249,252)` (= light `--workstation-panel-2` `#f7f9fc`), `color rgb(31,39,51)` (= light `--workstation-ink`), border mixed against the light `--workstation-signal` `#0f766e`. Both values differ from dark's, so neither theme is reusing the other's literal |
| AC-3 — the projection reaches a tooltip outside the workspace subtree | CI-covered by inspection: the selector names `.neo-tooltip` itself under `body:has(.workstation-viewport)`, so the tokens land on the node that reads them and no ancestor is assumed. See Deltas for why the theme-root shape does not work |
| AC-4 — no engine rule re-declared, no engine default changed | CI-covered by inspection: the diff is one token block in an app stylesheet; `src/tooltip/Base.scss` and both `theme-neo-*/tooltip/Base.scss` are untouched, and the sheet only loads with the Workstation |
| AC-5 — read by eye in the running app | Dark: **read by eye** — screenshot on the running app, tooltips sitting in the app's own language against its chrome. Light: **read by measurement only** — the Browser pane stopped compositing before I could capture it. Stated rather than glossed; the computed values under AC-2 are the evidence for that half |

## Deltas

- **The first shape was wrong, and the reason is the interesting part.** I initially wrote the projection the way this app already projects everything else — `--tooltip-*` beside `--agent-dock-preview-*` in `theme-neo-{dark,light}/apps/workstation/Viewport.scss`. It had no effect at all. The theme ships `:root .neo-theme-neo-* { --tooltip-bg: … }` at **(0,2,0)**, the app's projection block sits at the *same* (0,2,0), and `theme-neo-*/tooltip/Base.css` is appended after this app's sheets — so the tie goes to load order and the theme wins. Measured, not deduced: enumerating every `--tooltip-bg` declaration in `document.styleSheets` showed both selectors present, app first, theme second. **The existing `--agent-dock-preview-*` projections work only because nothing else declares those tokens.** The fix names the floating element directly, reaching (0,2,1).
- **That is also this app's own established idiom**, which is why the block sits where it does: `body:has(.workstation-workspace) .neo-button.neo-tab-overflow-control` and `body:has(.workstation-viewport) .neo-menu-list.neo-tab-overflow-menu` already solve exactly this problem for the two other floating direct-body embodiments. The tooltip is the third, and it belongs beside them rather than in a new place.
- **One block, not two.** My first version tuned the signal mix per theme (14% dark / 8% light) on the argument that a tint reads differently on each ground. The sibling bridges do not do that — they carry one set of mixes and let the palette tokens differ — and consistency with them is worth more than the tuning. Dropped.
- **`--tooltip-fontsize` is included at 12px**; the overflow menu sets the same. `--tooltip-height` and `--tooltip-padding` are left with the engine: structure, not identity.

**Corrected 2026-09-02 (@neo-fable-clio):** I first wrote that those projections "work only because nothing else declares them". They are safe by DESIGN, not by absence — the dock values layer declares its defaults at `:where(.neo-theme-*)`, which carries zero specificity, so a `:root .neo-theme-*` projection beats them outright. The tooltip theme sheet declares at that same `:root .neo-theme-*`, which is why only this token ties and loses on load order (#17293 is the anchor I should have cited).

## Test Evidence

- **Before/after on the rendered rule, not on token values.** A `.neo-tooltip` element was appended to the live document so the engine's own rule ran against the live cascade, then removed. Before: `rgb(62,99,221)` in both themes. After: `rgb(26,33,44)` dark, `rgb(247,249,252)` light.
- **The negative result that redirected the work is recorded above** — the first implementation measured *identically* to the baseline, which is how the specificity tie surfaced. A token change that appears to do nothing is indistinguishable from a token change that was never loaded; enumerating the declarations is what separates them.
- Theme build clean; the compiled rule is present in `dist/development/css/src/apps/workstation/Workspace.css`. **Corrected 2026-09-02:** this line first named `dist/development/css/theme-neo-dark/apps/workstation/Workspace.css`, which does not exist. The check that "confirmed" it was `grep … | head -1 && echo`, whose exit status is `head`'s — and `head` exits 0 on empty input, so the confirmation could not fail. Re-verified with a bare `grep -q` plus a negative control on the wrong path. Caught by @neo-fable-clio in review.
- **Bound, stated plainly:** the light theme was verified by computed values only. The Browser pane stopped compositing frames before I could screenshot it, and I would rather name that than imply a visual read I did not make.

## Post-Merge Validation

- [ ] A look at the light theme by eye on a machine with a live preview, since AC-5's light half rests on measurement. Nothing else — the dark half is read and both halves are measured.

## Commits

- `2dcbcf9752` — the tooltip bridge joins the app's floating chrome.

Authored by Ada (Claude Opus 5, Claude Code). Session 7596538d-5324-419a-b043-95c585d833ea.

Cross-family note: the GPT seats are at 0% weekly quota (operator, 2026-09-01 22:20Z); a fable-family review is the sanctioned exception for an opus-authored PR.

