### PR TITLE
docs(dock): the retire budget is a range, the park receipt names physical (#18123)

### DIFF
--- a/apps/workstation/view/Workspace.mjs
+++ b/apps/workstation/view/Workspace.mjs
@@ -413,6 +413,12 @@ class Workspace extends DockWorkspace {
     lastTourReceipt = null
     /**
      * Most recent exact-handle park admission receipt.
+     *
+     * `parked` and `physical` are separate answers, and the pair is the point: `parked: true` says
+     * the park was SATISFIED, `physical: false` that it performed no platform effect. A main-window
+     * target under a native titlebar is exactly that case — there is nothing to move, so the park
+     * succeeds having done nothing. A reader taking `parked` as proof of a platform call would go
+     * looking for a move that never happened.
      * @member {Object|null} lastVesselParkReceipt=null
      * @protected
      */
@@ -3234,6 +3240,10 @@ class Workspace extends DockWorkspace {
         // popup's own Main actor (`opener.focus()`, granted under the user activation a keyboard
         // command carries — the pointer conversion path); a popup target is focused by its owner
         // through the handle it minted.
+        //
+        // A main-window target under a native titlebar never arrives here: it returns satisfied
+        // above, having nothing to park. So the main branch below serves the pointer conversion
+        // path alone — there is no native-titlebar main case to find.
         const focusTarget = () => targetIsMain
             ? Neo.Main.windowFocus({windowId: entry.windowId})
             : Neo.Main.windowNativeFocus({

--- a/src/manager/DragCoordinator.mjs
+++ b/src/manager/DragCoordinator.mjs
@@ -52,8 +52,15 @@ class DragCoordinator extends Manager {
         nativeWindowRetireRetryMs: 250,
         /**
          * How many retirement retries a committed native drop makes before giving up on the close.
-         * At the default cadence this is 20 s of holding; past it the pane stays home and the popup
-         * simply remains for the user to close.
+         * Past it the pane stays home and the popup simply remains for the user to close.
+         *
+         * The budget is a RANGE, not `limit × cadence`, because each attempt also awaits the close
+         * verification: `Neo.Main#windowNativeClose` polls `win.closed` up to 6 × 50 ms before
+         * reporting failure, and the next attempt is scheduled only after that resolves. So a cycle
+         * costs the cadence plus up to 300 ms — **20 s of holding when every close verifies at once,
+         * up to ≈ 44 s when each attempt exhausts its poll**. Erring long is the safe direction here
+         * (a released popup left on screen is the worse outcome), but the range is stated because
+         * this is where someone goes to shorten the budget and `80 × 250 ms` is the wrong answer.
          * @member {Number} nativeWindowRetireRetryLimit=80
          */
         nativeWindowRetireRetryLimit: 80,


### PR DESCRIPTION
Resolves #18123

Three doc sites from the native-drop reviews, each one where a reader would have computed or looked for the wrong thing. The retire budget's documented duration was off by about 2.2×, the park receipt documented none of its fields, and the focus verb invited a search for a branch that does not exist.

Evidence: L2 (unit — every claim is a statement about source the reader reads, so the falsifier is the source itself, quoted below) → L2 required (all four ACs are documentation-versus-mechanism claims). Residual: none.

## AC Evidence
| AC-1 | `DragCoordinator.mjs` — the budget now states both bounds, derived from `Main#windowNativeClose`'s poll quoted in Test Evidence; `20 s of holding when every close verifies at once, up to ≈ 44 s when each attempt exhausts its poll` |
| AC-2 | `apps/workstation/view/Workspace.mjs` — `lastVesselParkReceipt` names `parked` and `physical` as separate answers, with the main-window-target case that produces `parked: true, physical: false` |
| AC-3 | same file — the `focusTarget` comment states that a native-titlebar main target returns satisfied earlier and never reaches the verb, so the main branch serves the pointer conversion path alone |
| AC-4 | `unit/manager` + `unit/apps/workstation` **152 passed**, doc-only change |

## Deltas from ticket

**AC-1 offered a fork and I took the doc restatement, deliberately.** The alternative was making the cadence honest by subtracting the measured poll from the 250 ms delay so the budget really is 20 s. I did not, for two reasons: erring long is the safe direction here (a released popup left on screen is the worse outcome, which the cadence's own JSDoc already argues), and it would be a behaviour change on a path whose behaviour this ticket puts out of scope.

**I measured the poll's BOUND from source rather than its typical runtime duration.** The ticket suggested "a one-line measurement of the poll's typical duration". A typical-case figure varies by platform and by how fast the OS releases a dragged titlebar, and it would decay silently; the bound is `6 × 50 ms` in the source and cannot drift without the code changing. So the JSDoc states the range with both ends rather than one representative number.

**AC-2 was narrower than what I found.** The ticket says the receipt JSDoc "lacks `physical`". It documented **no** fields at all. I still documented only the `parked` / `physical` pair rather than the shape: the receipt carries thirteen keys, and a full field list is the kind of world-atlas comment that rots. The pair is documented because their relationship is the counter-intuitive part.

## Test Evidence

All coverage runs in CI.

The one thing CI cannot check is whether the new numbers match the mechanism, so here is the falsifier for AC-1, read at `f8432c1ccb`:

```js
// src/Main.mjs — windowNativeClose
for (let attempt = 0; attempt < 6 && !win.closed; attempt++) {
    await new Promise(resolve => setTimeout(resolve, 50))
}
```

Up to 300 ms per attempt, awaited before the next attempt is scheduled at `nativeWindowRetireRetryMs` (250 ms). So a cycle is 250–550 ms and 80 of them is 20 s–44 s, which is what the JSDoc now says. Also swept for other sites citing the old 20 s figure: none.

## Post-Merge Validation
- [ ] None. Documentation-only; no runtime surface changes.

Authored by Vega (Opus 5, Claude Code). Session e8ea32a2-b9a8-43ea-84ba-b83081ec4b3d.
