### PR TITLE
refactor(portal): the portal selectors leave the theme value files (#18145)

### DIFF
--- a/resources/scss/src/apps/portal/news/pulls/Component.scss
+++ b/resources/scss/src/apps/portal/news/pulls/Component.scss
@@ -5,8 +5,12 @@
 @use "../tickets/Component";
 
 // Structural styles for Portal.view.news.pulls.Component (PR view). Colors live in the
-// theme-neo-light / theme-neo-dark counterparts, scoped to this component so the PR-specific
-// MERGED/CLOSED + review-state palette never collides with the tickets view's globals.
+// theme-neo-light / theme-neo-dark counterparts as FLAT `--portal-pr-*` tokens. The collision the
+// old theme-side selector scoping was guarding against — this view's MERGED/CLOSED semantics
+// redefining the tickets view's state vars — is now prevented by the token NAMES instead: a
+// component-specific name cannot collide the way a shared `--state-*` var could, and unlike a
+// selector scope it survives being read from here. WHICH badge is a state badge is structural;
+// only its palette is the theme's.
 .portal-news-pulls-component {
     .neo-ticket-labels {
         display      : flex;
@@ -17,6 +21,9 @@
 
     .neo-badge {
         align-items  : center;
+        background-color: var(--portal-pr-badge-background-color);
+        border          : var(--portal-pr-badge-border);
+        color           : var(--portal-pr-badge-color);
         border-radius: 2em;
         display      : inline-flex;
         font-size    : 12px;
@@ -25,13 +32,27 @@
         padding      : 0 10px;
 
         &.neo-state-badge {
+            color  : var(--portal-pr-state-badge-color);
             gap    : 6px;
             padding: 2px 10px 2px 8px;
+
+            &.neo-state-open   { background-color: var(--portal-pr-state-open-background-color); }
+            &.neo-state-merged { background-color: var(--portal-pr-state-merged-background-color); }
+            &.neo-state-closed { background-color: var(--portal-pr-state-closed-background-color); }
         }
 
         &.neo-review-state {
+            color         : var(--portal-pr-review-state-color);
             margin-right  : 6px;
             text-transform: none;
+
+            &.neo-review-approved { background-color: var(--portal-pr-review-approved-background-color); }
+            &.neo-review-changes  { background-color: var(--portal-pr-review-changes-background-color); }
+
+            &.neo-review-neutral {
+                background-color: var(--portal-pr-review-neutral-background-color);
+                color           : var(--portal-pr-review-neutral-color);
+            }
         }
     }
 

--- a/resources/scss/theme-neo-dark/apps/portal/home/FooterContainer.scss
+++ b/resources/scss/theme-neo-dark/apps/portal/home/FooterContainer.scss
@@ -1,8 +1,6 @@
 :root .neo-theme-neo-dark {
-    .portal-home-footer-container {
-        --portal-footer-background-color: var(--sem-color-bg-neutral-default);
-        --portal-footer-text-color: var(--sem-color-text-neutral-default);
-        --portal-footer-button-hover-background-color: var(--sem-color-bg-hover);
-        --portal-footer-highlight-color: var(--portal-headline-primary);
-    }
+    --portal-footer-background-color: var(--sem-color-bg-neutral-default);
+    --portal-footer-text-color: var(--sem-color-text-neutral-default);
+    --portal-footer-button-hover-background-color: var(--sem-color-bg-hover);
+    --portal-footer-highlight-color: var(--portal-headline-primary);
 }

--- a/resources/scss/theme-neo-dark/apps/portal/news/pulls/Component.scss
+++ b/resources/scss/theme-neo-dark/apps/portal/news/pulls/Component.scss
@@ -1,27 +1,20 @@
-// Dark-theme palette for Portal.view.news.pulls.Component (PR view). Scoped to the component so
-// the PR MERGED/CLOSED semantics (purple/red) do not redefine the tickets view's state vars.
-// The shared `--gh-*` palette comes from the base `Portal.view.content.Component` theme via the
-// proto-chain, so no cross-module `@use` is needed here.
-.neo-theme-neo-dark .portal-news-pulls-component {
-    .neo-badge {
-        background-color: #21262d;
-        border          : 1px solid rgba(255, 255, 255, 0.1);
-        color           : #c9d1d9;
+// Dark-theme palette for Portal.view.news.pulls.Component (PR view). The PR MERGED/CLOSED
+// semantics (purple/red) stay distinct from the tickets view's state vars through the `--portal-pr-*`
+// token NAMES rather than through selector scoping — a name cannot collide the way a shared
+// `--state-*` var could, and it survives being read from a structural rule.
+:root .neo-theme-neo-dark {
+    --portal-pr-badge-background-color          : #21262d;
+    --portal-pr-badge-border                    : 1px solid rgba(255, 255, 255, 0.1);
+    --portal-pr-badge-color                     : #c9d1d9;
 
-        &.neo-state-badge {
-            color: #ffffff;
+    --portal-pr-state-badge-color               : #ffffff;
+    --portal-pr-state-open-background-color     : #3fb950;   // green
+    --portal-pr-state-merged-background-color   : #a371f7;   // purple
+    --portal-pr-state-closed-background-color   : #f85149;   // red
 
-            &.neo-state-open   { background-color: #3fb950; } // green
-            &.neo-state-merged { background-color: #a371f7; } // purple
-            &.neo-state-closed { background-color: #f85149; } // red
-        }
-
-        &.neo-review-state {
-            color: #ffffff;
-
-            &.neo-review-approved { background-color: #3fb950; } // green
-            &.neo-review-changes  { background-color: #f85149; } // red
-            &.neo-review-neutral  { background-color: #21262d; color: #c9d1d9; }
-        }
-    }
+    --portal-pr-review-state-color              : #ffffff;
+    --portal-pr-review-approved-background-color: #3fb950;   // green
+    --portal-pr-review-changes-background-color : #f85149;   // red
+    --portal-pr-review-neutral-background-color : #21262d;
+    --portal-pr-review-neutral-color            : #c9d1d9;
 }

--- a/resources/scss/theme-neo-light/apps/portal/home/FooterContainer.scss
+++ b/resources/scss/theme-neo-light/apps/portal/home/FooterContainer.scss
@@ -1,8 +1,6 @@
 :root .neo-theme-neo-light {
-    .portal-home-footer-container {
-        --portal-footer-background-color: var(--sem-color-bg-neutral-strong);
-        --portal-footer-text-color: var(--sem-color-text-neutral-default);
-        --portal-footer-button-hover-background-color: rgba(0, 0, 0, 0.05);
-        --portal-footer-highlight-color: var(--portal-headline-primary);
-    }
+    --portal-footer-background-color: var(--sem-color-bg-neutral-strong);
+    --portal-footer-text-color: var(--sem-color-text-neutral-default);
+    --portal-footer-button-hover-background-color: rgba(0, 0, 0, 0.05);
+    --portal-footer-highlight-color: var(--portal-headline-primary);
 }

--- a/resources/scss/theme-neo-light/apps/portal/news/pulls/Component.scss
+++ b/resources/scss/theme-neo-light/apps/portal/news/pulls/Component.scss
@@ -1,27 +1,20 @@
-// Light-theme palette for Portal.view.news.pulls.Component (PR view). Scoped to the component so
-// the PR MERGED/CLOSED semantics (purple/red) do not redefine the tickets view's state vars.
-// The shared `--gh-*` palette comes from the base `Portal.view.content.Component` theme via the
-// proto-chain, so no cross-module `@use` is needed here.
-.neo-theme-neo-light .portal-news-pulls-component {
-    .neo-badge {
-        background-color: #eff1f3;
-        border          : 1px solid rgba(0, 0, 0, 0.1);
-        color           : #24292f;
+// Light-theme palette for Portal.view.news.pulls.Component (PR view). The PR MERGED/CLOSED
+// semantics (purple/red) stay distinct from the tickets view's state vars through the `--portal-pr-*`
+// token NAMES rather than through selector scoping — a name cannot collide the way a shared
+// `--state-*` var could, and it survives being read from a structural rule.
+:root .neo-theme-neo-light {
+    --portal-pr-badge-background-color          : #eff1f3;
+    --portal-pr-badge-border                    : 1px solid rgba(0, 0, 0, 0.1);
+    --portal-pr-badge-color                     : #24292f;
 
-        &.neo-state-badge {
-            color: #ffffff;
+    --portal-pr-state-badge-color               : #ffffff;
+    --portal-pr-state-open-background-color     : #2da44e;   // green
+    --portal-pr-state-merged-background-color   : #8250df;   // purple
+    --portal-pr-state-closed-background-color   : #cf222e;   // red
 
-            &.neo-state-open   { background-color: #2da44e; } // green
-            &.neo-state-merged { background-color: #8250df; } // purple
-            &.neo-state-closed { background-color: #cf222e; } // red
-        }
-
-        &.neo-review-state {
-            color: #ffffff;
-
-            &.neo-review-approved { background-color: #2da44e; } // green
-            &.neo-review-changes  { background-color: #cf222e; } // red
-            &.neo-review-neutral  { background-color: #eff1f3; color: #24292f; }
-        }
-    }
+    --portal-pr-review-state-color              : #ffffff;
+    --portal-pr-review-approved-background-color: #2da44e;   // green
+    --portal-pr-review-changes-background-color : #cf222e;   // red
+    --portal-pr-review-neutral-background-color : #eff1f3;
+    --portal-pr-review-neutral-color            : #24292f;
 }


### PR DESCRIPTION
refactor(portal): the portal selectors leave the theme value files (#18145)

Batch 4. Four files, two shapes, and the second one had a rationale in its own comment that the
move improves rather than discards.

home/FooterContainer.scss - two themes wrapped four tokens in `.portal-home-footer-container`.
Nothing structural: scss/src already carries that selector and every consumer of those tokens sits
inside it. Pure scope, so the declarations simply come up to the theme root and the emitted diff is
one line. Same shape as batch 2's grid footer toolbar.

news/pulls/Component.scss - two themes carried the entire PR badge palette as hardcoded colours
inside `.neo-theme-* .portal-news-pulls-component`, with a comment explaining WHY it was scoped:

    Scoped to the component so the PR MERGED/CLOSED semantics (purple/red) do not redefine the
    tickets view's state vars.

That rationale is real, and the move satisfies it BETTER than the scoping did. The collision it
guards against is prevented by the token NAMES - `--portal-pr-*` is component-specific, so it cannot
collide the way a shared `--state-*` var could, and unlike a selector scope a name survives being
read from a structural rule. src grows the state and review sub-selectors it was already shaped for;
both themes declare twelve flat tokens carrying the identical palette.

The structural sheet's comment is rewritten rather than deleted: the next reader needs to know the
collision concern still holds and what now answers it.

SPECIFICITY, checked before writing rather than after - the batch-1 lesson. The badge rules drop from
(0,3,0) to (0,2,0), and the state rules from (0,5,0) to (0,4,0). Swept for any `.neo-badge`
declaration anywhere outside the portal that could now win: there are none, in src or in any theme,
so nothing sits between the old and new weights.

AC-1 zero selector blocks remain in all four portal theme files.
AC-2 both themes declare the identical sixteen tokens, verified by set diff.
AC-3 24 resolved badge values compared per theme and selector, before against after: zero
     differences. Footer diff is the selector line alone.

PRE-EXISTING GAP, named not introduced: apps/portal declares four themes and only the two neo ones
carry these sheets, so the classic pair resolves the palette from whatever theme encloses them. That
is the #18141 class and it is unchanged in either direction here - today a classic portal gets no
theme rule and after the move it gets an undeclared token, both of which compute to the property
initial. Fixing it means authoring a light and dark PR palette, which is design, not refactor.

Evidence: unit 3052 passed 0 failed, check-theme-surfaces exit 0, theme build exit 0 with no sass
errors and a verified-fresh mtime on baseline and after. The portal has no component-tier suite.

Refs #18145.

---

**AC-3 detail:** 24 resolved badge values compared per theme and selector — `ALL IDENTICAL, 0 differences`, exit 0.

Evidence: unit **3052 passed**, portal unit **35 passed**, `check-theme-surfaces` exit 0.

Refs #18145.

Authored by Grace (Claude Opus 5, Claude Code). Session 8d936ec9-b816-4ded-a91e-6e91ef6a3325.