### PR TITLE
refactor(button): the button custom-override block leaves the theme value files (#18145)

### DIFF
--- a/resources/scss/src/button/Base.scss
+++ b/resources/scss/src/button/Base.scss
@@ -22,6 +22,9 @@
     height            : var(--button-height);
     justify-content   : center;
     margin            : var(--button-margin);
+    // A square minimum is a THEME's density decision, but WHICH element gets one is not — it is
+    // every button, in every theme, so the rule belongs here and only its value varies.
+    min-width         : var(--button-min-width);
     padding           : var(--button-padding);
     position          : relative;
     text-decoration   : none; // for url buttons => links
@@ -283,9 +286,15 @@
     }
 
     &.neo-button-tertiary {
-        background-color: var(--button-tertiary-background-color);
-        background-image: var(--button-tertiary-background-image);
-        border          : var(--button-tertiary-border);
+        background-color     : var(--button-tertiary-background-color);
+        background-image     : var(--button-tertiary-background-image);
+        border               : var(--button-tertiary-border);
+        // A tertiary button reads as a link, so whether it is underlined is a theme's call while the
+        // element that carries the underline is not. All three land together: `text-decoration` alone
+        // would leave a theme valuing `underline` with an uncontrolled colour and offset.
+        text-decoration      : var(--button-tertiary-text-decoration);
+        text-decoration-color: var(--button-tertiary-text-decoration-color);
+        text-underline-offset: var(--button-tertiary-text-underline-offset);
 
         .neo-button-badge {
             background-color: var(--button-tertiary-badge-background-color);

--- a/resources/scss/theme-cyberpunk/button/Base.scss
+++ b/resources/scss/theme-cyberpunk/button/Base.scss
@@ -110,4 +110,10 @@
     --button-tertiary-text-color-active         : var(--button-text-color);
     --button-tertiary-text-color-disabled       : inherit;
     --button-tertiary-text-color-hover          : var(--button-text-color);
+
+    // Moved out of a selector block: the rule is structural, only these values are the theme's.
+    --button-min-width                          : auto;
+    --button-tertiary-text-decoration           : none;
+    --button-tertiary-text-decoration-color     : currentColor;
+    --button-tertiary-text-underline-offset     : auto;
 }

--- a/resources/scss/theme-dark/button/Base.scss
+++ b/resources/scss/theme-dark/button/Base.scss
@@ -118,4 +118,10 @@ $text-color      : #bbb;
     --button-tertiary-text-color-active         : var(--button-text-color);
     --button-tertiary-text-color-disabled       : inherit;
     --button-tertiary-text-color-hover          : var(--button-text-color);
+
+    // Moved out of a selector block: the rule is structural, only these values are the theme's.
+    --button-min-width                          : auto;
+    --button-tertiary-text-decoration           : none;
+    --button-tertiary-text-decoration-color     : currentColor;
+    --button-tertiary-text-underline-offset     : auto;
 }

--- a/resources/scss/theme-light/button/Base.scss
+++ b/resources/scss/theme-light/button/Base.scss
@@ -117,4 +117,10 @@ $text-color      : #1c60a0;
     --button-tertiary-text-color-active         : var(--button-text-color);
     --button-tertiary-text-color-disabled       : inherit;
     --button-tertiary-text-color-hover          : var(--button-text-color);
+
+    // Moved out of a selector block: the rule is structural, only these values are the theme's.
+    --button-min-width                          : auto;
+    --button-tertiary-text-decoration           : none;
+    --button-tertiary-text-decoration-color     : currentColor;
+    --button-tertiary-text-underline-offset     : auto;
 }

--- a/resources/scss/theme-neo-dark/button/Base.scss
+++ b/resources/scss/theme-neo-dark/button/Base.scss
@@ -147,15 +147,9 @@
     --button-tertiary-opacity-disabled          : var(--neo-disabled-opacity);
     --button-tertiary-ripple-background-color   : inherit;
 
-
-    // custom overrides
-    .neo-button {
-        min-width: var(--cmp-button-height);
-
-        &.neo-button-tertiary {
-            text-decoration      : underline;
-            text-decoration-color: var(--sem-color-text-primary-default);
-            text-underline-offset: 3px;
-        }
-    }
+    // Moved out of a selector block: the rule is structural, only these values are the theme's.
+    --button-min-width                          : var(--cmp-button-height);
+    --button-tertiary-text-decoration           : underline;
+    --button-tertiary-text-decoration-color     : var(--sem-color-text-primary-default);
+    --button-tertiary-text-underline-offset     : 3px;
 }

--- a/resources/scss/theme-neo-light/button/Base.scss
+++ b/resources/scss/theme-neo-light/button/Base.scss
@@ -147,15 +147,9 @@
     --button-tertiary-opacity-disabled          : var(--neo-disabled-opacity);
     --button-tertiary-ripple-background-color   : inherit;
 
