### PR TITLE
fix(grid): a native drag out of a grid ends the drag-to-scroll gesture it grew out of (#18099)

### DIFF
--- a/src/main/addon/GridDragScroll.mjs
+++ b/src/main/addon/GridDragScroll.mjs
@@ -79,7 +79,16 @@ class GridDragScroll extends Base {
      */
     construct(config) {
         super.construct(config);
-        Neo.bindMethods(this, ['onDragStart', 'onMonitorEnd', 'onMonitorMove'])
+
+        let me = this;
+
+        Neo.bindMethods(me, ['onDragStart', 'onMonitorEnd', 'onMonitorMove', 'onNativeDragStart']);
+
+        // A native HTML5 drag ends the mouse-event stream of the gesture it grew out of: from
+        // `dragstart` on, the browser delivers only `drag*` events, so the `mouseup` a monitor or an
+        // active drag waits for never arrives. Document level, capture, once for the page — the drag
+        // may start on a registered row or on any foreign draggable node.
+        document.addEventListener('dragstart', me.onNativeDragStart, {capture: true})
     }
 
     /**
@@ -314,6 +323,46 @@ class GridDragScroll extends Base {
         document.removeEventListener('mouseup',   me.onMonitorEnd,  {capture: true});
         document.removeEventListener('touchmove', me.onMonitorMove, {capture: true, passive: false});
         document.removeEventListener('touchend',  me.onMonitorEnd,  {capture: true})
+    }
+
+    /**
+     * A native HTML5 drag has begun somewhere in the document — `Neo.main.addon.NativeDragSource`
+     * arms grid rows for one, and any foreign `draggable` node qualifies too. The gesture this addon
+     * was tracking is over at this moment: the browser will not deliver the `mousemove` that would
+     * feed it or the `mouseup` that would end it. A monitor left armed would qualify on the next
+     * button-less pointer move (elapsed time and distance from the original press both pass) and
+     * start a drag-scroll nobody is holding, with the grabbing cursor stuck on the body; an active
+     * drag would keep scrolling under the pointer for the same reason. Both end here — the active
+     * drag without a kinetic tail, since nothing was released.
+     * @param {DragEvent} event
+     */
+    onNativeDragStart(event) {
+        let me = this;
+
+        me.monitorDrag && me.onMonitorEnd(event);
+        me.activeDrag  && me.cancelActiveDrag()
+    }
+
+    /**
+     * Drops an active drag on the floor: no fling, cursor restored, listeners and a running kinetic
+     * frame removed. Tolerates both shapes `activeDrag` takes — the tracked gesture from
+     * {@link #startDrag} and the `{id, animation}` handle {@link #autoScroll} leaves behind.
+     */
+    cancelActiveDrag() {
+        let me                     = this,
+            {animation, listeners} = me.activeDrag;
+
+        animation && cancelAnimationFrame(animation);
+
+        if (listeners) {
+            document.removeEventListener('mousemove', listeners.move, {capture: true});
+            document.removeEventListener('mouseup',   listeners.end,  {capture: true});
+            document.removeEventListener('touchmove', listeners.move, {capture: true, passive: false});
+            document.removeEventListener('touchend',  listeners.end,  {capture: true})
+        }
+
+        document.body.style.removeProperty('cursor');
+        me.activeDrag = null
     }
 
     /**

--- a/test/playwright/component/apps/grid-focus/app.mjs
+++ b/test/playwright/component/apps/grid-focus/app.mjs
@@ -11,6 +11,12 @@ import Viewport      from '../../../../../src/container/Viewport.mjs';
  * store's last row — must land DOM focus on the grid View (the single focus anchor), and a real
  * drag inside a body tall enough to scroll must still scroll it without selecting any text.
  * `#grid-focus-outside` in index.html is the focusable target the leave arm moves focus to.
+ *
+ * The long grid's first three rows are also native HTML5 drag sources (`nativeDragZone`), the way
+ * a consumer grid hands rows to an iframe or another window: a press on one of them turns into a
+ * browser drag after a few pixels, which ends the mouse-event stream the drag-to-scroll addon's
+ * monitor waits on. Rows further down stay plain, so the same body still proves ordinary
+ * drag-to-scroll.
  * @class Neo.test.playwright.GridFocusModel
  * @extends Neo.data.Model
  */
@@ -75,11 +81,15 @@ export const onStart = () => Neo.app({
             store : ShortStore,
             columns
         }, {
-            module: GridContainer,
-            id    : 'grid-focus-long',
-            flex  : 1,
-            store : LongStore,
-            columns
+            module        : GridContainer,
+            id            : 'grid-focus-long',
+            flex          : 1,
+            store         : LongStore,
+            columns,
+            nativeDragZone: {
+                delegate: '.neo-grid-row:nth-child(-n+3)',
+                types   : {'text/plain': '{data-record-id}'}
+            }
         }]
     },
     name: 'Test.Playwright.GridFocus'

--- a/test/playwright/component/apps/grid-focus/neo-config.json
+++ b/test/playwright/component/apps/grid-focus/neo-config.json
@@ -3,7 +3,7 @@
     "basePath"        : "../../../../../",
     "environment"     : "development",
     "mainPath"        : "./Main.mjs",
-    "mainThreadAddons": ["DragDrop", "Navigator", "ResizeObserver", "Stylesheet"],
+    "mainThreadAddons": ["DragDrop", "NativeDragSource", "Navigator", "ResizeObserver", "Stylesheet"],
     "themes"          : ["neo-theme-neo-dark", "neo-theme-neo-light"],
     "useSharedWorkers": false
 }

