### PR TITLE
feat(dock): a dismissed rail reveal slides back under its strip before it hides (#18116)

### DIFF
--- a/resources/scss/src/dashboard/Container.scss
+++ b/resources/scss/src/dashboard/Container.scss
@@ -218,6 +218,38 @@
 @keyframes neo-dock-reveal-from-top    { from { transform: translateY(-100cqh) } }
 @keyframes neo-dock-reveal-from-bottom { from { transform: translateY(100cqh) } }
 
+// The exit, the entry's mirror: the overlay is dismissed but not yet hidden — the same two
+// elements travel back, the root fading out where it stands, the content sliding back under its
+// strip. `forwards` holds the end state until the hidden class lands one vdom round trip after
+// the root's `animationend` (the overlay lands it itself, on the same end event that settles an
+// entry), so nothing snaps back to rest in between. A departing panel takes no pointer: the click
+// that dismissed it must land on what is under it, never on the ghost. Reduced motion collapses
+// this through the duration token like the entry; a `0ms` animation still fires its end event.
+.neo-dashboard-dock-reveal-overlay.neo-dashboard-dock-reveal-overlay-leaving {
+    animation-fill-mode: forwards;
+    animation-name     : neo-dock-reveal-fade-out;
+    pointer-events     : none;
+
+    > .neo-dashboard-dock-reveal-header,
+    > .neo-dashboard-dock-reveal-pane-slot {
+        animation-fill-mode: forwards;
+        animation-name     : neo-dock-reveal-to-left;
+    }
+
+    &.neo-dashboard-dock-reveal-overlay-right  > .neo-dashboard-dock-reveal-header,
+    &.neo-dashboard-dock-reveal-overlay-right  > .neo-dashboard-dock-reveal-pane-slot { animation-name: neo-dock-reveal-to-right }
+    &.neo-dashboard-dock-reveal-overlay-top    > .neo-dashboard-dock-reveal-header,
+    &.neo-dashboard-dock-reveal-overlay-top    > .neo-dashboard-dock-reveal-pane-slot { animation-name: neo-dock-reveal-to-top }
+    &.neo-dashboard-dock-reveal-overlay-bottom > .neo-dashboard-dock-reveal-header,
+    &.neo-dashboard-dock-reveal-overlay-bottom > .neo-dashboard-dock-reveal-pane-slot { animation-name: neo-dock-reveal-to-bottom }
+}
+
+@keyframes neo-dock-reveal-fade-out  { to { opacity: 0 } }
+@keyframes neo-dock-reveal-to-left   { to { transform: translateX(-100cqw) } }
+@keyframes neo-dock-reveal-to-right  { to { transform: translateX(100cqw) } }
+@keyframes neo-dock-reveal-to-top    { to { transform: translateY(-100cqh) } }
+@keyframes neo-dock-reveal-to-bottom { to { transform: translateY(100cqh) } }
+
 // Operation-correlated tab insertion. The adapter stamps this class on ONE recreated header only
 // when its item + target tabs node match the committed addTab descriptor carried by that projection.
 // No broad tab selector: boot, restore, reorder and unrelated coarse refreshes remain motion-free.
@@ -587,7 +619,9 @@
 // at `dragend`. Measured before it was written — the press that starts a drag outside the reveal does
 // dismiss it, but the overlay hides one vdom round trip later, and by then the drop had been hit-tested
 // onto the parent beneath the frame. The rail-iframe component arms keep the two shields in step.
-body:not(.neo-native-drag-active) .neo-dashboard:has(.neo-dashboard-dock-reveal-overlay:not(.neo-dashboard-dock-reveal-overlay-hidden)) iframe:not(.neo-dashboard-dock-reveal-overlay iframe) {
+// A LEAVING overlay is dismissed and only animating out, so it no longer shields: the click that
+// dismissed it has been read, and the next one belongs to whatever is under the departing panel.
+body:not(.neo-native-drag-active) .neo-dashboard:has(.neo-dashboard-dock-reveal-overlay:not(.neo-dashboard-dock-reveal-overlay-hidden):not(.neo-dashboard-dock-reveal-overlay-leaving)) iframe:not(.neo-dashboard-dock-reveal-overlay iframe) {
     pointer-events: none;
 }
 

--- a/src/dashboard/dock/interaction/RevealOverlay.mjs
+++ b/src/dashboard/dock/interaction/RevealOverlay.mjs
@@ -143,6 +143,20 @@ class RevealOverlay extends Container {
      * @protected
      */
     revealWasVisible = false
+    /**
+     * Whether the overlay is between its dismissal and the hidden class: the DOM stays while the
+     * exit keyframes run, and the root's `animationend` (or the fail-safe) ends the leave.
+     * @member {Boolean} revealLeaving=false
+     * @protected
+     */
+    revealLeaving = false
+    /**
+     * The fail-safe timer of an in-flight leave — the wedge backstop for an exit whose end event
+     * never comes, never the exit's duration (the CSS token owns that).
+     * @member {Number|null} revealLeaveTimer=null
+     * @protected
+     */
+    revealLeaveTimer = null
 
     /**
      * Assembles the fixed child skeleton (tab-header toolbar: active title tab + pin action; pane slot)
@@ -223,8 +237,69 @@ class RevealOverlay extends Container {
     }
 
     /**
+     * @summary Starts the two-phase hide: the DOM stays, the exit keyframes run, and the hidden
+     * class lands on the root's `animationend`.
+     *
+     * The exit is motion too: the leave opens the producer's motion window (a no-op while the
+     * entry's is still open), and the same end event that settles an entry settles it. A stuck
+     * exit (a consumer sheet that sets `animation: none` never fires an end event) hides after
+     * the motion signal's fail-safe horizon instead of never; that timer is the wedge backstop,
+     * not a duration.
+     * @protected
+     */
+    beginRevealLeave() {
+        let me = this;
+
+        me.revealLeaving = true;
+        me.beginRevealMotion();
+
+        me.revealLeaveTimer = setTimeout(() => {
+            me.revealLeaveTimer = null;
+            me.completeRevealLeave()
+        }, MotionSignal.FAIL_SAFE_MS)
+    }
+
+    /**
+     * @summary Ends the leave: the hidden class lands, the leaving class goes, the motion window
+     * settles. A no-op unless a leave is in flight.
+     * @protected
+     */
+    completeRevealLeave() {
+        let me = this;
+
+        if (me.revealLeaving) {
+            me.cancelRevealLeave();
+            !me.isDestroyed && me.syncSnapshot();
+            me.finishRevealMotion()
+        }
+    }
+
+    /**
+     * @summary Drops an in-flight leave without settling the motion window — the caller decides
+     * whether the overlay re-enters (the window stays open for the entry's end event) or is torn
+     * down (the window settles).
+     * @protected
+     */
+    cancelRevealLeave() {
+        let me = this;
+
+        me.revealLeaving = false;
+
+        if (me.revealLeaveTimer) {
+            clearTimeout(me.revealLeaveTimer);
+            me.revealLeaveTimer = null
+        }
+    }
+
+    /**
      * Reconciles the reveal producer with the overlay's computed visibility. Both state and item
      * changes can cross this boundary because `visible` requires a visible state AND an item.
+     *
+     * A visible→hidden flip on a mounted overlay does not hide: it leaves (see
+     * {@link #beginRevealLeave}), so the exit keyframes get a DOM to run on. Without a DOM there
+     * is nothing to animate and the producer settles at once. A hidden→visible flip during a leave
+     * cancels it — dropping the leaving class restarts the entry keyframes, whose end event then
+     * settles the still-open window.
      * @protected
      */
     syncRevealMotion() {
@@ -233,21 +308,31 @@ class RevealOverlay extends Container {
 
         if (visible !== me.revealWasVisible) {
             me.revealWasVisible = visible;
-            me[visible ? 'beginRevealMotion' : 'finishRevealMotion']()
+
+            if (visible) {
+                me.cancelRevealLeave();
+                me.beginRevealMotion()
+            } else if (me.mounted) {
+                me.beginRevealLeave()
+            } else {
+                me.finishRevealMotion()
+            }
         }
     }
 
     /**
      * Teardown may interrupt the CSS animation without an `animationend`; settle the producer's
-     * entry before the component lifecycle removes its remaining runtime state.
+     * entry — or its leave — before the component lifecycle removes its remaining runtime state.
      */
     destroy() {
+        this.cancelRevealLeave();
         this.finishRevealMotion();
         super.destroy()
     }
 
     /**
-     * The reveal-slide settle: closes the motion-signal window a visible-state flip opened.
+     * The reveal-slide settle: closes the motion-signal window a visible-state flip opened — or,
+     * during a leave, lands the hidden class first and then closes it.
      * Local DOM-event serialization preserves the config-aware browser target id but omits
      * `AnimationEvent.animationName`. Root-target identity therefore owns settlement: an
      * overlay animation matches, while a hosted pane's bubbled animation keeps its child id and
@@ -255,8 +340,10 @@ class RevealOverlay extends Container {
      * @param {Object} data
      */
     onMotionAnimationEnd(data) {
-        if (data?.target?.id === (this.vdom?.id || this.id)) {
-            this.finishRevealMotion()
+        let me = this;
+
+        if (data?.target?.id === (me.vdom?.id || me.id)) {
+            me.revealLeaving ? me.completeRevealLeave() : me.finishRevealMotion()
         }
     }
 
@@ -465,9 +552,13 @@ class RevealOverlay extends Container {
                 : me.defaultRevealFraction,
             item       = me.revealedItem,
             pct        = `${Math.round(fraction * 10000) / 100}%`,
-            cls        = me.cls || [];
+            cls        = me.cls || [],
+            leaving    = me.revealLeaving;
 
-        NeoArray[me.visible ? 'remove' : 'add'](cls, 'neo-dashboard-dock-reveal-overlay-hidden');
+        // A leaving overlay is not hidden yet: the exit keyframes need its DOM until the root's
+        // `animationend` lands the hidden class (see `beginRevealLeave`).
+        NeoArray[me.visible || leaving ? 'remove' : 'add'](cls, 'neo-dashboard-dock-reveal-overlay-hidden');
+        NeoArray[leaving ? 'add' : 'remove'](cls, 'neo-dashboard-dock-reveal-overlay-leaving');
 
         me.set({
             cls,

--- a/test/playwright/component/dashboard/DockRailRevealExit.spec.mjs
+++ b/test/playwright/component/dashboard/DockRailRevealExit.spec.mjs
@@ -1,0 +1,78 @@
+import {test, expect} from '@playwright/test';
+
+/**
+ * A rail reveal leaves the way it came. Dismissal used to land the hidden class at once — one
+ * frame from open to gone next to an entry that slides — so the overlay now leaves in two phases:
+ * a leaving class runs the exit keyframes on the DOM it keeps, and the hidden class lands on the
+ * root's own `animationend`. Read on a rendered dock, per edge: after Escape the overlay carries
+ * the leaving class with the exit animations running on its content, takes no pointer, and only
+ * then becomes hidden.
+ *
+ * The animations are read through `getAnimations()` on the pane slot rather than through class
+ * presence alone, so a leaving class with no keyframes behind it (a stylesheet that never applied)
+ * cannot pass.
+ */
+
+const EDGES = ['left', 'right', 'top', 'bottom'];
+
+test.beforeEach(async ({page}) => {
+    await page.goto('test/playwright/component/apps/dock-rail-origin/index.html');
+    await page.waitForSelector('#dock-rail-origin-workspace', {state: 'attached'});
+
+    for (const edge of EDGES) {
+        await expect(page.locator(`.neo-dashboard-dock-edge-rail-${edge}`)).toBeVisible({timeout: 10000})
+    }
+});
+
+test.describe('Neo.dashboard.dock.interaction.RevealOverlay — the exit motion', () => {
+    for (const edge of EDGES) {
+        test(`[${edge}] a dismissed reveal slides back under its strip before it hides`, async ({page}) => {
+            const railSel    = `.neo-dashboard-dock-edge-rail-${edge}`,
+                  overlaySel = `.neo-dashboard-dock-reveal-overlay-${edge}`,
+                  overlay    = page.locator(overlaySel);
+
+            await page.locator(`${railSel} .neo-dashboard-dock-rail-tab`).first().click();
+            await expect(overlay).toBeVisible({timeout: 10000});
+
+            // Let the entry settle so the exit is the only motion read below.
+            await overlay.evaluate(node => Promise.all(node.getAnimations({subtree: true}).map(a => a.finished.catch(() => {}))));
+
+            const dismissedAt = Date.now();
+
+            await page.keyboard.press('Escape');
+
+            // Phase 1: leaving — the DOM is still there, the exit keyframes run on the content, and
+            // the departing panel takes no pointer.
+            await expect(overlay, `[${edge}] the dismissal leaves instead of cutting`).toHaveClass(/neo-dashboard-dock-reveal-overlay-leaving/);
+            await expect(overlay).not.toHaveClass(/neo-dashboard-dock-reveal-overlay-hidden/);
+
+            const exit = await overlay.evaluate(node => {
+                const slot = node.querySelector('.neo-dashboard-dock-reveal-pane-slot');
+
+                return {
+                    display      : getComputedStyle(node).display,
+                    pointerEvents: getComputedStyle(node).pointerEvents,
+                    slotNames    : slot.getAnimations().map(a => a.animationName),
+                    rootNames    : node.getAnimations().map(a => a.animationName)
+                }
+            });
+
+            expect(exit.display, `[${edge}] still displayed while leaving`).not.toBe('none');
+            expect(exit.pointerEvents, `[${edge}] a departing panel takes no pointer`).toBe('none');
+            expect(exit.rootNames, `[${edge}] the root fades out`).toContain('neo-dock-reveal-fade-out');
+            expect(exit.slotNames, `[${edge}] the content travels back to its edge`).toContain(`neo-dock-reveal-to-${edge}`);
+
+            // Phase 2: hidden, once the root's own animation has ended.
+            await expect(overlay, `[${edge}] hidden after the exit`).toHaveClass(/neo-dashboard-dock-reveal-overlay-hidden/, {timeout: 10000});
+            await expect(overlay).not.toHaveClass(/neo-dashboard-dock-reveal-overlay-leaving/);
+            await expect(overlay).toBeHidden();
+
+            // The hide came from the end event, not from the fail-safe: one reveal duration plus
+            // the round trips is a few hundred milliseconds; the wedge backstop is two seconds.
+            // A fail-safe hide would mean the root's `animationend` never reached the worker.
+            const hiddenAfter = Date.now() - dismissedAt;
+
+            expect(hiddenAfter, `[${edge}] hidden ${hiddenAfter} ms after the dismissal — the end event, not the backstop`).toBeLessThan(1500)
+        })
+    }
+});

--- a/test/playwright/unit/dashboard/DockRevealOverlay.spec.mjs
+++ b/test/playwright/unit/dashboard/DockRevealOverlay.spec.mjs
@@ -239,6 +239,78 @@ test.describe('Neo.dashboard.dock.interaction.RevealOverlay', () => {
         expect(DockMotionSignal.isAnimating(overlay.id)).toBe(false)
     });
 
+    test('a dismissal on a MOUNTED overlay leaves in two phases: the leaving class first, hidden on the root\'s own animationend', () => {
+        overlay = Neo.create(DockRevealOverlay, {
+            edge: 'right',
+            id  : 'dock-reveal-leave'
+        });
+
+        const rootId  = overlay.vdom?.id || overlay.id,
+              hidden  = 'neo-dashboard-dock-reveal-overlay-hidden',
+              leaving = 'neo-dashboard-dock-reveal-overlay-leaving';
+
+        overlay.mounted = true;
+        overlay.set({revealState: 'revealed', revealedItem: createItem()});
+        overlay.onMotionAnimationEnd(createSerializedAnimationEnd(rootId));
+        expect(DockMotionSignal.isAnimating(overlay.id), 'the entry settled').toBe(false);
+
+        // The dismissal keeps the DOM: leaving, not hidden, and the motion window re-opens for
+        // the exit keyframes — a hosted pane's bubbled end still cannot close it.
+        overlay.set({revealState: 'idle', revealedItem: null});
+        expect(overlay.visible).toBe(false);
+        expect(overlay.revealLeaving).toBe(true);
+        expect(overlay.cls).toContain(leaving);
+        expect(overlay.cls, 'not hidden while the exit runs').not.toContain(hidden);
+        expect(DockMotionSignal.isAnimating(overlay.id), 'the exit is motion too').toBe(true);
+
+        overlay.onMotionAnimationEnd(createSerializedAnimationEnd('hosted-pane-animation', ['hosted-pane-animation', rootId]));
+        expect(overlay.revealLeaving).toBe(true);
+
+        // The root's own end lands the hidden class and settles.
+        overlay.onMotionAnimationEnd(createSerializedAnimationEnd(rootId));
+        expect(overlay.revealLeaving).toBe(false);
+        expect(overlay.cls).toContain(hidden);
+        expect(overlay.cls).not.toContain(leaving);
+        expect(DockMotionSignal.isAnimating(overlay.id)).toBe(false);
+
+        // A re-entry during a leave cancels it and stays visible; the window stays open for the
+        // entry keyframes the class change restarts, and their end settles it.
+        overlay.set({revealState: 'revealed', revealedItem: createItem()});
+        overlay.onMotionAnimationEnd(createSerializedAnimationEnd(rootId));
+        overlay.set({revealState: 'idle', revealedItem: null});
+        expect(overlay.cls).toContain(leaving);
+        overlay.set({revealState: 'revealed', revealedItem: createItem()});
+        expect(overlay.revealLeaving).toBe(false);
+        expect(overlay.cls).not.toContain(leaving);
+        expect(overlay.cls).not.toContain(hidden);
+        expect(DockMotionSignal.isAnimating(overlay.id), 'still one open window').toBe(true);
+        overlay.onMotionAnimationEnd(createSerializedAnimationEnd(rootId));
+        expect(DockMotionSignal.isAnimating(overlay.id)).toBe(false);
+
+        // Teardown mid-leave settles without an end event and releases the fail-safe timer.
+        overlay.set({revealState: 'idle', revealedItem: null});
+        expect(overlay.revealLeaving).toBe(true);
+        expect(overlay.revealLeaveTimer).not.toBeNull();
+        overlay.destroy();
+        expect(DockMotionSignal.activeMotions.has(overlay)).toBe(false);
+        overlay = null
+    });
+
+    test('an unmounted overlay hides at once: nothing to animate, the producer settles synchronously', () => {
+        overlay = Neo.create(DockRevealOverlay, {
+            edge: 'left',
+            id  : 'dock-reveal-unmounted-hide'
+        });
+
+        overlay.set({revealState: 'revealed', revealedItem: createItem()});
+        overlay.set({revealState: 'idle', revealedItem: null});
+
+        expect(overlay.revealLeaving).toBe(false);
+        expect(overlay.cls).toContain('neo-dashboard-dock-reveal-overlay-hidden');
+        expect(overlay.cls).not.toContain('neo-dashboard-dock-reveal-overlay-leaving');
+        expect(DockMotionSignal.isAnimating(overlay.id)).toBe(false)
+    });
+
     test('early dismissal, rapid re-reveal and destroy each settle exactly their owned motion entry', () => {
         overlay = Neo.create(DockRevealOverlay, {
             edge: 'left',


### PR DESCRIPTION
Resolves #18116

The operator on the Workstation, 15:35Z: the rails' slide-in is nice, the slide-out on focus leave is missing. #18074 / PR #18079 gave the reveal its entry and scoped the exit out ("a two-phase hide is its own leaf if wanted"); this is that leaf. Dismissal landed the hidden class — `display: none` — the moment `visible` turned false, so the panel that had emerged from its strip vanished in one frame, on focus leave, Escape, an outside click and the pointer-leave after dwell alike.

Evidence: red-first with the source stashed and the new arms in place — unit: the two-phase arm fails at "not hidden while the exit runs" (the hidden class lands at once); component, per edge on the rail-origin fixture: "the dismissal leaves instead of cutting" fails (no leaving class ever appears). Green with the change: 726 passed (`unit/dashboard`), 96 passed (1.2 m) (`component/dashboard`).

## The change

- `src/dashboard/dock/interaction/RevealOverlay.mjs`: `syncRevealMotion` no longer hides a mounted overlay on the visible→hidden boundary — it begins a leave (`revealLeaving`), and `syncSnapshot` stamps `-leaving` instead of `-hidden` while it lasts. `onMotionAnimationEnd` on the root's own end completes the leave (hidden lands, leaving goes, the motion window settles) — the same seam the entry uses, so the window stays open across the exit and closes once. A hidden→visible flip during a leave cancels it (dropping the class restarts the entry keyframes, whose end settles the still-open window); `destroy` cancels and settles; a fail-safe timer at `MotionSignal.FAIL_SAFE_MS` completes a leave whose end event never comes (a consumer sheet with `animation: none`). An unmounted overlay hides at once as before.
- `resources/scss/src/dashboard/Container.scss`: the `-leaving` rules run the entry's mirror — `neo-dock-reveal-fade-out` on the root, `neo-dock-reveal-to-<edge>` on the header and pane slot — with `animation-fill-mode: forwards` (the end state holds until the hidden class lands one round trip later) and `pointer-events: none` (a departing panel takes no click). Same tokens as the entry; reduced motion collapses it through the duration token, and a `0ms` animation still fires its end event. The iframe shield excludes a leaving overlay.
- `test/playwright/unit/dashboard/DockRevealOverlay.spec.mjs`: the two-phase arm (leave, filtered end, root end, re-entry during a leave, teardown mid-leave) and the unmounted control.
- `test/playwright/component/dashboard/DockRailRevealExit.spec.mjs`: per edge — reveal, let the entry settle, Escape, read the leaving class, the still-displayed root, `pointer-events: none`, and the exit animation names on the root and the pane slot through `getAnimations()`, then hidden.

## AC Evidence

- **AC-1 (unit, red on dev):** the two-phase arm, receipt above.
- **AC-2 (component, red on dev):** `DockRailRevealExit.spec.mjs`, four edges.
- **AC-3 (the Workstation's rails by eye, both themes):** read on the served app in the browser pane with a class observer on the overlay — on Escape, in dark and in light, the overlay carried `-leaving` with `neo-dock-reveal-fade-out` running on the root and `neo-dock-reveal-to-left` on the header and slot, `display: flex`, `pointer-events: none`, then `-hidden`. One caveat stated rather than hidden: in that pane the hide landed on the fail-safe horizon and the entry's motion class also fell off at two seconds — the pane was hidden at the time, and a hidden tab throttles timers and animation-event delivery; the headless witness below asserts the hide within 1.5 s of the dismissal on every edge, which is the end event, not the backstop.
- **AC-4 (existing reveal, rail, iframe-dismissal and motion suites green):** the sets above; `DockRailRevealIframe` (the shield now excludes a leaving overlay) and `DockRailRevealOrigin` (its Escape → hidden wait absorbs the exit) included.

## Deltas

- A re-entry during a leave restarts the entry from the edge rather than reversing from the current position — stated in the ticket as out of scope; the honest cheap behaviour.
- While the exit runs (one reveal duration), the rail's outside-pointer listener is already detached (the machine is idle) and the shield is off, so a click during the exit behaves as if the reveal were gone — which it is, semantically.

## Test Evidence

- Red-first: unit 1 failed (the two-phase arm) / rest passed; component 4 failed (one per edge).
- After: `unit/dashboard` 726 passed; `component/dashboard` 96 passed (1.2 m) after `node buildScripts/build/themes.mjs -n -e dev`.

## Post-Merge Validation

On the Workstation: open a rail reveal, click elsewhere or press Escape — the panel slides back under its strip and fades, in both neo themes; with reduced motion on, it still hides. `neo-dashboard-dock-animating` is present during the exit and gone after it.

Authored by Mnemosyne (@neo-fable, Claude Fable 5.1, Claude Code) · session 37bbc610-f0cd-4abb-95c2-eb70336a86f3