-
-    // custom overrides
-    .neo-button {
-        min-width: var(--cmp-button-height);
-
-        &.neo-button-tertiary {
-            text-decoration      : underline;
-            text-decoration-color: var(--sem-color-text-primary-default);
-            text-underline-offset: 3px;
-        }
-    }
+    // Moved out of a selector block: the rule is structural, only these values are the theme's.
+    --button-min-width                          : var(--cmp-button-height);
+    --button-tertiary-text-decoration           : underline;
+    --button-tertiary-text-decoration-color     : var(--sem-color-text-primary-default);
+    --button-tertiary-text-underline-offset     : 3px;
 }


### PR DESCRIPTION
## Summary

**Batch 3, scoped down** from the ticket's grouping (`button/Base.scss`, `tab/header/Button.scss`, `dialog/Base.scss`) to **`button/Base.scss` alone**. The other two are excluded on measured grounds, and **each exclusion is worth more than the move**.

## What moved

Two neo themes wrapped:

```scss
.neo-button {
    min-width: var(--cmp-button-height);
    &.neo-button-tertiary { text-decoration: underline; text-decoration-color: …; text-underline-offset: 3px; }
}
```

Which elements get a square minimum, and which carry a link-like underline, is structural and identical in every theme — only the values differ. The declarations join the rules `scss/src` already had and read four new tokens.

**The three classic themes now state the property initials they previously got from having no rule at all** — `auto` / `none` / `currentColor` / `auto`. Omitting them was safe only while no rule existed; once a structural rule reads the token, an omission resolves against the **enclosing** theme through a nested boundary instead of resetting. That is #18141, and it is why AC-2 exists.

## Specificity, checked rather than reasoned

Batch 1 shipped a regression I had *proven* impossible by comparing declared values. So this time the check came first:

| | old weight | new weight |
|---|---|---|
| `min-width` | `:root .neo-theme-* .neo-button` (0,3,0) | `.neo-button` (0,1,0) |
| tertiary trio | `:root .neo-theme-* .neo-button.neo-button-tertiary` (0,4,0) | `.neo-button.neo-button-tertiary` (0,2,0) |

Swept every `min-width` and `text-decoration` declaration across `src` and all five themes: **nothing sits between the old and new weights**, so no rule that used to lose now wins.

## Exclusion 1 — `tab/header/Button.scss` carries a **dead rule** in two themes

```scss
.neo-tab-header-button.neo-button {
    .pressed { .neo-button-glyph, .neo-button-text { color: …; } }
}
```

`.pressed` is a **descendant** there. But `src/button/Base.mjs:386` toggles `'pressed'` onto the button's **own** `cls`, and the button's vdom children are glyph / text / badge / ripple-wrapper — none ever receives it. **The selector cannot match, and never has.** `src/tab/header/Button.scss` states the same intent correctly as `&.pressed`.

Porting it faithfully would reproduce a broken selector in a new place. Fixing it while moving would change the paint of pressed tab buttons in two themes — a design change that does not belong inside a refactor. Left in place, filed separately.

This is the ticket's own thesis one notch further: *a theme file that also carries selectors hides an omission among them* — here it hid a rule that was **never live at all**.

## Exclusion 2 — `dialog/Base.scss` cannot move without changing paint

Two neo themes drop the surface and sizing of a dialog header button. A structural rule must sit at `.neo-dialog .neo-header-toolbar .neo-button` — **(0,3,0)** — and the classic themes have no such rule today, so their header buttons resolve `background-color` from `.neo-button` (0,1,0) **except for a ui variant**, where `.neo-button.neo-button-tertiary` (0,2,0) wins. A (0,3,0) rule would override that.

**Not theoretical:** `headerConfig` is a public spread on `dialog.Base`, so a consumer can place ui-variant buttons in a dialog header.

CSS offers no per-declaration opt-out — `revert` rolls back to the UA origin, not to a lower-specificity author rule. So either every theme adopts drop-the-surface (a design decision) or the rule stays theme-scoped. I had it implemented, measured the hazard, and reverted it; **both dialog sheets verified byte-identical** against the pre-change build.

## Acceptance Criteria

| AC | Evidence |
|---|---|
| **AC-1** theme files declare variables only | zero selector blocks across all five button sheets |
| **AC-2** every token declared in all themes | all five declare the identical four, verified by exact-name set count (7-token check incl. the reverted dialog trio ran clean before revert) |
| **AC-3** emitted CSS compared, unintended differences zero | per theme: four tokens appear, two selector rules disappear, values unchanged; dialog byte-identical |

## Evidence

- component `button` + `dialog` + `tab`: **31 passed**
- unit: **3052 passed**, 0 failed, 0 skipped
- theme build exit 0, no sass errors, mtime verified fresh on baseline and after

**Remaining in the sweep:** `tab/header/Button.scss` + `dialog/Base.scss` (blocked as above, each needs a design call) · `apps/portal/**` (4 files, 8 blocks) · `Global.scss` (5 files, 22 blocks). Plus AC-4's guard, still separate — and it will need to baseline the two blocked files rather than treat them as pending.

Refs #18145.

Authored by Grace (Claude Opus 5, Claude Code). Session 8d936ec9-b816-4ded-a91e-6e91ef6a3325.
