### PR TITLE
fix(dock): restoreTab declares its change class, so dev goes green

### DIFF
--- a/src/dashboard/dock/model/Operations.mjs
+++ b/src/dashboard/dock/model/Operations.mjs
@@ -100,8 +100,12 @@ class Operations extends Base {
         // placement-neutral, which is what lets it keep the item-only path.
         setItemPinned    : 'topology',
         setItemAutoHidden: 'topology',
-        transferItem     : 'topology',
-        transferNode     : 'topology'
+        // Structural on BOTH branches, which is why the name alone does not settle it: it delegates
+        // to `addTab` when the home node survives, and otherwise mints a node outright
+        // (`doc.nodes[nodeId] = {type: 'tabs', …}`, id-collision-safe via `Document.genId`).
+        restoreTab  : 'topology',
+        transferItem: 'topology',
+        transferNode: 'topology'
     })
 
     /**

--- a/test/playwright/unit/dashboard/DockOperationChangeClass.spec.mjs
+++ b/test/playwright/unit/dashboard/DockOperationChangeClass.spec.mjs
@@ -79,7 +79,11 @@ test.describe('Neo.dashboard.dock.model.Operations — the change-class beside t
             expect(Operations.changeClassFor(op), `${op} moves a boundary`).toBe('geometry')
         }
 
-        for (const op of ['addTab', 'moveItem', 'splitNode', 'moveNode', 'closeItem', 'detachItem']) {
+        // `restoreTab` is structural on BOTH branches — it delegates to `addTab` when the home node
+        // survives and mints a node when it does not — so the class holds however the restore lands.
+        // AC-3: it already fell through to the `topology` default, so declaring it changes no
+        // behaviour; the arm exists so the map cannot drift from dispatch again.
+        for (const op of ['addTab', 'moveItem', 'splitNode', 'moveNode', 'closeItem', 'detachItem', 'restoreTab']) {
             expect(Operations.changeClassFor(op), `${op} may restructure`).toBe('topology')
         }
     });


### PR DESCRIPTION
Resolves #18175

`dev` is red on the `unit` job, which blocks every open PR. First seen on #18174, unrelated to the cause.

The failing arm is the completeness guard from #18152 and **it is working as designed**:

```
DockOperationChangeClass.spec.mjs:47
  every operation in the dispatch table carries a change class
  + Array [ "restoreTab" ]
```

`restoreTab` landed in `operationHandlers` via #18164 / PR #18165 (`5e67e5e486`) while `operationChangeClass` predates it. The arm's own comment states the contract it just enforced: *a new operation added to dispatch without a class fails here rather than silently degrading.*

Evidence: L2 (unit) → L2 sufficient; the defect is a map that drifted from its sibling. Residual: none.

## AC Evidence

| AC | Evidence |
|---|---|
| AC-1 — `changeClassFor('restoreTab')` is `topology`, completeness green both ways | the arm, extended to name `restoreTab` in the structural set |
| AC-2 — the unit job is green on current `dev` | full unit **3080 passed** locally; CI on this PR is the check that matters |
| AC-3 — no behaviour change | an undeclared operation already fell through to `topology`, so `getRefreshOptions` returned `{}` before and returns `{}` now |

## Why `topology`, verified rather than assumed

The name suggests an `addTab` sibling, and on one branch it is — `restoreTab` delegates to `addTab` when the home node still exists. On the other it **mints a node**: `doc.nodes[nodeId] = {activeItemId: itemId, items: [itemId], type: 'tabs'}`, id-collision-safe via `Document.genId`. Creating a node is structural, so the class holds however the restore lands — which is the part a name-based guess would have got right by luck rather than by reading.

## Deltas

- **The arm was not weakened to unblock CI.** It is the only thing keeping the two maps in step, and relaxing it would trade a red build for a silent drift — the precise failure it exists to prevent.
- **Not merging the class into `operationHandlers`.** Making the maps structurally inseparable is a real design question (the dispatch table's shape and every reader of it), and not one to answer while `dev` is red. Recorded in the ticket's Out of Scope.

## Commits

- `0a7af10d9f` — restoreTab declares its change class.

Authored by Ada (Claude Opus 5, Claude Code). Session 7596538d-5324-419a-b043-95c585d833ea.