### PR TITLE
ci(test): cache the components job's Chromium install, keyed on the Playwright version (#18126)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -298,14 +298,18 @@ jobs:
       # The components suite launches real Chromium against the dev server; unit runs
       # browserless, so browser provisioning stays scoped to this suite.
       #
+      # Browser provisioning has two network tails, and each has turned a five-minute
+      # job into a fifteen-minute one: the browser download (20 to 40 seconds on a good
+      # day, five to eleven minutes on a bad one) and the apt install of its system
+      # libraries (seconds when the mirror answers, five minutes when it does not).
+      #
       # The browser binaries are cached across runs, keyed on the installed Playwright
       # version: a new version ships a new browser build and misses on purpose. The
-      # download is network-bound — 20 to 40 seconds on a good day, five to eleven
-      # minutes on a bad one, which turned five-minute jobs into fifteen — while a
-      # restore takes seconds. The cache is saved right after a successful install,
-      # not at job end, so a red test run still leaves the browser behind for the next
-      # one. The apt libraries are not cached; `install-deps` puts them in place on a
-      # hit, from the runner's local mirror.
+      # cache is saved right after a successful download, not at job end, so a red test
+      # run still leaves the browser behind for the next one. The system libraries are
+      # not installed on a schedule: a launch probe asks the browser whether anything is
+      # missing, and apt runs only when it is — on the runner image that ships Chrome,
+      # it is not.
       - name: Resolve Playwright version
         id: playwright
         if: ${{ matrix.run == 'true' && steps.head.outputs.current == 'true' && matrix.suite == 'components' }}
@@ -321,7 +325,7 @@ jobs:
 
       - name: Install Playwright Chromium
         if: ${{ matrix.run == 'true' && steps.head.outputs.current == 'true' && matrix.suite == 'components' && steps.playwright-cache.outputs.cache-hit != 'true' }}
-        run: npx playwright install --with-deps chromium
+        run: npx playwright install chromium
 
       - name: Save Playwright Chromium
         if: ${{ matrix.run == 'true' && steps.head.outputs.current == 'true' && matrix.suite == 'components' && steps.playwright-cache.outputs.cache-hit != 'true' }}
@@ -330,8 +334,16 @@ jobs:
           path: ~/.cache/ms-playwright
           key: ${{ steps.playwright-cache.outputs.cache-primary-key }}
 
+      # A failed launch names the missing libraries in its output and hands the job to
+      # the apt step below; a job that still cannot launch after it fails in the tests.
+      - name: Verify Chromium launches
+        id: chromium-probe
+        if: ${{ matrix.run == 'true' && steps.head.outputs.current == 'true' && matrix.suite == 'components' }}
+        continue-on-error: true
+        run: node -e "require('playwright').chromium.launch().then(browser => browser.close())"
+
       - name: Install Playwright system dependencies
-        if: ${{ matrix.run == 'true' && steps.head.outputs.current == 'true' && matrix.suite == 'components' && steps.playwright-cache.outputs.cache-hit == 'true' }}
+        if: ${{ matrix.run == 'true' && steps.head.outputs.current == 'true' && matrix.suite == 'components' && steps.chromium-probe.outcome == 'failure' }}
         run: npx playwright install-deps chromium
 
       - name: Skip ${{ matrix.suite }} tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -297,9 +297,42 @@ jobs:
 
       # The components suite launches real Chromium against the dev server; unit runs
       # browserless, so browser provisioning stays scoped to this suite.
-      - name: Install Playwright Chromium
+      #
+      # The browser binaries are cached across runs, keyed on the installed Playwright
+      # version: a new version ships a new browser build and misses on purpose. The
+      # download is network-bound — 20 to 40 seconds on a good day, five to eleven
+      # minutes on a bad one, which turned five-minute jobs into fifteen — while a
+      # restore takes seconds. The cache is saved right after a successful install,
+      # not at job end, so a red test run still leaves the browser behind for the next
+      # one. The apt libraries are not cached; `install-deps` puts them in place on a
+      # hit, from the runner's local mirror.
+      - name: Resolve Playwright version
+        id: playwright
         if: ${{ matrix.run == 'true' && steps.head.outputs.current == 'true' && matrix.suite == 'components' }}
