### PR TITLE
fix(tab): every theme states the inline header's paint, because a fallback is not a reset (#18141)

### DIFF
--- a/resources/scss/src/tab/Container.scss
+++ b/resources/scss/src/tab/Container.scss
@@ -1,8 +1,15 @@
 .neo-tab-container {
     // The public inline-header hooks belong to the variant selector, not the generic toolbar. A
     // consumer may set the tokens on any ancestor; ui:null and standalone containers never match
-    // this rule and therefore keep their established paint. Every fallback is transparent / none,
-    // so a theme that values nothing (the legacy themes) paints exactly what it painted before.
+    // this rule and therefore keep their established paint.
+    //
+    // Every fallback is transparent / none, but a FALLBACK IS A DEFAULT, NEVER A RESET: `var()`
+    // reaches it only when the property is unset on the element AND every ancestor. Custom
+    // properties inherit, and themes value them at `:root .neo-theme-*` — so a theme scope nested
+    // inside another (component.Base#getTheme walks the component chain precisely to support that)
+    // keeps the OUTER theme's value wherever it declares nothing of its own. Every theme therefore
+    // states all three hooks explicitly, including the flat classic values; omitting one does not
+    // opt out of a surface, it opts in to whichever ancestor decided last.
     //
     // Longhands only: a `background` shorthand carries an implicit `background-image: none` that
     // fights any consumer valuing the image hook. The hairline is an INSET shadow rather than a

--- a/resources/scss/src/tab/Container.scss
+++ b/resources/scss/src/tab/Container.scss
@@ -3,13 +3,18 @@
     // consumer may set the tokens on any ancestor; ui:null and standalone containers never match
     // this rule and therefore keep their established paint.
     //
-    // Every fallback is transparent / none, but a FALLBACK IS A DEFAULT, NEVER A RESET: `var()`
-    // reaches it only when the property is unset on the element AND every ancestor. Custom
-    // properties inherit, and themes value them at `:root .neo-theme-*` — so a theme scope nested
-    // inside another (component.Base#getTheme walks the component chain precisely to support that)
-    // keeps the OUTER theme's value wherever it declares nothing of its own. Every theme therefore
-    // states all three hooks explicitly, including the flat classic values; omitting one does not
-    // opt out of a surface, it opts in to whichever ancestor decided last.
+    // Every fallback is transparent / none, and it is load-bearing for a theme that ships no `tab/`
+    // sheet at all — but a FALLBACK IS A DEFAULT, NEVER A RESET: `var()` reaches it only when the
+    // property is unset on the element AND every ancestor. Custom properties inherit, and themes
+    // value them at `:root .neo-theme-*` — so a theme scope nested inside another
+    // (component.Base#getTheme walks the component chain precisely to support that) keeps the OUTER
+    // theme's value wherever it declares nothing of its own. Omitting a hook does not opt out of a
+    // surface; it opts in to whichever ancestor decided last.
+    //
+    // So every theme that OWNS a `tab/` sheet states all three hooks explicitly, including the flat
+    // classic values. Four do. `theme-cyberpunk` builds with no `tab/` directory, so a cyberpunk
+    // scope nested inside a neo one still inherits the neo surface — a known gap in the wider
+    // "not every theme styles every widget" family, not something this rule can reach.
     //
     // Longhands only: a `background` shorthand carries an implicit `background-image: none` that
     // fights any consumer valuing the image hook. The hairline is an INSET shadow rather than a

--- a/resources/scss/src/tab/Container.scss
+++ b/resources/scss/src/tab/Container.scss
@@ -3,18 +3,9 @@
     // consumer may set the tokens on any ancestor; ui:null and standalone containers never match
     // this rule and therefore keep their established paint.
     //
-    // Every fallback is transparent / none, and it is load-bearing for a theme that ships no `tab/`
-    // sheet at all — but a FALLBACK IS A DEFAULT, NEVER A RESET: `var()` reaches it only when the
-    // property is unset on the element AND every ancestor. Custom properties inherit, and themes
-    // value them at `:root .neo-theme-*` — so a theme scope nested inside another
-    // (component.Base#getTheme walks the component chain precisely to support that) keeps the OUTER
-    // theme's value wherever it declares nothing of its own. Omitting a hook does not opt out of a
-    // surface; it opts in to whichever ancestor decided last.
-    //
-    // So every theme that OWNS a `tab/` sheet states all three hooks explicitly, including the flat
-    // classic values. Four do. `theme-cyberpunk` builds with no `tab/` directory, so a cyberpunk
-    // scope nested inside a neo one still inherits the neo surface — a known gap in the wider
-    // "not every theme styles every widget" family, not something this rule can reach.
+    // A fallback is a default, never a reset: custom properties inherit, so a theme that declares
+    // nothing keeps the enclosing theme's value instead of falling back. Each theme with a `tab/`
+    // sheet therefore states all three hooks, the flat classic values included.
     //
     // Longhands only: a `background` shorthand carries an implicit `background-image: none` that
     // fights any consumer valuing the image hook. The hairline is an INSET shadow rather than a

--- a/resources/scss/theme-dark/tab/Container.scss
+++ b/resources/scss/theme-dark/tab/Container.scss
@@ -7,10 +7,8 @@
     --tab-header-action-glyph-color-active         : #fff;
     --tab-header-action-glyph-color-hover          : #fff;
     --tab-header-action-size                       : 20px;
-    // Classic chrome remains intentionally flat, and all three inline hooks say so EXPLICITLY. A
-    // custom property a theme omits is not reset to the structural fallback — it inherits, so a
-    // classic scope nested inside a neo one would keep the neo surface and hairline. Only a
-    // declared value resets at a theme boundary; separation stays with the content border above.
+    // Classic chrome is intentionally flat, stated rather than omitted: an omitted custom property
+    // inherits the enclosing theme's value instead of resetting. Separation is the content border.
     --tab-header-inline-background-color           : transparent;
     --tab-header-inline-background-image           : none;
     --tab-header-inline-box-shadow                 : none;

--- a/resources/scss/theme-dark/tab/Container.scss
+++ b/resources/scss/theme-dark/tab/Container.scss
@@ -7,9 +7,13 @@
     --tab-header-action-glyph-color-active         : #fff;
     --tab-header-action-glyph-color-hover          : #fff;
     --tab-header-action-size                       : 20px;
-    // Classic chrome remains intentionally flat; this explicit value must not decay into reliance
-    // on the structural fallback.
+    // Classic chrome remains intentionally flat, and all three inline hooks say so EXPLICITLY. A
+    // custom property a theme omits is not reset to the structural fallback — it inherits, so a
+    // classic scope nested inside a neo one would keep the neo surface and hairline. Only a
+    // declared value resets at a theme boundary; separation stays with the content border above.
+    --tab-header-inline-background-color           : transparent;
     --tab-header-inline-background-image           : none;
+    --tab-header-inline-box-shadow                 : none;
 
     // Inline inherits the classic theme's established 25px / square geometry and tightens only what
     // a dock header cannot afford: horizontal padding and the title's weight — beside an action

--- a/resources/scss/theme-light/tab/Container.scss
+++ b/resources/scss/theme-light/tab/Container.scss
@@ -7,10 +7,8 @@
     --tab-header-action-glyph-color-active         : #1c60a0;
     --tab-header-action-glyph-color-hover          : #1c60a0;
     --tab-header-action-size                       : 20px;
-    // Classic chrome remains intentionally flat, and all three inline hooks say so EXPLICITLY. A
-    // custom property a theme omits is not reset to the structural fallback — it inherits, so a
-    // classic scope nested inside a neo one would keep the neo surface and hairline. Only a
-    // declared value resets at a theme boundary; separation stays with the content border above.
+    // Classic chrome is intentionally flat, stated rather than omitted: an omitted custom property
+    // inherits the enclosing theme's value instead of resetting. Separation is the content border.
     --tab-header-inline-background-color           : transparent;
     --tab-header-inline-background-image           : none;
     --tab-header-inline-box-shadow                 : none;

--- a/resources/scss/theme-light/tab/Container.scss
+++ b/resources/scss/theme-light/tab/Container.scss
@@ -7,9 +7,13 @@
     --tab-header-action-glyph-color-active         : #1c60a0;
     --tab-header-action-glyph-color-hover          : #1c60a0;
     --tab-header-action-size                       : 20px;
-    // Classic chrome remains intentionally flat; this explicit value must not decay into reliance
-    // on the structural fallback.
+    // Classic chrome remains intentionally flat, and all three inline hooks say so EXPLICITLY. A
+    // custom property a theme omits is not reset to the structural fallback — it inherits, so a
+    // classic scope nested inside a neo one would keep the neo surface and hairline. Only a
+    // declared value resets at a theme boundary; separation stays with the content border above.
+    --tab-header-inline-background-color           : transparent;
     --tab-header-inline-background-image           : none;
+    --tab-header-inline-box-shadow                 : none;
 
     // Inline inherits the classic theme's established 25px / square geometry and tightens only what
     // a dock header cannot afford: horizontal padding and the title's weight — beside an action

--- a/test/playwright/component/apps/dock-lock/neo-config.json
+++ b/test/playwright/component/apps/dock-lock/neo-config.json
@@ -4,7 +4,7 @@
     "environment"     : "development",
     "mainPath"        : "./Main.mjs",
     "mainThreadAddons": ["DragDrop", "Navigator", "Stylesheet"],
-    "themes"          : ["neo-theme-neo-dark", "neo-theme-neo-light"],
+    "themes"          : ["neo-theme-neo-dark", "neo-theme-neo-light", "neo-theme-light", "neo-theme-dark"],
     "useAiClient"     : true,
     "useSharedWorkers": false
 }

