### PR TITLE
test(dashboard): a host override is the only opener that runs (#18153)

### DIFF
--- a/test/playwright/unit/dashboard/DockWorkspace.spec.mjs
+++ b/test/playwright/unit/dashboard/DockWorkspace.spec.mjs
@@ -3156,6 +3156,53 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
             }
         });
 
+        test('a host override is the ONLY opener that runs — the engine default does not also fire', async () => {
+            class HostOpenerWorkspace extends PlainWorkspace {
+                static config = {className: 'Test.Unit.Dashboard.DockWorkspace.HostOpenerWorkspace'}
+
+                hostOpens = []
+
+                openTearOutVessel(request) {
+                    this.hostOpens.push(request);
+                    return {admissionToken: request.admissionToken, windowName: `host-${request.itemId}`}
+                }
+            }
+
+            Neo.setupClass(HostOpenerWorkspace);
+
+            workspace = Neo.create(HostOpenerWorkspace, {dockModel: createDocument()});
+
+            const opens              = [],
+                  {useSharedWorkers} = Neo.config,
+                  originalMain       = Neo.Main;
+
+            // Shared workers ON, so the ENGINE default would happily open a window here. That is the
+            // whole point of the arm: the risk is not that a host override fails, it is that the
+            // engine adds a second vessel behind it — two windows for one gesture, one of them
+            // holding nothing, and neither owner aware of the other.
+            Neo.Main = {
+                getByPath    : () => Promise.resolve('https://example.test/app/index.html'),
+                getWindowData: () => Promise.resolve({innerHeight: 800, outerHeight: 860, screenLeft: 0, screenTop: 0}),
+                windowOpen   : data => { opens.push(data); return Promise.resolve(true) }
+            };
+            Neo.config.useSharedWorkers = true;
+
+            try {
+                const vessel = await workspace.acquireTearOutVessel({admissionToken: 5, itemId: 'editor'});
+
+                expect(workspace.hostOpens, 'the host opener ran exactly once').toHaveLength(1);
+                expect(vessel).toMatchObject({windowName: 'host-editor'});
+
+                // Witnessed on the WINDOW, not on which method was called: `Neo.Main.windowOpen` is
+                // the only thing the engine default does that a host cannot undo, so an empty
+                // collector is the honest statement that no second vessel exists.
+                expect(opens, 'the engine opened nothing of its own').toEqual([])
+            } finally {
+                Neo.Main = originalMain;
+                Neo.config.useSharedWorkers = useSharedWorkers
+            }
+        });
+
         test('without useSharedWorkers there is no vessel to open, and none is attempted', async () => {
             workspace = Neo.create(PlainWorkspace, {dockModel: createDocument()});
 


### PR DESCRIPTION
## Summary

**AC-3 had no arm.** Sweeping #18153's acceptance criteria against the tree, AC-1, AC-2 and AC-4 each had one; AC-3 — *"a host that overrides `openTearOutVessel` keeps exactly one lifecycle owner; the engine default does not also run"* — asserted nothing.

## The risk is not the one the AC sounds like

A host override that fails to run is hard to get wrong; JS shadowing handles it. The failure mode worth an arm is the **engine opening a second vessel behind a working override** — two windows for one gesture, one of them holding nothing, and neither owner aware of the other.

So the arm turns shared workers **ON**, which is the condition under which the engine default would happily open. A host override with `useSharedWorkers: false` proves nothing here: the engine could not have opened anyway, and the arm would pass for the wrong reason.

## Witnessed on the window, not on the call

```js
expect(workspace.hostOpens, 'the host opener ran exactly once').toHaveLength(1);
expect(opens, 'the engine opened nothing of its own').toEqual([])
```

`Neo.Main.windowOpen` is the only thing the engine default does that a host cannot undo, so an empty collector is the honest statement that no second vessel exists. Asserting *"the host opener was called"* would pass with a second window standing open beside it — the same class the ticket's avoided-traps list names for AC-1 (witness the window, not the action).

## Non-vacuity, checked rather than claimed

Calling the base opener alongside the override inside `acquireTearOutVessel`:

```js
await Workspace.prototype.openTearOutVessel.call(me, request);
vessel = await me.openTearOutVessel(request)
```

turns the arm red on that exact line — `the engine opened nothing of its own`. Reverted; the mutant is a receipt, not a change.

## AC-2 was already met — recorded so nobody re-derives it

The `terminal-first connect lands one admitted live pane` arm already drives the full round trip and asserts identity on return. It also clears **AC-2's own bar**, which is stricter than it looks: *"must fail on a re-creation, not only on an absence."*

I checked both mutants rather than reading the assertion and assuming:

| Mutant | Result |
|---|---|
| the return **loses** the instance | red at the **stranding** assertion — never reaches the identity check |
| the return brings home a **lookalike** (same `reference`, fresh instance) | red at `expect(workspace.getReference('tearout-pane-preview')).toBe(pane)` |

The second is the one that settles AC-2. The first is exactly the false comfort the AC warns about: it proves the arm catches a *disappearance*, which is not the defect AC-2 names. Had I stopped at the first mutant I would have written a redundant AC-2 arm on the strength of a receipt that did not cover the claim.

## Evidence

`DockWorkspace` **95 passed**, exit 0. No source change — this PR is one test arm plus its mutation receipts.

Refs #18153.

Authored by Grace (Claude Opus 5, Claude Code). Session 8d936ec9-b816-4ded-a91e-6e91ef6a3325.
