### PR TITLE
refactor(dock): the swap generations' keyframes come from one declaration (#18129)

### DIFF
--- a/resources/scss/src/dashboard/Container.scss
+++ b/resources/scss/src/dashboard/Container.scss
@@ -222,10 +222,28 @@
 }
 
 @keyframes neo-dock-reveal-fade        { from { opacity: 0 } }
-@keyframes neo-dock-reveal-from-left   { from { transform: translateX(-100cqw) } }
-@keyframes neo-dock-reveal-from-right  { from { transform: translateX(100cqw) } }
-@keyframes neo-dock-reveal-from-top    { from { transform: translateY(-100cqh) } }
-@keyframes neo-dock-reveal-from-bottom { from { transform: translateY(100cqh) } }
+
+// The per-edge entry travel, emitted once per SWAP GENERATION. The retarget rules below need a
+// second `animation-name` per direction — a CSS animation restarts only when its name changes —
+// but the two generations have to stay geometrically IDENTICAL. Maintained by hand they could
+// drift apart silently, and the symptom is peculiarly hard to read: alternating retargets would
+// render differently from each other, one sliding the tuned distance and the next the old one, on
+// every second interaction. It looks like a rendering glitch rather than a CSS error, and an arm
+// that asserts each generation runs an animation cannot see it. Both names therefore come from
+// this single declaration; `DockRailRevealRetarget.spec.mjs` asserts the two generations' keyframes
+// are equal, so a future edit cannot reach one twin without the other (#18129).
+$dock-reveal-entry-travel: (
+    left  : translateX(-100cqw),
+    right : translateX(100cqw),
+    top   : translateY(-100cqh),
+    bottom: translateY(100cqh)
+);
+
+@each $generation in ('', '-b') {
+    @each $edge, $travel in $dock-reveal-entry-travel {
+        @keyframes neo-dock-reveal-from-#{$edge}#{$generation} { from { transform: $travel } }
+    }
+}
 
 // A retarget — the reveal follows a click on another item of the same rail while it is open — is an
 // entry for the incoming content with no exit for the root: the panel stays where it is, the new
@@ -263,12 +281,15 @@
     &.neo-dashboard-dock-reveal-overlay-bottom > .neo-dashboard-dock-reveal-pane-slot { animation-name: neo-dock-reveal-from-bottom }
 }
 
-@keyframes neo-dock-reveal-hold-a        { to { opacity: 1 } }
-@keyframes neo-dock-reveal-hold-b        { to { opacity: 1 } }
-@keyframes neo-dock-reveal-from-left-b   { from { transform: translateX(-100cqw) } }
-@keyframes neo-dock-reveal-from-right-b  { from { transform: translateX(100cqw) } }
-@keyframes neo-dock-reveal-from-top-b    { from { transform: translateY(-100cqh) } }
-@keyframes neo-dock-reveal-from-bottom-b { from { transform: translateY(100cqh) } }
+// One held frame per generation. The root must fire its OWN `animationend` to settle the motion
+// window — `onMotionAnimationEnd` matches on root target identity, and the children's ends bubble
+// past it — while staying exactly where it is, since an edge-ward root would overlap the rail strip
+// mid-entry and intercept clicks (#18074). A no-op opacity keyframe of the same token duration is
+// what buys the end event without the movement. Emitted from one declaration for the same reason
+// the travel above is: the two generations must not drift.
+@each $generation in ('a', 'b') {
+    @keyframes neo-dock-reveal-hold-#{$generation} { to { opacity: 1 } }
+}
 
 // The exit, the entry's mirror: the overlay is dismissed but not yet hidden — the same two
 // elements travel back, the root fading out where it stands, the content sliding back under its

