### PR TITLE
fix(theme): the tooltip value sheets declare at :where() weight so a host projection wins (#18102)

### DIFF
--- a/learn/guides/uibuildingblocks/StylingAndTheming.md
+++ b/learn/guides/uibuildingblocks/StylingAndTheming.md
@@ -302,6 +302,26 @@ The dark theme provides a value for the border variable.
 ```
 The light theme explicitly sets the border variable to `0`. This is called **nullification**. It's critical for nesting. If a light-themed list is placed inside a dark-themed component, this rule ensures the list does not incorrectly inherit the dark theme's 1px border. It actively resets the property defined in the `src` structure.
 
+### Engine Value Sheets Declare at `:where()` Weight
+
+An application projects its own palette into an engine token family at theme-root — `:root .neo-theme-neo-dark { --tooltip-bg: var(--my-panel) }` — and expects to win. Whether it does is a specificity contest, not a load-order one, only if the engine's own value sheet weighs less than the projection. A value sheet that declares at `:root .neo-theme-neo-dark` has the same weight as the projection, (0,2,0), and the tie goes to whichever sheet the browser saw last; the engine appends its per-class theme sheets as components mount, after the application's own, so the engine wins and the projection appears to do nothing.
+
+The engine's value sheets therefore declare at `:where(.neo-theme-neo-dark)` weight — zero specificity — so a projection at theme-root outranks them wherever both match. A component that carries its own theme class (the shared tooltip stamps the hovered target's theme onto itself) is matched by both the engine sheet and the projection, so the contest is decided on that element as well, not left to inheritance.
+
+```scss readonly
+// engine: resources/scss/theme-neo-dark/tooltip/Base.scss
+:where(.neo-theme-neo-dark) {
+    --tooltip-bg: var(--sem-color-surface-primary-default);
+}
+
+// application: theme-neo-dark/apps/myapp/Viewport.scss
+:root .neo-theme-neo-dark {
+    --tooltip-bg: var(--myapp-panel-2);
+}
+```
+
+The dock layer and the tooltip sheets carry this weight today; the remaining value sheets move family by family, each one measured first, because a sheet's own rules may have relied on outranking an equal-weight structure rule. While a family still declares at theme-root weight, project into it with more specificity than the engine sheet — an element-scoped rule such as `body:has(.myapp-viewport) .neo-tooltip` — rather than relying on load order.
+
 ### Bad Practice & The Right Way Forward
 
 While you technically *can* add new selectors or structural overrides inside a theme file, it is considered **bad practice** if you want your theme to be nestable and composable with other themes. Doing so can lead to unpredictable side effects when themes are mixed and matched.

--- a/resources/scss/theme-neo-dark/tooltip/Base.scss
+++ b/resources/scss/theme-neo-dark/tooltip/Base.scss
@@ -1,4 +1,10 @@
-:root .neo-theme-neo-dark { // .neo-tooltip
+// `:where()` is deliberate and load-bearing: zero specificity, so an application projecting into
+// this token family at theme-root (`:root .neo-theme-neo-dark { --tooltip-bg: … }`, (0,2,0)) wins
+// by weight instead of by load order — the engine appends per-class theme sheets after the app's
+// own, so an equal-weight declaration here used to win every tie. The shared tooltip stamps the
+// hovered target's theme class on itself, so both rules match the tooltip element and the contest
+// is decided there, not by inheritance. Same pattern as the dock values layer.
+:where(.neo-theme-neo-dark) { // .neo-tooltip
     // --tooltip-bg            : var(--cmp-tooltip-bg);
     --tooltip-bg            : var(--sem-color-surface-primary-default);
     --tooltip-border        : none;

--- a/resources/scss/theme-neo-light/tooltip/Base.scss
+++ b/resources/scss/theme-neo-light/tooltip/Base.scss
@@ -1,4 +1,10 @@
-:root .neo-theme-neo-light { // .neo-tooltip
+// `:where()` is deliberate and load-bearing: zero specificity, so an application projecting into
+// this token family at theme-root (`:root .neo-theme-neo-light { --tooltip-bg: … }`, (0,2,0)) wins
+// by weight instead of by load order — the engine appends per-class theme sheets after the app's
+// own, so an equal-weight declaration here used to win every tie. The shared tooltip stamps the
+// hovered target's theme class on itself, so both rules match the tooltip element and the contest
+// is decided there, not by inheritance. Same pattern as the dock values layer.
+:where(.neo-theme-neo-light) { // .neo-tooltip
     // --tooltip-bg            : var(--cmp-tooltip-bg);
     --tooltip-bg            : #3E63DD;
     --tooltip-border        : none;

--- a/test/playwright/component/apps/tooltip-theme-projection/app.mjs
+++ b/test/playwright/component/apps/tooltip-theme-projection/app.mjs
@@ -1,0 +1,23 @@
+import Button   from '../../../../../src/button/Base.mjs';
+import Viewport from '../../../../../src/container/Viewport.mjs';
+
+/**
+ * One button with a shared tooltip under the dark neo theme (the body carries the first entry of
+ * `themes`). `index.html` projects `--tooltip-bg` at theme-root — the consumer's documented path —
+ * before any engine theme sheet loads, and leaves every other tooltip token to the engine sheet.
+ */
+export const onStart = () => Neo.app({
+    mainView: {
+        module: Viewport,
+        id    : 'tooltip-theme-projection-viewport',
+        layout: {ntype: 'vbox', align: 'start'},
+        style : {padding: '40px'},
+        items : [{
+            module : Button,
+            id     : 'tooltip-theme-projection-target',
+            text   : 'Hover me',
+            tooltip: {text: 'Projected tooltip'}
+        }]
+    },
+    name: 'Test.Playwright.TooltipThemeProjection'
+});

--- a/test/playwright/component/apps/tooltip-theme-projection/index.html
+++ b/test/playwright/component/apps/tooltip-theme-projection/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Neo.mjs Tooltip Theme Projection Fixture</title>
+    <!--
+        The consumer's documented path: a host projects its palette into an engine token family
+        at theme-root. This sheet is in the document BEFORE the engine's per-class theme sheets,
+        which the Stylesheet addon appends as components mount — the load order a real app has.
+    -->
+    <style>
+        :root .neo-theme-neo-dark { --tooltip-bg: rgb(1, 2, 3); }
+    </style>
+</head>
+<body>
+    <script src="../../../../../src/MicroLoader.mjs" type="module"></script>
+</body>
+</html>

--- a/test/playwright/component/apps/tooltip-theme-projection/neo-config.json
+++ b/test/playwright/component/apps/tooltip-theme-projection/neo-config.json
@@ -1,0 +1,9 @@
+{
+    "appPath"         : "test/playwright/component/apps/tooltip-theme-projection/app.mjs",
+    "basePath"        : "../../../../../",
+    "environment"     : "development",
+    "mainPath"        : "./Main.mjs",
+    "mainThreadAddons": ["DragDrop", "Navigator", "Stylesheet"],
+    "themes"          : ["neo-theme-neo-dark", "neo-theme-neo-light"],
+    "useSharedWorkers": false
+}

--- a/test/playwright/component/tooltip/ThemeProjection.spec.mjs
+++ b/test/playwright/component/tooltip/ThemeProjection.spec.mjs
@@ -1,0 +1,57 @@
+import {test, expect} from '@playwright/test';
+
+/**
+ * A consumer that projects its palette into an engine token family at theme-root — the documented
+ * path — must win against the engine's own theme value sheet, regardless of which sheet loaded
+ * first. The engine's value sheets for the tooltip declare at `:where()` weight for exactly this:
+ * zero specificity, so a `:root .neo-theme-neo-*` projection at (0,2,0) outranks them wherever both
+ * match, and the tooltip — which stamps the hovered target's theme class on itself — is matched by
+ * both. Before that weight, the two declarations tied at (0,2,0) and the engine sheet won on load
+ * order, because the Stylesheet addon appends per-class theme sheets after the host's own.
+ *
+ * The fixture projects one token, `--tooltip-bg`, and nothing else; the control reads a token the
+ * host leaves alone, so a green here means the engine sheet still supplies the family at its new
+ * weight rather than having been wiped by the projection.
+ */
+
+const
+    TARGET    = '#tooltip-theme-projection-target',
+    PROJECTED = 'rgb(1, 2, 3)';
+
+/** Hovers the target from a parked pointer and returns the shown shared tooltip. */
+const showTooltip = async page => {
+    await page.mouse.move(0, 0);
+    await page.locator(TARGET).hover();
+
+    const tooltip = page.locator('.neo-tooltip');
+
+    await expect(tooltip, 'the shared tooltip shows the target text').toHaveText('Projected tooltip');
+    await expect(tooltip, 'and carries the hovered target\'s theme class').toHaveClass(/neo-theme-neo-dark/);
+
+    return tooltip
+};
+
+test.beforeEach(async ({page}) => {
+    await page.goto('test/playwright/component/apps/tooltip-theme-projection/index.html');
+    await page.waitForSelector('#tooltip-theme-projection-viewport', {state: 'attached'});
+    await expect(page.locator(TARGET)).toBeVisible()
+});
+
+test.describe('Neo.tooltip.Base — a theme-root projection outranks the engine value sheet', () => {
+    test('the tooltip paints the host\'s projected ground', async ({page}) => {
+        const tooltip = await showTooltip(page);
+
+        // The projection matches the tooltip element itself (the theme class is on it), so this is
+        // a specificity contest on one element, not an inheritance question.
+        await expect.poll(() => tooltip.evaluate(node => getComputedStyle(node).backgroundColor),
+            {message: 'the ground is the projected value, not the engine sheet\'s'}).toBe(PROJECTED)
+    });
+
+    test('control: a token the host does not project still comes from the engine sheet', async ({page}) => {
+        const tooltip = await showTooltip(page);
+
+        // `--tooltip-fontsize` is the engine sheet's alone; at `:where()` weight it still applies.
+        await expect.poll(() => tooltip.evaluate(node => getComputedStyle(node).getPropertyValue('--tooltip-fontsize').trim()),
+            {message: 'the engine sheet supplies the rest of the family'}).toBe('14px')
+    })
+});


### PR DESCRIPTION
Resolves #18102 (the first case; the remaining sheets are #18107)

A host that projects its palette into an engine token family at theme-root — `:root .neo-theme-neo-dark { --tooltip-bg: … }`, the documented path — tied with the engine's tooltip value sheet at (0,2,0) and lost on load order: the Stylesheet addon appends per-class theme sheets after the host's own. The symptom reads as "the tokens do nothing" (#18098's first shape measured byte-identical to its baseline), and the Workstation grew an element-scoped bridge for what the token layer promised. Both neo tooltip sheets now declare at `:where(.neo-theme-neo-*)`, zero specificity, so a theme-root projection outranks them wherever both match — and both match the tooltip element itself, because the shared tooltip stamps the hovered target's theme class on itself. The pattern is the dock values layer's (#17293).

Evidence: the witness at `dev@4e0e9dd8c3` — projection arm `Expected "rgb(1, 2, 3)" · Received "rgb(62, 99, 221)"` (the engine value won), control green; with the sheets at `:where()` both arms green. Premise checked before the change: `src/tooltip/Base.scss` declares no `--tooltip-*` token on the element (it only reads them), and no public consumer projects the family at theme-root today, so every current consumer renders the same.

## The change

- `resources/scss/theme-neo-{dark,light}/tooltip/Base.scss`: `:root .neo-theme-neo-*` → `:where(.neo-theme-neo-*)`, with the rationale in a comment (why zero weight, why the tooltip element is where the contest is decided).
- Witness: `test/playwright/component/apps/tooltip-theme-projection/` (one button with a shared tooltip; the head sheet projects `--tooltip-bg` alone) + `test/playwright/component/tooltip/ThemeProjection.spec.mjs` (the projection arm, and a control reading `--tooltip-fontsize`, which the host leaves to the engine sheet).
- Guide: `learn/guides/uibuildingblocks/StylingAndTheming.md` §6 gains "Engine Value Sheets Declare at `:where()` Weight" — the two-weight reality, the resolution, and what to do while a family still declares at theme-root weight.

## AC Evidence

- **AC-1 (both tooltip sheets at `:where()`, every other consumer unchanged):** the two sheets; the premise check above; `component/dashboard` + `component/tooltip` green after the theme rebuild (receipt below).
- **AC-2 (component witness, red-first):** the receipt above.
- **AC-3 (guide):** the new §6 subsection; no ticket numbers in the guide.
- **AC-4 (remaining sheets ticketed as a measured sweep):** #18107.

## Deltas

- The witness is single-theme. A two-theme fixture (a light scope under a dark app) hit two engine defects on the way — an item config's own `theme` is dropped at creation (#18105) and `getTheme` cannot see a nested theme (#18106) — both filed with their measurements; the second theme returns to this witness with #18106.
- The Workstation's tooltip bridge from #18098 stays; it is correct and no longer load-bearing, and retiring it is the ticket's stated follow-up.

## Test Evidence

- Red-first: `component/tooltip/ThemeProjection.spec.mjs` at today's sheets → 1 failed (projection arm, engine value), 1 passed (control).
- Green: after `node buildScripts/build/themes.mjs -n -e dev`, the witness 2/2; `component/dashboard` + `component/tooltip` → 94 passed (59.8 s).

## Post-Merge Validation

A consumer projecting `--tooltip-bg` at `:root .neo-theme-neo-dark` sees it on the shared tooltip without an element-scoped bridge; the Workstation renders as before.

Authored by Mnemosyne (@neo-fable, Claude Fable 5.1, Claude Code) · session 37bbc610-f0cd-4abb-95c2-eb70336a86f3
