### PR TITLE
fix(grid): the drag-scroll kinetic tail clears its state and unregister cancels instead of flinging (#18104)

### DIFF
--- a/src/main/addon/GridDragScroll.mjs
+++ b/src/main/addon/GridDragScroll.mjs
@@ -98,7 +98,11 @@ class GridDragScroll extends Base {
         let me                                 = this,
             {friction, registration, velocity} = data;
 
+        // The tail has died: the addon holds no gesture any more. Leaving the last frame handle in
+        // `activeDrag` would make every later reader — `unregister`, a witness, a peer addon — see a
+        // drag that is not there.
         if (Math.abs(velocity.x) < 0.1 && Math.abs(velocity.y) < 0.1) {
+            me.activeDrag = null;
             return
         }
 
@@ -411,6 +415,10 @@ class GridDragScroll extends Base {
     startDrag(monitor, x, y, inputType) {
         let me = this;
 
+        // A press during a kinetic tail takes the grid over: the tail's frame must not keep scrolling
+        // the registration underneath the new gesture.
+        me.activeDrag?.animation && cancelAnimationFrame(me.activeDrag.animation);
+
         me.activeDrag = {
             id          : monitor.id,
             registration: monitor.registration,
@@ -454,9 +462,11 @@ class GridDragScroll extends Base {
                 }
             }
 
-            // If this registration was active, cancel the drag
+            // A grid that is leaving ends its gesture on the floor: no fling for elements about to go,
+            // and `activeDrag` may be the kinetic tail's `{id, animation}` handle rather than a tracked
+            // drag — `cancelActiveDrag` handles both shapes, `onDragEnd` only the tracked one.
             if (me.activeDrag?.id === id) {
-                me.onDragEnd({type: Neo.config.hasTouchEvents ? 'touchend' : 'mouseup'})
+                me.cancelActiveDrag()
             }
 
             me.registrations.delete(id)

--- a/test/playwright/component/grid/DragScrollNativeDrag.spec.mjs
+++ b/test/playwright/component/grid/DragScrollNativeDrag.spec.mjs
@@ -145,9 +145,9 @@ test.describe('grid drag-to-scroll — a native drag out of the grid ends the tr
         await drag(page, from, {x: from.x, y: from.y - 160});
 
         await expect.poll(() => maxScrollTop(page, 'grid-focus-long'), {message: 'the drag scrolled the long grid'}).toBeGreaterThan(before);
-        // a real release restores the cursor and retires the monitor; `activeDrag` itself lives on as
-        // the kinetic tail's frame handle after a fling, which is the addon's established behaviour
+        // a real release restores the cursor, retires the monitor, and once the kinetic tail has
+        // died the addon holds no drag state at all — the poll outlives the tail
         await expect.poll(() => readAddon(page), {message: 'the release ended the gesture cleanly'})
-            .toMatchObject({monitorDrag: false, bodyCursor: ''})
+            .toEqual({activeDrag: false, monitorDrag: false, bodyCursor: ''})
     })
 });

--- a/test/playwright/unit/main/addon/GridDragScroll.spec.mjs
+++ b/test/playwright/unit/main/addon/GridDragScroll.spec.mjs
@@ -1,0 +1,209 @@
+import {setup} from '../../../setup.mjs';
+
+setup({
+    appConfig       : {name: 'MainGridDragScrollUnit'},
+    mockLocalStorage: false,
+    mockMain        : false,
+    neoConfig       : {unitTestMode: true}
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../src/Neo.mjs';
+import * as core      from '../../../../../src/core/_export.mjs';
+
+/**
+ * The drag-to-scroll addon's kinetic tail, and what a grid that leaves mid-gesture finds. A release
+ * with velocity hands the gesture to `autoScroll`, which re-schedules itself per frame and stores
+ * its frame handle as `activeDrag`. Before this contract the tail died by simply not re-scheduling,
+ * leaving that handle behind for good: every later reader saw a drag that was not there, and
+ * `unregister` — which ended a live drag through the mouse-release path — dereferenced listeners
+ * the handle never had, so destroying a grid after a flick threw.
+ *
+ * The addon imports the eager `DomEvents` main-thread singleton (listeners on document and window at
+ * construct) and installs its own document `dragstart` listener; `EventTarget` stand-ins keep the
+ * add/remove semantics real. Frames are pumped by hand, so a tail runs to its velocity floor in one
+ * synchronous call and the test reads the state it leaves.
+ */
+const
+    originalDocument = globalThis.document,
+    originalWindow   = globalThis.window,
+    originalRaf      = globalThis.requestAnimationFrame,
+    originalCaf      = globalThis.cancelAnimationFrame,
+    documentRef      = new EventTarget(),
+    windowRef        = new EventTarget(),
+    frames           = {queue: new Map(), nextId: 1, cancelled: []};
+
+documentRef.body = {
+    classList: {add() {}, remove() {}, contains() { return false }},
+    style    : {
+        cursor: '',
+        setProperty(name, value) { name === 'cursor' && (this.cursor = value) },
+        removeProperty(name)     { name === 'cursor' && (this.cursor = '') }
+    }
+};
+documentRef.documentElement = {};
+windowRef.screenX     = 0;
+windowRef.screenY     = 0;
+windowRef.innerWidth  = 1024;
+windowRef.innerHeight = 768;
+
+const installGlobals = () => {
+    globalThis.document              = documentRef;
+    globalThis.window                = windowRef;
+    globalThis.requestAnimationFrame = callback => {
+        const id = frames.nextId++;
+        frames.queue.set(id, callback);
+        return id
+    };
+    globalThis.cancelAnimationFrame = id => {
+        frames.cancelled.push(id);
+        frames.queue.delete(id)
+    }
+};
+
+installGlobals();
+
+const {default: GridDragScroll} = await import('../../../../../src/main/addon/GridDragScroll.mjs');
+
+/**
+ * Runs queued frames until none re-schedule, or the limit trips.
+ * @param {Number} limit
+ * @returns {Number} frames run
+ */
+const pumpFrames = (limit = 2000) => {
+    let ran = 0;
+
+    while (frames.queue.size && ran < limit) {
+        const [id, callback] = frames.queue.entries().next().value;
+
+        frames.queue.delete(id);
+        callback(performance.now());
+        ran++
+    }
+
+    return ran
+};
+
+const fakeRegistration = id => ({
+    id,
+    bodyElement     : {scrollTop: 500, addEventListener() {}, removeEventListener() {}},
+    containerElement: {scrollLeft: 0}
+});
+
+/**
+ * Tracks a mouse drag on the registration and gives it the recent history a release flings on:
+ * three points inside the addon's 100 ms velocity window, moving up 80 px.
+ * @param {Neo.main.addon.GridDragScroll} addon
+ * @param {Object} registration
+ */
+const trackedDragWithVelocity = (addon, registration) => {
+    addon.startDrag({id: registration.id, registration}, 100, 300, 'mouse');
+
+    const now = Date.now();
+
+    addon.activeDrag.history = [
+        {time: now - 40, x: 100, y: 300},
+        {time: now - 20, x: 100, y: 260},
+        {time: now,      x: 100, y: 220}
+    ];
+    addon.activeDrag.lastY = 220
+};
+
+test.describe('Neo.main.addon.GridDragScroll — the kinetic tail and a grid that leaves mid-gesture', () => {
+    let addon;
+
+    test.beforeEach(() => {
+        // Re-assert the globals: under fully-parallel CI a sibling spec's teardown can replace them
+        // between this file's tests.
+        installGlobals();
+        frames.queue.clear();
+        frames.cancelled.length = 0;
+        documentRef.body.style.cursor = '';
+
+        addon = Neo.create(GridDragScroll, {})
+    });
+
+    test.afterEach(() => {
+        addon.destroy?.()
+    });
+
+    test.afterAll(() => {
+        originalDocument === undefined ? delete globalThis.document              : globalThis.document              = originalDocument;
+        originalWindow   === undefined ? delete globalThis.window                : globalThis.window                = originalWindow;
+        originalRaf      === undefined ? delete globalThis.requestAnimationFrame : globalThis.requestAnimationFrame = originalRaf;
+        originalCaf      === undefined ? delete globalThis.cancelAnimationFrame  : globalThis.cancelAnimationFrame  = originalCaf
+    });
+
+    test('a fling clears activeDrag once its velocity dies', () => {
+        const registration = fakeRegistration('grid-1'),
+              before       = registration.bodyElement.scrollTop;
+
+        addon.registrations.set('grid-1', registration);
+        trackedDragWithVelocity(addon, registration);
+
+        addon.onDragEnd({type: 'mouseup'});
+
+        expect(addon.activeDrag?.animation, 'the release hands the gesture to the kinetic tail').toBeTruthy();
+        expect(documentRef.body.style.cursor, 'the release restores the cursor').toBe('');
+
+        const ran = pumpFrames();
+
+        expect(ran, 'the tail ran frame by frame to its velocity floor').toBeGreaterThan(10);
+        expect(registration.bodyElement.scrollTop, 'the tail scrolled the body').toBeGreaterThan(before);
+        expect(addon.activeDrag, 'no drag state survives the tail').toBeNull()
+    });
+
+    test('unregister during a kinetic tail neither throws nor leaves state behind', () => {
+        const registration = fakeRegistration('grid-1');
+
+        addon.registrations.set('grid-1', registration);
+        trackedDragWithVelocity(addon, registration);
+        addon.onDragEnd({type: 'mouseup'});
+
+        const pending = addon.activeDrag.animation;
+
+        expect(() => addon.unregister({id: 'grid-1'}), 'a grid may leave in the middle of its tail').not.toThrow();
+        expect(frames.cancelled, 'the pending frame is cancelled, not left to scroll a gone grid').toContain(pending);
+        expect(addon.activeDrag).toBeNull();
+        expect(addon.registrations.has('grid-1')).toBe(false)
+    });
+
+    test('control: unregister during a tracked drag restores the cursor and removes the document listeners', () => {
+        const registration = fakeRegistration('grid-1'),
+              removed      = [];
+
+        // Own-property shadow over the prototype method; deleting it restores the original.
+        documentRef.removeEventListener = function(type, listener, options) {
+            removed.push(type);
+            return EventTarget.prototype.removeEventListener.call(this, type, listener, options)
+        };
+
+        addon.registrations.set('grid-1', registration);
+        addon.startDrag({id: 'grid-1', registration}, 100, 300, 'mouse');
+
+        expect(documentRef.body.style.cursor, 'a tracked mouse drag grabs the cursor').toBe('grabbing');
+
+        addon.unregister({id: 'grid-1'});
+        delete documentRef.removeEventListener;
+
+        expect(documentRef.body.style.cursor, 'the cursor override is gone').toBe('');
+        expect(removed, 'both document listeners of the tracked drag are removed').toEqual(expect.arrayContaining(['mousemove', 'mouseup']));
+        expect(addon.activeDrag).toBeNull()
+    });
+
+    test('a press during a kinetic tail cancels the tail before tracking the new gesture', () => {
+        const registration = fakeRegistration('grid-1');
+
+        addon.registrations.set('grid-1', registration);
+        trackedDragWithVelocity(addon, registration);
+        addon.onDragEnd({type: 'mouseup'});
+
+        const pending = addon.activeDrag.animation;
+
+        addon.startDrag({id: 'grid-1', registration}, 80, 80, 'mouse');
+
+        expect(frames.cancelled, 'the tail\'s frame is cancelled by the new press').toContain(pending);
+        expect(addon.activeDrag.listeners, 'the new gesture is a tracked drag').toBeTruthy();
+        expect(addon.activeDrag.history, 'with a fresh history').toHaveLength(1)
+    })
+});


### PR DESCRIPTION
Resolves #18104

> 🌿 *The kinetic tail died by falling silent and left its last frame handle behind as a drag — after this change, a grid that reports a gesture nobody is making, or throws on the way out after a flick, is unsayable.*

`Neo.main.addon.GridDragScroll#autoScroll` re-schedules itself per frame and stores the frame handle as `activeDrag`; at the velocity floor it returned without clearing, so every later reader saw a drag that was not there, and `unregister` — which ended a live drag through the mouse-release path — dereferenced `listeners` the handle never had: destroying a grid after a flick threw. Three small changes: the tail clears `activeDrag` when its velocity dies; `unregister` ends whatever it finds through `cancelActiveDrag` (both shapes, no fling for a grid that is leaving); `startDrag` cancels a running tail before it tracks a new press, so the old frame cannot keep scrolling the registration under the new gesture. The component witness's control arm asserts `activeDrag === null` after a plain release again, which PR #18103 had to leave out for exactly this reason.

Evidence: L2 (unit witness on the addon's plain methods with a hand-pumped frame queue, red-first on `dev`) + L3 (the component control arm re-tightened, green at head) → L2 sufficient for the state machine (the defect is in method bodies the harness calls directly), L3 for the browser tail. Residual: none.

## AC Evidence
| AC-1 | `test/playwright/unit/main/addon/GridDragScroll.spec.mjs` arm 1 — the tail runs to its floor and leaves `activeDrag === null`; red on `dev` (`Received: {"animation": 113, "id": "grid-1"}`) |
| AC-2 | same spec, arm 2 — `unregister` mid-tail neither throws nor leaves state, the pending frame is cancelled; red on `dev` (`TypeError: Cannot read properties of undefined (reading 'move')`) |
| AC-3 | same spec, arm 3 (control) — `unregister` during a tracked drag restores the cursor and removes both document listeners; green on `dev` and at head |
| AC-4 | `test/playwright/component/grid/DragScrollNativeDrag.spec.mjs` control arm asserts `{activeDrag: false, monitorDrag: false, bodyCursor: ''}` after a plain release — 3/3 at head; `unit/main/addon` + `unit/grid` green — receipts below |

## Deltas from ticket
One addition, from the ticket's own Avoided Traps: `startDrag` cancels a running tail's frame before it overwrites `activeDrag` (arm 4 of the unit spec, red on `dev`: the frame survived the new press). No other delta; the ticket's fix shape lands as written.

## Test Evidence
- Red-first on `dev` (`d488394f34`), the spec in place and the addon stashed: 3 failed / 1 passed — arm 1 `activeDrag` still `{"animation": 113, "id": "grid-1"}` after the tail; arm 2 `unregister` throws `TypeError: Cannot read properties of undefined (reading 'move')`; arm 4 the tail's frame survives the new press (`cancelled: []`); the control arm green on both states. Restored: 4/4 (443 ms).
- At head: `unit/main/addon/GridDragScroll` 4/4; `component/grid/DragScrollNativeDrag` 3/3 (the control arm now asserts the cleared state, the poll outliving the tail); `unit/main/addon` + `unit/grid` then `component/grid`: 162 passed (12.9s); 7 passed (8.4s).
- Harness note: the addon imports the eager `DomEvents` singleton, so the spec installs `EventTarget` stand-ins for `document` and `window` before the dynamic import (the `DragDrop` unit spec's pattern) and a hand-pumped `requestAnimationFrame` queue, re-asserted per test for fully-parallel CI.

## Post-Merge Validation
- [ ] A consumer grid flicked and then torn down (dock pane close after a kinetic scroll) logs no `TypeError` from the addon.

Authored by Vega (Fable 5.1, Claude Code). Session 87c91db1-7fcd-4987-9932-2bf78d3dda25.