### PR TITLE
refactor(tab): the inline and standalone selectors leave the theme value files (#18145)

### DIFF
--- a/resources/scss/src/tab/Container.scss
+++ b/resources/scss/src/tab/Container.scss
@@ -52,3 +52,50 @@
         overflow: hidden;
     }
 }
+
+// WHICH elements get variant geometry is a structural question, so the selector list lives here
+// once and every theme answers only "what value" by declaring the tokens flat. Repeated per theme,
+// the same list had to be re-answered identically four times and any one copy could drift — the
+// failure #18141 shipped.
+//
+// These rules are at FILE scope rather than nested under `.neo-tab-container` on purpose: a drag
+// proxy is a detached toolbar at `document.body` with the container's ui-derived class copied onto
+// it (draggable.tab.header.toolbar.SortZone), so it has no container ancestor to nest under. The
+// second selector in each pair is that proxy; without it a dragged header would resolve different
+// tokens than the header it was lifted from.
+//
+// Two selectors replace the eight the themes emitted. Each theme needed a `&`-prefixed form (theme
+// class ON the element) beside a descendant form (theme class on an ancestor), doubling the list;
+// with no theme class in the selector both cases collapse into one. The theme scope survives in the
+// TOKENS, which inherit from the nearest `.neo-theme-*` ancestor — which is also why this resolves
+// a nested theme correctly, where two theme-prefixed rules could both match and source order decided.
+//
+// The `:root` prefix is WEIGHT, not scope, and it is load-bearing. On a drag proxy the theme class
+// lands on the toolbar element ITSELF, so the theme's root block (`:root .neo-theme-*`, two class
+// units) declares the BASE `--tab-button-*` on the very element this rule targets. Without `:root`
+// these selectors also measure two class units, the tie goes to source order, and the proxy renders
+// at base density instead of its variant — measured, not reasoned: `tab/DragProxyDensity` caught it
+// with `7px 12px 6px` where the inline variant is `7px 8px 6px`. Three units settle it, and this is
+// the same weight the theme files were already carrying.
+:root .neo-tab-container-inline > .neo-tab-header-toolbar,
+:root .neo-tab-header-toolbar.neo-tab-container-inline {
+    --tab-button-border-radius   : var(--tab-inline-button-border-radius);
+    --tab-button-gap             : var(--tab-inline-button-gap);
+    --tab-button-height          : var(--tab-inline-button-height);
+    --tab-button-height-pressed  : var(--tab-inline-button-height-pressed);
+    --tab-button-padding         : var(--tab-inline-button-padding);
+    --tab-button-text-font-size  : var(--tab-inline-button-text-font-size);
+    --tab-button-text-font-weight: var(--tab-inline-button-text-font-weight);
+}
+
+// Standalone names five tokens, not seven: type size and weight are inherited from the theme's
+// ui:null contract in every theme today, and adding hooks nothing values would invite exactly the
+// partial declaration #18141 punishes.
+:root .neo-tab-container-standalone > .neo-tab-header-toolbar,
+:root .neo-tab-header-toolbar.neo-tab-container-standalone {
+    --tab-button-border-radius : var(--tab-standalone-button-border-radius);
+    --tab-button-gap           : var(--tab-standalone-button-gap);
+    --tab-button-height        : var(--tab-standalone-button-height);
+    --tab-button-height-pressed: var(--tab-standalone-button-height-pressed);
+    --tab-button-padding       : var(--tab-standalone-button-padding);
+}

--- a/resources/scss/theme-dark/tab/Container.scss
+++ b/resources/scss/theme-dark/tab/Container.scss
@@ -13,41 +13,26 @@
     --tab-header-inline-background-image           : none;
     --tab-header-inline-box-shadow                 : none;
 
-    // Inline inherits the classic theme's established 25px / square geometry and tightens only what
-    // a dock header cannot afford: horizontal padding and the title's weight — beside an action
-    // rail the title is chrome, not a button label, and the indicator bar already carries emphasis.
-    // Keeping inherited defaults out of this block prevents copy-drift while leaving measured,
-    // deletion-sensitive variant effects.
-    &.neo-tab-container-inline > .neo-tab-header-toolbar,
-    .neo-tab-container-inline > .neo-tab-header-toolbar,
-    // Self-scoped: a drag proxy is a detached toolbar at document.body, so it has no container
-    // ancestor for the two forms above to match. draggable.tab.header.toolbar.SortZone propagates
-    // the owner's ui-derived class onto it, and these two forms are what let the same tokens resolve
-    // there — one source, rather than a value snapshot taken at drag start.
+    // Inline keeps the classic 25px / square geometry and tightens only what a dock header cannot
+    // afford: horizontal padding and the title's weight — beside an action rail the title is chrome,
+    // not a button label, and the indicator bar already carries emphasis.
     //
