### PR TITLE
fix(drag): the hold-to-drop timer restarts when the drop zone changes (#18173)

### DIFF
--- a/src/manager/DragCoordinator.mjs
+++ b/src/manager/DragCoordinator.mjs
@@ -1103,8 +1103,11 @@ class DragCoordinator extends Manager {
      * renders its own affordances through `onRemoteDragMove` on EVERY position update — per
      * frame, not only after the dwell timer — while the dwell/settle contract keeps gating the
      * COMMIT. Target switches and hover loss end the previous target's preview exact-once.
+     * Returns the target's resolved preview so the caller can tell WHICH drop this frame landed on.
+     * A sort zone is one object per window, so it cannot answer that — see `onWindowPositionChange`.
      * @param {String} windowId The MOVING popup's window id.
      * @param {Object|null} candidate The current drop candidate, or null when nothing claims.
+     * @returns {Object|null} The owner-computed preview, or null when no target claims the drag.
      */
     updateNativeHover(windowId, candidate) {
         let me       = this,
@@ -1118,7 +1121,7 @@ class DragCoordinator extends Manager {
         if (next) {
             me.nativeHoverTargets.set(windowId, next);
 
-            next.onRemoteDragMove({
+            return next.onRemoteDragMove({
                 draggedItem: candidate.draggedItem,
                 // The hold is the gesture: the target receives the dwell clock the commit below is
                 // scheduled from — same start, same duration — so it can paint the hold running out.
@@ -1137,9 +1140,11 @@ class DragCoordinator extends Manager {
                 proxyRect     : candidate.proxyRect,
                 sourceSortZone: candidate.sourceSortZone
             })
-        } else {
-            me.nativeHoverTargets.delete(windowId)
         }
+
+        me.nativeHoverTargets.delete(windowId);
+
+        return null
     }
 
     /**
@@ -1157,7 +1162,7 @@ class DragCoordinator extends Manager {
         let me         = this,
             {windowId} = data,
             current    = me.nativeWindowDropCandidates.get(windowId),
-            sourceDrag, candidate, dwellRemaining, firstSeenAt, delay, now;
+            sourceDrag, candidate, dwellRemaining, firstSeenAt, delay, now, preview, previewId;
 
         // Parking, embodiment, target settlement, and strict source retry can all publish geometry
         // of their own. Their retained generation owns the terminal; never reinterpret those
@@ -1198,7 +1203,32 @@ class DragCoordinator extends Manager {
         // from the same start the commit below is scheduled from.
         candidate.firstSeenAt = firstSeenAt;
 
-        me.updateNativeHover(windowId, candidate);
+        preview = me.updateNativeHover(windowId, candidate);
+
+        // A sort zone is ONE object per window, so the carry-over above cannot see the user moving
+        // between zones INSIDE a window — every split child, edge band and tab strip shares it. A
+        // main window always has a valid drop area, so the clock armed on entry and never restarted,
+        // and the commit fired on whichever zone happened to resolve first while the user was still
+        // choosing. The resolved preview is the identity that actually changes: `previewId` carries
+        // node AND placement kind, so a tab-into → split-left switch over one node re-arms too,
+        // because it is a different drop.
+        previewId = preview?.previewId ?? null;
+
+        // A frame that resolves NO preview is a momentary gap, not a new zone: re-arming there would
+        // restart a hold the user is legitimately completing.
+        if (previewId && current && previewId !== current.dropPreviewId && firstSeenAt !== now) {
+            firstSeenAt = candidate.firstSeenAt = now;
+
+            // Re-sent, not merely rescheduled: the target paints the ring from `armedAt`, so leaving
+            // the stale clock in place would drain a ring whose commit has just been pushed out.
+            me.updateNativeHover(windowId, candidate)
+        }
+
+        // The last zone that actually RESOLVED, carried across gaps. Storing the gap itself would
+        // erase that memory and make the next resolving frame look like a change — re-arming a hold
+        // the user never left.
+        candidate.dropPreviewId = previewId ?? current?.dropPreviewId ?? null;
+
         me.clearNativeWindowDropCandidate(windowId);
 
         dwellRemaining = Math.max(0, me.nativeWindowDropDwellMs - (now - firstSeenAt));

--- a/test/playwright/unit/manager/DragCoordinator.spec.mjs
+++ b/test/playwright/unit/manager/DragCoordinator.spec.mjs
@@ -724,6 +724,117 @@ test.describe('Neo.manager.DragCoordinator — the §2.8.1 claim protocol', () =
         }
     });
 
+    test.describe('#18173 the hold restarts when the drop zone changes', () => {
+        /**
+         * Drives native geometry frames against ONE window whose target returns a controllable
+         * preview. A real clock cannot express this: consecutive frames land in the same
+         * millisecond, so a re-arm would be indistinguishable from a carry-over.
+         * @param {String[]} previewIds One per frame; null means the frame resolved no preview.
+         * @returns {{payloads: Object[], delays: Number[]}}
+         */
+        const runFrames = previewIds => {
+            const
+                draggedItem = {id: 'tab-1'},
+                payloads    = [],
+                delays      = [],
+                originalNow = Date.now,
+                originalST  = globalThis.setTimeout;
+
+            let clock = 10_000,
+                frame = 0;
+
+            const target = {
+                ...createZone('workspace-main', 'win-main'),
+                onRemoteDragMove(payload) {
+                    payloads.push(payload);
+                    // The frame index advances per COORDINATOR frame, not per call: a re-arm re-sends
+                    // the hover, and both sends belong to the same frame and the same resolved zone.
+                    const id = previewIds[Math.min(frame, previewIds.length - 1)];
+                    return id ? {previewId: id} : null
+                }
+            };
+
+            const source = {
+                ...createSource(),
+                windowId           : 'win-popup',
+                getNativeWindowDrag: windowId => windowId === 'win-popup'
+                    ? {draggedItem, embodyNativeHover: true, widgetName: 'tab-1'}
+                    : null
+            };
+
+            registerWindow('win-main',  0,   0,   800, 600);
+            registerWindow('win-popup', 100, 100, 300, 200);
+
+            DragCoordinator.register(target);
+            DragCoordinator.register(source);
+
+            Date.now = () => clock;
+            globalThis.setTimeout = (fn, delay) => { delays.push(delay); return 0 };
+
+            try {
+                for (frame = 0; frame < previewIds.length; frame++) {
+                    DragCoordinator.onWindowPositionChange({windowId: 'win-popup'});
+                    clock += 300   // the user travels; well inside the 1200ms hold
+                }
+            } finally {
+                Date.now              = originalNow;
+                globalThis.setTimeout = originalST;
+                DragCoordinator.clearNativeWindowDropCandidate('win-popup');
+                DragCoordinator.endNativeGesture?.('win-popup')
+            }
+
+            return {delays, payloads}
+        };
+
+        test('AC-1/AC-2 a NEW zone restarts the hold — the commit is pushed out by the full duration', () => {
+            const {delays, payloads} = runFrames(['preview:tab-1:node-a:tab-into', 'preview:tab-1:node-b:split-left']);
+
+            // Frame 2 resolves a different zone 300ms in. Without the re-arm the commit stays
+            // scheduled 300ms earlier and fires while the user is still choosing — the operator's
+            // report: a main window always has a valid drop area, so the clock never restarted.
+            expect(delays.at(-1), 'the hold starts over, it does not run down')
+                .toBe(DragCoordinator.nativeWindowDropDwellMs);
+
+            // AC-5: the target paints from the same start the commit was scheduled from, so the ring
+            // does not drain against a timer that has just been pushed out.
+            expect(payloads.at(-1).dwell.armedAt).toBe(10_300);
+            expect(payloads.at(-1).dwell.armedAt).toBeGreaterThan(payloads[0].dwell.armedAt)
+        });
+
+        test('AC-3 a PLACEMENT change over one node restarts it too — that is a different drop', () => {
+            const {delays} = runFrames(['preview:tab-1:node-a:tab-into', 'preview:tab-1:node-a:split-left']);
+
+            // Same node, different placement. `previewId` carries both, which is why keying on a
+            // node id alone would miss this one.
+            expect(delays.at(-1)).toBe(DragCoordinator.nativeWindowDropDwellMs)
+        });
+
+        test('AC-4 holding STILL keeps one clock — the hold is completable', () => {
+            const {delays, payloads} = runFrames(Array(3).fill('preview:tab-1:node-a:tab-into'));
+
+            // 600ms elapsed over three frames on one zone, so the remaining hold has shrunk by that
+            // much. A re-arm here would make the gesture impossible to finish.
+            expect(delays.at(-1)).toBe(DragCoordinator.nativeWindowDropDwellMs - 600);
+            expect(payloads.at(-1).dwell.armedAt, 'one start, all three frames').toBe(payloads[0].dwell.armedAt)
+        });
+
+        test('AC-6 a frame resolving NO preview is a gap, not a new zone', () => {
+            const {delays} = runFrames(['preview:tab-1:node-a:tab-into', null, 'preview:tab-1:node-a:tab-into']);
+
+            // The middle frame resolves nothing while the sort zone still accepts the drag. Treating
+            // that as a change would restart a hold the user is legitimately completing.
+            expect(delays.at(-1)).toBe(DragCoordinator.nativeWindowDropDwellMs - 600)
+        });
+
+        test('the hover frame is re-sent on a re-arm, and NOT re-sent otherwise', () => {
+            expect(runFrames(['preview:tab-1:node-a:tab-into', 'preview:tab-1:node-b:tab-into']).payloads,
+                'a zone change repaints the ring from its new start').toHaveLength(3);
+
+            expect(runFrames(['preview:tab-1:node-a:tab-into', 'preview:tab-1:node-a:tab-into']).payloads,
+                'a steady hold costs exactly one frame each').toHaveLength(2)
+        })
+    });
+
     test('THE OVERLAP FALSIFIER holds when the clock moves mid-pass — the winner is not the loop order', () => {
         const source = createSource();
 

--- a/test/playwright/unit/manager/DragCoordinator.spec.mjs
+++ b/test/playwright/unit/manager/DragCoordinator.spec.mjs
@@ -734,11 +734,23 @@ test.describe('Neo.manager.DragCoordinator — the §2.8.1 claim protocol', () =
          */
         const runFrames = previewIds => {
             const
-                draggedItem = {id: 'tab-1'},
-                payloads    = [],
-                delays      = [],
-                originalNow = Date.now,
-                originalST  = globalThis.setTimeout;
+                draggedItem   = {id: 'tab-1'},
+                payloads      = [],
+                delays        = [],
+                originalNow   = Date.now,
+                originalST    = globalThis.setTimeout,
+                originalDwell = DragCoordinator.nativeWindowDropDwellMs,
+                // PINNED, never read from the live config. `DragCoordinator` is a singleton shared
+                // across spec FILES in one worker, and `draggable/dashboard/SortZone.spec.mjs`
+                // leaves `nativeWindowDropDwellMs` at 450 in its own afterEach. An expectation
+                // derived from the ambient value therefore passes when this file runs alone and
+                // fails in a full run — which is exactly what it did, and why it reproduced for
+                // nobody who ran the spec on its own.
+                //
+                // The arithmetic also has to stay clear of `nativeWindowDropSettleMs` (250): the
+                // scheduled delay is `Math.max(settle, remaining)`, so at 450 the third frame's
+                // remainder went NEGATIVE and the floor answered instead of the hold.
+                DWELL_MS      = 1200;
 
             let clock = 10_000,
                 frame = 0;
@@ -770,6 +782,7 @@ test.describe('Neo.manager.DragCoordinator — the §2.8.1 claim protocol', () =
 
             Date.now = () => clock;
             globalThis.setTimeout = (fn, delay) => { delays.push(delay); return 0 };
+            DragCoordinator.nativeWindowDropDwellMs = DWELL_MS;
 
             try {
                 for (frame = 0; frame < previewIds.length; frame++) {
@@ -777,8 +790,9 @@ test.describe('Neo.manager.DragCoordinator — the §2.8.1 claim protocol', () =
                     clock += 300   // the user travels; well inside the 1200ms hold
                 }
             } finally {
-                Date.now              = originalNow;
-                globalThis.setTimeout = originalST;
+                Date.now                                = originalNow;
+                globalThis.setTimeout                   = originalST;
+                DragCoordinator.nativeWindowDropDwellMs = originalDwell;
                 DragCoordinator.clearNativeWindowDropCandidate('win-popup');
                 DragCoordinator.endNativeGesture?.('win-popup')
             }
@@ -792,8 +806,7 @@ test.describe('Neo.manager.DragCoordinator — the §2.8.1 claim protocol', () =
             // Frame 2 resolves a different zone 300ms in. Without the re-arm the commit stays
             // scheduled 300ms earlier and fires while the user is still choosing — the operator's
             // report: a main window always has a valid drop area, so the clock never restarted.
-            expect(delays.at(-1), 'the hold starts over, it does not run down')
-                .toBe(DragCoordinator.nativeWindowDropDwellMs);
+            expect(delays.at(-1), 'the hold starts over, it does not run down').toBe(1200);
 
             // AC-5: the target paints from the same start the commit was scheduled from, so the ring
             // does not drain against a timer that has just been pushed out.
@@ -806,7 +819,7 @@ test.describe('Neo.manager.DragCoordinator — the §2.8.1 claim protocol', () =
 
             // Same node, different placement. `previewId` carries both, which is why keying on a
             // node id alone would miss this one.
-            expect(delays.at(-1)).toBe(DragCoordinator.nativeWindowDropDwellMs)
+            expect(delays.at(-1)).toBe(1200)
         });
 
         test('AC-4 holding STILL keeps one clock — the hold is completable', () => {
@@ -814,7 +827,9 @@ test.describe('Neo.manager.DragCoordinator — the §2.8.1 claim protocol', () =
 
             // 600ms elapsed over three frames on one zone, so the remaining hold has shrunk by that
             // much. A re-arm here would make the gesture impossible to finish.
-            expect(delays.at(-1)).toBe(DragCoordinator.nativeWindowDropDwellMs - 600);
+            // 600 elapsed, 600 remain — comfortably above the 250ms settle floor, so this asserts
+            // the remaining hold rather than the floor.
+            expect(delays.at(-1)).toBe(600);
             expect(payloads.at(-1).dwell.armedAt, 'one start, all three frames').toBe(payloads[0].dwell.armedAt)
         });
 
@@ -823,7 +838,7 @@ test.describe('Neo.manager.DragCoordinator — the §2.8.1 claim protocol', () =
 
             // The middle frame resolves nothing while the sort zone still accepts the drag. Treating
             // that as a change would restart a hold the user is legitimately completing.
-            expect(delays.at(-1)).toBe(DragCoordinator.nativeWindowDropDwellMs - 600)
+            expect(delays.at(-1)).toBe(600)
         });
 
         test('the hover frame is re-sent on a re-arm, and NOT re-sent otherwise', () => {


### PR DESCRIPTION
## Summary

Operator report from a live customer demo:

> dragging a popup triggers the 1.2s re-integration timer. This one does NOT yet reset, as soon as the drop zone changes… dragging over a main window always has a valid drop area, and then users have to fight the initial timer.

## The defect

`onWindowPositionChange` carried the dwell clock forward whenever the sort zone and the dragged item were unchanged:

```js
firstSeenAt = current?.targetSortZone === candidate.targetSortZone &&
    current?.draggedItem === candidate.draggedItem
        ? current.firstSeenAt
        : now;
```

**A sort zone is one object per window, not a drop zone.** Every split child, edge band and tab strip inside a main window shares it, so this only re-armed when the popup crossed into a *different window*.

The consequence is exactly the report: a main window always has a valid drop area, so the clock armed the moment the popup entered and never restarted. By the time the user reached the zone they wanted, the 1200 ms was spent and the commit fired on whichever zone happened to resolve first. **Worst in a rich layout with many zones — the demo case.**

## The fix

The resolved **preview** is the identity that actually changes.

`DragTarget#onRemoteDragMove` already returns the owner-computed preview and the coordinator discarded it. `updateNativeHover` now returns it, and its `previewId` — `preview:<subject>:<node>:<kind>` — keys the dwell.

Because that id carries the **placement kind** as well as the node, a `tab-into` → `split-left` switch over one node re-arms too. Keying on a node id alone would miss it, and it is a different drop.

**A re-arm re-sends the hover frame**, it does not merely reschedule. The target paints the ring from `armedAt`, so leaving the stale clock in place would drain a ring whose commit has just been pushed out. The re-send fires only on an actual zone change, never per frame — asserted in both directions.

## The bug my own arm caught before it shipped

A frame that resolves **no** preview is a gap, not a new zone. My first version stored that gap as the candidate's zone id — which erased the memory of the last real zone, so the next resolving frame looked like a change and **re-armed a hold the user had never left**.

`AC-6` was written before the code and went red on it. The candidate now remembers the last zone it actually resolved:

```js
candidate.dropPreviewId = previewId ?? current?.dropPreviewId ?? null;
```

## Red-first control

Restored `DragCoordinator.mjs` to the merge base and re-ran the new arms:

```
3 failed, 2 passed
```

The two that pass at the baseline are supposed to: **AC-4** (a steady hold keeps one clock) and **AC-6** (a gap is not a change) are the unchanged-behaviour controls, so passing before *and* after is what "unregressed" means. The three failures are the defect witnesses.

## Acceptance Criteria

| AC | Evidence |
|---|---|
| **AC-1** a new zone re-arms; commit pushed out by the full duration | `delays.at(-1) === 1200` after a zone change 300 ms in |
| **AC-2** red-first | the same arm fails at the merge base |
| **AC-3** a placement change over one node re-arms | `tab-into` → `split-left`, same node |
| **AC-4** holding still does **not** re-arm | 3 frames on one zone → `1200 - 600`; one `armedAt` throughout |
| **AC-5** painted hold agrees with the rescheduled commit | `payloads.at(-1).dwell.armedAt === 10_300`, the value the timeout was computed from |
| **AC-6** a null-preview frame does not re-arm | gap frame between two identical zones → `1200 - 600` |
| **AC-7** crossing windows still re-arms | unchanged path; existing arms green |
| **AC-8** exact-head suites green | below |

## A note on the test's clock

The spec stubs `Date.now`. A real clock cannot express this: consecutive frames land in the same millisecond, so a re-arm would be **indistinguishable from a carry-over** — the arm would pass either way. It also stubs `setTimeout` to read the scheduled delay directly rather than waiting 1.2 s, so the assertion is on the schedule rather than on elapsed wall time.

## Evidence

- `manager/DragCoordinator`: **54 passed**
- unit: **3077 passed**, 0 failed, 0 skipped
- component `dashboard`: **107 passed**

Resolves #18173. Refs #18115, #18151.

Authored by Grace (Claude Opus 5, Claude Code). Session 8d936ec9-b816-4ded-a91e-6e91ef6a3325.
