### PR TITLE
fix(dock): the preview overlay carries its own geometry

### DIFF
--- a/resources/scss/src/apps/workstation/Workspace.scss
+++ b/resources/scss/src/apps/workstation/Workspace.scss
@@ -273,14 +273,10 @@
     padding : 12px;
     position: relative;
 
-    // Persistent drag affordances share this host's local geometry. The preview sits below the
-    // indicator menu and stays pointer-transparent so the sort-zone drag remains the sole owner.
-    > .neo-dock-preview {
-        inset         : 0;
-        pointer-events: none;
-        position      : absolute;
-        z-index       : 25;
-    }
+    // Persistent drag affordances share this host's local geometry. `position: relative` above is
+    // the whole contract this app owes them: the preview and the indicator layer both position
+    // themselves against it from the engine sheet. This app used to re-declare the preview's
+    // `inset`/`position`/`z-index` here — the engine now owns that pair, so the copy is gone.
 }
 
 // The generic overflow button is a floating direct-body child. Scope its cockpit skin to

--- a/resources/scss/src/dashboard/dock/interaction/Preview.scss
+++ b/resources/scss/src/dashboard/dock/interaction/Preview.scss
@@ -4,8 +4,24 @@
     to   { transform: scaleY(1) }
 }
 
+// The preview's own geometry, owned here rather than by each consumer. A dock host lays out `fit`,
+// so an UNPOSITIONED preview is an in-flow `.neo-layout-fit-item` — `flex: 1 0 100%`, a second full
+// host width in the flex row. `overflow-x: hidden` hides the scrollbar but the host stays
+// programmatically scrollable, so any focus or scroll-into-view aimed past the first width shifts
+// the whole workspace out to the left, permanently: nothing scrolls it back once the re-projection
+// has retired the old shell. Lifting the preview out of the flow means the host has no overflow at
+// rest, and the transient two-shell width the reconciler stages during a swap clamps back to 0 on
+// its own.
+//
+// `z-index` sits between the reveal overlay (20) and the drop-indicator layer (30) — the value the
+// consumers that re-derived this rule had each arrived at. The sibling indicator layer already owns
+// its own `inset`/`position`/`z-index` in the engine sheet; this is the pair the preview was
+// missing. A consumer may still override the stacking value.
 .neo-dock-preview {
+    inset          : 0;
     pointer-events : none;
+    position       : absolute;
+    z-index        : 25;
 
     .neo-dock-preview-affordance {
         border-radius  : 3px;

--- a/resources/scss/src/examples/dashboard/choreography/DemoAWorkspace.scss
+++ b/resources/scss/src/examples/dashboard/choreography/DemoAWorkspace.scss
@@ -74,14 +74,10 @@
 
     // The preview renderer + indicator menu are absolute overlay SIBLINGS of the projection
     // (never inside it — the coarse refresh replaces only the projection child, so these keep
-    // their instances across every re-projection). The preview stays pointer-transparent for
-    // the same reason the indicator layer is: the sort-zone drag owns the pointer.
-    > .neo-dock-preview {
-        inset         : 0;
-        pointer-events: none;
-        position      : absolute;
-        z-index       : 25;
-    }
+    // their instances across every re-projection). `position: relative` above is the whole
+    // contract this example owes them: both overlays position themselves against it from the
+    // engine sheet. This file used to re-declare the preview's `inset`/`position`/`z-index`;
+    // the engine now owns that pair, so the copy is gone.
 }
 
 .agentos-dockdemo-pane {

--- a/test/playwright/component/apps/dock-preview-geometry/app.mjs
+++ b/test/playwright/component/apps/dock-preview-geometry/app.mjs
@@ -1,0 +1,111 @@
+import Container      from '../../../../../src/container/Base.mjs';
+import DockPreview    from '../../../../../src/dashboard/dock/interaction/Preview.mjs';
+import DockWorkspace  from '../../../../../src/dashboard/dock/Workspace.mjs';
+import DropIndicators from '../../../../../src/dashboard/dock/interaction/DropIndicators.mjs';
+import Viewport       from '../../../../../src/container/Viewport.mjs';
+import '../../../../../src/tab/Container.mjs';
+
+/**
+ * @summary The BARE consumer: a dock host that declares nothing but `position: relative`.
+ *
+ * Every shipping consumer of the dock either carries an app stylesheet or copied one, so none of
+ * them can witness what the engine owes a host that carries neither. This fixture deliberately has
+ * no stylesheet at all — the host's only contract is the positioning context, which is what a
+ * downstream app supplies when it reads the docs and stops there.
+ *
+ * The projection is child 0 and the two overlays are PERSISTENT siblings, mirroring the shape both
+ * the Workstation and Demo-A give their host: object permanence across every re-projection.
+ */
+const fixtureDocument = {
+    schema: 'neo.dock.zone.v1',
+    root  : 'root',
+    items : {
+        main : {componentRef: 'main',  title: 'Main',  kind: 'panel'},
+        aside: {componentRef: 'aside', title: 'Aside', kind: 'panel'}
+    },
+    nodes: {
+        root        : {type: 'tabs', items: ['main', 'aside'], activeItemId: 'main'}
+    }
+};
+
+class PreviewGeometryWorkspace extends DockWorkspace {
+    static config = {
+        /**
+         * @member {String} className='Test.Playwright.Component.DockPreviewGeometry.Workspace'
+         * @protected
+         */
+        className: 'Test.Playwright.Component.DockPreviewGeometry.Workspace',
+        /**
+         * @member {String[]} cls=['dock-preview-geometry-workspace']
+         */
+        cls: ['dock-preview-geometry-workspace'],
+        /**
+         * The projection mounts into this child, and the overlays sit beside it.
+         * @member {String} dockHostReference='dock-host'
+         */
+        dockHostReference: 'dock-host',
+        /**
+         * @member {String} id='dock-preview-geometry-workspace'
+         */
+        id: 'dock-preview-geometry-workspace',
+        /**
+         * @member {Object} layout={ntype:'vbox',align:'stretch'}
+         */
+        layout: {ntype: 'vbox', align: 'stretch'}
+    }
+
+    /**
+     * Builds the host and its two persistent overlay siblings. The host gets `position: relative`
+     * through an inline style rather than a class, so this fixture stays stylesheet-free and the
+     * spec measures the engine sheet alone.
+     */
+    onConstructed() {
+        super.onConstructed();
+
+        let me = this;
+
+        me.add({
+            cls  : ['dock-preview-geometry-host', 'neo-dashboard', 'neo-dashboard-dock-query-host'],
+            flex : 1,
+            items: [me.projectDockModel(), {
+                module   : DockPreview,
+                reference: 'dock-preview'
+            }, {
+                module   : DropIndicators,
+                reference: 'drop-indicators'
+            }],
+            layout   : {ntype: 'fit'},
+            module   : Container,
+            reference: 'dock-host',
+            style    : {position: 'relative'}
+        });
+
+        me.onDockZoneDocumentChange(structuredClone(fixtureDocument))
+    }
+
+    /**
+     * @summary Resolves one test pane. The panes carry no geometry of their own — the assertions
+     * read the host and the preview, never the pane.
+     * @param {String} itemId
+     * @param {Object} item
+     * @returns {Object}
+     */
+    resolvePane(itemId, item) {
+        return {
+            cls  : ['dock-preview-geometry-pane', `dock-preview-geometry-pane-${itemId}`],
+            id   : `dock-preview-geometry-pane-${itemId}`,
+            ntype: 'component',
+            vdom : {cn: [{tag: 'span', text: `${item?.title || itemId} pane`}]}
+        }
+    }
+}
+
+PreviewGeometryWorkspace = Neo.setupClass(PreviewGeometryWorkspace);
+
+export const onStart = () => Neo.app({
+    mainView: {
+        module: Viewport,
+        items : [{module: PreviewGeometryWorkspace, flex: 1}]
+    },
+    name: 'Test.Playwright.DockPreviewGeometry'
+});

--- a/test/playwright/component/apps/dock-preview-geometry/index.html
+++ b/test/playwright/component/apps/dock-preview-geometry/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Neo.mjs Dock Preview Geometry Test App</title>
+</head>
+<body>
+    <script src="../../../../../src/MicroLoader.mjs" type="module"></script>
+</body>
+</html>

--- a/test/playwright/component/apps/dock-preview-geometry/neo-config.json
+++ b/test/playwright/component/apps/dock-preview-geometry/neo-config.json
@@ -1,0 +1,10 @@
+{
+    "appPath"         : "test/playwright/component/apps/dock-preview-geometry/app.mjs",
+    "basePath"        : "../../../../../",
+    "environment"     : "development",
+    "mainPath"        : "./Main.mjs",
+    "mainThreadAddons": ["DragDrop", "Navigator", "Stylesheet"],
+    "themes"          : ["neo-theme-neo-dark", "neo-theme-neo-light"],
+    "useAiClient"     : true,
+    "useSharedWorkers": false
+}

--- a/test/playwright/component/dashboard/DockPreviewGeometry.spec.mjs
+++ b/test/playwright/component/dashboard/DockPreviewGeometry.spec.mjs
@@ -1,0 +1,97 @@
+import {test, expect} from '@playwright/test';
+
+/**
+ * The preview overlay's own geometry, measured on a host that declares nothing but the positioning
+ * context — the shape a downstream consumer arrives at by reading the docs and stopping there.
+ *
+ * A dock host lays out `fit`, so a preview the engine never positions is an in-flow
+ * `.neo-layout-fit-item` at `flex: 1 0 100%` — a second full host width in the flex row. The host
+ * then stays programmatically scrollable behind `overflow-x: hidden`, and any focus or
+ * scroll-into-view aimed past the first width shifts the whole workspace out to the left. Nothing
+ * scrolls it back: the preview keeps the overflow alive after the re-projection has retired the old
+ * shell, so the displacement is permanent until a reload.
+ *
+ * **Why the fixture carries no stylesheet.** Every shipping consumer either wrote the missing rule
+ * or copied it from one that had, so none of them can witness what the engine owes a host that did
+ * neither. A fixture with an app sheet would pass whether or not the engine sheet positions the
+ * preview, which is the failure mode this file exists to make impossible.
+ *
+ * **Why `scrollWidth === clientWidth` is the assertion.** It reads the CAUSE. The visible symptom is
+ * a displaced shell — but a shell can be displaced for other reasons, and it can also sit correctly
+ * at x=0 while the overflow quietly persists, waiting for the next focus call. The shell's position
+ * is asserted too, as the consequence; the overflow is asserted as the thing that must not exist.
+ *
+ * @see https://github.com/neomjs/neo/issues/18142
+ */
+
+const HOST = '.dock-preview-geometry-host';
+
+/**
+ * Reads the host's overflow state together with the preview's computed position, in one evaluate so
+ * every number describes the same frame.
+ * @param {Object} page
+ * @returns {Promise<Object>}
+ */
+const readGeometry = page => page.evaluate(host => {
+    const el      = document.querySelector(host),
+          preview = el?.querySelector(':scope > .neo-dock-preview'),
+          shell   = el?.querySelector(':scope > .neo-dashboard-dock-tabs, :scope > .neo-layout-fit-item');
+
+    return {
+        clientWidth : el?.clientWidth,
+        hostLeft    : el?.getBoundingClientRect().left,
+        position    : preview && getComputedStyle(preview).position,
+        present     : !!preview,
+        scrollLeft  : el?.scrollLeft,
+        scrollWidth : el?.scrollWidth,
+        shellLeft   : shell?.getBoundingClientRect().left,
+        shellPresent: !!shell
+    }
+}, HOST);
+
+test.beforeEach(async ({page}) => {
+    await page.goto('test/playwright/component/apps/dock-preview-geometry/index.html');
+    await page.waitForSelector('#dock-preview-geometry-workspace', {state: 'attached'});
+    await expect(page.locator(`${HOST} .neo-dock-preview`)).toBeAttached({timeout: 10000})
+});
+
+test.describe('Neo.dashboard.dock.interaction.Preview — the overlay carries its own geometry (#18142)', () => {
+    test('a host that declares only position:relative gets no overflow from the preview', async ({page}) => {
+        const geometry = await readGeometry(page);
+
+        // Non-vacuity first: with no preview and no shell every assertion below is trivially true,
+        // and this fixture would report a pass for an engine sheet that positions nothing.
+        expect(geometry.present,      'the preview overlay must exist for this to measure anything').toBe(true);
+        expect(geometry.shellPresent, 'the projected shell must exist for the same reason').toBe(true);
+        expect(geometry.clientWidth,  'the host must have laid out').toBeGreaterThan(0);
+
+        expect(geometry.position, 'the engine sheet positions the preview root').toBe('absolute');
+
+        // The cause. An in-flow preview adds a full host width to the flex row; an absolute one
+        // adds none, so the host has no overflow to be scrolled into.
+        expect(geometry.scrollWidth, 'the preview must not make the fit host scrollable')
+            .toBe(geometry.clientWidth);
+
+        // The consequence, asserted separately: a host that cannot scroll cannot strand its shell.
+        expect(geometry.scrollLeft, 'the host rests unscrolled').toBe(0);
+        expect(Math.abs(geometry.shellLeft - geometry.hostLeft),
+            'the shell sits at the host\'s left edge').toBeLessThanOrEqual(1)
+    });
+
+    test('a scroll forced onto the host cannot survive, because there is nowhere to scroll to', async ({page}) => {
+        // The defect was never the scroll itself — the reconciler legitimately stages two shells for
+        // a few frames, so a transient scroll is expected. It was that the preview kept the overflow
+        // alive afterwards, so the scroll had somewhere to persist. Driving one directly is the
+        // sharper witness: with the overlay out of the flow the host clamps straight back to 0.
+        const settled = await page.evaluate(host => {
+            const el = document.querySelector(host);
+
+            el.scrollLeft = 5000;
+
+            return {attempted: 5000, scrollLeft: el.scrollLeft, scrollWidth: el.scrollWidth, clientWidth: el.clientWidth}
+        }, HOST);
+
+        expect(settled.scrollWidth, 'still no overflow after the attempt').toBe(settled.clientWidth);
+        expect(settled.scrollLeft,  'the host clamps back to its only valid scroll position').toBe(0)
+    })
+});


### PR DESCRIPTION
Resolves #18142

Related: #18138 (the same ownership pattern on a different rule — a declaration the engine's reveal needs, living in consumer stylesheets), Epic #13158

@neo-opus-vega measured this in a downstream dock workspace: after a pin → rail → pin-back cycle the whole workspace stood one host width to the **left** of the viewport. It did not reproduce in `apps/workstation`, and the difference was one stylesheet rule the Workstation carried and the downstream host did not.

Evidence: L3 (browser — the defect is a layout-participation property of a rendered host) → L3 sufficient; every AC is readable in the component harness. Residual: none.

## Why an unpositioned overlay displaces the workspace

A dock host lays out `fit`. `Fit.scss` gives the host `display: flex` and every item `flex: 1 0 100%` — so a preview the engine never positions is an **in-flow** `.neo-layout-fit-item`, a second full host width in the flex row. `overflow-x: hidden` hides the scrollbar but the host stays programmatically scrollable, and any focus or scroll-into-view aimed past the first width shifts it. Nothing scrolls it back: the preview keeps the overflow alive after the re-projection has retired the old shell, so the displacement is permanent until a reload.

The sibling drop-indicator layer already owns its geometry in the engine sheet (`Container.scss:708` — `inset: 0; position: absolute; z-index: 30`). The preview was the one overlay whose positioning every consumer had to re-derive.

## AC Evidence

| AC | Evidence |
|---|---|
| AC-1 — the engine sheet positions `.neo-dock-preview` absolutely with `inset: 0` | the rule, emitted to `dist/development/css/src/dashboard/dock/interaction/Preview.css`; the new spec asserts `getComputedStyle(preview).position === 'absolute'` on a host with no stylesheet |
| AC-2 — `scrollWidth === clientWidth` on such a host | `DockPreviewGeometry.spec.mjs`, both arms. Red-first receipt below |
| AC-3 — the Workstation and Demo-A keep their overlay geometry | `component/dashboard` **105 passed**, `unit/dashboard` + `unit/apps/workstation` **779 passed**, full unit **3036 passed** |
| AC-4 — consumer duplicates removed | both retired, not annotated as no-ops. `grep -c neo-dock-preview` on each built consumer sheet returns **0** |

## Deltas from ticket

- **The witness is a new fixture, not an arm on an existing one.** The ticket offered `WorkstationDragAffordancesNL` or a component spec on a bare workspace. The first is one of tonight's non-deterministic specs and an arm there would inherit that. The second turned out to need a fixture that does not exist: **no component fixture mounts a `DockPreview` at all**, because the preview is a *consumer-provided* sibling (`Workspace.mjs:63` — `dockHostReference` exists "when a consumer keeps persistent overlay siblings"), not something the Workspace creates.
- **The fixture deliberately carries no stylesheet.** That is the whole point: every shipping consumer either wrote the missing rule or copied one that had, so **none of them can witness what the engine owes a host that did neither**. A fixture with an app sheet would pass whether or not the engine positions the preview.
- **My first attempt put the arm on `dock-rail-origin` and it failed on its own non-vacuity guard** — `.neo-dock-preview` is simply absent there. Recorded because that guard is the only reason the arm did not silently pass while measuring nothing.
- **The duplicates are removed rather than left as documented no-ops.** The ticket allowed either. Three copies of a workaround for a fixed bug is how the next reader concludes it is still required — the same reasoning I put in #18138's AC-4.

## Test Evidence

**Red-first, with the engine rule reverted and both consumer copies already gone** — the true "before" for a bare host:

```
2 failed
  the engine sheet positions the preview root
      Expected: "absolute"   Received: "static"
  the host clamps back to its only valid scroll position
      Expected: 1280         Received: 2560
```

`2560` against a `clientWidth` of `1280` is the doubled host width, reproduced independently in the component harness — the same 2× ratio the ticket measured as 1600/3200 on the downstream app. With the rule: **2 passed**.

**The second arm drives the scroll directly rather than waiting for one.** The defect was never the scroll itself — the reconciler legitimately stages two shells for a few frames, so a transient scroll is expected and correct. It was that the preview kept the overflow alive *afterwards*, so the scroll had somewhere to persist. Setting `scrollLeft = 5000` and asserting it clamps to `0` reads that property without depending on a gesture.

**Why `scrollWidth === clientWidth` and not the shell's position.** It reads the cause. A shell can be displaced for other reasons, and it can also sit correctly at x=0 while the overflow quietly persists, waiting for the next focus call. The shell's position is asserted too, as the consequence.

## Post-Merge Validation

- [ ] The downstream workspace that reported it: pin → rail → pin-back with only `position: relative` on the host, and confirm the workspace stays put. The mechanism is witnessed here on an equivalent bare host; this is the report path.

## Commits

- `53d93ff2df` — the preview overlay carries its own geometry.

Authored by Ada (Claude Opus 5, Claude Code). Session 7596538d-5324-419a-b043-95c585d833ea.

Cross-family note: same-family clearance is armed today (@neo-opus-grace, 2026-09-02T15:53Z) — the GPT seats are on a weekly rate limit.
