### PR TITLE
fix(dock): maximize fills the dock host inset by a gap, on a shadow, for edge-band and center nodes alike (#18122)

### DIFF
--- a/resources/scss/src/dashboard/Container.scss
+++ b/resources/scss/src/dashboard/Container.scss
@@ -26,6 +26,15 @@
     // collapses it with its siblings below.
     --dock-transition-duration-reveal: var(--motion-panel, 280ms);
 
+    // ── Maximize presentation ────────────────────────────────────────────────────────────
+    // A maximized pane fills the DOCK HOST inset by a gap, and floats on a shadow. Both are
+    // paint-contract values a consumer tunes, never worker literals: the workspace writes the
+    // measured host rect as `calc()` against the gap token, so the token resolves in CSS. A
+    // `0px` gap and `none` are the byte-identical opt-outs. The shadow is neutral on purpose,
+    // like the drop chips' — the engine cannot know a host's palette.
+    --dock-maximize-gap   : 8px;
+    --dock-maximize-shadow: 0 16px 40px rgb(0 0 0 / 35%);
+
     // ── Splitter affordance floor ────────────────────────────────────────────────────────
     // The engine's duty here is DISCOVERABILITY; aesthetics are the consumer's. A host that
     // sets nothing must still get a findable drag target — an invisible splitter is the
@@ -654,9 +663,21 @@ body:not(.neo-native-drag-active) .neo-dashboard:has(.neo-dashboard-dock-reveal-
     // An opaque surface is part of the contract: the committed layout reflows underneath the
     // fixed pane, and a transparent header band would ghost the covered nodes' chrome through.
     background: var(--dock-maximize-background, var(--neo-background-color, #fff));
+    box-shadow: var(--dock-maximize-shadow);
     margin    : 0;
     position  : fixed;
     z-index   : var(--dock-maximize-z-index, 40);
+}
+
+// An edge-band node keeps its band measure while maximized — `max-inline-size: 50%` and its
+// block-axis twin cap the inline rect the workspace wrote, so a left or right band stopped at
+// half the host while a center node filled it. The maximized node is not a band for the
+// duration: the caps lift on the node itself, at a weight above the per-edge band rules.
+.neo-dashboard-dock-tabs.neo-dock-maximized {
+    max-block-size : none;
+    max-inline-size: none;
+    min-block-size : 0;
+    min-inline-size: 0;
 }
 
 // While a restore FLIP glides the pane from the workspace rect back into its flow slot, the

--- a/src/dashboard/dock/Workspace.mjs
+++ b/src/dashboard/dock/Workspace.mjs
@@ -2571,19 +2571,22 @@ class Workspace extends Container {
     }
 
     /**
-     * Measures the workspace root's live viewport rect — the geometry authority for the
-     * maximize presentation. The workspace measures ITSELF: `inset: 0` would answer to the
-     * viewport or an incidental fixed containing block instead of the workspace. `null` is the
-     * fail-safe trigger (unmounted mid-gesture, zero-area rect).
+     * Measures the dock host's live viewport rect — the geometry authority for the maximize
+     * presentation. A maximized pane fills the DOCK AREA, not the app view: a workspace that
+     * frames its host with a tour bar or a status bar keeps them in sight. The host is measured
+     * explicitly (the workspace root stands in while no host is mounted): `inset: 0` would answer
+     * to the viewport or an incidental fixed containing block instead. `null` is the fail-safe
+     * trigger (unmounted mid-gesture, zero-area rect).
      * @returns {Promise<Object|null>}
      * @protected
      */
     async measureDockMaximizeRect() {
         let me   = this,
+            id   = me.getDockHost()?.id || me.id,
             rect = null;
 
         try {
-            rect = await Neo.main.DomAccess.getBoundingClientRect({id: me.id, windowId: me.windowId})
+            rect = await Neo.main.DomAccess.getBoundingClientRect({id, windowId: me.windowId})
         } catch (error) {
             rect = null
         }
@@ -2591,6 +2594,29 @@ class Workspace extends Container {
         Array.isArray(rect) && (rect = rect[0]);
 
         return (rect?.width > 0 && rect?.height > 0) ? rect : null
+    }
+
+    /**
+     * @summary The four inline rect values of a maximized node: the measured host rect inset by
+     * the gap token on every side.
+     *
+     * The gap is a paint-contract value (`--dock-maximize-gap` on `.neo-dashboard`), never a
+     * worker literal, so the rect is written as `calc()` against the token and resolves in CSS —
+     * a consumer tunes the gap without a worker round trip. The FLIP measures the DOM and is
+     * unaffected by how the values are expressed.
+     * @param {Object} rect The host's live viewport rect
+     * @returns {Object} `{height, left, top, width}`
+     * @protected
+     */
+    dockMaximizeRectStyle(rect) {
+        const gap = 'var(--dock-maximize-gap, 0px)';
+
+        return {
+            height: `calc(${rect.height}px - 2 * ${gap})`,
+            left  : `calc(${rect.left}px + ${gap})`,
+            top   : `calc(${rect.top}px + ${gap})`,
+            width : `calc(${rect.width}px - 2 * ${gap})`
+        }
     }
 
     /**
@@ -2817,12 +2843,7 @@ class Workspace extends Container {
                 ...tabContainer.cls.filter(c => c !== 'neo-dock-maximize-restoring'),
                 'neo-dock-maximized'
             ])],
-            wrapperStyle: {
-                height: `${rect.height}px`,
-                left  : `${rect.left}px`,
-                top   : `${rect.top}px`,
-                width : `${rect.width}px`
-            }
+            wrapperStyle: me.dockMaximizeRectStyle(rect)
         });
 
         if (animate) {
@@ -3133,12 +3154,7 @@ class Workspace extends Container {
         tabContainer = me.getDockHost()?.down?.({dockNodeId: nodeId});
 
         tabContainer && !tabContainer.isDestroyed && tabContainer.set({
-            wrapperStyle: {
-                height: `${rect.height}px`,
-                left  : `${rect.left}px`,
-                top   : `${rect.top}px`,
-                width : `${rect.width}px`
-            }
+            wrapperStyle: me.dockMaximizeRectStyle(rect)
         })
     }
 

--- a/test/playwright/component/dashboard/DockActionTooltips.spec.mjs
+++ b/test/playwright/component/dashboard/DockActionTooltips.spec.mjs
@@ -21,8 +21,11 @@ const actionButton = (node, glyph) => node.locator(`.neo-tab-header-toolbar .neo
 
 /**
  * Hovers one control and waits for the app's shared tooltip — one node, mounted on show — to carry
- * the expected text. The pointer parks on a neutral spot first, so hovering the same control twice
- * (before and after a toggle) re-enters it and the singleton reconfigures.
+ * the expected text. The pointer parks on a neutral spot first and the previous tooltip is waited
+ * OUT (it lingers for the singleton's hide delay after a leave), so hovering the same control twice
+ * (before and after a toggle) re-enters it and the singleton reconfigures — a lingering tooltip over
+ * a control that moved with its pane (maximize insets the pane by a gap) would otherwise take the
+ * hover itself and keep its stale text.
  * @param {Object} page
  * @param {Object} locator
  * @param {String} text
@@ -30,6 +33,7 @@ const actionButton = (node, glyph) => node.locator(`.neo-tab-header-toolbar .neo
  */
 const expectTooltip = async (page, locator, text) => {
     await page.mouse.move(0, 0);
+    await expect(page.locator('.neo-tooltip'), 'the previous tooltip is gone before the next hover').toBeHidden();
     await locator.hover();
     await expect(page.locator('.neo-tooltip'), `hovering shows "${text}"`).toHaveText(text)
 };

--- a/test/playwright/component/dashboard/DockMaximize.spec.mjs
+++ b/test/playwright/component/dashboard/DockMaximize.spec.mjs
@@ -75,17 +75,32 @@ const expectMaximizedCount = async (page, count) => {
     }
 };
 
-const maximizedRectMatchesWorkspace = page => page.waitForFunction(() => {
+/**
+ * The maximized node fills the DOCK HOST inset by the gap token on every side — not the workspace
+ * root, not the viewport. The expected rect is derived from the rendered host and the token's
+ * computed value, so a host framed by other chrome, or a consumer that tunes the gap, both
+ * measure against the same contract.
+ */
+const maximizedRectMatchesHost = page => page.waitForFunction(() => {
+    const el   = document.querySelector('.neo-dock-maximized'),
+          host = document.querySelector('#dock-maximize-workspace .neo-dashboard');
+
+    if (!el || !host) return false;
+
+    const a   = el.getBoundingClientRect(),
+          b   = host.getBoundingClientRect(),
+          gap = parseFloat(getComputedStyle(host).getPropertyValue('--dock-maximize-gap')) || 0;
+
+    return Math.abs(a.top - (b.top + gap)) < 1.5 && Math.abs(a.left - (b.left + gap)) < 1.5
+        && Math.abs(a.width - (b.width - 2 * gap)) < 1.5 && Math.abs(a.height - (b.height - 2 * gap)) < 1.5
+});
+
+/** The rendered maximize chrome: the shadow token applied, no residual band cap. */
+const readMaximizedChrome = page => page.evaluate(() => {
     const el = document.querySelector('.neo-dock-maximized'),
-          ws = document.getElementById('dock-maximize-workspace');
+          cs = getComputedStyle(el);
 
-    if (!el || !ws) return false;
-
-    const a = el.getBoundingClientRect(),
-          b = ws.getBoundingClientRect();
-
-    return Math.abs(a.top - b.top) < 1.5 && Math.abs(a.left - b.left) < 1.5
-        && Math.abs(a.width - b.width) < 1.5 && Math.abs(a.height - b.height) < 1.5
+    return {boxShadow: cs.boxShadow, maxInlineSize: cs.maxInlineSize, maxBlockSize: cs.maxBlockSize}
 });
 
 test.beforeEach(async ({page}) => {
@@ -115,7 +130,7 @@ test.describe('dock maximize — presentation, never topology', () => {
         expect(maxBox.x).toBeLessThan(closeBox.x)
     });
 
-    test('maximize paints the measured workspace rect on the SAME node — iframe intact — and Escape restores with focus return', async ({page}) => {
+    test('maximize paints the dock host\'s rect, inset by the gap, on the SAME node — iframe intact — and Escape restores with focus return', async ({page}) => {
         const side = tabsNodeWith(page, 'Frame');
 
         await page.evaluate(() => {
@@ -130,7 +145,11 @@ test.describe('dock maximize — presentation, never topology', () => {
         await actionButton(side, 'fa-window-maximize').click();
 
         await expect(page.locator('.neo-dock-maximized')).toHaveCount(1);
-        await maximizedRectMatchesWorkspace(page);
+        await maximizedRectMatchesHost(page);
+
+        const chrome = await readMaximizedChrome(page);
+
+        expect(chrome.boxShadow, 'the maximized pane floats on the shadow token').not.toBe('none');
 
         expect(await readWorkspace(page, ['maximizedNodeId'])).toEqual(['side-tabs']);
 
@@ -166,6 +185,31 @@ test.describe('dock maximize — presentation, never topology', () => {
             document.activeElement?.classList?.contains('neo-tab-header-button')
             && document.activeElement.textContent.includes('Frame')
         )
+    });
+
+    test('an edge-band node maximizes to the same host rect as a center node — the band caps lift for the duration', async ({page}) => {
+        const edge = tabsNodeWith(page, 'Pinned');
+
+        await tabButton(edge, 'Pinned').click();
+        await actionButton(edge, 'fa-window-maximize').click();
+
+        await expect(page.locator('.neo-dock-maximized')).toHaveCount(1);
+        expect(await readWorkspace(page, ['maximizedNodeId'])).toEqual(['edge-tabs']);
+
+        // The band's `max-inline-size: 50%` used to survive the maximize class and cap the written
+        // rect at half the host; the host-rect match below is the regression, the cap read the cause.
+        await maximizedRectMatchesHost(page);
+
+        const chrome = await readMaximizedChrome(page);
+
+        expect(chrome.maxInlineSize, 'no band cap on the inline axis while maximized').toBe('none');
+        expect(chrome.maxBlockSize,  'no band cap on the block axis while maximized').toBe('none');
+
+        await page.keyboard.press('Escape');
+        await expect(page.locator('.neo-dock-maximized')).toHaveCount(0);
+
+        // Restored: the band measure applies again.
+        expect(await edge.evaluate(node => getComputedStyle(node).maxInlineSize), 'the band cap returns on restore').not.toBe('none')
     });
 
     test('the committed document and captured perspectives never observe maximize', async ({page}) => {
@@ -289,7 +333,7 @@ test.describe('dock maximize — presentation, never topology', () => {
 
         await tabButton(main, 'Alpha').click();
         await actionButton(main, 'fa-window-maximize').click();
-        await maximizedRectMatchesWorkspace(page);
+        await maximizedRectMatchesHost(page);
 
         // The observation exists exactly as long as the presentation does.
         await expect.poll(async () => (await readWorkspace(page, ['dockMaximizeResizeObserved']))[0]).toBe(true);
@@ -300,7 +344,7 @@ test.describe('dock maximize — presentation, never topology', () => {
 
         // Delivery witnessed, then the re-measured rect re-applied.
         await expect.poll(async () => (await readWorkspace(page, ['resizeEventCount']))[0], {timeout: 10_000}).toBeGreaterThan(0);
-        await maximizedRectMatchesWorkspace(page)
+        await maximizedRectMatchesHost(page)
     });
 
     test('while maximized, cross-zone and tear-out drag flags suppress and lift exactly on restore', async ({page}) => {
@@ -455,7 +499,7 @@ test.describe('dock maximize — presentation, never topology', () => {
 
             return el && el.style.transform === ''
         });
-        await maximizedRectMatchesWorkspace(page);
+        await maximizedRectMatchesHost(page);
 
         // The restore glide: the workspace holds `neo-dock-maximize-restoring` (the paint-order
         // hold) for exactly the motion window — it must appear with the gesture and leave when


### PR DESCRIPTION
Resolves #18122

The operator on the Workstation: maximizing the Queues pane fills half the screen, maximizing other items fills it all, and the intent — fill the workspace, not the viewport, with a slight gap and a shadow. Measured on the served app: `measureDockMaximizeRect` measured the **workspace root** (`me.id`), the whole app view (`{0, 0, 1239, 720}`), not the dock host (`{0, 98, 1239, 622}`); and the edge-band node `left-tabs` rendered **640 × 720** against a written width of 1239 px because `.neo-dashboard-dock-edge-band-left` keeps `max-inline-size: 50%` under `.neo-dock-maximized` — a `max-*` constraint applies to an inline width too. Center nodes carry no cap, hence the asymmetry.

Evidence: red-first with the source and stylesheet stashed — the shadow read fails (`box-shadow: none`) and the edge-band arm fails at the host-rect match (half width); green with the change: 97 passed (1.3 m) (`component/dashboard`).

## The change

- `Workspace#measureDockMaximizeRect` measures `getDockHost()` (the workspace root stands in while no host is mounted). The resize re-measure (`onDockMaximizeResize`) shares the source.
- `Workspace#dockMaximizeRectStyle(rect)`: the four inline values as `calc()` against `var(--dock-maximize-gap, 0px)` — the gap resolves in CSS, a consumer tunes it without a worker round trip, and the FLIP measures the DOM as before. Both write sites use it.
- `Container.scss`: `--dock-maximize-gap: 8px` and `--dock-maximize-shadow` on `.neo-dashboard` (neutral shadow, like the drop chips'; `0px` and `none` are the byte-identical opt-outs); `.neo-dock-maximized` gains the shadow; `.neo-dashboard-dock-tabs.neo-dock-maximized` lifts `max-*` / `min-*` on both axes at a weight above the per-edge band rules.
- `DockMaximize.spec.mjs`: `maximizedRectMatchesHost` (host rect inset by the token's computed value) replaces the workspace-rect matcher; the shadow is read on the existing arm; a new arm maximizes the edge-band node `edge-tabs` to the same rect, reads the lifted caps, and sees the cap return on restore.

## AC Evidence

- **AC-1 (center node = host rect inset by the gap; red on dev):** the existing arm with the new matcher; red-first on the shadow read.
- **AC-2 (edge-band node renders the same rect; red on dev):** the new arm, red-first at the host-rect match.
- **AC-3 (shadow applied, no residual cap; Escape restores):** both arms.
- **AC-4 (resize re-measure keeps the host rect; FLIP and the dashboard sets green):** `component/dashboard` 97 passed (1.3 m), `unit/dashboard` 726 passed.
- **AC-5 (the Workstation by eye):** read on the served app at an emulated 1280×720 (the browser pane was hidden, which collapses the real viewport): host `{0, 98, 1280, 622}`; Queues maximized `{8, 106, 1264, 606}`, Metrics maximized `{8, 106, 1264, 606}` — identical, the host inset by 8 px on every side, tour bar and status strip in view, `box-shadow` on, `max-inline-size: none` on the maximized band node; Queues restores to `{33, 110, 255, 417}`. Two screenshots taken (Queues and Metrics maximized) match: the same inset panel above the dock area.

## Deltas

- The engine default gap is 8 px and the shadow is on by default: every consumer's maximize now insets and floats. A consumer that wants the old edge-to-edge paint sets `--dock-maximize-gap: 0px; --dock-maximize-shadow: none`. Stated because it is a visible default change, not only a fix.
- On a workspace with no host reference the host IS the workspace, so nothing moves there except the gap and the shadow.
- `DockActionTooltips.spec.mjs`'s hover helper now waits the previous tooltip OUT before re-hovering. Bisected, not guessed: with the gap alone (shadow and cap lift kept) the arm failed because the shared tooltip lingers for its 400 ms hide delay after a leave, and the gap moves the maximized header under that lingering tooltip, so the next hover landed on the tooltip and kept its stale text. A test-instrument fix; the user-facing side of it — a tooltip that outlives a click by 400 ms while its control moves — is pre-existing and unchanged.

## Test Evidence

- Red-first: `DockMaximize.spec.mjs` — 2 failed (shadow read; edge-band host-rect match).
- After `node buildScripts/build/themes.mjs -n -e dev`: `component/dashboard` 97 passed (1.3 m); `unit/dashboard` 726 passed.

## Post-Merge Validation

On the Workstation, maximize Queues and then Metrics: both fill the dock area (tour bar and status bar still visible) inset by 8 px on every side, on a shadow, in both themes; Escape restores each to its slot.

Authored by Mnemosyne (@neo-fable, Claude Fable 5.1, Claude Code) · session 37bbc610-f0cd-4abb-95c2-eb70336a86f3