--- a/test/playwright/component/apps/dock-theme-nesting/index.html
+++ b/test/playwright/component/apps/dock-theme-nesting/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Neo.mjs Dock Theme Nesting Test App</title>
+</head>
+<body>
+    <button id="dock-lock-outside-focus" type="button">Outside dock focus</button>
+    <script src="../../../../../src/MicroLoader.mjs" type="module"></script>
+</body>
+</html>

--- a/test/playwright/component/apps/dock-theme-nesting/neo-config.json
+++ b/test/playwright/component/apps/dock-theme-nesting/neo-config.json
@@ -4,7 +4,7 @@
     "environment"     : "development",
     "mainPath"        : "./Main.mjs",
     "mainThreadAddons": ["DragDrop", "Navigator", "Stylesheet"],
-    "themes"          : ["neo-theme-neo-dark", "neo-theme-neo-light"],
+    "themes"          : ["neo-theme-neo-dark", "neo-theme-neo-light", "neo-theme-light", "neo-theme-dark"],
     "useAiClient"     : true,
     "useSharedWorkers": false
 }

--- a/test/playwright/component/dashboard/DockInlineHeaderPaint.spec.mjs
+++ b/test/playwright/component/dashboard/DockInlineHeaderPaint.spec.mjs
@@ -20,7 +20,12 @@ const INLINE_HEADER = '.neo-tab-container-inline > .neo-tab-header-toolbar';
 let controlId;
 
 test.beforeEach(async ({page}) => {
-    await page.goto('test/playwright/component/apps/dock-lock/index.html');
+    // `dock-theme-nesting` reuses `dock-lock`'s app with a four-theme config, following the
+    // `dock-static-boot` / `-overlap` pattern. The nested arms below need the classic theme
+    // stylesheets in the document — a theme class declares nothing if no sheet defines it — and that
+    // requirement belongs to THIS spec. Configuring it on the shared `dock-lock` fixture would make
+    // every other consumer of it boot two stylesheets it never reads.
+    await page.goto('test/playwright/component/apps/dock-theme-nesting/index.html');
     await page.waitForSelector('#dock-lock-workspace', {state: 'attached'});
     await page.waitForSelector(INLINE_HEADER, {state: 'visible'});
 

--- a/test/playwright/component/dashboard/DockInlineHeaderPaint.spec.mjs
+++ b/test/playwright/component/dashboard/DockInlineHeaderPaint.spec.mjs
@@ -140,5 +140,39 @@ test.describe('Neo.tab.Container — the inline header paints a flat surface wit
         expect(tier, 'the semantic large height must resolve').toBeGreaterThan(0);
         // An inset shadow paints inside the box; a border-bottom would have added a pixel here.
         expect(Math.abs(measured.inline.height - tier), 'the inline header is exactly the density tier tall').toBeLessThanOrEqual(1)
-    })
+    });
+
+    for (const classic of ['neo-theme-light', 'neo-theme-dark']) {
+        test(`${classic} nested inside a neo scope resets the surface rather than inheriting it`, async ({page}) => {
+            // The discriminating arm, and the nesting is what makes it one. A classic theme applied
+            // to the document ALONE would read transparent even while broken, because no ancestor
+            // declares the token and the structural fallback covers it — so a non-nested arm cannot
+            // fail on this defect. Custom properties inherit, so only an outer scope that DOES value
+            // the token proves the inner one resets it. `component.Base#getTheme` walks the component
+            // chain to support exactly this shape, and theme classes land on several elements at once
+            // in a live app, so a nested scope is ordinary rather than contrived.
+            await applyTheme(page, 'neo-theme-neo-dark');
+
+            const nested = await page.evaluate(name => {
+                const container = document.querySelector('.neo-tab-container-inline');
+
+                if (!container) throw new Error('no inline tab container to nest a theme on');
+
+                container.classList.add(name);
+                return container.className
+            }, classic);
+
+            expect(nested, `the inline container carries the nested ${classic} scope`).toContain(classic);
+
+            const measured = await measure(page, controlId);
+
+            // The outer scope must genuinely value the token, or the arm proves nothing: without
+            // this, an inner reset and an inner nothing are indistinguishable.
+            expect(measured.surfaceToken, 'the outer neo scope still values the highlighted surface').toMatch(/^rgb/);
+
+            expect(measured.inline.backgroundColor, `${classic} paints no surface inside a neo scope`).toBe('rgba(0, 0, 0, 0)');
+            expect(measured.inline.backgroundImage, `${classic} paints no image inside a neo scope`).toBe('none');
+            expect(measured.inline.boxShadow, `${classic} carries no hairline inside a neo scope`).toBe('none')
+        })
+    }
 });


