### PR TITLE
feat(dock): a retargeted rail reveal slides its incoming pane in from the edge (#18117)

### DIFF
--- a/resources/scss/src/dashboard/Container.scss
+++ b/resources/scss/src/dashboard/Container.scss
@@ -218,6 +218,49 @@
 @keyframes neo-dock-reveal-from-top    { from { transform: translateY(-100cqh) } }
 @keyframes neo-dock-reveal-from-bottom { from { transform: translateY(100cqh) } }
 
+// A retarget — the reveal follows a click on another item of the same rail while it is open — is an
+// entry for the incoming content with no exit for the root: the panel stays where it is, the new
+// header and pane emerge from under the strip over the old ones. A CSS animation restarts only
+// when its name changes, so the overlay alternates two swap generations: one names a duplicate
+// set of the entry keyframes, the other the entry's own. The root runs a held keyframe of the same
+// duration so its own `animationend` fires and settles the motion window, exactly as an entry does.
+// The generation clears when the overlay hides, so the next entry runs the entry rules above; the
+// leaving rules below outrank both generations, so a dismissal mid-swap still leaves.
+.neo-dashboard-dock-reveal-overlay-swap-1 {
+    animation-name: neo-dock-reveal-hold-b;
+
+    > .neo-dashboard-dock-reveal-header,
+    > .neo-dashboard-dock-reveal-pane-slot { animation-name: neo-dock-reveal-from-left-b }
+
+    &.neo-dashboard-dock-reveal-overlay-right  > .neo-dashboard-dock-reveal-header,
+    &.neo-dashboard-dock-reveal-overlay-right  > .neo-dashboard-dock-reveal-pane-slot { animation-name: neo-dock-reveal-from-right-b }
+    &.neo-dashboard-dock-reveal-overlay-top    > .neo-dashboard-dock-reveal-header,
+    &.neo-dashboard-dock-reveal-overlay-top    > .neo-dashboard-dock-reveal-pane-slot { animation-name: neo-dock-reveal-from-top-b }
+    &.neo-dashboard-dock-reveal-overlay-bottom > .neo-dashboard-dock-reveal-header,
+    &.neo-dashboard-dock-reveal-overlay-bottom > .neo-dashboard-dock-reveal-pane-slot { animation-name: neo-dock-reveal-from-bottom-b }
+}
+
+.neo-dashboard-dock-reveal-overlay-swap-2 {
+    animation-name: neo-dock-reveal-hold-a;
+
+    > .neo-dashboard-dock-reveal-header,
+    > .neo-dashboard-dock-reveal-pane-slot { animation-name: neo-dock-reveal-from-left }
+
+    &.neo-dashboard-dock-reveal-overlay-right  > .neo-dashboard-dock-reveal-header,
+    &.neo-dashboard-dock-reveal-overlay-right  > .neo-dashboard-dock-reveal-pane-slot { animation-name: neo-dock-reveal-from-right }
+    &.neo-dashboard-dock-reveal-overlay-top    > .neo-dashboard-dock-reveal-header,
+    &.neo-dashboard-dock-reveal-overlay-top    > .neo-dashboard-dock-reveal-pane-slot { animation-name: neo-dock-reveal-from-top }
+    &.neo-dashboard-dock-reveal-overlay-bottom > .neo-dashboard-dock-reveal-header,
+    &.neo-dashboard-dock-reveal-overlay-bottom > .neo-dashboard-dock-reveal-pane-slot { animation-name: neo-dock-reveal-from-bottom }
+}
+
+@keyframes neo-dock-reveal-hold-a        { to { opacity: 1 } }
+@keyframes neo-dock-reveal-hold-b        { to { opacity: 1 } }
+@keyframes neo-dock-reveal-from-left-b   { from { transform: translateX(-100cqw) } }
+@keyframes neo-dock-reveal-from-right-b  { from { transform: translateX(100cqw) } }
+@keyframes neo-dock-reveal-from-top-b    { from { transform: translateY(-100cqh) } }
+@keyframes neo-dock-reveal-from-bottom-b { from { transform: translateY(100cqh) } }
+
 // The exit, the entry's mirror: the overlay is dismissed but not yet hidden — the same two
 // elements travel back, the root fading out where it stands, the content sliding back under its
 // strip. `forwards` holds the end state until the hidden class lands one vdom round trip after

--- a/src/dashboard/dock/interaction/RevealOverlay.mjs
+++ b/src/dashboard/dock/interaction/RevealOverlay.mjs
@@ -157,6 +157,21 @@ class RevealOverlay extends Container {
      * @protected
      */
     revealLeaveTimer = null
+    /**
+     * The retarget swap generation while the overlay shows: `0` for an entry, then `1` and `2`
+     * alternating on every retarget so the content's entry keyframes restart (see `beginRevealSwap`).
+     * @member {Number} revealSwapGeneration=0
+     * @protected
+     */
+    revealSwapGeneration = 0
+    /**
+     * The dock item id last shown while visible. A re-entry after a leave compares against it: a
+     * different item is a retarget that happened to pass through hidden (a rail's pressed-button
+     * group releases the old tab before it presses the new one), the same item is a plain return.
+     * @member {String|null} revealShownItemId=null
+     * @protected
+     */
+    revealShownItemId = null
 
     /**
      * Assembles the fixed child skeleton (tab-header toolbar: active title tab + pin action; pane slot)
@@ -269,6 +284,7 @@ class RevealOverlay extends Container {
 
         if (me.revealLeaving) {
             me.cancelRevealLeave();
+            me.revealSwapGeneration = 0;
             !me.isDestroyed && me.syncSnapshot();
             me.finishRevealMotion()
         }
@@ -310,11 +326,19 @@ class RevealOverlay extends Container {
             me.revealWasVisible = visible;
 
             if (visible) {
+                // A re-entry cancels an in-flight leave. When it brings a DIFFERENT item than the
+                // one that was leaving, it is a retarget that passed through hidden — the incoming
+                // content gets its entry, exactly as a retarget that never hid.
+                let leaving  = me.revealLeaving,
+                    retarget = leaving && me.revealShownItemId && me.revealedItem?.dockItemId !== me.revealShownItemId;
+
                 me.cancelRevealLeave();
-                me.beginRevealMotion()
+                retarget ? me.beginRevealSwap() : me.beginRevealMotion()
             } else if (me.mounted) {
                 me.beginRevealLeave()
             } else {
+                // No DOM to animate: hidden at once, and the next entry runs the entry rules.
+                me.revealSwapGeneration = 0;
                 me.finishRevealMotion()
             }
         }
@@ -421,12 +445,35 @@ class RevealOverlay extends Container {
      * @protected
      */
     afterSetRevealedItem(value, oldValue) {
-        let me = this;
+        let me = this,
+            // A retarget: the reveal follows a click on another item of the same rail while it is
+            // open — visible before and after, a different item. Read before the motion sync moves
+            // the visibility bookkeeping on.
+            retarget = me.revealWasVisible && me.visible && value?.dockItemId !== oldValue?.dockItemId && !!oldValue;
 
         // `visible` requires an item, so item-only removal/re-addition crosses the same CSS
         // display boundary even when the machine state remains `revealed`.
         me.syncRevealMotion();
+        retarget && me.beginRevealSwap();
         me.isConstructed && me.syncSnapshot()
+    }
+
+    /**
+     * @summary A retarget re-runs the content's entry: the incoming header and pane emerge from
+     * under the strip over the old ones while the root stays where it is.
+     *
+     * A CSS animation restarts only when its name changes, so two swap generations alternate —
+     * one names a duplicate set of the entry keyframes, the other the entry's own — and the root
+     * runs a held keyframe of the same duration so its own `animationend` settles the motion
+     * window exactly as an entry's does. The generation clears when the overlay hides, so the next
+     * entry runs the entry rules.
+     * @protected
+     */
+    beginRevealSwap() {
+        let me = this;
+
+        me.revealSwapGeneration = me.revealSwapGeneration === 1 ? 2 : 1;
+        me.beginRevealMotion()
     }
 
     /**
@@ -559,6 +606,17 @@ class RevealOverlay extends Container {
         // `animationend` lands the hidden class (see `beginRevealLeave`).
         NeoArray[me.visible || leaving ? 'remove' : 'add'](cls, 'neo-dashboard-dock-reveal-overlay-hidden');
         NeoArray[leaving ? 'add' : 'remove'](cls, 'neo-dashboard-dock-reveal-overlay-leaving');
+
+        // The swap generation is stamped from the count alone. It survives a leave — a leave may be
+        // cancelled by a retarget, and the next swap has to alternate against the class that is
+        // still on the node — and resets only when a hide completes (see `completeRevealLeave` and
+        // the no-DOM hide in `syncRevealMotion`), so the next entry runs the entry rules.
+        if (me.visible) {
+            me.revealShownItemId = item?.dockItemId ?? null
+        }
+
+        NeoArray[me.revealSwapGeneration === 1 ? 'add' : 'remove'](cls, 'neo-dashboard-dock-reveal-overlay-swap-1');
+        NeoArray[me.revealSwapGeneration === 2 ? 'add' : 'remove'](cls, 'neo-dashboard-dock-reveal-overlay-swap-2');
 
         me.set({
             cls,

--- a/test/playwright/component/apps/dock-rail-retarget/app.mjs
+++ b/test/playwright/component/apps/dock-rail-retarget/app.mjs
@@ -1,0 +1,88 @@
+import DockWorkspace from '../../../../../src/dashboard/dock/Workspace.mjs';
+import Viewport      from '../../../../../src/container/Viewport.mjs';
+import '../../../../../src/tab/Container.mjs';
+
+/**
+ * One right-edge rail carrying TWO auto-hidden items, so a reveal can be retargeted from one to the
+ * other by clicking the second tab while the first is open — the gesture whose motion this fixture
+ * exists to witness. The center pane is a plain component; the rail panes are plain components too,
+ * each with a large labelled block so the slot visibly holds one or the other.
+ */
+const fixtureDocument = {
+    schema: 'neo.dock.zone.v1',
+    root  : 'root',
+    items : {
+        main : {componentRef: 'main',  title: 'Main',  kind: 'panel'},
+        alpha: {componentRef: 'alpha', title: 'Alpha', kind: 'panel', autoHidden: true},
+        beta : {componentRef: 'beta',  title: 'Beta',  kind: 'panel', autoHidden: true}
+    },
+    nodes: {
+        root       : {type: 'edge-zone', zones: {center: {nodeId: 'main-tabs'}, right: {nodeId: 'edge-tabs', extent: 0.3}}},
+        'main-tabs': {type: 'tabs', items: ['main'],           activeItemId: 'main'},
+        'edge-tabs': {type: 'tabs', items: ['alpha', 'beta'],  activeItemId: 'alpha'}
+    }
+};
+
+/**
+ * @summary The fixture workspace for the reveal retarget motion: two items on one rail.
+ * @class Test.Playwright.Component.DockRailRetarget.Workspace
+ * @extends Neo.dashboard.dock.Workspace
+ */
+class RailRetargetWorkspace extends DockWorkspace {
+    static config = {
+        /**
+         * @member {String} className='Test.Playwright.Component.DockRailRetarget.Workspace'
+         * @protected
+         */
+        className: 'Test.Playwright.Component.DockRailRetarget.Workspace',
+        /**
+         * @member {String} id='dock-rail-retarget-workspace'
+         */
+        id: 'dock-rail-retarget-workspace',
+        /**
+         * @member {Object} layout={ntype:'vbox',align:'stretch'}
+         */
+        layout: {ntype: 'vbox', align: 'stretch'},
+        /**
+         * Mirrors the shape both shipping consumers give their dock host.
+         * @member {Object} style={position:'relative'}
+         */
+        style: {position: 'relative'}
+    }
+
+    /**
+     * @param {Object} config
+     */
+    construct(config) {
+        super.construct(config);
+
+        this.add(this.projectDockModel());
+        this.onDockZoneDocumentChange(structuredClone(fixtureDocument))
+    }
+
+    /**
+     * @summary Resolves one pane: a labelled block per item.
+     * @param {String} itemId
+     * @param {Object} item
+     * @returns {Object}
+     */
+    resolvePane(itemId, item) {
+        return {
+            cls  : ['dock-rail-retarget-pane', `dock-rail-retarget-pane-${itemId}`],
+            id   : `dock-rail-retarget-pane-${itemId}`,
+            ntype: 'component',
+            style: {padding: '24px'},
+            vdom : {cn: [{tag: 'h2', text: `${item.title} pane`}]}
+        }
+    }
+}
+
+RailRetargetWorkspace = Neo.setupClass(RailRetargetWorkspace);
+
+export const onStart = () => Neo.app({
+    mainView: {
+        module: Viewport,
+        items : [{module: RailRetargetWorkspace, flex: 1}]
+    },
+    name: 'Test.Playwright.DockRailRetarget'
+});

--- a/test/playwright/component/apps/dock-rail-retarget/index.html
+++ b/test/playwright/component/apps/dock-rail-retarget/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Neo.mjs Dock Rail Retarget Fixture</title>
+</head>
+<body>
+    <script src="../../../../../src/MicroLoader.mjs" type="module"></script>
+</body>
+</html>

--- a/test/playwright/component/apps/dock-rail-retarget/neo-config.json
+++ b/test/playwright/component/apps/dock-rail-retarget/neo-config.json
@@ -1,0 +1,9 @@
+{
+    "appPath"         : "test/playwright/component/apps/dock-rail-retarget/app.mjs",
+    "basePath"        : "../../../../../",
+    "environment"     : "development",
+    "mainPath"        : "./Main.mjs",
+    "mainThreadAddons": ["DragDrop", "Navigator", "Stylesheet"],
+    "themes"          : ["neo-theme-neo-dark", "neo-theme-neo-light"],
+    "useSharedWorkers": false
+}

--- a/test/playwright/component/dashboard/DockRailRevealRetarget.spec.mjs
+++ b/test/playwright/component/dashboard/DockRailRevealRetarget.spec.mjs
@@ -1,0 +1,78 @@
+import {test, expect} from '@playwright/test';
+
+/**
+ * Retargeting a reveal — clicking another item of the same rail while one is open — swapped the
+ * pane in one frame: the state machine follows the click without closing, so no visibility
+ * boundary is crossed and no motion runs. Now the incoming content enters the way a fresh reveal
+ * does, while the root stays where it is: a swap generation class alternates two names for the
+ * same keyframes, which is what makes a CSS animation restart, and the root runs a held keyframe
+ * of the same duration so its own end event settles the motion window as an entry's does.
+ *
+ * Read on a rendered dock: after the retarget the overlay is never hidden or leaving, its title is
+ * the new item's, the slot carries a running entry animation again, and the swap class alternates
+ * on the next retarget. The animations are read through `getAnimations()`, so a class without
+ * keyframes behind it cannot pass.
+ */
+
+const
+    OVERLAY = '.neo-dashboard-dock-reveal-overlay-right',
+    TAB     = title => `.neo-dashboard-dock-edge-rail-right .neo-dashboard-dock-rail-tab:has-text("${title}")`;
+
+const settleAnimations = overlay => overlay.evaluate(node =>
+    Promise.all(node.getAnimations({subtree: true}).map(a => a.finished.catch(() => {}))));
+
+const readSlotAnimations = overlay => overlay.evaluate(node => ({
+    root : node.getAnimations().map(a => `${a.animationName}:${a.playState}`),
+    slot : node.querySelector('.neo-dashboard-dock-reveal-pane-slot').getAnimations().map(a => `${a.animationName}:${a.playState}`),
+    title: node.querySelector('.neo-dashboard-dock-reveal-title')?.textContent.trim()
+}));
+
+test.beforeEach(async ({page}) => {
+    await page.goto('test/playwright/component/apps/dock-rail-retarget/index.html');
+    await page.waitForSelector('#dock-rail-retarget-workspace', {state: 'attached'});
+    await expect(page.locator(TAB('Alpha'))).toBeVisible({timeout: 10000});
+    await expect(page.locator(TAB('Beta'))).toBeVisible()
+});
+
+test.describe('Neo.dashboard.dock.interaction.RevealOverlay — a retarget slides the incoming pane in', () => {
+    test('clicking the other item of an open rail re-runs the content entry, and the next retarget alternates', async ({page}) => {
+        const overlay = page.locator(OVERLAY);
+
+        await page.locator(TAB('Alpha')).click();
+        await expect(overlay).toBeVisible({timeout: 10000});
+        await settleAnimations(overlay);
+
+        expect(await overlay.evaluate(node => node.getAnimations({subtree: true}).length), 'the entry has settled').toBe(0);
+
+        // Retarget: the overlay stays visible (never hidden, never leaving), the title follows, and
+        // the slot runs the entry keyframes again under the swap generation.
+        await page.locator(TAB('Beta')).click();
+
+        await expect(overlay, 'the first retarget stamps swap generation 1').toHaveClass(/neo-dashboard-dock-reveal-overlay-swap-1/);
+        await expect(overlay).not.toHaveClass(/neo-dashboard-dock-reveal-overlay-(hidden|leaving)/);
+
+        const first = await readSlotAnimations(overlay);
+
+        expect(first.title).toBe('Beta');
+        expect(first.slot.some(name => name.startsWith('neo-dock-reveal-from-right-b:')), `the incoming pane slides in from its edge (${first.slot})`).toBe(true);
+        expect(first.root.some(name => name.startsWith('neo-dock-reveal-hold-b:')), `the root holds for the same duration (${first.root})`).toBe(true);
+
+        await settleAnimations(overlay);
+
+        // Back to Alpha: the generation alternates so the animation restarts again.
+        await page.locator(TAB('Alpha')).click();
+
+        await expect(overlay, 'the second retarget alternates to generation 2').toHaveClass(/neo-dashboard-dock-reveal-overlay-swap-2/);
+        await expect(overlay).not.toHaveClass(/neo-dashboard-dock-reveal-overlay-swap-1/);
+
+        const second = await readSlotAnimations(overlay);
+
+        expect(second.title).toBe('Alpha');
+        expect(second.slot.some(name => name.startsWith('neo-dock-reveal-from-right:')), `the alternate generation reuses the entry's own keyframes (${second.slot})`).toBe(true);
+
+        // Dismissal clears the generation so the next entry runs the entry rules, not a swap.
+        await page.keyboard.press('Escape');
+        await expect(overlay).toHaveClass(/neo-dashboard-dock-reveal-overlay-hidden/, {timeout: 10000});
+        await expect(overlay).not.toHaveClass(/neo-dashboard-dock-reveal-overlay-swap-/)
+    })
+});

--- a/test/playwright/unit/dashboard/DockRevealOverlay.spec.mjs
+++ b/test/playwright/unit/dashboard/DockRevealOverlay.spec.mjs
@@ -311,6 +311,109 @@ test.describe('Neo.dashboard.dock.interaction.RevealOverlay', () => {
         expect(DockMotionSignal.isAnimating(overlay.id)).toBe(false)
     });
 
+    test('a retarget while visible flips the swap generation and opens one motion window; hidden retargets do not', () => {
+        overlay = Neo.create(DockRevealOverlay, {
+            edge: 'right',
+            id  : 'dock-reveal-swap'
+        });
+
+        const rootId = overlay.vdom?.id || overlay.id,
+              swap1  = 'neo-dashboard-dock-reveal-overlay-swap-1',
+              swap2  = 'neo-dashboard-dock-reveal-overlay-swap-2';
+
+        // An entry is generation 0: no swap class.
+        overlay.set({revealState: 'revealed', revealedItem: createItem({dockItemId: 'alpha', title: 'Alpha'})});
+        overlay.onMotionAnimationEnd(createSerializedAnimationEnd(rootId));
+        expect(overlay.revealSwapGeneration).toBe(0);
+        expect(overlay.cls).not.toContain(swap1);
+
+        // Retarget to another item while visible: generation 1, one motion window.
+        overlay.set({revealedItem: createItem({dockItemId: 'beta', title: 'Beta'})});
+        expect(overlay.revealSwapGeneration).toBe(1);
+        expect(overlay.cls).toContain(swap1);
+        expect(overlay.cls).not.toContain(swap2);
+        expect(overlay.titleTab.text).toBe('Beta');
+        expect(DockMotionSignal.isAnimating(overlay.id), 'the swap is motion').toBe(true);
+        expect(DockMotionSignal.activeMotions.get(overlay)?.count, 'one window, not two').toBe(1);
+
+        // The root's own end settles it, like an entry.
+        overlay.onMotionAnimationEnd(createSerializedAnimationEnd(rootId));
+        expect(DockMotionSignal.isAnimating(overlay.id)).toBe(false);
+
+        // The same item again is not a retarget.
+        overlay.set({revealedItem: createItem({dockItemId: 'beta', title: 'Beta'})});
+        expect(overlay.revealSwapGeneration).toBe(1);
+        expect(DockMotionSignal.isAnimating(overlay.id)).toBe(false);
+
+        // The next retarget alternates.
+        overlay.set({revealedItem: createItem({dockItemId: 'alpha', title: 'Alpha'})});
+        expect(overlay.revealSwapGeneration).toBe(2);
+        expect(overlay.cls).toContain(swap2);
+        expect(overlay.cls).not.toContain(swap1);
+        overlay.onMotionAnimationEnd(createSerializedAnimationEnd(rootId));
+
+        // Hiding clears the generation; a retarget while hidden opens nothing.
+        overlay.set({revealState: 'idle', revealedItem: null});
+        expect(overlay.revealSwapGeneration).toBe(0);
+        expect(overlay.cls).not.toContain(swap2);
+        overlay.revealedItem = createItem({dockItemId: 'beta', title: 'Beta'});
+        expect(overlay.revealSwapGeneration, 'no swap while hidden').toBe(0);
+        expect(DockMotionSignal.isAnimating(overlay.id)).toBe(false)
+    });
+
+    test('a retarget that passes through hidden on a mounted overlay is still a retarget: the leave is cancelled and the incoming item gets its entry', () => {
+        overlay = Neo.create(DockRevealOverlay, {
+            edge: 'right',
+            id  : 'dock-reveal-swap-via-leave'
+        });
+
+        const rootId  = overlay.vdom?.id || overlay.id,
+              swap1   = 'neo-dashboard-dock-reveal-overlay-swap-1',
+              leaving = 'neo-dashboard-dock-reveal-overlay-leaving';
+
+        overlay.mounted = true;
+        overlay.set({revealState: 'revealed-focused', revealedItem: createItem({dockItemId: 'alpha', title: 'Alpha'})});
+        overlay.onMotionAnimationEnd(createSerializedAnimationEnd(rootId));
+
+        // A pressed-button rail releases the old tab before it presses the new one: idle, then the
+        // other item — within one tick, so the leave never reaches the DOM.
+        overlay.set({revealState: 'idle', revealedItem: null});
+        expect(overlay.revealLeaving).toBe(true);
+        expect(overlay.cls).toContain(leaving);
+
+        overlay.set({revealState: 'revealed-focused', revealedItem: createItem({dockItemId: 'beta', title: 'Beta'})});
+        expect(overlay.revealLeaving, 'the leave is cancelled').toBe(false);
+        expect(overlay.cls).not.toContain(leaving);
+        expect(overlay.revealSwapGeneration, 'the incoming item gets its entry').toBe(1);
+        expect(overlay.cls).toContain(swap1);
+        expect(DockMotionSignal.activeMotions.get(overlay)?.count, 'one window across leave, cancel and swap').toBe(1);
+        overlay.onMotionAnimationEnd(createSerializedAnimationEnd(rootId));
+        expect(DockMotionSignal.isAnimating(overlay.id)).toBe(false);
+
+        // The same item returning after a cancelled leave is a plain re-entry, not a retarget: the
+        // generation is neither advanced nor reset — the class still on the node is the one the
+        // NEXT retarget has to alternate against.
+        overlay.set({revealState: 'idle', revealedItem: null});
+        expect(overlay.revealSwapGeneration, 'a leave keeps the generation').toBe(1);
+        overlay.set({revealState: 'revealed-focused', revealedItem: createItem({dockItemId: 'beta', title: 'Beta'})});
+        expect(overlay.revealSwapGeneration, 'a return of the same item is not a swap').toBe(1);
+        expect(overlay.cls).toContain(swap1);
+        overlay.onMotionAnimationEnd(createSerializedAnimationEnd(rootId));
+        expect(DockMotionSignal.isAnimating(overlay.id)).toBe(false);
+
+        // A retarget after that alternates, and a completed leave resets to the entry rules.
+        overlay.set({revealState: 'idle', revealedItem: null});
+        overlay.set({revealState: 'revealed-focused', revealedItem: createItem({dockItemId: 'alpha', title: 'Alpha'})});
+        expect(overlay.revealSwapGeneration, 'the next retarget alternates').toBe(2);
+        overlay.onMotionAnimationEnd(createSerializedAnimationEnd(rootId));
+        overlay.set({revealState: 'idle', revealedItem: null});
+        overlay.onMotionAnimationEnd(createSerializedAnimationEnd(rootId));
+        expect(overlay.revealLeaving).toBe(false);
+        expect(overlay.revealSwapGeneration, 'a completed leave resets the generation').toBe(0);
+        expect(overlay.cls).not.toContain(swap1);
+        expect(overlay.cls).not.toContain('neo-dashboard-dock-reveal-overlay-swap-2')
+    });
+
     test('early dismissal, rapid re-reveal and destroy each settle exactly their owned motion entry', () => {
         overlay = Neo.create(DockRevealOverlay, {
             edge: 'left',


### PR DESCRIPTION
Resolves #18117 (T1 — the incoming pane slides in; T2, the outgoing cross-fade, stays a design leaf)

**Stacked on #18118** (the exit motion): base `agent/18116-reveal-exit-motion`, retargets to `dev` when #18118 merges.

The operator's exploration on the Workstation: clicking another item of the same rail while a reveal is open. Today `RevealStateMachine` retargets (`revealed*` + `tabClick(other)` → `revealed-focused(other)`), the overlay's `afterSetRevealedItem` crosses no visibility boundary, and the rail swaps the slot's content — title and pane change in one frame, nothing moves. Now the incoming header and pane emerge from under the strip over the old ones while the root stays where it is.

Evidence: red-first with the source stashed — unit: the retarget arm fails at `revealSwapGeneration` (undefined); component: "the first retarget stamps swap generation 1" fails (no swap class, no restarted animation). Green: 728 passed (`unit/dashboard`), 97 passed (1.2 m) (`component/dashboard`).

## The change

- `RevealOverlay#afterSetRevealedItem`: a retarget (visible before and after, a different `dockItemId`) calls `beginRevealSwap`, which alternates `revealSwapGeneration` between 1 and 2 and opens the motion window; `syncSnapshot` stamps `-swap-1` / `-swap-2` while the overlay shows and clears the generation when it hides or leaves.
- `Container.scss`: generation 1 names duplicate copies of the entry keyframes (`neo-dock-reveal-from-<edge>-b`) on the header and slot, generation 2 the entry's own — a CSS animation restarts only when its name changes; the root runs `neo-dock-reveal-hold-a/b` (a held keyframe of the same duration) so its own `animationend` settles the motion window exactly as an entry's does. The swap block sits above the leaving block and below it in specificity, so a dismissal mid-swap still leaves.
- `DockRevealOverlay.spec.mjs`: the generations, one window per retarget settled by the root's end, the same item is not a retarget, hidden retargets open nothing.
- `test/playwright/component/apps/dock-rail-retarget/` (one right rail, two items) + `DockRailRevealRetarget.spec.mjs`: entry settles, retarget stamps generation 1 with `from-right-b` running on the slot and `hold-b` on the root, the title follows, the next retarget alternates to generation 2 with the entry's own names, Escape clears the generation.

## AC Evidence

- **AC-1 (component, red on dev):** the witness above.
- **AC-2 (unit, red on dev):** the retarget arm.
- **AC-3 (exit, entry and reveal suites green; reduced motion through the token):** the sets above; the swap reads the same `--dock-transition-duration-reveal`.

## Measured on the way

The first witness run failed with a motion window open and no swap class: on a rendered rail the retarget passes THROUGH HIDDEN within one tick — the focus-leave dismissal races the click, the overlay's item goes to null and back to the new one before the vdom flushes — so the single-transition predicate never saw it. The overlay now also treats a re-entry after a leave that brings a different item than the one last shown (`revealShownItemId`) as a retarget, and the swap generation survives a cancelled leave (it resets only when a hide completes); without the latter the second retarget landed on the same class and restarted nothing. Both routes are pinned in the unit spec.

## Deltas

- The outgoing pane is under the incoming slide from its first frame (one slot, so the swap itself is instant); a true cross-fade of the outgoing pane needs an outgoing layer and the reparent decision the ticket's T2 names.
- A retarget that passes through hidden is handled as a retarget, not as a leave plus a fresh entry — the ticket assumed one transition; the rendered path has two.

## Test Evidence

- Red-first: unit 1 failed (retarget arm); component 1 failed.
- After: `unit/dashboard` 728 passed; `component/dashboard` 97 passed (1.2 m) after `node buildScripts/build/themes.mjs -n -e dev`.

## Post-Merge Validation

On the Workstation's left rail: open one item, click the other — the new pane slides in from the strip over the old, the panel itself does not move; Escape then slides the panel out. Reduced motion collapses both.

Authored by Mnemosyne (@neo-fable, Claude Fable 5.1, Claude Code) · session 37bbc610-f0cd-4abb-95c2-eb70336a86f3
