### PR TITLE
feat(workstation): the theme toggle reveals from the pointer

### DIFF
--- a/apps/workstation/view/Workspace.mjs
+++ b/apps/workstation/view/Workspace.mjs
@@ -692,7 +692,7 @@ class Workspace extends DockWorkspace {
                 layout: {ntype: 'vbox', align: 'stretch', pack: 'center'}
             }, {
                 cls      : ['workstation-theme-button'],
-                handler  : () => me.toggleWorkspaceTheme(),
+                handler  : data => me.toggleWorkspaceTheme(data),
                 iconCls  : isLight ? 'fa fa-moon' : 'fa fa-sun',
                 ntype    : 'button',
                 reference: 'theme-toggle',
@@ -2624,10 +2624,34 @@ class Workspace extends DockWorkspace {
     }
 
     /**
-     * @returns {String} The newly applied theme.
+     * @summary Flips the workspace theme, revealed from the pointer where the browser supports it.
+     *
+     * The flip happens AFTER the awaited call, deliberately: `startViewTransition()` resolves once
+     * the transition has started, and `delay` is the window this method has to mutate the DOM
+     * before the new state is captured. Flipping first would let the transition capture the
+     * already-changed DOM as both states and the reveal would play over no visible difference.
+     *
+     * The reveal is decorative. Without the View Transition API the engine returns false and the
+     * flip still runs, so a browser that lacks the feature behaves exactly as before.
+     *
+     * Raw pointer coordinates go to the engine rather than a radius computed here: the App worker
+     * knows where the pointer was, not how a pseudo-element resolves a length, so the unit decision
+     * stays in `DomUtils.createRevealAnimation()` instead of gaining a copy per app.
+     * @param {Object} [data] The click event. Absent coordinates yield NO circular reveal:
+     * `createRevealAnimation()` returns null, the transition still runs as the browser's default
+     * cross-fade, and the flip is unaffected. Nothing here throws on a missing event
+     * @returns {Promise<String>} The newly applied theme.
      */
-    toggleWorkspaceTheme() {
-        return this.setWorkspaceTheme(this.theme === 'neo-theme-neo-light'
+    async toggleWorkspaceTheme(data) {
+        const me = this;
+
+        await Neo.main.DomAccess.startViewTransition({
+            delay   : 100,
+            reveal  : {x: data?.clientX, y: data?.clientY},
+            windowId: me.windowId
+        });
+
+        return me.setWorkspaceTheme(me.theme === 'neo-theme-neo-light'
             ? 'neo-theme-neo-dark'
             : 'neo-theme-neo-light')
     }

--- a/apps/workstation/view/Workspace.mjs
+++ b/apps/workstation/view/Workspace.mjs
@@ -2631,8 +2631,10 @@ class Workspace extends DockWorkspace {
      * before the new state is captured. Flipping first would let the transition capture the
      * already-changed DOM as both states and the reveal would play over no visible difference.
      *
-     * The reveal is decorative. Without the View Transition API the engine returns false and the
-     * flip still runs, so a browser that lacks the feature behaves exactly as before.
+     * The reveal is decorative, and that holds for every way it can fail: no View Transition API
+     * returns false, a failed reveal is caught inside the engine, and a rejected remote round trip
+     * is caught here. The flip runs in all three cases, so a browser or a transport that cannot
+     * deliver the animation still behaves exactly as before.
      *
      * Raw pointer coordinates go to the engine rather than a radius computed here: the App worker
      * knows where the pointer was, not how a pseudo-element resolves a length, so the unit decision
@@ -2645,11 +2647,16 @@ class Workspace extends DockWorkspace {
     async toggleWorkspaceTheme(data) {
         const me = this;
 
+        // The catch is the decorative promise kept. The engine resolves rather than rejects — no API
+        // returns false, a failed reveal is caught inside — but this is a REMOTE method, and the
+        // transport can reject for reasons the callee never sees. Without this, a rejected round trip
+        // would skip the flip entirely and leave the button doing nothing at all, which is a worse
+        // outcome than the missing animation it was supposed to guard.
         await Neo.main.DomAccess.startViewTransition({
             delay   : 100,
             reveal  : {x: data?.clientX, y: data?.clientY},
             windowId: me.windowId
-        });
+        }).catch(() => {});
 
         return me.setWorkspaceTheme(me.theme === 'neo-theme-neo-light'
             ? 'neo-theme-neo-dark'

--- a/test/playwright/unit/apps/workstation/Workspace.spec.mjs
+++ b/test/playwright/unit/apps/workstation/Workspace.spec.mjs
@@ -2815,7 +2815,7 @@ test.describe('Workspace — the theme toggle reveals from the pointer (#18125)'
      * @param {Object} config {data, startResult, startingTheme}
      * @returns {Promise<Object>} {calls, themeAtCall, themeAfter, threw}
      */
-    async function toggleWithStubbedTransition({data, startResult = true, startingTheme = 'neo-theme-neo-light'} = {}) {
+    async function toggleWithStubbedTransition({data, startResult = true, reject = false, startingTheme = 'neo-theme-neo-light'} = {}) {
         const
             originalDomAccess = Neo.main.DomAccess,
             domAccess         = originalDomAccess ?? Neo.ns('Neo.main.DomAccess', true),
@@ -2827,6 +2827,11 @@ test.describe('Workspace — the theme toggle reveals from the pointer (#18125)'
         domAccess.startViewTransition = async payload => {
             calls.push(payload);
             themeAtCall = workspace.theme;
+
+            if (reject) {
+                throw new Error('remote round trip rejected')
+            }
+
             return startResult
         };
 
@@ -2882,6 +2887,17 @@ test.describe('Workspace — the theme toggle reveals from the pointer (#18125)'
 
         // The reveal is decorative: today's instant flip is the floor this change must not regress.
         expect(themeAfter, 'the theme flips whether or not the transition ran').toBe('neo-theme-neo-dark')
+    });
+
+    test('a rejected remote round trip still flips the theme', async () => {
+        // The engine resolves rather than rejects, but this is a REMOTE method and the transport can
+        // fail for reasons the callee never sees. Before this method awaited anything it was
+        // infallible; without the guard a rejected round trip would skip the flip and leave the
+        // button doing nothing — a worse outcome than the animation it was meant to protect.
+        const {themeAfter, threw} = await toggleWithStubbedTransition({reject: true});
+
+        expect(threw, 'a decorative reveal must never take the flip down with it').toBeNull();
+        expect(themeAfter, 'the theme flips even when the transition never happened').toBe('neo-theme-neo-dark')
     });
 
     test('a toggle with no event neither throws nor invents a reveal origin', async () => {

--- a/test/playwright/unit/apps/workstation/Workspace.spec.mjs
+++ b/test/playwright/unit/apps/workstation/Workspace.spec.mjs
@@ -2806,3 +2806,94 @@ test.describe('refreshDockWorkspace — DockFlip is told the OUTCOME, not the re
         expect(options.geometryOnly, 'a proven in-place landing keeps its admission').toBe(true)
     })
 });
+
+test.describe('Workspace — the theme toggle reveals from the pointer (#18125)', () => {
+    /**
+     * Runs `toggleWorkspaceTheme` against a stubbed engine, capturing the theme as it stood at the
+     * moment the transition was requested. That snapshot is the whole point: the reveal only shows a
+     * difference if the flip lands INSIDE the transition's capture window, i.e. after this call.
+     * @param {Object} config {data, startResult, startingTheme}
+     * @returns {Promise<Object>} {calls, themeAtCall, themeAfter, threw}
+     */
+    async function toggleWithStubbedTransition({data, startResult = true, startingTheme = 'neo-theme-neo-light'} = {}) {
+        const
+            originalDomAccess = Neo.main.DomAccess,
+            domAccess         = originalDomAccess ?? Neo.ns('Neo.main.DomAccess', true),
+            originalStart     = domAccess.startViewTransition,
+            calls             = [];
+
+        let workspace, themeAtCall = null, themeAfter = null, threw = null;
+
+        domAccess.startViewTransition = async payload => {
+            calls.push(payload);
+            themeAtCall = workspace.theme;
+            return startResult
+        };
+
+        try {
+            workspace = Neo.create(Workspace, {theme: startingTheme});
+
+            try {
+                themeAfter = await workspace.toggleWorkspaceTheme(data)
+            } catch (error) {
+                threw = error
+            }
+
+            return {calls, themeAtCall, themeAfter, threw}
+        } finally {
+            originalStart
+                ? domAccess.startViewTransition = originalStart
+                : delete domAccess.startViewTransition;
+
+            workspace?.destroy()
+        }
+    }
+
+    test('the flip lands inside the capture window, not before the transition starts', async () => {
+        const {calls, themeAtCall, themeAfter} = await toggleWithStubbedTransition({
+            data: {clientX: 120, clientY: 40}
+        });
+
+        expect(calls, 'the engine transition must actually have been requested').toHaveLength(1);
+
+        // The discriminating assertion. Flipping first would leave the transition capturing the
+        // already-dark DOM as both states — a reveal playing over no visible difference, which no
+        // end-state check can tell apart from a working one.
+        expect(themeAtCall, 'the OLD theme must still be applied when the transition is requested')
+            .toBe('neo-theme-neo-light');
+
+        expect(themeAfter, 'and the new theme is applied once the window is open').toBe('neo-theme-neo-dark')
+    });
+
+    test('the pointer and window reach the engine, which owns the reveal geometry', async () => {
+        const {calls} = await toggleWithStubbedTransition({data: {clientX: 120, clientY: 40}});
+
+        expect(calls[0].reveal, 'raw coordinates travel; no radius is computed in the app')
+            .toEqual({x: 120, y: 40});
+
+        expect(calls[0].delay, 'the caller declares its own capture window').toBe(100);
+        expect(calls[0]).toHaveProperty('windowId')
+    });
+
+    test('a browser without the View Transition API still flips the theme', async () => {
+        const {themeAfter, threw} = await toggleWithStubbedTransition({startResult: false});
+
+        expect(threw, 'a false return is the documented no-API answer, not a failure').toBeNull();
+
+        // The reveal is decorative: today's instant flip is the floor this change must not regress.
+        expect(themeAfter, 'the theme flips whether or not the transition ran').toBe('neo-theme-neo-dark')
+    });
+
+    test('a toggle with no event neither throws nor invents a reveal origin', async () => {
+        const {calls, themeAfter, threw} = await toggleWithStubbedTransition({data: undefined});
+
+        expect(threw, 'a missing event must not reach the engine as a crash').toBeNull();
+
+        // Undefined coordinates are how `createRevealAnimation` is told there is no origin — it
+        // returns null and the transition runs as the browser's default cross-fade. Passing a
+        // made-up origin here would paint a circle from a place the user never clicked.
+        expect(calls[0].reveal, 'no origin is fabricated').toEqual({x: undefined, y: undefined});
+
+        expect(themeAfter, 'and the flip still happens').toBe('neo-theme-neo-dark')
+    })
+});


### PR DESCRIPTION
Resolves #18125

Related: #17739 / PR #17743 (the engine primitive this consumes), #18116 / #18117 (the rail motion that makes an instant theme flip conspicuous), PR #13430 (the archived note that this cannot be witnessed headless)

The operator, exploring before the rehearsal: the Portal's theme button plays a growing-circle reveal from the pointer and the Workstation's flips instantly. `Neo.main.DomAccess.startViewTransition()` was already app-neutral with the Portal as its only caller, so this adds a second caller — no engine change, no new file, no SCSS.

Evidence: L3 (real browser, served app, payload and animation object read at the runtime boundary) → L3 required (AC-1 is rendered appearance). Residual: AC-6, the rasterised circle, which is **unobservable to any runtime signal** — see Test Evidence.

## AC Evidence

| AC | Evidence |
|---|---|
| AC-1 — the reveal plays from the pointer | outside-CI, served app: a real click produces `document.startViewTransition` called (`transitionStarted: true`), the engine receiving `{delay: 100, reveal: {x: 415, y: 32}, windowId}`, and `createRevealAnimation()` on that exact payload returning `circle(0% at 90.2% 4.3%)` → `circle(133.3% at 90.2% 4.3%)`. Every boundary the Portal can be measured at, matched |
| AC-2 — the flip lands inside the capture window | unit, **mutation-tested**: reordering the implementation to flip-first turns the ordering arm red on `themeAtCall` (`Expected "neo-theme-neo-light" · Received "neo-theme-neo-dark"`) while the other three stay green |
| AC-3 — no View Transition API still flips | unit: a stub returning `false` still yields `neo-theme-neo-dark`, with no throw. Today's instant flip is the floor |
| AC-4 — the origin is the pointer, never fabricated | unit: a toggle with no event passes `{x: undefined, y: undefined}` and does not throw. `createRevealAnimation()` returns `null` for that, so the transition runs as the browser's default cross-fade — no circle is invented from a place nobody clicked |
| AC-5 — every existing caller survives the async signature | enumerated, not assumed: `grep -RIn toggleWorkspaceTheme apps/ test/ src/` returns exactly two hits — the definition and the one button handler. No tour or spec caller exists |
| AC-6 — read by eye | **residual, operator hand-check.** Stated rather than glossed; see the bound below |

## Deltas

- **A comment I wrote asserted a property the code did not have, and I caught it before committing.** The first JSDoc said absent coordinates "fall back to the engine's default origin". They do not: `createRevealAnimation()` returns `null`, and the transition runs as a plain cross-fade. The comment now says that. A comment claiming a guarantee is a test obligation, and AC-4 is the arm.
- **The unit arms cannot witness the reveal, so the browser check was not optional.** They inject `data` directly, so a click that never delivered coordinates would pass all four. That is why the payload was read at the runtime boundary rather than inferred from `showRipple`'s use of `data.clientX`.
- **Main window only, by operator scope.** `setWorkspaceTheme` deliberately fans across `Neo.appsByName[me.appName]` — its comment says iterating the window-keyed registry "would let a Workstation toggle retheme an unrelated co-hosted app" — while `document.startViewTransition()` captures one whole document. So vessels keep flipping instantly, and a co-hosted app would be swept by a circle without changing colour. Neither is introduced here; both fall out of animating a document while theming an app. Recorded in the ticket's Out of Scope rather than discovered during a demo.

## Test Evidence

- Full unit suite **3028 passed**. `check-theme-surfaces`: *"Workstation theme guard: parity + token-only + completeness pass."* `check-reactive-tags` reports only pre-existing findings in `apps/portal/`, none in either file this PR touches.
- **Mutation test, not just red-first.** Reverting to `dev` would have made the arms red for the trivial reason that the feature is absent. Instead the implementation was mutated to the *plausible wrong* version — flip before the await — and the ordering arm failed on exactly that, 1 failed / 47 passed. The three other arms stayed green, which shows they assert independent properties rather than restating one.
- **The bound, named plainly.** I tried to observe the rasterised circle by sampling `document.getAnimations()` for `::view-transition-new(root)` across the animation. It read empty — and so did **the Portal's shipped reveal under the identical sampler**. The control is what saved the claim: my instrument cannot see view-transition pseudo-elements in this context, so it says nothing about either app. Without running the Portal I would have reported a Workstation defect that does not exist. This is the same limit the engine's own JSDoc records — a reveal that registers and then rasterises wrongly "stays invisible to every runtime signal this method can read".

## Post-Merge Validation

- [ ] AC-6 — click the Workstation theme button in a real browser and confirm the circle grows from the pointer, both directions. Everything upstream of the rasteriser is verified; this is the one step no instrument here can take.

## Commits

- `10b7361c4a` — the theme toggle reveals from the pointer.

Authored by Ada (Claude Opus 5, Claude Code). Session 7596538d-5324-419a-b043-95c585d833ea.

Cross-family note: same-family clearance is armed today (@neo-opus-grace, 2026-09-02T15:53Z) — the GPT seats are on a weekly rate limit, so opus↔fable and opus↔opus reviews are gate-clearing.