-    // BOTH are required, and the `&` form is the one that is easy to miss: DragZone#createDragProxy
-    // pushes the resolved theme class onto the PROXY ITSELF, so theme + toolbar + variant all land on
-    // a single element and the descendant form below cannot match it. The descendant form still
-    // carries the case where an ancestor holds the theme.
-    &.neo-tab-header-toolbar.neo-tab-container-inline,
-    .neo-tab-header-toolbar.neo-tab-container-inline {
-        --tab-button-padding         : 7px 8px 6px;
-        --tab-button-text-font-weight: 400;
-    }
+    // The inherited four are now STATED. They were omitted while the selector lived here, which was
+    // safe only because the block sat inside this theme's own scope; read from a structural rule the
+    // omission would resolve against the ENCLOSING theme, which is the #18141 defect exactly.
+    --tab-inline-button-border-radius              : 0;
+    --tab-inline-button-gap                        : 0;
+    --tab-inline-button-height                     : 25px;
+    --tab-inline-button-height-pressed             : 25px;
+    --tab-inline-button-padding                    : 7px 8px 6px;
+    --tab-inline-button-text-font-size             : var(--button-text-font-size);
+    --tab-inline-button-text-font-weight           : 400;
 
     // Standalone gives classic-theme consumers a coherent free-standing card treatment without
-    // changing the ui:null default above.
-    &.neo-tab-container-standalone > .neo-tab-header-toolbar,
-    .neo-tab-container-standalone > .neo-tab-header-toolbar,
-    // The detached-proxy pair, mirroring the inline block above. SortZone propagates whatever
-    // non-null `ui` the owner holds, so every variant the themes name needs both self-scoped
-    // forms — an inline-only self-scope would leave a standalone proxy silently ancestor-scoped.
-    &.neo-tab-header-toolbar.neo-tab-container-standalone,
-    .neo-tab-header-toolbar.neo-tab-container-standalone {
-        --tab-button-border-radius : 8px;
-        --tab-button-gap           : 4px;
-        --tab-button-height        : 40px;
-        --tab-button-height-pressed: 40px;
-        --tab-button-padding       : 7px 16px 6px;
-    }
+    // changing the ui:null default.
+    --tab-standalone-button-border-radius          : 8px;
+    --tab-standalone-button-gap                    : 4px;
+    --tab-standalone-button-height                 : 40px;
+    --tab-standalone-button-height-pressed         : 40px;
+    --tab-standalone-button-padding                : 7px 16px 6px;
 }

--- a/resources/scss/theme-light/tab/Container.scss
+++ b/resources/scss/theme-light/tab/Container.scss
@@ -13,41 +13,26 @@
     --tab-header-inline-background-image           : none;
     --tab-header-inline-box-shadow                 : none;
 
-    // Inline inherits the classic theme's established 25px / square geometry and tightens only what
-    // a dock header cannot afford: horizontal padding and the title's weight — beside an action
-    // rail the title is chrome, not a button label, and the indicator bar already carries emphasis.
-    // Keeping inherited defaults out of this block prevents copy-drift while leaving measured,
-    // deletion-sensitive variant effects.
-    &.neo-tab-container-inline > .neo-tab-header-toolbar,
-    .neo-tab-container-inline > .neo-tab-header-toolbar,
-    // Self-scoped: a drag proxy is a detached toolbar at document.body, so it has no container
-    // ancestor for the two forms above to match. draggable.tab.header.toolbar.SortZone propagates
-    // the owner's ui-derived class onto it, and these two forms are what let the same tokens resolve
-    // there — one source, rather than a value snapshot taken at drag start.
+    // Inline keeps the classic 25px / square geometry and tightens only what a dock header cannot
+    // afford: horizontal padding and the title's weight — beside an action rail the title is chrome,
+    // not a button label, and the indicator bar already carries emphasis.
     //
