### PR TITLE
fix(workstation): a native titlebar drop onto the main window parks on the move, not on a focus the platform never grants (#18112)

### DIFF
--- a/apps/workstation/view/Workspace.mjs
+++ b/apps/workstation/view/Workspace.mjs
@@ -254,6 +254,13 @@ class Workspace extends DockWorkspace {
      */
     tearOutParkGeometries = {}
     /**
+     * Park attempts per vessel item id since that vessel last parked. The coordinator retries a
+     * refused park; a stalled retry reads live as a rising count with the same `refusedAt`.
+     * @member {Object} tearOutParkAttempts={}
+     * @protected
+     */
+    tearOutParkAttempts = {}
+    /**
      * Exact `{tabsNodeId, index}` placement captured at each detach commit — the return truth.
      * @member {Object} tearOutPlacements={}
      * @protected
@@ -3055,6 +3062,7 @@ class Workspace extends DockWorkspace {
 
         if (disposed) {
             delete me.tearOutParkGeometries[itemId];
+            delete me.tearOutParkAttempts[itemId];
 
             route?.nativeHandleKey && await Neo.main.addon.DragDrop.retireWindowDragOrphanRecovery({
                 nativeHandleKey: route.nativeHandleKey,
@@ -3075,8 +3083,12 @@ class Workspace extends DockWorkspace {
      * resize / move / refocus chain is the platform-law choreography (z-order hides the parked
      * vessel). A source whose outer frame cannot fit behind the target first shrinks through its
      * exact native route; a refocus refusal compensates to the original extent and source rect.
+     * On the native-titlebar path to the MAIN window the focus and refocus steps are best-effort
+     * and recorded, and only the move gates — the platform never grants a popup an opener focus
+     * without a user activation, and an OS titlebar drag carries none (see the focus verb below).
      * @param {Object} vessel
      * @param {String} vessel.itemId
+     * @param {Boolean} [vessel.nativeTitlebar=false] The park follows an OS titlebar drag terminal
      * @param {String} vessel.windowName
      * @returns {Promise<Boolean>}
      * @protected
@@ -3145,6 +3157,8 @@ class Workspace extends DockWorkspace {
         };
         me.lastVesselRestoreReceipt = null;
 
+        me.lastVesselParkReceipt.parkAttempts = me.tearOutParkAttempts[itemId] = (me.tearOutParkAttempts[itemId] ?? 0) + 1;
+
         if (
             !route?.nativeHandleKey || route.ownerWindowId !== me.windowId ||
             route.targetWindowId !== entry.windowId || route.capabilities?.position !== true ||
@@ -3163,10 +3177,17 @@ class Workspace extends DockWorkspace {
             return false
         }
 
-        const focusTarget = () => targetIsMain
-            // The root window has no opener-minted nativeRoute. Route the focus verb through the
-            // exact popup Main actor instead: a popup may focus its opener under the user
-            // activation carried by the titlebar gesture.
+        // The root window has no opener-minted nativeRoute, so a main target is focused through the
+        // popup's own Main actor: `opener.focus()`, which the platform grants only under a user
+        // activation. A keyboard command carries one; an OS titlebar drag delivers no DOM event to
+        // the popup at all, so on the native path to a main target the focus steps are best-effort
+        // and recorded, and the MOVE is the gate — run from the owner through the popup's handle,
+        // it needs no activation, is refused while the OS still holds the window, and is granted
+        // the moment the user lets go. The popup is retired right after the commit, and the
+        // platform hands focus back to the remaining window on its close, which is what the
+        // refocus existed to arrange.
+        const bestEffortFocus = targetIsMain && nativeTitlebar,
+              focusTarget     = () => targetIsMain
             ? Neo.Main.windowFocus({windowId: entry.windowId})
             : Neo.Main.windowNativeFocus({
                 nativeHandleKey: targetRoute.nativeHandleKey,
@@ -3179,9 +3200,9 @@ class Workspace extends DockWorkspace {
 
             me.lastVesselParkReceipt.focused = focused;
 
-            if (!focused) {
-                // Expected while a native titlebar drag still holds the source popup: the dragged
-                // window keeps focus until the OS releases it. The coordinator retries the park.
+            if (!focused && !bestEffortFocus) {
+                // A popup target: the owner focuses a window it opened, which the platform grants
+                // once the OS releases the dragged source. The coordinator retries the park.
                 me.lastVesselParkReceipt.refusedAt = 'focus';
                 return false
             }
@@ -3217,7 +3238,7 @@ class Workspace extends DockWorkspace {
 
             me.lastVesselParkReceipt.refocused = refocused;
 
-            if (!refocused) {
+            if (!refocused && !bestEffortFocus) {
                 const restoreData = {
                     nativeHandleKey: route.nativeHandleKey,
                     targetWindowId : route.targetWindowId,
@@ -3241,6 +3262,7 @@ class Workspace extends DockWorkspace {
                 return false
             }
 
+            delete me.tearOutParkAttempts[itemId];
             me.lastVesselParkReceipt.parked = true;
 
             return true

--- a/test/playwright/unit/apps/workstation/Workspace.spec.mjs
+++ b/test/playwright/unit/apps/workstation/Workspace.spec.mjs
@@ -1368,7 +1368,7 @@ test.describe.serial('Workstation.view.Workspace', () => {
         }
     });
 
-    test('native-titlebar parking uses the exact native route and compensates without pointer drag state', async () => {
+    test('native-titlebar parking uses the exact native route; on the main target a refused refocus is recorded and the park stands', async () => {
         const
             workspace           = Neo.create(Workspace, {}),
             originalDragDrop    = Neo.main.addon.DragDrop,
@@ -1457,15 +1457,18 @@ test.describe.serial('Workstation.view.Workspace', () => {
 
             nativeMoveCalls.length = 0;
 
+            // The second park sees its refocus refused. On the main target under a native titlebar
+            // drag that is recorded and nothing compensates: the popup is retired after the commit
+            // and the platform hands focus back on its close. No restore move, no live pointer session.
             await expect(workspace.parkTearOutVessel({
                 itemId        : 'alerts',
                 nativeTitlebar: true,
                 windowName    : 'tearout-alerts'
-            })).resolves.toBe(false);
+            })).resolves.toBe(true);
 
-            expect(nativeMoveCalls.map(({x, y}) => ({x, y}))).toEqual([
-                {x: targetRect.x, y: targetRect.y},
-                {x: sourceRect.x, y: sourceRect.y}
+            expect(workspace.lastVesselParkReceipt).toMatchObject({focused: true, moved: true, refocused: false, parked: true});
+            expect(nativeMoveCalls.map(({x, y}) => ({x, y})), 'the park move only — no compensation').toEqual([
+                {x: targetRect.x, y: targetRect.y}
             ]);
             expect(focusCalls).toEqual([
                 {windowId: sourceWindowId},
@@ -1474,6 +1477,154 @@ test.describe.serial('Workstation.view.Workspace', () => {
                 {windowId: sourceWindowId}
             ]);
             expect(pointerCalls).toEqual([])
+        } finally {
+            Neo.main.addon.DragDrop     = originalDragDrop;
+            Neo.manager.Window.get      = originalManagerGet;
+            Neo.Main.windowNativeFocus  = originalNativeFocus;
+            Neo.Main.windowNativeMoveTo = originalNativeMove;
+            Neo.Main.windowFocus        = originalWindowFocus;
+            workspace.destroy()
+        }
+    });
+
+    /**
+     * An OS titlebar drag delivers no DOM event to the popup, so the popup carries no user
+     * activation and `opener.focus()` is declined — every time, released or not. For a MAIN target
+     * on the native path the focus steps are therefore best-effort and recorded, and the MOVE is the
+     * strict gate: refused while the OS still holds the window, granted on release, and needing no
+     * activation because it runs from the owner through the popup's handle.
+     */
+    test('a native-titlebar drop onto the MAIN window parks on the move, not on a focus the platform never grants', async () => {
+        const
+            workspace           = Neo.create(Workspace, {}),
+            originalDragDrop    = Neo.main.addon.DragDrop,
+            originalManagerGet  = Neo.manager.Window.get,
+            originalNativeFocus = Neo.Main.windowNativeFocus,
+            originalNativeMove  = Neo.Main.windowNativeMoveTo,
+            originalWindowFocus = Neo.Main.windowFocus,
+            moveResults         = [false, true], // the OS still holds the window, then the user lets go
+            focusCalls          = [],
+            nativeMoveCalls     = [],
+            ownerWindowId       = workspace.windowId,
+            sourceWindowId      = 'window-alerts',
+            sourceRect          = {height: 320, width: 480, x: 420, y: 240},
+            targetRect          = {height: 700, width: 1000, x: 30, y: 50};
+
+        try {
+            workspace.tearOutPanes.alerts = {windowId: sourceWindowId, windowName: 'tearout-alerts'};
+            workspace.vesselConversionTargetWindowId = ownerWindowId;
+
+            Neo.manager.Window.get = windowId => ({
+                [sourceWindowId]: {
+                    innerRect  : sourceRect,
+                    nativeRoute: {
+                        capabilities   : {position: true},
+                        nativeHandleKey: `handle-${sourceWindowId}`,
+                        ownerWindowId,
+                        targetWindowId : sourceWindowId
+                    }
+                },
+                [ownerWindowId]: {innerRect: targetRect, nativeRoute: null}
+            })[windowId] ?? null;
+            Neo.Main.windowFocus = async data => {
+                focusCalls.push(data);
+                return false // no activation: the platform declines, released or not
+            };
+            Neo.Main.windowNativeFocus  = async () => true;
+            Neo.Main.windowNativeMoveTo = async data => {
+                nativeMoveCalls.push(data);
+                return moveResults.shift()
+            };
+            Neo.main.addon.DragDrop = {
+                parkWindowDrag  : async () => true,
+                resumeWindowDrag: async () => true
+            };
+
+            const park = () => workspace.parkTearOutVessel({itemId: 'alerts', nativeTitlebar: true, windowName: 'tearout-alerts'});
+
+            // Attempt 1: the OS still holds the window — the move is refused, the park is refused
+            // at the move, and the receipt says so.
+            await expect(park(), 'refused while the OS holds the window').resolves.toBe(false);
+            expect(workspace.lastVesselParkReceipt).toMatchObject({focused: false, moved: false, parkAttempts: 1, refusedAt: 'move'});
+            expect(workspace.lastVesselParkReceipt.parked, 'not parked').not.toBe(true);
+
+            // Attempt 2: released — the move is granted, the park succeeds with focus and refocus
+            // recorded as refused, and nothing compensates the move.
+            await expect(park(), 'parks on release').resolves.toBe(true);
+            expect(workspace.lastVesselParkReceipt).toMatchObject({focused: false, moved: true, refocused: false, parked: true, parkAttempts: 2});
+            expect(workspace.lastVesselParkReceipt.compensated, 'a refused refocus compensates nothing on this path').toBeUndefined();
+            expect(nativeMoveCalls.map(({x, y}) => ({x, y})), 'two moves to the target frame origin, no restore').toEqual([
+                {x: targetRect.x, y: targetRect.y},
+                {x: targetRect.x, y: targetRect.y}
+            ]);
+            expect(focusCalls, 'focus was attempted on every step, never trusted').toEqual([
+                {windowId: sourceWindowId},
+                {windowId: sourceWindowId},
+                {windowId: sourceWindowId}
+            ]);
+
+            // A later park starts a fresh count.
+            moveResults.push(true);
+            await expect(park()).resolves.toBe(true);
+            expect(workspace.lastVesselParkReceipt.parkAttempts, 'the count resets after a park').toBe(1)
+        } finally {
+            Neo.main.addon.DragDrop     = originalDragDrop;
+            Neo.manager.Window.get      = originalManagerGet;
+            Neo.Main.windowNativeFocus  = originalNativeFocus;
+            Neo.Main.windowNativeMoveTo = originalNativeMove;
+            Neo.Main.windowFocus        = originalWindowFocus;
+            workspace.destroy()
+        }
+    });
+
+    test('control: a POPUP target still refuses the park when its owner-routed focus is refused', async () => {
+        const
+            workspace           = Neo.create(Workspace, {}),
+            originalDragDrop    = Neo.main.addon.DragDrop,
+            originalManagerGet  = Neo.manager.Window.get,
+            originalNativeFocus = Neo.Main.windowNativeFocus,
+            originalNativeMove  = Neo.Main.windowNativeMoveTo,
+            originalWindowFocus = Neo.Main.windowFocus,
+            nativeMoveCalls     = [],
+            ownerWindowId       = workspace.windowId,
+            sourceWindowId      = 'window-alerts',
+            targetWindowId      = 'window-target',
+            sourceRect          = {height: 320, width: 480, x: 420, y: 240},
+            targetRect          = {height: 700, width: 1000, x: 30, y: 50},
+            routeFor            = (targetWindowId, capabilities) => ({
+                capabilities,
+                nativeHandleKey: `handle-${targetWindowId}`,
+                ownerWindowId,
+                targetWindowId
+            });
+
+        try {
+            workspace.tearOutPanes.alerts = {windowId: sourceWindowId, windowName: 'tearout-alerts'};
+            workspace.vesselConversionTargetWindowId = targetWindowId;
+
+            Neo.manager.Window.get = windowId => ({
+                [sourceWindowId]: {innerRect: sourceRect, nativeRoute: routeFor(sourceWindowId, {position: true})},
+                [targetWindowId]: {innerRect: targetRect, nativeRoute: routeFor(targetWindowId, {focus: true})}
+            })[windowId] ?? null;
+            Neo.Main.windowFocus        = async () => true;
+            Neo.Main.windowNativeFocus  = async () => false; // the owner's focus of a window it opened — refused here
+            Neo.Main.windowNativeMoveTo = async data => {
+                nativeMoveCalls.push(data);
+                return true
+            };
+            Neo.main.addon.DragDrop = {
+                parkWindowDrag  : async () => true,
+                resumeWindowDrag: async () => true
+            };
+
+            await expect(workspace.parkTearOutVessel({
+                itemId        : 'alerts',
+                nativeTitlebar: true,
+                windowName    : 'tearout-alerts'
+            }), 'a popup target keeps the strict focus gate').resolves.toBe(false);
+
+            expect(workspace.lastVesselParkReceipt).toMatchObject({focused: false, refusedAt: 'focus'});
+            expect(nativeMoveCalls, 'nothing moved').toEqual([])
         } finally {
             Neo.main.addon.DragDrop     = originalDragDrop;
             Neo.manager.Window.get      = originalManagerGet;


### PR DESCRIPTION
Resolves #18112

The operator's own report today: pop a pane out on the Workstation, drag the popup by its OS titlebar over the main window, release — the highlight followed, nothing happened, the pane never came home. Vega read the receipts live: every claim valid, every park refused at `focus`. The park's first step gives the target focus so the parked popup falls behind it; for a main target that verb is the popup's own `opener.focus()` (`Neo.Main.windowFocus`), which the platform grants only under a user activation, and an OS titlebar drag delivers no DOM event to the popup at all. So the refusal was certain on every attempt, released or not; my #18055 retry re-asked a verb that could never be granted, and after the retry limit the gesture ended silently. The popup-over-popup path works because there the owner focuses a window it opened.

Evidence: the new unit arm at `dev@f6811898ed` — `windowFocus` stubbed to refuse, `windowNativeMoveTo` stubbed to refuse then grant — the first park returned `false` at `refusedAt: 'focus'` and never reached the move (red on the receipt shape); with the change the first attempt refuses at the move (`parkAttempts: 1`), the second parks on release with `focused: false, refocused: false, parked: true, parkAttempts: 2`, no compensation, both moves to the target frame origin.

## The change

`apps/workstation/view/Workspace.mjs#parkTearOutVessel`:
- `bestEffortFocus = targetIsMain && nativeTitlebar`: the focus and refocus steps are attempted and recorded truthfully but no longer refuse the park or compensate the move on that path. The move stays the strict gate: run from the owner through the popup's handle, no activation needed, refused while the OS holds the window, granted on release.
- The receipt gains `parkAttempts` (a per-vessel count, reset when a park lands or the vessel is disposed), so a stalled retry reads live as a rising count with the same `refusedAt`.
- The popup-target branch is unchanged: `windowNativeFocus` on the owner's handle keeps its strict gate (control arm).
- The focus verb's comment no longer claims an activation the gesture never carries; the method's JSDoc states the main-target rule.

`test/playwright/unit/apps/workstation/Workspace.spec.mjs`: the main-target arm (red-first), the popup-target control, and the existing native-titlebar arm brought to the new contract (a refused refocus on the main target is recorded and the park stands; no restore move).

## AC Evidence

- **AC-1 (a native drop onto main commits on release, no click required):** the mechanism above; the hand check is AC-5.
- **AC-2 (best-effort focus, strict move, truthful receipt with `parkAttempts`; red-first):** the main-target arm, receipt above.
- **AC-3 (a popup target still refuses on a refused focus):** the control arm.
- **AC-4 (`WorkstationNativeTitlebarDragNL` + `WorkstationNativePopupOverPopupNL` under the Brain root; `unit/manager` green):** `WorkstationNativeTitlebarDragNL` 1/1 (the path this change touches); `WorkstationNativePopupOverPopupNL` is flaky in isolation at its own placement wait ("Target page … has been closed" after the target vessel is placed beside main) — 1 pass in 3 on this branch and 1 pass in 3 at `dev`'s `Workspace.mjs` with the branch's file swapped out, so pre-existing and not attributable to this change; defect-noted to its author; `unit/apps/workstation` + `unit/manager`: 91 passed (9.1 s).
- **AC-5 (operator hand check, post-merge):** owned by @tobiu — drag a popup over the main window by its titlebar, release, no further input; the pane comes home within the retry window.

## Deltas

- During the handoff the retired-to-be popup may sit above the main window for the milliseconds between the park and the retire, where the refocus used to hide it. Accepted: the alternative was no park at all, and the platform restores focus on the close.
- `parkAttempts` also counts a park refused at the authority check (a truthful count of asks), which the ticket did not specify either way.

## Test Evidence

- Red-first: the main-target arm 1 failed / 2 passed (control + existing arm green on today's code).
- After: `unit/apps/workstation/Workspace.spec.mjs` + `unit/manager/DragCoordinator.spec.mjs` → 91 passed (9.1 s).
- NL under the Brain root: `WorkstationNativeTitlebarDragNL` 1/1 (the path this change touches); `WorkstationNativePopupOverPopupNL` is flaky in isolation at its own placement wait ("Target page … has been closed" after the target vessel is placed beside main) — 1 pass in 3 on this branch and 1 pass in 3 at `dev`'s `Workspace.mjs` with the branch's file swapped out, so pre-existing and not attributable to this change; defect-noted to its author (headless platforms grant every focus, so these prove the path still commits, not the refusal).

## Post-Merge Validation

AC-5 on the Workstation, by the operator, before the demo. Then the popup lifecycle receipt (`lastVesselParkReceipt`) should read `parked: true` with `focused: false` on that gesture — the honest shape of the platform's rule.

Authored by Mnemosyne (@neo-fable, Claude Fable 5.1, Claude Code) · session 37bbc610-f0cd-4abb-95c2-eb70336a86f3