### PR DESCRIPTION
Resolves #18141

Switching a running app from a neo theme to a classic one left the `ui: 'inline'` dock tab header on its dark neo surface, and a consumer had written an in-app override to compensate. Reported by @tobiu on the running app.

**A `var()` fallback is a default, never a reset.** It is reached only when the property is unset on the element **and every ancestor**, and custom properties inherit from the `:root .neo-theme-*` element that declares them. A theme scope nested inside another therefore keeps the **outer** theme's value wherever it declares nothing of its own. Omitting a token does not opt out of a surface — it opts in to whatever the nearest declaring ancestor decided.

Evidence: L3 (browser — the defect is a computed-style property under a nested theme scope, only observable on rendered chrome) → L3 sufficient. Residual: none for this ticket; two follow-ups are named and deliberately out of scope.

Micro-review eligible: no — three lines of SCSS, but the premise it corrects is engine-wide and the witness needed a fixture change to be able to fail at all.

## Where it came from

#18095 / PR #18097 (merged today, 14:39:53Z) gave the inline header a flat surface plus a hairline by valuing `--tab-header-inline-background-color` and `--tab-header-inline-box-shadow` **in the two neo themes only**, on the premise its own structural comment states:

> *"Every fallback is transparent / none, so a theme that values nothing (the legacy themes) paints exactly what it painted before."*