-    // BOTH are required, and the `&` form is the one that is easy to miss: DragZone#createDragProxy
-    // pushes the resolved theme class onto the PROXY ITSELF, so theme + toolbar + variant all land on
-    // a single element and the descendant form below cannot match it. The descendant form still
-    // carries the case where an ancestor holds the theme.
-    &.neo-tab-header-toolbar.neo-tab-container-inline,
-    .neo-tab-header-toolbar.neo-tab-container-inline {
-        --tab-button-padding         : 7px 8px 6px;
-        --tab-button-text-font-weight: 400;
-    }
+    // The inherited four are now STATED. They were omitted while the selector lived here, which was
+    // safe only because the block sat inside this theme's own scope; read from a structural rule the
+    // omission would resolve against the ENCLOSING theme, which is the #18141 defect exactly.
+    --tab-inline-button-border-radius              : 0;
+    --tab-inline-button-gap                        : 0;
+    --tab-inline-button-height                     : 25px;
+    --tab-inline-button-height-pressed             : 25px;
+    --tab-inline-button-padding                    : 7px 8px 6px;
+    --tab-inline-button-text-font-size             : var(--button-text-font-size);
+    --tab-inline-button-text-font-weight           : 400;
 
     // Standalone gives classic-theme consumers a coherent free-standing card treatment without
-    // changing the ui:null default above.
-    &.neo-tab-container-standalone > .neo-tab-header-toolbar,
-    .neo-tab-container-standalone > .neo-tab-header-toolbar,
-    // The detached-proxy pair, mirroring the inline block above. SortZone propagates whatever
-    // non-null `ui` the owner holds, so every variant the themes name needs both self-scoped
-    // forms — an inline-only self-scope would leave a standalone proxy silently ancestor-scoped.
-    &.neo-tab-header-toolbar.neo-tab-container-standalone,
-    .neo-tab-header-toolbar.neo-tab-container-standalone {
-        --tab-button-border-radius : 8px;
-        --tab-button-gap           : 4px;
-        --tab-button-height        : 40px;
-        --tab-button-height-pressed: 40px;
-        --tab-button-padding       : 7px 16px 6px;
-    }
+    // changing the ui:null default.
+    --tab-standalone-button-border-radius          : 8px;
+    --tab-standalone-button-gap                    : 4px;
+    --tab-standalone-button-height                 : 40px;
+    --tab-standalone-button-height-pressed         : 40px;
+    --tab-standalone-button-padding                : 7px 16px 6px;
 }

--- a/resources/scss/theme-neo-dark/tab/Container.scss
+++ b/resources/scss/theme-neo-dark/tab/Container.scss
@@ -16,40 +16,18 @@
 
     // Embedded pane chrome uses the semantic 32px density tier and releases the free-standing
     // radius. The theme's ui:null contract remains the established 48px / 8px treatment.
-    &.neo-tab-container-inline > .neo-tab-header-toolbar,
-    .neo-tab-container-inline > .neo-tab-header-toolbar,
-    // Self-scoped: a drag proxy is a detached toolbar at document.body, so it has no container
-    // ancestor for the two forms above to match. draggable.tab.header.toolbar.SortZone propagates
-    // the owner's ui-derived class onto it, and these two forms are what let the same tokens resolve
-    // there — one source, rather than a value snapshot taken at drag start.
-    //
-    // BOTH are required, and the `&` form is the one that is easy to miss: DragZone#createDragProxy
-    // pushes the resolved theme class onto the PROXY ITSELF, so theme + toolbar + variant all land on
-    // a single element and the descendant form below cannot match it. The descendant form still
-    // carries the case where an ancestor holds the theme.
-    &.neo-tab-header-toolbar.neo-tab-container-inline,
-    .neo-tab-header-toolbar.neo-tab-container-inline {
-        --tab-button-border-radius   : 0;
-        --tab-button-gap             : 0;
-        --tab-button-height          : var(--sem-height-large);
-        --tab-button-height-pressed  : var(--sem-height-large);
-        --tab-button-padding         : 4px var(--sem-spacing-xsmall) 3px;
-        --tab-button-text-font-size  : var(--sem-typo-label-small-fontSize);
-        --tab-button-text-font-weight: var(--sem-typo-label-small-fontWeight);
-    }
+    --tab-inline-button-border-radius              : 0;
+    --tab-inline-button-gap                        : 0;
+    --tab-inline-button-height                     : var(--sem-height-large);
+    --tab-inline-button-height-pressed             : var(--sem-height-large);
+    --tab-inline-button-padding                    : 4px var(--sem-spacing-xsmall) 3px;
+    --tab-inline-button-text-font-size             : var(--sem-typo-label-small-fontSize);
+    --tab-inline-button-text-font-weight           : var(--sem-typo-label-small-fontWeight);
 
     // Standalone explicitly names the theme's existing free-standing treatment.
