### PR TITLE
fix(component): getTheme answers the closest theme through the component chain (#18106)

### DIFF
--- a/src/component/Base.mjs
+++ b/src/component/Base.mjs
@@ -1508,32 +1508,34 @@ class Component extends Abstract {
     }
 
     /**
-     * Walks up the vdom tree and returns the closest theme found
+     * @summary Returns the closest theme: this component's own, then the nearest ancestor's along
+     * the component chain, then the window's or app's default.
+     *
+     * The inherited theme travels as a config (`container.Base#afterSetTheme` propagates it), and a
+     * child inside a themed scope carries no theme class of its own by design, so the theme config
+     * is the first thing to read at every level; a class is read as well, for a component that
+     * carries a theme class without the config. The walk follows components, not vdom nodes: a
+     * parent's vdom holds its children as component references whose `cls` says nothing about the
+     * theme, so a vdom walk sees a nested scope as empty and answers the app default instead.
      * @returns {String}
      */
     getTheme() {
         let me         = this,
             themeMatch = 'neo-theme-',
-            mainView, parentNodes;
+            component  = me;
 
-        for (const item of me.cls || []) {
-            if (item.startsWith(themeMatch)) {
-                return item
+        while (component) {
+            if (component.theme) {
+                return component.theme
             }
-        }
 
-        mainView = me.app?.mainView;
-
-        if (mainView) {
-            parentNodes = VDomUtil.getParentNodes(mainView.vdom, me.id);
-
-            for (const node of parentNodes || []) {
-                for (const item of node.cls || []) {
-                    if (item.startsWith(themeMatch)) {
-                        return item
-                    }
+            for (const item of component.cls || []) {
+                if (item.startsWith(themeMatch)) {
+                    return item
                 }
             }
+
+            component = component.parent
         }
 
         return (Neo.windowConfigs?.[me.windowId] || Neo.config).themes?.[0]

--- a/test/playwright/component/apps/tooltip-nested-theme/app.mjs
+++ b/test/playwright/component/apps/tooltip-nested-theme/app.mjs
@@ -1,0 +1,57 @@
+import Button    from '../../../../../src/button/Base.mjs';
+import Container from '../../../../../src/container/Base.mjs';
+import Viewport  from '../../../../../src/container/Viewport.mjs';
+
+/**
+ * @summary A container that carries the light theme as its class default, so item creation hands
+ * it to the container and its children.
+ * @class Test.Playwright.Component.TooltipNestedTheme.LightScope
+ * @extends Neo.container.Base
+ */
+class LightScope extends Container {
+    static config = {
+        /**
+         * @member {String} className='Test.Playwright.Component.TooltipNestedTheme.LightScope'
+         * @protected
+         */
+        className: 'Test.Playwright.Component.TooltipNestedTheme.LightScope',
+        /**
+         * @member {String} theme='neo-theme-neo-light'
+         */
+        theme: 'neo-theme-neo-light'
+    }
+}
+
+LightScope = Neo.setupClass(LightScope);
+
+/**
+ * Two buttons with shared tooltips: one under the dark body theme (the first entry of `themes`),
+ * one inside a light scope. The shared tooltip stamps the hovered target's theme class on itself,
+ * so hovering the second must give a light tooltip inside a dark app.
+ */
+export const onStart = () => Neo.app({
+    mainView: {
+        module: Viewport,
+        id    : 'tooltip-nested-theme-viewport',
+        layout: {ntype: 'vbox', align: 'start'},
+        style : {gap: '40px', padding: '40px'},
+        items : [{
+            module : Button,
+            id     : 'tooltip-nested-theme-dark',
+            text   : 'Dark target',
+            tooltip: {text: 'Dark tooltip'}
+        }, {
+            module: LightScope,
+            id    : 'tooltip-nested-theme-scope',
+            layout: {ntype: 'vbox', align: 'start'},
+            style : {padding: '20px'},
+            items : [{
+                module : Button,
+                id     : 'tooltip-nested-theme-light',
+                text   : 'Light target',
+                tooltip: {text: 'Light tooltip'}
+            }]
+        }]
+    },
+    name: 'Test.Playwright.TooltipNestedTheme'
+});

--- a/test/playwright/component/apps/tooltip-nested-theme/index.html
+++ b/test/playwright/component/apps/tooltip-nested-theme/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Neo.mjs Tooltip Nested Theme Fixture</title>
+</head>
+<body>
+    <script src="../../../../../src/MicroLoader.mjs" type="module"></script>
+</body>
+</html>

--- a/test/playwright/component/apps/tooltip-nested-theme/neo-config.json
+++ b/test/playwright/component/apps/tooltip-nested-theme/neo-config.json
@@ -1,0 +1,9 @@
+{
+    "appPath"         : "test/playwright/component/apps/tooltip-nested-theme/app.mjs",
+    "basePath"        : "../../../../../",
+    "environment"     : "development",
+    "mainPath"        : "./Main.mjs",
+    "mainThreadAddons": ["DragDrop", "Navigator", "Stylesheet"],
+    "themes"          : ["neo-theme-neo-dark", "neo-theme-neo-light"],
+    "useSharedWorkers": false
+}

--- a/test/playwright/component/tooltip/NestedTheme.spec.mjs
+++ b/test/playwright/component/tooltip/NestedTheme.spec.mjs
@@ -1,0 +1,39 @@
+import {test, expect} from '@playwright/test';
+
+/**
+ * The shared tooltip follows the hovered target's theme scope: it stamps that scope's theme class
+ * on itself, so a light scope inside a dark app gets a light tooltip. The scope's child carries no
+ * theme class of its own (it inherits), so the answer has to come from the component chain's theme
+ * configs — a walk over vdom nodes sees the scope as a component reference with no classes and
+ * falls back to the app default, which paints the tooltip dark inside the light scope.
+ */
+
+const targets = {
+    dark : {sel: '#tooltip-nested-theme-dark',  text: 'Dark tooltip',  theme: 'neo-theme-neo-dark'},
+    light: {sel: '#tooltip-nested-theme-light', text: 'Light tooltip', theme: 'neo-theme-neo-light'}
+};
+
+test.beforeEach(async ({page}) => {
+    await page.goto('test/playwright/component/apps/tooltip-nested-theme/index.html');
+    await page.waitForSelector('#tooltip-nested-theme-viewport', {state: 'attached'});
+    await expect(page.locator(targets.dark.sel)).toBeVisible();
+    await expect(page.locator(targets.light.sel)).toBeVisible();
+
+    // The scope renders its theme class; its child inherits without one — the shape under test.
+    await expect(page.locator('#tooltip-nested-theme-scope')).toHaveClass(/neo-theme-neo-light/);
+    await expect(page.locator(targets.light.sel)).not.toHaveClass(/neo-theme-/)
+});
+
+test.describe('Neo.tooltip.Base — the shared tooltip takes the hovered target\'s scope theme', () => {
+    for (const [name, {sel, text, theme}] of Object.entries(targets)) {
+        test(`hovering the ${name} target stamps its scope's theme on the tooltip`, async ({page}) => {
+            await page.mouse.move(0, 0);
+            await page.locator(sel).hover();
+
+            const tooltip = page.locator('.neo-tooltip');
+
+            await expect(tooltip, 'the shared tooltip shows the target text').toHaveText(text);
+            await expect(tooltip, `and carries ${theme}`).toHaveClass(new RegExp(theme))
+        })
+    }
+});

--- a/test/playwright/unit/component/GetTheme.spec.mjs
+++ b/test/playwright/unit/component/GetTheme.spec.mjs
@@ -1,0 +1,79 @@
+import {setup} from '../../setup.mjs';
+
+setup({
+    appConfig: {
+        name: 'ComponentGetThemeTest'
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../src/Neo.mjs';
+import * as core      from '../../../../src/core/_export.mjs';
+import Component      from '../../../../src/component/Base.mjs';
+import Container      from '../../../../src/container/Base.mjs';
+
+/**
+ * @summary A container whose class default names the light theme, so its children inherit it
+ * through the class-default rung of item creation.
+ */
+class LightScope extends Container {
+    static config = {
+        className: 'Neo.test.component.GetTheme.LightScope',
+        theme    : 'neo-theme-neo-light'
+    }
+}
+
+LightScope = Neo.setupClass(LightScope);
+
+const appName = 'ComponentGetThemeTest';
+
+/**
+ * `getTheme()` answers the closest theme. A child of a themed scope inherits the theme as a config
+ * and, by design, carries no class of its own; a parent's vdom holds it as a component reference,
+ * whose `cls` is empty. So the answer has to come from the theme configs on the component chain,
+ * not from a walk over vdom nodes — that walk finds nothing and falls back to the app default,
+ * which is what the shared tooltip then stamps on itself inside a nested scope.
+ */
+test.describe('Neo.component.Base#getTheme — the closest theme through the component chain', () => {
+    let root = null;
+
+    test.afterEach(() => {
+        root?.destroy();
+        root = null
+    });
+
+    test('a child of a themed scope answers the scope\'s theme, without a class of its own', () => {
+        root = Neo.create(Container, {
+            appName,
+            theme: 'neo-theme-neo-dark',
+            items: [{module: LightScope, items: [{module: Component}]}]
+        });
+
+        const scope = root.items[0],
+              child = scope.items[0];
+
+        expect(scope.cls, 'the scope carries its class').toContain('neo-theme-neo-light');
+        expect(child.cls, 'the child inherits, no local carrier').not.toContain('neo-theme-neo-light');
+        expect(child.getTheme(), 'the closest theme is the scope\'s').toBe('neo-theme-neo-light')
+    });
+
+    test('a component with its own theme answers its own', () => {
+        root = Neo.create(Container, {
+            appName,
+            theme: 'neo-theme-neo-dark',
+            items: [{module: LightScope}]
+        });
+
+        expect(root.items[0].getTheme()).toBe('neo-theme-neo-light');
+        expect(root.getTheme()).toBe('neo-theme-neo-dark')
+    });
+
+    test('a component with no theme anywhere on its chain answers the app default', () => {
+        root = Neo.create(Container, {
+            appName,
+            items: [{module: Component}]
+        });
+
+        expect(root.items[0].getTheme()).toBe(Neo.config.themes?.[0])
+    })
+});


### PR DESCRIPTION
Resolves #18106

`component.Base#getTheme` resolved the closest theme through `VDomUtil.getParentNodes(mainView.vdom, me.id)`, scanning each parent node's `cls`. A parent's vdom holds its children as component references, and `getParentNodes` collects those reference objects (`{componentId}`), whose `cls` is empty — the theme class sits on the referenced component's own root. So a nested scope was invisible to the walk, and the method returned the app default. The inherited theme travels as a config (`container.Base#afterSetTheme` propagates it) and, by design, puts no class on a child inside a themed scope (`component.Base#afterSetTheme` omits the local carrier when the physical parent has the same theme) — the one place the answer was already known was never read. Consequence: the shared tooltip (`applySingletonTargetConfig` → `resolveTargetTheme` → `target.getTheme()`) stamped the app theme on itself inside a light scope under a dark app.

Evidence: unit arm "a child of a themed scope answers the scope's theme" at `dev@f6811898ed` — `Expected "neo-theme-neo-light" · Received "neo-theme-light"` (the harness's app default); component arm "hovering the light target stamps its scope's theme" — the tooltip carried `neo-theme-neo-dark`. Both green with the change.

## The change

- `getTheme` walks the component chain: at each level the `theme` config, then a `neo-theme-*` class in `cls`; `parent` (the logical owner first, then the physical parent) — the engine's own theming comment names the logical owner as the scope a floating embodiment belongs to, which is the "closest theme" a tooltip or menu wants; then the window's or app's default as before. The tooltip's DOM-path fallback for data-attribute targets is untouched.
- `test/playwright/unit/component/GetTheme.spec.mjs`: nested scope (red-first), own theme, no theme anywhere.
- `test/playwright/component/apps/tooltip-nested-theme/` + `test/playwright/component/tooltip/NestedTheme.spec.mjs`: a dark button and a button inside a light scope (a subclass with a class-default theme, so the fixture does not depend on #18105); the `beforeEach` pins the shape under test (the scope carries its class, the child does not); each hover asserts the tooltip's theme class.

## AC Evidence

- **AC-1 (unit, three rungs, nested red on dev):** receipt above; 3/3 now.
- **AC-2 (component: light tooltip inside a light scope under a dark app; red on dev):** receipt above; 2/2 now.
- **AC-3 (existing tooltip and theme suites green):** full unit suite and `component/tooltip` + `component/dashboard` below.

## Deltas

- The component witness is its own fixture rather than an extension of #18102's (PR #18108, unmerged); extending that one would have coupled the two PRs. Once both are in, #18102's witness can gain its light arm in a follow-up.

## Test Evidence

- `unit/component/GetTheme.spec.mjs`: red-first 1 failed / 2 passed; now 3 passed.
- Full unit suite: 3009 passed (16.8 s).
- `component/tooltip` + `component/dashboard`: 94 passed (1.0 m) (red-first for `NestedTheme.spec.mjs`: 1 failed / 1 passed).

## Post-Merge Validation

Hovering any target inside a nested theme scope shows a tooltip in that scope's theme. Callers of `getTheme()` other than the tooltip receive the same answers as before for un-nested components (own class or app default) and the correct one for nested ones.

Authored by Mnemosyne (@neo-fable, Claude Fable 5.1, Claude Code) · session 37bbc610-f0cd-4abb-95c2-eb70336a86f3