True for a theme with no themed ancestor. False for a nested one — and nesting is a first-class feature: `component.Base#getTheme` walks the component chain precisely to support it, and @neo-opus-vega measured on 2026-08-31 that theme classes land on several elements at once in a live app (*"any bridge pinned to one element is one re-render from being shadowed again"*).

**The counter-statement was already four lines away**, on the single token the classic themes did declare:

> *"Classic chrome remains intentionally flat; this explicit value must not decay into reliance on the structural fallback."*

Right rule, applied to one of three siblings. Verified independently by @neo-opus-ada: `--tab-header-inline-background-color` light=0 dark=0 neo-light=1 neo-dark=1; `-background-image` 1/1/1/1; `-box-shadow` 0/0/1/1.

## AC Evidence

| AC | Evidence |
|---|---|
| AC-1 classic themes paint no surface and no hairline, nested or not | Emitted CSS: `theme-light` and `theme-dark` now carry `--tab-header-inline-background-color:transparent;--tab-header-inline-background-image:none;--tab-header-inline-box-shadow:none`. Two new nested arms green |
| AC-2 the neo themes are unchanged | Neither neo theme source is touched; `theme-neo-dark/tab/Container.css` still emits `surface-neutral-highlighted` + `inset 0 -1px 0 border-default`. The three pre-existing arms stay green |
| AC-3 a witness that fails against the current tree | Red-first below. **The arm nests deliberately** — see *Why a non-nested arm cannot fail* |
| AC-4 the structural comment no longer teaches the premise | `src/tab/Container.scss` now states that a fallback is a default and not a reset, why inheritance makes omission load-bearing, and that every theme states all three hooks |

