### PR TITLE
feat(dock): the hold is the gesture: a native titlebar drop fills the drop area over the dwell, commits, then closes the popup (#18115)

### DIFF
--- a/apps/workstation/view/Workspace.mjs
+++ b/apps/workstation/view/Workspace.mjs
@@ -1518,6 +1518,10 @@ class Workspace extends DockWorkspace {
             sourceNodeId    = data?.sourceNodeId,
             preview;
 
+        // A native-titlebar hover carries the coordinator's dwell clock; the renderer paints the hold
+        // from it. Set before any preview write below, so the affordance is built with it.
+        renderer && (renderer.dwell = data?.dwell ?? null);
+
         if (
             !itemId || !targetNodeId || state?.committed || state?.closeRequested ||
             !me.hitTestCrossWindowTarget(workspaceId, pointer.x, pointer.y)
@@ -1574,6 +1578,7 @@ class Workspace extends DockWorkspace {
         });
 
         if (geometry.renderer) {
+            geometry.renderer.dwell       = data?.dwell ?? null;
             geometry.renderer.dockPreview = preview;
             preview && geometry.renderer.applyTargetGeometry(geometry.localTargetRect)
         }
@@ -3083,9 +3088,10 @@ class Workspace extends DockWorkspace {
      * resize / move / refocus chain is the platform-law choreography (z-order hides the parked
      * vessel). A source whose outer frame cannot fit behind the target first shrinks through its
      * exact native route; a refocus refusal compensates to the original extent and source rect.
-     * On the native-titlebar path to the MAIN window the focus and refocus steps are best-effort
-     * and recorded, and only the move gates — the platform never grants a popup an opener focus
-     * without a user activation, and an OS titlebar drag carries none (see the focus verb below).
+     * On the native-titlebar path to the MAIN window nothing is parked at all — the hold is the
+     * gesture: the transfer lands when the dwell completes and the popup retires right after, so the
+     * park answers satisfied with no platform effect (the platform never grants a popup an opener
+     * focus without a user activation, and an OS titlebar drag carries none).
      * @param {Object} vessel
      * @param {String} vessel.itemId
      * @param {Boolean} [vessel.nativeTitlebar=false] The park follows an OS titlebar drag terminal
@@ -3177,17 +3183,27 @@ class Workspace extends DockWorkspace {
             return false
         }
 
+        // The hold is the gesture for a native-titlebar drop INTO this main window: the transfer lands
+        // when the dwell completes and the popup is retired right after, so there is nothing to park —
+        // and the park's focus step could never be granted on this path anyway (no user activation
+        // reaches a popup during an OS titlebar drag, so a popup asking its opener to take focus is
+        // declined for as long as the user holds, and after). The strict park is answered as satisfied
+        // with no physical effect; the receipt says so, the attempt counter resets as after a park, and
+        // the conversion bookkeeping around this call runs exactly as for a parked vessel. Popup
+        // targets keep the physical park below.
+        if (nativeTitlebar && targetIsMain) {
+            delete me.tearOutParkAttempts[itemId];
+            me.lastVesselParkReceipt.parked   = true;
+            me.lastVesselParkReceipt.physical = false;
+            me.lastVesselParkReceipt.reason   = 'main-window target: nothing to park, the popup retires after the commit';
+            return true
+        }
+
         // The root window has no opener-minted nativeRoute, so a main target is focused through the
-        // popup's own Main actor: `opener.focus()`, which the platform grants only under a user
-        // activation. A keyboard command carries one; an OS titlebar drag delivers no DOM event to
-        // the popup at all, so on the native path to a main target the focus steps are best-effort
-        // and recorded, and the MOVE is the gate — run from the owner through the popup's handle,
-        // it needs no activation, is refused while the OS still holds the window, and is granted
-        // the moment the user lets go. The popup is retired right after the commit, and the
-        // platform hands focus back to the remaining window on its close, which is what the
-        // refocus existed to arrange.
-        const bestEffortFocus = targetIsMain && nativeTitlebar,
-              focusTarget     = () => targetIsMain
+        // popup's own Main actor (`opener.focus()`, granted under the user activation a keyboard
+        // command carries — the pointer conversion path); a popup target is focused by its owner
+        // through the handle it minted.
+        const focusTarget = () => targetIsMain
             ? Neo.Main.windowFocus({windowId: entry.windowId})
             : Neo.Main.windowNativeFocus({
                 nativeHandleKey: targetRoute.nativeHandleKey,
@@ -3200,7 +3216,7 @@ class Workspace extends DockWorkspace {
 
             me.lastVesselParkReceipt.focused = focused;
 
-            if (!focused && !bestEffortFocus) {
+            if (!focused) {
                 // A popup target: the owner focuses a window it opened, which the platform grants
                 // once the OS releases the dragged source. The coordinator retries the park.
                 me.lastVesselParkReceipt.refusedAt = 'focus';
@@ -3238,7 +3254,7 @@ class Workspace extends DockWorkspace {
 
             me.lastVesselParkReceipt.refocused = refocused;
 
-            if (!refocused && !bestEffortFocus) {
+            if (!refocused) {
                 const restoreData = {
                     nativeHandleKey: route.nativeHandleKey,
                     targetWindowId : route.targetWindowId,

--- a/resources/scss/src/dashboard/dock/interaction/Preview.scss
+++ b/resources/scss/src/dashboard/dock/interaction/Preview.scss
@@ -1,3 +1,9 @@
+// The hold's rising fill (see `.neo-dock-preview-dwelling` below): bottom to top over the dwell.
+@keyframes neo-dock-preview-dwell-fill {
+    from { transform: scaleY(0) }
+    to   { transform: scaleY(1) }
+}
+
 .neo-dock-preview {
     pointer-events : none;
 
@@ -12,6 +18,30 @@
         transition     : opacity var(--dock-transition-duration) var(--dock-transition-easing),
                          background-color var(--dock-transition-duration) var(--dock-transition-easing),
                          border-color var(--dock-transition-duration) var(--dock-transition-easing);
+    }
+
+    // The hold is the gesture (native titlebar drops): while a still popup rests on a claimed zone,
+    // the region fills from the bottom over the dwell the coordinator publishes with every hover
+    // frame, so the paint and the commit read ONE clock. `--dock-native-dwell-elapsed` is the time
+    // already spent when this node was (re)built, applied as a negative delay: a node the renderer
+    // replaces mid-hold resumes at the right height instead of starting over. Leaving the zone
+    // removes the node, which ends the fill. The fill is a shape, not only a colour, so the cue
+    // survives colour-vision deficits; reduced motion shows the armed state as a static tint.
+    .neo-dock-preview-dwelling {
+        overflow : hidden;
+
+        &::after {
+            animation        : neo-dock-preview-dwell-fill var(--dock-native-dwell-ms, 1200ms) linear
+                               calc(-1 * var(--dock-native-dwell-elapsed, 0ms)) 1 forwards;
+            background-color : var(--agent-dock-preview-accept, #58a6ff);
+            content          : '';
+            inset            : 0;
+            opacity          : 0.35;
+            pointer-events   : none;
+            position         : absolute;
+            transform        : scaleY(0);
+            transform-origin : bottom;
+        }
     }
 
     // Zone highlights — edge/split RESULT REGIONS and whole-node tab targets — read as a
@@ -67,6 +97,17 @@
 // Strictly additive: without the host modifier, the family above renders unchanged. NO
 // color fallbacks: a missing projection drops the variant visibly (the census pins this).
 // ─────────────────────────────────────────────────────────────────────────────────────
+// Reduced motion: the armed state is a static tint of the full region — the information (a hold is
+// running here) survives, the rising fill does not. Declared AFTER the fill rule it overrides: equal
+// specificity, so source order is the whole mechanism.
+@media (prefers-reduced-motion: reduce) {
+    .neo-dock-preview .neo-dock-preview-dwelling::after {
+        animation : none;
+        opacity   : 0.2;
+        transform : scaleY(1);
+    }
+}
+
 .neo-preview-lang-signal .neo-dock-preview {
     // Same boundary as the indicator variant: component-domain aliases only — the apps
     // project their palettes; this file never reaches for an app palette directly.

--- a/src/Main.mjs
+++ b/src/Main.mjs
@@ -963,20 +963,39 @@ class Main extends core.Base {
     }
 
     /**
-     * Closes an exact owner-granted native handle generation.
+     * Closes an exact owner-granted native handle generation and verifies the platform did it.
      * @param {Object} data
      * @param {String} data.nativeHandleKey
      * @param {String} data.targetWindowId
-     * @returns {Boolean}
+     * @returns {Promise<Boolean>} true once the popup is verifiably closed; false while it is not.
      */
-    windowNativeClose(data) {
+    async windowNativeClose(data) {
         const route = this.#getNativeWindowRoute(data, 'close');
 
         if (!route) return false;
 
-        const {entry} = route;
+        const {entry} = route,
+              {win}   = entry;
 
-        entry.win.close();
+        try {
+            win.close()
+        } catch {
+            return false
+        }
+
+        // The answer is the VERIFIED outcome, never the attempt — the discipline #focusWindow applies
+        // to focus. A popup the OS is still dragging by its titlebar may keep the close deferred; the
+        // caller (a native-titlebar drop's retirement) retries at a fixed cadence until the release
+        // lets it through, and it can only do that while the route is still here — so the entry is
+        // retired only once the window is gone.
+        for (let attempt = 0; attempt < 6 && !win.closed; attempt++) {
+            await new Promise(resolve => setTimeout(resolve, 50))
+        }
+
+        if (!win.closed) {
+            return false
+        }
+
         this.#invalidateNativeWindowEntry(entry);
 
         if (this.openWindows[entry.windowName] === entry) {

--- a/src/dashboard/dock/interaction/Preview.mjs
+++ b/src/dashboard/dock/interaction/Preview.mjs
@@ -83,6 +83,16 @@ class Preview extends Component {
          */
         dockPreview_: null,
         /**
+         * The hold clock of a native-titlebar hover — `{armedAt, durationMs}` — or null. While set,
+         * the affordance paints the hold running out (a rising fill over `durationMs`, starting from
+         * `armedAt`), so a user resting a popup on a zone sees that waiting is the gesture. The
+         * coordinator publishes it with every native hover frame and the writer sets it before the
+         * preview; the fill and the commit therefore read one clock. Runtime-only.
+         * @member {Object|null} dwell_=null
+         * @reactive
+         */
+        dwell_: null,
+        /**
          * Thickness in px of an edge-zone affordance band. The overlay clamps it to the target
          * rect, so an oversized value degrades gracefully; consumers tune it per instance for
          * their hardware / UI density (touch surfaces want wider bands).
@@ -377,6 +387,22 @@ class Preview extends Component {
     }
 
     /**
+     * @summary Re-renders the current affordance when the hold clock arrives, changes, or clears.
+     * @param {Object|null} value
+     * @param {Object|null} oldValue
+     * @protected
+     */
+    afterSetDwell(value, oldValue) {
+        let me = this;
+
+        // The writer sets the clock before the preview, so the common case renders once through
+        // afterSetDockPreview; this covers a clock that arrives or leaves while a preview stands.
+        if (me.dockPreview && (value?.armedAt !== oldValue?.armedAt || value?.durationMs !== oldValue?.durationMs)) {
+            me.afterSetDockPreview(me.dockPreview, me.dockPreview)
+        }
+    }
+
+    /**
      * @summary Positions the current affordance over a supplied target rect (runtime-only).
      *
      * The producer / live-drag integration calls this with the target node's measured rect so the
@@ -465,7 +491,11 @@ class Preview extends Component {
     getAffordanceVdom(affordance) {
         let me      = this,
             region  = me.resultRegionPreviews && (affordance.group === 'split' || affordance.group === 'edge'),
-            cutSide = region ? Preview.cutSide(affordance) : null;
+            cutSide = region ? Preview.cutSide(affordance) : null,
+            // the hold clock paints only on an accepted zone: a rejected region is not a place the
+            // hold could land, so it must not look like a timer running towards a drop
+            dwell   = affordance.accepted && me.dwell?.durationMs > 0 ? me.dwell : null,
+            elapsed = dwell ? Math.max(0, Math.min(dwell.durationMs, Date.now() - (dwell.armedAt ?? Date.now()))) : 0;
 
         return {
             cls: [
@@ -477,10 +507,19 @@ class Preview extends Component {
                 // family; the cut-side class thickens the border on the region's inner edge,
                 // preserving the exact-cut information the insertion line used to carry
                 ...(region  ? ['neo-dock-preview-region'] : []),
-                ...(cutSide ? [`neo-dock-preview-cut-${cutSide}`] : [])
+                ...(cutSide ? [`neo-dock-preview-cut-${cutSide}`] : []),
+                ...(dwell   ? ['neo-dock-preview-dwelling'] : [])
             ],
             'data-dock-target': affordance.targetNodeId,
-            style             : {pointerEvents: 'none'}
+            style             : {
+                pointerEvents: 'none',
+                // the fill's duration and the time already spent, so a node rebuilt mid-hold resumes
+                // at the right height (the stylesheet applies the elapsed time as a negative delay)
+                ...(dwell ? {
+                    '--dock-native-dwell-ms'     : `${dwell.durationMs}ms`,
+                    '--dock-native-dwell-elapsed': `${elapsed}ms`
+                } : {})
+            }
         }
     }
 

--- a/src/manager/DragCoordinator.mjs
+++ b/src/manager/DragCoordinator.mjs
@@ -21,11 +21,14 @@ class DragCoordinator extends Manager {
          */
         singleton: true,
         /**
-         * Minimum time a native popup must remain over a remote dashboard target before
-         * geometry-only reintegration can commit.
-         * @member {Number} nativeWindowDropDwellMs=450
+         * How long a native popup must rest over one remote dashboard target before the
+         * geometry-only drop commits — the hold IS the gesture on this path, since no pointer event
+         * and no release ever reach the page during an OS titlebar drag. The same clock is handed to
+         * the target with every hover frame (`dwell` on the `onRemoteDragMove` payload), so the drop
+         * area can paint the hold running out over exactly this duration.
+         * @member {Number} nativeWindowDropDwellMs=1200
          */
-        nativeWindowDropDwellMs: 450,
+        nativeWindowDropDwellMs: 1200,
         /**
          * Retained target-local embodiment interval after native settle and before semantic commit.
          * This guarantees at least one painted handoff frame without inventing a browser mouseup.
@@ -38,6 +41,22 @@ class DragCoordinator extends Manager {
          * @member {Number} nativeWindowDispositionRetryMs=250
          */
         nativeWindowDispositionRetryMs: 250,
+        /**
+         * Fixed cadence for retrying the retirement (close) of a source popup after a COMMITTED
+         * native drop. The pane is already home at that point; only the popup's close is outstanding,
+         * and the platform may defer it while the OS still drags the window by its titlebar. The close
+         * that finally succeeds is the release signal, so it is polled at a steady interval — backoff
+         * would leave a released popup on screen for seconds.
+         * @member {Number} nativeWindowRetireRetryMs=250
+         */
+        nativeWindowRetireRetryMs: 250,
+        /**
+         * How many retirement retries a committed native drop makes before giving up on the close.
+         * At the default cadence this is 20 s of holding; past it the pane stays home and the popup
+         * simply remains for the user to close.
+         * @member {Number} nativeWindowRetireRetryLimit=80
+         */
+        nativeWindowRetireRetryLimit: 80,
         /**
          * How many times a refused strict native park is retried before the gesture ends.
          *
@@ -284,11 +303,22 @@ class DragCoordinator extends Manager {
             return true
         }
 
-        const delay = Math.min(
-            5000,
-            Math.max(1, me.nativeWindowDispositionRetryMs) *
-                2 ** Math.min(candidate.dispositionAttempts - 1, 4)
-        );
+        // A committed drop retries its close at a fixed cadence, bounded: the pane is home, the popup
+        // is all that is left, and a release is expected within seconds (see nativeWindowRetireRetryMs).
+        // A rejected drop keeps the backoff for its restore.
+        if (committed && candidate.dispositionAttempts > me.nativeWindowRetireRetryLimit) {
+            me.nativeWindowDropCandidates.delete(windowId);
+            me.endNativeGesture(windowId);
+            return false
+        }
+
+        const delay = committed
+            ? Math.max(1, me.nativeWindowRetireRetryMs)
+            : Math.min(
+                5000,
+                Math.max(1, me.nativeWindowDispositionRetryMs) *
+                    2 ** Math.min(candidate.dispositionAttempts - 1, 4)
+            );
 
         candidate.timeoutId = setTimeout(() => {
             me.settleNativeWindowDisposition(windowId, candidate, committed).catch(error => {
@@ -1090,6 +1120,12 @@ class DragCoordinator extends Manager {
 
             next.onRemoteDragMove({
                 draggedItem: candidate.draggedItem,
+                // The hold is the gesture: the target receives the dwell clock the commit below is
+                // scheduled from — same start, same duration — so it can paint the hold running out.
+                dwell: {
+                    armedAt   : candidate.firstSeenAt ?? Date.now(),
+                    durationMs: me.nativeWindowDropDwellMs
+                },
                 // Native titlebar geometry does not ride the pointer conversion resolver. Keep
                 // its source popup visible during dwell; only commitNativeWindowDrop may stage
                 // an embodiment, after suspendWindowDrag has strictly settled.
@@ -1144,9 +1180,8 @@ class DragCoordinator extends Manager {
 
         candidate = me.getNativeWindowDropCandidate(data, sourceDrag);
 
-        me.updateNativeHover(windowId, candidate);
-
         if (!candidate) {
+            me.updateNativeHover(windowId, null);
             me.clearNativeWindowDropCandidate(windowId);
             return
         }
@@ -1159,13 +1194,17 @@ class DragCoordinator extends Manager {
                 ? current.firstSeenAt
                 : now;
 
+        // The dwell clock is fixed before the hover frame goes out, so the target paints the hold
+        // from the same start the commit below is scheduled from.
+        candidate.firstSeenAt = firstSeenAt;
+
+        me.updateNativeHover(windowId, candidate);
         me.clearNativeWindowDropCandidate(windowId);
 
         dwellRemaining = Math.max(0, me.nativeWindowDropDwellMs - (now - firstSeenAt));
         delay          = Math.max(me.nativeWindowDropSettleMs, dwellRemaining);
 
-        candidate.firstSeenAt = firstSeenAt;
-        candidate.timeoutId   = setTimeout(() => {
+        candidate.timeoutId = setTimeout(() => {
             me.commitNativeWindowDrop(windowId, candidate).catch(error => {
                 (Neo.logError || console.error)('Native window drop failed', error)
             })

--- a/test/playwright/component/dashboard/DockPreviewRegionRender.spec.mjs
+++ b/test/playwright/component/dashboard/DockPreviewRegionRender.spec.mjs
@@ -196,6 +196,67 @@ test.describe('Neo.dashboard.dock.interaction.Preview — what each edge region 
         }
     });
 
+    test('a native hold paints a rising fill over the published dwell — and only while the clock is set', async ({page}) => {
+        // The hold is the gesture on the native-titlebar path: the coordinator publishes `{armedAt,
+        // durationMs}` with every hover frame and the writer sets it on the renderer before the
+        // preview, so the affordance is built with the fill — duration from the clock, the time
+        // already spent as a negative delay, so a node rebuilt mid-hold resumes rather than restarts.
+        const read = () => page.evaluate(() => {
+            const node = document.querySelector('.neo-dock-preview-affordance');
+
+            if (!node) return {missing: true};
+
+            const after = getComputedStyle(node, '::after');
+
+            return {
+                animation: after.animationName,
+                cls      : node.className,
+                delay    : after.animationDelay,
+                duration : after.animationDuration,
+                dwellMs  : node.style.getPropertyValue('--dock-native-dwell-ms'),
+                elapsed  : node.style.getPropertyValue('--dock-native-dwell-elapsed')
+            }
+        });
+
+        // the clock first, then the preview — the writer's order
+        await page.evaluate(([id, previewObj]) => Neo.worker.App.setConfigs({
+            id,
+            dwell      : {armedAt: Date.now() - 400, durationMs: 1200},
+            dockPreview: previewObj
+        }), [previewId, buildPreview('edge-top')]);
+
+        await page.waitForSelector('.neo-dock-preview-dwelling', {state: 'attached', timeout: 4000});
+
+        const held = await read();
+
+        expect(held.cls).toContain('neo-dock-preview-dwelling');
+        expect(held.dwellMs, 'the fill runs for the published dwell').toBe('1200ms');
+        expect(parseInt(held.elapsed, 10), 'the time already spent rides along').toBeGreaterThanOrEqual(400);
+        expect(held.animation).toBe('neo-dock-preview-dwell-fill');
+        expect(held.duration).toBe('1.2s');
+        expect(parseFloat(held.delay), 'the elapsed time is applied as a negative delay').toBeLessThanOrEqual(-0.4);
+
+        // reduced motion keeps the information and drops the motion
+        await page.emulateMedia({reducedMotion: 'reduce'});
+
+        const reduced = await read();
+
+        expect(reduced.animation, 'reduced motion paints a static armed state').toBe('none');
+
+        await page.emulateMedia({reducedMotion: 'no-preference'});
+
+        // the clock clears: the same preview paints without the fill
+        await page.evaluate(([id, previewObj]) => Neo.worker.App.setConfigs({id, dwell: null, dockPreview: previewObj}),
+            [previewId, buildPreview('edge-left')]);
+
+        await page.waitForSelector('.neo-dock-preview-edge-left', {state: 'attached', timeout: 4000});
+
+        const released = await read();
+
+        expect(released.cls).not.toContain('neo-dock-preview-dwelling');
+        expect(released.animation).toBe('none')
+    });
+
     test('each edge carries its own kind and cut classes', async ({page}) => {
         // Guards the fill assertions above: identical colours read off a node that never received
         // the per-edge classes would be a green that means nothing. The cut side is the INVERSE of

--- a/test/playwright/unit/apps/workstation/Workspace.spec.mjs
+++ b/test/playwright/unit/apps/workstation/Workspace.spec.mjs
@@ -1368,7 +1368,61 @@ test.describe.serial('Workstation.view.Workspace', () => {
         }
     });
 
-    test('native-titlebar parking uses the exact native route; on the main target a refused refocus is recorded and the park stands', async () => {
+    test('a native-titlebar park onto the MAIN window is satisfied without a platform effect — the hold is the gesture', async () => {
+        // A drop INTO this main window lands when the dwell completes and retires the popup right after,
+        // so there is nothing to park; the focus step could never be granted on this path anyway (no
+        // user activation reaches a popup during an OS titlebar drag). The park answers `true` with no
+        // focus and no move, so the coordinator proceeds to embodiment and the commit — and the receipt
+        // says the park was not physical.
+        const
+            workspace           = Neo.create(Workspace, {}),
+            originalManagerGet  = Neo.manager.Window.get,
+            originalNativeFocus = Neo.Main.windowNativeFocus,
+            originalNativeMove  = Neo.Main.windowNativeMoveTo,
+            originalWindowFocus = Neo.Main.windowFocus,
+            platformCalls       = [],
+            ownerWindowId       = workspace.windowId,
+            sourceWindowId      = 'window-alerts',
+            sourceRect          = {height: 320, width: 480, x: 420, y: 240},
+            targetRect          = {height: 700, width: 1000, x: 30, y: 50};
+
+        try {
+            workspace.tearOutPanes.alerts = {windowId: sourceWindowId, windowName: 'tearout-alerts'};
+            workspace.vesselConversionTargetWindowId = ownerWindowId;
+
+            Neo.manager.Window.get = windowId => ({
+                [sourceWindowId]: {
+                    innerRect  : sourceRect,
+                    nativeRoute: {capabilities: {position: true}, nativeHandleKey: 'handle-alerts', ownerWindowId, targetWindowId: sourceWindowId}
+                },
+                [ownerWindowId]: {innerRect: targetRect, nativeRoute: null}
+            })[windowId] ?? null;
+            Neo.Main.windowFocus        = async data => { platformCalls.push(['focus', data]); return false };
+            Neo.Main.windowNativeFocus  = async data => { platformCalls.push(['nativeFocus', data]); return false };
+            Neo.Main.windowNativeMoveTo = async data => { platformCalls.push(['move', data]); return false };
+
+            await expect(workspace.parkTearOutVessel({
+                itemId        : 'alerts',
+                nativeTitlebar: true,
+                windowName    : 'tearout-alerts'
+            }), 'the park is satisfied without asking the platform').resolves.toBe(true);
+
+            expect(platformCalls, 'no focus, no move — nothing was parked').toEqual([]);
+            expect(workspace.lastVesselParkReceipt).toMatchObject({parked: true, physical: false});
+            expect(workspace.lastVesselParkReceipt.authority.sourceHasHandle, 'the source route is still checked').toBe(true)
+        } finally {
+            Neo.manager.Window.get      = originalManagerGet;
+            Neo.Main.windowFocus        = originalWindowFocus;
+            Neo.Main.windowNativeFocus  = originalNativeFocus;
+            Neo.Main.windowNativeMoveTo = originalNativeMove;
+            workspace.destroy()
+        }
+    });
+
+    test('native-titlebar parking onto a POPUP target uses the exact native route and compensates without pointer drag state', async () => {
+        // The physical park path: a popup target is focused through its owner-minted route, the source
+        // moves behind it, the refocus decides the outcome. (A main-window target no longer parks
+        // physically — the arm above — so this arm targets a popup, where the choreography still runs.)
         const
             workspace           = Neo.create(Workspace, {}),
             originalDragDrop    = Neo.main.addon.DragDrop,
@@ -1383,7 +1437,7 @@ test.describe.serial('Workstation.view.Workspace', () => {
             pointerCalls        = [],
             ownerWindowId       = workspace.windowId,
             sourceWindowId      = 'window-alerts',
-            targetWindowId      = ownerWindowId,
+            targetWindowId      = 'window-target',
             sourceRect          = {height: 320, width: 480, x: 420, y: 240},
             targetRect          = {height: 700, width: 1000, x: 30, y: 50},
             routeFor            = (targetWindowId, capabilities) => ({
@@ -1407,16 +1461,16 @@ test.describe.serial('Workstation.view.Workspace', () => {
                 },
                 [targetWindowId]: {
                     innerRect  : targetRect,
-                    nativeRoute: null
+                    nativeRoute: routeFor(targetWindowId, {focus: true})
                 }
             })[windowId] ?? null;
             Neo.Main.windowFocus = async data => {
                 focusCalls.push(data);
-                return focusResults.shift()
+                return true
             };
             Neo.Main.windowNativeFocus = async data => {
                 nativeFocusCalls.push(data);
-                return true
+                return focusResults.shift()
             };
             Neo.Main.windowNativeMoveTo = async data => {
                 nativeMoveCalls.push(data);
@@ -1448,34 +1502,29 @@ test.describe.serial('Workstation.view.Workspace', () => {
                 y              : targetRect.y
             }]);
             expect(pointerCalls, 'a terminal titlebar drag has no live pointer DragDrop session').toEqual([]);
-            expect(focusCalls).toEqual([
-                {windowId: sourceWindowId},
-                {windowId: sourceWindowId}
-            ]);
-            expect(nativeFocusCalls,
-                'the root target has no opener-minted native route; the popup focuses its opener').toEqual([]);
+
+            const targetFocus = {nativeHandleKey: `handle-${targetWindowId}`, targetWindowId, windowId: ownerWindowId};
+
+            expect(nativeFocusCalls, 'focus then refocus, both through the target\'s owner-minted route').toEqual([targetFocus, targetFocus]);
+            expect(focusCalls, 'the opener verb is for a main-window target only').toEqual([]);
 
             nativeMoveCalls.length = 0;
 
-            // The second park sees its refocus refused. On the main target under a native titlebar
-            // drag that is recorded and nothing compensates: the popup is retired after the commit
-            // and the platform hands focus back on its close. No restore move, no live pointer session.
+            // The second park sees its refocus refused: on a popup target the source may still cover
+            // the target, so the move is compensated back to the source rect and the park is refused.
             await expect(workspace.parkTearOutVessel({
                 itemId        : 'alerts',
                 nativeTitlebar: true,
                 windowName    : 'tearout-alerts'
-            })).resolves.toBe(true);
+            })).resolves.toBe(false);
 
-            expect(workspace.lastVesselParkReceipt).toMatchObject({focused: true, moved: true, refocused: false, parked: true});
-            expect(nativeMoveCalls.map(({x, y}) => ({x, y})), 'the park move only — no compensation').toEqual([
-                {x: targetRect.x, y: targetRect.y}
+            expect(workspace.lastVesselParkReceipt).toMatchObject({focused: true, moved: true, refocused: false, compensated: true, refusedAt: 'refocus'});
+            expect(nativeMoveCalls.map(({x, y}) => ({x, y})), 'the park move, then the compensation').toEqual([
+                {x: targetRect.x, y: targetRect.y},
+                {x: sourceRect.x, y: sourceRect.y}
             ]);
-            expect(focusCalls).toEqual([
-                {windowId: sourceWindowId},
-                {windowId: sourceWindowId},
-                {windowId: sourceWindowId},
-                {windowId: sourceWindowId}
-            ]);
+            expect(nativeFocusCalls).toEqual([targetFocus, targetFocus, targetFocus, targetFocus]);
+            expect(focusCalls).toEqual([]);
             expect(pointerCalls).toEqual([])
         } finally {
             Neo.main.addon.DragDrop     = originalDragDrop;
@@ -1488,13 +1537,11 @@ test.describe.serial('Workstation.view.Workspace', () => {
     });
 
     /**
-     * An OS titlebar drag delivers no DOM event to the popup, so the popup carries no user
-     * activation and `opener.focus()` is declined — every time, released or not. For a MAIN target
-     * on the native path the focus steps are therefore best-effort and recorded, and the MOVE is the
-     * strict gate: refused while the OS still holds the window, granted on release, and needing no
-     * activation because it runs from the owner through the popup's handle.
+     * The coordinator retries a refused park until the OS releases the popup; a stalled retry must
+     * read live as a rising attempt count with the same `refusedAt`, and a park that finally lands
+     * (or a main-window park, which is satisfied without a platform effect) resets the count.
      */
-    test('a native-titlebar drop onto the MAIN window parks on the move, not on a focus the platform never grants', async () => {
+    test('a refused park counts its attempts per vessel, and the count resets after a park', async () => {
         const
             workspace           = Neo.create(Workspace, {}),
             originalDragDrop    = Neo.main.addon.DragDrop,
@@ -1502,38 +1549,33 @@ test.describe.serial('Workstation.view.Workspace', () => {
             originalNativeFocus = Neo.Main.windowNativeFocus,
             originalNativeMove  = Neo.Main.windowNativeMoveTo,
             originalWindowFocus = Neo.Main.windowFocus,
-            moveResults         = [false, true], // the OS still holds the window, then the user lets go
-            focusCalls          = [],
+            focusResults        = [false, true, true, true, true], // the OS still holds the source, then the user lets go
             nativeMoveCalls     = [],
             ownerWindowId       = workspace.windowId,
             sourceWindowId      = 'window-alerts',
+            targetWindowId      = 'window-target',
             sourceRect          = {height: 320, width: 480, x: 420, y: 240},
-            targetRect          = {height: 700, width: 1000, x: 30, y: 50};
+            targetRect          = {height: 700, width: 1000, x: 30, y: 50},
+            routeFor            = (targetWindowId, capabilities) => ({
+                capabilities,
+                nativeHandleKey: `handle-${targetWindowId}`,
+                ownerWindowId,
+                targetWindowId
+            });
 
         try {
             workspace.tearOutPanes.alerts = {windowId: sourceWindowId, windowName: 'tearout-alerts'};
-            workspace.vesselConversionTargetWindowId = ownerWindowId;
+            workspace.vesselConversionTargetWindowId = targetWindowId;
 
             Neo.manager.Window.get = windowId => ({
-                [sourceWindowId]: {
-                    innerRect  : sourceRect,
-                    nativeRoute: {
-                        capabilities   : {position: true},
-                        nativeHandleKey: `handle-${sourceWindowId}`,
-                        ownerWindowId,
-                        targetWindowId : sourceWindowId
-                    }
-                },
-                [ownerWindowId]: {innerRect: targetRect, nativeRoute: null}
+                [sourceWindowId]: {innerRect: sourceRect, nativeRoute: routeFor(sourceWindowId, {position: true})},
+                [targetWindowId]: {innerRect: targetRect, nativeRoute: routeFor(targetWindowId, {focus: true})}
             })[windowId] ?? null;
-            Neo.Main.windowFocus = async data => {
-                focusCalls.push(data);
-                return false // no activation: the platform declines, released or not
-            };
-            Neo.Main.windowNativeFocus  = async () => true;
+            Neo.Main.windowFocus        = async () => true;
+            Neo.Main.windowNativeFocus  = async () => focusResults.shift();
             Neo.Main.windowNativeMoveTo = async data => {
                 nativeMoveCalls.push(data);
-                return moveResults.shift()
+                return true
             };
             Neo.main.addon.DragDrop = {
                 parkWindowDrag  : async () => true,
@@ -1542,31 +1584,32 @@ test.describe.serial('Workstation.view.Workspace', () => {
 
             const park = () => workspace.parkTearOutVessel({itemId: 'alerts', nativeTitlebar: true, windowName: 'tearout-alerts'});
 
-            // Attempt 1: the OS still holds the window — the move is refused, the park is refused
-            // at the move, and the receipt says so.
+            // Attempt 1: the OS still holds the source — the owner's focus of the target is refused,
+            // the park is refused at the focus, and the receipt counts the attempt.
             await expect(park(), 'refused while the OS holds the window').resolves.toBe(false);
-            expect(workspace.lastVesselParkReceipt).toMatchObject({focused: false, moved: false, parkAttempts: 1, refusedAt: 'move'});
-            expect(workspace.lastVesselParkReceipt.parked, 'not parked').not.toBe(true);
+            expect(workspace.lastVesselParkReceipt).toMatchObject({focused: false, parkAttempts: 1, refusedAt: 'focus'});
+            expect(nativeMoveCalls, 'nothing moved on a refused focus').toEqual([]);
 
-            // Attempt 2: released — the move is granted, the park succeeds with focus and refocus
-            // recorded as refused, and nothing compensates the move.
+            // Attempt 2: released — focus, move and refocus are granted; the park lands and the count
+            // reads the retry that got it there.
             await expect(park(), 'parks on release').resolves.toBe(true);
-            expect(workspace.lastVesselParkReceipt).toMatchObject({focused: false, moved: true, refocused: false, parked: true, parkAttempts: 2});
-            expect(workspace.lastVesselParkReceipt.compensated, 'a refused refocus compensates nothing on this path').toBeUndefined();
-            expect(nativeMoveCalls.map(({x, y}) => ({x, y})), 'two moves to the target frame origin, no restore').toEqual([
-                {x: targetRect.x, y: targetRect.y},
-                {x: targetRect.x, y: targetRect.y}
-            ]);
-            expect(focusCalls, 'focus was attempted on every step, never trusted').toEqual([
-                {windowId: sourceWindowId},
-                {windowId: sourceWindowId},
-                {windowId: sourceWindowId}
-            ]);
+            expect(workspace.lastVesselParkReceipt).toMatchObject({focused: true, moved: true, refocused: true, parked: true, parkAttempts: 2});
 
             // A later park starts a fresh count.
-            moveResults.push(true);
             await expect(park()).resolves.toBe(true);
-            expect(workspace.lastVesselParkReceipt.parkAttempts, 'the count resets after a park').toBe(1)
+            expect(workspace.lastVesselParkReceipt.parkAttempts, 'the count resets after a park').toBe(1);
+
+            // A main-window park is satisfied without a platform effect and resets the count as well.
+            workspace.tearOutParkAttempts.alerts = 3;
+            workspace.vesselConversionTargetWindowId = ownerWindowId;
+            Neo.manager.Window.get = windowId => ({
+                [sourceWindowId]: {innerRect: sourceRect, nativeRoute: routeFor(sourceWindowId, {position: true})},
+                [ownerWindowId] : {innerRect: targetRect, nativeRoute: null}
+            })[windowId] ?? null;
+
+            await expect(park()).resolves.toBe(true);
+            expect(workspace.lastVesselParkReceipt).toMatchObject({parked: true, physical: false, parkAttempts: 4});
+            expect(workspace.tearOutParkAttempts.alerts, 'a satisfied main-window park clears the count').toBeUndefined()
         } finally {
             Neo.main.addon.DragDrop     = originalDragDrop;
             Neo.manager.Window.get      = originalManagerGet;

--- a/test/playwright/unit/main/MainNativeWindowRoute.spec.mjs
+++ b/test/playwright/unit/main/MainNativeWindowRoute.spec.mjs
@@ -488,6 +488,19 @@ async function runNativeWindowRouteProbe(scenario) {
                     })
                 };
                 exactCompletion = await Main.windowNativeMoveTo({...route, x: 420, y: 320})
+            } else if (scenario === 'native-close' || scenario === 'native-close-deferred') {
+                // The verified close: a platform that keeps the window (an OS titlebar drag still
+                // holding it) answers false and keeps the route for the caller's retry; one that closes
+                // answers true and retires the entry.
+                popup.close = () => {
+                    events.push('close');
+                    scenario === 'native-close' && (state.closed = true)
+                };
+                globalThis.setTimeout = callback => {
+                    callback();
+                    return 1
+                };
+                exactCompletion = await Main.windowNativeClose(route)
             } else if (
                 scenario === 'native-resize' ||
                 scenario === 'native-resize-default-denied' ||
@@ -732,6 +745,25 @@ test.describe('Neo.Main native window routes (#15396)', () => {
         expect(result.closed).toBe(true);
         expect(result.hasEntry).toBe(false);
         expect(result.route).toBeNull()
+    });
+
+    test('a native close is the VERIFIED outcome: a deferred close answers false and keeps the route, a done close retires the entry', async () => {
+        // Before this contract `windowNativeClose` returned true for the attempt and dropped the route at
+        // once, so a popup the OS still held by its titlebar read as closed while it stood on screen —
+        // and the retirement retry that relies on the route had nothing left to retry with.
+        const [deferred, done] = await Promise.all([
+            runNativeWindowRouteProbe('native-close-deferred'),
+            runNativeWindowRouteProbe('native-close')
+        ]);
+
+        expect(deferred.events, 'the close was asked for').toContain('close');
+        expect(deferred.exactCompletion, 'a window that is still there is not closed').toBe(false);
+        expect(deferred.closed).toBe(false);
+        expect(deferred.hasEntry, 'the route survives for the retry').toBe(true);
+
+        expect(done.exactCompletion).toBe(true);
+        expect(done.closed).toBe(true);
+        expect(done.hasEntry, 'a verified close retires the entry').toBe(false)
     });
 
     test('cross-origin open preserves direct browser navigation and exposes no native route', async () => {

--- a/test/playwright/unit/manager/DragCoordinator.spec.mjs
+++ b/test/playwright/unit/manager/DragCoordinator.spec.mjs
@@ -678,6 +678,52 @@ test.describe('Neo.manager.DragCoordinator — the §2.8.1 claim protocol', () =
         expect(DragCoordinator.pointerClaimArbiter).toBeNull()
     });
 
+    test('a NATIVE hover frame carries the dwell clock the commit is scheduled from — the hold is the gesture', () => {
+        // No pointer event and no release reach the page while the OS drags a popup, so the target
+        // paints the hold from the same start and duration the coordinator commits on. A second frame
+        // over the same target keeps the start: the clock belongs to the hold, not to the frame.
+        const
+            draggedItem = {id: 'tab-1'},
+            payloads    = [],
+            target      = {
+                ...createZone('workspace-main', 'win-main'),
+                onRemoteDragMove(payload) { payloads.push(payload) }
+            },
+            source = {
+                ...createSource(),
+                windowId           : 'win-popup',
+                getNativeWindowDrag: windowId => windowId === 'win-popup'
+                    ? {draggedItem, embodyNativeHover: true, widgetName: 'tab-1'}
+                    : null
+            };
+
+        registerWindow('win-main',  0,   0,   800, 600);
+        registerWindow('win-popup', 100, 100, 300, 200);
+
+        DragCoordinator.register(target);
+        DragCoordinator.register(source);
+
+        try {
+            DragCoordinator.onWindowPositionChange({windowId: 'win-popup'});
+
+            const first = payloads.at(-1)?.dwell;
+
+            expect(first, 'the hover frame names the clock').toEqual({
+                armedAt   : expect.any(Number),
+                durationMs: DragCoordinator.nativeWindowDropDwellMs
+            });
+
+            DragCoordinator.onWindowPositionChange({windowId: 'win-popup'});
+
+            expect(payloads).toHaveLength(2);
+            expect(payloads.at(-1).dwell.armedAt, 'the same hold keeps its start across frames').toBe(first.armedAt)
+        } finally {
+            // the commit timer is armed for the dwell — end the gesture before it can fire into a torn-down stage
+            DragCoordinator.clearNativeWindowDropCandidate('win-popup');
+            DragCoordinator.endNativeGesture?.('win-popup')
+        }
+    });
+
     test('THE OVERLAP FALSIFIER holds when the clock moves mid-pass — the winner is not the loop order', () => {
         const source = createSource();
 


### PR DESCRIPTION
Resolves #18115

> 🌿 *A popup resting on a drop zone waited for a release the page can never see — after this change, a native titlebar drop that needs the user to let go before anything happens is unsayable: the hold is the gesture.*

The native-titlebar drop is geometry-only: no pointer event and no release reach the page while the OS drags a popup. The coordinator now treats the hold as the gesture. `nativeWindowDropDwellMs` is 1200 ms and the same clock travels to the target with every hover frame (`dwell: {armedAt, durationMs}` on `onRemoteDragMove`), so the drop area paints the hold running out: the previewed region fills from the bottom over exactly that duration (a `::after` rising fill on `.neo-dock-preview-dwelling`, its duration and the time already spent published as custom properties, the latter as a negative delay so a node rebuilt mid-hold resumes rather than restarts; reduced motion shows a static armed tint). When the dwell completes on a still popup over the main window, the transfer commits at once — no focus, no move: for a main-window target the Workstation's strict park answers satisfied without a platform effect (`parkTearOutVessel`, `nativeTitlebar && targetIsMain`, receipt `parked: true, physical: false`), so the conversion bookkeeping around the park handler runs exactly as for a parked vessel while nothing is parked. The popup is retired afterwards through its owner handle: `windowNativeClose` now verifies the close (polls `win.closed`, keeps the route while the window stands) and the committed-retirement retry runs at a fixed 250 ms cadence bounded at 20 s, so a close the platform defers while the titlebar is still held lands the instant the user lets go — the indirect release signal the operator asked for. Popup-over-popup keeps its strict park.

Evidence: L2 (four unit arms across the coordinator, `Main.mjs` and the Workstation, red-first on `dev`) + L3 (the fill rendered and read off the browser in the preview component spec, red-first) → L2 + L3 sufficient for every engine-observable AC; the hand test (AC-6) stays operator-owned because no rig can hold a window. Residual: AC-6, Residual-Owner: @tobiu.

## AC Evidence
| AC-1 | `test/playwright/component/dashboard/DockPreviewRegionRender.spec.mjs` — the dwell arm: `neo-dock-preview-dwelling`, `--dock-native-dwell-ms: 1200ms`, elapsed ≥ 400 ms as a negative delay, `animation-name: neo-dock-preview-dwell-fill` / `1.2s`; reduced motion `none`; cleared clock → no fill. Red on `dev` (`TimeoutError: waiting for locator('.neo-dock-preview-dwelling')` — the renderer has no clock to paint) |
| AC-2 | `test/playwright/unit/apps/workstation/Workspace.spec.mjs` — a native-titlebar park onto the main window resolves `true` with zero platform calls (`windowFocus`, `windowNativeFocus`, `windowNativeMoveTo` all stubbed to refuse and never reached), receipt `{parked: true, physical: false}`, the source route still checked; the sibling arm keeps a popup target on the physical park. `test/playwright/unit/manager/DragCoordinator.spec.mjs` — the hover frame carries `{armedAt, durationMs}` with a stable `armedAt` across frames. Red on `dev`: `Expected: true, Received: false` — on `dev` the park dies at the focus step; the coordinator arm `dwell: undefined` on the hover frame |
| AC-3 | `test/playwright/unit/main/MainNativeWindowRoute.spec.mjs` — `native-close-deferred` answers `false` and keeps the route; `native-close` answers `true` and retires the entry. Red on `dev` (`Expected: false, Received: true` — the attempt was reported as the outcome). Fixed cadence + bound: `settleNativeWindowDisposition` (diff) |
| AC-4 | `parkTearOutVessel` untouched; popup targets take `onConversionIn` as before (Workspace unit arm, control half). NL: `WorkstationNativeTitlebarDragNL` 1/1 · `WorkstationNativePopupOverPopupNL` 1/1 at head under the Brain root |
| AC-5 | One constant: `nativeWindowDropDwellMs` → payload `durationMs` → `--dock-native-dwell-ms`; `unit/manager` + `component/dashboard`: `unit/manager/DragCoordinator` + `unit/main/MainNativeWindowRoute` + `unit/apps/workstation/Workspace` 105 passed (12.9s); `component/dashboard` 93 passed (59.9s) |
| AC-6 | Operator hand check on the Workstation (three runs: hold still → fill → pane lands → popup gone; release early → still lands ~1 s after the popup stops; pass over without stopping → nothing). Post-Merge, operator-owned |

## Deltas from ticket
Four, all measured. (0) The ticket had the Workstation answer the park with `null` and the coordinator treat `null` as "no park needed". Built and run under the Brain root, that shape died: `WorkstationNativeTitlebarDragNL` ended with an empty candidate map, no park receipt and the pane still in the popup — the embodiment relies on the conversion bookkeeping the park handler (`VesselPark.onConversionIn`) wraps around the physical park, and a `null` skipped all of it. The shipped shape keeps the handler flow whole and lets the park itself answer satisfied for a main-window target with no platform effect (`parked: true, physical: false`); the coordinator contract is untouched. (1) The ticket named a second, non-colour channel as the embodied proxy "materialising" during the hold; the hover contract keeps `embodyProxy: false` until the commit (the popup must stay visible while the user holds it), so there is no proxy to ramp — the rising fill IS the shape channel (a growing area, not only a hue), and the ticket's AC-1 is corrected to say so. (2) No new `lastNativeRetireReceipt`: the Workstation's existing close receipt already records `stage: 'platform-refused'` per attempt through the verified close, and the coordinator's `dispositionAttempts` counts the retries — readable live with what exists. (3) The retire retry cadence is a named constant pair (`nativeWindowRetireRetryMs` 250, `nativeWindowRetireRetryLimit` 80) rather than a reuse of the disposition backoff constant, so the two policies can be tuned apart.

(5) Rebased over Mnemosyne’s #18114 (merged while this PR was open, same function): her best-effort-focus branch in `parkTearOutVessel` became unreachable behind this PR’s main-target early return and is removed rather than left dead; her `tearOutParkAttempts` accounting stays and the no-op park resets it like a landed park; her main-target unit arm is retargeted to a popup-target `parkAttempts` arm (refused focus counts, the landed retry reads 2, a later park resets, the main no-op resets too); her popup control arm is untouched. Announced to her as a fork notice.

## Test Evidence
- Red-first on `dev` (`f6811898ed`), the specs in place and the six source files stashed: coordinator hover arm `dwell: undefined` (dev’s 450 ms constant read back as the expectation), `Main.mjs` close arm `Expected: false, Received: true`, Workspace park arm `Expected: true, Received: false`, component arm `TimeoutError: waiting for locator(.neo-dock-preview-dwelling)`.
- At head: the three unit specs 105 passed (12.9s); `component/dashboard` 93 passed (59.9s); the two native NL specs 1/1 each after the rebase onto `1e3866e328`.
- `WorkstationNativePopupOverPopupNL` is unstable independent of this PR — measured, not assumed: at the dev head `99b5be2a23` in the same tree it fails 3/3 (`placing the target vessel did not hand it to the main window`, then twice `Target page, context or browser has been closed` at the target-placement wait — the symptom Mnemosyne defect-noted this afternoon); on this branch it alternates pass/fail with a third symptom (the last claim resolves to `workstation-main` instead of the vessel — the arbiter’s same-tick tie-break when both windows intersect the corner anchor, the stale-outerRect class). This diff touches neither rect publication nor claims; the flake goes under #18059’s family. `WorkstationNativeTitlebarDragNL` (the main-window path this PR changes) is 1/1 before and after the rebase.
- NL under the Brain root: `WorkstationNativeTitlebarDragNL` 1/1 · `WorkstationNativePopupOverPopupNL` 1/1 at head under the Brain root.
- The consumer bump for the demo follows the merge (the fix is Workstation + engine; the demo consumer has tear-out off).

## Post-Merge Validation
- [ ] AC-6 hand check by the operator on the Workstation, three runs as above; the close's behaviour while the titlebar is still held (accepted at once, or deferred to release) recorded here from the receipt.
- [ ] Doc follow-ups from review, not folded into the approved head: the retire budget JSDoc undercounts the close poll (≈ 44 s worst case, not 20 s — Grace), `physical` beside `parked` in the receipt JSDoc, the focus-verb comment naming that the main-target native path never reaches it (Mnemosyne) — #18123.
- [ ] `WorkstationNativePopupOverPopupNL` flake in isolation — #18121 filed with the three measured symptoms. (defect-noted by Mnemosyne, my spec) — attributed under #18059's family.

Authored by Vega (Fable 5.1, Claude Code). Session 87c91db1-7fcd-4987-9932-2bf78d3dda25.


