### PR TITLE
fix(dock): pop-out survives a commit, and its pane is found after the re-projection (#18153)

### DIFF
--- a/src/dashboard/dock/Workspace.mjs
+++ b/src/dashboard/dock/Workspace.mjs
@@ -982,6 +982,17 @@ class Workspace extends Container {
      * @protected
      */
     resolveTearOutPane(itemId) {
+        const held = this.tearOutPaneHandles[itemId];
+
+        // The held handle FIRST, and this is what makes the default actually adopt. The tear-out
+        // sequence is capture → re-project → adopt: `captureTearOutPane` stores the pane while it is
+        // still in the tree, the detach re-projection then removes it, and adoption runs afterwards.
+        // A tree-only lookup therefore succeeds at capture and returns null at the moment it matters,
+        // so a hook-free consumer got a vessel window that opened and never received its pane.
+        if (held && !held.isDestroyed) {
+            return held
+        }
+
         const matches = this.getDockHost()?.down({dockItemId: itemId}, false) || [];
 
         return matches.find(component => this.isDockTearOutCandidate(component)) || null
@@ -1638,6 +1649,31 @@ class Workspace extends Container {
     }
 
     /**
+     * @summary Re-evaluates the retained pop-out action against current truth after every commit.
+     *
+     * Pop-out was the one engine action with no sync. Its `hidden` is projected once as
+     * `!activeItemId || !dockPopOutActionAvailable` and then lives on a RETAINED action instance
+     * that survives re-projection, so nothing ever recomputed it: the control was correct at boot
+     * and silently gone after the first layout commit. For a consumer whose reason to be here is
+     * multi-window, the feature disappeared until reload.
+     *
+     * Mirrors the projected expression from the same reader (`dockPopOutActionActive`), so the
+     * projected and the synced answer cannot drift. Change-guarded like its siblings, so re-walking
+     * retained nodes stays idempotent.
+     * @param {Neo.tab.Container} tabContainer
+     * @protected
+     */
+    syncDockPopOutAction(tabContainer) {
+        if (!this.enableDockPopOutAction) return;
+
+        let action = tabContainer?.getActionItem?.('pop-out'),
+            itemId = this.getActiveDockItemId(tabContainer),
+            hidden = !itemId || !this.dockPopOutActionActive;
+
+        action && action.hidden !== hidden && (action.hidden = hidden)
+    }
+
+    /**
      * Synchronizes the retained lock action and every projected pane/button against committed
      * item truth. The action stays one stable instance; per-item hidden/icon state moves on it.
      *
@@ -2002,6 +2038,7 @@ class Workspace extends Container {
             me.syncDockCloseAction(tab);
             me.syncDockLockAction(tab);
             me.syncDockPinAction(tab);
+            me.syncDockPopOutAction(tab);
             me.syncDockReloadAction(tab)
         });
 

--- a/test/playwright/unit/dashboard/DockWorkspace.spec.mjs
+++ b/test/playwright/unit/dashboard/DockWorkspace.spec.mjs
@@ -3067,6 +3067,76 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
                 'a real pane still qualifies — the guard is not simply refusing everything').toBe(true)
         });
 
+        test('the held handle wins, so adoption still finds the pane after the detach re-projection', () => {
+            workspace = Neo.create(PlainWorkspace, {dockModel: createDocument()});
+
+            const treePane = workspace.resolveTearOutPane('editor');
+
+            expect(treePane, 'the pane is in the tree before the detach').toBeTruthy();
+
+            // The held handle is a DISTINCT instance on purpose. My first version of this arm
+            // detached the pane to simulate the re-projection and passed against the unfixed
+            // engine — `pane.parent` was undefined, so `remove` silently did nothing and the tree
+            // still answered. A control that quietly does nothing reads exactly like a control that
+            // passed. Asserting the handle wins over a live tree answer cannot no-op.
+            const held = Neo.create(Container, {items: []});
+
+            workspace.tearOutPaneHandles.editor = held;
+
+            // The sequence is capture -> re-project -> adopt: the capture stores the pane while it
+            // is still in the tree, the detach re-projection removes it, adoption runs afterwards.
+            // A tree-only resolver therefore succeeds at capture and returns null when it matters —
+            // measured on a real consumer as adopted=NULL with the vessel window open.
+            expect(workspace.resolveTearOutPane('editor'), 'the held handle answers first').toBe(held);
+            expect(workspace.resolveTearOutPane('editor')).not.toBe(treePane);
+
+            expect(workspace.releaseTearOutPane('editor'), 'and it is releasable for return').toBe(held);
+
+            held.destroy()
+        });
+
+        test('the post-commit sweep re-evaluates pop-out, so it survives a layout commit', () => {
+            class PopOutSweepWitness extends PlainWorkspace {
+                static config = {className: 'Test.Unit.Dashboard.DockWorkspace.PopOutSweepWitness'}
+
+                popOutSyncLog = []
+
+                // Deliberately does NOT call super: the defect is that the SWEEP never reached this
+                // action at all, so the witness is whether it is invoked — not what it computes.
+                // Calling super would make the arm red on the base class missing the method, which
+                // is a different (and weaker) claim.
+                syncDockPopOutAction(tabContainer) {
+                    this.popOutSyncLog.push(tabContainer)
+                }
+            }
+
+            Neo.setupClass(PopOutSweepWitness);
+
+            workspace = Neo.create(PopOutSweepWitness, {dockModel: createDocument()});
+
+            workspace.syncDockHeaderActions();
+
+            // close, lock, pin and reload were all swept; pop-out was the one engine action with no
+            // sync. Its hidden state is projected once and then lives on a RETAINED instance, so it
+            // was correct at boot and silently gone after the first commit — measured on a real
+            // consumer as the control disappearing from the header after one addTab plus one close.
+            expect(workspace.popOutSyncLog.length, 'the sweep reaches pop-out like every sibling action')
+                .toBeGreaterThan(0)
+        });
+
+        test('a destroyed handle does not shadow the tree', () => {
+            workspace = Neo.create(PlainWorkspace, {dockModel: createDocument()});
+
+            // A stale handle must not win over a live pane, or a re-created pane would be
+            // unreachable behind a corpse.
+            workspace.tearOutPaneHandles.editor = {isDestroyed: true};
+
+            const resolved = workspace.resolveTearOutPane('editor');
+
+            expect(resolved, 'the tree answers instead').toBeTruthy();
+            expect(resolved.isDestroyed).toBeFalsy()
+        });
+
         test('a rail tab is not the pane either, and the whole button category is refused', () => {
             workspace = Neo.create(PlainWorkspace, {dockModel: createDocument()});
 


### PR DESCRIPTION
Refs #18153 — **does not close it.** Two defects @neo-opus-vega measured on a real consumer after #18155 merged. Both made pop-out useless for the multi-window case this epic serves.

Evidence: L2 (unit) for both, against L3 field measurements supplied by @neo-opus-vega.

## 1. Pop-out had no post-commit sync — the severe one

`syncDockHeaderActions` swept close, lock, pin and reload. **Never pop-out.** Its `hidden` is projected once as `!activeItemId || !dockPopOutActionAvailable` and then lives on a **retained** action instance across re-projections, so nothing ever recomputed it.

Measured, same app, same session:

```
boot:                      acts = [More tabs, lock, pop out, maximize, close]
after 1 addTab + 1 close:  acts = [lock, maximize, close]        <- GONE
```

Correct at boot, silently absent after the first layout commit, until reload. For a consumer whose reason to evaluate Neo is multi-window, the headline feature disappears on first use. Same class as #18039 (reload lost after a rail round trip), for the one action that never got a sync.

`syncDockPopOutAction` mirrors the projected expression from the same reader (`dockPopOutActionActive`) so the projected and synced answers cannot drift, and is change-guarded like its siblings.

## 2. The merged resolver never adopted for a hook-free consumer

`resolveTearOutPane` consulted only the host tree and never `tearOutPaneHandles` — the map `captureTearOutPane` fills. The sequence is **capture → re-project → adopt**: the capture stores the pane while it is still in the tree, the detach re-projection removes it, adoption runs afterwards. So the tree lookup succeeded at capture and returned null exactly when it mattered.

@neo-opus-vega's acceptance test with both consumer hooks disabled:

```
Verbindung  adopted=NULL  vesselDocs=1     <- the window opens, the pane never arrives
Dokumente   adopted=NULL  vesselDocs=1
```

So #18153's zero-hooks promise was not met on dev. The held handle now answers first; a **destroyed** handle does not shadow a live tree.

She flagged this minutes before #18155 merged and the messages crossed — this is the follow-up, not a revert.

## Test Evidence

```
head:  unit/dashboard 97 passed · full unit 3055 · exit 0
dev:   2 failed  (both new arms)
```

**One arm needed rewriting because it passed against the unfixed engine.** My first version detached the pane to simulate the re-projection — but `pane.parent` was undefined, so `remove` silently did nothing, the tree still answered, and the control read exactly like a control that passed. It now asserts a **distinct** held instance wins over a live tree answer, which cannot no-op.

**The sweep arm records invocation and deliberately does not call `super`.** The defect is that the sweep never reached this action at all; calling super would make the arm red on the base class lacking the method, which is a weaker claim than the one being made.

## Deltas from ticket

Neither defect was an AC. AC-8 (does the pane come home after a failed adoption) is still open and is the remaining item on the vessel seam, along with AC-5a/5b.

---

Authored by Grace (Claude Opus 5, Claude Code). Session fb58e855-74b2-4367-9f83-5877f151f024.