### PR TITLE
fix(dock): a dismissed reveal keeps its pane until the exit ends (#18134)

### DIFF
--- a/src/dashboard/dock/interaction/Rail.mjs
+++ b/src/dashboard/dock/interaction/Rail.mjs
@@ -308,13 +308,14 @@ class Rail extends Container {
         me.revealOverlay = overlay;
 
         overlay.on({
-            revealEscape      : me.onOverlayEscape,
-            revealFocusEnter  : me.onOverlayFocusEnter,
-            revealFocusLeave  : me.onOverlayFocusLeave,
-            revealPinRequested: me.onRevealPinRequested,
-            revealPointerEnter: me.onOverlayPointerEnter,
-            revealPointerLeave: me.onOverlayPointerLeave,
-            scope             : me
+            revealEscape       : me.onOverlayEscape,
+            revealFocusEnter   : me.onOverlayFocusEnter,
+            revealFocusLeave   : me.onOverlayFocusLeave,
+            revealLeaveComplete: me.onOverlayLeaveComplete,
+            revealPinRequested : me.onRevealPinRequested,
+            revealPointerEnter : me.onOverlayPointerEnter,
+            revealPointerLeave : me.onOverlayPointerLeave,
+            scope              : me
         });
 
         me.syncRevealOverlay();
@@ -547,6 +548,21 @@ class Rail extends Container {
      */
     onOverlayFocusEnter() {
         this.revealMachine?.overlayFocusEnter()
+    }
+
+    /**
+     * @summary The exit has finished: detach the pane the leave was carrying.
+     *
+     * {@link #syncRevealPane} skips the detach while a leave is in flight, so the keyframes run over
+     * the real pane instead of an empty slot. This is the other half — without it the pane would
+     * stay parked in a hidden overlay. Re-running the sync rather than removing directly keeps ONE
+     * detach path: by the time this fires the machine has settled, so the sync sees the same rail
+     * item it would have seen on the dismissal frame and does exactly what it would have done then.
+     * A retarget mid-exit never reaches here — it cancels the leave and detaches on arrival.
+     * @protected
+     */
+    onOverlayLeaveComplete() {
+        this.syncRevealPane(this.currentRevealRailItem())
     }
 
     /**
@@ -795,6 +811,22 @@ class Rail extends Container {
     }
 
     /**
+     * @summary The rail item the machine currently reveals, or `null` once dismissed.
+     *
+     * One source for the lookup, because two readers now need the same answer at two different
+     * moments: {@link #syncRevealOverlay} on the transition frame, and
+     * {@link #onOverlayLeaveComplete} once the exit has finished. Deriving it twice would let the
+     * deferred detach act on a different item than the one the dismissal decided on.
+     * @returns {Object|null}
+     * @protected
+     */
+    currentRevealRailItem() {
+        const me = this;
+
+        return (me.railItems || []).find(item => item.dockItemId === me.revealMachine?.revealedItemId) || null
+    }
+
+    /**
      * Pushes the current reveal snapshot into the bound overlay, when one exists, and keeps the
      * overlay's pane slot in sync.
      * @protected
@@ -809,7 +841,7 @@ class Rail extends Container {
             return
         }
 
-        railItem = (me.railItems || []).find(item => item.dockItemId === machine.revealedItemId) || null;
+        railItem = me.currentRevealRailItem();
 
         overlay.set({
             edge        : me.getValidatedEdge(me.edge),
@@ -935,6 +967,19 @@ class Rail extends Container {
         currentId = me.revealOverlay.revealPaneItemId ?? null;
         nextId    = railItem?.dockItemId ?? null;
         child     = slot.items?.[0];
+
+        // A dismissal used to detach the pane on the transition frame, while the overlay's two-phase
+        // hide was still animating its root out — so the exit keyframes played over an EMPTY slot
+        // and the panel read as an instant hide. Defer to the overlay's own terminal instead: it
+        // fires `revealLeaveComplete` once the hidden class lands, and this sync runs again then.
+        //
+        // Only a DISMISSAL defers. A retarget carries a `nextId` and must swap immediately, so the
+        // incoming pane arrives with its own entry rather than after the outgoing one has finished
+        // leaving — and a cancelled leave never reaches the terminal, so a re-entry keeps its pane
+        // without a second guard here.
+        if (!nextId && me.revealOverlay.revealLeaving) {
+            return
+        }
 
         if (currentId === nextId) {
             child && nextId && me.syncDockLockPane?.(child, nextId);

--- a/src/dashboard/dock/interaction/RevealOverlay.mjs
+++ b/src/dashboard/dock/interaction/RevealOverlay.mjs
@@ -286,7 +286,15 @@ class RevealOverlay extends Container {
             me.cancelRevealLeave();
             me.revealSwapGeneration = 0;
             !me.isDestroyed && me.syncSnapshot();
-            me.finishRevealMotion()
+            me.finishRevealMotion();
+
+            // The terminal is announced, because the overlay is not the only owner of what the exit
+            // shows. It controls when its own DOM goes; the rail controls when the revealed PANE
+            // goes, and until this event existed the rail had no way to learn an exit was running —
+            // so it detached the pane on the dismissal frame and the keyframes played over an empty
+            // slot. A cancelled leave never reaches here (`cancelRevealLeave` clears the flag
+            // first), so a re-entry mid-exit keeps its pane by construction, not by a second guard.
+            !me.isDestroyed && me.fire('revealLeaveComplete', {overlay: me})
         }
     }
 

--- a/test/playwright/component/dashboard/DockRailRevealExit.spec.mjs
+++ b/test/playwright/component/dashboard/DockRailRevealExit.spec.mjs
@@ -37,6 +37,15 @@ test.describe('Neo.dashboard.dock.interaction.RevealOverlay — the exit motion'
             // Let the entry settle so the exit is the only motion read below.
             await overlay.evaluate(node => Promise.all(node.getAnimations({subtree: true}).map(a => a.finished.catch(() => {}))));
 
+            // What the slot HOLDS, not only that it animates. The arm below asserted the slot's
+            // animation names and its `display`, all of which an EMPTY slot satisfies — and the rail
+            // detached the pane on the dismissal frame, so the keyframes ran over nothing and the
+            // panel read as an instant hide on the served app while this stayed green.
+            const paneCount = await overlay.evaluate(node =>
+                node.querySelector('.neo-dashboard-dock-reveal-pane-slot').children.length);
+
+            expect(paneCount, `[${edge}] the reveal must hold a pane before it is dismissed`).toBeGreaterThan(0);
+
             const dismissedAt = Date.now();
 
             await page.keyboard.press('Escape');
@@ -51,6 +60,7 @@ test.describe('Neo.dashboard.dock.interaction.RevealOverlay — the exit motion'
 
                 return {
                     display      : getComputedStyle(node).display,
+                    paneCount    : slot.children.length,
                     pointerEvents: getComputedStyle(node).pointerEvents,
                     slotNames    : slot.getAnimations().map(a => a.animationName),
                     rootNames    : node.getAnimations().map(a => a.animationName)
@@ -62,6 +72,10 @@ test.describe('Neo.dashboard.dock.interaction.RevealOverlay — the exit motion'
             expect(exit.rootNames, `[${edge}] the root fades out`).toContain('neo-dock-reveal-fade-out');
             expect(exit.slotNames, `[${edge}] the content travels back to its edge`).toContain(`neo-dock-reveal-to-${edge}`);
 
+            // The assertion this arm was missing: something must be travelling. An empty slot
+            // carries the same animation name and the same computed styles as a full one.
+            expect(exit.paneCount, `[${edge}] the pane is still mounted while the exit runs — an empty slot must not pass`).toBe(paneCount);
+
             // Phase 2: hidden, once the root's own animation has ended.
             await expect(overlay, `[${edge}] hidden after the exit`).toHaveClass(/neo-dashboard-dock-reveal-overlay-hidden/, {timeout: 10000});
             await expect(overlay).not.toHaveClass(/neo-dashboard-dock-reveal-overlay-leaving/);
@@ -72,7 +86,53 @@ test.describe('Neo.dashboard.dock.interaction.RevealOverlay — the exit motion'
             // A fail-safe hide would mean the root's `animationend` never reached the worker.
             const hiddenAfter = Date.now() - dismissedAt;
 
-            expect(hiddenAfter, `[${edge}] hidden ${hiddenAfter} ms after the dismissal — the end event, not the backstop`).toBeLessThan(1500)
+            expect(hiddenAfter, `[${edge}] hidden ${hiddenAfter} ms after the dismissal — the end event, not the backstop`).toBeLessThan(1500);
+
+            // …and the deferral ends. A pane parked forever in a hidden overlay would satisfy every
+            // assertion above and leak the instance the exit was protecting.
+            const settled = await overlay.evaluate(node =>
+                node.querySelector('.neo-dashboard-dock-reveal-pane-slot').children.length);
+
+            expect(settled, `[${edge}] the pane is detached once the overlay is hidden`).toBe(0)
+        })
+    }
+
+    /**
+     * The operator saw this in one skin and not the other, which is the whole reason it needs a
+     * theme dimension. The overlay's surface is deliberately the host's — `--dock-reveal-background`
+     * resolves to `--neo-background-color` — so an empty overlay fading out is nearly invisible on a
+     * dark ground and just barely legible on a light one. A single-theme eye-read would have called
+     * this working (light) or shown nothing at all (dark); neither is evidence.
+     *
+     * The assertion is deliberately theme-INDEPENDENT: what must hold in both skins is that a pane
+     * is travelling, not what it looks like while it does.
+     */
+    for (const theme of ['neo-theme-neo-light', 'neo-theme-neo-dark']) {
+        test(`[${theme}] the exit carries its pane in both skins`, async ({page}) => {
+            const overlay = page.locator('.neo-dashboard-dock-reveal-overlay-left');
+
+            await page.evaluate(name => {
+                for (const el of [document.body, document.documentElement]) {
+                    el.classList.forEach(c => c.startsWith('neo-theme-') && el.classList.remove(c))
+                }
+                document.body.classList.add(name)
+            }, theme);
+
+            await page.locator('.neo-dashboard-dock-edge-rail-left .neo-dashboard-dock-rail-tab').first().click();
+            await expect(overlay).toBeVisible({timeout: 10000});
+            await overlay.evaluate(node => Promise.all(node.getAnimations({subtree: true}).map(a => a.finished.catch(() => {}))));
+
+            await page.keyboard.press('Escape');
+            await expect(overlay).toHaveClass(/neo-dashboard-dock-reveal-overlay-leaving/);
+
+            const during = await overlay.evaluate(node => {
+                const slot = node.querySelector('.neo-dashboard-dock-reveal-pane-slot');
+
+                return {paneCount: slot.children.length, slotNames: slot.getAnimations().map(a => a.animationName)}
+            });
+
+            expect(during.paneCount, `[${theme}] a pane travels with the exit`).toBeGreaterThan(0);
+            expect(during.slotNames, `[${theme}] and it is actually animating`).toContain('neo-dock-reveal-to-left')
         })
     }
 });


### PR DESCRIPTION
Resolves #18134

The rail detached the revealed pane on the dismissal frame while the overlay's two-phase hide kept only its root mounted, so the exit keyframes played over an empty slot — the root faded and the slot travelled back to its edge with nothing inside either of them, which is indistinguishable from an instant hide. The overlay now announces its leave terminal and the rail defers the detach to it.

Evidence: L3 (browser — the defect is a DOM-occupancy property during a running animation, only observable on a rendered dock) → L3 sufficient; every AC is readable in the component harness. Residual: AC-7, Residual-Owner: #18134 remains open for the Workstation e2e arm (see Deltas).

Micro-review eligible: no — this changes a component lifecycle contract (a new overlay event and a deferred detach), so it wants the full form despite being small.

## AC Evidence

| AC | Evidence |
|---|---|
| AC-1 the pane is mounted while `-leaving` is on the node | `DockRailRevealExit.spec.mjs`, all four edges: `exit.paneCount` equals the pre-dismissal count. Red-first below |
| AC-2 detached once the leave completes | same arms: `settled` is `0` after the hidden class lands — a pane parked forever in a hidden overlay would satisfy AC-1 and leak. **What guarantees the terminal always arrives** is #18118's fail-safe: `beginRevealLeave` arms `revealLeaveTimer` at `MotionSignal.FAIL_SAFE_MS` → `completeRevealLeave()`, which is exactly where the new `revealLeaveComplete` fires — so a wedged exit detaches on the fail-safe horizon rather than never (see Deltas) |
| AC-3 a re-entry mid-exit keeps its pane | by construction, not by a guard: `cancelRevealLeave` clears the flag before `completeRevealLeave` can fire, so a cancelled leave never reaches the terminal. Existing re-entry arm in `DockRevealOverlay.spec.mjs` stays green |
| AC-4 a retarget mid-exit swaps immediately | the defer is gated on `!nextId`; a retarget carries one and takes the unchanged path. `DockRailRevealRetarget` 3/3 |
| AC-5 the exit arm can no longer pass on an empty slot | the `paneCount` assertion above is exactly that tightening |
| AC-6 neighbouring suites green | `component/dashboard` **103 passed**, `unit/dashboard` **728 passed** |
| AC-8 both themes | two new arms, light and dark, each asserting a pane travels **and** that it is animating |

## Deltas from ticket

- **AC-7 (the Workstation e2e) is not in this PR, and #18134 stays open for it.** The component fixture was green while the served app was visibly wrong, so an arm on the app's own rails is the one that would have caught this originally. It belongs in the e2e tier under the Brain root, which runs in no CI workflow — worth doing properly rather than rushed the night before a rehearsal. The mechanism is fixed and witnessed here; the report-path arm is the follow-up.
- **AC-3 is satisfied structurally rather than by a new arm.** A cancelled leave cannot reach the terminal, so there is no code path for the deferred detach to fire on a re-entry. Adding an arm for an unreachable path would assert the absence of something that cannot happen; the existing re-entry coverage plus AC-4's retarget arms pin the reachable neighbours.
- **This PR becomes the second consumer of #18118's fail-safe timer, and that is load-bearing.** A deferral that hangs on an event is only as good as what happens when the event never arrives. It does arrive: the fail-safe path runs `completeRevealLeave()`, which fires the new terminal, so a stuck exit detaches late rather than not at all. The coupling worth stating for whoever touches this next — Ada's review note, adopted: correctness now rests on `revealLeaving` being the only thing that can wedge `syncRevealPane`, and on that timer being the sole guarantee it clears. If the fail-safe is ever removed or made conditional, the failure mode is a silently parked pane in a hidden overlay, and AC-2 asserts `settled === 0` on the happy path only — nothing here would catch it.
- **`currentRevealRailItem()` extracted.** Two readers now need the same answer at different moments — the transition frame and the leave terminal — and deriving it twice would let the deferred detach act on a different item than the dismissal decided on.

## Test Evidence

**Red-first — all six arms fail against `dev`.** Source reverted to `origin/dev`, spec kept:

```
6 failed
  [left] / [right] / [top] / [bottom] a dismissed reveal slides back under its strip before it hides
  [neo-theme-neo-light] / [neo-theme-neo-dark] the exit carries its pane in both skins
```

**The measurement, before and after:**

```
                       dev    fix
before dismiss          1      1
during leave            0      1     ← the defect and its repair
after hidden            0      0     ← the deferral still ends
```

**Why the previous witness passed.** It asserted the slot's `animationName`, its `display` and its `pointer-events` — all true of an empty slot. It read a property of the animation, never what was being animated.

**The theme dimension is not decoration.** The operator saw a fast slide in light and nothing in dark. `--dock-reveal-background` deliberately resolves to `--neo-background-color`, so an empty overlay fading out has only a 22 %-alpha hairline and its shadow to show for itself: barely legible on a light ground, invisible on a dark one. A single-theme eye-read would have called this working or shown nothing at all.

## Post-Merge Validation

- [ ] The operator's own path on the Workstation: dismiss a rail reveal by Escape **and** by focus-leave, in both neo themes — the panel slides back under its strip with its content, rather than the empty chrome flickering.

---

Authored by Grace (Claude Opus 5, Claude Code). Session fb58e855-74b2-4367-9f83-5877f151f024.
