### PR TITLE
test(draggable): SortZone hands the coordinator back its own defaults (#18180)

### DIFF
--- a/test/playwright/unit/draggable/dashboard/SortZone.spec.mjs
+++ b/test/playwright/unit/draggable/dashboard/SortZone.spec.mjs
@@ -18,7 +18,10 @@ import InstanceManager from '../../../../../src/manager/Instance.mjs';
  */
 test.describe.serial('Neo.draggable.dashboard.SortZone Directional Logic', () => {
     let DashboardContainer, DashboardSortZone, Rectangle, realApplyDeltas, realDragCoordinatorOnDragEnd,
-        realDragCoordinatorOnWindowPositionChange, sortZone;
+        realDragCoordinatorOnWindowPositionChange, sortZone,
+        // Captured from the engine rather than written as literals, so `afterEach` restores what
+        // the coordinator actually declares and cannot drift when a default moves.
+        engineDwellMs, engineSettleMs;
 
     test.beforeAll(async () => {
         const containerModule = await import('../../../../../src/dashboard/Container.mjs');
@@ -29,6 +32,12 @@ test.describe.serial('Neo.draggable.dashboard.SortZone Directional Logic', () =>
 
         const rectModule = await import('../../../../../src/util/Rectangle.mjs');
         Rectangle = rectModule.default;
+
+        // Captured HERE, not at the top of this hook: `Neo.manager.DragCoordinator` does not exist
+        // until the imports above pull it in, so an earlier read yields `undefined` and any restore
+        // guarded on it silently does nothing — which is how the leak below survived its own fix.
+        engineDwellMs  = Neo.manager.DragCoordinator.nativeWindowDropDwellMs;
+        engineSettleMs = Neo.manager.DragCoordinator.nativeWindowDropSettleMs;
 
         realDragCoordinatorOnDragEnd = Object.getPrototypeOf(Neo.manager.DragCoordinator).onDragEnd;
         realDragCoordinatorOnWindowPositionChange = Object.getPrototypeOf(Neo.manager.DragCoordinator).onWindowPositionChange;
@@ -67,8 +76,19 @@ test.describe.serial('Neo.draggable.dashboard.SortZone Directional Logic', () =>
             DragCoordinator.nativeWindowDropCandidates.clear()
         }
         if (DragCoordinator) {
-            DragCoordinator.nativeWindowDropDwellMs  = 450;
-            DragCoordinator.nativeWindowDropSettleMs = 250;
+            // RESTORE, not configure. These were literals — `450` / `250` — written where the
+            // engine's own values belong. `250` happened to match its default and was harmless;
+            // `1200` did not, so every later spec in this worker inherited a HALVED drag dwell.
+            //
+            // It surfaced as `1 flaky` rather than a failure, because a Playwright retry runs in a
+            // fresh worker and a cross-file isolation leak heals there by construction — the job
+            // still exits 1. It cost a peer half an hour of unreproducible debugging, because the
+            // file that fails is never the file that leaks.
+            //
+            // Same lesson the stub-deletion block below already records: a mutation that survives
+            // its suite is indistinguishable from the engine simply behaving differently.
+            DragCoordinator.nativeWindowDropDwellMs  = engineDwellMs;
+            DragCoordinator.nativeWindowDropSettleMs = engineSettleMs;
             DragCoordinator.sortZones = new Map();
             DragCoordinator.activeTargetZone = null;
 
@@ -762,6 +782,18 @@ test.describe.serial('Neo.draggable.dashboard.SortZone Directional Logic', () =>
         expect(calls).toEqual(['move']);
         expect(DragCoordinator.nativeWindowDropCandidates.size).toBe(0)
     });
+
+    // Placed LAST in a `describe.serial`, so the preceding `afterEach` has already run: this asserts
+    // the suite hands the shared singleton back the way it found it. It is the only arm here that
+    // protects OTHER files — a config literal written where a restore belongs leaked a halved drag
+    // dwell into every later spec in the worker, and the file that failed was never this one.
+    test('the suite leaves the coordinator carrying the ENGINE defaults, not this fixture\'s', () => {
+        const {nativeWindowDropDwellMs, nativeWindowDropSettleMs} = Neo.manager.DragCoordinator;
+
+        expect(nativeWindowDropDwellMs,  'dwell restored').toBe(engineDwellMs);
+        expect(nativeWindowDropSettleMs, 'settle restored').toBe(engineSettleMs)
+    });
+
 });
 
 /**


### PR DESCRIPTION
## Summary

`SortZone.spec.mjs`'s `afterEach` wrote **literals** where the engine's values belong:

```js
DragCoordinator.nativeWindowDropDwellMs  = 450;   // engine default: 1200
DragCoordinator.nativeWindowDropSettleMs = 250;   // engine default: 250
```

`DragCoordinator` is a **singleton shared across spec files in one Playwright worker**. `250` happens to match its default and was harmless — and would stop being harmless the moment that default moved. `1200` does not match, so **every later spec in that worker inherited a halved drag dwell**.

## Why it was so expensive to find

It cost a red CI run and a peer half an hour of unreproducible debugging, because **the file that fails is never the file that leaks**. Running the failing spec alone can never reproduce it.

It also surfaces as `1 flaky` rather than a plain failure: **a Playwright retry runs in a fresh worker, so a cross-file isolation leak heals there by construction** — while the job still exits 1. A green retry beside a red job is the signature of this class, not evidence of a flake.

## The fix, and the mistake inside it

The `afterEach` now restores values captured from the coordinator itself, so the restore cannot drift when a default moves. The same file already records this exact lesson two lines below, about its five stubbed methods:

> a stub that survives its suite is indistinguishable from the method simply not working

**Where the capture happens is the whole fix, and my first attempt got it wrong.** I read `Neo.manager?.DragCoordinator` at the top of `beforeAll` — but the singleton does not exist until the dynamic imports below pull it in. The capture yielded `undefined`, my `!== undefined` guard skipped the restore entirely, and the suite left behind `0` instead of `450`. **My fix silently did nothing, and made it worse.**

The capture now sits beside the existing prototype reads, which are already positioned after those imports, and the restore is **unguarded** so a missing capture fails loudly instead of quietly.

## The guard, and why its control has to be the whole file

A final arm in the `describe.serial` asserts the suite hands the singleton back as it found it. It is the only test in that file protecting **other** files, and it is placed last so the preceding `afterEach` has already run.

Mutation-checked: reinstating the `450` literal turns it red — `Expected: 1200, Received: 450`.

**Filtering to that one arm with `-g` makes the mutation pass.** With nothing before it, no `afterEach` has fired, so the arm sees the `beforeAll` value and agrees. I ran exactly that filtered control first and read it as "the guard is vacuous" — the filter had removed the condition the guard depends on. The control has to be the whole file.

## A correction to the ticket, and to myself

`SortZone.spec.mjs:641` and `:745` do `Object.assign(DragCoordinator, {nativeWindowDropDwellMs: 0, …})`. The ticket scoped these out as *"per-fixture config objects, not singleton writes"* — they **are** singleton writes, so that reasoning is wrong.

But the conclusion is right: the `afterEach` already neutralises them, so they need no change. I briefly reported the opposite from a `0` reading that **my own broken fix had produced**, not the tree's behaviour. Measured after repair: the baseline leaks `450`, not `0`.

## Evidence

- `draggable/dashboard/SortZone`: **21 passed** (20 + the new guard)
- unit: **3117 passed**, 0 failed, 0 skipped
- leak witness — an independent probe spec asserting the singleton's dwell after this suite runs, `--workers=1`: **`Expected 1200, Received 450` before, 21 passed after.** Kept as evidence rather than committed; the in-file guard is the durable form.

Resolves #18180. Refs #18173.

Authored by Grace (Claude Opus 5, Claude Code). Session 8d936ec9-b816-4ded-a91e-6e91ef6a3325.
