### PR TITLE
fix(dock): a pane whose home collapsed comes home to it, not to the first node (#18164)

### DIFF
--- a/src/dashboard/dock/Workspace.mjs
+++ b/src/dashboard/dock/Workspace.mjs
@@ -1281,17 +1281,20 @@ class Workspace extends Container {
      * @protected
      */
     async reintegrateTearOutItem(itemId, pane) {
-        let me         = this,
-            placement  = me.tearOutPlacements[itemId],
-            doc        = me.dockModel,
-            storedHome = placement && doc?.nodes?.[placement.tabsNodeId]?.type === 'tabs' ? placement.tabsNodeId : null,
-            fallback   = storedHome || Object.entries(doc?.nodes || {}).find(([, node]) => node.type === 'tabs')?.[0],
+        let me        = this,
+            placement = me.tearOutPlacements[itemId],
+            doc       = me.dockModel,
+            // The first tabs node in document order is not a placement — it is wherever enumeration
+            // happens to start. It stands in only for an item with NO record at all, because a pane
+            // somewhere valid beats a pane dropped out of the tree.
+            lastResort = () => Object.entries(doc?.nodes || {}).find(([, node]) => node.type === 'tabs')?.[0],
+            target     = placement || {tabsNodeId: lastResort()},
             live       = pane && !pane.isDestroyed,
             result;
 
         delete me.tearOutPlacements[itemId];
 
-        if (!doc?.items?.[itemId] || !fallback) {
+        if (!doc?.items?.[itemId] || !target.tabsNodeId) {
             me.settleTearOutPane(pane);
             me.afterTearOutPaneReturn({itemId, pane, returned: false});
             return false
@@ -1317,12 +1320,13 @@ class Workspace extends Container {
             }
         }
 
-        result = me.applyDockZoneOperation({
-            operation : 'addTab',
-            itemId,
-            tabsNodeId: fallback,
-            ...(storedHome ? {index: placement.index} : {})
-        });
+        result = me.applyDockZoneOperation({operation: 'restoreTab', itemId, ...target});
+
+        if (result?.errors?.length > 0 && placement) {
+            // The recorded home resolved to nothing — its zone AND the sibling it collapsed into are
+            // both gone. Losing the position is bad; losing the pane is worse.
+            result = me.applyDockZoneOperation({operation: 'restoreTab', itemId, tabsNodeId: lastResort()})
+        }
 
         if (result?.errors?.length === 0) {
             me.onDockZoneDocumentChange(result.document);

--- a/src/dashboard/dock/model/Document.mjs
+++ b/src/dashboard/dock/model/Document.mjs
@@ -543,10 +543,17 @@ class Document extends Base {
      * @summary Mutating helper: grafts an already-present node back into the home
      * {@link Neo.dashboard.dock.model.Document.captureNodeHome} recorded for it.
      *
-     * Three resolutions, most faithful first: the recorded parent still holds the slot (an
-     * edge-zone that lost the key, or a split that kept ≥ 2 other children); otherwise the sibling
-     * the collapsed split folded into is re-split against, restoring orientation, side and ratio;
-     * otherwise nothing resolves and this fails closed rather than guessing a home.
+     * Three resolutions, most faithful first: the recorded parent still holds the slot and it is
+     * still FREE (an edge-zone that lost the key, or a split that kept ≥ 2 other children);
+     * otherwise the sibling the collapsed split folded into is re-split against, restoring
+     * orientation, side and ratio; otherwise nothing resolves and this fails closed rather than
+     * guessing a home.
+     *
+     * A recorded coordinate can go wrong two ways, and they need different answers: it can become
+     * INVALID (the node is gone — what the sibling anchor exists for) or OCCUPIED (someone else
+     * took the slot). Restoration guards the first by instinct and forgets the second, so the
+     * single-slot edge-zone path checks ownership explicitly; the split path is safe only because
+     * insertion is additive.
      *
      * Fails closed on purpose: choosing an arbitrary node here would look like a restoration and be
      * a relocation. Deciding that somewhere beats nowhere belongs to the caller, which knows whether
@@ -565,8 +572,17 @@ class Document extends Base {
         let parent = document.nodes[home.parentId];
 
         if (parent?.type === 'edge-zone' && typeof home.slot === 'string') {
-            Document.setZoneNodeId(parent, home.slot, nodeId);
-            return []
+            const occupant = Document.getZoneNodeId(parent.zones?.[home.slot]);
+
+            // An edge zone holds ONE node per key, so writing the slot REPLACES whatever is there.
+            // A vessel is long-lived: the user can dock another pane to this edge while the pane is
+            // out, and overwriting would orphan that node — a silently lost pane, and not the one
+            // being restored. An occupied slot is therefore not a home. This is the ownership
+            // question, distinct from the existence question every other path asks.
+            if (!occupant || occupant === nodeId) {
+                Document.setZoneNodeId(parent, home.slot, nodeId);
+                return []
+            }
         }
 
         if (parent?.type === 'split' && typeof home.slot === 'number') {

--- a/src/dashboard/dock/model/Document.mjs
+++ b/src/dashboard/dock/model/Document.mjs
@@ -478,16 +478,130 @@ class Document extends Base {
      * BEFORE the detach commit, restore passes the pair straight into `addTab`'s clamped
      * `index`. Fail-closed: an item no tabs node currently holds captures `null` (catalog
      * presence is not placement; there is nothing to restore to).
+     *
+     * `home` carries the tabs node's OWN position, because a `tabsNodeId` is only restorable
+     * while that node still exists — and for the commonest tear-out (a pane alone in its zone)
+     * it never does: the emptied node is removed on commit and an emptied split collapses with
+     * it. The id alone therefore describes a home that is guaranteed to be gone exactly when it
+     * is needed. See {@link Neo.dashboard.dock.model.Document.captureNodeHome}.
      * @param {Object} document
      * @param {String} itemId
-     * @returns {{tabsNodeId: String, index: Number}|null}
+     * @returns {{tabsNodeId: String, index: Number, home: Object|null}|null}
      * @static
      */
     static captureItemPlacement(document, itemId) {
         let tabsNodeId = Document.findContainingTabsId(document, itemId),
             index      = tabsNodeId ? document.nodes[tabsNodeId].items.indexOf(itemId) : -1;
 
-        return index >= 0 ? {tabsNodeId, index} : null
+        return index >= 0 ? {tabsNodeId, index, home: Document.captureNodeHome(document, tabsNodeId)} : null
+    }
+
+    /**
+     * @summary Captures a node's own position well enough to REBUILD it, not merely to find it.
+     *
+     * Records the parent slot plus, for a split parent, the orientation, the node's size share and
+     * a sibling anchor. The sibling is what makes the record survive its own parent: removing a
+     * node from a two-child split leaves one child, and `normalizeTree` collapses that split away
+     * too — so `parentId` is unresolvable in precisely the case this record exists for. The sibling
+     * is the node that split collapsed INTO, so it is still there.
+     *
+     * An edge-zone parent needs no anchor: an edge-zone node survives losing every zone, so its id
+     * and the zone key remain resolvable.
+     * @param {Object} document
+     * @param {String} nodeId
+     * @returns {{parentId:String, slot:(Number|String), orientation:String, size:Number, siblingId:String, position:String}|null}
+     * @static
+     */
+    static captureNodeHome(document, nodeId) {
+        let slot = Document.findParentSlot(document, nodeId);
+
+        if (!slot) return null;
+
+        let parent = document.nodes[slot.parentId],
+            home   = {parentId: slot.parentId, slot: slot.slot};
+
+        if (parent?.type === 'split' && typeof slot.slot === 'number') {
+            let children = parent.children || [],
+                sizes    = Array.isArray(parent.sizes) ? parent.sizes : [],
+                size     = sizes[slot.slot],
+                before   = children[slot.slot - 1],
+                after    = children[slot.slot + 1];
+
+            home.orientation = parent.orientation;
+            home.size        = typeof size === 'number' && size > 0 && size < 1 ? size : 0.5;
+
+            if (before || after) {
+                home.siblingId = before || after;
+                home.position  = before ? 'after' : 'before'
+            }
+        }
+
+        return home
+    }
+
+    /**
+     * @summary Mutating helper: grafts an already-present node back into the home
+     * {@link Neo.dashboard.dock.model.Document.captureNodeHome} recorded for it.
+     *
+     * Three resolutions, most faithful first: the recorded parent still holds the slot (an
+     * edge-zone that lost the key, or a split that kept ≥ 2 other children); otherwise the sibling
+     * the collapsed split folded into is re-split against, restoring orientation, side and ratio;
+     * otherwise nothing resolves and this fails closed rather than guessing a home.
+     *
+     * Fails closed on purpose: choosing an arbitrary node here would look like a restoration and be
+     * a relocation. Deciding that somewhere beats nowhere belongs to the caller, which knows whether
+     * a pane is otherwise about to be dropped.
+     * @param {Object} document the working (already-cloned) document
+     * @param {String} nodeId
+     * @param {Object} home
+     * @returns {String[]} the (possibly empty) errors — empty means it mutated `document`
+     * @protected
+     * @static
+     */
+    static restoreNodeHome(document, nodeId, home) {
+        if (!document.nodes[nodeId]) return [`unknown node "${nodeId}"`];
+        if (!home)                   return [`no recorded home for "${nodeId}"`];
+
+        let parent = document.nodes[home.parentId];
+
+        if (parent?.type === 'edge-zone' && typeof home.slot === 'string') {
+            Document.setZoneNodeId(parent, home.slot, nodeId);
+            return []
+        }
+
+        if (parent?.type === 'split' && typeof home.slot === 'number') {
+            let children = parent.children || (parent.children = []),
+                at       = Math.max(0, Math.min(home.slot, children.length)),
+                size     = typeof home.size === 'number' ? home.size : 1 / (children.length + 1);
+
+            children.splice(at, 0, nodeId);
+
+            if (Array.isArray(parent.sizes)) {
+                // Whatever the survivors' ratios are now, they sum to 1, so scaling them by the share
+                // being reclaimed frees exactly that share and leaves their ratios TO EACH OTHER
+                // untouched. It does not recover the split's pre-detach geometry: `normalizeTree`
+                // resets a split's sizes to equal when a child collapses, so that is already gone
+                // before this runs. This helper restores POSITION; geometry is not recoverable here.
+                parent.sizes = parent.sizes.map(value => value * (1 - size));
+                parent.sizes.splice(at, 0, size)
+            }
+
+            return []
+        }
+
+        if (home.siblingId && document.nodes[home.siblingId]) {
+            // The split that held both is gone, so it had exactly two children — the sibling's share
+            // is the remainder, exactly rather than approximately.
+            let sizes = home.position === 'before' ? [home.size, 1 - home.size] : [1 - home.size, home.size];
+
+            return Document.attachNode(document, nodeId, home.siblingId, {
+                orientation: home.orientation,
+                position   : home.position,
+                sizes
+            })
+        }
+
+        return [`the recorded home of "${nodeId}" no longer resolves`]
     }
 
     /**

--- a/src/dashboard/dock/model/Operations.mjs
+++ b/src/dashboard/dock/model/Operations.mjs
@@ -42,6 +42,7 @@ class Operations extends Base {
                 ? Operations.moveItem(document, {itemId: descriptor.itemId, targetNodeId: descriptor.tabsNodeId, index: descriptor.index})
                 : Operations.addTab(document, descriptor),
         applyDocument    : (document, descriptor) => Operations.applyDocument(document, descriptor),
+        restoreTab       : (document, descriptor) => Operations.restoreTab(document, descriptor),
         setActiveItem    : (document, descriptor) => Operations.setActiveItem(document, descriptor),
         moveItem         : (document, descriptor) => Operations.moveItem(document, descriptor),
         splitNode        : (document, descriptor) => Operations.splitNode(document, descriptor),
@@ -112,6 +113,47 @@ class Operations extends Base {
         node.activeItemId = itemId;
 
         return Document.commit(document, doc)
+    }
+
+    /**
+     * @summary Returns `itemId` to `tabsNodeId` at `index`, REBUILDING that node from `home` when
+     * the detach removed it.
+     *
+     * `addTab` requires its target to exist, which is the one thing a returning pane cannot count
+     * on: a pane alone in its zone empties the node on the way out, the node is dropped on commit,
+     * and a two-child split collapses behind it. That is the common tear-out, not the rare one — a
+     * pane with siblings is the case whose home survives.
+     *
+     * Distinct from `addTab` because the precondition is inverted, so neither has to carry the
+     * other's branch: this one only reaches its rebuild path when the node is absent, and delegates
+     * verbatim when it is present.
+     * @param {Object} document
+     * @param {Object} args {home, index, itemId, tabsNodeId}
+     * @returns {{document:Object, errors:String[]}}
+     * @static
+     */
+    static restoreTab(document, {home, index, itemId, tabsNodeId} = {}) {
+        if (!document.items?.[itemId]) return {document, errors: [`unknown item "${itemId}"`]};
+
+        if (document.nodes?.[tabsNodeId]?.type === 'tabs') {
+            return Operations.addTab(document, {itemId, index, tabsNodeId})
+        }
+
+        if (!tabsNodeId) return {document, errors: ['restoreTab requires a tabsNodeId']};
+
+        let doc = Document.clone(document),
+            // Reuse the recorded id when nothing has claimed it, so a round trip leaves the document
+            // it started from rather than one that merely looks like it.
+            nodeId = doc.nodes[tabsNodeId] ? Document.genId(doc, tabsNodeId) : tabsNodeId,
+            errors;
+
+        Document.detachFromTabs(doc, itemId);
+
+        doc.nodes[nodeId] = {activeItemId: itemId, items: [itemId], type: 'tabs'};
+
+        errors = Document.restoreNodeHome(doc, nodeId, home);
+
+        return errors.length > 0 ? {document, errors} : Document.commit(document, doc)
     }
 
     /**

--- a/test/playwright/unit/dashboard/DockWorkspace.spec.mjs
+++ b/test/playwright/unit/dashboard/DockWorkspace.spec.mjs
@@ -873,6 +873,37 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
             expect(detached.nodes['editor-tabs']).toBeUndefined()
         });
 
+        test('a pane docked into the recorded home while the vessel is open is NOT displaced', async () => {
+            workspace = Neo.create(PlainWorkspace, {dockModel: createEdgeDocument()});
+
+            const placement = Document.captureItemPlacement(workspace.dockModel, 'inspector'),
+                  detached  = workspace.applyTearOutOperation({operation: 'detachItem', itemId: 'inspector'});
+
+            expect(detached.errors).toEqual([]);
+            workspace.onDockZoneDocumentChange(detached.document);
+            expect(detached.document.nodes[placement.tabsNodeId], 'the home is gone').toBeUndefined();
+
+            // A vessel window is long-lived, so this interleaving is ordinary: while the pane is
+            // out, something else takes the edge it left. The occupant must survive — losing a pane
+            // the user never touched is strictly worse than the misplacement this seam fixes.
+            const occupied = Document.clone(workspace.dockModel);
+
+            occupied.items['late']       = {componentRef: 'Late', title: 'Late', kind: 'panel'};
+            occupied.nodes['late-right']  = {type: 'tabs', items: ['late'], activeItemId: 'late'};
+            Document.setZoneNodeId(occupied.nodes[placement.home.parentId], placement.home.slot, 'late-right');
+            workspace.onDockZoneDocumentChange(occupied);
+
+            expect(await workspace.reintegrateTearOutItem('inspector', null)).toBe(true);
+
+            const doc = workspace.dockModel;
+
+            expect(Document.getZoneNodeId(doc.nodes[placement.home.parentId].zones[placement.home.slot]),
+                'the occupant kept the slot').toBe('late-right');
+            expect(doc.nodes['late-right'].items, 'and kept its item').toEqual(['late']);
+            expect(Document.findContainingTabsId(doc, 'inspector'), 'the returner still landed somewhere').toBeTruthy();
+            expect(Document.validate(doc)).toEqual([])
+        });
+
         test('a recorded home that resolves to NOTHING falls back rather than dropping the pane', async () => {
             workspace = Neo.create(PlainWorkspace, {dockModel: createDocument()});
 

--- a/test/playwright/unit/dashboard/DockWorkspace.spec.mjs
+++ b/test/playwright/unit/dashboard/DockWorkspace.spec.mjs
@@ -778,6 +778,115 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
         expect(workspace.getDockProjectionOptions()).toEqual({})
     });
 
+    test.describe('#18164 a pane whose home collapsed comes home anyway', () => {
+        /**
+         * Drives the real detach through `applyTearOutOperation` — the wrapper that records the
+         * placement — and commits it, so reintegration reads exactly the state a closed vessel
+         * leaves behind. Anything less (hand-writing `tearOutPlacements`) would test the record I
+         * wrote rather than the one the engine keeps.
+         * @param {String} itemId
+         * @returns {Object} the committed post-detach document
+         */
+        const detach = itemId => {
+            const result = workspace.applyTearOutOperation({operation: 'detachItem', itemId});
+
+            expect(result.errors).toEqual([]);
+            workspace.onDockZoneDocumentChange(result.document);
+
+            return result.document
+        };
+
+        test('AC-1/AC-4 a pane ALONE in its split child returns to that side, not to the first tabs node', async () => {
+            workspace = Neo.create(PlainWorkspace, {dockModel: createDocument()});
+
+            // `editor` is alone in `editor-tabs`, the left child of a two-child split — the exact
+            // shape the operator's consumer reported, and the common tear-out rather than the rare one.
+            const detached = detach('editor');
+
+            expect(detached.nodes['editor-tabs'], 'the emptied home is gone').toBeUndefined();
+            expect(detached.nodes['root-split'],  'and the split collapsed with it').toBeUndefined();
+
+            expect(await workspace.reintegrateTearOutItem('editor', null)).toBe(true);
+
+            const doc     = workspace.dockModel,
+                  splitId = Object.keys(doc.nodes).find(id => doc.nodes[id].type === 'split'),
+                  split   = doc.nodes[splitId];
+
+            expect(split, 'the split was rebuilt').toBeTruthy();
+            expect(split.orientation).toBe('horizontal');
+            expect(doc.nodes[split.children[0]].items, 'back on the LEFT, where it left from').toEqual(['editor']);
+            expect(split.children[1]).toBe('side-tabs');
+
+            // Reading tab order would pass on a wrong zone: `side-tabs` holds the same two items
+            // either way. The node topology is the only witness that distinguishes them.
+            expect(doc.nodes['side-tabs'].items).toEqual(['preview', 'terminal']);
+            expect(Document.validate(doc)).toEqual([])
+        });
+
+        test('AC-3 a pane with SIBLINGS returns to its own node at its own index', async () => {
+            workspace = Neo.create(PlainWorkspace, {dockModel: createDocument()});
+
+            const detached = detach('preview');
+
+            expect(detached.nodes['side-tabs'], 'the home survived — terminal held it open').toBeTruthy();
+
+            expect(await workspace.reintegrateTearOutItem('preview', null)).toBe(true);
+            expect(workspace.dockModel.nodes['side-tabs'].items, 'index 0, not appended').toEqual(['preview', 'terminal'])
+        });
+
+        test('AC-5 the SAME pane instance comes home — asserted on the component id', async () => {
+            workspace = Neo.create(PlainWorkspace, {dockModel: createDocument()});
+
+            const pane   = Neo.create(Container, {}),
+                  paneId = pane.id,
+                  seen   = [];
+
+            workspace.afterTearOutPaneReturn = data => seen.push(data);
+
+            detach('editor');
+
+            expect(await workspace.reintegrateTearOutItem('editor', pane)).toBe(true);
+
+            // A node moved between documents is necessarily re-created, so DOM identity cannot carry
+            // this. The instance is what survives, and its id is how that is honestly read.
+            expect(seen).toHaveLength(1);
+            expect(seen[0].returned).toBe(true);
+            expect(seen[0].pane.id).toBe(paneId);
+            expect(pane.isDestroyed, 'a returned pane is never settled').toBeFalsy();
+
+            pane.destroy()
+        });
+
+        test('AC-6 an item with NO recorded placement still lands somewhere valid', async () => {
+            workspace = Neo.create(PlainWorkspace, {dockModel: createDocument()});
+
+            const detached = detach('editor');
+
+            // The record is the thing being taken away here: without it there is no home to rebuild,
+            // and the first tabs node in document order is a last resort rather than a placement.
+            delete workspace.tearOutPlacements.editor;
+
+            expect(await workspace.reintegrateTearOutItem('editor', null)).toBe(true);
+
+            expect(Document.findContainingTabsId(workspace.dockModel, 'editor'), 'somewhere beats nowhere').toBeTruthy();
+            expect(Document.validate(workspace.dockModel)).toEqual([]);
+            expect(detached.nodes['editor-tabs']).toBeUndefined()
+        });
+
+        test('a recorded home that resolves to NOTHING falls back rather than dropping the pane', async () => {
+            workspace = Neo.create(PlainWorkspace, {dockModel: createDocument()});
+
+            detach('editor');
+
+            // Both halves of the record point at nodes that no longer exist — the zone AND the
+            // sibling its split collapsed into. The restore fails closed; the return path must not.
+            Object.assign(workspace.tearOutPlacements.editor.home, {parentId: 'gone', siblingId: 'gone-too'});
+
+            expect(await workspace.reintegrateTearOutItem('editor', null)).toBe(true);
+            expect(Document.findContainingTabsId(workspace.dockModel, 'editor')).toBeTruthy()
+        })
+    });
+
     test.describe('#17681 engine tear-out lifecycle matrix', () => {
         let previousApps, previousGetByPath, urls;
 

--- a/test/playwright/unit/dashboard/DockZoneModel.spec.mjs
+++ b/test/playwright/unit/dashboard/DockZoneModel.spec.mjs
@@ -2008,6 +2008,49 @@ test.describe('Neo.dashboard.dock.model.Document', () => {
             )
         });
 
+        test('an OCCUPIED home is not a home — the new occupant survives, the returner goes elsewhere', () => {
+            const {document: detached, placement} = detachAlone(doc(), 'terminal');
+
+            expect(detached.nodes.root.zones.right).toBeUndefined();
+
+            // A vessel is long-lived. While the pane is out, the user docks something else to the
+            // very edge it left — an ordinary sequence, not an exotic one.
+            const occupied = Document.clone(detached);
+
+            occupied.nodes['new-right'] = {type: 'tabs', items: ['inspector'], activeItemId: 'inspector'};
+            Document.setZoneNodeId(occupied.nodes.root, 'right', 'new-right');
+
+            const {document: restored, errors} = Operations.applyOperation(occupied, {
+                operation: 'restoreTab', itemId: 'terminal', ...placement
+            });
+
+            // The recorded coordinate is VALID and NOT MINE. Writing it would orphan `new-right`:
+            // an edge zone holds one node per key, so the occupant would be referenced by nothing —
+            // a lost pane, and not the one being restored.
+            expect(errors.length, 'an occupied slot resolves to nothing, rather than being taken').toBeGreaterThan(0);
+            expect(restored, 'and the document is returned untouched').toEqual(occupied);
+
+            // The occupant is what this arm exists for: it must still be reachable from the root.
+            expect(Document.getZoneNodeId(occupied.nodes.root.zones.right)).toBe('new-right');
+            expect(Document.reachableNodeIds(occupied).has('new-right')).toBe(true)
+        });
+
+        test('a slot holding the returner ITSELF is still its own — re-entry is not an overwrite', () => {
+            const source    = doc(),
+                  placement = Document.captureItemPlacement(source, 'terminal');
+
+            // The ownership guard must not refuse the node its own slot: `side-tabs` is still in
+            // `zones.right` here, so an occupancy check that only asked "is anything there?" would
+            // send a pane away from the home it never lost.
+            const {document: restored, errors} = Operations.applyOperation(source, {
+                operation: 'restoreTab', itemId: 'terminal', ...placement
+            });
+
+            expect(errors).toEqual([]);
+            expect(Document.getZoneNodeId(restored.nodes.root.zones.right)).toBe('side-tabs');
+            expect(restored.nodes['side-tabs'].items).toEqual(['terminal'])
+        });
+
         test('AC-6 with NO recorded placement the item still lands somewhere valid', () => {
             const {document: detached} = detachAlone(doc(), 'terminal');
 

--- a/test/playwright/unit/dashboard/DockZoneModel.spec.mjs
+++ b/test/playwright/unit/dashboard/DockZoneModel.spec.mjs
@@ -1873,11 +1873,195 @@ test.describe('Neo.dashboard.dock.model.Document', () => {
         }
     });
 
+    test.describe('restoreTab — a home that no longer exists (#18164)', () => {
+        /**
+         * Detaching the LAST item of a zone is the common tear-out, not the rare one: the emptied
+         * tabs node is dropped on commit and a two-child split collapses behind it. Every arm here
+         * starts from that state, so `tabsNodeId` names a node that is genuinely gone.
+         * @param {Object} source
+         * @param {String} itemId
+         * @returns {{document:Object, placement:Object}}
+         */
+        function detachAlone(source, itemId) {
+            const placement          = Document.captureItemPlacement(source, itemId),
+                  {document, errors} = Operations.applyOperation(source, {operation: 'detachItem', itemId});
+
+            expect(errors).toEqual([]);
+            expect(document.nodes[placement.tabsNodeId], 'the home is gone — that is the premise').toBeUndefined();
+
+            return {document, placement}
+        }
+
+        test('AC-1 a pane ALONE in an edge zone returns to THAT zone, asserted on the node topology', () => {
+            const {document: detached, placement} = detachAlone(doc(), 'terminal');
+
+            expect(detached.nodes.root.zones.right, 'the emptied zone collapsed').toBeUndefined();
+
+            const {document: restored, errors} = Operations.applyOperation(detached, {
+                operation: 'restoreTab', itemId: 'terminal', ...placement
+            });
+
+            expect(errors).toEqual([]);
+
+            const zoneId = Document.getZoneNodeId(restored.nodes.root.zones.right);
+
+            expect(zoneId, 'the right zone exists again').toBeTruthy();
+            expect(restored.nodes[zoneId].items).toEqual(['terminal']);
+
+            // The tab ORDER of main-tabs would read identically whether or not this worked, which is
+            // why the assertion is on the zone and never on a tab sequence.
+            expect(restored.nodes['main-tabs'].items).toEqual(['strategy', 'swarm'])
+        });
+
+        test('AC-2 RED: the pre-fix record — a tabsNodeId with no home — cannot rebuild it', () => {
+            const {document: detached, placement} = detachAlone(doc(), 'terminal');
+
+            // Exactly what `captureItemPlacement` used to return: the id of a node that is
+            // guaranteed absent by the time it is read, and nothing to reconstruct it from.
+            const {errors} = Operations.applyOperation(detached, {
+                operation: 'restoreTab', itemId: 'terminal', tabsNodeId: placement.tabsNodeId, index: placement.index
+            });
+
+            expect(errors.length, 'fails closed rather than inventing a home').toBeGreaterThan(0);
+
+            // And the old resolution's actual outcome: the FIRST tabs node in document order, which
+            // is the centre — the wrong zone, reported as a successful return.
+            const fallback = Object.entries(detached.nodes).find(([, node]) => node.type === 'tabs')?.[0];
+
+            expect(fallback, 'document order hands back the CENTRE, not the right edge').toBe('main-tabs')
+        });
+
+        test('AC-3 a pane that SHARED its node returns to that node at its index — the surviving path is untouched', () => {
+            const source    = doc(),
+                  placement = Document.captureItemPlacement(source, 'strategy');
+
+            const {document: detached} = Operations.applyOperation(source, {operation: 'detachItem', itemId: 'strategy'});
+
+            expect(detached.nodes['main-tabs'], 'the home survived — it had a sibling').toBeTruthy();
+
+            const {document: restored, errors} = Operations.applyOperation(detached, {
+                operation: 'restoreTab', itemId: 'strategy', ...placement
+            });
+
+            expect(errors).toEqual([]);
+            expect(restored.nodes['main-tabs'].items, 'back at index 0, not appended').toEqual(['strategy', 'swarm'])
+        });
+
+        test('AC-4 a pane alone in a SPLIT child returns to that side of the split, with its ratio', () => {
+            const source = splitDoc([0.7, 0.3]);
+
+            const {document: detached, placement} = detachAlone(source, 'terminal');
+
+            expect(placement.home).toEqual({
+                parentId: 'main-split', slot: 1, orientation: 'horizontal', size: 0.3, siblingId: 'main-tabs', position: 'after'
+            });
+
+            // The split lost a child and collapsed into the survivor, so the recorded PARENT is gone
+            // too — the sibling anchor is the only thing left pointing at where this belonged.
+            expect(detached.nodes['main-split'], 'the split collapsed with it').toBeUndefined();
+
+            const {document: restored, errors} = Operations.applyOperation(detached, {
+                operation: 'restoreTab', itemId: 'terminal', ...placement
+            });
+
+            expect(errors).toEqual([]);
+
+            const splitId = Object.keys(restored.nodes).find(id => restored.nodes[id].type === 'split'),
+                  split   = restored.nodes[splitId];
+
+            expect(split.orientation).toBe('horizontal');
+            expect(split.children[0], 'the sibling keeps the near side').toBe('main-tabs');
+            expect(restored.nodes[split.children[1]].items, 'the returner keeps the far side').toEqual(['terminal']);
+            expect(split.sizes[0]).toBeCloseTo(0.7, 6);
+            expect(split.sizes[1]).toBeCloseTo(0.3, 6)
+        });
+
+        test('a split that KEPT other children takes the node back at its slot, scaling the survivors', () => {
+            const source = splitDoc([0.5, 0.25]);
+
+            source.nodes['main-split'].children.push('extra-tabs');
+            source.nodes['main-split'].sizes = [0.5, 0.25, 0.25];
+            source.nodes['extra-tabs']       = {type: 'tabs', items: ['inspector'], activeItemId: 'inspector'};
+
+            const {document: detached, placement} = detachAlone(source, 'terminal');
+
+            expect(detached.nodes['main-split'], 'three children minus one still splits').toBeTruthy();
+            expect(detached.nodes['main-split'].children).toEqual(['main-tabs', 'extra-tabs']);
+
+            const {document: restored, errors} = Operations.applyOperation(detached, {
+                operation: 'restoreTab', itemId: 'terminal', ...placement
+            });
+
+            expect(errors).toEqual([]);
+
+            const split = restored.nodes['main-split'];
+
+            expect(split.children[1], 'back in the MIDDLE slot, not appended').toBe(placement.tabsNodeId);
+            expect(split.sizes[1], 'it reclaims the share it recorded').toBeCloseTo(0.25, 6);
+            expect(split.sizes.reduce((total, size) => total + size, 0)).toBeCloseTo(1, 6);
+
+            // The survivors' ratio TO EACH OTHER is what is preserved — not the split's pre-detach
+            // geometry, which `normalizeTree` already reset to equal when the child collapsed.
+            // Restoring position is the contract here; geometry is explicitly out of its scope.
+            expect(split.sizes[0] / split.sizes[2]).toBeCloseTo(
+                detached.nodes['main-split'].sizes[0] / detached.nodes['main-split'].sizes[1], 6
+            )
+        });
+
+        test('AC-6 with NO recorded placement the item still lands somewhere valid', () => {
+            const {document: detached} = detachAlone(doc(), 'terminal');
+
+            const fallback = Object.entries(detached.nodes).find(([, node]) => node.type === 'tabs')?.[0];
+
+            const {document: restored, errors} = Operations.applyOperation(detached, {
+                operation: 'restoreTab', itemId: 'terminal', tabsNodeId: fallback
+            });
+
+            expect(errors).toEqual([]);
+            expect(restored.nodes['main-tabs'].items).toContain('terminal');
+            expect(Document.validate(restored)).toEqual([])
+        });
+
+        test('the restored node reclaims its ORIGINAL id, so a round trip lands on the document it left', () => {
+            const source = doc();
+
+            const {document: detached, placement} = detachAlone(source, 'terminal');
+
+            const {document: restored} = Operations.applyOperation(detached, {
+                operation: 'restoreTab', itemId: 'terminal', ...placement
+            });
+
+            expect(restored.nodes['side-tabs'], 'the id is free, so it is reused').toBeTruthy();
+            expect(restored).toEqual(source)
+        });
+
+        test('fails closed on an unknown item, and on a home whose sibling ALSO went away', () => {
+            expect(Operations.applyOperation(doc(), {operation: 'restoreTab', itemId: 'ghost', tabsNodeId: 'main-tabs'}).errors)
+                .toEqual(['unknown item "ghost"']);
+
+            const {document: detached, placement} = detachAlone(splitDoc(), 'terminal');
+
+            placement.home.parentId  = 'vanished-split';
+            placement.home.siblingId = 'vanished-tabs';
+
+            const {document: unchanged, errors} = Operations.applyOperation(detached, {
+                operation: 'restoreTab', itemId: 'terminal', ...placement
+            });
+
+            expect(errors.length).toBeGreaterThan(0);
+            expect(unchanged, 'a failed restore returns the input untouched').toEqual(detached)
+        });
+
+        test('restoreTab joins the derived vocabulary, so the dispatch table and Operations.operations agree', () => {
+            expect(Operations.operations).toContain('restoreTab')
+        })
+    });
+
     test.describe('captureItemPlacement (exact-position return, stored half)', () => {
         test('captures the holding tabs node and the exact index', () => {
-            expect(Document.captureItemPlacement(doc(), 'strategy')).toEqual({tabsNodeId: 'main-tabs', index: 0});
-            expect(Document.captureItemPlacement(doc(), 'swarm')).toEqual({tabsNodeId: 'main-tabs', index: 1});
-            expect(Document.captureItemPlacement(doc(), 'terminal')).toEqual({tabsNodeId: 'side-tabs', index: 0})
+            expect(Document.captureItemPlacement(doc(), 'strategy')).toEqual({tabsNodeId: 'main-tabs', index: 0, home: {parentId: 'root', slot: 'center'}});
+            expect(Document.captureItemPlacement(doc(), 'swarm')).toEqual({tabsNodeId: 'main-tabs', index: 1, home: {parentId: 'root', slot: 'center'}});
+            expect(Document.captureItemPlacement(doc(), 'terminal')).toEqual({tabsNodeId: 'side-tabs', index: 0, home: {parentId: 'root', slot: 'right'}})
         });
 
         test('fails closed when no tabs node holds the item — catalog presence is not placement', () => {
@@ -1898,7 +2082,7 @@ test.describe('Neo.dashboard.dock.model.Document', () => {
             // put it BACK at index 1, which is exactly the defect the stored pair compensates
             const placement = Document.captureItemPlacement(source, 'strategy');
 
-            expect(placement).toEqual({tabsNodeId: 'main-tabs', index: 0});
+            expect(placement).toEqual({tabsNodeId: 'main-tabs', index: 0, home: {parentId: 'root', slot: 'center'}});
 
             const {document: detached} = Operations.applyOperation(source, {operation: 'detachItem', itemId: 'strategy'});
 

--- a/test/playwright/unit/examples/dashboard/crossWindow/DemoBWorkspace.spec.mjs
+++ b/test/playwright/unit/examples/dashboard/crossWindow/DemoBWorkspace.spec.mjs
@@ -1619,7 +1619,9 @@ test.describe.serial('Neo.examples.dashboard.crossWindow.DemoBWorkspace', () => 
         const result = workspace.applyTearOutOperation({operation: 'detachItem', itemId: 'timeline'});
 
         expect(result.errors).toEqual([]);
-        expect(workspace.tearOutPlacements.timeline).toEqual({tabsNodeId: 'side-tabs', index: 1});
+        // `home` carries the tabs node's OWN position, so the record can rebuild a zone the detach
+        // collapsed rather than only find one that survived.
+        expect(workspace.tearOutPlacements.timeline).toEqual({tabsNodeId: 'side-tabs', index: 1, home: {parentId: 'root', slot: 'right'}});
 
         workspace.onWorkspaceDocumentChange('demo-b-main', result.document);
         expect(workspace.getDockZoneDocument().nodes['side-tabs'].items).toEqual(['inspector', 'console']);


### PR DESCRIPTION
## Summary

A right-edge pane torn out and returned came back as a **centre tab**. @neo-opus-vega measured it on a downstream consumer and filed #18164 with the diagnosis; this is the fix.

The round trip worked. Only the placement was wrong — and it was wrong *by construction*, for exactly the pane most likely to be torn out.

```
BEFORE pop-out : ["Dokumente", "Editor", "Verbindung"]   Verbindung is the RIGHT EDGE
AFTER  close   : ["Dokumente", "Verbindung", "Editor"]   back in the CENTRE
```

## The defect

`reintegrateTearOutItem` held the right record and could not use it:

```js
storedHome = placement && doc?.nodes?.[placement.tabsNodeId]?.type === 'tabs' ? placement.tabsNodeId : null,
fallback   = storedHome || Object.entries(doc?.nodes || {}).find(([, node]) => node.type === 'tabs')?.[0],
```

`tearOutPlacements` records the exact pre-detach `{tabsNodeId, index}` — the right intent. But the guard requires that node to **still exist**, and for a pane alone in its zone it never does: the emptied tabs node is dropped on commit, and a two-child split collapses behind it.

So `storedHome` is `null` and the resolution falls through to *the first tabs node in document order* — not a placement, but wherever enumeration happens to start. **Guaranteed wrong for a pane alone in its zone; correct only for a pane with siblings.** The passing case is the rare one.

## The fix

Make the record sufficient to **rebuild** its home rather than only to find one that survived.

**`Document.captureNodeHome`** records the parent slot and, for a split parent, the orientation, the node's share, and a **sibling anchor**. The sibling is what makes the record outlive its own parent:

> removing a child from a two-child split leaves one child, and `normalizeTree` collapses that split too — so `parentId` is unresolvable in precisely the case the record exists for. The sibling is the node that split collapsed **into**, so it is still there.

An edge-zone parent needs no anchor: an edge-zone node survives losing every zone.

**`Document.restoreNodeHome`** grafts a node back, most faithful first — recorded parent still holds the slot → sibling re-split against, restoring orientation, side and ratio → **fail closed**. Failing closed is the point: picking an arbitrary node there would *look like* a restoration and *be* a relocation.

**`Operations.restoreTab`** is the reducer entry. Distinct from `addTab` because the precondition is inverted — `addTab` requires its target to exist, this one rebuilds when it does not and delegates verbatim when it does, so neither carries the other's branch. It joins the derived vocabulary through the dispatch table, so `Operations.operations` agrees by construction.

The arbitrary first-tabs-node fallback **stays**, now only for an item with no record at all, and the code says so. The return path retries through it when a recorded home resolves to nothing: losing the position is bad, losing the pane is worse.

## What I got wrong, and what it revealed

My first size arm asserted that the survivors' **pre-detach ratios** were preserved. They are not, and could not be: `normalizeTree` already resets a split's sizes to equal when a child collapses, so that geometry is gone before restore ever runs. The ticket puts geometry out of scope; my arm quietly assumed otherwise and the red caught it. The code now states the constraint rather than implying a guarantee it cannot make — what is preserved is the returner's recorded share and the survivors' ratios *to each other*.

Second: my first suite read came back `3049 passed` under a `tail -2` that hid a `1 failed` line above it, plus `16 did not run`. The failure was a fourth `toEqual` on the record shape, in a spec that reads `tearOutPlacements` **directly** rather than calling the producer I had grepped for. I had swept on the producer's name, which cannot see a consumer that never calls it. Re-swept on the field name; the e2e reference uses `Object.keys` and is unaffected.

## Acceptance Criteria

| AC | Where | State |
|---|---|---|
| AC-1 alone in an edge zone returns to that edge zone, asserted on node topology | `DockZoneModel` + `DockWorkspace` | ✅ |
| AC-2 red-first: the same witness fails at the current head | control below | ✅ |
| AC-3 a pane with siblings still returns to its node — surviving path unchanged | both specs | ✅ |
| AC-4 alone in a centre split child returns to that position in the split | both specs | ✅ |
| AC-5 object permanence, asserted by component id not DOM identity | `DockWorkspace` | ✅ |
| AC-6 no recorded placement → last resort still returns it somewhere valid | both specs | ✅ |
| AC-7 exact-head unit + component suites green | below | ✅ |

## Red-first control

Restored the three source files to the merge base and re-ran the new arms:

```
model arms     : 8 failed, 1 passed
workspace arms : 2 failed, 3 passed
```

The three workspace arms that pass at the baseline are **supposed to** — AC-3 and AC-6 are the unchanged-path controls, so passing before *and* after is what "unregressed" means. The failing arms are the defect witnesses.

## Evidence

- unit `3066 passed`, **0 failed, 0 skipped** (the previous run's `16 did not run` was the cascade behind the hidden failure, now fixed)
- component `dashboard` `105 passed`
- assertion is on the **document's node topology**, never on tab order — a correct tab order over a wrong zone would pass, and the two are only coincidentally related

## Out of scope

Collapse-on-empty itself (ADR 0029 §2.7 stays exactly as it is — this restores the inverse for a returning pane), the vessel lifecycle and declining-hook family (#18151 and subs), and split geometry beyond the node's position.

Resolves #18164. Refs #18151, #18153.

Authored by Grace (Claude Opus 5, Claude Code). Session 8d936ec9-b816-4ded-a91e-6e91ef6a3325.
