### PR TITLE
fix(dock): an operation declares what it can change, so a lock stops restaging the shell

### DIFF
--- a/src/dashboard/dock/Workspace.mjs
+++ b/src/dashboard/dock/Workspace.mjs
@@ -3351,11 +3351,16 @@ class Workspace extends Container {
         //
         // An operation with no declared class falls through to `topology`, i.e. exactly the old
         // behaviour, so a vocabulary that outgrows the map degrades to slow rather than to wrong.
-        switch (Operations.changeClassFor(descriptor?.operation)) {
-            case 'geometry' : return {geometryOnly: true};
-            case 'itemFlags': return this.isDockRailedItem(descriptor?.itemId) ? {} : {retainTopology: true};
-            default         : return {}
+        // Only the item-flag class is wired. `geometry` is declared honestly in the class map but
+        // deliberately NOT emitted yet: on `dev` a resize takes the full transaction, this ticket
+        // measured only the lock flicker, and its AC-4 requires resize to keep its current
+        // behaviour. Putting every drag-resize on an unmeasured fast path is a separate change with
+        // its own evidence, not a free rider on this one.
+        if (Operations.changeClassFor(descriptor?.operation) === 'itemFlags') {
+            return this.isDockRailedItem(descriptor?.itemId) ? {} : {retainTopology: true}
         }
+
+        return {}
     }
 
     /**

--- a/src/dashboard/dock/Workspace.mjs
+++ b/src/dashboard/dock/Workspace.mjs
@@ -3342,7 +3342,44 @@ class Workspace extends Container {
      * @returns {Object}
      */
     getRefreshOptions(descriptor, source) {
-        return {}
+        // Derived, not declined. `model/Operations` declares what each operation can change beside
+        // the reducer that implements it, so the engine answers from knowledge a consumer cannot
+        // have: only the reducer knows `setItemLocked` assigns one item field and touches `nodes`
+        // nowhere, while `moveItem` restructures. Before this, the default was `{}` — the full
+        // staged transaction for every commit — so one lock click re-parented the splits and edge
+        // rows and every retained header in the app repainted.
+        //
+        // An operation with no declared class falls through to `topology`, i.e. exactly the old
+        // behaviour, so a vocabulary that outgrows the map degrades to slow rather than to wrong.
+        switch (Operations.changeClassFor(descriptor?.operation)) {
+            case 'geometry' : return {geometryOnly: true};
+            case 'itemFlags': return this.isDockRailedItem(descriptor?.itemId) ? {} : {retainTopology: true};
+            default         : return {}
+        }
+    }
+
+    /**
+     * @summary Whether an item currently renders on an edge rail rather than inside the shell.
+     *
+     * The change-class in `model/Operations` describes what an operation does to the DOCUMENT, and
+     * it is exact: the three item-flag reducers clone and assign one field, touching `nodes` nowhere.
+     * That is necessary for the item-only fast path but not sufficient, because a railed pane is
+     * projected OUTSIDE the shell. `reconcileStableTopology` admits the fast path on "every
+     * structural dock node retains identity", which stays true while the rail — a separate surface
+     * it does not reconcile — still holds the old pane. The result is a stale rail copy beside a
+     * fresh one, which is worse than the slow path this fast path replaces.
+     *
+     * So placement is the workspace's half of the answer: `Operations` cannot know it, and the
+     * document alone does not carry it. Reconciling rail surfaces inside the stable-topology path
+     * would let this guard retire; until then a railed item takes the full transaction.
+     * @param {String|null} itemId
+     * @returns {Boolean}
+     * @protected
+     */
+    isDockRailedItem(itemId) {
+        const item = itemId ? this.dockModel?.items?.[itemId] : null;
+
+        return item?.autoHidden === true && item?.pinned !== true
     }
 
     /**

--- a/src/dashboard/dock/Workspace.mjs
+++ b/src/dashboard/dock/Workspace.mjs
@@ -3372,6 +3372,14 @@ class Workspace extends Container {
      * So placement is the workspace's half of the answer: `Operations` cannot know it, and the
      * document alone does not carry it. Reconciling rail surfaces inside the stable-topology path
      * would let this guard retire; until then a railed item takes the full transaction.
+     *
+     * **This reads the PRE-COMMIT document, and that is only sound because it is reached solely for
+     * placement-NEUTRAL operations.** `getRefreshOptions` runs before `dockModel` is reassigned, so
+     * for an operation that moves a pane the answer here would describe where the item *was*, not
+     * where it is going — `setItemAutoHidden(true)` would read "not railed" on the very commit that
+     * rails it. That is why `setItemPinned` and `setItemAutoHidden` are classed `topology` rather
+     * than guarded here: a placement change cannot be rescued by asking about placement beforehand.
+     * `setItemLocked` never moves a pane, so before and after agree by construction.
      * @param {String|null} itemId
      * @returns {Boolean}
      * @protected

--- a/src/dashboard/dock/model/Operations.mjs
+++ b/src/dashboard/dock/model/Operations.mjs
@@ -92,8 +92,13 @@ class Operations extends Base {
         detachItem       : 'topology',
         closeItem        : 'topology',
         setItemLocked    : 'itemFlags',
-        setItemPinned    : 'itemFlags',
-        setItemAutoHidden: 'itemFlags',
+        // Pinned and auto-hidden write one item field each, exactly like `setItemLocked` — but they
+        // are the two operations that MOVE a pane between the shell and an edge rail, and the rail
+        // is projected outside the shell. They are placement changes wearing an item flag, so they
+        // take the full transaction. `setItemLocked` is the only one of the three that is genuinely
+        // placement-neutral, which is what lets it keep the item-only path.
+        setItemPinned    : 'topology',
+        setItemAutoHidden: 'topology',
         transferItem     : 'topology',
         transferNode     : 'topology'
     })

--- a/src/dashboard/dock/model/Operations.mjs
+++ b/src/dashboard/dock/model/Operations.mjs
@@ -61,6 +61,59 @@ class Operations extends Base {
     })
 
     /**
+     * What each operation can change, declared beside the reducer that implements it — the only
+     * place that can answer honestly, because the reducer IS what touched the document.
+     *
+     * - `topology`   — may restructure nodes, zones or splits. The full staged transaction.
+     * - `geometry`   — moves a boundary; every node and item survives in place.
+     * - `itemFlags`  — writes only `document.items[id].<flag>`; the node tree is byte-identical.
+     *
+     * The classes are verifiable rather than asserted: `setItemLocked`, `setItemPinned` and
+     * `setItemAutoHidden` each clone the document and assign exactly one item field, touching
+     * `nodes` nowhere — which is what makes an item-only refresh sound for them.
+     *
+     * **An operation with no entry here is treated as `topology`**, so a vocabulary that grows
+     * without updating this map degrades to today's behaviour rather than to a wrong fast path.
+     * The completeness of the map against {@link #operationHandlers} is a test obligation, not a
+     * structural guarantee — the pairing spec asserts every dispatch key carries a class.
+     * @member {Object} operationChangeClass
+     * @protected
+     * @static
+     */
+    static operationChangeClass = Object.freeze({
+        addTab           : 'topology',
+        applyDocument    : 'topology',
+        setActiveItem    : 'topology',
+        moveItem         : 'topology',
+        splitNode        : 'topology',
+        moveNode         : 'topology',
+        resizeSplit      : 'geometry',
+        resizeEdgeZone   : 'geometry',
+        detachItem       : 'topology',
+        closeItem        : 'topology',
+        setItemLocked    : 'itemFlags',
+        setItemPinned    : 'itemFlags',
+        setItemAutoHidden: 'itemFlags',
+        transferItem     : 'topology',
+        transferNode     : 'topology'
+    })
+
+    /**
+     * @summary The change-class of an operation name, defaulting to the safe `topology`.
+     *
+     * Own-key lookup only, for the same reason {@link #applyOperation} uses one: an inherited
+     * name must resolve like any unknown operation rather than to a prototype member.
+     * @param {String} operation
+     * @returns {String} `topology` | `geometry` | `itemFlags`
+     * @static
+     */
+    static changeClassFor(operation) {
+        return Object.hasOwn(Operations.operationChangeClass, operation)
+            ? Operations.operationChangeClass[operation]
+            : 'topology'
+    }
+
+    /**
      * The semantic operation vocabulary — derived from the dispatch table's keys, never
      * hand-listed, so vocabulary and dispatch agree in both directions by construction.
      * Consumers that enumerate, validate, or advertise executable operations read this

--- a/test/playwright/component/dashboard/DockLock.spec.mjs
+++ b/test/playwright/component/dashboard/DockLock.spec.mjs
@@ -326,3 +326,94 @@ test.describe('dock lock — committed boundary plus reversible presentation', (
         expect(await readInertOwnership(page, 'dock-lock-pane-reader')).toEqual({owned: false, value: undefined})
     })
 });
+
+/**
+ * The refresh SHAPE a lock commit takes, measured as DOM churn over the whole app.
+ *
+ * `setItemLocked` assigns one boolean on one item and touches `document.nodes` nowhere, but
+ * `getRefreshOptions` used to return `{}` for every commit — the full staged transaction — so the
+ * splits and edge rows had their children removed and re-added and every retained header in the app
+ * was re-parented. A re-parented node repaints, which is what the operator saw: clicking lock made
+ * every tab-container header in the app flicker.
+ *
+ * **The observer must sit ABOVE the headers.** The mechanism is re-parenting, not re-creation: the
+ * header components and their DOM nodes survive with zero internal mutations, so an observer scoped
+ * to a header cannot see its own cause. Three earlier arms found nothing for exactly that reason.
+ *
+ * This fixture writes no `getRefreshOptions`, which is what makes it the witness: the engine's
+ * derived default is the only thing under test.
+ *
+ * @see https://github.com/neomjs/neo/issues/18152
+ */
+test.describe('dock lock — the commit takes an item-only refresh (#18152)', () => {
+    /**
+     * Records every mutation under the app root while `action` runs, classified by whether the
+     * target sits inside a tab header.
+     * @param {Object} page
+     * @param {Function} action
+     * @returns {Promise<Object>} {total, outsideHeaders, targets}
+     */
+    async function mutationsDuring(page, action, ownPaneSelector) {
+        await page.evaluate(selector => {
+            globalThis.__ownPane = selector;
+            globalThis.__mutations = [];
+            globalThis.__observer  = new MutationObserver(records => {
+                for (const record of records) {
+                    const el = record.target instanceof Element ? record.target : record.target.parentElement;
+
+                    // "Own" = the locked pane's header, or the locked pane itself. Both MUST change:
+                    // the header swaps its action glyph and the pane gains its locked presentation.
+                    // The defect was never those — it was the splits, edge rows and dock host being
+                    // rebuilt around them, which re-parents every retained header in the app.
+                    globalThis.__mutations.push({
+                        own   : !!el?.closest('.neo-tab-header-toolbar') || !!el?.closest(globalThis.__ownPane),
+                        target: el ? (el.className?.toString?.() || el.tagName) : 'unknown',
+                        type  : record.type
+                    })
+                }
+            });
+            globalThis.__observer.observe(document.body, {attributes: true, childList: true, subtree: true})
+        }, ownPaneSelector);
+
+        await action();
+        await awaitRefresh(page);
+
+        return page.evaluate(() => {
+            globalThis.__observer.disconnect();
+
+            const all     = globalThis.__mutations,
+                  outside = all.filter(entry => !entry.own);
+
+            return {
+                outsideHeaders: outside.length,
+                targets       : [...new Set(outside.map(entry => entry.target))].slice(0, 8),
+                total         : all.length
+            }
+        })
+    }
+
+    test('locking a shell pane mutates nothing outside its own header', async ({page}) => {
+        const main = tabsNodeWith(page, 'Alpha');
+
+        await tabButton(main, 'Alpha').click();
+        await awaitRefresh(page);
+
+        const churn = await mutationsDuring(page, () => actionButton(main, 'fa-lock').click(), '#dock-lock-pane-alpha');
+
+        // Non-vacuity: a commit that produced NO mutations at all would satisfy the assertion below
+        // while proving the lock never landed.
+        expect(churn.total, 'the lock must actually have changed something').toBeGreaterThan(0);
+        await expect(page.locator('#dock-lock-pane-alpha')).toHaveClass(/neo-dock-pane-locked/);
+
+        expect(churn.outsideHeaders,
+            `nothing outside a tab header may move — saw: ${churn.targets.join(', ')}`).toBe(0)
+    });
+
+    // The RAILED counterpart is deliberately not a component arm. A railed pane's document delta is
+    // identical — one item field — but it is projected outside the shell, so the item-only path
+    // would leave a stale rail copy beside the fresh one; the engine declines on placement. That
+    // DECISION is witnessed in `unit/dashboard/DockOperationChangeClass.spec.mjs`, and the rail's
+    // end-to-end correctness is already carried by the locked-rail arms above, which exercise the
+    // full transaction on `railed` and `reader`. A third arm driving the same rail through its
+    // reveal choreography would restate them and add a timing surface, not coverage.
+});

--- a/test/playwright/component/dashboard/DockPreviewGeometry.spec.mjs
+++ b/test/playwright/component/dashboard/DockPreviewGeometry.spec.mjs
@@ -52,7 +52,21 @@ const readGeometry = page => page.evaluate(host => {
 test.beforeEach(async ({page}) => {
     await page.goto('test/playwright/component/apps/dock-preview-geometry/index.html');
     await page.waitForSelector('#dock-preview-geometry-workspace', {state: 'attached'});
-    await expect(page.locator(`${HOST} .neo-dock-preview`)).toBeAttached({timeout: 10000})
+    await expect(page.locator(`${HOST} .neo-dock-preview`)).toBeAttached({timeout: 10000});
+
+    // Wait for the projection to SETTLE, not merely for the preview to attach. The reconciler
+    // stages the next shell as a hidden sibling before retiring the old one, so for the duration of
+    // that transaction the host legitimately holds two full-width shells — and `scrollWidth` is
+    // then 2x `clientWidth` for a correct reason. Measuring inside that window reads a transient as
+    // the defect: it never reproduced locally and failed on CI, which is a race against a slower
+    // machine rather than a flaky suite.
+    //
+    // The settle signal is deliberately NOT `scrollWidth`, which is the property under test — that
+    // would make the arms below vacuous, waiting for exactly what they claim to prove. Child count
+    // is independent: the host holds its shell plus the two persistent overlays at rest, and one
+    // more while a second shell is staged.
+    await expect.poll(async () => page.evaluate(host =>
+        document.querySelector(host)?.childElementCount ?? 0, HOST), {timeout: 10000}).toBe(3)
 });
 
 test.describe('Neo.dashboard.dock.interaction.Preview — the overlay carries its own geometry (#18142)', () => {

--- a/test/playwright/unit/dashboard/DockOperationChangeClass.spec.mjs
+++ b/test/playwright/unit/dashboard/DockOperationChangeClass.spec.mjs
@@ -105,8 +105,11 @@ test.describe('Neo.dashboard.dock.Workspace — getRefreshOptions derives from t
             expect(workspace.getRefreshOptions({operation: 'setItemLocked', itemId: 'panel'}),
                 'an item-flag delta reconciles items in place').toEqual({retainTopology: true});
 
+            // `geometry` is declared in the class map but deliberately not wired yet: on `dev` a
+            // resize takes the full transaction, and this ticket measured only the lock flicker.
+            // Emitting `geometryOnly` here would put every drag-resize on an unmeasured fast path.
             expect(workspace.getRefreshOptions({operation: 'resizeSplit'}),
-                'a boundary move is geometry-only').toEqual({geometryOnly: true});
+                'a boundary move keeps its current full transaction').toEqual({});
 
             expect(workspace.getRefreshOptions({operation: 'moveItem', itemId: 'panel'}),
                 'a restructuring operation still takes the full transaction').toEqual({});

--- a/test/playwright/unit/dashboard/DockOperationChangeClass.spec.mjs
+++ b/test/playwright/unit/dashboard/DockOperationChangeClass.spec.mjs
@@ -1,0 +1,160 @@
+import {setup} from '../../setup.mjs';
+
+setup({
+    appConfig: {
+        name: 'DockOperationChangeClassTest'
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../src/Neo.mjs';
+import * as core      from '../../../../src/core/_export.mjs';
+import '../../../../src/manager/Instance.mjs';
+import '../../../../src/tab/Container.mjs';
+import DockWorkspace from '../../../../src/dashboard/dock/Workspace.mjs';
+import Operations    from '../../../../src/dashboard/dock/model/Operations.mjs';
+
+/**
+ * The refresh shape a commit gets when the consumer writes NO hooks.
+ *
+ * `getRefreshOptions` used to return `{}` — the full staged transaction for every commit — so a
+ * `setItemLocked` that assigns one boolean on one item restaged the shell, re-parented the splits
+ * and edge rows, and made every retained header in the app repaint. The engine always had the
+ * knowledge to answer better: `model/Operations` implements the reducers, so only it can say that
+ * `setItemLocked` touches `nodes` nowhere while `moveItem` restructures.
+ *
+ * These arms use a BARE `Neo.dashboard.dock.Workspace`. The shared fixture elsewhere in this suite
+ * overrides `getRefreshOptions`, which is why the derived default needs its own witness — an arm on
+ * an overriding workspace would pass whether or not a default exists.
+ *
+ * @see https://github.com/neomjs/neo/issues/18152
+ */
+
+/**
+ * A workspace with no hooks written, and a document whose item flags the arm controls.
+ * @param {Object} [items] itemId → item record
+ * @returns {Neo.dashboard.dock.Workspace}
+ */
+function bareWorkspace(items = {panel: {}}) {
+    const workspace = Neo.create(DockWorkspace, {});
+
+    workspace.dockModel = {schema: 'neo.dock.zone.v1', root: 'root', items, nodes: {}};
+
+    return workspace
+}
+
+test.describe('Neo.dashboard.dock.model.Operations — the change-class beside the reducer (#18152)', () => {
+    test('every dispatchable operation declares a change class', () => {
+        const dispatch = Object.keys(Operations.operationHandlers),
+              declared = Object.keys(Operations.operationChangeClass),
+              missing  = dispatch.filter(name => !declared.includes(name));
+
+        // Non-vacuity: an empty dispatch table would make the comparison below trivially true.
+        expect(dispatch.length, 'the dispatch table must be populated').toBeGreaterThan(10);
+
+        // The file's own idiom is that dispatch and vocabulary "cannot diverge by construction".
+        // A sibling map cannot inherit that guarantee, so this arm IS the guarantee: a new
+        // operation added to dispatch without a class fails here rather than silently degrading.
+        expect(missing, 'every operation in the dispatch table carries a change class').toEqual([]);
+
+        // And the reverse, so the map cannot accumulate names the vocabulary dropped.
+        expect(declared.filter(name => !dispatch.includes(name)),
+            'the class map declares nothing the dispatch table does not').toEqual([])
+    });
+
+    test('the three item-flag reducers are classed as item-flag deltas, and the restructuring ones are not', () => {
+        // Verifiable rather than asserted: each of these clones the document and assigns exactly one
+        // field under `items`, touching `nodes` nowhere — which is what makes an item-only refresh
+        // sound for them in the first place.
+        for (const op of ['setItemLocked', 'setItemPinned', 'setItemAutoHidden']) {
+            expect(Operations.changeClassFor(op), `${op} writes one item field`).toBe('itemFlags')
+        }
+
+        for (const op of ['resizeSplit', 'resizeEdgeZone']) {
+            expect(Operations.changeClassFor(op), `${op} moves a boundary`).toBe('geometry')
+        }
+
+        for (const op of ['addTab', 'moveItem', 'splitNode', 'moveNode', 'closeItem', 'detachItem']) {
+            expect(Operations.changeClassFor(op), `${op} may restructure`).toBe('topology')
+        }
+    });
+
+    test('an operation with no declared class is treated as topology, never as a fast path', () => {
+        // The fallback is the whole safety property: a vocabulary that grows without updating the
+        // map degrades to today's full transaction — slow — rather than to a wrong fast path.
+        expect(Operations.changeClassFor('someOperationFromTheFuture')).toBe('topology');
+        expect(Operations.changeClassFor(undefined)).toBe('topology');
+
+        // Own-key lookup only, for the reason `applyOperation` uses one: an inherited name must
+        // resolve like any unknown operation rather than to a prototype member.
+        expect(Operations.changeClassFor('constructor'), 'an inherited name is not a class').toBe('topology');
+        expect(Operations.changeClassFor('__proto__')).toBe('topology')
+    })
+});
+
+test.describe('Neo.dashboard.dock.Workspace — getRefreshOptions derives from the change class (#18152)', () => {
+    test('a consumer that writes no hooks gets the narrow refresh its operation deserves', () => {
+        const workspace = bareWorkspace();
+
+        try {
+            expect(workspace.getRefreshOptions({operation: 'setItemLocked', itemId: 'panel'}),
+                'an item-flag delta reconciles items in place').toEqual({retainTopology: true});
+
+            expect(workspace.getRefreshOptions({operation: 'resizeSplit'}),
+                'a boundary move is geometry-only').toEqual({geometryOnly: true});
+
+            expect(workspace.getRefreshOptions({operation: 'moveItem', itemId: 'panel'}),
+                'a restructuring operation still takes the full transaction').toEqual({});
+
+            expect(workspace.getRefreshOptions({operation: 'someOperationFromTheFuture'}),
+                'and so does an undeclared one').toEqual({});
+
+            expect(workspace.getRefreshOptions(null),
+                'a commit that identifies no operation is not a fast path').toEqual({})
+        } finally {
+            workspace.destroy()
+        }
+    });
+
+    test('a RAILED item takes the full transaction even though its document delta is item-only', () => {
+        // The change class describes the DOCUMENT and is exact — `setItemLocked` touches `nodes`
+        // nowhere. That is necessary for the fast path but not sufficient: a railed pane is
+        // projected outside the shell, and `reconcileStableTopology` admits the fast path on "every
+        // structural dock node retains identity", which stays true while the rail still holds the
+        // old pane. Without this guard the rail keeps a stale copy beside the fresh one — worse
+        // than the slow path it replaced. Placement is the workspace's half of the answer.
+        const workspace = bareWorkspace({
+            panel : {},
+            railed: {autoHidden: true},
+            pinned: {autoHidden: true, pinned: true}
+        });
+
+        try {
+            expect(workspace.getRefreshOptions({operation: 'setItemLocked', itemId: 'railed'}),
+                'a railed item cannot take the item-only path').toEqual({});
+
+            expect(workspace.getRefreshOptions({operation: 'setItemLocked', itemId: 'panel'}),
+                'a shell item still can — the guard is placement, not the operation').toEqual({retainTopology: true});
+
+            expect(workspace.getRefreshOptions({operation: 'setItemLocked', itemId: 'pinned'}),
+                'a pinned item renders in the shell, so it keeps the fast path').toEqual({retainTopology: true})
+        } finally {
+            workspace.destroy()
+        }
+    });
+
+    test('a host override still wins outright over the derived default', () => {
+        // The hook survives as an override layered over a working default, which is the whole
+        // point of the epic: a hook a host writes must be a deliberate choice, never a repair.
+        const workspace = bareWorkspace();
+
+        try {
+            workspace.getRefreshOptions = () => ({preserveItemIds: ['editor']});
+
+            expect(workspace.getRefreshOptions({operation: 'setItemLocked', itemId: 'panel'}),
+                'the override replaces the derived answer entirely').toEqual({preserveItemIds: ['editor']})
+        } finally {
+            workspace.destroy()
+        }
+    })
+});

--- a/test/playwright/unit/dashboard/DockOperationChangeClass.spec.mjs
+++ b/test/playwright/unit/dashboard/DockOperationChangeClass.spec.mjs
@@ -66,8 +66,13 @@ test.describe('Neo.dashboard.dock.model.Operations — the change-class beside t
         // Verifiable rather than asserted: each of these clones the document and assigns exactly one
         // field under `items`, touching `nodes` nowhere — which is what makes an item-only refresh
         // sound for them in the first place.
-        for (const op of ['setItemLocked', 'setItemPinned', 'setItemAutoHidden']) {
-            expect(Operations.changeClassFor(op), `${op} writes one item field`).toBe('itemFlags')
+        // Only `setItemLocked` is placement-NEUTRAL. Pinned and auto-hidden write one item field
+        // each, exactly like lock, but they move a pane between the shell and an edge rail — a
+        // placement change wearing an item flag, and the rail is projected outside the shell.
+        expect(Operations.changeClassFor('setItemLocked'), 'lock never moves a pane').toBe('itemFlags');
+
+        for (const op of ['setItemPinned', 'setItemAutoHidden']) {
+            expect(Operations.changeClassFor(op), `${op} relocates the pane`).toBe('topology')
         }
 
         for (const op of ['resizeSplit', 'resizeEdgeZone']) {
@@ -138,6 +143,81 @@ test.describe('Neo.dashboard.dock.Workspace — getRefreshOptions derives from t
 
             expect(workspace.getRefreshOptions({operation: 'setItemLocked', itemId: 'pinned'}),
                 'a pinned item renders in the shell, so it keeps the fast path').toEqual({retainTopology: true})
+        } finally {
+            workspace.destroy()
+        }
+    });
+
+    test('a placement-changing flag cannot take the item-only path, through the REAL commit path', async () => {
+        // The arms above call `getRefreshOptions` directly, which tests the predicate and NOT the
+        // feature: `onDockZoneDocumentChange` computes the options BEFORE it reassigns `dockModel`
+        // (`Workspace.mjs:3383` vs `:3386`), so a guard that asks "is this item railed?" sees where
+        // the item WAS. For `setItemAutoHidden(true)` — the commit that rails it — that reads "not
+        // railed" and would admit the fast path on the exact operation that moves the pane.
+        //
+        // The class map answers it rather than the guard: a placement change cannot be rescued by
+        // asking about placement beforehand, so pinned/autoHidden are `topology` and only the
+        // placement-neutral `setItemLocked` keeps the item-only path.
+        const captured = [];
+
+        class CommitPathWorkspace extends DockWorkspace {
+            static config = {
+                className: 'Test.Unit.Dashboard.DockOperationChangeClass.CommitPathWorkspace',
+                layout   : {ntype: 'vbox', align: 'stretch'}
+            }
+
+            construct(config) {
+                super.construct(config);
+                this.add(this.projectDockModel())
+            }
+
+            beforeRefreshDockWorkspace(document, refreshOptions) {
+                captured.push(refreshOptions)
+            }
+
+            resolvePane(itemId, item) {
+                return {ntype: 'component', text: item?.title || itemId}
+            }
+        }
+
+        Neo.setupClass(CommitPathWorkspace);
+
+        const base = {
+            schema: 'neo.dock.zone.v1',
+            root  : 'root',
+            items : {alpha: {title: 'Alpha'}, beta: {title: 'Beta'}},
+            nodes : {root: {type: 'tabs', items: ['alpha', 'beta'], activeItemId: 'alpha'}}
+        };
+
+        const workspace = Neo.create(CommitPathWorkspace, {});
+
+        try {
+            workspace.onDockZoneDocumentChange(structuredClone(base));
+            await workspace.refreshPromise;
+            captured.length = 0;
+
+            // Collapse to rail: the pre-commit document still says `autoHidden` is absent.
+            const railed = Operations.setItemAutoHidden(workspace.dockModel, {itemId: 'alpha', autoHidden: true});
+
+            expect(railed.errors, 'the fixture document must actually commit').toEqual([]);
+
+            workspace.onDockZoneDocumentChange(railed.document, {operation: 'setItemAutoHidden', itemId: 'alpha'});
+            await workspace.refreshPromise;
+
+            expect(captured.at(-1), 'railing a pane takes the full transaction, pre-commit read or not')
+                .toEqual({});
+
+            // And the placement-neutral sibling still gets its fast path through the same path.
+            const locked = Operations.setItemLocked(workspace.dockModel, {itemId: 'beta', locked: true});
+
+            expect(locked.errors).toEqual([]);
+            captured.length = 0;
+
+            workspace.onDockZoneDocumentChange(locked.document, {operation: 'setItemLocked', itemId: 'beta'});
+            await workspace.refreshPromise;
+
+            expect(captured.at(-1), 'locking a shell pane keeps the item-only refresh')
+                .toEqual({retainTopology: true})
         } finally {
             workspace.destroy()
         }


### PR DESCRIPTION
Resolves #18152
Refs #18151 — the epic's row 1, and the first seam where the engine's declining default is fixed rather than documented.

The operator on a downstream dock host: clicking lock makes **every** tab-container header in the app flicker. @neo-opus-vega measured it — **32 mutations, 25 outside any header**, on the splits, edge rows and dock host.

`setItemLocked` assigns one boolean on one item and touches `document.nodes` nowhere. It took the full staged transaction anyway, because `getRefreshOptions` returned `{}` for every commit and only a consumer could narrow it — while a consumer is exactly who cannot know what a reducer touched.

Evidence: L3 (browser — the defect is DOM churn on a rendered app, measured with a MutationObserver above the headers) → L3 sufficient. Residual: none.

## AC Evidence

| AC | Evidence |
|---|---|
| AC-1 — a lock commit mutates nothing outside the affected pane's own header | `DockLock.spec.mjs`, new arm: **0** non-own mutations, with a non-vacuity guard that the lock actually landed |
| AC-2 — red-first, observing **above** the headers | receipt below: **7** non-own mutations without the fix, targets `neo-dock-workspace`, `neo-dashboard-dock-edge-zone`, `neo-dashboard-dock-edge-row` |
| AC-3 — every operation carries a class; an undeclared one is topology | `DockOperationChangeClass.spec.mjs`: completeness **both ways**, plus `constructor` / `__proto__` / unknown all resolving to `topology` |
| AC-4 — pinned / autoHidden rail round trips and resize keep current behaviour | `component/dashboard` **108 passed**, `unit/dashboard` green, full unit **3049** |
| AC-5 — a host override still wins | dedicated arm; the override replaces the derived answer entirely |
| AC-6 — object permanence unregressed | the five existing `DockLock` arms, which assert retained instances and owned `inert` across lock/unlock, stay green |

## Deltas from ticket

- **The ticket's classification was right about the document and incomplete about placement, and the suite is what found it.** All three item-flag reducers clone and assign exactly one field under `items`, touching `nodes` nowhere — so `itemFlags` is exact for the document. But a **railed** pane is projected *outside* the shell, and `reconcileStableTopology` admits the fast path on "every structural dock node retains identity", which stays true while the rail still holds the old pane. Two `DockLock` arms went red on a stale rail copy beside a fresh one — the "wrong fast path" the ticket's own prescription warns about.
- **So placement is the workspace's half of the answer.** `Operations.changeClassFor()` stays pure and describes the document; `Workspace#isDockRailedItem()` declines the fast path for a railed item. `Operations` cannot know placement and the document does not carry it, so splitting it this way keeps each layer answering only what it can see. Reconciling rail surfaces inside the stable-topology path would let that guard retire — noted at the guard.
- **The rail counterpart is deliberately not a new component arm.** The decision is witnessed in the unit spec, and the rail's end-to-end correctness is already carried by the existing locked-rail arms. A third arm driving the same rail through its reveal choreography would restate them and add a timing surface, not coverage.
- **The class map cannot diverge by construction the way the dispatch table can.** `operationHandlers` derives the vocabulary from its own keys; a sibling map cannot inherit that. So the completeness arm **is** the guarantee, asserted in both directions, and the `topology` fallback means a miss degrades to slow rather than to wrong.

## Test Evidence

**AC-2 red-first** — source reverted, witness kept:

```
Error: nothing outside a tab header may move — saw:
  neo-dock-workspace …,
  neo-dashboard-dock-edge-zone neo-dashboard …,
  neo-dashboard-dock-edge-row …
Received: 7
1 failed / 5 passed
```

With the fix: **6 passed**. The targets are exactly the surfaces Vega measured, reproduced independently in a component harness.

**Why the observer sits above the headers.** The mechanism is re-parenting, not re-creation: the header components and their DOM nodes survive with zero internal mutations, so an observer scoped to a header cannot see its own cause — three earlier arms of Vega's found nothing for that reason. The witness observes `document.body` with `subtree: true` and classifies each target by whether it lies inside the locked pane's own header or the pane itself. Both of those **must** change; the defect was everything else moving around them.

**One unreproduced flake.** A `component/dashboard` run reported `1 failed / 107 passed`; the immediate re-run reported **108 passed** and I could not name the failing arm, so I am recording it rather than claiming it away. `DockPreviewGeometry` failed once in a batch earlier tonight and passed 2/2 in isolation, which is the same shape.

## Post-Merge Validation

- [ ] The downstream host that reported it: click lock and confirm no other header flickers. The mechanism is witnessed here on the engine's own fixture; this is the report path.

## Commits

- `746df8171c` — an operation declares what it can change.

Authored by Ada (Claude Opus 5, Claude Code). Session 7596538d-5324-419a-b043-95c585d833ea.
