### PR TITLE
refactor(grid): the grid selectors leave the theme value files (#18145)

### DIFF
--- a/resources/scss/src/grid/Container.scss
+++ b/resources/scss/src/grid/Container.scss
@@ -2,6 +2,12 @@
     border             : 1px solid var(--grid-container-border-color);
     border-spacing     : 0;
     color              : var(--grid-container-color);
+    // WHICH element carries the UA colour scheme is structural — the grid owns scrollbars, form
+    // controls and the focus ring it inherits from the UA, and that ownership does not change per
+    // theme. Only the VALUE does, so the themes value the token and this rule stays their single
+    // answer to "where". Every theme declares it: an omission would inherit the ENCLOSING theme's
+    // scheme through a nested boundary rather than reset, which is the failure #18141 shipped.
+    color-scheme       : var(--grid-container-color-scheme);
     display            : flex;
     flex-direction     : column;
     font-size          : var(--grid-container-font-size);

--- a/resources/scss/theme-cyberpunk/grid/Container.scss
+++ b/resources/scss/theme-cyberpunk/grid/Container.scss
@@ -5,10 +5,7 @@
     --grid-cell-value-band-1-background-color  : rgba(0, 210, 255, 0.06);
     --grid-cell-value-band-2-background-color  : transparent;
     --grid-container-color                     : var(--cyber-text);
+    --grid-container-color-scheme              : dark;
     --grid-container-font-size                 : 13px;
     --grid-container-header-cell-border-bottom : 1px solid var(--cyber-cyan);
-
-    .neo-grid-container {
-        color-scheme: dark;
-    }
 }

--- a/resources/scss/theme-dark/grid/Container.scss
+++ b/resources/scss/theme-dark/grid/Container.scss
@@ -5,10 +5,7 @@
     --grid-cell-value-band-1-background-color  : #2d3e50;
     --grid-cell-value-band-2-background-color  : #3c3f41;
     --grid-container-color                     : #bbb;
+    --grid-container-color-scheme              : dark;
     --grid-container-font-size                 : 13px;
     --grid-container-header-cell-border-bottom : 2px solid #2b2b2b;
-
-    .neo-grid-container {
-        color-scheme: dark;
-    }
 }

--- a/resources/scss/theme-light/grid/Container.scss
+++ b/resources/scss/theme-light/grid/Container.scss
@@ -5,10 +5,7 @@
     --grid-cell-value-band-1-background-color  : #e6f7ff;
     --grid-cell-value-band-2-background-color  : #fff;
     --grid-container-color                     : #666;
+    --grid-container-color-scheme              : light;
     --grid-container-font-size                 : 13px;
     --grid-container-header-cell-border-bottom : 1px solid #ddd;
-
-    .neo-grid-container {
-        color-scheme: light;
-    }
 }

--- a/resources/scss/theme-neo-dark/grid/Container.scss
+++ b/resources/scss/theme-neo-dark/grid/Container.scss
@@ -5,10 +5,7 @@
     --grid-cell-value-band-1-background-color  : var(--purple-900);
     --grid-cell-value-band-2-background-color  : var(--sem-color-surface-neutral-default);
     --grid-container-color                     : var(--sem-color-text-neutral-default);
+    --grid-container-color-scheme              : dark;
     --grid-container-font-size                 : 13px;
     --grid-container-header-cell-border-bottom : 1px solid var(--purple-800);
-
-    .neo-grid-container {
-        color-scheme: dark;
-    }
 }

--- a/resources/scss/theme-neo-dark/grid/footer/Toolbar.scss
+++ b/resources/scss/theme-neo-dark/grid/footer/Toolbar.scss
@@ -1,7 +1,5 @@
 :root .neo-theme-neo-dark {
-    .neo-grid-footer-toolbar {
-        --grid-footer-toolbar-background-color: var(--purple-900);
-        --grid-footer-toolbar-color           : var(--sem-color-text-neutral-default);;
-        --grid-footer-toolbar-padding         : 4px 10px;
-    }
+    --grid-footer-toolbar-background-color: var(--purple-900);
+    --grid-footer-toolbar-color           : var(--sem-color-text-neutral-default);
+    --grid-footer-toolbar-padding         : 4px 10px;
 }

--- a/resources/scss/theme-neo-light/grid/Container.scss
+++ b/resources/scss/theme-neo-light/grid/Container.scss
@@ -5,10 +5,7 @@
     --grid-cell-value-band-1-background-color  : #e6f7ff;
     --grid-cell-value-band-2-background-color  : #fff;
     --grid-container-color                     : #666;
+    --grid-container-color-scheme              : light;
     --grid-container-font-size                 : 13px;
     --grid-container-header-cell-border-bottom : 1px solid #ddd;
-
-    .neo-grid-container {
-        color-scheme: light;
-    }
 }

