### PR TITLE
feat(dock): lock joins the default engine action set (#18185)

### DIFF
--- a/src/dashboard/dock/Workspace.mjs
+++ b/src/dashboard/dock/Workspace.mjs
@@ -130,7 +130,13 @@ class Workspace extends Container {
          * `locked` item field is the hard boundary: close, detach and source movement fail
          * closed in the reducer. Workspace presentation mirrors that truth by making the pane
          * inert, hiding close, and suppressing the tab drag source while preserving exact prior
-         * inert and drag-token ownership for unlock. Disabled by default.
+         * inert and drag-token ownership for unlock.
+         *
+         * On by default, like the other five. It was the one action a host had to ask for, from a
+         * time when the engine did not yet own it: the lock action, the pane delegation contract
+         * and the `itemFlags` change class that keeps a toggle from restaging the shell all landed
+         * afterwards, leaving a host enabling this to supply nothing. `false` remains the explicit
+         * opt-out, and withholds the icon configs from the projection context with it.
          *
          * The content half is delegable, exactly like reload: a pane implementing
          * `dockLock(locked: Boolean): void` owns what locked means for its content (a form
@@ -140,9 +146,9 @@ class Workspace extends Container {
          * `inert` at all. The probe is a pure `typeof` on the live card, never a resolver call.
          * The structural half — the reducer's refusals, the hidden close action, the suppressed
          * drag source, the `neo-dock-pane-locked` frame cue — is never delegated.
-         * @member {Boolean} enableDockLockAction=false
+         * @member {Boolean} enableDockLockAction=true
          */
-        enableDockLockAction: false,
+        enableDockLockAction: true,
         /**
          * Icon of the projected lock action while the active item is unlocked.
          * @member {String} dockLockIconCls='fa fa-lock'

--- a/src/dashboard/dock/projection/LayoutAdapter.mjs
+++ b/src/dashboard/dock/projection/LayoutAdapter.mjs
@@ -1056,9 +1056,11 @@ class LayoutAdapter extends Base {
         // Host actions precede the ENGINE SET, and `close` stays the rightmost control. The frozen
         // order is
         // `[tab overflow] → [host actions] → [lock · reload · pin · pop-out · maximize] → [close]`;
-        // lock remains opt-in, while the five greenfield rail identities default on and retain an
-        // explicit-false compatibility escape. Per-item and host capability changes their state,
-        // never this node-static array.
+        // all six default on for a HOST, and each retains an explicit-false escape. Lock alone is
+        // read here as a strict `=== true` where the other five accept anything but `false` — this
+        // is a projector, so it takes explicit context and an absent key is not a request; the
+        // default that matters to a host lives on `dashboard.dock.Workspace`. Per-item and host
+        // capability changes their state, never this node-static array.
         //
         // The resolver receives the node id ALONE, deliberately. Handing it the active item would
         // invite a per-item action LIST, and a list that changes between projections replaces the

--- a/test/playwright/unit/dashboard/DockWorkspace.spec.mjs
+++ b/test/playwright/unit/dashboard/DockWorkspace.spec.mjs
@@ -655,6 +655,40 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
         })
     });
 
+    test('lock is in the default engine set, and explicit false is still the escape', () => {
+        // Asserted on a workspace that configures NOTHING, which is the only shape that can witness
+        // a default. Every other lock spec passes `enableDockLockAction: true` explicitly, so the
+        // default itself was uncovered and could have been flipped either way unnoticed.
+        //
+        // The `LayoutAdapter` arm pairing `project({})` with `project({enableDockLockAction: false})`
+        // is a different claim and stays true: that is a projector, it takes explicit context, and
+        // an absent key there is not a request. The host-facing default lives here.
+        const projectedAction = (ws, name) => {
+            const tabs = collect(ws.projectDockModel(), config => config.dockNodeType === 'tabs')[0];
+
+            expect(tabs, 'the fixture must project a tabs node, or these assertions prove nothing').toBeTruthy();
+
+            return (tabs.headerActions || []).find(action => action.action === name)
+        };
+
+        workspace = Neo.create(PlainWorkspace, {dockModel: createDocument()});
+        expect(workspace.enableDockLockAction).toBe(true);
+        expect(projectedAction(workspace, 'lock')).toMatchObject({action: 'lock'});
+        workspace.destroy();
+
+        workspace = Neo.create(PlainWorkspace, {dockModel: createDocument(), enableDockLockAction: false});
+        expect(projectedAction(workspace, 'lock')).toBeUndefined();
+        workspace.destroy();
+
+        // The frozen order holds with lock present by default rather than by request.
+        workspace = Neo.create(PlainWorkspace, {dockModel: createDocument()});
+
+        const tabs = collect(workspace.projectDockModel(), config => config.dockNodeType === 'tabs')[0];
+
+        expect((tabs.headerActions || []).map(action => action.action))
+            .toEqual(['lock', 'reload', 'pin', 'pop-out', 'maximize', 'close'])
+    });
+
     test('an action the workspace does not own is re-emitted to the host with its node id', () => {
         workspace = Neo.create(PlainWorkspace, {
             dockModel          : createDocument(),


### PR DESCRIPTION
Resolves #18185

Lock now defaults on, like the other five header actions. It was the one a host had to ask for, from a time when the engine did not own it — the engine-owned lock action, the `dockLock` pane delegation contract and the `itemFlags` change class that keeps a toggle from restaging the shell all landed after the ticket that set the default off, leaving a host enabling this to supply nothing. `false` stays the explicit opt-out and still withholds the icon configs from the projection context, which is why the flip is one line rather than a projection edit.

Evidence: L2 (unit — a config default and its projection membership are decided in the projector, with no rendered surface to measure) → L2 required (every AC on #18185 is a projection or default-value claim). Residual: none.

## AC Evidence
| AC-1 | `DockWorkspace.spec.mjs` — `lock is in the default engine set…`, asserted on a `PlainWorkspace` with no `enableDockLockAction` config; mutation-checked, see Test Evidence |
| AC-2 | same arm — explicit `enableDockLockAction: false` yields no `lock` action; the adapter's `project({})` ≡ `project({enableDockLockAction: false})` pairing in `DockLockAction.spec.mjs:152` is untouched and still green |
| AC-3 | same arm — `['lock', 'reload', 'pin', 'pop-out', 'maximize', 'close']` asserted with lock present by default rather than by request |
| AC-4 | untouched behaviour, covered by `DockLockAction.spec.mjs` (`derives initial icon, policy visibility, and locked close state…`, `threads committed lock truth to a railed reveal pane…`); the diff changes no gating, only the default |
| AC-5 | `Operations.mjs:95` still reads `setItemLocked : 'itemFlags'`; `src/dashboard/dock/model/Operations.mjs` is not in this branch's diff, and `DockOperationChangeClass.spec.mjs`'s completeness arm covers it |
| AC-6 | whole dashboard unit family green — 888 passed, every existing lock spec keeping its explicit `true` |
| AC-7 | swept `src/` and `learn/` for prose calling lock opt-in / default-off: zero remaining. Two sites existed and both are in this diff — the config JSDoc, and the `LayoutAdapter` frozen-order comment |

## Deltas from ticket

**AC-1's wording was corrected on the ticket before implementing, and the correction is the interesting part of this PR.** As first written it asked for the assertion on "a projection with no `enableDockLockAction` key present" — which describes the **adapter**, not the workspace. `LayoutAdapter.project()` reads the key as a strict `=== true` and deliberately pairs an absent key with an explicit `false`; satisfying AC-1 literally would have meant flipping the projector's default and breaking that arm. A projector takes explicit context, so an absent key there is not a request. The host-facing default belongs on `dashboard.dock.Workspace`, and that is the only layer this PR changes.

The `LayoutAdapter` comment moved from "lock remains opt-in" to naming which layer owns the host-facing default. It had become misleading rather than wrong: the adapter's strictness is still real and still correct.

Nothing else. No behaviour, no gating, no delegation contract.

## Test Evidence

**Mutation-checked, because the flip is otherwise invisible.** Every pre-existing lock spec passes `enableDockLockAction: true` explicitly, so the default itself was uncovered and could have been flipped either way with a green suite. With the old `false` restored under the new arm:

```
1 failed
  [unit-engine] › DockWorkspace.spec.mjs › lock is in the default engine set, and explicit false is still the escape
110 passed
```

It fails alone. That is the arm witnessing the default rather than the flag.

## Post-Merge Validation
- [ ] A host currently passing `enableDockLockAction: true` can drop that line; consumer follow-ups are each host's own, per the ticket's Out of Scope.
- [ ] Lock now renders on every dock host including the examples and demos — worth one look at a rendered header for the frozen order with six actions rather than five, which unit coverage asserts structurally but does not paint.

Authored by Vega (Opus 5, Claude Code). Session e8ea32a2-b9a8-43ea-84ba-b83081ec4b3d.
