### PR TITLE
test(dock): the pin arm reads the button's name and glyph once its header has focus (#18100)

### DIFF
--- a/test/playwright/e2e/dashboard/DockPinCollapseNL.spec.mjs
+++ b/test/playwright/e2e/dashboard/DockPinCollapseNL.spec.mjs
@@ -166,11 +166,14 @@ test.describe('Dock pin/collapse round-trip (Neural Link)', () => {
             timeout: 10000
         }).toBeTruthy();
 
+        // The instance is worker truth from the first projection. Its NODE is not: a focus-gated
+        // action that is withdrawn has no DOM node at all (the toolbar withholds it rather than
+        // hiding it, so no stylesheet can resurrect it), and this header holds no focus yet. The
+        // accessible name and glyph are read below, once the gate is open.
         const pinAction = await app.callMethod(inspectorTabsId, 'getActionItem', ['pin']),
               pinButton = page.locator(`#${pinAction.id}`);
 
-        await expect(pinButton).toHaveAttribute('aria-label', 'unpin');
-        await expect(pinButton.locator('.neo-button-glyph')).toHaveClass(/fa-thumbtack-slash/);
+        await expect(pinButton, 'a withdrawn action has no node before its header has focus').toHaveCount(0);
 
         // Product truth #4: §2.7's fail-safe reaches the real product — the center stack projects the
         // action too, but hidden, because main content never rails.
@@ -196,6 +199,8 @@ test.describe('Dock pin/collapse round-trip (Neural Link)', () => {
         // Native gesture: collapse the inspector from its OWN header, once that pane holds focus.
         await focusPane(app, page, 'inspector');
         await expect(pinButton, 'a focused edge-owned pane offers the collapse').toBeVisible({ timeout: 10000 });
+        await expect(pinButton).toHaveAttribute('aria-label', 'unpin');
+        await expect(pinButton.locator('.neo-button-glyph')).toHaveClass(/fa-thumbtack-slash/);
         await pinButton.click();
 
         // Product truth #2: worker truth carries the collapse, committed through the semantic path.


### PR DESCRIPTION
Resolves #18100

Spec only. Since #18069 a focus-gated header action that is withdrawn has no DOM node at all — the toolbar withholds it instead of hiding it, so no consumer stylesheet can resurrect it. The component specs were adapted in that PR; the e2e sibling was not: the first arm of `test/playwright/e2e/dashboard/DockPinCollapseNL.spec.mjs` resolved the inspector's pin action through the worker (worker truth, still valid) and then read the button's `aria-label` and glyph by DOM id while the inspector header held no focus. Red on plain `dev` at line 172, "element(s) not found" — measured by Clio at 14:23Z, reproduced 14:42Z. The four theme arms focus first and were green throughout.

Evidence: red-first run at `dev@4e0e9dd8c3` (the locator error above); with the change, the whole spec 5/5 (arm 1 + four themes) with the e2e config against the Brain runtime root.

## The change

- The two DOM reads move behind `focusPane('inspector')`, next to the `toBeVisible` the arm already asserts before clicking.
- The pre-focus point now asserts the contract explicitly: `toHaveCount(0)` — no node before the gate opens — with a comment saying why (instance is worker truth from the first projection; the node exists only while the header's action gate is open).
- The worker-truth poll (`getActionItem('pin')` resolves before any focus) stays where it was.

## AC Evidence

- **AC-1 (arm 1 green on dev; whole spec 5/5):** run `fix-18100`, 5 passed.
- **AC-2 (worker-truth assertion unchanged in place):** lines 164–167 untouched.
- **AC-3 (diff is the spec only):** one file.

## Deltas

None.

## Test Evidence

- `npx playwright test -c playwright.config.e2e.mjs e2e/dashboard/DockPinCollapseNL.spec.mjs` with `NEO_AGENTOS_RUNTIME_ROOT=<brain>` → 5 passed.
- CI does not run the e2e project (#17853); the receipt above is the evidence, as for #18090.

## Post-Merge Validation

`DockPinCollapseNL.spec.mjs` is 5/5 on a Mac at `dev`. The same contract — no node before focus — is what `DockBootSweep.spec.mjs`'s `openActionGate` encodes on the component side.

Authored by Mnemosyne (@neo-fable, Claude Fable 5.1, Claude Code) · session 37bbc610-f0cd-4abb-95c2-eb70336a86f3
