### PR TITLE
fix(dock): a failed tear-out adoption reports instead of throwing into a listener (#18153)

### DIFF
--- a/src/dashboard/dock/Workspace.mjs
+++ b/src/dashboard/dock/Workspace.mjs
@@ -1049,8 +1049,13 @@ class Workspace extends Container {
 
     /**
      * @summary Compensates an admitted connection that cannot embody its live pane.
+     *
+     * Returns the reporting promise. Both callers throw immediately after and ignore it, but the
+     * compensation's own completion is otherwise unobservable — and an outcome nothing can await is
+     * an outcome nothing can assert.
      * @param {String} itemId
      * @param {Object} entry
+     * @returns {Promise<void>}
      * @protected
      */
     compensateFailedTearOutAdoption(itemId, entry={}) {
@@ -1063,14 +1068,19 @@ class Workspace extends Container {
         Promise.resolve(me.retireTearOutVessel(vessel)).then(closed => {
             closed && me.tearOutHandlers?.onVesselRetired(vessel)
         });
-        me.reintegrateTearOutItem(itemId, pane);
-
         // Reported HERE because this is the one place both failing paths already meet: the
         // document-change adoption and the window-connect adoption each call it before throwing.
         // Their throws do not reach anyone — `onWindowConnect` is registered as a worker event
         // listener, so an async throw becomes a rejected promise the emitter drops, which is why a
         // vessel could die with nothing but an unattributed unhandled rejection in the console.
-        me.onTearOutAdoptionFailed({entry, itemId, pane, reintegrated: !!pane})
+        //
+        // The report waits for the return to actually resolve, matching the `retireTearOutVessel`
+        // line above. Reading a pane HANDLE instead would answer a different question — one that is
+        // true in exactly the case worth alarming on, since a failed adoption is precisely when a
+        // pane was held and could still fail to come home.
+        return Promise.resolve(me.reintegrateTearOutItem(itemId, pane)).then(reintegrated => {
+            me.onTearOutAdoptionFailed({entry, itemId, pane, reintegrated})
+        })
     }
 
     /**

--- a/src/dashboard/dock/Workspace.mjs
+++ b/src/dashboard/dock/Workspace.mjs
@@ -1063,7 +1063,43 @@ class Workspace extends Container {
         Promise.resolve(me.retireTearOutVessel(vessel)).then(closed => {
             closed && me.tearOutHandlers?.onVesselRetired(vessel)
         });
-        me.reintegrateTearOutItem(itemId, pane)
+        me.reintegrateTearOutItem(itemId, pane);
+
+        // Reported HERE because this is the one place both failing paths already meet: the
+        // document-change adoption and the window-connect adoption each call it before throwing.
+        // Their throws do not reach anyone — `onWindowConnect` is registered as a worker event
+        // listener, so an async throw becomes a rejected promise the emitter drops, which is why a
+        // vessel could die with nothing but an unattributed unhandled rejection in the console.
+        me.onTearOutAdoptionFailed({entry, itemId, pane, reintegrated: !!pane})
+    }
+
+    /**
+     * @summary Reports an adoption that could not embody its pane, on the lifecycle's own channel.
+     *
+     * The engine opened a window, moved a pane out of the shell, failed to place it, closed the
+     * window again and put the pane back — a full round trip the user sees as "pop-out does
+     * nothing". That sequence must be attributable, and a throw into an event listener is not:
+     * it names no item, reaches no consumer, and cannot be told from an unrelated rejection.
+     *
+     * Fires `dockTearOutAdoptionFailed` and warns. A consumer that wants to surface it in its own
+     * UI listens; one that wants silence overrides. `reintegrated` distinguishes the recoverable
+     * case (the pane came home) from the one worth alarming on (it did not).
+     * @param {Object} data
+     * @param {Object} data.entry The vessel record the adoption was attempting.
+     * @param {String} data.itemId
+     * @param {Neo.component.Base|null} data.pane The released pane, or null when none was held.
+     * @param {Boolean} data.reintegrated
+     * @protected
+     */
+    onTearOutAdoptionFailed(data) {
+        const me = this;
+
+        console.warn(
+            `Dock tear-out: "${data.itemId}" could not enter its admitted vessel; the vessel was retired and the pane ${data.reintegrated ? 'returned' : 'was NOT returned'}`,
+            me.id
+        );
+
+        me.fire('dockTearOutAdoptionFailed', {component: me, ...data})
     }
 
     /**

--- a/test/playwright/unit/dashboard/DockWorkspace.spec.mjs
+++ b/test/playwright/unit/dashboard/DockWorkspace.spec.mjs
@@ -3277,14 +3277,14 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
             expect(resolved.isDestroyed).toBeFalsy()
         });
 
-        test('a failed adoption is reported on the lifecycle channel, not thrown into a listener', () => {
+        test('a failed adoption is reported on the lifecycle channel, not thrown into a listener', async () => {
             workspace = Neo.create(PlainWorkspace, {dockModel: createDocument()});
 
             const events = [];
 
             workspace.on('dockTearOutAdoptionFailed', event => events.push(event));
 
-            workspace.compensateFailedTearOutAdoption('editor', {windowName: 'neo-dock-tearout-editor'});
+            await workspace.compensateFailedTearOutAdoption('editor', {windowName: 'neo-dock-tearout-editor'});
 
             // Both failing paths throw AFTER compensating, and neither throw reaches anyone:
             // onWindowConnect is registered as a worker event listener, so its async throw becomes
@@ -3292,8 +3292,30 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
             // unattributed unhandled rejection. Reporting from the shared compensation path means
             // the signal fires once, wherever the failure originated.
             expect(events.length, 'the failure reaches consumers exactly once').toBe(1);
-            expect(events[0]).toMatchObject({component: workspace, itemId: 'editor'});
-            expect(events[0], 'and it says whether the pane came home').toHaveProperty('reintegrated')
+            expect(events[0]).toMatchObject({component: workspace, itemId: 'editor', reintegrated: true})
+        });
+
+        test('`reintegrated` reports the RETURN, not that a pane handle existed', async () => {
+            workspace = Neo.create(PlainWorkspace, {dockModel: createDocument()});
+
+            const events = [],
+                  pane   = Neo.create(Container, {});
+
+            workspace.tearOutPaneHandles.editor = pane;
+            workspace.on('dockTearOutAdoptionFailed', event => events.push(event));
+
+            // The distinguishing case, and the one a handle check cannot see: a held pane whose
+            // return then FAILS. `!!pane` answers true here — and a failed adoption is precisely
+            // when a pane was held, so the field would have read `true` on every firing it has.
+            workspace.reintegrateTearOutItem = async () => false;
+
+            await workspace.compensateFailedTearOutAdoption('editor', {windowName: 'neo-dock-tearout-editor'});
+
+            expect(events.length).toBe(1);
+            expect(events[0].pane, 'the pane is still reported — it was held').toBeTruthy();
+            expect(events[0].reintegrated, 'but it did not come home, and the field says so').toBe(false);
+
+            pane.destroy()
         });
 
         test('a rail tab is not the pane either, and the whole button category is refused', () => {

--- a/test/playwright/unit/dashboard/DockWorkspace.spec.mjs
+++ b/test/playwright/unit/dashboard/DockWorkspace.spec.mjs
@@ -3277,6 +3277,25 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
             expect(resolved.isDestroyed).toBeFalsy()
         });
 
+        test('a failed adoption is reported on the lifecycle channel, not thrown into a listener', () => {
+            workspace = Neo.create(PlainWorkspace, {dockModel: createDocument()});
+
+            const events = [];
+
+            workspace.on('dockTearOutAdoptionFailed', event => events.push(event));
+
+            workspace.compensateFailedTearOutAdoption('editor', {windowName: 'neo-dock-tearout-editor'});
+
+            // Both failing paths throw AFTER compensating, and neither throw reaches anyone:
+            // onWindowConnect is registered as a worker event listener, so its async throw becomes
+            // a rejected promise the emitter drops — a vessel could die leaving nothing but an
+            // unattributed unhandled rejection. Reporting from the shared compensation path means
+            // the signal fires once, wherever the failure originated.
+            expect(events.length, 'the failure reaches consumers exactly once').toBe(1);
+            expect(events[0]).toMatchObject({component: workspace, itemId: 'editor'});
+            expect(events[0], 'and it says whether the pane came home').toHaveProperty('reintegrated')
+        });
+
         test('a rail tab is not the pane either, and the whole button category is refused', () => {
             workspace = Neo.create(PlainWorkspace, {dockModel: createDocument()});
 


### PR DESCRIPTION
Refs #18153 — **does not close it.** AC-5 of the vessel seam. AC-4 and AC-8 stay open.

Evidence: L2 (unit — the defect is an unobservable failure path, reachable with a real workspace).

## The failure had no reader

Both adoption paths compensate and then throw:

```
adoptTearOutPane        :876  reparent false → compensate → throw   (:878)
onWindowConnect         :1116 reparent false → compensate → throw   (:1118)
```

Neither throw reaches anyone. `onWindowConnect` is registered as **`Neo.currentWorker.on({connect: this.onWindowConnect})`** and is `async`, so its throw becomes a rejected promise the emitter drops.

The user-visible consequence is the whole round trip: the engine opens a window, takes a pane out of the shell, fails to place it, closes the window again and puts the pane back — read as *"pop-out does nothing"* — leaving nothing but an unattributed unhandled rejection. @neo-opus-vega's original live report on a downstream consumer recorded exactly that: a `getVnode` console error *"plus an unhandled rejection"*, with no way to tell which item died.

## Reported where both paths already meet

`compensateFailedTearOutAdoption` is called by both sites before their throws, so the signal fires **exactly once** wherever the failure originated — rather than adding a second report beside a swallowed first one.

`onTearOutAdoptionFailed` warns and fires **`dockTearOutAdoptionFailed`**:

| field | meaning |
|---|---|
| `component` | the workspace |
| `itemId` | which pane died — the thing the unhandled rejection could not tell you |
| `entry` | the vessel record the adoption was attempting |
| `pane` | the released pane, or null |
| `reintegrated` | whether the pane came home — the recoverable case vs the one worth alarming on |

**The throws stay.** A caller that can act on one still can; what changes is that the failure is attributable even when nobody catches. Adding a signal *instead of* fixing the reader would have been two silences.

## Test Evidence

`unit/dashboard` **95 passed**, full unit **3053**, exit 0. The new arm asserts the event fires **exactly once** from the shared path and carries `reintegrated`, since "a failure was reported" is satisfied by a report that cannot say whether the user lost their pane.

## Deltas from ticket

AC-5 was filed as two (5a: report at the budget horizon; 5b: detect a vessel that dies before connecting). **Neither is what this fixes.** Tracing the path showed the engine already *raises* on the real failure and simply has no reader — so the correct first move is to give the existing signal one, not to add new detection beside it. 5a and 5b remain open and are now better scoped for having this in place.

---

Authored by Grace (Claude Opus 5, Claude Code). Session fb58e855-74b2-4367-9f83-5877f151f024.