--- a/resources/scss/theme-neo-light/grid/footer/Toolbar.scss
+++ b/resources/scss/theme-neo-light/grid/footer/Toolbar.scss
@@ -1,7 +1,5 @@
 :root .neo-theme-neo-light {
-    .neo-grid-footer-toolbar {
-        --grid-footer-toolbar-background-color: #5d83a7;
-        --grid-footer-toolbar-color           : #fff;
-        --grid-footer-toolbar-padding         : 4px 10px;
-    }
+    --grid-footer-toolbar-background-color: #5d83a7;
+    --grid-footer-toolbar-color           : #fff;
+    --grid-footer-toolbar-padding         : 4px 10px;
 }


### PR DESCRIPTION
## Summary

**Batch 2 of #18145.** Seven files, two different shapes — and the second is not what the ticket's block count suggests.

## `grid/Container.scss` — a property, not a token (5 themes)

Each theme wrapped `.neo-grid-container { color-scheme: dark|light }`.

**Which element carries the UA colour scheme is structural and identical in every theme** — the grid owns the scrollbars, form controls and focus ring it inherits from the UA, and that ownership does not change per theme. Only the value does. So the property moves into the existing `.neo-grid-container` rule in `scss/src` and reads a token the themes value flat.

**No new selector was needed.** `src/grid/Container.scss` already owned that rule, so this batch adds one property to it and one token per theme. That is the shape the ticket predicts wherever the structural sheet already exists — and the reason batch 2 is much smaller than batch 1 despite touching more files.

## `grid/footer/Toolbar.scss` — nothing structural was being decided (2 themes)

Two themes wrapped **three tokens** in `.neo-grid-footer-toolbar`. `src/grid/footer/Toolbar.scss` already carries that selector and already reads those exact tokens:

```scss
.neo-grid-footer-toolbar {
    background-color: var(--grid-footer-toolbar-background-color);
    color           : var(--grid-footer-toolbar-color);
    padding         : var(--grid-footer-toolbar-padding);
}
```

So the nested block was **pure scope**. This move introduces no token and relocates no rule — the declarations simply come up to the theme root. The emitted diff is one line:

```diff
- :root .neo-theme-neo-dark .neo-grid-footer-toolbar{--grid-footer-toolbar-…}
+ :root .neo-theme-neo-dark{--grid-footer-toolbar-…}
```

## The batch-1 lesson, applied rather than assumed

Batch 1 shipped a specificity regression I had *proven* couldn't exist, because I compared declared values and the defect was in their cascade. So before claiming this one is safe I swept every other `color-scheme` in the SCSS tree for a declaration that could now out-specify the `src` rule.

Every other hit is a separate **token** already declared flat at theme root — `--list-scrollbar-color-scheme`, `--grid-scrollbar-color-scheme`, `--neo-app-content-page-scrollbar-color-scheme`. Those are the pattern this sweep converges on, not competitors. The `src` rule is the only declaration of the `color-scheme` **property**, so nothing contends with it at any specificity.

## Acceptance Criteria

| AC | Evidence |
|---|---|
| **AC-1** theme files declare variables only | zero selector blocks across all seven |
| **AC-2** every token declared in all themes | all five declare `--grid-container-color-scheme`; footer tokens introduce nothing new — see the gap below |
| **AC-3** emitted CSS compared, unintended differences zero | per theme: the token appears, its selector rule disappears, values byte-identical; footer diff is the selector line alone |

**A pre-existing gap I am naming rather than papering over:** `theme-cyberpunk` and the classic pair declare no `--grid-footer-toolbar-*` at all, so a grid footer in those themes resolves them from whatever theme encloses it — the #18141 class. This batch does not change that behaviour in either direction, and fixing it means inventing three colour values for three themes, which is a design decision and not a refactor. Worth its own ticket; flagged here so it is not read as introduced.

## Evidence

- component `grid`: **11 passed**
- unit: **3052 passed**, 0 failed, 0 skipped
- `check-theme-surfaces`: exit 0
- theme build exit 0, no sass errors, **mtime verified fresh on both the baseline and the after** — see the note below

*(Both builds used `node ./buildScripts/build/themes.mjs -f -n -e esm -t all`. `npm run build-themes` dies on an interactive prompt while still reporting exit 0, leaving `dist/` stale — in batch 1 that produced a "clean" before/after diff of the same nine-hour-old bytes.)*

**Remaining after this batch:** `button/Base.scss`, `tab/header/Button.scss`, `dialog/Base.scss` (6 files, 16 blocks) · `apps/portal/**` (4 files, 8 blocks) · `Global.scss` (5 files, 22 blocks, likely its own ticket). Plus AC-4's guard, still deliberately separate.

Refs #18145.

Authored by Grace (Claude Opus 5, Claude Code). Session 8d936ec9-b816-4ded-a91e-6e91ef6a3325.
