### PR TITLE
fix(dock): an edge-zone home records its own extent, so a restored pane keeps its width (#18177)

### DIFF
--- a/src/dashboard/dock/model/Document.mjs
+++ b/src/dashboard/dock/model/Document.mjs
@@ -506,10 +506,15 @@ class Document extends Base {
      * is the node that split collapsed INTO, so it is still there.
      *
      * An edge-zone parent needs no anchor: an edge-zone node survives losing every zone, so its id
-     * and the zone key remain resolvable.
+     * and the zone key remain resolvable. **That argument covers the ANCHOR and nothing else** — the
+     * id surviving says nothing about the slot's geometry surviving. An edge zone's size lives on the
+     * DESCRIPTOR (`{nodeId, extent, resizable}`), and a sole-occupant tear-out clears the whole
+     * descriptor with the node, so the extent has to be recorded here or it is gone. `extent` and
+     * `resizable` are therefore the edge-zone counterpart of the split branch's `size` and
+     * `orientation`: absent when the descriptor declared none, never invented.
      * @param {Object} document
      * @param {String} nodeId
-     * @returns {{parentId:String, slot:(Number|String), orientation:String, size:Number, siblingId:String, position:String}|null}
+     * @returns {{parentId:String, slot:(Number|String), orientation:String, size:Number, siblingId:String, position:String, extent:Number, resizable:Boolean}|null}
      * @static
      */
     static captureNodeHome(document, nodeId) {
@@ -519,6 +524,17 @@ class Document extends Base {
 
         let parent = document.nodes[slot.parentId],
             home   = {parentId: slot.parentId, slot: slot.slot};
+
+        if (parent?.type === 'edge-zone' && typeof slot.slot === 'string') {
+            let descriptor = parent.zones?.[slot.slot];
+
+            if (Document.isJsonRecord(descriptor)) {
+                // Recorded only when declared: a slot that never carried an extent must come back
+                // without one, so the projection default keeps deciding rather than a value we made up.
+                typeof descriptor.extent  === 'number'  && (home.extent    = descriptor.extent);
+                typeof descriptor.resizable === 'boolean' && (home.resizable = descriptor.resizable)
+            }
+        }
 
         if (parent?.type === 'split' && typeof slot.slot === 'number') {
             let children = parent.children || [],
@@ -580,7 +596,27 @@ class Document extends Base {
             // being restored. An occupied slot is therefore not a home. This is the ownership
             // question, distinct from the existence question every other path asks.
             if (!occupant || occupant === nodeId) {
+                let existed = Document.isJsonRecord(parent.zones?.[home.slot]);
+
                 Document.setZoneNodeId(parent, home.slot, nodeId);
+
+                // `setZoneNodeId` spreads whatever descriptor it finds, so a SURVIVING slot keeps its
+                // own geometry — including a resize the user performed while the pane was out, which
+                // a stale record must never overwrite. Only an emptied slot has nothing to spread,
+                // and that is the one case the record fills.
+                if (!existed) {
+                    let target = parent.zones[home.slot];
+
+                    // Fail closed on a corrupt record rather than authoring a document `validate`
+                    // would reject: the extent contract is a finite number in the open interval (0,1).
+                    if (typeof home.extent === 'number' && Number.isFinite(home.extent) &&
+                        home.extent > 0 && home.extent < 1) {
+                        target.extent = home.extent
+                    }
+
+                    typeof home.resizable === 'boolean' && (target.resizable = home.resizable)
+                }
+
                 return []
             }
         }

--- a/test/playwright/unit/dashboard/DockZoneModel.spec.mjs
+++ b/test/playwright/unit/dashboard/DockZoneModel.spec.mjs
@@ -2100,6 +2100,111 @@ test.describe('Neo.dashboard.dock.model.Document', () => {
         })
     });
 
+    test.describe('#18177 an edge-zone home carries its own geometry', () => {
+        /**
+         * `doc()`'s right zone with a committed extent — the shape `resizeEdgeZone` leaves behind,
+         * and the one a sole-occupant tear-out erases along with the node.
+         * @param {Object} [descriptor={extent: 0.42, nodeId: 'side-tabs', resizable: true}]
+         * @returns {Object}
+         */
+        const sizedEdgeDoc = (descriptor={extent: 0.42, nodeId: 'side-tabs', resizable: true}) => {
+            const d = doc();
+
+            d.nodes.root.zones.right = descriptor;
+
+            return d
+        };
+
+        test('AC-1/AC-2 the record carries the slot\'s extent and resizable — and invents neither', () => {
+            expect(Document.captureNodeHome(sizedEdgeDoc(), 'side-tabs')).toEqual({
+                parentId: 'root', slot: 'right', extent: 0.42, resizable: true
+            });
+
+            // A slot that declared no geometry must come back with none, so the projection default
+            // keeps deciding. An invented 0.5 here would look like a restoration and be a resize.
+            expect(Document.captureNodeHome(doc(), 'side-tabs')).toEqual({parentId: 'root', slot: 'right'});
+
+            expect(Document.captureNodeHome(sizedEdgeDoc({extent: 0.3, nodeId: 'side-tabs', resizable: false}), 'side-tabs'))
+                .toMatchObject({resizable: false})
+        });
+
+        test('AC-3/AC-7 the ROUND TRIP: an emptied edge slot comes back at the extent it left with', () => {
+            const source = sizedEdgeDoc();
+
+            const placement = Document.captureItemPlacement(source, 'terminal'),
+                  detached  = Operations.applyOperation(source, {operation: 'detachItem', itemId: 'terminal'});
+
+            expect(detached.errors).toEqual([]);
+            expect(detached.document.nodes.root.zones.right, 'the descriptor went with the node').toBeUndefined();
+
+            const {document: restored, errors} = Operations.applyOperation(detached.document, {
+                operation: 'restoreTab', itemId: 'terminal', ...placement
+            });
+
+            expect(errors).toEqual([]);
+
+            // The assertion is on the DOCUMENT's extent, not on a rendered width: a pixel figure also
+            // moves when the projection legitimately re-lays-out, so it cannot isolate this property.
+            expect(restored.nodes.root.zones.right).toMatchObject({extent: 0.42, resizable: true});
+            expect(Document.getZoneNodeId(restored.nodes.root.zones.right)).toBe('side-tabs');
+            expect(Document.validate(restored)).toEqual([])
+        });
+
+        test('AC-4 a SURVIVING descriptor keeps its own extent — a stale record never overwrites a live gesture', () => {
+            const source    = sizedEdgeDoc(),
+                  placement = Document.captureItemPlacement(source, 'terminal');
+
+            // A vessel is long-lived: the user resizes that edge while the pane is out. The pane's
+            // node survives here (it still holds the item), so the descriptor is never cleared.
+            const widened = Document.clone(source);
+
+            widened.nodes.root.zones.right.extent = 0.6;
+
+            const {document: restored, errors} = Operations.applyOperation(widened, {
+                operation: 'restoreTab', itemId: 'terminal', ...placement
+            });
+
+            expect(errors).toEqual([]);
+            expect(restored.nodes.root.zones.right.extent, 'the newer gesture wins over the record').toBe(0.6)
+        });
+
+        test('AC-5 a CORRUPT recorded extent is discarded, and the document stays valid', () => {
+            const source    = sizedEdgeDoc(),
+                  placement = Document.captureItemPlacement(source, 'terminal');
+
+            const {document: detached} = Operations.applyOperation(source, {operation: 'detachItem', itemId: 'terminal'});
+
+            // `validate` rejects an extent outside the open interval (0, 1). A restore must fail
+            // closed on a corrupt record rather than author a document the model would refuse.
+            for (const bad of [0, 1, 1.5, -0.2, Number.NaN, Number.POSITIVE_INFINITY, '0.4']) {
+                const home = {...placement.home, extent: bad};
+
+                const {document: restored, errors} = Operations.applyOperation(detached, {
+                    operation: 'restoreTab', itemId: 'terminal', ...placement, home
+                });
+
+                expect(errors, `extent ${String(bad)} still restores the pane`).toEqual([]);
+                expect(Document.validate(restored), `extent ${String(bad)} never enters the document`).toEqual([]);
+                expect(restored.nodes.root.zones.right.extent, `extent ${String(bad)} is dropped`).toBeUndefined()
+            }
+        });
+
+        test('AC-6 the SPLIT branch is untouched — size and orientation still restore', () => {
+            const source = splitDoc([0.7, 0.3]);
+
+            const placement = Document.captureItemPlacement(source, 'terminal');
+
+            expect(placement.home).toEqual({
+                parentId: 'main-split', slot: 1, orientation: 'horizontal', size: 0.3, siblingId: 'main-tabs', position: 'after'
+            });
+
+            // No extent/resizable leaked onto a split home: they are the edge-zone counterpart, not
+            // an addition to every record.
+            expect(placement.home.extent).toBeUndefined();
+            expect(placement.home.resizable).toBeUndefined()
+        })
+    });
+
     test.describe('captureItemPlacement (exact-position return, stored half)', () => {
         test('captures the holding tabs node and the exact index', () => {
             expect(Document.captureItemPlacement(doc(), 'strategy')).toEqual({tabsNodeId: 'main-tabs', index: 0, home: {parentId: 'root', slot: 'center'}});


### PR DESCRIPTION
## Summary

@neo-opus-vega measured this on a consumer dock host: a single-pane right edge zone left at width **318** and came home at **272**. #18165 restores the *side* correctly; this restores the *size*.

## The finding is Vega's reading of my own JSDoc, and it is the part worth keeping

`captureNodeHome` recorded different amounts per parent type — a split home carried `orientation`, `size` and a sibling anchor; an edge-zone home carried only `{parentId, slot}`. I had justified that:

> An edge-zone parent needs no anchor: an edge-zone node survives losing every zone, so its id and the zone key remain resolvable.

**That argument is about resolvability, and it is true.** I generalised it into *"an edge-zone home needs nothing else recorded"*, which does not follow — **the id surviving says nothing about the geometry surviving.**

An edge zone's size lives on the **descriptor** (`{nodeId, extent, resizable}`), not on the node it points at. `setZoneNodeId` spreads a surviving descriptor, which is its documented intent — but a sole-occupant tear-out clears the whole descriptor along with the node, so there is nothing left to spread.

A true justification covering one axis, silently read as covering all of them. That is the shape of the defect, not "the branch is incomplete".

## The fix

**`captureNodeHome`** records `extent` and `resizable` when the descriptor declares them — **and only then**. A slot that never carried an extent comes back without one, so the projection default keeps deciding rather than a value we invented.

**`restoreNodeHome`** applies them only to a slot that was **actually emptied**:

```js
let existed = Document.isJsonRecord(parent.zones?.[home.slot]);
Document.setZoneNodeId(parent, home.slot, nodeId);
if (!existed) { /* fill from the record */ }
```

A vessel is long-lived, so the user can resize that edge *while the pane is out*. Overwriting a surviving descriptor from a stale record is the same mistake as overwriting an occupied slot — the refusal #18165 had to add — so both refusals now live in the same branch.

A recorded `extent` outside the finite open interval `(0, 1)` is **dropped**, because `Document.validate` rejects it and a restore must never author a document the model would refuse.

## Acceptance Criteria

| AC | Evidence |
|---|---|
| **AC-1** record carries `extent`; no extent → no record field | `toEqual({parentId, slot, extent, resizable})` and `toEqual({parentId, slot})` |
| **AC-2** `resizable` carried, incl. `false` | `toMatchObject({resizable: false})` |
| **AC-3 / AC-7** emptied slot rebuilds at the recorded extent | model round trip: detach → restore → `{extent: 0.42, resizable: true}`, document valid |
| **AC-4** a surviving descriptor keeps its own extent | user widens to `0.6` while out → `0.6` survives the restore |
| **AC-5** a corrupt recorded extent is discarded | walks `0`, `1`, `1.5`, `-0.2`, `NaN`, `Infinity`, `'0.4'` — pane still returns, document still valid, extent absent every time |
| **AC-6** split branch unchanged | `size` + `orientation` + anchor intact; no `extent`/`resizable` leaked onto a split home |
| **AC-8** JSDoc states what an edge-zone home records **and why** | the resolvability argument is now explicitly scoped to the anchor |

## Red-first control

Restored `Document.mjs` to `dev` and re-ran the new arms:

```
2 failed, 3 passed
```

The two failures are the defect witnesses (the record, and the round trip). The three that pass at the baseline are supposed to: **AC-4**, **AC-5** and **AC-6** are unchanged-behaviour controls. AC-5 passes trivially at `dev` because nothing is ever recorded there, which is the honest reading — it is a "must not start authoring invalid documents" guard, not a witness.

## The measurement stays in the ticket, not in the assertion

The witness here is the **committed document's `extent`**, never a rendered width. A pixel figure also moves when the projection legitimately re-lays-out, so it cannot isolate this property — which is why AC-7 is model-level and needs no app. Vega's `318 → 272` stays as the symptom that found it.

## Evidence

- `dashboard/DockZoneModel`: **156 passed**
- unit: **3085 passed**, 0 failed, 0 skipped (rebased onto `dev` after #18176 unblocked it)

Resolves #18177. Refs #18164, #18151.

Authored by Grace (Claude Opus 5, Claude Code). Session 8d936ec9-b816-4ded-a91e-6e91ef6a3325.
