### PR TITLE
fix(grid): a grid body owns its virtualization window, so a second grid cannot resize it (#18186)

### DIFF
--- a/src/grid/Body.mjs
+++ b/src/grid/Body.mjs
@@ -296,6 +296,25 @@ class GridBody extends Component {
 
         let me = this;
 
+        // Give this instance its own virtualization windows.
+        //
+        // `mountedRows`, `visibleRows` and `visibleColumns` are declared in `static config` as
+        // array literals, and updateMountedAndVisibleRows() / updateMountedAndVisibleColumns()
+        // write through them by index rather than reassigning — see the "update the array inline"
+        // comments at their assignment sites. A non-reactive config holding an array hands every
+        // instance the SAME object, so without this copy every grid body on the page shares one
+        // window and the last body to measure decides what all the others believe is mounted.
+        //
+        // The consequence is silent, because both repaint paths treat an out-of-window index as
+        // "nothing to do": onStoreRecordChange() skips the row and getRow() returns null, so a
+        // record change beyond the borrowed window updates the store and never reaches the DOM.
+        //
+        // Copying the current value rather than assigning a fresh `[0, 0]` keeps any window
+        // supplied through config, which is why this runs after super.construct().
+        me.mountedRows    = [...me.mountedRows];
+        me.visibleRows    = [...me.visibleRows];
+        me.visibleColumns = [...me.visibleColumns];
+
         me.addDomListeners([{
             click: me.onCellClick,
             dblclick: me.onCellDoubleClick,

--- a/test/playwright/e2e/workstation/WorkstationRowActionNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationRowActionNL.spec.mjs
@@ -1,0 +1,113 @@
+import {test, expect} from '../../fixtures.mjs';
+
+/**
+ * The `+1 pulse` row action must increment the Pulse cell of ITS OWN row, for every visible row.
+ *
+ * Operator report from the 100k Matrix pane: the action works for the first handful of rows and
+ * silently does nothing for the rest of the visible area. Nothing errors — the click lands, the
+ * button paints its press, and the counter three columns to the left simply does not move.
+ *
+ * **Why this is read by record id and not by row position.** The grid is buffered: rows are pooled
+ * DOM nodes recycled across records, so "row 7" is not a stable subject. Every assertion below pairs
+ * a button with the Pulse cell of the SAME `data-record-id`, which is the only pairing that survives
+ * recycling — and it is also the pairing the defect is suspected to break.
+ *
+ * The action column is a `component` column whose handler closes over `record` at component-creation
+ * time (`ScalePane.mjs`), so a recycled cell can keep a handler bound to the record it was first
+ * built for. That is a hypothesis; this spec only establishes the SYMPTOM, deliberately, so the
+ * mechanism can be falsified separately without rewriting the witness.
+ *
+ * @see https://github.com/neomjs/neo/issues/18186
+ */
+
+// Scoped to the SCALE pane, not `.neo-grid-container`: the Workstation renders two grids and the
+// feed matches first. A bare container selector read the feed's name column and reported every row
+// as failing — a red for the wrong reason, which is worse than a green.
+const GRID = '.workstation-scale-pane';
+
+/**
+ * Reads every rendered row of the scale grid as `{recordId, pulse}`, paired by identity.
+ * @param {import('@playwright/test').Page} page
+ * @returns {Promise<Object[]>}
+ */
+const readRows = page => page.evaluate(grid => {
+    const container = document.querySelector(grid);
+
+    if (!container) return [];
+
+    // The Pulse column index is DERIVED from the header, never hardcoded. The grid has eight
+    // columns (#, Work item, State, Throughput, Pulse, Load, Living signal, Action) and a guessed
+    // index silently reads a neighbour — a name column never increments, so the spec reports every
+    // row as broken and looks like a perfect witness while measuring nothing.
+    const headers = [...container.querySelectorAll('.neo-grid-header-button')]
+              .map(node => (node.textContent || '').trim()),
+          pulseIndex = headers.indexOf('Pulse');
+
+    return [...container.querySelectorAll('.neo-grid-row')].map(row => {
+        const cells = [...row.querySelectorAll('.neo-grid-cell')];
+
+        return {
+            hasAction: !!row.querySelector('.workstation-row-action'),
+            pulse    : pulseIndex > -1 ? (cells[pulseIndex]?.textContent || '').trim() : null,
+            pulseIndex,
+            recordId : row.dataset?.recordId ?? row.getAttribute('data-record-id')
+        }
+    }).filter(entry => entry.recordId && entry.hasAction)
+}, GRID);
+
+test.describe('Workstation 100k Matrix — a row action acts on its own row (Neural Link)', () => {
+    test('every visible +1 pulse increments the Pulse cell of its own record, not only the first rows', async ({page}) => {
+        await page.goto('/apps/workstation/index.html');
+        await page.waitForSelector(`${GRID} .neo-grid-row`, {state: 'visible', timeout: 30000});
+
+        // Non-vacuity: the defect is about rows BEYOND the first few, so a grid that rendered only a
+        // handful would make this pass while proving nothing about the reported case.
+        const before = await readRows(page);
+
+        expect(before.length, 'the matrix must render enough rows to reach the reported failure')
+            .toBeGreaterThan(8);
+
+        // The column mapping is itself a non-vacuity guard: reading a neighbouring column would
+        // report every row as failing and read exactly like a successful witness.
+        expect(before[0].pulseIndex, 'the Pulse column must be resolvable by its header')
+            .toBeGreaterThan(-1);
+        expect(before[0].pulse, 'and it must hold a number, not a name').toMatch(/^\d/);
+
+        const failures = [];
+
+        for (const {recordId, pulse} of before) {
+            const row = page.locator(`${GRID} .neo-grid-row[data-record-id="${recordId}"]`);
+
+            // `dispatchEvent`, not `click`. The Matrix animates continuously — a 10/sec feed, an
+            // animated counter and live sparklines — so an ordinary click times out on actionability,
+            // and `force: true` merely skips that check while still clicking the COORDINATES
+            // resolved a moment earlier, which the moving grid has since given to another row.
+            // Dispatching on the element itself is the only coordinate-free path to the handler.
+            await row.locator('.workstation-row-action').dispatchEvent('click');
+
+            let after = pulse;
+
+            // Poll rather than read once: the Pulse column animates its change, so a single read can
+            // land mid-transition and report a stale value for a row that DID increment. The poll is
+            // wrapped because a row that never changes is the defect under test — it must be
+            // recorded and the sweep continued, not thrown as an abort on the first bad row.
+            try {
+                await expect.poll(async () => {
+                    after = (await readRows(page)).find(entry => entry.recordId === recordId)?.pulse ?? pulse;
+
+                    return after
+                }, {timeout: 3000}).not.toBe(pulse)
+            } catch {
+                // unchanged within the window — captured below as a failure for this record
+            }
+
+            const digits   = value => Number(String(value).replace(/[^\d-]/g, '')),
+                  expected = digits(pulse) + 1;
+
+            digits(after) !== expected && failures.push({recordId, before: pulse, after})
+        }
+
+        expect(failures, `rows whose own Pulse cell did not increment: ${JSON.stringify(failures)}`)
+            .toEqual([])
+    })
+});

--- a/test/playwright/unit/grid/BodyWindowIsolation.spec.mjs
+++ b/test/playwright/unit/grid/BodyWindowIsolation.spec.mjs
@@ -1,0 +1,116 @@
+/**
+ * @file test/playwright/unit/grid/BodyWindowIsolation.spec.mjs
+ * @summary Each Neo.grid.Body owns its virtualization windows, so one grid cannot resize another's.
+ *
+ * `mountedRows`, `visibleRows` and `visibleColumns` are declared in `static config` as array
+ * literals, and the two window calculators write through them BY INDEX rather than reassigning
+ * (`me.mountedRows[0] = …` — "update the array inline"). A non-reactive config holding an array
+ * hands every instance the same object, so before the fix every grid body on a page shared one
+ * window and the last body to measure decided what all the others believed was mounted.
+ *
+ * Nothing reports that. `onStoreRecordChange()` and `getRow()` both treat an index outside the
+ * window as "nothing to do" — no row update, no warning — so on a page with two grids, a record
+ * change beyond the borrowed window reaches the store and never reaches the DOM. The store stays
+ * correct, which is what makes it hard to see: only the paint is missing.
+ *
+ * Observed on a page holding a tall grid and a short one, where the short grid clamped the tall
+ * grid to six mounted rows and every row below the sixth stopped repainting.
+ *
+ * @see Neo.grid.Body
+ * @see https://github.com/neomjs/neo/issues/18186
+ */
+
+import {setup} from '../../setup.mjs';
+
+setup({
+    neoConfig: {
+        allowVdomUpdatesInTests: true,
+        unitTestMode           : true,
+        useDomApiRenderer      : true,
+        useVdomWorker          : false
+    },
+    appConfig: {
+        name             : 'GridBodyWindowIsolationTest',
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../src/Neo.mjs';
+import * as core      from '../../../../src/core/_export.mjs';
+import GridBody       from '../../../../src/grid/Body.mjs';
+import Store          from '../../../../src/data/Store.mjs';
+
+/**
+ * A body with just enough state for the window calculator: it reads `availableRows`,
+ * `bufferRowRange`, `startIndex` and `store.count`, and nothing else.
+ * @param {Object} config
+ * @returns {Neo.grid.Body}
+ */
+const createBody = config => Neo.create(GridBody, {
+    appName: 'GridBodyWindowIsolationTest',
+    store  : Neo.create(Store, {
+        data: Array.from({length: 500}, (_, i) => ({id: i + 1, name: 'row ' + (i + 1)}))
+    }),
+    ...config
+});
+
+test.describe('Neo.grid.Body — one grid cannot resize another grid\'s window (#18186)', () => {
+    test.skip(!!process.env.NEO_TEST_SKIP_CI, 'bucket B: Grid tests require Playwright browsers in CI');
+
+    let feed, scale;
+
+    test.beforeEach(() => {
+        // Deliberately unequal geometries, mirroring the Workstation: a tall grid and a short one.
+        // Equal geometries would produce equal windows and the arm would pass while sharing.
+        scale = createBody({availableRows: 7, bufferRowRange: 10, startIndex: 0});
+        feed  = createBody({availableRows: 1, bufferRowRange: 2,  startIndex: 0})
+    });
+
+    test.afterEach(() => {
+        scale?.destroy?.();
+        feed?.destroy?.()
+    });
+
+    test('two bodies do not share the array objects their windows are written through', () => {
+        // Identity, asserted directly. The inline writes mean sharing the object IS the defect —
+        // every behavioural symptom below is downstream of this one fact.
+        expect(scale.mountedRows,    'mountedRows is per instance').not.toBe(feed.mountedRows);
+        expect(scale.visibleRows,    'visibleRows is per instance').not.toBe(feed.visibleRows);
+        expect(scale.visibleColumns, 'visibleColumns is per instance').not.toBe(feed.visibleColumns)
+    });
+
+    test('recomputing the tall grid\'s window leaves the short grid\'s window untouched', () => {
+        feed.updateMountedAndVisibleRows();
+
+        const feedWindow  = [...feed.mountedRows],
+              feedVisible = [...feed.visibleRows];
+
+        // The short grid's own geometry can only ever produce a 5-row window
+        // (availableRows 1 + 2 * bufferRowRange 2). Stating it makes the arm non-vacuous: if the
+        // calculator ever stops running, the assertions below would compare two untouched
+        // defaults and pass without measuring anything.
+        expect(feedWindow, 'the short grid measured its own geometry').toEqual([0, 5]);
+
+        scale.updateMountedAndVisibleRows();
+
+        // The tall grid reaches a window the short one cannot produce: availableRows 7 puts the
+        // visible end at 7, and bufferRowRange 10 extends the mounted end to 27.
+        expect(scale.mountedRows, 'the tall grid measured its own geometry').toEqual([0, 27]);
+        expect(scale.visibleRows, 'and its own visible range').toEqual([0, 7]);
+
+        // The point of the file: measuring one grid must not move the other.
+        expect(feed.mountedRows, 'the short grid keeps its window').toEqual(feedWindow);
+        expect(feed.visibleRows, 'and its visible range').toEqual(feedVisible)
+    });
+
+    test('the order the grids measure in does not decide what either believes is mounted', () => {
+        // The defect was order-dependent, so asserting one order proves only that order. Whichever
+        // measures last, both must end on their own numbers.
+        scale.updateMountedAndVisibleRows();
+        feed.updateMountedAndVisibleRows();
+
+        expect(scale.mountedRows, 'tall grid, measured first').toEqual([0, 27]);
+        expect(feed.mountedRows,  'short grid, measured last').toEqual([0, 5])
+    })
+});


### PR DESCRIPTION
## Summary

`Resolves #18186`

The `+1 pulse` button in the Workstation's 100k Matrix incremented the record and never repainted the cell, for every row below the sixth. Two lines of cause, and one of them is not in the grid at all — it is that the Workstation renders **two** grids.

`mountedRows`, `visibleRows` and `visibleColumns` are declared in `static config` as array literals, and both window calculators write through them **by index** rather than reassigning. Their own comments say so: `me.mountedRows[0] = mountedStart; // update the array inline`. A non-reactive config holding an array hands every instance the same object, so every grid body on the page shared one virtualization window, and whichever measured last decided what all the others believed was mounted.

The feed grid (`availableRows 1`, `bufferRowRange 2`) measured a 5-row window into the array the scale grid (`availableRows 7`, `bufferRowRange 10`) was reading. The scale grid then believed 6 of its 27 painted rows were mounted.

Both repaint paths gate on that window, and both treat anything outside it as nothing to do:

- `src/grid/Body.mjs:1310` — `onStoreRecordChange()` skips the row, so the new value never paints
- `src/grid/Body.mjs:1141` — `getRow()` returns `null`, so `grid/column/AnimatedChange.mjs:60` silently does nothing under its `if (row)`

No warning exists anywhere on that path. The store stayed correct throughout, which is exactly what made it hard to see: a button that visibly presses, a model that updates, and no paint.

Evidence: L2 (mutation-verified unit arms + an e2e witness on the running app, run locally) → L2 required (every close-target AC is observable from the sandbox). Residual: none.

`mountedColumns_` is reactive and always assigned a fresh array, so it was never affected. The copy runs after `super.construct()`, so a window supplied through config survives.

## How it was found

The route matters more than the diff, because three plausible readings were wrong first.

1. **Not the closure, and not the button.** Clicking and reading the **record** through the Neural Link rather than the DOM: `neo-record-7` went `73 → 74`, `neo-record-9` went `37 → 38`, while both Pulse cells stayed put. The handler always ran. Corroborated by 27 rows carrying 27 action buttons with **zero duplicate ids**. @tobiu raised the fat-arrow-vs-method difference against `examples/grid/bigData`; the same measurement rules it out, since `record.counter++` executes correctly under both forms and neither handler reads `this`.
2. **Not ordinal — the click order was a confound.** The report and the first witness both clicked top-to-bottom, so "the first six rows" and "the first six clicks" were indistinguishable. Clicking in reverse separates them: records 7–27 fail even when clicked *first*, records 1–6 pass even when clicked *last*.
3. **The window, measured.** `mountedRows: [0,5]` and `visibleRows: [0,1]` on a grid with 27 painted rows — and **both** bodies reporting byte-identical arrays despite different geometry. Calling `updateMountedAndVisibleRows()` on the scale body **alone** moved the feed body's window from `[0,5]` to `[0,27]`, a window its own `availableRows 1` can never produce. That single reading is the whole defect.

`examples/grid/bigData` has the same column pair and works, because it is the only grid on its page — the working control @tobiu pointed at is what made the two-grid precondition visible.

## Test Evidence

Mutation arms — the witness must be able to fail, and fail for this reason:

| State | `unit/grid/BodyWindowIsolation.spec.mjs` |
|---|---|
| Fix applied | `3 passed` |
| Fix reverted | `3 failed` — `expect(received).not.toBe(expected)` · `Expected: not [0, 0]` (the two bodies are one object) |

End to end, on the running app:

| State | `e2e/workstation/WorkstationRowActionNL.spec.mjs` |
|---|---|
| Before | `1 failed` — `neo-record-7` … `neo-record-27` never incremented |
| After | `1 passed` — all 27 rows increment their own Pulse cell |

Full unit suite at this head: **`3119 passed`**, zero failures, zero flaky.

The unit arms are deliberately built on **unequal** geometries. Two grids of the same size produce the same window, so the arms would pass while still sharing the array — the defect would be invisible to its own test. Each arm also asserts the geometry a body can produce *on its own* (`[0,5]` for the short grid, `[0,27]` for the tall one) before comparing them, so a calculator that stopped running could not be mistaken for isolation. A third arm reverses the measurement order, because the defect was order-dependent and asserting one order proves only that order.

## Note for reviewers

The e2e witness is the first commit and is red at its own parent; the fix is the second. Reviewing them in order shows the symptom before the cause.

Worth carrying past this PR: **single-grid coverage cannot witness a shared-instance defect.** Everything here needed two instances of the same class on one page to be visible at all, and the grid suite had no such fixture. That is a coverage shape, not a bug, and I have not widened this PR to chase it.

⚖️ **Ada** · `@neo-opus-ada` · Claude Opus 5 · Claude Code