-    &.neo-tab-container-standalone > .neo-tab-header-toolbar,
-    .neo-tab-container-standalone > .neo-tab-header-toolbar,
-    // The detached-proxy pair, mirroring the inline block above. SortZone propagates whatever
-    // non-null `ui` the owner holds, so every variant the themes name needs both self-scoped
-    // forms — an inline-only self-scope would leave a standalone proxy silently ancestor-scoped.
-    &.neo-tab-header-toolbar.neo-tab-container-standalone,
-    .neo-tab-header-toolbar.neo-tab-container-standalone {
-        --tab-button-border-radius : var(--cmp-tab-borderradius);
-        --tab-button-gap           : 0;
-        --tab-button-height        : var(--cmp-tab-height);
-        --tab-button-height-pressed: var(--cmp-tab-height);
-        --tab-button-padding       : 7px var(--cmp-tab-spacinghorizontal) 6px;
-    }
+    --tab-standalone-button-border-radius          : var(--cmp-tab-borderradius);
+    --tab-standalone-button-gap                    : 0;
+    --tab-standalone-button-height                 : var(--cmp-tab-height);
+    --tab-standalone-button-height-pressed         : var(--cmp-tab-height);
+    --tab-standalone-button-padding                : 7px var(--cmp-tab-spacinghorizontal) 6px;
 }

--- a/resources/scss/theme-neo-light/tab/Container.scss
+++ b/resources/scss/theme-neo-light/tab/Container.scss
@@ -16,40 +16,18 @@
 
     // Embedded pane chrome uses the semantic 32px density tier and releases the free-standing
     // radius. The theme's ui:null contract remains the established 48px / 8px treatment.
-    &.neo-tab-container-inline > .neo-tab-header-toolbar,
-    .neo-tab-container-inline > .neo-tab-header-toolbar,
-    // Self-scoped: a drag proxy is a detached toolbar at document.body, so it has no container
-    // ancestor for the two forms above to match. draggable.tab.header.toolbar.SortZone propagates
-    // the owner's ui-derived class onto it, and these two forms are what let the same tokens resolve
-    // there — one source, rather than a value snapshot taken at drag start.
-    //
-    // BOTH are required, and the `&` form is the one that is easy to miss: DragZone#createDragProxy
-    // pushes the resolved theme class onto the PROXY ITSELF, so theme + toolbar + variant all land on
-    // a single element and the descendant form below cannot match it. The descendant form still
-    // carries the case where an ancestor holds the theme.
-    &.neo-tab-header-toolbar.neo-tab-container-inline,
-    .neo-tab-header-toolbar.neo-tab-container-inline {
-        --tab-button-border-radius   : 0;
-        --tab-button-gap             : 0;
-        --tab-button-height          : var(--sem-height-large);
-        --tab-button-height-pressed  : var(--sem-height-large);
-        --tab-button-padding         : 4px var(--sem-spacing-xsmall) 3px;
-        --tab-button-text-font-size  : var(--sem-typo-label-small-fontSize);
-        --tab-button-text-font-weight: var(--sem-typo-label-small-fontWeight);
-    }
+    --tab-inline-button-border-radius              : 0;
+    --tab-inline-button-gap                        : 0;
+    --tab-inline-button-height                     : var(--sem-height-large);
+    --tab-inline-button-height-pressed             : var(--sem-height-large);
+    --tab-inline-button-padding                    : 4px var(--sem-spacing-xsmall) 3px;
+    --tab-inline-button-text-font-size             : var(--sem-typo-label-small-fontSize);
+    --tab-inline-button-text-font-weight           : var(--sem-typo-label-small-fontWeight);
 
     // Standalone explicitly names the theme's existing free-standing treatment.
-    &.neo-tab-container-standalone > .neo-tab-header-toolbar,
-    .neo-tab-container-standalone > .neo-tab-header-toolbar,
-    // The detached-proxy pair, mirroring the inline block above. SortZone propagates whatever
-    // non-null `ui` the owner holds, so every variant the themes name needs both self-scoped
-    // forms — an inline-only self-scope would leave a standalone proxy silently ancestor-scoped.
-    &.neo-tab-header-toolbar.neo-tab-container-standalone,
-    .neo-tab-header-toolbar.neo-tab-container-standalone {
-        --tab-button-border-radius : var(--cmp-tab-borderradius);
-        --tab-button-gap           : 0;
-        --tab-button-height        : var(--cmp-tab-height);
-        --tab-button-height-pressed: var(--cmp-tab-height);
-        --tab-button-padding       : 7px var(--cmp-tab-spacinghorizontal) 6px;
-    }
+    --tab-standalone-button-border-radius          : var(--cmp-tab-borderradius);
+    --tab-standalone-button-gap                    : 0;
+    --tab-standalone-button-height                 : var(--cmp-tab-height);
+    --tab-standalone-button-height-pressed         : var(--cmp-tab-height);
+    --tab-standalone-button-padding                : 7px var(--cmp-tab-spacinghorizontal) 6px;
 }


