### PR TITLE
test(dashboard): witness that a failed tear-out adoption returns the item (#18153)

### DIFF
--- a/test/playwright/unit/dashboard/DockWorkspace.spec.mjs
+++ b/test/playwright/unit/dashboard/DockWorkspace.spec.mjs
@@ -3393,6 +3393,36 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
             }
         });
 
+        test('a failed adoption returns the item to the document, not only the pane handle', async () => {
+            workspace = Neo.create(PlainWorkspace, {dockModel: createDocument()});
+
+            const pane = workspace.resolveTearOutPane('editor');
+
+            expect(pane, 'the fixture must project the pane, or this proves nothing').toBeTruthy();
+
+            workspace.captureTearOutPane('editor');
+
+            // Commit the detach the tear-out gesture commits, so the item is out of every tabs node
+            // exactly as it is when an adoption then fails.
+            const detached = workspace.applyDockZoneOperation({itemId: 'editor', operation: 'detachItem'});
+
+            expect(detached.errors, 'the detach must commit, or the compensation has nothing to undo').toEqual([]);
+            workspace.onDockZoneDocumentChange(detached.document);
+
+            expect(Document.findContainingTabsId(workspace.dockModel, 'editor'),
+                'the item is genuinely out of the tree at this point').toBeFalsy();
+
+            // The vessel died. compensateFailedTearOutAdoption is what must put it back — the user
+            // is left with a pane that vanished from the shell otherwise.
+            workspace.compensateFailedTearOutAdoption('editor', {windowName: 'neo-dock-tearout-editor'});
+
+            await workspace.refreshPromise;
+
+            expect(Document.findContainingTabsId(workspace.dockModel, 'editor'),
+                'the item is back in a tabs node').toBeTruthy();
+            expect(workspace.dockModel.items.editor, 'and its record survived the round trip').toBeTruthy()
+        });
+
         test('a rail tab is not the pane either, and the whole button category is refused', () => {
             workspace = Neo.create(PlainWorkspace, {dockModel: createDocument()});
 


### PR DESCRIPTION
Refs #18153 — AC-8. **Test only, no source change.**

Evidence: L2 (unit).

## AC-8 was a question, and the answer is that the engine already does it

AC-8 asked whether the pane comes home after an adoption fails, because @neo-opus-vega measured a real consumer with the tab count at **0** after the vessel closed. That is a data-loss-shaped symptom and it deserved an answer rather than an assumption.

Traced: `compensateFailedTearOutAdoption` calls `reintegrateTearOutItem` unconditionally, `detachItem` removes the item from its tabs node but **keeps its record in `document.items`**, so the `addTab` fallback path can put it back. The arm proves that end to end: commit the detach, assert the item is genuinely out of every tabs node, drive the compensation, assert it is back in one with its record intact.

**It passes against the unfixed engine too, and that is deliberate.** This characterizes existing behaviour; it does not cover a defect. Saying so explicitly, because an arm that is green on both sides is normally the shape of a vacuous test — here it is the finding.

## So what did @neo-opus-vega measure?

Better explained by the resolver gap than by AC-8's hypothesis: `resolveTearOutPane` searched the host tree only, so **no pane was ever found** and adoption failed for a different reason than the one AC-8 suspected. Fixed separately in #18160, where her `adopted=NULL` receipt is the red-first.

I would rather close AC-8 with a witness and a corrected explanation than leave it open on a symptom that has since been attributed elsewhere.

## Deltas from ticket

AC-8 needed no engine change. Remaining on the vessel seam: AC-5a and AC-5b (report at the budget horizon; detect a vessel that dies before connecting), both still open and both narrower now that #18157 gives the existing failure a reader.

---

Authored by Grace (Claude Opus 5, Claude Code). Session fb58e855-74b2-4367-9f83-5877f151f024.