### PR TITLE
docs(main): the per-file stylesheet fan-out states why it exists

### DIFF
--- a/src/main/addon/Stylesheet.mjs
+++ b/src/main/addon/Stylesheet.mjs
@@ -91,6 +91,15 @@ class Stylesheet extends Base {
     }
 
     /**
+     * Loads one file per class per declared theme. The fan-out is intentional and bundling is not
+     * an available alternative: any component tree, at any nesting depth, can be moved from the
+     * main window into another one, so a second window's class set is not knowable ahead of time.
+     * Pre-bundling would mean shipping every possible combination of those trees — which costs more
+     * than it saves and still cannot cover a combination nobody anticipated.
+     *
+     * File granularity is what makes the delta work instead: a window fetches exactly the classes
+     * it ends up rendering, and a single changed class is swapped in every open window without
+     * rebuilding anything. The per-class request count is the price of that, deliberately paid.
      * @param {Object} data
      * @param {String} data.appName
      * @param {String} data.className


### PR DESCRIPTION
Comment only. No behaviour change, no test change.

**Two agents independently proposed collapsing this in one night.** @neo-opus-vega measured it (25 requests / 9 classes in a vessel, 234 / 5781ms on boot) and filed it as an engine default of #18151's class; I had a patch written — one that deliberately kept every sheet loading and only removed non-rendering themes from the awaited set, because collapsing to the active theme alone would break nested theme scopes.

@tobiu stopped it, and then gave the reason bundling is not an available alternative at all:

> *"CSS load file by file. 100% intentional."*
> *"this is the ONLY way to get cross window delta css updates."*
> *"you can move ANY thinkable component tree (can be deeply nested) from a main window into a different window. that means you would need to bundle ALL POSSIBLE combinations. which outbeats its purpose. to get granular delta updates, file by file."*

That last one is the argument, and it is stronger than `delta updates` alone: a second window's class set **is not knowable ahead of time**, because any tree at any depth can move into it. Pre-bundling would mean shipping every possible combination — more cost than it saves, and still blind to a combination nobody anticipated. File granularity is not an optimisation that lost to boot time; it is the only shape that supports the feature.

**Nothing in the source said it.** The cost is measurable in any devtools network tab; the reason lived only in the operator's head. So the file read as an oversight to two readers in a row, and the second one was careful enough about *how* to change it that being careful never surfaced *whether*.

Four lines, at the method that pays the cost.

## Deltas from ticket

No ticket. This is the smallest possible capture of a rationale that has now cost two agents' time; filing a ticket to add a comment would cost more than the comment.

---

Authored by Grace (Claude Opus 5, Claude Code). Session fb58e855-74b2-4367-9f83-5877f151f024.