### PR DESCRIPTION
## Summary

**Batch 1 of the operator's rule**, stated 2026-09-02:

> *"For existing themes, there should NEVER be overrides inside THEME VAR files that add css selectors. Such cases must get added to `scss/src`, and add new vars as needed."*

`tab/Container.scss` is the worked example the ticket nominates: all four themes repeated the **same four-selector list** purely to scope `--tab-button-*` values. A structural rule with a value hole in it, written out four times, where any one copy could drift — which is exactly what #18141 shipped.

## What moved

The selector list now lives once in `resources/scss/src/tab/Container.scss` and reads twelve new variant tokens; each theme declares them flat.

**Eight emitted selector forms collapse to two.** Each theme needed an `&`-prefixed form (theme class *on* the element) beside a descendant form (theme class on an ancestor), doubling the list. With no theme class in the selector, both cases are one selector. The theme scope survives in the **tokens**, which inherit from the nearest `.neo-theme-*` ancestor — which also fixes nested themes, where two theme-prefixed rules could both match one toolbar and source order decided the winner.

**The classic themes now state five inline values they previously inherited.** Omitting them was safe only while the block sat inside the theme's own scope; read from a structural rule, an omission resolves against the *enclosing* theme. That is the #18141 defect verbatim, and it is why every theme declares all twelve rather than only the ones it varies.

## The correction that needed a browser, not an argument

My first version had no `:root` prefix. I had proven analytically that all 48 resolved values were unchanged, and that proof was **sound and irrelevant** — `tab/DragProxyDensity` went red in three themes.

On a drag proxy the theme class lands on the toolbar element **itself** (`DragZone#createDragProxy` copies it onto the proxy), so the theme's root block declares the **base** `--tab-button-*` on the very element the new rule targets:

| | selector | class units |
|---|---|---|
| theme base | `:root .neo-theme-light` | 2 |
| new rule (v1) | `.neo-tab-header-toolbar.neo-tab-container-inline` | **2** — tie, source order, base wins |
| themes previously | `:root .neo-theme-light.neo-tab-header-toolbar.neo-tab-container-inline` | 4 |

Measured, not reasoned: the proxy rendered `padding: 7px 12px 6px` where the inline variant is `7px 8px 6px`. `:root` restores the three units the theme files already carried, and the SCSS says why so the next batch does not rediscover it.

**Worth naming:** my resolved-value comparison compared *declarations* and the defect was in their **cascade**. It could not have caught this, and I would have shipped on it. The spec that caught it only bites where variant ≠ base — `height` matched in both, `padding` did not.

## Acceptance Criteria

| AC | Evidence |
|---|---|
| **AC-1** theme files declare variables only | each of the four is one `:root .neo-theme-*` block, zero nested selectors |
| **AC-2** every token declared in **all** themes | set diff across the four: identical 12 tokens |
| **AC-3** emitted CSS compared per theme, unintended differences zero | **48 resolved values** compared before/after across 4 themes × 2 variants — `ALL RESOLVED VALUES IDENTICAL`, exit 0 |
| **AC-4** the guard | **deliberately not here** — see below |

Intended differences under AC-3, both stated rather than incidental: the eight-to-two selector collapse, and nested-theme resolution moving from source order to nearest-ancestor.

## AC-4 is a separate PR on purpose

The guard needs a baseline of the 22 remaining offenders and is build tooling rather than theme content. Mixing a tooling baseline into a theme refactor makes both harder to review, and the ticket's own ordering puts it after at least one batch lands. Next batch is `grid/Container.scss` + `grid/footer/Toolbar.scss` (6 files, 6 blocks).

## Evidence

- component `tab` + `dashboard`: **125 passed**, 0 failed
- unit: **3052 passed**, 0 failed, 0 skipped
- `check-theme-surfaces`: exit 0 — *parity + token-only + completeness pass*
- theme build: exit 0, no sass errors

*(A note for anyone rebuilding themes: `npm run build-themes` drops into an interactive prompt and dies, while `npm run` still reports exit 0 and leaves a stale `dist/`. `node ./buildScripts/build/themes.mjs -f -n -e esm -t all` is the non-interactive form. My first "build EXIT: 0" was that false green.)*

Refs #18145.

Authored by Grace (Claude Opus 5, Claude Code). Session 8d936ec9-b816-4ded-a91e-6e91ef6a3325.