--- a/test/playwright/component/grid/DragScrollNativeDrag.spec.mjs
+++ b/test/playwright/component/grid/DragScrollNativeDrag.spec.mjs
@@ -1,0 +1,153 @@
+import {test, expect} from '@playwright/test';
+
+/**
+ * A native HTML5 drag out of a grid must end the drag-to-scroll gesture the grid was tracking.
+ * `Neo.main.addon.GridDragScroll` arms a monitor on every left press over a registered body and
+ * waits for `mousemove` / `mouseup` to decide whether the press becomes a drag-scroll. When the
+ * pressed row is a native drag source (`nativeDragZone`), the browser starts an HTML5 drag a few
+ * pixels later and, from `dragstart` on, delivers no mouse events at all for that gesture — the
+ * release the monitor waits for never arrives. Left armed, the monitor qualifies on the next
+ * button-less pointer move (elapsed time and distance from the original press both pass) and starts
+ * a drag-scroll nobody is holding: the grabbing cursor sticks to the body and the grid scrolls under
+ * a plain move until some later click ends it. The fix ends the monitor on the document's
+ * `dragstart`, so these arms measure the addon's gesture state, not the drop.
+ *
+ * The fixture (`apps/grid-focus`) makes the long grid's first three rows native drag sources and
+ * leaves the rest plain, so the control — ordinary drag-to-scroll on the same body — stays reachable
+ * beside the native arms. The outside button is the drop target: nothing handles the drop, which is
+ * the consumer's case as well when a frame refuses the payload.
+ */
+const readAddon = page => page.evaluate(() => {
+    const addon = Neo.main?.addon?.GridDragScroll;
+
+    return {
+        activeDrag : Boolean(addon?.activeDrag),
+        monitorDrag: Boolean(addon?.monitorDrag),
+        bodyCursor : document.body.style.cursor
+    }
+});
+
+const viewIdOf = (page, gridId) => page.locator(`#${gridId} .neo-grid-view`).first().getAttribute('id');
+
+const maxScrollTop = (page, gridId) => page.evaluate(id =>
+    Math.max(0, ...Array.from(document.querySelectorAll(`#${id}, #${id} *`)).map(el => el.scrollTop || 0)), gridId);
+
+/**
+ * Presses on the long grid's first row, holds past the addon's activation delay, drags onto the
+ * outside button and releases there. Returns the drag lifecycle events the document saw, so an arm
+ * can prove the browser really ran a native drag before it reads the addon.
+ * @param {import('@playwright/test').Page} page
+ * @returns {Promise<String[]>}
+ */
+const nativeRowDrag = async page => {
+    await page.evaluate(() => {
+        globalThis.__dragEvents = [];
+        ['dragstart', 'dragend', 'mouseup'].forEach(type =>
+            document.addEventListener(type, () => globalThis.__dragEvents.push(type), {capture: true}))
+    });
+
+    const row    = await page.locator('#grid-focus-long .neo-grid-row:visible').first().boundingBox(),
+          target = await page.locator('#grid-focus-outside').boundingBox(),
+          from   = {x: row.x + 40, y: row.y + row.height / 2},
+          to     = {x: target.x + target.width / 2, y: target.y + target.height / 2};
+
+    await page.mouse.move(from.x, from.y);
+    await page.mouse.down();
+    await page.waitForTimeout(150); // past the addon's delay: the monitor is fully armed
+
+    for (let i = 1; i <= 15; i++) {
+        await page.mouse.move(from.x + (to.x - from.x) * i / 15, from.y + (to.y - from.y) * i / 15);
+        await page.waitForTimeout(30)
+    }
+
+    await page.waitForTimeout(100);
+    await page.mouse.up();
+    await page.waitForTimeout(100);
+
+    return page.evaluate(() => globalThis.__dragEvents)
+};
+
+/**
+ * A plain pointer drag in steps, held past the activation delay — the sibling spec's control.
+ * @param {import('@playwright/test').Page} page
+ * @param {{x: Number, y: Number}} from
+ * @param {{x: Number, y: Number}} to
+ * @returns {Promise<void>}
+ */
+const drag = async (page, from, to) => {
+    await page.mouse.move(from.x, from.y);
+    await page.mouse.down();
+    await page.waitForTimeout(150);
+
+    for (let i = 1; i <= 12; i++) {
+        await page.mouse.move(from.x + (to.x - from.x) * i / 12, from.y + (to.y - from.y) * i / 12);
+        await page.waitForTimeout(25)
+    }
+
+    await page.mouse.up()
+};
+
+test.beforeEach(async ({page}) => {
+    await page.goto('test/playwright/component/apps/grid-focus/index.html');
+    await page.waitForSelector('#grid-focus-long .neo-grid-row', {state: 'visible'});
+    await page.waitForSelector('#grid-focus-short .neo-grid-row', {state: 'visible'});
+    // both bodies registered with the drag-scroll addon — the subject of the contract is in place
+    await expect.poll(() => page.evaluate(() => Neo.main?.addon?.GridDragScroll?.registrations?.size ?? 0), {timeout: 15000})
+        .toBeGreaterThanOrEqual(2);
+    // and the native drag source addon is up, or the row press below never becomes a browser drag
+    await expect.poll(() => page.evaluate(() => Boolean(Neo.main?.addon?.NativeDragSource)), {timeout: 15000}).toBe(true)
+});
+
+test.describe('grid drag-to-scroll — a native drag out of the grid ends the tracked gesture', () => {
+    test('after a native row drag is dropped, the addon holds no gesture and the body cursor is restored', async ({page}) => {
+        const events = await nativeRowDrag(page);
+
+        expect(events, 'the press became a browser drag').toContain('dragstart');
+        expect(events, 'the browser reported the drop').toContain('dragend');
+        expect(events, 'a native drag ends without a mouseup — the event the monitor was waiting for').not.toContain('mouseup');
+
+        await expect.poll(() => readAddon(page), {message: 'no monitor, no active drag, no cursor override survive the drop'})
+            .toEqual({activeDrag: false, monitorDrag: false, bodyCursor: ''})
+    });
+
+    test('a button-less pointer move over the grid after the drop neither starts a drag-scroll nor scrolls the view', async ({page}) => {
+        const events = await nativeRowDrag(page);
+
+        expect(events, 'the press became a browser drag').toContain('dragstart');
+
+        const viewId = await viewIdOf(page, 'grid-focus-long'),
+              box    = await page.locator(`#${viewId}`).boundingBox(),
+              before = await maxScrollTop(page, 'grid-focus-long'),
+              centre = {x: box.x + box.width / 2, y: box.y + box.height / 2};
+
+        // the pointer comes back over the grid with no button held — the operator's "move back"
+        await page.mouse.move(centre.x, centre.y);
+        await page.waitForTimeout(100);
+
+        for (let i = 1; i <= 8; i++) {
+            await page.mouse.move(centre.x, centre.y - i * 20);
+            await page.waitForTimeout(40)
+        }
+
+        await page.waitForTimeout(200);
+
+        expect(await readAddon(page), 'a plain move starts no drag-scroll and sticks no cursor').toEqual({activeDrag: false, monitorDrag: false, bodyCursor: ''});
+        expect(await maxScrollTop(page, 'grid-focus-long'), 'the view did not scroll under a button-less move').toBe(before)
+    });
+
+    test('control: an ordinary drag on a plain row of the same grid still scrolls it', async ({page}) => {
+        // rows below the third are not drag sources — a press there is a drag-scroll, not a browser drag
+        const viewId = await viewIdOf(page, 'grid-focus-long'),
+              box    = await page.locator(`#${viewId}`).boundingBox(),
+              before = await maxScrollTop(page, 'grid-focus-long'),
+              from   = {x: box.x + box.width / 2, y: box.y + box.height * 0.75};
+
+        await drag(page, from, {x: from.x, y: from.y - 160});
+
+        await expect.poll(() => maxScrollTop(page, 'grid-focus-long'), {message: 'the drag scrolled the long grid'}).toBeGreaterThan(before);
+        // a real release restores the cursor and retires the monitor; `activeDrag` itself lives on as
+        // the kinetic tail's frame handle after a fling, which is the addon's established behaviour
+        await expect.poll(() => readAddon(page), {message: 'the release ended the gesture cleanly'})
+            .toMatchObject({monitorDrag: false, bodyCursor: ''})
+    })
+});


