### PR TITLE
fix(test): SortZone restores the dwell configuration it was handed (#18180)

### DIFF
--- a/test/playwright/unit/draggable/dashboard/SortZone.spec.mjs
+++ b/test/playwright/unit/draggable/dashboard/SortZone.spec.mjs
@@ -17,8 +17,8 @@ import InstanceManager from '../../../../../src/manager/Instance.mjs';
  * @summary Tests for Neo.draggable.dashboard.SortZone directional thresholds
  */
 test.describe.serial('Neo.draggable.dashboard.SortZone Directional Logic', () => {
-    let DashboardContainer, DashboardSortZone, Rectangle, realApplyDeltas, realDragCoordinatorOnDragEnd,
-        realDragCoordinatorOnWindowPositionChange, sortZone;
+    let DashboardContainer, DashboardSortZone, Rectangle, dwellConfigOnEntry, realApplyDeltas,
+        realDragCoordinatorOnDragEnd, realDragCoordinatorOnWindowPositionChange, sortZone;
 
     test.beforeAll(async () => {
         const containerModule = await import('../../../../../src/dashboard/Container.mjs');
@@ -38,6 +38,31 @@ test.describe.serial('Neo.draggable.dashboard.SortZone Directional Logic', () =>
         // files, so an unrestored override runs THIS file's fixture against a later spec's
         // components — the tell is a SortZone stack frame surfacing inside an unrelated spec.
         realApplyDeltas = Neo.applyDeltas;
+
+        // Captured before the suite mutates anything, because two tests below `Object.assign` a
+        // dwell of 0 straight onto the coordinator to make the hold commit synchronously. That is a
+        // legitimate fixture need; handing 0 to the next spec is not.
+        //
+        // These are non-reactive configs, so they live as OWN properties on the shared singleton
+        // with no prototype value underneath — once a spec overwrites one there is nothing left to
+        // fall back to, which is why the original has to be carried rather than re-derived.
+        dwellConfigOnEntry = {
+            dwellMs : Neo.manager.DragCoordinator.nativeWindowDropDwellMs,
+            settleMs: Neo.manager.DragCoordinator.nativeWindowDropSettleMs
+        };
+    });
+
+    // The leak witness. Asserting equality with what we found — rather than the literals 1200/250 —
+    // keeps the engine defaults at `src/manager/DragCoordinator.mjs` the only place they are stated,
+    // so moving a default can never make this file wrong. A cross-file leak is invisible from inside
+    // the file it lands in; the only place it is observable is here, at the boundary the leak crosses.
+    test.afterAll(() => {
+        const DragCoordinator = Neo.manager?.DragCoordinator;
+
+        expect(DragCoordinator.nativeWindowDropDwellMs, 'the suite hands the next spec the dwell it was given')
+            .toBe(dwellConfigOnEntry.dwellMs);
+        expect(DragCoordinator.nativeWindowDropSettleMs, 'the suite hands the next spec the settle it was given')
+            .toBe(dwellConfigOnEntry.settleMs)
     });
 
     test.beforeEach(() => {
@@ -67,8 +92,13 @@ test.describe.serial('Neo.draggable.dashboard.SortZone Directional Logic', () =>
             DragCoordinator.nativeWindowDropCandidates.clear()
         }
         if (DragCoordinator) {
-            DragCoordinator.nativeWindowDropDwellMs  = 450;
-            DragCoordinator.nativeWindowDropSettleMs = 250;
+            // Restoring what the suite was handed, not the literals this fixture happens to like.
+            // The previous `= 450` here was an assignment wearing a restore's clothing: it neither
+            // matched the engine default (1200) nor anything this file had saved, so it published a
+            // halved dwell to every later spec in the worker — while masking the 0 the two
+            // `Object.assign` tests below leave behind, which is worse.
+            DragCoordinator.nativeWindowDropDwellMs  = dwellConfigOnEntry.dwellMs;
+            DragCoordinator.nativeWindowDropSettleMs = dwellConfigOnEntry.settleMs;
             DragCoordinator.sortZones = new Map();
             DragCoordinator.activeTargetZone = null;
 


### PR DESCRIPTION
Resolves #18180

`SortZone.spec.mjs` now restores the drag-dwell configuration it was handed instead of assigning two literals over it, so the suite stops publishing its fixture state to every later spec sharing the Playwright worker. An `afterAll` witnesses the invariant directly — the values on the way out equal the values on the way in — which is the only place a cross-file leak is observable at all.

Evidence: L2 (mutation-verified unit arms, three states, run locally) → L2 required (every close-target AC is a unit-observable property of one spec file; no production path changes). Residual: none — the diff is test-only and `src/` is untouched.

## Why the old line was not a restore

`Neo.manager.DragCoordinator` is a singleton shared across spec **files** in one worker, and `nativeWindowDropDwellMs` / `nativeWindowDropSettleMs` are non-reactive configs — own properties with no prototype value underneath. Once a spec overwrites one, nothing remains to fall back to.

The `afterEach` assigned `450` / `250`: neither the engine defaults (`1200` / `250`) nor anything the file had saved. An assignment wearing a restore's clothing. Because worker assignment decides who runs after this file, the damage only ever surfaced in CI — and a retry gets a fresh worker, so the leak heals by construction on re-run. That is what an isolation defect looks like when it is filed as a flake.

## AC Evidence

| AC | Evidence |
|---|---|
| **AC-1** captures rather than hardcodes | `dwellConfigOnEntry` is read in `beforeAll`; the literals `450` / `250` are gone from the file |
| **AC-2** suite exits on the engine values | `afterAll` asserts both against the captured entry values; green in the file run and in the 3116-test suite |
| **AC-3** mutation-verified both ways | three states, receipts below — **AC revised on the ticket**, see Deltas |
| **AC-4** moving a default needs no edit here | the spec states no dwell literal at all; the assertion compares entry-state to exit-state, so `src/manager/DragCoordinator.mjs` stays the only place the defaults live |
| **AC-5** #18174's `unit` job green, zero flaky | **not observable as written** — #18174 merged at 09:37Z before this branch existed. Nearest honest equivalent: full `unit` green, zero flaky, below |

## Deltas from ticket

Three, all found by the witness rather than by reading. Recorded in full on #18180; summarised here:

1. **The leaked value is `0`, not `450`.** The ticket names 450. Removing the assignment and asserting post-suite state gives `Expected: 1200 / Received: 0`. The `= 450` was a *partial mask* over a `0` the suite had already left behind, so the milder value is the one that reached CI.
2. **The ticket's Out of Scope is wrong.** It reads the `nativeWindowDropDwellMs: 0` sites as "per-fixture config objects, not singleton writes". They are `Object.assign(DragCoordinator, {…})` — direct singleton writes, and the actual origin of the leak. I classified them on their shape instead of on what they are assigned to.
3. **AC-3's named red arm no longer exists.** It asks for `DragCoordinator.spec.mjs:817` failing `Expected: -150 / Received: 250`. The second commit on the merged #18174 pinned that arm (`DWELL_MS = 1200; // PINNED, never read from the live config`), correctly making the victim immune. Worth flagging for @neo-opus-ada: its `finally` restores `originalDwell`, i.e. whatever ambient value it found — the pin protects that file and **preserves** the leak for whoever follows. AC-3 is revised on the ticket to a witness that still exists.

The fix stayed inside `SortZone.spec.mjs` as scoped; the diagnosis (cross-file singleton leak masquerading as a flake) is unchanged.

## Test Evidence

Mutation arms — the witness must be able to fail, and fail for this reason:

| State | Result |
|---|---|
| Fix applied | `20 passed` (file), `74 passed` exit 0 (ordered single-worker two-file run) |
| Restore reverted to `450` / `250` — the dev defect | `1 failed`: `the suite hands the next spec the dwell it was given` · `Expected: 1200 / Received: 450` |
| Restore deleted outright | `1 failed`, same assertion · `Expected: 1200 / Received: 0` |

The discriminating instrument is the ordered single-worker run, since nothing scoped to one file can witness a cross-file leak:

```
npm run test-unit -- --workers=1 \
  test/playwright/unit/draggable/dashboard/SortZone.spec.mjs \
  test/playwright/unit/manager/DragCoordinator.spec.mjs
→ 74 passed, exit 0
```

Full suite, to falsify the real risk that some spec was passing *because* of the leaked value: `npm run test-unit` → **3116 passed, exit 0, zero flaky**. Nothing depended on it.

## Post-Merge Validation

- [ ] Two consecutive full `unit` runs on `dev` show zero `flaky` entries — the leak's signature was a green retry, so absence of the retry is the merged-state observable.

## Commits

- `e31f307` — capture in `beforeAll`, restore in `afterEach`, witness in `afterAll`

Refs #18173, #18174.

Authored by Grace (Claude Opus 5, Claude Code). Session fa6f7884-973f-4509-b4c3-ff8864214cd1.
