### PR TITLE
fix(dock): a rejected projection phase settles the host to one shell and reports it (#18143)

### DIFF
--- a/src/dashboard/dock/Workspace.mjs
+++ b/src/dashboard/dock/Workspace.mjs
@@ -3522,7 +3522,7 @@ class Workspace extends Container {
         const {onProjectionStaged, retainTopology: forcedRetainTopology, waitForOverflowProjection} =
             me.getReconcileOptions(document, refreshOptions) || {};
 
-        const result = await Reconciler.reconcileProjection({
+        const projection = {
             geometryOnly,
             host,
             nextConfig,
@@ -3549,7 +3549,24 @@ class Workspace extends Container {
             retainTopology: forcedRetainTopology ?? retainTopology,
             shellIndex    : me.dockShellIndex,
             waitForOverflowProjection
-        });
+        };
+
+        // `try`/`await` rather than a `.catch()` on the call: the reconciler is the seam consumers and
+        // specs substitute, and a double is free to return a plain result rather than a promise.
+        // Chaining `.catch()` onto the return would make this method require a thenable that the
+        // contract never promised — a pre-existing spec double proved it by throwing here.
+        let result;
+
+        try {
+            result = await Reconciler.reconcileProjection(projection)
+        } catch (error) {
+            result = me.onDockProjectionFailed(error, document, tabInsertDescriptor, refreshOptions)
+        }
+
+        // The failure path owns the remainder of this cycle. Running the maximize sync and the FLIP
+        // over a shell the committed document does not describe would animate the recovery itself,
+        // and `afterRefreshDockWorkspace` consumers read `result` as a completed projection.
+        if (result === null) return;
 
         // Awaited on purpose: refreshPromise is the settled-surface contract, and a maximize
         // presentation that re-applies after it settles is a surface nobody can await.
@@ -3593,6 +3610,64 @@ class Workspace extends Container {
             // change-guarded, so re-running it on settled chrome is idempotent.
             me.syncDockHeaderActions()
         }
+    }
+
+    /**
+     * @summary Surfaces a failed dock projection and spends ONE clean re-projection repairing it.
+     *
+     * A projection phase that rejects has already settled the host back to a single visible shell
+     * ({@link Neo.dashboard.dock.projection.Reconciler#settleFailedProjection}), so what is left is
+     * a shell whose CONTENT may lag the committed document. The document itself is untouched by a
+     * failed projection and a rejected vdom flight adopts no vnode, so re-projecting from that same
+     * document is the repair — this is the caller-side half of the reject-then-re-diff contract that
+     * `VdomLifecycle#executeVdomUpdate` provides.
+     *
+     * Observability is the other half of the fix. Before this, the rejection escaped as an unhandled
+     * rejection: `onDockZoneDocumentChange` attaches its `.catch` to the PREVIOUS refresh, never the
+     * one it is starting, so nothing on the live path ever saw the failure.
+     *
+     * **Exactly one retry.** A deterministic failure must not hot-loop, so the re-projection carries
+     * `isDockProjectionRetry` and a second failure surfaces without scheduling a third attempt. The
+     * retry replaces `refreshPromise` rather than chaining onto it — the current value IS this cycle,
+     * and awaiting it from inside itself would never settle.
+     * @param {Error} error The failure, marked `isDockProjectionFailure` with a `projectionRecovery` verdict.
+     * @param {Object} document The committed dock document the repair re-projects from.
+     * @param {Object} tabInsertDescriptor
+     * @param {Object} [refreshOptions={}]
+     * @returns {null} Signals the caller that this cycle is over and was handled.
+     * @protected
+     */
+    onDockProjectionFailed(error, document, tabInsertDescriptor, refreshOptions={}) {
+        const me = this;
+
+        // Only the transaction's own typed failure is recoverable this way. Anything else is a bug
+        // in the projection inputs and must keep its original loud path.
+        if (!error?.isDockProjectionFailure) {
+            throw error
+        }
+
+        const isRetry  = refreshOptions.isDockProjectionRetry === true,
+              recovery = error.projectionRecovery;
+
+        console.warn(
+            `Dock projection failed (${recovery}); ${isRetry ? 'the repair attempt failed too, not retrying again' : 'scheduling one clean re-projection'}`,
+            me.id, error
+        );
+
+        me.fire('dockProjectionFailed', {component: me, error, isRetry, recovery});
+
+        if (!isRetry && !me.isDestroyed) {
+            me.refreshPromise = me.timeout(0).then(() => {
+                if (!me.isDestroyed) {
+                    return me.refreshDockWorkspace(tabInsertDescriptor, document, {
+                        ...refreshOptions,
+                        isDockProjectionRetry: true
+                    })
+                }
+            })
+        }
+
+        return null
     }
 
     /**

--- a/src/dashboard/dock/projection/Reconciler.mjs
+++ b/src/dashboard/dock/projection/Reconciler.mjs
@@ -433,15 +433,31 @@ class Reconciler extends Base {
 
         const commitBars = new Set();
 
-        this.reconcileTabChrome(
-            plans,
-            placeholders,
-            currentTabs,
-            nextShell,
-            resolveItem,
-            preserveItemIds,
-            commitBars
-        );
+        // Phases 2-4 are the window in which the host holds TWO shells, and every one of them ends in
+        // an awaited flight that can reject: a landing ancestor update whose stored vnode still
+        // references chrome a phase destroyed silently is enough (`util.VNode.getVnode` throws on a
+        // reference whose component has left the registry). Without this guard the rejection unwinds
+        // out of the whole method and the host keeps both shells — the outgoing one visible and
+        // populated, the staged one hidden and half-built — and since every later commit reconciles
+        // against `host.items[shellIndex]` again, that state never self-heals.
+        //
+        // `VdomLifecycle#executeVdomUpdate` already promises the half this method needs: a rejected
+        // flight adopts no vnode and rejects every parked promise, "so the next cycle re-diffs
+        // cleanly". The dock is the caller that has to USE that cleanliness — settle the host back to
+        // exactly one shell, then let the workspace re-project from the committed document.
+        let retainedRoot = false,
+            swapped      = false;
+
+        try {
+            this.reconcileTabChrome(
+                plans,
+                placeholders,
+                currentTabs,
+                nextShell,
+                resolveItem,
+                preserveItemIds,
+                commitBars
+            );
 
         // Existing pane/button pairs move through the host's common-ancestor transaction below.
         // A parked pane has no surviving button DOM to move, so its newly materialized pair needs
@@ -450,45 +466,60 @@ class Reconciler extends Base {
         // leave the toolbar's VDOM change invisible to the main-thread delta boundary. Silent
         // insertion also bypasses the SortZone's insert listener, so restore its delegated marker
         // before that one owner commit.
-        await Promise.all([...commitBars].map(bar => {
-            bar.sortZone?.adjustItemCls(true);
-            bar.updateDepth = -1;
-            return bar.promiseUpdate()
-        }));
+            await Promise.all([...commitBars].map(bar => {
+                bar.sortZone?.adjustItemCls(true);
+                bar.updateDepth = -1;
+                return bar.promiseUpdate()
+            }));
 
-        // A removed logical tab can be the source of a returning pane. Hide that now-empty source in
-        // the descendant commit; the ancestor/cleanup phases destroy it with its retiring shell once.
-        currentTabs.forEach((tab, nodeId) => {
-            if (!plans.has(nodeId)) {
-                tab.setSilent({hideMode: 'visibility', hidden: true})
-            }
-        });
-        host.updateDepth = -1;
-        host.update();
-        await host.promiseUpdate();
-
-        this.moveRetainedTabChrome(plans);
-
-        // A tabs node may itself be the projected root. In that case its staging placeholder has
-        // disappeared and the retained tab is both old and new shell; never retire it as source chrome.
-        nextShell = nextShell.isDestroyed ? host.items[shellIndex] : nextShell;
-
-        const retainedRoot = oldShell === nextShell;
-
-        if (!retainedRoot) {
-            oldShell.setSilent({hideMode: 'visibility', hidden: true});
-            nextShell.setSilent({hidden: false})
-        }
-
-        host.updateDepth = -1;
-        host.update();
-        await host.promiseUpdate();
-
-        if (!retainedRoot) {
-            host.remove(oldShell, true, true);
+            // A removed logical tab can be the source of a returning pane. Hide that now-empty source in
+            // the descendant commit; the ancestor/cleanup phases destroy it with its retiring shell once.
+            currentTabs.forEach((tab, nodeId) => {
+                if (!plans.has(nodeId)) {
+                    tab.setSilent({hideMode: 'visibility', hidden: true})
+                }
+            });
             host.updateDepth = -1;
             host.update();
-            await host.promiseUpdate()
+            await host.promiseUpdate();
+
+            this.moveRetainedTabChrome(plans);
+
+            // A tabs node may itself be the projected root. In that case its staging placeholder has
+            // disappeared and the retained tab is both old and new shell; never retire it as source chrome.
+            nextShell = nextShell.isDestroyed ? host.items[shellIndex] : nextShell;
+
+            retainedRoot = oldShell === nextShell;
+
+            if (!retainedRoot) {
+                oldShell.setSilent({hideMode: 'visibility', hidden: true});
+                nextShell.setSilent({hidden: false})
+            }
+
+            host.updateDepth = -1;
+            host.update();
+            // The swap is only true once this flight LANDS: a rejection here leaves the visibility
+            // change unadopted, so recovery must treat the outgoing shell as the one still on screen.
+            await host.promiseUpdate();
+
+            swapped = !retainedRoot;
+
+            if (!retainedRoot) {
+                host.remove(oldShell, true, true);
+                host.updateDepth = -1;
+                host.update();
+                await host.promiseUpdate()
+            }
+        } catch (error) {
+            error.isDockProjectionFailure = true;
+            error.projectionRecovery      = await this.settleFailedProjection({
+                host, nextShell, oldShell, retainedRoot, shellIndex, swapped
+            });
+
+            // Re-thrown rather than wrapped: the original message and stack ARE the diagnostic (the
+            // live report that produced this guard read `Component not found for id: …` out of
+            // `syncVnodeTree`), and a wrapper buries the one line that names the stale reference.
+            throw error
         }
 
         const overflowPlugins = [...new Set([...plans.values()]
@@ -510,6 +541,74 @@ class Reconciler extends Base {
         // "no topology swap can be pending" must NOT be told otherwise, however the call was
         // admitted. See the in-place return above.
         return {currentTabs, landedInPlace: false, nextShell, overflowPlugins, plans}
+    }
+
+    /**
+     * @summary Settles a host back to exactly one visible shell after a projection phase rejected.
+     *
+     * The transaction's whole hazard is the interval where the host holds two shells. This does NOT
+     * try to restore the outgoing shell's contents — chrome has already moved and leavers are already
+     * destroyed by the time most rejections land, and reconstructing that by hand would be a second
+     * unaudited projection. It restores the only invariant later commits depend on: **one shell, at
+     * `shellIndex`, visible.** Recovering the CONTENT is the follow-up re-projection's job, which is
+     * sound because a rejected flight adopts no vnode, the committed document is untouched by a
+     * failed projection, and a consumer's `resolveItem` re-materializes a pane whose instance is gone.
+     *
+     * Which shell survives follows the last landed flight rather than intent: before the visibility
+     * swap commits, the outgoing shell is the one on screen and the staged one is retired; after it
+     * commits, the staged shell is the survivor and the swap is simply finished.
+     *
+     * A retired STAGED shell is detached but deliberately not destroyed — see the call below — so it
+     * outlives this method holding whatever panes had already moved into it. That is intentional and
+     * temporary: the repair re-projection re-parents those panes by identity and leaves the detached
+     * shell empty and unreferenced.
+     *
+     * The recovery commits too, so it can reject in turn. That is reported, never thrown: the caller
+     * re-throws the ORIGINAL failure, whose message names the actual cause.
+     * @param {Object}  data
+     * @param {Neo.container.Base} data.host The dock host holding both shells.
+     * @param {Neo.component.Base} data.nextShell The staged shell inserted at `shellIndex + 1`.
+     * @param {Neo.component.Base} data.oldShell The outgoing shell at `shellIndex`.
+     * @param {Boolean} data.retainedRoot The projected root was the retained tab; nothing was staged.
+     * @param {Number}  data.shellIndex Index the surviving shell must occupy.
+     * @param {Boolean} data.swapped The visibility swap LANDED, so the staged shell is on screen.
+     * @returns {Promise<String>} `retained-root` | `retired-staged` | `completed-swap` | `unrecoverable`
+     * @static
+     */
+    static async settleFailedProjection({host, nextShell, oldShell, retainedRoot, shellIndex, swapped}) {
+        // A retained root never staged a second shell, so the host was never in the two-shell window.
+        if (retainedRoot) return 'retained-root';
+
+        const survivor = swapped ? nextShell : oldShell,
+              casualty = swapped ? oldShell  : nextShell;
+
+        try {
+            if (casualty && !casualty.isDestroyed && host.indexOf(casualty) > -1) {
+                // Destroy ONLY the outgoing shell, which the success path destroys anyway. The staged
+                // shell must be detached WITHOUT destroying it: by the time most rejections land,
+                // `reconcileTabChrome` has already moved live pane/button pairs into it, and
+                // destroying it would take them with it — the precise opposite of the
+                // reparent-never-recreate promise this transaction exists to keep. Detached, those
+                // panes stay alive and the repair re-projection re-parents them out by identity,
+                // because `resolveItem` returns the consumer's own instances.
+                host.remove(casualty, swapped, true)
+            }
+
+            if (survivor && !survivor.isDestroyed) {
+                survivor.setSilent({hidden: false})
+            }
+
+            host.updateDepth = -1;
+            host.update();
+            await host.promiseUpdate();
+
+            // Positional, not incidental: every later commit reconciles against `host.items[shellIndex]`,
+            // so a survivor that settled anywhere else would send the next projection at the wrong node.
+            return host.items?.[shellIndex] === survivor ? (swapped ? 'completed-swap' : 'retired-staged') : 'unrecoverable'
+        } catch (recoveryError) {
+            console.warn('Dock projection recovery failed; the host may still hold two shells', host?.id, recoveryError);
+            return 'unrecoverable'
+        }
     }
 
     /**

--- a/test/playwright/unit/dashboard/DockProjectionReconciler.spec.mjs
+++ b/test/playwright/unit/dashboard/DockProjectionReconciler.spec.mjs
@@ -754,5 +754,151 @@ test.describe('Neo.dashboard.dock.projection.Reconciler', () => {
         } finally {
             host.destroy()
         }
+    });
+
+    /**
+     * The transaction's failure path. Phases 2-4 each end in an awaited host flight, and the host
+     * holds TWO shells for that whole window — so a rejection anywhere in it used to unwind out of
+     * the method and leave both shells in place, the outgoing one visible and the staged one hidden,
+     * with every later commit reconciling against `host.items[shellIndex]` forever.
+     *
+     * A rejecting flight is injected by counting `host.promiseUpdate` calls, which is what the phases
+     * ARE: #1 stages the shell, #2 closes tab chrome, #3 swaps visibility, #4 retires the old shell.
+     * Rejecting #2 and #3 leaves the swap unlanded (the outgoing shell must survive); rejecting #4
+     * happens after it landed (the staged shell must survive and the swap simply finishes) — so the
+     * two recovery verdicts are both reachable and are asserted by name rather than inferred.
+     */
+    const reconcileWithRejectedFlight = async rejectOnCall => {
+        const
+            model = createSplitModel(),
+            panes = Object.fromEntries(Object.entries(model.items)
+                .map(([itemId, item]) => [itemId, Neo.create(Component, {header: {text: item.title}})])),
+            host  = Neo.create(Container, {
+                items: [DockLayoutAdapter.project(model, {
+                    resolveComponentRef: (_componentRef, _item, itemId) => panes[itemId]
+                })]
+            }),
+            oldShell     = host.items[0],
+            nextModel    = structuredClone(model),
+            placeholders = new Map();
+
+        // Any topology change that stages a second shell; the failure is about the transaction, not
+        // about which mutation asked for it.
+        nextModel.nodes['root-split'].sizes = [0.3, 0.7];
+        nextModel.nodes['root-split'].children.reverse();
+
+        const nextConfig = DockLayoutAdapter.project(nextModel, {
+            resolveComponentRef(_componentRef, item, itemId) {
+                const placeholder = Neo.create(Component, {header: {text: item.title}, hidden: true});
+
+                placeholders.set(itemId, placeholder);
+
+                return placeholder
+            }
+        });
+
+        const original = host.promiseUpdate.bind(host);
+
+        let calls = 0;
+
+        host.promiseUpdate = function() {
+            calls++;
+
+            return calls === rejectOnCall
+                // The shape the live report carried: a landing ancestor flight whose stored vnode
+                // still references chrome an earlier phase destroyed silently.
+                ? Promise.reject(new Error('util.VNode.getVnode: Component not found for id: neo-tab-header-button-10'))
+                : original()
+        };
+
+        let error = null;
+
+        try {
+            await DockProjectionReconciler.reconcileProjection({
+                host,
+                nextConfig,
+                placeholders,
+                resolveItem: itemId => panes[itemId]
+            })
+        } catch (e) {
+            error = e
+        }
+
+        host.promiseUpdate = original;
+
+        return {calls, error, host, model, oldShell, panes}
+    };
+
+    for (const [phase, rejectOnCall, expectedRecovery, expectedSurvivor] of [
+        ['2 (tab chrome)',      2, 'retired-staged', 'old'],
+        ['3 (visibility swap)', 3, 'retired-staged', 'old'],
+        ['4 (retire outgoing)', 4, 'completed-swap', 'staged']
+    ]) {
+        test(`a rejected flight in phase ${phase} leaves exactly one visible shell and reports it`, async () => {
+            const {error, host, oldShell, panes} = await reconcileWithRejectedFlight(rejectOnCall);
+
+            try {
+                // The failure must still reach the caller — the recovery repairs the host, it never
+                // swallows the cause. Its message is the diagnostic and must survive unwrapped.
+                expect(error, 'the projection failure reaches the caller').toBeTruthy();
+                expect(error.message).toContain('Component not found for id');
+                expect(error.isDockProjectionFailure, 'the failure is typed so the workspace can route it').toBe(true);
+                expect(error.projectionRecovery).toBe(expectedRecovery);
+
+                // The invariant every later commit depends on: ONE shell, at shellIndex, visible.
+                expect(host.items.length, 'the host holds exactly one shell').toBe(1);
+                expect(host.items[0].hidden, 'the surviving shell is visible').not.toBe(true);
+
+                expectedSurvivor === 'old'
+                    ? expect(host.items[0], 'the outgoing shell survives an unlanded swap').toBe(oldShell)
+                    : expect(host.items[0], 'the staged shell survives a landed swap').not.toBe(oldShell);
+
+                // Reparent-never-recreate holds THROUGH the failure: a recovery that destroyed the
+                // retired staged shell would take the panes already moved into it, which is the exact
+                // promise the transaction exists to keep.
+                Object.entries(panes).forEach(([itemId, pane]) => {
+                    expect(pane.isDestroyed, `pane "${itemId}" survives the failed projection`).toBeFalsy()
+                })
+            } finally {
+                host.destroy()
+            }
+        })
+    }
+
+    test('the next projection after a failure reconciles normally onto the surviving shell', async () => {
+        const {host, model, panes} = await reconcileWithRejectedFlight(2);
+
+        try {
+            const placeholders = new Map(),
+                  nextConfig   = DockLayoutAdapter.project(structuredClone(model), {
+                      resolveComponentRef(_componentRef, item, itemId) {
+                          const placeholder = Neo.create(Component, {header: {text: item.title}, hidden: true});
+
+                          placeholders.set(itemId, placeholder);
+
+                          return placeholder
+                      }
+                  });
+
+            // No injected rejection this time: the repair the workspace schedules, run by hand. The
+            // committed document is untouched by a failed projection, so re-projecting from it is the
+            // whole repair — and it must find one shell to reconcile against, not two.
+            const result = await DockProjectionReconciler.reconcileProjection({
+                host, nextConfig, placeholders, resolveItem: itemId => panes[itemId]
+            });
+
+            expect(result, 'the repair projection completes').toBeTruthy();
+            expect(host.items.length, 'the repair leaves one shell behind').toBe(1);
+            expect(host.items[0].hidden, 'the repaired shell is visible').not.toBe(true);
+
+            // Identity, not just presence: the repair re-parented the SAME pane instances out of the
+            // detached staged shell rather than re-creating them.
+            Object.entries(panes).forEach(([itemId, pane]) => {
+                expect(pane.isDestroyed, `pane "${itemId}" survives the repair`).toBeFalsy();
+                expect(Boolean(pane.parent), `pane "${itemId}" is parented again`).toBe(true)
+            })
+        } finally {
+            host.destroy()
+        }
     })
 });