### PR DESCRIPTION
Resolves #18099

> 🌿 *A row dragged out of a grid left the grid holding a gesture nobody was making — after this change, a drag-to-scroll that starts under an unpressed pointer is unsayable.*

`Neo.main.addon.GridDragScroll` arms a monitor on every left press over a registered body and waits for `mousemove` / `mouseup` to decide whether the press becomes a drag-scroll. When the pressed row is a native drag source (`nativeDragZone`, armed by `NativeDragSource`), the browser starts an HTML5 drag a few pixels later and from `dragstart` on delivers no mouse events for that gesture at all — the release the monitor (or an already active drag) waits for never arrives. The stale document listener then qualifies on the next button-less move and starts a drag-scroll nobody is holding: grabbing cursor stuck on the body, the grid scrolling under a plain move. The addon now listens for `dragstart` on the document (capture, once per page) and ends whatever it was tracking there — a monitor through `onMonitorEnd`, an active drag through a new `cancelActiveDrag` that restores the cursor and removes listeners and a running kinetic frame without a fling, since nothing was released. The `grid-focus` fixture gains `NativeDragSource` and a `nativeDragZone` on the long grid's first three rows, so the same body proves the native arms and the plain drag-to-scroll control side by side.

Evidence: L3 (real Chromium native drag on a rendered grid, three arms red-first on `dev`) → L3 required (the defect is browser event-stream behaviour; only a real drag can produce it). Residual: none.

