### PR TITLE
fix(examples): the cross-window chrome guard counts semantic tab buttons (#17578)

### DIFF
--- a/examples/dashboard/crossWindow/DemoBWorkspace.mjs
+++ b/examples/dashboard/crossWindow/DemoBWorkspace.mjs
@@ -83,7 +83,8 @@ import '../../../src/toolbar/Base.mjs';  // registers the `toolbar` ntype the ba
  * lost the field on precisely the failures it exists to explain. Verdicts are computed from the RAW
  * observation before normalization, so the admitted/rejected population is unchanged by it.
  * @param {Object} data
- * @param {Number|undefined} data.observedBarItemCount Rendered tab-bar child count.
+ * @param {Number|undefined} data.observedBarItemCount Semantic tab-button count of the source bar —
+ * `tab.header.Toolbar#getTabButtons()`, never `items.length`. See the `barItemCount` note below.
  * @param {String|undefined} data.observedNodeId Live `dockNodeId` of the source tabs node.
  * @param {String[]} [data.observedProjectedItemIds=[]] Live projected dock item ids.
  * @param {String|undefined} data.observedWorkspaceId Live `dockWorkspaceId` of the source sort zone.
@@ -101,9 +102,12 @@ export const describeCrossWindowChromeMismatch = ({
     sourceNodeId,
     sourceWorkspaceId
 }={}) => {
-    // `barItemCount` compares the tab bar's rendered children against the DOCUMENT's item count, so any
-    // header-action chrome the bar carries that is not a projected dock item makes the two disagree —
-    // the first term to suspect while header actions keep landing on that surface.
+    // `barItemCount` compares the source bar's SEMANTIC tab buttons against the DOCUMENT's item count.
+    // It must never be fed `bar.items.length`: the action group and the spacer share that array with the
+    // tab buttons, so a raw child count disagrees with the document by the number of header actions the
+    // bar happens to carry — measured, not supposed. `tab.header.Toolbar#getTabButtons()` is the single
+    // membership answer the tab SortZone already shares, which is why `projectedItemIds` agreed with the
+    // document on the very run where this term did not.
     let chromeMismatch = {
         dockNodeId      : {expected: sourceNodeId,           actual: observedNodeId,                 mismatch: observedNodeId          !== sourceNodeId},
         dockWorkspaceId : {expected: sourceWorkspaceId,      actual: observedWorkspaceId,            mismatch: observedWorkspaceId     !== sourceWorkspaceId},
@@ -2113,7 +2117,7 @@ class DemoBWorkspace extends Container {
             }
 
             let {chromeMismatch, error: chromeError} = describeCrossWindowChromeMismatch({
-                observedBarItemCount    : sourceBar?.items?.length,
+                observedBarItemCount    : sourceBar?.getTabButtons()?.length,
                 observedNodeId          : sourceTabs?.dockNodeId,
                 observedProjectedItemIds: projectedItems,
                 observedWorkspaceId     : sourceZone?.dockWorkspaceId,

--- a/test/playwright/e2e/dashboard/DemoBPerspectivesNL.spec.mjs
+++ b/test/playwright/e2e/dashboard/DemoBPerspectivesNL.spec.mjs
@@ -2,6 +2,13 @@ import {test, expect}    from '../../fixtures.mjs';
 import {demoBTourScript} from '../../../../examples/dashboard/crossWindow/demoBPerspectives.mjs';
 
 /**
+ * Success sentinel for the popup-hosting poll below. The poll returns either this string or the
+ * executor's own cross-window receipt, so the failure diff carries the refused precondition.
+ * @type {String}
+ */
+const HOSTED = 'the popup hosts the live workbench pane';
+
+/**
  * @summary Moves only the real headless-Chrome popup vessel outside the source viewport.
  * Product browsers honor the app-owned placement request; CDP supplies the missing window-manager
  * behavior in headless Chrome without bypassing Neo's pointer, preview, or commit path.
@@ -136,8 +143,28 @@ test.describe('Dashboard Demo B — topology perspective + shared-heap popup jou
             // finish before Playwright samples the transient vessel; its structured receipt and
             // final document/log assertions below are the zero-pause correctness witness.
             if (run === 0) {
-                await expect(popup.locator('.agentos-dockdemo-counter-pane'), 'the real popup hosts the live workbench pane')
-                    .toBeVisible({timeout: 10000});
+                // A bare visibility wait reports "element(s) not found" and stops there, while the
+                // reason sits one call away: a cross-window step the executor refuses records its
+                // own error string on the TourRunner log. Polling the receipt beside the pane makes
+                // a failure name the refused precondition instead of only its symptom — the same
+                // reason `DemoBWorkspace#describeCrossWindowChromeMismatch` reports every term
+                // separately rather than collapsing a conjunction into one string.
+                await expect.poll(async () => {
+                    if (await popup.locator('.agentos-dockdemo-counter-pane').isVisible()) {
+                        return HOSTED
+                    }
+
+                    let log         = (await app.getComponent(wsId, ['tourRunner.log']))['tourRunner.log'] || [],
+                        crossWindow = log.filter(entry => entry.type === 'cross-window');
+
+                    return crossWindow.length > 0
+                        ? `cross-window receipt: ${JSON.stringify(crossWindow)}`
+                        : 'the pane is not hosted, and the tour has not reached its cross-window step'
+                }, {
+                    message  : 'the real popup hosts the live workbench pane',
+                    timeout  : 10000,
+                    intervals: [250]
+                }).toBe(HOSTED);
 
                 await expect.poll(readCounter, {
                     message  : 'worker truth must show the original instance mounted once into the popup',


### PR DESCRIPTION
Refs #17578 — **does not close it.** This fires the instrument PR #17986 landed, acts on what it named, and hands the ticket back its original defect. The defect the ticket is actually about is still outstanding.

PR #17986 ended with a hypothesis and an explicit "do not bank it": *"`barItemCount` compares the tab bar's rendered children against the document's item count… I have not measured which term fires."* Measured now. It is `barItemCount`, and it was **masking** the defect #17578 was filed for.

Evidence: L1 (three live runs of the committed reproduction under the Brain root at `dev@ec6856b804`). Residual: the remaining refusal is named, not fixed — see *What is underneath*. Residual-Owner: #17578 stays open.

Micro-review eligible: no — the diff is small, but the finding it encodes changes what #17578 is about.

## The measurement

```
run 1  bare spec              → "element(s) not found", receipt never read
run 2  receipt-carrying spec  → errors: ["source drag chrome does not match
                                 the current workspace document: barItemCount"]
run 3  guard corrected        → errors: ["remote target did not expose a
                                 settled semantic preview"]
```

That term alone. Numbers, from a sibling spec's artifact of the same day (`DemoBCrossWindowDragNL`, 12:40Z — corroboration from an earlier head, not from run 2):

| term | expected | actual | mismatch |
|---|---|---|---|
| `barItemCount` | 1 | **8** | **true** |
| `dockNodeId` | `workbench-tabs` | `workbench-tabs` | false |
| `dockWorkspaceId` | `demo-b-main` | `demo-b-main` | false |
| `projectedCount` | 1 | 1 | false |
| `projectedItemIds` | `["workbench"]` | `["workbench"]` | false |

## The mechanism — one fact, two channels

`toolbar.Base#getActionItems()` is `(this.items || []).filter(item => item.isToolbarAction === true)`. Header actions and the spacer **share the `items` array with the tab buttons**, and `Workspace` defaults five actions on. So `sourceBar.items.length` disagrees with the document by however many actions the bar carries — eight children for one item.

The engine already owns the right answer. `tab.header.Toolbar#getTabButtons()` is documented as *"only semantic tab-header buttons, excluding the action group and spacer"* and, one JSDoc down, as **"the single semantic membership answer shared with the tab SortZone."** That is exactly why `projectedItemIds` — the SortZone's view — agreed with the document on the very run where `barItemCount` did not. Both channels were in the same receipt, disagreeing, the whole time.

## The instrument could not reach a reader

Worth stating because it cost two days. #17986's per-term `chromeMismatch` payload is dropped **twice** before anyone could read it:

- `Neo.ai.client.TourRunner` builds its `cross-window` log entry from `applied` + `errors` only (`src/ai/client/TourRunner.mjs:462`) and drops `result.debug`. The error *string* survives, and that string does carry the term names.
- The spec then died at a bare `toBeVisible` **forty lines before** it ever read `tourRunner.log` — reporting the symptom and stopping one call short of the recorded cause.

An arm that cannot report why it failed is the same defect the instrument was built to fix, one layer up. The popup-hosting wait is now a poll returning either the hosted sentinel or the executor's own cross-window receipt.

## What changed

| | |
|---|---|
| `describeCrossWindowChromeMismatch` | untouched — same verdict logic |
| call site | `sourceBar?.items?.length` → `sourceBar?.getTabButtons()?.length` |
| JSDoc + term comment | contract documented as semantic, with the reason |
| `DemoBPerspectivesNL` popup wait | carries the executor's receipt into the failure |

## What is underneath — the reason this does not close #17578

With the term corrected the step advances and refuses **differently**: `remote target did not expose a settled semantic preview` — `DemoBWorkspace.mjs:2305`, the `if (!remoteSnapshot.ready)` bail. That is the branch #17578's own *"Anchors relocated"* section describes as the producer of `candidateDiagnostics`, and it is where the August diagnosis lived.

So the last ten days were two defects in series. `d3f7d5a809` (#17562) introduced the chrome guard; header actions then made `barItemCount` false; the step began aborting **before any gesture started**, which is why the 2026-08-31 reading found `claimTrace: []`, `pointerGestureToken: null`, `SortZone.traces: 0`. The 2026-08-22/23 diagnosis was never falsified — it became unreachable. It is reachable again.

The standing hypothesis for the remaining gate is @neo-fable's whitebox reading of 2026-08-29, unchanged by this PR: `conversionSettlement: false`, the park receipt's `sourcePositionCapable: true` contradicting `manager.Window`'s `capabilities.position: false` for the source window.

## Verification and its honest bound

- Three runs above, each one gate further down. The guard term moving from failing to passing **is** the red-first: run 2 fails on `barItemCount`, run 3 does not.
- Unit spec `DemoBWorkspace.spec.mjs` covers the helper, which is unchanged — it passes a synthetic `observedBarItemCount` and never sees the call site. There is no tier below e2e that can witness this fix; saying so rather than manufacturing a green.
- **The cross-window e2e tour runs in no CI workflow** and needs `NEO_AGENTOS_RUNTIME_ROOT`, or it silently matches zero tests and exits 1 with "No tests found". CI green on this PR is therefore not evidence about this code path.

## Post-Merge Validation

- [ ] Re-run `DemoBCrossWindowDragNL` — it hits the same guard (its 12:40Z artifact carries the identical `barItemCount` receipt), so it should clear the same first gate.

---

Authored by Grace (Claude Opus 5, Claude Code). Session fb58e855-74b2-4367-9f83-5877f151f024.