+        run: echo "version=$(node -p "require('@playwright/test/package.json').version")" >> "$GITHUB_OUTPUT"
+
+      - name: Restore Playwright Chromium
+        id: playwright-cache
+        if: ${{ matrix.run == 'true' && steps.head.outputs.current == 'true' && matrix.suite == 'components' }}
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-chromium-${{ runner.os }}-${{ steps.playwright.outputs.version }}
+
+      - name: Install Playwright Chromium
+        if: ${{ matrix.run == 'true' && steps.head.outputs.current == 'true' && matrix.suite == 'components' && steps.playwright-cache.outputs.cache-hit != 'true' }}
         run: npx playwright install --with-deps chromium
+
+      - name: Save Playwright Chromium
+        if: ${{ matrix.run == 'true' && steps.head.outputs.current == 'true' && matrix.suite == 'components' && steps.playwright-cache.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ steps.playwright-cache.outputs.cache-primary-key }}
+
+      - name: Install Playwright system dependencies
+        if: ${{ matrix.run == 'true' && steps.head.outputs.current == 'true' && matrix.suite == 'components' && steps.playwright-cache.outputs.cache-hit == 'true' }}
+        run: npx playwright install-deps chromium
 
       - name: Skip ${{ matrix.suite }} tests
         if: ${{ matrix.run != 'true' || steps.head.outputs.current != 'true' }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -340,7 +340,7 @@ jobs:
         id: chromium-probe
         if: ${{ matrix.run == 'true' && steps.head.outputs.current == 'true' && matrix.suite == 'components' }}
         continue-on-error: true
-        run: node -e "require('playwright').chromium.launch().then(browser => browser.close())"
+        run: node -e "require('@playwright/test').chromium.launch().then(browser => browser.close())"
 
       - name: Install Playwright system dependencies
         if: ${{ matrix.run == 'true' && steps.head.outputs.current == 'true' && matrix.suite == 'components' && steps.chromium-probe.outcome == 'failure' }}


### PR DESCRIPTION
Resolves #18126

The operator saw a components job fail after 13 minutes on a CI that was brought under 6. Read from the Actions API: the tests had not moved — the job spent 8m42s in `npx playwright install --with-deps chromium`, a step with no cache in front of it, and the tests took their usual 4m17s. An earlier green job that day spent 10m40s in the same step (15m05s total). The re-run of the red job, on a fresh runner, spent 4m51s there. Across 28 recent components jobs the step takes 20–40 s on most, about a minute on three, and the outliers above when the browser CDN drags. Unit and components are parallel matrix jobs (they start within a second of each other after the 5 s scope job); the repo split serialized nothing.

## Two network tails, not one

The first commit cached the browser and kept `npx playwright install-deps chromium` on a hit. Its hit run restored in 3 s and then spent **5m36s** in that apt step — the job came in at 10m18s, worse than the miss. The step's log names what the runner image lacked: **no shared library at all, only font packages** (`fonts-freefont-ttf`, `fonts-ipafont-gothic`, `fonts-tlwg-loma-otf`, `fonts-unifont`, `fonts-wqy-zenhei`, `xfonts-*`), fetched from a mirror that took five minutes over them. So the slow-CI tail has two sources — the browser CDN and the apt mirror — and every run before this PR paid both inside `--with-deps`. No component spec compares screenshots (0 `toHaveScreenshot` / `toMatchSnapshot`), and the suite's text is Latin, which the image's own fonts cover; the CJK, Thai and bitmap fonts apt added were never load-bearing.

## The change

`.github/workflows/test.yml`, the components arm only:

- **Resolve Playwright version** reads the installed `@playwright/test` version after `npm ci`.
- **Restore Playwright Chromium** (`actions/cache/restore@v4`) restores `~/.cache/ms-playwright` under `playwright-chromium-<os>-<version>`. A new Playwright version is a new browser build and misses on purpose.
- **Install Playwright Chromium** runs only on a miss and downloads only the browser (`npx playwright install chromium`, no `--with-deps`).
- **Save Playwright Chromium** (`actions/cache/save@v4`) saves right after a successful download, not at job end — a red test run still leaves the browser behind for the next one.
- **Verify Chromium launches** (`continue-on-error`) launches and closes the browser once; a failed launch names the missing libraries in its output.
- **Install Playwright system dependencies** runs only when that probe failed: `npx playwright install-deps chromium`. On the runner image that ships Chrome it does not run at all; on an image that drops a library it runs, and a browser that still cannot launch fails in the tests, loudly.

The unit arm, the scope classification, the test command and the artifact upload are untouched. `dev` is the default branch, so the cache its first post-merge run saves serves every later PR branch; a PR branch's own save serves its later pushes.

## AC Evidence

- **AC-1 (browser provisioning on a hit):** run 4 below — restore plus probe, no download, no apt.
- **AC-2 (a version change misses and installs):** the key carries the resolved version; runs 1 and 3 are misses (run 3 after deleting the entry on purpose) and downloaded the browser.
- **AC-3 (unit untouched, still parallel):** the unit job carries no new step; its start time stays within a second of the components job's on every run.
- **AC-4 (tests unchanged):** the components tests pass on every run, with the fonts apt used to add absent on runs 3 and 4.

## Test Evidence

1. First commit, miss (17:05Z): Resolve 0 s · Restore 0 s (no entry) · `install --with-deps` 26 s · Save 4 s (entry `playwright-chromium-Linux-1.61.1`, 261 MiB) · tests 4m15s green · components 5m14s, unit 1m06s, both started 17:05:27.
2. First commit, hit (re-run, 17:12Z): Restore 3 s · install and save skipped · `install-deps` **5m36s** (fonts only, slow mirror) · tests 4m13s green · components 10m18s. The measurement that produced the second commit.
3. Second commit, miss (17:25Z, the cache entry deleted first): Resolve 0 s · Restore 0 s (no entry) · `install chromium` 12 s · Save 5 s (entry re-created, 261 MiB) · Verify Chromium launches 1 s, passed · system dependencies skipped · tests 4m12s green · components 5m01s, unit 1m23s, both started 17:25:45.
4. Second commit, hit (17:32Z, re-run of the same commit): Resolve 0 s · Restore 4 s · install and save skipped · Verify Chromium launches 2 s, passed · system dependencies skipped · tests 4m13s green · components 4m52s, unit 1m36s, both started 17:32:38.

5. Third commit, hit (17:52Z, the probe loading the declared package): Resolve 0 s · Restore 3 s · install and save skipped · Verify Chromium launches 2 s, passed · system dependencies skipped · tests 4m18s green · components 4m52s, unit 1m22s, both started 17:52:46.

Browser provisioning on a hit is 6 s (runs 1 and 2 of the old design: 31 s on a good day, 4m51s to 10m40s on a bad one, plus up to 5m36s of apt). The components job's floor is now the tests themselves.

## Review cycle 1 (Grace)

The probe loaded `playwright`, a transitive package this repo does not declare; under `continue-on-error` a module-not-found would have been indistinguishable from missing libraries and would have turned apt back on for every run while staying green. The probe now loads the declared `@playwright/test`, which re-exports `chromium` (verified locally: the export is present and launch-and-close resolves). Run 5 is the hit path with the declared package.

## Post-Merge Validation

The first components job on `dev` after the merge misses and saves; the next one restores in seconds. Read from the jobs' step timings.

Authored by Mnemosyne (@neo-fable, Claude Fable 5.1, Claude Code) · session 37bbc610-f0cd-4abb-95c2-eb70336a86f3
