### PR TITLE
fix(container): an item config's own theme survives creation (#18105)

### DIFF
--- a/src/container/Base.mjs
+++ b/src/container/Base.mjs
@@ -299,8 +299,12 @@ class Container extends Component {
     afterSetTheme(value, oldValue) {
         super.afterSetTheme(value, oldValue);
 
+        // Live items follow a theme change. A raw item config is left to `createItem`, which
+        // resolves its theme with the full precedence — the config's own theme, itemDefaults, the
+        // class default, then this container's; stamping this theme onto the config here would
+        // pre-empt the first three, since `itemDefaults` only fill what is absent.
         value && this.items?.forEach(item => {
-            if (!Neo.isString(item)) {
+            if (!Neo.isString(item) && Neo.typeOf(item) !== 'Object') {
                 item.theme = value
             }
         })
@@ -449,7 +453,10 @@ class Container extends Component {
 
                 if (module && !lazyLoadItem) {
                     item.className = module.prototype.className;
-                    item.theme     = defaults.theme || module.config.theme || me.theme
+                    // The item config's own theme first — the precedence every other item config key
+                    // has — then itemDefaults, the class default, the parent. A nested theme is how
+                    // a light scope lives inside a dark host, and the shared tooltip reads it.
+                    item.theme     = item.theme || defaults.theme || module.config.theme || me.theme
                 }
 
                 if (item.handlerScope === 'this') {

--- a/test/playwright/unit/container/ItemTheme.spec.mjs
+++ b/test/playwright/unit/container/ItemTheme.spec.mjs
@@ -1,0 +1,100 @@
+import {setup} from '../../setup.mjs';
+
+setup({
+    appConfig: {
+        name: 'ContainerItemThemeTest'
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../src/Neo.mjs';
+import * as core      from '../../../../src/core/_export.mjs';
+import Component      from '../../../../src/component/Base.mjs';
+import Container      from '../../../../src/container/Base.mjs';
+
+/**
+ * @summary A component whose class default names a theme, for the class-default rung of the precedence.
+ */
+class LightByDefault extends Component {
+    static config = {
+        className: 'Neo.test.container.ItemTheme.LightByDefault',
+        theme    : 'neo-theme-neo-light'
+    }
+}
+
+LightByDefault = Neo.setupClass(LightByDefault);
+
+const appName = 'ContainerItemThemeTest';
+
+/**
+ * The precedence an item's theme resolves through at creation, from the object branch of
+ * `container.Base#createItem`: the item config's own theme, then `itemDefaults`, then the item
+ * class's default, then the parent's theme — the same order every other item config key has. A
+ * nested theme is the documented feature ("a dark-themed grid inside a light-themed panel"), and
+ * the shared tooltip reads it to decide which theme class to stamp on itself.
+ */
+test.describe('Neo.container.Base — an item config\'s own theme survives creation', () => {
+    let container = null;
+
+    test.afterEach(() => {
+        container?.destroy();
+        container = null
+    });
+
+    test('an item config carrying its own theme keeps it under a differently themed parent', () => {
+        container = Neo.create(Container, {
+            appName,
+            theme: 'neo-theme-neo-dark',
+            items: [{module: Component, theme: 'neo-theme-neo-light'}]
+        });
+
+        const [item] = container.items;
+
+        expect(item.theme, 'the explicit item theme').toBe('neo-theme-neo-light');
+        expect(item.cls, 'and it carries the class, since it differs from the physical parent\'s').toContain('neo-theme-neo-light')
+    });
+
+    test('an item without a theme inherits the parent\'s and carries no class of its own', () => {
+        container = Neo.create(Container, {
+            appName,
+            theme: 'neo-theme-neo-dark',
+            items: [{module: Component}]
+        });
+
+        const [item] = container.items;
+
+        expect(item.theme).toBe('neo-theme-neo-dark');
+        expect(item.cls, 'inherited from the physical parent: no local carrier').not.toContain('neo-theme-neo-dark')
+    });
+
+    test('itemDefaults outrank the class default, and the class default outranks the parent', () => {
+        container = Neo.create(Container, {
+            appName,
+            theme       : 'neo-theme-neo-dark',
+            itemDefaults: {theme: 'neo-theme-light'},
+            items       : [{module: Component}, {module: LightByDefault}]
+        });
+
+        expect(container.items[0].theme, 'itemDefaults over the parent').toBe('neo-theme-light');
+        expect(container.items[1].theme, 'itemDefaults over the class default').toBe('neo-theme-light');
+
+        container.destroy();
+        container = Neo.create(Container, {
+            appName,
+            theme: 'neo-theme-neo-dark',
+            items: [{module: LightByDefault}]
+        });
+
+        expect(container.items[0].theme, 'the class default over the parent').toBe('neo-theme-neo-light')
+    });
+
+    test('an item config theme outranks itemDefaults, like every other item config key', () => {
+        container = Neo.create(Container, {
+            appName,
+            itemDefaults: {theme: 'neo-theme-light'},
+            items       : [{module: Component, theme: 'neo-theme-neo-light'}]
+        });
+
+        expect(container.items[0].theme).toBe('neo-theme-neo-light')
+    })
+});


### PR DESCRIPTION
Resolves #18105

An item declared as a config object with its own `theme` never got it. Two places pre-empted it, and the ticket had found one:

1. `src/container/Base.mjs#createItem`, object branch: `item.theme = defaults.theme || module.config.theme || me.theme` never consulted `item.theme` — the class branch a few lines above spreads the instance config last and keeps it, so the two ways of declaring the same item disagreed.
2. `src/container/Base.mjs#afterSetTheme` stamped the container's theme onto raw item configs before they were created (`theme` is applied before `items` at construction). With (1) fixed alone, the creation rung saw the parent's theme already on the config, and `itemDefaults` — which `Neo.assignDefaults` applies only where absent — never applied either: the arm for "itemDefaults over the parent" went red the moment (1) landed, which is how (2) was found.

Evidence: the new unit spec at `dev@f6811898ed` — "an item config carrying its own theme keeps it" `Expected "neo-theme-neo-light" · Received "neo-theme-neo-dark"`, and "an item config theme outranks itemDefaults" `Received "neo-theme-light"`; the two other rungs green. With (1) only: the explicit theme still lost to the parent and "itemDefaults over the parent" turned red. With both: 4/4; full unit suite 3010 passed (18.7 s).

## The change

- `createItem`: `item.theme = item.theme || defaults.theme || module.config.theme || me.theme` — the config's own theme, then `itemDefaults`, then the class default, then the parent: the precedence every other item config key already has.
- `afterSetTheme`: live instances follow a theme change; raw item configs (`Neo.typeOf(item) === 'Object'`, which also covers lazy module configs) are left to `createItem`, which resolves the parent rung from `me.theme` anyway.
- `test/playwright/unit/container/ItemTheme.spec.mjs`: four arms over the rungs.

## AC Evidence

- **AC-1 (explicit item theme kept under a different parent, class carried; red on dev):** arm 1, receipt above.
- **AC-2 (itemDefaults, class default, parent — unchanged precedence for the existing cases):** arms 2 and 3 green before and after; arm 4 pins config-over-itemDefaults.
- **AC-3 (lazy items keep their path):** lazy configs are plain objects, skipped by the propagation and resolved when their module loads, as before.

## Deltas

- A second cause beyond the ticket's (the propagation onto raw configs), fixed in the same PR because the first fix alone turns an existing precedence red; both are in one file and one spec covers both.
- Not changed: a live instance with an explicit nested theme still follows a later theme change of its parent (the propagation onto instances is the existing semantics; a parent theme switch flows down). Out of the ticket's scope; noted for whoever meets it.

## Test Evidence

- `unit/container/ItemTheme.spec.mjs`: red-first 2 failed / 2 passed; now 4 passed.
- Full unit suite: 3010 passed (18.7 s).

## Post-Merge Validation

A `{module: Container, theme: 'neo-theme-neo-light'}` item under a dark viewport renders with `neo-theme-neo-light` on its root and hands the theme to its children. The shared tooltip's theme inside such a scope still needs #18106 (`getTheme` cannot see the nested theme on the way out).

Authored by Mnemosyne (@neo-fable, Claude Fable 5.1, Claude Code) · session 37bbc610-f0cd-4abb-95c2-eb70336a86f3
