### PR TITLE
test(dashboard): a retainTopology request over a changed topology is refused (#18188)

### DIFF
--- a/test/playwright/unit/dashboard/DockProjectionReconciler.spec.mjs
+++ b/test/playwright/unit/dashboard/DockProjectionReconciler.spec.mjs
@@ -501,6 +501,110 @@ test.describe('Neo.dashboard.dock.projection.Reconciler', () => {
         }
     });
 
+    test.describe('#18188 a retainTopology REQUEST over a changed topology is refused', () => {
+        // `retainTopology` is an admission request, not a statement of fact. A host sends it for
+        // `detachItem`, and a detach CAN restructure: emptying a tabs node drops it and collapses a
+        // two-child split behind it. The consumer is safe only because `reconcileStableTopology`
+        // refuses — and until now nothing asserted that it does.
+        //
+        // What these arms witness, measured rather than assumed: the refusal is OVER-DETERMINED.
+        // Removing the node-count clause, the missing-node clause, or the child-order clause on its
+        // own leaves the others still refusing, and all three arms stay green. They go red once the
+        // guard is weakened far enough to actually admit a changed topology — with every structural
+        // clause but the missing-node one removed, one arm fails; with that one gone too, two do.
+        //
+        // So this block protects the CONTRACT ("a changed topology is refused") rather than any
+        // single line of it. Worth stating, because a reader who assumed a one-clause mutation would
+        // turn them red — as the ticket's own AC-5 did — would wrongly conclude they cover nothing.
+
+        test('AC-1/AC-2 a detach that COLLAPSES a node falls through to the staged transaction', async () => {
+            // `alpha` is the sole occupant of `alpha-tabs`, the left child of a two-child split.
+            // Removing it empties the node, so the projection has FEWER structural nodes than the
+            // shell — the exact case the node-count clause exists for.
+            const receipt = await reconcileModel(createSplitModel(), nextModel => {
+                delete nextModel.nodes['alpha-tabs'];
+                delete nextModel.items.alpha;
+                nextModel.root = 'beta-tabs';
+                delete nextModel.nodes['root-split']
+            }, {retainTopology: true});
+
+            try {
+                // AC-1: the request was REFUSED. `landedInPlace` is the honest read of the path
+                // actually taken; the request itself says only what the caller hoped for.
+                expect(receipt.result.landedInPlace, 'the fast path was refused').not.toBe(true);
+                expect(receipt.stagedCount, 'the staged transaction ran instead').toBe(1);
+
+                // AC-2: refusing is only half the contract. A guard that refuses AND renders wrongly
+                // would satisfy the assertion above and be worthless, so the OUTCOME is asserted —
+                // which node set the host ends up projecting, not which shell object carries it.
+                // Shell identity is the staged path's own business and asserting it would couple
+                // this arm to an implementation detail the contract does not promise.
+                // The staged path leaves BOTH shells on the host — it moves the surviving nodes
+                // into a fresh shell and the committing surface completes the swap and disposes the
+                // source. At this layer the new shell is the host item that is not the old one;
+                // identifying it by exclusion states that, where an index would just encode it.
+                const newShell = receipt.host.items.find(item => item !== receipt.oldShell);
+
+                expect(newShell, 'a fresh shell was staged').toBeTruthy();
+
+                const tabs = DockProjectionReconciler.collectProjectedTabs(newShell);
+
+                expect([...tabs.keys()], 'only the surviving node is projected').toEqual(['beta-tabs']);
+                expect(tabs.get('beta-tabs').getTabButtons().map(button => button.text)).toEqual(['Beta'])
+            } finally {
+                receipt.host.destroy()
+            }
+        });
+
+        test('AC-3 a node-count INCREASE is refused too, so the size clause holds both ways', async () => {
+            const model = createSplitModel();
+
+            // Catalogued but unplaced, so a live pane exists for it before the mutation adds its
+            // node — the same shape the same-topology arrival arm below uses. Introducing the item
+            // only in `nextModel` would leave `resolveItem` with nothing to hand back, and the arm
+            // would die on pane resolution instead of testing the size clause.
+            model.items.gamma = {componentRef: 'gamma', kind: 'panel', title: 'Gamma'};
+
+            const receipt = await reconcileModel(model, nextModel => {
+                nextModel.nodes['gamma-tabs'] = {activeItemId: 'gamma', items: ['gamma'], type: 'tabs'};
+                nextModel.nodes['root-split'].children.push('gamma-tabs');
+                nextModel.nodes['root-split'].sizes = [0.4, 0.35, 0.25]
+            }, {retainTopology: true});
+
+            try {
+                expect(receipt.result.landedInPlace, 'a grown tree is not the same tree').not.toBe(true);
+                expect(receipt.stagedCount).toBe(1)
+            } finally {
+                receipt.host.destroy()
+            }
+        });
+
+        test('AC-4 CONTROL: a detach whose node SURVIVES still lands in place', async () => {
+            // Without this, the arms above would stay green if the guard began refusing everything —
+            // which would silently retire the fast path rather than protect it.
+            const model = createSplitModel();
+
+            model.items.gamma = {componentRef: 'gamma', kind: 'panel', title: 'Gamma'};
+            model.nodes['alpha-tabs'].items.push('gamma');
+
+            // `gamma` leaves the node but `alpha` holds it open, so the structural tree is identical
+            // and the fast path is legitimately admissible. `preserveItemIds` keeps the departing
+            // pane resolvable, which is the same shape a real detach uses.
+            const receipt = await reconcileModel(model, nextModel => {
+                nextModel.nodes['alpha-tabs'].items        = ['alpha'];
+                nextModel.nodes['alpha-tabs'].activeItemId = 'alpha'
+            }, {preserveItemIds: ['gamma'], retainTopology: true});
+
+            try {
+                expect(receipt.result.landedInPlace, 'the node survived, so the fast path holds').toBe(true);
+                expect(receipt.result.nextShell).toBe(receipt.oldShell)
+            } finally {
+                receipt.panes.gamma.destroy();
+                receipt.host.destroy()
+            }
+        })
+    });
+
     test('reconciles an explicit same-topology item arrival without replacing the shell', async () => {
         // The stack-return adoption shape: the arriving pane exists as a live instance
         // (it survived its previous workspace), the structural shell is unchanged, and one tabs


### PR DESCRIPTION
## Summary

Found while answering an operator question — *"can we now simplify `apps/workstation` and the examples?"* — by measuring which engine hooks each consumer still overrides.

`apps/workstation` requests the reconciler fast path for a detach:

```js
retainTopology: operation === 'detachItem' || operation === 'transferNode',
```

A detach **can** restructure: emptying a tabs node drops it and collapses a two-child split behind it (#18164 / #18177). So a consumer asks to reuse a shell the very operation it names may have rebuilt.

**That is safe, and that is the point.** `retainTopology` is an admission **request**, not a statement of fact. `reconcileStableTopology` refuses it on any structural delta and `reconcileProjection` falls through to the full staged transaction. The method's own JSDoc says a caller needing *"no topology swap happened"* must read `landedInPlace` rather than the request.

**Nothing observed a real refusal from the real reconciler.** `landedInPlace` appears seven times across two files at `origin/dev` — once in `DockWorkspace.spec.mjs:2668` and six times in `apps/workstation/Workspace.spec.mjs`, including two dedicated arms at `:2794` and `:2803` that exercise both values. Those arms stub `reconcileProjection` to *return* a chosen `landedInPlace` and then assert what `DockFlip.play` receives, so they cover the **forwarding** seam: a staged fallback must not reach `DockFlip` still labelled geometry-only, and an in-place landing must keep its admission so the fix cannot be the trivially safe "always false".

That is real coverage of a different seam. What no arm did was let the **real** reconciler decide: every arm that reaches `reconcileStableTopology` exercises the accept path, and the refusal itself — the `null` return on a structural delta, and the fall-through it triggers — had no observed coverage at all.

*(Corrected per RA-1 on Vega's review — the original sentence said "exactly once in the whole suite", a completeness claim scoped to the whole suite but measured in one file. The understatement would have led a reader to rebuild the forwarding arms that already exist.)*

The engine's own `getRefreshOptions` emits `retainTopology` only for the `itemFlags` class, so it never requests it for a topology-changing operation. **The refusal is reachable only from a host** — which is why the gap was invisible from the engine's own tests.

## Arms

| AC | Arm |
|---|---|
| **AC-1/AC-2** | a detach that **collapses** a node is refused, **and still projects correctly** — a guard that refused and rendered wrongly would satisfy AC-1 alone |
| **AC-3** | a node-count **increase** is refused, covering the size clause in both directions |
| **AC-4** | **control** — a detach whose node **survives** still lands in place, so the refusal is discriminating |

AC-4 is the one that matters most: without it the suite stays green if the guard starts refusing *everything*, silently retiring the fast path the epic just built.

## AC-5 was wrong, and the correction is the interesting part

The ticket predicted that loosening the node-count clause would turn AC-1 red. **It does not.** Measured, one clause at a time:

| mutation | result |
|---|---|
| remove the node-count clause | **3 passed** |
| remove the missing-node clause | **3 passed** |
| remove the child-order clause | **3 passed** |
| remove every structural clause except missing-node | **1 failed** |
| remove that one too | **2 failed** |

**The refusal is over-determined** — each clause is individually redundant for these shapes, and the others still refuse. The arms go red only once the guard is weakened far enough to genuinely admit a changed topology.

So this block protects the **contract**, not any single line. That is recorded in the spec itself, because a reader expecting a one-clause mutation to turn it red would otherwise conclude the arms cover nothing — the opposite of the truth.

## Two arm defects I found while writing them, both mine

- **The staged path leaves both shells on the host.** It moves surviving nodes into a fresh shell and the committing surface completes the swap, so asserting on `host.items[0]` read the *source* shell. The new one is identified by exclusion now, which states the property instead of encoding an index.
- **The increase arm introduced its item only in `nextModel`**, leaving `resolveItem` nothing to hand back — so it died on pane resolution rather than testing the clause it names. The item is catalogued-but-unplaced in the source model now, the same shape the sibling arrival arm uses.

## On the original question

For the record, since this came out of it: the epic's win is that a **new** consumer writes zero hooks — not that `apps/workstation` loses bulk. Only **693 of its 5493 lines** are engine-hook overrides, and 72 of its 93 methods are its own app logic. The one override that *is* pure re-derivation, `getRefreshOptions`, cannot retire until the engine emits the `geometry` class, which #18152 deliberately deferred for its own evidence.

## Evidence

`dashboard/DockProjectionReconciler` **23 passed** · unit **3117 passed, 0 failed, 0 skipped**.

Resolves #18188. Refs #18151.

Authored by Grace (Claude Opus 5, Claude Code). Session 8d936ec9-b816-4ded-a91e-6e91ef6a3325.