## AC Evidence
| AC-1 | `src/main/addon/GridDragScroll.mjs` — `construct` binds and installs the document `dragstart` listener; `onNativeDragStart` + `cancelActiveDrag` (diff). Nothing else in the addon changes; `ClickFocus` 4/4 and `NativeDragZone` 2/2 at head |
| AC-2 | `test/playwright/component/grid/DragScrollNativeDrag.spec.mjs` arm 1 — red on `dev` (`activeDrag: true, bodyCursor: "grabbing"` after the drop), green at head; receipts below |
| AC-3 | same spec, arm 2 — red on `dev` (a button-less move over the grid found `activeDrag: true`, cursor `grabbing`), green at head |
| AC-4 | same spec, arm 3 (control) — the plain drag on a non-source row scrolls the long grid before and after; asserts the cursor restored and the monitor retired, not `activeDrag === null`, see Deltas |
| AC-5 | `component/grid` + `component/dashboard` green at head — receipts below; `NativeDragZone.spec.mjs` unchanged, 2/2 |

## Deltas from ticket
Two, both measured. (1) The ticket expected the active-drag case to end through `onDragEnd({type: 'mouseup'})` (the `unregister` precedent) with an empty history yielding zero velocity. On the fixture the first `mousemove` already exceeds `minDistance`, so the addon holds an ACTIVE drag with one history point when `dragstart` fires — and `onDragEnd`'s fling path would run with whatever two points it finds; a cancel is the honest end for a gesture nobody released, so `cancelActiveDrag` exists and `onNativeDragStart` uses it. (2) The control arm does not assert `activeDrag === null` after an ordinary release: `autoScroll` replaces `activeDrag` with its `{id, animation}` frame handle on every tick and never clears it when the velocity dies — established behaviour, outside this ticket. `cancelActiveDrag` tolerates that shape (it cancels the frame). The related latent defect — `unregister` calling `onDragEnd` after a fling reads `activeDrag.listeners` off that handle — is noted for a follow-up ticket, not fixed here.