## Test Evidence

**Red-first** — `git checkout origin/dev --` on the two theme sources, rebuild themes, same spec:

```
2 failed
  neo-theme-light nested inside a neo scope resets the surface rather than inheriting it
  neo-theme-dark  nested inside a neo scope resets the surface rather than inheriting it
    Expected: "rgba(0, 0, 0, 0)"
    Received: "rgb(41, 45, 40)"      ← the neo-dark highlighted surface, inherited across the boundary
3 passed
```

Restored, rebuilt: **5 passed**. Neighbouring suite `component/dashboard` **105 passed** (103 before, plus these two arms), exit 0.

## Why a non-nested arm cannot fail — and the red that fooled me first

A classic theme applied to the document **alone** reads `transparent` **even while broken**: nothing declares the token, so the structural fallback covers it. Only an outer scope that genuinely values the token can discriminate, which is why the arm asserts the outer surface token resolves to a real colour before asserting the inner header is transparent.

That subtlety has teeth. The first run of these arms failed at the **fixed** head with exactly the same message and the same `rgb(41, 45, 40)`. The cause was not the fix — the `dock-lock` fixture configured only the two neo themes, so no sheet defined `:root .neo-theme-light` and adding that class declared nothing. **The red was measuring an absent stylesheet.** Second commit configures all four themes, which is also the reported configuration: the defect was found switching a running app between the families, which only an app loading both can do.

So the same red means two different things, and the fixture commit is what makes it mean the product. Worth knowing before trusting a future red on this arm.

## Deltas from ticket

None. Both follow-ups the ticket names are still out of scope and unclaimed:

1. **No CSS selectors inside theme value files** (@tobiu's standing rule) — measured: 26 theme files, 62 nested selector blocks, including this same `tab/Container.scss` in all four themes.
2. **Components with no classic-theme styling at all** (markdown, portal) — a real gap, a different one.

## Post-Merge Validation

- [ ] The operator's own path: switch the running app from `neo-theme-neo-dark` to `neo-theme-light` and confirm the inline dock header no longer keeps the dark surface, and that the in-app override written to compensate is no longer doing anything.

---

Authored by Grace (Claude Opus 5, Claude Code). Session fb58e855-74b2-4367-9f83-5877f151f024.
