### PR TITLE
fix(portal): a rejected reveal round trip cannot take the theme switch with it

### DIFF
--- a/apps/portal/view/ViewportController.mjs
+++ b/apps/portal/view/ViewportController.mjs
@@ -282,11 +282,17 @@ class ViewportController extends Controller {
         // The reveal geometry belongs to the realm that owns the DOM: the App worker knows where
         // the pointer was, not how a pseudo-element resolves a length. Passing the raw coordinates
         // keeps the unit decision in one engine place instead of one copy per app.
+        //
+        // The catch is the decorative promise kept. The engine resolves rather than rejects — no
+        // API returns false, a failed reveal is caught inside — but this is a REMOTE method, and
+        // the transport can reject for reasons the callee never sees. Without this, a rejected
+        // round trip would skip the theme change entirely and leave the button doing nothing at
+        // all, which is a worse outcome than the missing animation it was meant to guard.
         await Neo.main.DomAccess.startViewTransition({
             delay   : 100,
-            reveal  : {x: data.clientX, y: data.clientY},
+            reveal  : {x: data?.clientX, y: data?.clientY},
             windowId: me.windowId
-        });
+        }).catch(() => {});
 
         me.setTheme(newTheme)
     }

--- a/test/playwright/unit/apps/portal/view/ViewportController.spec.mjs
+++ b/test/playwright/unit/apps/portal/view/ViewportController.spec.mjs
@@ -1,0 +1,115 @@
+import {setup} from '../../../../setup.mjs';
+
+setup({
+    appConfig: {
+        name: 'PortalViewportControllerTest'
+    }
+});
+
+import {test, expect}     from '@playwright/test';
+import Neo                from '../../../../../../src/Neo.mjs';
+import * as core          from '../../../../../../src/core/_export.mjs';
+import ViewportController from '../../../../../../apps/portal/view/ViewportController.mjs';
+
+/**
+ * `onSwitchTheme` awaits a REMOTE method before applying the theme. The engine itself resolves
+ * rather than rejects — `startViewTransition` returns false without the View Transition API and
+ * catches a failed reveal internally — but the worker-side call is a proxy, and its transport can
+ * reject for reasons the main-thread method never observes.
+ *
+ * The reveal is decorative. Losing it must cost an animation, never the theme change, so these arms
+ * pin the flip against every way the awaited call can fail.
+ */
+test.describe('Portal.view.ViewportController — the theme switch survives its decorative reveal', () => {
+    /**
+     * Runs `onSwitchTheme` against a stubbed engine and reports what the theme did.
+     * @param {Object} config {data, reject, startResult, startingTheme}
+     * @returns {Promise<Object>} {calls, themeAfter, threw}
+     */
+    async function switchThemeWith({data = {clientX: 40, clientY: 12}, noEvent = false, reject = false, startResult = true, startingTheme = 'neo-theme-neo-light'} = {}) {
+        const
+            originalDomAccess = Neo.main.DomAccess,
+            domAccess         = originalDomAccess ?? Neo.ns('Neo.main.DomAccess', true),
+            originalStart     = domAccess.startViewTransition,
+            calls             = [];
+
+        let themeAfter = null,
+            threw      = null;
+
+        domAccess.startViewTransition = async payload => {
+            calls.push(payload);
+
+            if (reject) {
+                throw new Error('remote round trip rejected')
+            }
+
+            return startResult
+        };
+
+        // The SHIPPED method, run against the minimal `this` it actually reads. Constructing the
+        // controller would boot the viewport's services (the SEO fetch among them) to exercise five
+        // lines, and the extra machinery would be noise this arm cannot fail on meaningfully.
+        const context = {
+            component: {theme: startingTheme},
+            windowId : 1,
+            setTheme : theme => {themeAfter = theme}
+        };
+
+        try {
+            // `noEvent` calls with NO argument, which is the real shape. Passing `data: undefined`
+            // would hit this helper's own default and silently test the with-pointer case instead.
+            await (noEvent
+                ? ViewportController.prototype.onSwitchTheme.call(context)
+                : ViewportController.prototype.onSwitchTheme.call(context, data))
+        } catch (error) {
+            threw = error
+        } finally {
+            originalStart
+                ? domAccess.startViewTransition = originalStart
+                : delete domAccess.startViewTransition
+        }
+
+        return {calls, themeAfter, threw}
+    }
+
+    test('a rejected remote round trip still switches the theme', async () => {
+        const {themeAfter, threw} = await switchThemeWith({reject: true});
+
+        expect(threw, 'a decorative reveal must never take the theme switch down with it').toBeNull();
+        expect(themeAfter, 'the theme switches even when the transition never happened').toBe('neo-theme-neo-dark')
+    });
+
+    test('a browser without the View Transition API still switches the theme', async () => {
+        const {themeAfter, threw} = await switchThemeWith({startResult: false});
+
+        expect(threw, 'a false return is the documented no-API answer, not a failure').toBeNull();
+        expect(themeAfter, 'the pre-existing floor: the theme switches either way').toBe('neo-theme-neo-dark')
+    });
+
+    test('the pointer reaches the engine, which owns the reveal geometry', async () => {
+        const {calls} = await switchThemeWith({data: {clientX: 40, clientY: 12}});
+
+        expect(calls, 'the engine transition must actually have been requested').toHaveLength(1);
+        expect(calls[0].reveal, 'raw coordinates travel; no radius is computed in the app').toEqual({x: 40, y: 12});
+        expect(calls[0].delay, 'the caller declares its own capture window').toBe(100)
+    });
+
+    test('a switch with no event neither throws nor invents a reveal origin', async () => {
+        // Undefined coordinates are how `createRevealAnimation` is told there is no origin — it
+        // returns null and the transition runs as the browser's default cross-fade. A fabricated
+        // origin would paint a circle from a place nobody clicked.
+        const {calls, themeAfter, threw} = await switchThemeWith({noEvent: true});
+
+        expect(threw, 'a missing event must not reach the engine as a crash').toBeNull();
+        expect(calls[0].reveal, 'no origin is fabricated').toEqual({x: undefined, y: undefined});
+        expect(themeAfter, 'and the switch still happens').toBe('neo-theme-neo-dark')
+    });
+
+    test('the switch reverses out of the dark theme', async () => {
+        // The direction the other arms never exercise: a controller that starts dark must resolve
+        // light, or a one-way switch would pass every assertion above.
+        const {themeAfter} = await switchThemeWith({startingTheme: 'neo-theme-neo-dark'});
+
+        expect(themeAfter, 'the toggle is a toggle, not a one-way trip').toBe('neo-theme-neo-light')
+    })
+});


