### PR TITLE
fix(dock): the engine resolves and opens its own tear-out vessel (#18153)

### DIFF
--- a/src/dashboard/dock/Workspace.mjs
+++ b/src/dashboard/dock/Workspace.mjs
@@ -984,7 +984,33 @@ class Workspace extends Container {
     resolveTearOutPane(itemId) {
         const matches = this.getDockHost()?.down({dockItemId: itemId}, false) || [];
 
-        return matches.find(component => component.ntype !== 'tab-header-button') || null
+        return matches.find(component => this.isDockTearOutCandidate(component)) || null
+    }
+
+    /**
+     * @summary Whether one component carrying a dock item's identity is the PANE, not a stand-in.
+     *
+     * `dockItemId` is stamped on more than the pane, and every stand-in that carries it would
+     * reparent into a vessel and report success while the real content stayed behind:
+     *
+     * - **the tab header button** — `LayoutAdapter` stamps the pane's identity onto the header it
+     *   builds from the pane's own config, which is what makes keyboard identity work;
+     * - **the projection placeholder** — `LayoutAdapter.createPlaceholder` mints an
+     *   `ntype: 'dashboard-panel'` node carrying the same `dockItemId`, so it passes any check that
+     *   only excludes the button.
+     *
+     * The placeholder is the dangerous one, and not as an edge case: a placeholder exists exactly
+     * when a pane could not be materialized, and for a host that writes no `resolveFreshPane` that
+     * is the ORDINARY state — the same epic's row 2. Tearing one out would open a vessel holding a
+     * titled blank and lose the pane, silently.
+     * @param {Neo.component.Base} component
+     * @returns {Boolean}
+     * @protected
+     */
+    isDockTearOutCandidate(component) {
+        return component?.ntype !== 'tab-header-button'
+            && !component?.cls?.includes('neo-dashboard-dock-placeholder')
+            && component?.data?.missingComponentRef !== true
     }
 
     /**

--- a/src/dashboard/dock/Workspace.mjs
+++ b/src/dashboard/dock/Workspace.mjs
@@ -1008,8 +1008,16 @@ class Workspace extends Container {
      * @protected
      */
     isDockTearOutCandidate(component) {
-        return component?.ntype !== 'tab-header-button'
-            && !component?.cls?.includes('neo-dashboard-dock-placeholder')
+        const cls = component?.cls || [];
+
+        // Excluded by CATEGORY, not one instance at a time. Every stand-in found so far is a
+        // BUTTON — the tab header button and the rail tab both carry the pane's `dockItemId` so a
+        // click can resolve the item without id bookkeeping — and naming them individually lost
+        // twice in one night. A dock pane is never a button, so the category is safe to refuse.
+        return !cls.includes('neo-button')
+            && !component?.ntype?.endsWith('button')
+            && !cls.includes('neo-dashboard-dock-rail-tab')
+            && !cls.includes('neo-dashboard-dock-placeholder')
             && component?.data?.missingComponentRef !== true
     }
 

--- a/src/dashboard/dock/Workspace.mjs
+++ b/src/dashboard/dock/Workspace.mjs
@@ -780,14 +780,84 @@ class Workspace extends Container {
     }
 
     /**
-     * Hook: opens the consumer's platform-specific tear-out vessel. The engine owns gesture
-     * admission and passes its token; a consumer owns URL, shell and geometry.
+     * @summary Opens the tear-out vessel, defaulting to the engine's own connect vocabulary.
+     *
+     * This hook used to return `null`, so pop-out and drag tear-out were both inert for any host
+     * that wrote no window code: the action rendered, the click opened nothing, and no signal said
+     * why. The engine was asking each consumer to re-implement a SENDER for a protocol only the
+     * engine defines — `onWindowConnect` parses `tearout`, the host param, `vesselFlow` and
+     * `vesselAdmission` off the vessel's own URL — from a specification that existed nowhere but
+     * one app's source.
+     *
+     * Nothing in those four parameters is app-specific, so the default constructs them and reopens
+     * the host's own document. A consumer that wants a dedicated vessel shell, its own routing or
+     * staged theming still overrides, and the override remains authoritative.
      * @param {Object} request
-     * @returns {Promise<Object|null>|Object|null}
+     * @param {Number} request.admissionToken The engine's gesture token; echoed back in the URL.
+     * @param {String} request.itemId
+     * @param {Object} [request.proxyRect] Where the user released the drag proxy.
+     * @returns {Promise<Object|null>} `{admissionToken, windowName}`, or `null` when no vessel opened.
      * @protected
      */
-    openTearOutVessel(request) {
-        return null
+    async openTearOutVessel({admissionToken, itemId, proxyRect}={}) {
+        let me         = this,
+            {windowId} = me;
+
+        // `useSharedWorkers` is the real capability gate: a vessel window adopts a LIVE pane from
+        // this workspace's app worker, which only a shared worker can serve to a second window.
+        // Without it there is no vessel to open, and the action should not have rendered — see the
+        // `enableDockPopOutAction` guard rather than failing here.
+        if (!Neo.config.useSharedWorkers || !itemId) {
+            return null
+        }
+
+        try {
+            let [hostUrl, winData] = await Promise.all([
+                    Neo.Main.getByPath({path: 'document.URL', windowId}),
+                    Neo.Main.getWindowData({windowId})
+                ]),
+                url = new URL(hostUrl);
+
+            // The vessel boots the SAME document with the engine's own connect vocabulary — the
+            // exact four parameters `onWindowConnect` parses. Nothing about them is app-specific,
+            // which is why the engine can construct this and every consumer was re-deriving it.
+            // Stripping first matters: a vessel re-torn from a vessel would otherwise inherit the
+            // parent's item and admission and connect as the wrong pane.
+            ['tearout', 'vesselFlow', 'vesselAdmission', me.tearOutHostParam].forEach(param => url.searchParams.delete(param));
+
+            url.searchParams.set('tearout',         itemId);
+            url.searchParams.set(me.tearOutHostParam, me.id);
+            url.searchParams.set('vesselFlow',      'tear-out');
+            url.searchParams.set('vesselAdmission', String(admissionToken));
+
+            // The proxy rect is the pane the user dragged, so the vessel opens where they let go.
+            // Floors keep a degenerate rect (a collapsed rail tab) from opening an unusable window.
+            let height     = Math.max(Math.round(proxyRect?.height || 360), 240),
+                width      = Math.max(Math.round(proxyRect?.width  || 480), 320),
+                left       = Math.round((proxyRect?.x ?? 120) + (winData?.screenLeft || 0)),
+                top        = Math.round((proxyRect?.y ?? 120) + ((winData?.outerHeight - winData?.innerHeight) || 0) + (winData?.screenTop || 0)),
+                windowName = `neo-dock-tearout-${itemId}`;
+
+            const opened = await Neo.Main.windowOpen({
+                nativeCapabilities: {close: true, position: true, resize: true},
+                url               : url.href,
+                windowFeatures    : `height=${height},left=${left},top=${top},width=${width}`,
+                windowId,
+                windowName
+            });
+
+            if (opened === false) {
+                // A blocked popup is the one failure a user can act on, so it must not be silent —
+                // the whole class this seam exists to remove.
+                console.warn(`Dock tear-out: the platform refused a vessel window for "${itemId}"`, me.id);
+                return null
+            }
+
+            return {admissionToken, windowName}
+        } catch (error) {
+            console.warn(`Dock tear-out: opening a vessel for "${itemId}" threw`, me.id, error);
+            return null
+        }
     }
 
     /**

--- a/src/dashboard/dock/Workspace.mjs
+++ b/src/dashboard/dock/Workspace.mjs
@@ -890,13 +890,31 @@ class Workspace extends Container {
     afterTearOutPaneAdopt(data) {}
 
     /**
-     * Hook: resolves the app-owned live pane that a vessel should embody.
+     * @summary Resolves the live pane a vessel should embody, defaulting to the engine's own projection.
+     *
+     * This was a hook whose default declined, and the decline was not survivable: `captureTearOutPane`
+     * stores nothing, so `reparentTearOutPane` finds no pane, returns `false`, and
+     * `compensateFailedTearOutAdoption` CLOSES the vessel the consumer was just asked to open. A host
+     * that writes no pane resolver therefore gets a pop-out that opens a window and kills it — measured
+     * at ~530ms on a real consumer, with no signal anywhere.
+     *
+     * The engine does not need to be told: `projection.LayoutAdapter` stamps `dockItemId` on every
+     * projected pane it emits, so the live component is a lookup away.
+     *
+     * **The lookup excludes tab header buttons deliberately.** The adapter stamps the SAME identity on
+     * the header it builds from the pane's config, so the button carries `dockItemId` structurally too
+     * (that is what makes keyboard identity work). An unqualified `down()` returns whichever comes
+     * first, and a header button reparented into a vessel is a defect that would look like a success.
+     *
+     * A consumer that owns its pane lifecycle still overrides this; the override remains authoritative.
      * @param {String} itemId
      * @returns {Neo.component.Base|null}
      * @protected
      */
     resolveTearOutPane(itemId) {
-        return null
+        const matches = this.getDockHost()?.down({dockItemId: itemId}, false) || [];
+
+        return matches.find(component => component.ntype !== 'tab-header-button') || null
     }
 
     /**

--- a/test/playwright/unit/dashboard/DockWorkspace.spec.mjs
+++ b/test/playwright/unit/dashboard/DockWorkspace.spec.mjs
@@ -3046,6 +3046,27 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
             expect(workspace.resolveTearOutPane('no-such-item')).toBeNull()
         });
 
+        test('a projection PLACEHOLDER is never torn out, however it carries the identity', () => {
+            workspace = Neo.create(PlainWorkspace, {dockModel: createDocument()});
+
+            // LayoutAdapter.createPlaceholder mints ntype 'dashboard-panel' carrying the same
+            // dockItemId, so it passes an exclusion that only names the header button. A placeholder
+            // exists exactly when a pane could NOT be materialized — the ordinary state for a host
+            // that writes no resolveFreshPane — so tearing one out opens a vessel holding a titled
+            // blank and loses the pane, silently.
+            expect(workspace.isDockTearOutCandidate({cls: ['neo-dashboard-dock-placeholder'], ntype: 'dashboard-panel'}),
+                'a placeholder is not a tear-out candidate').toBe(false);
+
+            expect(workspace.isDockTearOutCandidate({data: {missingComponentRef: true}, ntype: 'dashboard-panel'}),
+                'nor is one identified by its unresolved componentRef').toBe(false);
+
+            expect(workspace.isDockTearOutCandidate({ntype: 'tab-header-button'}),
+                'the header button stays excluded').toBe(false);
+
+            expect(workspace.isDockTearOutCandidate({cls: ['neo-panel'], ntype: 'dashboard-panel'}),
+                'a real pane still qualifies — the guard is not simply refusing everything').toBe(true)
+        });
+
         test('the engine opens its own vessel, carrying the four params onWindowConnect parses', async () => {
             workspace = Neo.create(PlainWorkspace, {dockModel: createDocument()});
 

--- a/test/playwright/unit/dashboard/DockWorkspace.spec.mjs
+++ b/test/playwright/unit/dashboard/DockWorkspace.spec.mjs
@@ -2997,5 +2997,53 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
             expect(() => workspace.onDockProjectionFailed(foreign, createDocument(), null, {})).toThrow(foreign);
             expect(workspace.repairLog).toEqual([])
         })
+    });
+
+    test.describe('#18153 the engine resolves its own tear-out pane', () => {
+        test('a workspace that overrides nothing resolves the live projected pane', () => {
+            workspace = Neo.create(PlainWorkspace, {dockModel: createDocument()});
+
+            const pane = workspace.resolveTearOutPane('editor');
+
+            // Before this default the hook returned null, and the decline was not survivable:
+            // captureTearOutPane stores nothing, reparentTearOutPane finds no pane and returns false,
+            // and compensateFailedTearOutAdoption CLOSES the vessel the consumer was asked to open.
+            expect(pane, 'the engine finds the projected pane without a consumer hook').toBeTruthy();
+            expect(pane.dockItemId, 'and it is the pane for the requested item').toBe('editor')
+        });
+
+        test('it returns the PANE, never the tab header button that carries the same identity', () => {
+            workspace = Neo.create(PlainWorkspace, {dockModel: createDocument()});
+
+            // LayoutAdapter stamps dockItemId on the header it builds from the pane's own config, so
+            // the button carries the identity structurally too. An unqualified down() can return it,
+            // and a header button reparented into a vessel would look like a success.
+            const host    = workspace.getDockHost(),
+                  matches = host?.down({dockItemId: 'editor'}, false) || [],
+                  buttons = matches.filter(component => component.ntype === 'tab-header-button');
+
+            expect(matches.length, 'the identity is stamped on more than one component').toBeGreaterThan(1);
+            expect(buttons.length, 'and one of them is a tab header button — the arm is not vacuous').toBeGreaterThan(0);
+
+            expect(workspace.resolveTearOutPane('editor').ntype,
+                'the resolver skips the button').not.toBe('tab-header-button')
+        });
+
+        test('captureTearOutPane now retains a handle, which is what makes the vessel survivable', () => {
+            workspace = Neo.create(PlainWorkspace, {dockModel: createDocument()});
+
+            workspace.captureTearOutPane('editor');
+
+            // The whole failure chain starts here: an empty handle map is what makes the reparent
+            // fail and the engine close its own vessel.
+            expect(workspace.tearOutPaneHandles.editor, 'the handle map is populated').toBeTruthy();
+            expect(workspace.releaseTearOutPane('editor'), 'and the pane is releasable for return').toBeTruthy()
+        });
+
+        test('an unknown itemId still resolves to null rather than an arbitrary component', () => {
+            workspace = Neo.create(PlainWorkspace, {dockModel: createDocument()});
+
+            expect(workspace.resolveTearOutPane('no-such-item')).toBeNull()
+        })
     })
 });

--- a/test/playwright/unit/dashboard/DockWorkspace.spec.mjs
+++ b/test/playwright/unit/dashboard/DockWorkspace.spec.mjs
@@ -3067,6 +3067,23 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
                 'a real pane still qualifies — the guard is not simply refusing everything').toBe(true)
         });
 
+        test('a rail tab is not the pane either, and the whole button category is refused', () => {
+            workspace = Neo.create(PlainWorkspace, {dockModel: createDocument()});
+
+            // `interaction/Rail#createTabConfig` mints a Button carrying the pane's dockItemId so a
+            // click resolves the item without id bookkeeping — it cleared an exclusion that named
+            // only the header button and the placeholder. Naming stand-ins one at a time lost twice,
+            // so the guard refuses the CATEGORY: a dock pane is never a button.
+            expect(workspace.isDockTearOutCandidate({cls: ['neo-dashboard-dock-rail-tab', 'neo-button'], ntype: 'button'}),
+                'a rail tab is refused').toBe(false);
+
+            expect(workspace.isDockTearOutCandidate({cls: ['neo-button'], ntype: 'button'}),
+                'and so is any other button carrying the identity').toBe(false);
+
+            expect(workspace.isDockTearOutCandidate({cls: ['neo-panel'], ntype: 'dashboard-panel'}),
+                'while a real pane is untouched by the widening').toBe(true)
+        });
+
         test('the engine opens its own vessel, carrying the four params onWindowConnect parses', async () => {
             workspace = Neo.create(PlainWorkspace, {dockModel: createDocument()});
 

--- a/test/playwright/unit/dashboard/DockWorkspace.spec.mjs
+++ b/test/playwright/unit/dashboard/DockWorkspace.spec.mjs
@@ -3044,6 +3044,99 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
             workspace = Neo.create(PlainWorkspace, {dockModel: createDocument()});
 
             expect(workspace.resolveTearOutPane('no-such-item')).toBeNull()
+        });
+
+        test('the engine opens its own vessel, carrying the four params onWindowConnect parses', async () => {
+            workspace = Neo.create(PlainWorkspace, {dockModel: createDocument()});
+
+            const opens              = [],
+                  {useSharedWorkers} = Neo.config,
+                  MainStub           = {
+                      getByPath    : () => Promise.resolve('https://example.test/app/index.html?existing=keep'),
+                      getWindowData: () => Promise.resolve({innerHeight: 800, outerHeight: 860, screenLeft: 40, screenTop: 20}),
+                      windowOpen   : data => { opens.push(data); return Promise.resolve(true) }
+                  },
+                  originalMain   = Neo.Main;
+
+            Neo.Main         = MainStub;
+            Neo.config.useSharedWorkers = true;
+
+            try {
+                const vessel = await workspace.openTearOutVessel({admissionToken: 7, itemId: 'editor', proxyRect: {height: 500, width: 640, x: 100, y: 60}});
+
+                expect(opens.length, 'the engine opened a window without any consumer hook').toBe(1);
+
+                const url = new URL(opens[0].url);
+
+                // The exact vocabulary onWindowConnect parses. A consumer re-deriving these from
+                // one app's source is the defect; the engine defines them, so it can write them.
+                expect(url.searchParams.get('tearout')).toBe('editor');
+                expect(url.searchParams.get(workspace.tearOutHostParam)).toBe(workspace.id);
+                expect(url.searchParams.get('vesselFlow')).toBe('tear-out');
+                expect(url.searchParams.get('vesselAdmission')).toBe('7');
+                expect(url.searchParams.get('existing'), 'the host document\'s own params survive').toBe('keep');
+
+                // The proxy rect is where the user let go, offset into screen space.
+                expect(opens[0].windowFeatures).toContain('width=640');
+                expect(opens[0].windowFeatures).toContain('height=500');
+
+                expect(vessel).toMatchObject({admissionToken: 7, windowName: 'neo-dock-tearout-editor'})
+            } finally {
+                Neo.Main = originalMain;
+                Neo.config.useSharedWorkers = useSharedWorkers
+            }
+        });
+
+        test('a vessel re-torn from a vessel does not inherit the parent\'s item or admission', async () => {
+            workspace = Neo.create(PlainWorkspace, {dockModel: createDocument()});
+
+            const opens              = [],
+                  {useSharedWorkers} = Neo.config,
+                  originalMain       = Neo.Main;
+
+            // The host document ALREADY carries vessel params — the case a re-tear produces.
+            Neo.Main = {
+                getByPath    : () => Promise.resolve(`https://example.test/i.html?tearout=preview&vesselFlow=tear-out&vesselAdmission=3&${workspace.tearOutHostParam}=stale-host`),
+                getWindowData: () => Promise.resolve({innerHeight: 800, outerHeight: 860, screenLeft: 0, screenTop: 0}),
+                windowOpen   : data => { opens.push(data); return Promise.resolve(true) }
+            };
+            Neo.config.useSharedWorkers = true;
+
+            try {
+                await workspace.openTearOutVessel({admissionToken: 9, itemId: 'terminal'});
+
+                const url = new URL(opens[0].url);
+
+                // Without the strip, the vessel would connect as the PARENT's pane against a stale
+                // host id — a wrong pane in a real window, which reads as a success.
+                expect(url.searchParams.getAll('tearout')).toEqual(['terminal']);
+                expect(url.searchParams.getAll('vesselAdmission')).toEqual(['9']);
+                expect(url.searchParams.get(workspace.tearOutHostParam)).toBe(workspace.id)
+            } finally {
+                Neo.Main = originalMain;
+                Neo.config.useSharedWorkers = useSharedWorkers
+            }
+        });
+
+        test('without useSharedWorkers there is no vessel to open, and none is attempted', async () => {
+            workspace = Neo.create(PlainWorkspace, {dockModel: createDocument()});
+
+            const opens              = [],
+                  {useSharedWorkers} = Neo.config,
+                  originalMain       = Neo.Main;
+
+            Neo.Main = {windowOpen: data => { opens.push(data); return Promise.resolve(true) }};
+            Neo.config.useSharedWorkers = false;
+
+            try {
+                // A live pane cannot be served to a second window without a shared worker, so
+                // opening one would produce an empty vessel — worse than not opening it.
+                expect(await workspace.openTearOutVessel({admissionToken: 1, itemId: 'editor'})).toBeNull();
+                expect(opens, 'no window is opened').toEqual([])
+            } finally {
+                Neo.Main = originalMain;
+                Neo.config.useSharedWorkers = useSharedWorkers
+            }
         })
     })
 });


### PR DESCRIPTION
Refs #18153, Refs #18151 — **does not close either.** This is the first cut of the vessel seam: the deterministic decline that kills a pop-out. The default opener and the swallowed throw are still open on the sub.

Evidence: L2 (unit — the defect is a resolver returning `null` and the handle map it starves; fully reachable with a real workspace). Residual: AC-1/4/5/8 remain, Residual-Owner: #18153.

## What was happening

A host that writes no pane resolver got a pop-out that **opens a window and then kills it**. Measured by @neo-opus-vega on a real consumer: window opens at +31ms, connects, dies at **+532ms**, no signal anywhere.

The chain is fully deterministic — no race:

```
resolveTearOutPane(itemId) → null                    (the declining default)
  captureTearOutPane stores nothing                   :848  → tearOutPaneHandles stays empty
  reparentTearOutPane: !pane → return FALSE           :951
    compensateFailedTearOutAdoption                   :877 → :923
      retireTearOutVessel → consumer closeTearOutVessel   ← the window dies here
    throw '… could not enter its admitted vessel'     :878  ← swallowed, see AC-5
```

I first attributed the 532ms elsewhere and told Vega to stop looking at the engine. She falsified that with an isolation receipt — no-op'ing her own `closeTearOutVessel` stopped the closing, proving the close came through the engine. The trace above is hers to credit.

## The fix

`projection.LayoutAdapter` already stamps `dockItemId` on every projected pane it emits, so the engine never needed to be told:

```js
resolveTearOutPane(itemId) {
    const matches = this.getDockHost()?.down({dockItemId: itemId}, false) || [];

    return matches.find(component => component.ntype !== 'tab-header-button') || null
}
```

**The button exclusion is the load-bearing half.** The adapter stamps the *same* identity on the header it builds from the pane's own config — that is what makes keyboard identity work — so an unqualified `down()` returns whichever comes first. A header button reparented into a vessel would look like a success and lose the pane.

A consumer that owns its pane lifecycle still overrides; the override stays authoritative.

## Test Evidence

**Red-first** — `git checkout origin/dev -- src/dashboard/dock/Workspace.mjs`, spec kept:

```
3 failed / 86 passed
  a workspace that overrides nothing resolves the live projected pane
  it returns the PANE, never the tab header button that carries the same identity
  captureTearOutPane now retains a handle, which is what makes the vessel survivable
```

At head: `unit/dashboard` **89 passed**, full unit suite **3047 passed**, exit 0.

**The fourth arm passes on both trees on purpose.** "An unknown itemId still resolves to null" is a guard against the fix over-reaching, not a witness for the defect — an arm that goes red on both sides would be measuring the wrong thing.

**Non-vacuity is asserted, not assumed.** The button arm first proves the identity really is stamped on more than one component and that one of them really is a `tab-header-button`, before asserting the resolver skips it. Without that, the arm passes on a tree where the button never carried the stamp at all.

## Deltas from ticket

- **AC-7 as filed was wrong and is superseded by this diff.** I wrote it as "adoption waits for registration", hypothesising a `Neo.apps[windowId]` race carried over from #18121. Reading the path showed `onWindowConnect` already early-returns on a missing app, so the race cannot reach `reparentTearOutPane` by that route — the pane, not the app, is what is missing. Correcting on the ticket rather than shipping an AC the diff does not satisfy.
- **AC-1 (default opener), AC-4, AC-5 (the swallowed throw at `:878`) and AC-8 (does the pane come home) are untouched** and stay on #18153.

## Post-Merge Validation

- [ ] @neo-opus-vega's downstream app: pop out with no `resolveTearOutPane` override and confirm the vessel survives past ~532ms. Her `closeTearOutVessel` no-op is the probe that proves it.

---

Authored by Grace (Claude Opus 5, Claude Code). Session fb58e855-74b2-4367-9f83-5877f151f024.
