### PR TITLE
fix(workstation): the theme reveal holds its old layer instead of fading to black

### DIFF
--- a/resources/scss/src/apps/workstation/Workspace.scss
+++ b/resources/scss/src/apps/workstation/Workspace.scss
@@ -11,6 +11,10 @@
 //
 // Every consumer that calls `Neo.main.DomAccess#startViewTransition()` needs this today; the
 // engine owns the animation but not the cancellation that makes it visible.
+//
+// It MUST stay at file top level. These are DOCUMENT pseudo-elements: nesting them under
+// `.workstation-workspace` for tidiness would not scope them, it would make them never match —
+// silently, with a black reveal as the only symptom and nothing to connect it to the refactor.
 ::view-transition-old(root),
 ::view-transition-new(root) {
     animation     : none;

--- a/resources/scss/src/apps/workstation/Workspace.scss
+++ b/resources/scss/src/apps/workstation/Workspace.scss
@@ -2,6 +2,21 @@
 // app-owned Workstation token layer; all motion rides the dashboard aliases, including the
 // reduced-motion collapse owned by Neo.dashboard.Container.
 
+// The theme reveal's other half, and it is a CANCELLATION rather than decoration. The browser
+// cross-fades the two view-transition snapshots by default — old fades out over ~250ms — while
+// `DomUtils.createRevealAnimation()` grows the circle on the NEW layer for 500ms and never
+// touches the old one. Without this the old snapshot is already gone for the back half of the
+// reveal, and everything outside the circle paints as bare backdrop: black. `mix-blend-mode`
+// overrides the UA's `plus-lighter` on the image pair, which blows out where the layers overlap.
+//
+// Every consumer that calls `Neo.main.DomAccess#startViewTransition()` needs this today; the
+// engine owns the animation but not the cancellation that makes it visible.
+::view-transition-old(root),
+::view-transition-new(root) {
+    animation     : none;
+    mix-blend-mode: normal;
+}
+
 .workstation-workspace {
     // The grid/tab token bridge sits on `.workstation-viewport`, one level up: the `?popout=`
     // vessel is a viewport WITHOUT a workspace, so a bridge scoped here never reached the pane it


### PR DESCRIPTION
Resolves #18136

Related: #18125 / PR #18127 (the change that introduced the second caller — this is its regression, and mine), #17739 / PR #17743 (the reveal's geometry contract)

The operator, comparing the two callers side by side: in the Portal the circle expands and the **previous theme** is visible outside it; in `apps/workstation` everything outside the circle was **pitch black**.

The browser cross-fades the two view-transition snapshots by default — `::view-transition-old(root)` fades out over ~250ms — while `DomUtils.createRevealAnimation()` grows the circle on the **new** layer for 500ms and never touches the old one. So the old snapshot was already gone for the back half of the reveal, and everything outside the circle painted as bare backdrop. It reads loudest in a dense app: losing the old snapshot means losing a whole screen of panes, grids and text rather than a mostly-empty page.

Evidence: L3 (the loaded stylesheet enumerated at runtime on the served app, before and after) → L4 required for the compositing itself (AC-1 is what the eye sees mid-animation). Residual: AC-4, stated under Test Evidence — I cannot observe it, and I say why rather than implying I did.

## The census was the defect

| app | calls `startViewTransition` | ships the pseudo-element rule |
|---|---|---|
| `apps/portal` | 1 | **1** |
| `apps/workstation` | 1 | **0** |

The Portal has never had this bug because it cancels the UA default itself, in `resources/scss/src/apps/portal/Viewport.scss:10`. Nothing on the call path says so.

## AC Evidence

| AC | Evidence |
|---|---|
| AC-1 — the previous theme shows outside the circle, no black frame | **operator eye-read** — the residual below. The causal chain is the operator's own A/B: same engine call, rule present → correct, rule absent → black, rule now present |
| AC-2 — the rule is in the Workstation's **loaded** stylesheets | outside-CI, served app, `document.styleSheets` enumerated **after a reload with my runtime probe removed**: exactly **1** hit, `selector: "::view-transition-old(root), ::view-transition-new(root)"`, `css: "animation: … none; mix-blend-mode: normal"`, `href: apps/workstation/Workspace.css`. Before the change the same enumeration returned **0** |
| AC-3 — the Portal is untouched | `git diff --stat -- resources/scss/src/apps/portal/` is empty; the built rule is byte-identical in both apps' emitted CSS |
| AC-4 — read by eye | **residual, operator hand-check** |

## Deltas

- **The comment is half the change.** Two bare declarations with no reason are exactly how this requirement became invisible to the second consumer; the comment names what is being cancelled, that it is a cancellation rather than decoration, and that the engine owns the animation but not this.
- **I did not move it into the engine, and that is the right long-term fix.** The reveal is an engine capability whose contract is split across two realms — `DomAccess`/`DomUtils` own the animation, while the UA-default cancellation that makes it visible lives in a consumer stylesheet. Consumer #3 will hit this too. But it is a compositing change for every consumer and the rehearsal is in the morning; it is filed as the follow-up rather than folded in here.
- **A `0px`/`none`-style opt-out was considered and rejected.** Nothing wants the UA cross-fade *and* the circular reveal simultaneously — they are two designs for the same moment — so a knob here would be a configuration nobody has a reason to set.

## Test Evidence

- **Before/after on the loaded artifact, not the source.** Enumerating `document.styleSheets` on the served Workstation returned **0** matching rules before and **1** after, with the runtime probe explicitly removed and the page reloaded so the hit is the shipped sheet.
- **The emitted CSS is byte-identical to the Portal's**, compared in `dist/development/css/src/apps/{workstation/Workspace,portal/Viewport}.css`.
- The toggle itself still works end to end on the served app: a real pointer click flips to `neo-theme-neo-light`, ground `rgb(242, 245, 249)` (the light `--workstation-ground`), and the control relabels to "Dark mode".
- `check-theme-coverage` and `check-whitespace` pass in the pre-commit gate.

**The bound, named plainly.** I could not observe the mid-transition compositing. My `getAnimations()` sampler reads empty for view-transition pseudo-elements in this browser context — and it reads empty for **the Portal's shipped, working reveal** under the identical sampler, so the instrument says nothing about either app. That control is what stops me claiming a visual verification I did not make. What I can evidence is that the one structural difference between a working caller and a broken one is now gone.

## Post-Merge Validation

- [ ] AC-1 / AC-4 — switch the Workstation theme both ways and confirm the previous theme is visible outside the growing circle with no black frame, in both themes. This is the one step no instrument here can take.

## Commits

- `7198ddc33b` — the theme reveal holds its old layer instead of fading to black.

Authored by Ada (Claude Opus 5, Claude Code). Session 7596538d-5324-419a-b043-95c585d833ea.

Cross-family note: same-family clearance is armed today (@neo-opus-grace, 2026-09-02T15:53Z) — the GPT seats are on a weekly rate limit, so opus↔fable and opus↔opus reviews are gate-clearing.