--- a/test/playwright/component/dashboard/DockRailRevealRetarget.spec.mjs
+++ b/test/playwright/component/dashboard/DockRailRevealRetarget.spec.mjs
@@ -74,5 +74,66 @@ test.describe('Neo.dashboard.dock.interaction.RevealOverlay — a retarget slide
         await page.keyboard.press('Escape');
         await expect(overlay).toHaveClass(/neo-dashboard-dock-reveal-overlay-hidden/, {timeout: 10000});
         await expect(overlay).not.toHaveClass(/neo-dashboard-dock-reveal-overlay-swap-/)
+    });
+
+    /**
+     * The arm above proves each generation RUNS an animation. That is not enough, and the gap is
+     * the reason this one exists: the two generations exist only so the `animation-name` differs —
+     * a CSS animation restarts on nothing else — while the geometry they animate must stay equal.
+     * Emitted from one SCSS declaration they cannot diverge; maintained as twins they could, and
+     * the symptom is a rendering glitch nobody would read as a CSS error: alternating retargets
+     * travelling different distances, wrong on every second interaction. Presence is identical in
+     * both worlds, so only a comparison of the two generations' own keyframes discriminates.
+     *
+     * Read from the running animation rather than the sheet, so what is compared is what the
+     * browser will actually interpolate — `100cqw` resolved against the live container, on the same
+     * element at the same size for both generations.
+     */
+    test('the two swap generations differ in NAME and agree in GEOMETRY', async ({page}) => {
+        const
+            overlay = page.locator(OVERLAY),
+            // The slot's own running entry animation, with its keyframes as the browser computed
+            // them. Null rather than a throw if nothing runs — an absent animation is a failure the
+            // assertions below should report, not a stack trace here.
+            readGeometry = () => overlay.evaluate(node => {
+                const
+                    slot = node.querySelector('.neo-dashboard-dock-reveal-pane-slot'),
+                    anim = slot?.getAnimations().find(a => a.animationName?.startsWith('neo-dock-reveal-from-'));
+
+                return anim ? {
+                    name     : anim.animationName,
+                    keyframes: anim.effect.getKeyframes().map(({offset, transform}) => ({offset, transform}))
+                } : null
+            });
+
+        await page.locator(TAB('Alpha')).click();
+        await expect(overlay).toBeVisible({timeout: 10000});
+        await settleAnimations(overlay);
+
+        await page.locator(TAB('Beta')).click();
+        await expect(overlay).toHaveClass(/neo-dashboard-dock-reveal-overlay-swap-1/);
+
+        const generationOne = await readGeometry();
+
+        await settleAnimations(overlay);
+
+        await page.locator(TAB('Alpha')).click();
+        await expect(overlay).toHaveClass(/neo-dashboard-dock-reveal-overlay-swap-2/);
+
+        const generationTwo = await readGeometry();
+
+        // Non-vacuity: a null read on either side would make the equality below trivially true.
+        expect(generationOne, 'generation 1 must actually be animating the slot').not.toBeNull();
+        expect(generationTwo, 'generation 2 must actually be animating the slot').not.toBeNull();
+        expect(generationOne.keyframes.length, 'and the keyframes must have been readable').toBeGreaterThan(0);
+
+        // The mechanism: different names are the ONLY reason the animation restarts.
+        expect(generationTwo.name, 'the generations must name different keyframes, or nothing restarts')
+            .not.toBe(generationOne.name);
+
+        // The invariant: and yet they must travel identically.
+        expect(generationTwo.keyframes,
+            `the two generations must animate the same geometry — ${generationOne.name} vs ${generationTwo.name}`)
+            .toEqual(generationOne.keyframes)
     })
 });

