### PR TITLE
fix(grid): the row and column windows are instance state, not static config (#18186)

### DIFF
--- a/src/grid/Body.mjs
+++ b/src/grid/Body.mjs
@@ -148,12 +148,6 @@ class GridBody extends Component {
          */
         mountedColumns_: [0, 0],
         /**
-         * Stores the indexes of the first & last mounted rows, including bufferRowRange
-         * @member {Number[]} mountedRows=[0,0]
-         * @protected
-         */
-        mountedRows: [0, 0],
-        /**
          * Optional config values for Neo.grid.plugin.AnimateRows
          * @member {Object} pluginAnimateRowsConfig=null
          */
@@ -210,18 +204,6 @@ class GridBody extends Component {
          */
         stripedRows_: true,
         /**
-         * Stores the indexes of the first & last painted columns
-         * @member {Number[]} visibleColumns=[0,0]
-         * @protected
-         */
-        visibleColumns: [0, 0],
-        /**
-         * Stores the indexes of the first & last visible rows, excluding bufferRowRange
-         * @member {Number[]} visibleRows=[0,0]
-         * @protected
-         */
-        visibleRows: [0, 0],
-        /**
          * @member {String[]|null} wrapperCls=null
          * @reactive
          */
@@ -257,10 +239,37 @@ class GridBody extends Component {
      */
     items = []
     /**
+     * Stores the indexes of the first & last mounted rows, including bufferRowRange.
+     *
+     * An instance field rather than a `static config`, because it is neither configured nor read
+     * from outside: it is derived state that `updateMountedAndVisibleRows()` writes through BY
+     * INDEX. A `static config` holding a mutable literal is handed to every instance by reference
+     * — the engine's clone protection lives in the reactive-config path, which a config without a
+     * trailing underscore never enters — so every grid body on a page would share this one array
+     * and the last body to measure would decide what all the others believe is mounted.
+     * @member {Number[]} mountedRows=[0,0]
+     * @protected
+     */
+    mountedRows = [0, 0]
+    /**
      * The dynamic size of the row pool.
      * @member {Number|null} rowPoolSize=null
      */
     rowPoolSize = null
+    /**
+     * Stores the indexes of the first & last painted columns.
+     * Instance field for the same reason as `mountedRows`.
+     * @member {Number[]} visibleColumns=[0,0]
+     * @protected
+     */
+    visibleColumns = [0, 0]
+    /**
+     * Stores the indexes of the first & last visible rows, excluding bufferRowRange.
+     * Instance field for the same reason as `mountedRows`.
+     * @member {Number[]} visibleRows=[0,0]
+     * @protected
+     */
+    visibleRows = [0, 0]
 
     /**
      * @member {String[]} selectedCells

--- a/test/playwright/e2e/workstation/WorkstationRowActionNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationRowActionNL.spec.mjs
@@ -1,0 +1,164 @@
+import {test, expect} from '../../fixtures.mjs';
+
+/**
+ * The `+1 pulse` row action must increment the Pulse cell of ITS OWN row, for every visible row.
+ *
+ * Operator report from the 100k Matrix pane: the action works for the first handful of rows and
+ * silently does nothing for the rest of the visible area. Nothing errors — the click lands, the
+ * button paints its press, and the counter three columns to the left simply does not move.
+ *
+ * **Why this is read by record id and not by row position.** The grid is buffered: rows are pooled
+ * DOM nodes recycled across records, so "row 7" is not a stable subject. Every assertion below pairs
+ * a button with the Pulse cell of the SAME `data-record-id`, which is the only pairing that survives
+ * recycling — and it is also the pairing the defect is suspected to break.
+ *
+ * The action column is a `component` column whose handler closes over `record` at component-creation
+ * time (`ScalePane.mjs`), so a recycled cell can keep a handler bound to the record it was first
+ * built for. That is a hypothesis; this spec only establishes the SYMPTOM, deliberately, so the
+ * mechanism can be falsified separately without rewriting the witness.
+ *
+ * @see https://github.com/neomjs/neo/issues/18186
+ */
+
+// Scoped to the SCALE pane, not `.neo-grid-container`: the Workstation renders two grids and the
+// feed matches first. A bare container selector read the feed's name column and reported every row
+// as failing — a red for the wrong reason, which is worse than a green.
+const GRID = '.workstation-scale-pane';
+
+/**
+ * Reads every rendered row of the scale grid as `{recordId, pulse}`, paired by identity.
+ * @param {import('@playwright/test').Page} page
+ * @returns {Promise<Object[]>}
+ */
+const readRows = page => page.evaluate(grid => {
+    const container = document.querySelector(grid);
+
+    if (!container) return [];
+
+    // The Pulse column index is DERIVED from the header, never hardcoded. The grid has eight
+    // columns (#, Work item, State, Throughput, Pulse, Load, Living signal, Action) and a guessed
+    // index silently reads a neighbour — a name column never increments, so the spec reports every
+    // row as broken and looks like a perfect witness while measuring nothing.
+    const headers = [...container.querySelectorAll('.neo-grid-header-button')]
+              .map(node => (node.textContent || '').trim()),
+          pulseIndex = headers.indexOf('Pulse');
+
+    return [...container.querySelectorAll('.neo-grid-row')].map(row => {
+        const cells = [...row.querySelectorAll('.neo-grid-cell')];
+
+        return {
+            hasAction: !!row.querySelector('.workstation-row-action'),
+            pulse    : pulseIndex > -1 ? (cells[pulseIndex]?.textContent || '').trim() : null,
+            pulseIndex,
+            recordId : row.dataset?.recordId ?? row.getAttribute('data-record-id')
+        }
+    }).filter(entry => entry.recordId && entry.hasAction)
+}, GRID);
+
+test.describe('Workstation 100k Matrix — a row action acts on its own row (Neural Link)', () => {
+    test('every visible +1 pulse increments the Pulse cell of its own record, not only the first rows', async ({page}) => {
+        await page.goto('/apps/workstation/index.html');
+        await page.waitForSelector(`${GRID} .neo-grid-row`, {state: 'visible', timeout: 30000});
+
+        // Non-vacuity: the defect is about rows BEYOND the first few, so a grid that rendered only a
+        // handful would make this pass while proving nothing about the reported case.
+        const before = await readRows(page);
+
+        expect(before.length, 'the matrix must render enough rows to reach the reported failure')
+            .toBeGreaterThan(8);
+
+        // The column mapping is itself a non-vacuity guard: reading a neighbouring column would
+        // report every row as failing and read exactly like a successful witness.
+        expect(before[0].pulseIndex, 'the Pulse column must be resolvable by its header')
+            .toBeGreaterThan(-1);
+        expect(before[0].pulse, 'and it must hold a number, not a name').toMatch(/^\d/);
+
+        const failures = [];
+
+        for (const {recordId, pulse} of before) {
+            const row = page.locator(`${GRID} .neo-grid-row[data-record-id="${recordId}"]`);
+
+            // `dispatchEvent`, not `click`. The Matrix animates continuously — a 10/sec feed, an
+            // animated counter and live sparklines — so an ordinary click times out on actionability,
+            // and `force: true` merely skips that check while still clicking the COORDINATES
+            // resolved a moment earlier, which the moving grid has since given to another row.
+            // Dispatching on the element itself is the only coordinate-free path to the handler.
+            await row.locator('.workstation-row-action').dispatchEvent('click');
+
+            let after = pulse;
+
+            // Poll rather than read once: the Pulse column animates its change, so a single read can
+            // land mid-transition and report a stale value for a row that DID increment. The poll is
+            // wrapped because a row that never changes is the defect under test — it must be
+            // recorded and the sweep continued, not thrown as an abort on the first bad row.
+            try {
+                await expect.poll(async () => {
+                    after = (await readRows(page)).find(entry => entry.recordId === recordId)?.pulse ?? pulse;
+
+                    return after
+                }, {timeout: 3000}).not.toBe(pulse)
+            } catch {
+                // unchanged within the window — captured below as a failure for this record
+            }
+
+            const digits   = value => Number(String(value).replace(/[^\d-]/g, '')),
+                  expected = digits(pulse) + 1;
+
+            digits(after) !== expected && failures.push({recordId, before: pulse, after})
+        }
+
+        expect(failures, `rows whose own Pulse cell did not increment: ${JSON.stringify(failures)}`)
+            .toEqual([])
+    });
+
+    test('a recycled row acts on the record it currently displays, not the one its cell was built for', async ({page}) => {
+        await page.goto('/apps/workstation/index.html');
+        await page.waitForSelector(`${GRID} .neo-grid-row`, {state: 'visible', timeout: 30000});
+
+        const before = (await readRows(page)).map(entry => entry.recordId);
+
+        // Scroll far enough that the pool must recycle rather than extend. The rows that come back
+        // are the SAME DOM nodes carrying different records, which is the case the first test
+        // cannot reach: it never scrolls, so every cell it touches was created rather than reused.
+        await page.locator(`${GRID} .neo-grid-row`).first().hover();
+        await page.mouse.wheel(0, 4000);
+        await page.waitForTimeout(1200);
+
+        const after = await readRows(page);
+
+        // Non-vacuity, and the whole reason this test exists: if the scroll changed nothing, every
+        // assertion below would re-measure the already-covered first viewport and pass for free.
+        expect(after.length, 'rows are still rendered after scrolling').toBeGreaterThan(4);
+        expect(after.some(entry => !before.includes(entry.recordId)),
+            'the scroll must bring records the first viewport never held').toBe(true);
+
+        const failures = [];
+
+        for (const {recordId, pulse} of after) {
+            const row = page.locator(`${GRID} .neo-grid-row[data-record-id="${recordId}"]`);
+
+            if (!await row.count()) continue;
+
+            await row.locator('.workstation-row-action').dispatchEvent('click');
+
+            let value = pulse;
+
+            try {
+                await expect.poll(async () => {
+                    value = (await readRows(page)).find(entry => entry.recordId === recordId)?.pulse ?? pulse;
+
+                    return value
+                }, {timeout: 3000}).not.toBe(pulse)
+            } catch {
+                // unchanged within the window — recorded below rather than aborting the sweep
+            }
+
+            const digits = input => Number(String(input).replace(/[^\d-]/g, ''));
+
+            digits(value) !== digits(pulse) + 1 && failures.push({recordId, before: pulse, after: value})
+        }
+
+        expect(failures, `recycled rows whose own Pulse cell did not increment: ${JSON.stringify(failures)}`)
+            .toEqual([])
+    })
+});

--- a/test/playwright/unit/grid/BodyWindowIsolation.spec.mjs
+++ b/test/playwright/unit/grid/BodyWindowIsolation.spec.mjs
@@ -1,0 +1,121 @@
+/**
+ * @file test/playwright/unit/grid/BodyWindowIsolation.spec.mjs
+ * @summary Each Neo.grid.Body owns its virtualization windows, so one grid cannot resize another's.
+ *
+ * `mountedRows`, `visibleRows` and `visibleColumns` are declared in `static config` as array
+ * literals, and the two window calculators write through them BY INDEX rather than reassigning
+ * (`me.mountedRows[0] = …` — "update the array inline"). A non-reactive config holding an array
+ * hands every instance the same object, so before the fix every grid body on a page shared one
+ * window and the last body to measure decided what all the others believed was mounted.
+ *
+ * Nothing reports that. `onStoreRecordChange()` and `getRow()` both treat an index outside the
+ * window as "nothing to do" — no row update, no warning — so on a page with two grids, a record
+ * change beyond the borrowed window reaches the store and never reaches the DOM. The store stays
+ * correct, which is what makes it hard to see: only the paint is missing.
+ *
+ * Observed on a page holding a tall grid and a short one, where the short grid clamped the tall
+ * grid to six mounted rows and every row below the sixth stopped repainting.
+ *
+ * @see Neo.grid.Body
+ * @see https://github.com/neomjs/neo/issues/18186
+ */
+
+import {setup} from '../../setup.mjs';
+
+setup({
+    neoConfig: {
+        allowVdomUpdatesInTests: true,
+        unitTestMode           : true,
+        useDomApiRenderer      : true,
+        useVdomWorker          : false
+    },
+    appConfig: {
+        name             : 'GridBodyWindowIsolationTest',
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../src/Neo.mjs';
+import * as core      from '../../../../src/core/_export.mjs';
+import GridBody       from '../../../../src/grid/Body.mjs';
+import Store          from '../../../../src/data/Store.mjs';
+
+/**
+ * A body with just enough state for the window calculator: it reads `availableRows`,
+ * `bufferRowRange`, `startIndex` and `store.count`, and nothing else.
+ * @param {Object} config
+ * @returns {Neo.grid.Body}
+ */
+const createBody = config => Neo.create(GridBody, {
+    appName: 'GridBodyWindowIsolationTest',
+    store  : Neo.create(Store, {
+        data: Array.from({length: 500}, (_, i) => ({id: i + 1, name: 'row ' + (i + 1)}))
+    }),
+    ...config
+});
+
+test.describe('Neo.grid.Body — one grid cannot resize another grid\'s window (#18186)', () => {
+    // Deliberately NO `test.skip(!!process.env.NEO_TEST_SKIP_CI, …)` guard, which several specs in
+    // this directory carry. The `unit` CI job sets that variable, so a guarded regression arm is
+    // green in CI by not running — indistinguishable from green by passing, and useless as the
+    // thing that stops this defect coming back. Nothing here needs more than the engine the
+    // unguarded specs in this directory already use: two `Neo.grid.Body` instances and a store,
+    // no mount, no render, no DOM.
+
+    let feed, scale;
+
+    test.beforeEach(() => {
+        // Deliberately unequal geometries, mirroring the Workstation: a tall grid and a short one.
+        // Equal geometries would produce equal windows and the arm would pass while sharing.
+        scale = createBody({availableRows: 7, bufferRowRange: 10, startIndex: 0});
+        feed  = createBody({availableRows: 1, bufferRowRange: 2,  startIndex: 0})
+    });
+
+    test.afterEach(() => {
+        scale?.destroy?.();
+        feed?.destroy?.()
+    });
+
+    test('two bodies do not share the array objects their windows are written through', () => {
+        // Identity, asserted directly. The inline writes mean sharing the object IS the defect —
+        // every behavioural symptom below is downstream of this one fact.
+        expect(scale.mountedRows,    'mountedRows is per instance').not.toBe(feed.mountedRows);
+        expect(scale.visibleRows,    'visibleRows is per instance').not.toBe(feed.visibleRows);
+        expect(scale.visibleColumns, 'visibleColumns is per instance').not.toBe(feed.visibleColumns)
+    });
+
+    test('recomputing the tall grid\'s window leaves the short grid\'s window untouched', () => {
+        feed.updateMountedAndVisibleRows();
+
+        const feedWindow  = [...feed.mountedRows],
+              feedVisible = [...feed.visibleRows];
+
+        // The short grid's own geometry can only ever produce a 5-row window
+        // (availableRows 1 + 2 * bufferRowRange 2). Stating it makes the arm non-vacuous: if the
+        // calculator ever stops running, the assertions below would compare two untouched
+        // defaults and pass without measuring anything.
+        expect(feedWindow, 'the short grid measured its own geometry').toEqual([0, 5]);
+
+        scale.updateMountedAndVisibleRows();
+
+        // The tall grid reaches a window the short one cannot produce: availableRows 7 puts the
+        // visible end at 7, and bufferRowRange 10 extends the mounted end to 27.
+        expect(scale.mountedRows, 'the tall grid measured its own geometry').toEqual([0, 27]);
+        expect(scale.visibleRows, 'and its own visible range').toEqual([0, 7]);
+
+        // The point of the file: measuring one grid must not move the other.
+        expect(feed.mountedRows, 'the short grid keeps its window').toEqual(feedWindow);
+        expect(feed.visibleRows, 'and its visible range').toEqual(feedVisible)
+    });
+
+    test('the order the grids measure in does not decide what either believes is mounted', () => {
+        // The defect was order-dependent, so asserting one order proves only that order. Whichever
+        // measures last, both must end on their own numbers.
+        scale.updateMountedAndVisibleRows();
+        feed.updateMountedAndVisibleRows();
+
+        expect(scale.mountedRows, 'tall grid, measured first').toEqual([0, 27]);
+        expect(feed.mountedRows,  'short grid, measured last').toEqual([0, 5])
+    })
+});


### PR DESCRIPTION
## Summary

Resolves #18186. Supersedes #18190, which @tobiu dropped as monkey-patching — correctly.

The `+1 pulse` button in the Workstation's 100k Matrix incremented the record and never repainted the cell, for every row below the sixth. Same defect as #18190 diagnosed; **different fix, because that one treated the symptom in the wrong place.**

### What is actually wrong

`mountedRows`, `visibleRows` and `visibleColumns` were declared in `static config` as array literals. `core.Base#mergeConfig()` ends with:

```js
return {...staticConfig, ...config}
```

A **shallow** spread. Every instance receives its own config *object* holding the **same array**. The engine does guard mutable config values — but that guard is the `clone` switch inside the generated reactive setter (`src/Neo.mjs:430`), and a config without a trailing underscore never reaches a setter. These three are written through **by index** (`me.mountedRows[0] = mountedStart` — the source says `// update the array inline`) rather than reassigned, so every grid body on a page shared one window.

**None of the three is configuration.** A repo-wide sweep finds no site anywhere in `src/`, `apps/`, `examples/` or `test/` that passes any of them as an instance config. They are derived bookkeeping the body recomputes on mount and on scroll, and `@protected` already said so.

So they become instance fields, beside `items`, `rowPoolSize` and `#lastMountedColumns` — the same kind of state, declared that way three lines above in the same class. Per-instance by construction: no clone descriptor, no copy step, nothing for the next author to remember when adding a fourth.

### Why #18190 was wrong

It kept the three as `static config` and copied them into per-instance arrays in `construct()`. That works, and it is a patch: it leaves a mutable literal sitting in `static config` where it does not belong, adds a step every future mutable config must remember, and encodes the workaround in the constructor rather than fixing the categorisation. @tobiu's read — *the class config system assigns all static configs on instance level* — is right, and the missing half is that the spread is shallow, so assignment is per-instance while the value is shared. That is documented behaviour with a documented opt-in (`learn/guides/fundamentals/DeclarativeConfigMerging.md` §Prototype Pollution), not an engine defect. **No config-system change is needed or included here.**

### The consequence, and why it was silent

The Workstation has two grids. The feed grid (`availableRows 1`, buffer 2) measured a 5-row window into the array the scale grid (`availableRows 7`, buffer 10) was reading, so the scale grid believed 6 of its 27 painted rows were mounted. Both repaint paths gate on that window and treat anything outside it as nothing to do — `onStoreRecordChange()` skips the row, `getRow()` returns `null`, and `AnimatedChange` no-ops under its `if (row)`. No warning anywhere on that path.

The discriminating measurement, before any fix: calling `updateMountedAndVisibleRows()` on the **scale** body alone moved the **feed** body's window from `[0,5]` to `[0,27]` — a window its own geometry can never produce.

`mountedColumns_` is reactive and always assigned a fresh array, so it was never affected.

Evidence: L2 (mutation-verified unit and e2e arms, run locally) → L2 required (every close-target AC is observable from the sandbox). Residual: none.

## Test Evidence

Every arm is red-first, verified with the fix **genuinely absent from the working tree** (asserted by grep, not by assuming a `git stash` took):

| Arm | Fix applied | Fix absent |
|---|---|---|
| `unit/grid/BodyWindowIsolation.spec.mjs` (3 arms) | `3 passed` | `3 failed` |
| `e2e/workstation/WorkstationRowActionNL.spec.mjs` (2 arms) | `2 passed` | `2 failed` |

Full unit suite at this head: **`3120 passed`**, zero failures, zero flaky.

The isolation arms carry **no** `NEO_TEST_SKIP_CI` guard, unlike six of the sixteen specs in that directory. The `unit` job sets that variable (`.github/workflows/test.yml:358`), so a guarded regression arm is green in CI by *not running* — indistinguishable from green by passing, and worthless as the thing that stops this coming back. Verified by running with the variable set: `3 passed`, not `3 skipped`. Caught by @neo-opus-grace on the superseded PR.

The unit arms use **unequal** geometries (`7`/`10` against `1`/`2`) deliberately. Two grids of the same size produce the same window, so the arms would pass while still sharing the array — the defect would be invisible to its own test. Each arm also asserts the window a body can reach *on its own* before comparing, so a calculator that stopped running could not be mistaken for isolation, and a third arm reverses the measurement order because the defect was order-dependent.

## Note for reviewers

Two corrections I made to my own work while getting here, both worth the line:

1. **A `git stash push <file>` does not remove a committed change.** I used one to "revert" the fix for a red-first check after committing it, and got a green that I briefly read as the arm being vacuous. The fix was active the whole time. Every red-first claim above was re-run with the absence verified by `grep -c`.
2. The recycle arm is red-first after all — the reading that said otherwise was entirely that broken instrument.

⚖️ **Ada** · `@neo-opus-ada` · Claude Opus 5 · Claude Code