## Test Evidence
- Red-first on `dev` (`b59a171562`), fixture and spec in place, addon unfixed: `DragScrollNativeDrag` 3 failed — arm 1 `activeDrag: true, bodyCursor: "grabbing"` after the drop; arm 2 the same after the button-less move back; arm 3 red only on the `activeDrag === null` expectation later dropped (Deltas 2), the scroll assertion green. The fixture's first delegate (`[data-record-id]:nth-child(-n+3)`) matched CELLS, which turned the control's press into a native drag and broke `ClickFocus`'s control as well (3/4); the delegate is `.neo-grid-row:nth-child(-n+3)` and both controls are green.
- At head: `grid/DragScrollNativeDrag` + `grid/ClickFocus` + `component/NativeDragZone` 9/9 (8.1s); `component/grid` + `component/dashboard` — 99/99 (1.0m) — includes the new spec; `unit/grid/LockedColumns` (the one unit spec naming the addon) 12 passed (2.5s).
- Consumer reproduction that motivated the ticket: the operator's grid (rows a native source, drop onto an editor iframe) measured `monitorDrag: true` through `dragstart`/`dragend` with no `mouseup`, then `activeDrag: true` + `grabbing` on the way back — the same mechanism, the monitor shape rather than the active one.

## Post-Merge Validation
- [x] The demo consumer, on the engine bump carrying this commit — measured on the merged head `d488394f34` served to the consumer, headless: `monitorDrag: false, activeDrag: false, cursor: ""` during the drag, after the drop on the editor frame, and after the button-less move back over the grid; `dragstart` and `dragend` seen, no `mouseup`, zero console errors. The operator’s window reloaded onto the same build.
- [x] Follow-up ticket for `unregister` after a fling (Deltas 2): #18104.

Authored by Vega (Fable 5.1, Claude Code). Session 87c91db1-7fcd-4987-9932-2bf78d3dda25.