--- a/test/playwright/component/dashboard/DockRailRevealRetarget.spec.mjs
+++ b/test/playwright/component/dashboard/DockRailRevealRetarget.spec.mjs
@@ -89,7 +89,7 @@ test.describe('Neo.dashboard.dock.interaction.RevealOverlay — a retarget slide
      * browser will actually interpolate — `100cqw` resolved against the live container, on the same
      * element at the same size for both generations.
      */
-    test('the two swap generations differ in NAME and agree in GEOMETRY', async ({page}) => {
+    test('the running generations differ in NAME and agree in GEOMETRY on the rail under test', async ({page}) => {
         const
             overlay = page.locator(OVERLAY),
             // The slot's own running entry animation, with its keyframes as the browser computed
@@ -135,5 +135,57 @@ test.describe('Neo.dashboard.dock.interaction.RevealOverlay — a retarget slide
         expect(generationTwo.keyframes,
             `the two generations must animate the same geometry — ${generationOne.name} vs ${generationTwo.name}`)
             .toEqual(generationOne.keyframes)
+    });
+
+    /**
+     * The arm above reads what the browser will actually interpolate, which is the stronger claim —
+     * but it can only reach the ONE edge this fixture's rail uses. A hand-written `from-top-b` with
+     * different geometry would emit, build, and pass it. The `@each` is what makes that structurally
+     * impossible; this arm is the backstop for a loop someone later unwinds in part, so it has to
+     * cover all four pairs rather than the one on screen.
+     *
+     * Read from the live stylesheets, so what is compared is the SHIPPED CSS — the same artifact the
+     * browser resolves — rather than the SCSS source, which is the thing under suspicion.
+     */
+    test('every generation pair is emitted identically — the backstop covers all four edges, not only the rail under test', async ({page}) => {
+        const pairs = await page.evaluate(() => {
+            const bodies = {};
+
+            for (const sheet of document.styleSheets) {
+                let rules;
+
+                // A cross-origin sheet throws on access and is never ours.
+                try { rules = sheet.cssRules } catch { continue }
+
+                for (const rule of rules ?? []) {
+                    if (rule.type === CSSRule.KEYFRAMES_RULE && rule.name.startsWith('neo-dock-reveal-')) {
+                        // Last definition wins in CSS, so a later override must overwrite here too —
+                        // otherwise a drifted twin appended after the loop would be invisible.
+                        bodies[rule.name] = [...rule.cssRules].map(frame => `${frame.keyText}{${frame.style.cssText}}`).join('')
+                    }
+                }
+            }
+
+            return [
+                ...['left', 'right', 'top', 'bottom'].map(edge => ({
+                    pair: edge,
+                    base: bodies[`neo-dock-reveal-from-${edge}`],
+                    twin: bodies[`neo-dock-reveal-from-${edge}-b`]
+                })),
+                {pair: 'hold', base: bodies['neo-dock-reveal-hold-a'], twin: bodies['neo-dock-reveal-hold-b']}
+            ]
+        });
+
+        // Non-vacuity: an empty or partial read would make every equality below trivially true.
+        expect(pairs, 'four directional pairs plus the hold pair').toHaveLength(5);
+
+        for (const {pair, base, twin} of pairs) {
+            expect(base, `the ${pair} base keyframe must exist in the shipped CSS`).toBeTruthy();
+            expect(twin, `the ${pair} twin keyframe must exist in the shipped CSS`).toBeTruthy()
+        }
+
+        for (const {pair, base, twin} of pairs) {
+            expect(twin, `the ${pair} generations must be emitted identically`).toBe(base)
+        }
     })
 });


### PR DESCRIPTION
Resolves #18129

The retarget slide needs a second `animation-name` per direction — a CSS animation restarts on nothing else — and the sheet supplied the twins by hand. One `@each` over the generations now emits both names from a single travel map, and the hold pair likewise, so they cannot drift apart; the emitted CSS is unchanged. The other half was the witness: asserting each generation *runs* an animation gives an identical answer whether or not the twins agree, so a new component arm reads both generations' keyframes off the running animations and asserts they differ in NAME and agree in GEOMETRY.

Evidence: L2 (unit-equivalent — the built CSS diffed against a pre-change baseline) + L3 (browser arm reading `getAnimations()` on a rendered dock) → L3 sufficient: every AC is observable in the component harness, and the drift this guards is a paint property the arm reads directly. Residual: none.

Micro-review eligible: contained — a build-identical SCSS refactor plus one arm; no consumed surface, no runtime behaviour, no cascade relationship changed.

## AC Evidence

| AC | Evidence |
|---|---|
| AC-1 the built `Container.css` carries the same eight keyframe names with the same bodies | outside-CI: rebuilt with `node buildScripts/build/themes.mjs -n -e dev` before and after; the 16 normalised `@keyframes neo-dock-reveal-*` blocks diff **empty**. Receipt below. |
| AC-2 the new arm fails with one twin altered and passes with the loop; the retarget and exit specs and both full sets stay green | outside-CI (two mutations, on two different edges) + CI: receipts below; `component/dashboard` **100 passed**, `unit/dashboard` **728 passed**, `DockRailRevealRetarget` 3/3, `DockRailRevealExit` 4/4 |
| AC-3 the documented specificity story is unchanged | CI: no selector was touched — the diff moves only `@keyframes` declarations, which carry no specificity. The swap and leaving blocks are byte-identical. |

## Deltas from ticket

- The ticket proposed one `@each` over `('', '-b')`. Shipped as that plus a named `$dock-reveal-entry-travel` map, so the per-edge geometry is declared once rather than repeated inside the loop body — the same reason the loop exists, applied one level down.
- The hold pair got its own small loop. The ticket mentions it in the problem statement but not the proposed change; leaving `hold-a`/`hold-b` hand-written would have left two of the eight blocks exposed to exactly the drift being removed.
- The arm compares keyframes as the **browser computed them** (`effect.getKeyframes()` off the running animation) rather than as authored, so `100cqw` is compared resolved against the live container, on the same element at the same size for both generations. That is what will actually be interpolated.

## Test Evidence

**AC-1 — the emitted CSS is unchanged.** Sixteen `@keyframes neo-dock-reveal-*` blocks captured from `dist/development/css/src/dashboard/Container.css`, normalised and sorted, before and after:

```
diff -u kf-before.txt kf-after.txt   →   (no output)
✓ built output IDENTICAL to pre-change baseline
```

**AC-2 — the arm discriminates the drift it exists to catch.** Simulating the hazard the loop removes, by overriding one twin after the loop emits it:

```scss
@keyframes neo-dock-reveal-from-right-b { from { transform: translateX(90cqw) } }
```

Built CSS then carries both definitions (the later wins), and the suite reports:

```
1 failed   the two swap generations differ in NAME and agree in GEOMETRY
1 passed   clicking the other item of an open rail re-runs the content entry, and the next retarget alternates
```

**The pre-existing arm passes on the drift.** That is the finding restated as a receipt: presence is identical in both worlds, so only the geometry comparison discriminates. Probe removed, AC-1 re-verified after removal, and the pair is 2/2 green.

**Second commit — the backstop now covers all four edges (Ada's review challenge).** The running-animation arm reads what the browser will actually interpolate, but it can only reach the ONE edge the fixture's rail uses; a hand-written `from-top-b` would emit, build and pass it. A second arm reads every `neo-dock-reveal-*` keyframes rule off the live stylesheets and asserts all four directional pairs plus the hold pair are emitted identically.

Verified against the gap it closes rather than the one already covered — `from-top-b` drifted to `-90cqh` on a **right**-rail fixture:

```
1 failed   every generation pair is emitted identically — the backstop covers all four edges…
2 passed   (both running-animation arms, including the geometry one)
```

The two running arms pass on a top-edge drift, which is the challenge reproduced and answered in the same run. The first arm was also renamed to say what it proves: its old title claimed the generations agree in geometry, while it demonstrated that for the rail under test.

## Post-Merge Validation

- [ ] None required. No runtime behaviour changes and the built CSS is byte-identical; the retarget motion on the served Workstation is unaffected by construction.

---

Raised as a Depth Floor challenge in my review of #18120 (non-blocking), accepted by the author as a post-merge follow-up and ticketed as #18129; taken by an Opus seat per the operator's Fable-budget direction of 2026-09-02.

Related: #18117, #18120, #18074

Authored by Grace (Claude Opus 5, Claude Code). Session fb58e855-74b2-4367-9f83-5877f151f024.