### PR DESCRIPTION
Resolves #18130

Related: PR #18127 (the Workstation caller, guarded there, where this was found), #17739 / PR #17743 (the engine contract documenting what `startViewTransition` can and cannot observe)

`onSwitchTheme` awaits a **remote** method before applying the theme. The engine is well behaved — it returns `false` without the View Transition API and catches a rejected `ready` internally — but the worker-side call is a **proxy**: it posts a message and returns a promise created worker-side. A transport rejection rejects *that* promise, `setTheme` is never reached, and the theme button silently does nothing. Strictly worse than the outcome the call exists to improve.

Evidence: L2 (unit — the failure mode is a rejected promise, fully reachable in the unit harness) → L2 sufficient: every AC is a control-flow property, not rendered appearance. Residual: none.

## AC Evidence

| AC | Evidence |
|---|---|
| AC-1 — a rejected round trip still applies the theme switch, no throw | `ViewportController.spec.mjs`: a stub that throws still yields `neo-theme-neo-dark` with `threw === null` |
| AC-2 — the arm is red without the guard, and no other arm changes state under that mutation | control below: **1 failed / 4 passed**, the failure being that arm alone |
| AC-3 — existing behaviour untouched when the call resolves | the pointer arm asserts `reveal: {x: 40, y: 12}` and `delay: 100` reach the engine unchanged; the no-API arm pins the pre-existing floor |
| AC-4 — the comment explains the transport-vs-callee distinction | the engine method looks infallible from the call site, and that appearance is exactly what makes the omission easy; the comment says so |

## The change

- `.catch(() => {})` on the awaited call, with the reason in a comment.
- `data?.clientX` / `data?.clientY` for parity with the Workstation caller: a handler invoked without event data now yields no reveal origin instead of throwing. `createRevealAnimation()` returns `null` for absent coordinates, so the transition runs as the browser's default cross-fade — no origin is fabricated from a place nobody clicked.
- `test/playwright/unit/apps/portal/view/ViewportController.spec.mjs` — five arms. **This controller had no unit spec at all before.**

## Deltas

- **The guard is not in the engine, and I checked that rather than assuming it.** Two callers needing the same catch is normally the "N sites, one idiom, missing primitive" signal. It is wrong here: `DomAccess.startViewTransition` runs on the main thread and cannot see a transport failure of the promise the *worker* holds — by the time it fails there is nothing for the callee to catch. A bridge-level catch would swallow rejections for every remote call in the framework. Per-caller is the one shape that felt like duplication and is not.
- **The arms call the shipped method against a minimal `this`** (`ViewportController.prototype.onSwitchTheme.call(context, data)`) rather than constructing the controller. Constructing it boots the viewport's services — the SEO fetch among them — to exercise five lines, and that machinery is noise the arm cannot fail on meaningfully. The method's whole `this` surface is `component`, `windowId`, `setTheme`.
- **One arm was silently testing the wrong thing until it failed.** The no-event case originally passed `data: undefined`, which hit the helper's own default parameter and exercised the *with-pointer* path while claiming to test the absent one — `Received {x: 40, y: 12}`. It now calls `onSwitchTheme` with no argument at all. Recorded because a passing version of that arm would have witnessed nothing.

## Test Evidence

- **Red-first, mutation form.** With `.catch(() => {})` removed:

```
1 failed   a rejected remote round trip still switches the theme
             Error: a decorative reveal must never take the theme switch down with it
             Received: [Error: remote round trip rejected]
4 passed
```

Exactly one arm fires and it is the right one — the other four are untouched by the guard, so it discriminates the transport failure alone rather than being coupled to it.

- Full unit suite **3036 passed**.

## Post-Merge Validation

None. The failure mode is a rejected promise, fully covered by the unit arms; the resolving path is unchanged and already carried by the Portal's existing behaviour.

## Commits

- `bd53ff9b4e` — a rejected reveal round trip cannot take the theme switch with it.

Authored by Ada (Claude Opus 5, Claude Code). Session 7596538d-5324-419a-b043-95c585d833ea.

Cross-family note: same-family clearance is armed today (@neo-opus-grace, 2026-09-02T15:53Z) — the GPT seats are on a weekly rate limit, so opus↔fable and opus↔opus reviews are gate-clearing.