--- a/test/playwright/unit/dashboard/DockWorkspace.spec.mjs
+++ b/test/playwright/unit/dashboard/DockWorkspace.spec.mjs
@@ -322,6 +322,25 @@ class SweepWitnessWorkspace extends PlainWorkspace {
 Neo.setupClass(SweepWitnessWorkspace);
 
 /**
+ * Records the scheduled projection repair instead of running it. The contract under test is WHAT gets
+ * scheduled and how often, not what a second projection then does — the reconciler's own spec owns that.
+ */
+class RepairWitnessWorkspace extends PlainWorkspace {
+    static config = {
+        className: 'Test.Unit.Dashboard.DockWorkspace.RepairWitnessWorkspace'
+    }
+
+    repairLog = []
+
+    refreshDockWorkspace(tabInsertDescriptor, document, refreshOptions) {
+        this.repairLog.push(refreshOptions);
+        return Promise.resolve()
+    }
+}
+
+Neo.setupClass(RepairWitnessWorkspace);
+
+/**
  * The recreate fallback wired (`resolveFreshPane` overridden), so `reload` is offered on every node
  * with an active item while no pane carries `dockReload()` — the Workstation's shape. Which nodes the
  * post-settle sweep REACHES is then the only thing deciding whether the action shows.
@@ -2919,5 +2938,64 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
 
         expect(workspace.afterSetMounted(true, false)).toBe(null);
         expect(workspace.sweepLog).toEqual([])
+    });
+
+    test.describe('#18143 a failed projection is observable and repaired exactly once', () => {
+        const failure = recovery => Object.assign(
+            new Error('util.VNode.getVnode: Component not found for id: neo-tab-header-button-10'),
+            {isDockProjectionFailure: true, projectionRecovery: recovery}
+        );
+
+        test('it warns, fires dockProjectionFailed, and schedules ONE repair carrying the retry flag', async () => {
+            workspace = Neo.create(RepairWitnessWorkspace, {dockModel: createDocument()});
+
+            const events = [];
+
+            workspace.on('dockProjectionFailed', event => events.push(event));
+
+            const error  = failure('retired-staged'),
+                  result = workspace.onDockProjectionFailed(error, createDocument(), null, {});
+
+            // null is the caller's signal that this cycle is over and handled — the maximize sync and
+            // the FLIP must not run over a shell the committed document does not describe.
+            expect(result, 'the caller is told the cycle was handled').toBe(null);
+
+            expect(events.length, 'the failure reaches consumers as an event').toBe(1);
+            expect(events[0]).toMatchObject({component: workspace, error, isRetry: false, recovery: 'retired-staged'});
+
+            await workspace.refreshPromise;
+
+            expect(workspace.repairLog.length, 'exactly one repair is scheduled').toBe(1);
+            expect(workspace.repairLog[0].isDockProjectionRetry, 'the repair is marked so it cannot recurse').toBe(true)
+        });
+
+        test('a failure DURING the repair surfaces without scheduling a third attempt', async () => {
+            workspace = Neo.create(RepairWitnessWorkspace, {dockModel: createDocument()});
+
+            const events = [];
+
+            workspace.on('dockProjectionFailed', event => events.push(event));
+
+            workspace.onDockProjectionFailed(failure('completed-swap'), createDocument(), null, {isDockProjectionRetry: true});
+
+            await workspace.refreshPromise;
+
+            // The hot-loop guard: a deterministic fault would otherwise re-project forever, and the
+            // symptom of that is far worse than the stranded shell this whole path exists to fix.
+            expect(events.length, 'the second failure is still reported').toBe(1);
+            expect(events[0].isRetry, 'and is reported AS a retry').toBe(true);
+            expect(workspace.repairLog, 'no third attempt is scheduled').toEqual([])
+        });
+
+        test('an error that is not the transaction\'s own failure keeps its loud path', () => {
+            workspace = Neo.create(RepairWitnessWorkspace, {dockModel: createDocument()});
+
+            const foreign = new Error('a bug in the projection inputs');
+
+            // Only the typed failure is recoverable this way. Swallowing anything else would turn a
+            // genuine projection bug into a silent re-projection loop.
+            expect(() => workspace.onDockProjectionFailed(foreign, createDocument(), null, {})).toThrow(foreign);
+            expect(workspace.repairLog).toEqual([])
+        })
     })
 });


### PR DESCRIPTION
Resolves #18143

The dock projection is a four-phase transaction, and for the whole window between staging the next shell and retiring the old one the host holds **two** shells. Every phase ends in an awaited host flight that can reject, and nothing caught it — not `reconcileProjection`, not `refreshDockWorkspace` (the call sits outside both `try` blocks in that method), and `onDockZoneDocumentChange` attaches its `.catch` to the **previous** refresh rather than the one it starts. So a rejection unwound out of the method and left both shells in place: the outgoing one visible and populated, the staged one hidden and half-built. Every later commit reconciles against `host.items[shellIndex]` again, so it never self-healed.

Found live by @neo-opus-vega in a consumer app at human pace, read through the Neural Link with the broken window still open.

Evidence: L2 (unit — the defect is a host-state invariant across an awaited transaction, fully reachable with a real host and an injected rejecting flight) → L2 sufficient. Residual: **AC-3's race is characterized, not closed** — see below. Residual-Owner: #18143 stays open.

Micro-review eligible: no — a new failure path through the reconciler plus a new consumer-facing event.

## The shape of the fix

`VdomLifecycle#executeVdomUpdate` already promises the half this needed: a rejected flight adopts no vnode and rejects every parked promise, *"so the next cycle re-diffs cleanly."* The dock was the caller that had to **use** that cleanliness.

Phases 2–4 are now one guarded transaction. On rejection, `Reconciler#settleFailedProjection` restores the only invariant later commits depend on — **one shell, at `shellIndex`, visible** — and re-throws. It deliberately does **not** rebuild content: the committed document is untouched by a failed projection, so the repair is a clean re-projection from it.

**The survivor follows the last landed flight, not intent.** `swapped` is set only *after* the visibility-swap flight resolves, so a rejection at that flight correctly treats the outgoing shell as the one still on screen. Before the swap: retire the staged shell, outgoing survives. After it: finish the swap, staged survives.

## The design call I most want challenged

**A retired staged shell is detached but NOT destroyed.** By the time most rejections land, `reconcileTabChrome` has already moved live pane/button pairs into it, so `remove(shell, true, true)` would destroy those panes — the exact opposite of the reparent-never-recreate promise this transaction exists to keep. Detached, the panes stay alive and the repair re-parents them by identity, because `resolveItem` returns the consumer's own instances.

Cost, stated plainly: a detached empty shell outlives the repair. I judged a leaked container cheaper than destroyed panes. If you disagree, the alternative is salvaging children before destroying, which is a second unaudited projection in the failure path.

## What changed

| | |
|---|---|
| `Reconciler#reconcileProjection` | phases 2–4 wrapped; failure marked `isDockProjectionFailure` + `projectionRecovery` and **re-thrown, not wrapped** — the original message and stack are the diagnostic |
| `Reconciler#settleFailedProjection` | new; returns `retained-root` \| `retired-staged` \| `completed-swap` \| `unrecoverable` |
| `Workspace#refreshDockWorkspace` | `try`/`await` around the projection; a handled failure ends the cycle before the maximize sync and the FLIP |
| `Workspace#onDockProjectionFailed` | new; warns, fires `dockProjectionFailed`, schedules exactly one repair |

**New consumer-facing surface** — `dockProjectionFailed`, fired on the workspace:

| field | type | meaning |
|---|---|---|
| `component` | `Neo.dashboard.dock.Workspace` | the workspace whose projection failed |
| `error` | `Error` | the original failure, carrying `isDockProjectionFailure` and `projectionRecovery` |
| `isRetry` | `Boolean` | `true` when the repair itself failed; no further attempt follows |
| `recovery` | `String` | the `settleFailedProjection` verdict |

Additive: no existing event, config or method signature changes.

## Test Evidence

**Red-first** — `git checkout origin/dev -- src/dashboard/dock/projection/Reconciler.mjs`, specs kept:

```
4 failed / 16 passed
  a rejected flight in phase 2 (tab chrome)      leaves exactly one visible shell and reports it
  a rejected flight in phase 3 (visibility swap) leaves exactly one visible shell and reports it
  a rejected flight in phase 4 (retire outgoing) leaves exactly one visible shell and reports it
  the next projection after a failure reconciles normally onto the surviving shell
    "the host holds exactly one shell"   Expected: 1   Received: 2      ← the defect, literally
```

Restored: `DockProjectionReconciler` **20 passed**, `DockWorkspace` + reconciler together **105 passed**, full unit suite **3043 passed** (exit 0) — the change sits on the core refresh path every dock consumer goes through, so the whole suite is the honest neighbour check.

The rejecting flight is injected by counting `host.promiseUpdate` calls, which is what the phases *are*. Both recovery verdicts are reachable and asserted **by name**, not inferred — rejecting #2/#3 leaves the swap unlanded, rejecting #4 happens after it landed. Pane survival is asserted on every arm; the repair arm asserts **identity**, not mere presence.

**A pre-existing spec double corrected the implementation.** My first version chained `.catch()` onto the reconciler call and threw `Reconciler.reconcileProjection(...).catch is not a function` in an unrelated existing test: the reconciler is a seam consumers and specs substitute, and a double may return a plain result rather than a promise. `try`/`await` requires nothing the contract never promised. That is why the shape is what it is.

## Deltas from ticket

**AC-3 is discharged by its second branch, not its first.** The ticket allows either reproducing the stale-reference race red-first or characterizing it with the AC-1 guard as the shipped mitigation. This PR does the latter, deliberately:

- The race's trigger is not established. Vega's two headless reproductions (three pin cycles each, Chrome and Chromium) did not hit it; the operator did, at human pace. `MotionSignal.enter/leave` is the one workspace-level vdom write on the refresh path and remains the candidate opener, but nothing here pins the timing that lands it inside a later transaction's phase 2.
- Fabricating a red arm from my own reconstruction of that timing would prove my reconstruction, not the product.
- The guard is trigger-independent: it repairs a rejection from *any* opener, which is why it is worth shipping ahead of the characterization.

The ticket's Fix §2 also offers a maintainer call — enroll the retiring bar in `commitBars` (fail-loud) versus letting `VNode.createMap` skip a destroyed reference (degrade). **Not taken here.** It changes what a landing flight does for every consumer of `util/VNode`, and it deserves its own ticket rather than riding a failure-path PR.

## Post-Merge Validation

- [ ] AC-4 hand check: three pin → rail → pin-back cycles on a right-edge pane in `apps/workstation`, and in a consumer host with a heavy DOM, leave one shell.

---

Authored by Grace (Claude Opus 5, Claude Code). Session fb58e855-74b2-4367-9f83-5877f151f024.
