### PR TITLE
build(scss): a theme value file declares variables, never selectors (#18145)

### DIFF
--- a/.github/workflows/theme-value-file-lint.yml
+++ b/.github/workflows/theme-value-file-lint.yml
@@ -1,0 +1,52 @@
+name: Theme Value File Lint
+
+# CI mirror of the `.husky/pre-commit` guard, so `git commit --no-verify` cannot bypass it.
+#
+# The rule (operator, 2026-09-02): a theme value file declares variables, never selectors. Which
+# elements get a value is structural and belongs in `resources/scss/src`; a theme only answers what
+# its value is. See `buildScripts/util/check-theme-value-files.mjs` for why that is a defect class
+# rather than a style preference.
+
+on:
+  pull_request:
+    branches: [dev]
+    paths:
+      # The invariant is scanned ⊆ watched. The guard walks EVERY theme file, so every theme file
+      # must re-run it; a filter narrower than the scan lets the introducing PR land ungated and
+      # turns the next unrelated run red — late, misattributed enforcement.
+      - 'resources/scss/theme-*/**/*.scss'
+      # The baseline is an INPUT to the verdict, so editing it must re-run the check. Otherwise a
+      # file can be blessed by editing the record of what exists, with nothing re-reading reality.
+      - 'buildScripts/util/check-theme-value-files-baseline.json'
+      - 'buildScripts/util/check-theme-value-files.mjs'
+      - '.github/workflows/theme-value-file-lint.yml'
+  push:
+    branches: [dev]
+    paths:
+      - 'resources/scss/theme-*/**/*.scss'
+      - 'buildScripts/util/check-theme-value-files-baseline.json'
+      - 'buildScripts/util/check-theme-value-files.mjs'
+      - '.github/workflows/theme-value-file-lint.yml'
+
+concurrency:
+  group: theme-value-file-lint-${{ github.run_attempt == '1' && github.ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+
+      # No install: the guard reads files and walks braces with the standard library only. Stated
+      # rather than assumed, because `fixed-sleep-lint.yml` carries the scar of a workflow whose
+      # "nothing to resolve" comment stayed true right up until discovery moved to a parse tree.
+      # If this guard ever grows a parser, this step is the tripwire — add `npm ci` with it.
+      - name: Require theme value files to declare variables, never selectors
+        run: node ./buildScripts/util/check-theme-value-files.mjs

--- a/buildScripts/util/check-theme-value-files-baseline.json
+++ b/buildScripts/util/check-theme-value-files-baseline.json
@@ -1,0 +1,47 @@
+[
+    {
+        "file": "resources/scss/theme-cyberpunk/Global.scss",
+        "blocks": 1,
+        "reason": "pending #18145 — Global.scss is the sweep last batch; the ticket expects it to graduate to its own ticket."
+    },
+    {
+        "file": "resources/scss/theme-dark/Global.scss",
+        "blocks": 1,
+        "reason": "pending #18145 — Global.scss is the sweep last batch; the ticket expects it to graduate to its own ticket."
+    },
+    {
+        "file": "resources/scss/theme-light/Global.scss",
+        "blocks": 1,
+        "reason": "pending #18145 — Global.scss is the sweep last batch; the ticket expects it to graduate to its own ticket."
+    },
+    {
+        "file": "resources/scss/theme-neo-dark/Global.scss",
+        "blocks": 10,
+        "reason": "pending #18145 — Global.scss is the sweep last batch; the ticket expects it to graduate to its own ticket."
+    },
+    {
+        "file": "resources/scss/theme-neo-dark/dialog/Base.scss",
+        "blocks": 3,
+        "reason": "exempt #18145 — see the neo-light entry; same rule, same blocker."
+    },
+    {
+        "file": "resources/scss/theme-neo-dark/tab/header/Button.scss",
+        "blocks": 3,
+        "reason": "exempt #18171 — see the neo-light entry; same dead selector."
+    },
+    {
+        "file": "resources/scss/theme-neo-light/Global.scss",
+        "blocks": 10,
+        "reason": "pending #18145 — Global.scss is the sweep last batch; the ticket expects it to graduate to its own ticket."
+    },
+    {
+        "file": "resources/scss/theme-neo-light/dialog/Base.scss",
+        "blocks": 3,
+        "reason": "exempt #18145 — a structural rule for a dialog header button must sit at (0,3,0), which would override a ui-variant background winning at (0,2,0) in themes carrying no such rule today. CSS has no per-declaration opt-out, so this needs a design decision rather than a refactor."
+    },
+    {
+        "file": "resources/scss/theme-neo-light/tab/header/Button.scss",
+        "blocks": 3,
+        "reason": "exempt #18171 — the block writes .pressed as a DESCENDANT of a class that lands on the button itself, so it has never matched. Porting it reproduces a dead selector; fixing it repaints pressed tabs in two themes."
+    }
+]

--- a/buildScripts/util/check-theme-value-files.mjs
+++ b/buildScripts/util/check-theme-value-files.mjs
@@ -63,63 +63,77 @@ const
  * 1, so ANY block opened at depth ≥ 1 is a nested rule regardless of how its selector is written.
  * Comments and strings are stripped first so a brace inside either cannot move the count. `@`-rules
  * stay allowed — `@include` composes values rather than deciding which elements receive them.
+ *
+ * **The depth-0 block is checked too, and that is not symmetry — it closes a real escape.** Treating
+ * depth 0 as "the file's own wrapper" is a convention no code enforces: nothing stops a file having a
+ * SECOND top-level block, and one declaring `color: red` was reported compliant. Worse, it is the
+ * shape ordinary editing produces — appending to a theme file lands at column 0, so the easiest way
+ * to add an override was the one way this guard could not see it.
+ *
+ * The test is the rule itself rather than a proxy for it: a top-level block may declare custom
+ * properties and nothing else. Failing on "more than one top-level block" would also have worked on
+ * today's tree, and would ban a legitimate second variables-only scope; this does not.
  * @param {String} file Absolute path.
  * @returns {{line: Number, text: String}[]}
  */
 export function findSelectorBlocks(file) {
     const
-        lines  = fs.readFileSync(file, 'utf8').split('\n'),
-        blocks = [];
+        blocks = [],
+        source = fs.readFileSync(file, 'utf8')
+            // Comments and strings first, so a brace inside either cannot move the depth.
+            .replace(/\/\*[\s\S]*?\*\//g, '')
+            .replace(/\/\/[^\n]*/g, '')
+            .replace(/(['"])(?:\\.|(?!\1).)*\1/g, '')
+            // SCSS interpolation is not a block. `--button-border: #{$w} #{$s};` carries two `#{`
+            // openers, and counting them made an already-clean file report 34 selectors.
+            .replace(/#\{[^{}]*\}/g, '');
 
-    let depth     = 0,
-        inComment = false;
+    let depth  = 0,
+        line   = 1,
+        buffer = '';
 
-    lines.forEach((raw, index) => {
-        let code      = raw,
-            opensHere = 0;
+    /**
+     * @summary Records a declaration if `buffer` holds one that a theme file may not declare.
+     * @param {Number} at
+     */
+    const flushDeclaration = at => {
+        const declaration = buffer.match(/([a-zA-Z-][\w-]*)\s*:/);
 
-        // Strip block comments (possibly spanning lines), then line comments and strings.
-        if (inComment) {
-            const end = code.indexOf('*/');
+        // Only DIRECTLY inside the theme's own scope. Deeper text already belongs to a nested block
+        // that was reported when it opened.
+        depth === 1 && declaration && !declaration[1].startsWith('--') && !buffer.trim().startsWith('@') &&
+            blocks.push({kind: 'top-level property', line: at, text: buffer.trim().slice(0, 90)});
 
-            if (end === -1) return;
+        buffer = ''
+    };
 
-            code      = code.slice(end + 2);
-            inComment = false
+    for (const char of source) {
+        if (char === '\n') { line++; buffer += ' '; continue }
+
+        if (char === '{') {
+            // The selector is whatever preceded the brace. At depth ≥ 1 that is a nested rule; at
+            // depth 0 it is the file's own scope, whose CONTENTS `flushDeclaration` then polices.
+            depth > 0 && !buffer.trim().startsWith('@') && buffer.trim() &&
+                blocks.push({kind: 'nested selector', line, text: buffer.trim().slice(0, 90)});
+
+            depth++;
+            buffer = '';
+            continue
         }
 
-        code = code.replace(/\/\*[\s\S]*?\*\//g, '');
-
-        const open = code.indexOf('/*');
-
-        if (open !== -1) {
-            inComment = true;
-            code      = code.slice(0, open)
+        if (char === '}') {
+            // A one-line block (`.probe { color: red }`) closes without a `;`, so the declaration is
+            // only ever seen here. Flushing BEFORE the depth drop is what catches it — the earlier
+            // line-based version missed exactly this shape.
+            flushDeclaration(line);
+            depth = Math.max(0, depth - 1);
+            continue
         }
 
-        code = code.replace(/\/\/.*$/, '').replace(/(['"])(?:\\.|(?!\1).)*\1/g, '');
+        if (char === ';') { flushDeclaration(line); continue }
 
-        // SCSS INTERPOLATION is not a block. `--button-border: #{$width} #{$style};` carries two
-        // `#{` openers, and counting them made a file this sweep had already cleaned report 34
-        // selectors. Stripped before the walk so the depth stays structural.
-        code = code.replace(/#\{[^{}]*\}/g, '');
-
-        const atRule = /^\s*@/.test(code);
-
-        for (const char of code) {
-            if (char === '{') {
-                // Depth 0 → the file's own theme wrapper. Depth ≥ 1 → a nested rule, unless this
-                // line is an at-rule: `@include`/`@if`/`@each` compose values and control flow,
-                // they do not decide which elements receive them.
-                depth > 0 && !atRule && opensHere++;
-                depth++
-            } else if (char === '}') {
-                depth = Math.max(0, depth - 1)
-            }
-        }
-
-        opensHere && blocks.push({line: index + 1, text: raw.trim()})
-    });
+        buffer += char
+    }
 
     return blocks
 }
@@ -180,9 +194,10 @@ export function collectThemeValueFileFailures() {
 
         if (!recorded) {
             failures.push(
-                `[new-selector] ${file} declares ${blocks.length} selector block(s); a theme file ` +
-                `answers "what value", never "which elements". Move the selector to resources/scss/src ` +
-                `and add tokens: ` + blocks.map(block => `${file}:${block.line} ${block.text.trim()}`).join(' | ')
+                `[new-selector] ${file} declares ${blocks.length} rule(s) that are not variables; a ` +
+                `theme file answers "what value", never "which elements". Move the selector to ` +
+                `resources/scss/src and add tokens: ` +
+                blocks.map(block => `${file}:${block.line} (${block.kind}) ${block.text.trim()}`).join(' | ')
             );
             continue
         }

--- a/buildScripts/util/check-theme-value-files.mjs
+++ b/buildScripts/util/check-theme-value-files.mjs
@@ -1,0 +1,226 @@
+#!/usr/bin/env node
+/**
+ * @module buildScripts/util/check-theme-value-files
+ * @summary Enforces the operator rule that a theme value file declares variables, never selectors.
+ *
+ * Stated by the operator on 2026-09-02, while reviewing the nested-theme contract:
+ *
+ *   "For existing themes, there should NEVER be overrides inside THEME VAR files that add css
+ *    selectors. Such cases must get added to `scss/src`, and add new vars as needed."
+ *
+ * The reason is a defect class, not tidiness. A theme file answers *what is this theme's value for
+ * X*; a selector answers *which elements get X* — a structural question every theme then has to
+ * re-answer identically, and any one copy can drift. That drift has shipped once already, and the
+ * sweep found a rule in two themes whose selector had never matched at all: a value list makes a
+ * missing line obvious, while a selector block makes a broken line invisible.
+ *
+ * ## Why a separate guard rather than a check inside `check-theme-surfaces`
+ *
+ * That guard owns the Workstation surface and its CI workflow filters on Workstation paths. This
+ * rule spans every theme file, so folding it in would either widen that filter — running the
+ * Workstation parity/token-only/completeness checks on unrelated theme edits — or leave this rule
+ * silent for the files it most needs to watch. Two contracts, two scopes, two owners.
+ *
+ * ## Baseline
+ *
+ * `check-theme-value-files-baseline.json` records the offenders that predate the guard, so it can
+ * be introduced BEFORE the sweep finishes rather than after. Each entry carries a `reason`, and the
+ * two kinds are not the same thing:
+ *
+ * - `pending`  — ordinary sweep work; a later batch removes the entry.
+ * - `exempt`   — blocked on a decision, with the ticket that owns it. Without this distinction a
+ *                blocked file reads as unfinished work forever and nobody can tell whether the
+ *                sweep is done.
+ *
+ * A baselined file whose block count DROPS fails too. That is deliberate: it forces the batch that
+ * cleans a file to shrink the baseline in the same commit, so the record cannot rot into a list of
+ * problems that no longer exist.
+ *
+ * **Sunset:** the guard is permanent — it is the rule's enforcement. The BASELINE retires: when it
+ * reaches zero entries the file is deleted and this loader treats a missing baseline as empty.
+ */
+import fs              from 'node:fs';
+import path            from 'node:path';
+import {fileURLToPath} from 'node:url';
+
+const
+    dirname      = path.dirname(fileURLToPath(import.meta.url)),
+    repoRoot     = path.resolve(dirname, '../..'),
+    themeRoot    = path.join(repoRoot, 'resources/scss'),
+    baselinePath = path.join(dirname, 'check-theme-value-files-baseline.json');
+
+/**
+ * @summary Finds every selector block nested inside a theme file's own scope.
+ *
+ * Detected by BRACE DEPTH rather than by matching selector text. A first attempt used a regex for
+ * "indented, no colon, ends in `{`" and mutation-testing showed it blind to two shapes this repo
+ * actually contains: the one-liner (`&.neo-state-open { background-color: … }`, all over the
+ * portal palette) and the pseudo-class (`&:not(.hljs) {`, whose colon the regex read as a
+ * declaration). A guard that silently misses the forms it exists to catch is worse than none,
+ * because its green is mistaken for coverage.
+ *
+ * Depth is structural and shape-agnostic: the file's own `:root .neo-theme-*` wrapper opens depth
+ * 1, so ANY block opened at depth ≥ 1 is a nested rule regardless of how its selector is written.
+ * Comments and strings are stripped first so a brace inside either cannot move the count. `@`-rules
+ * stay allowed — `@include` composes values rather than deciding which elements receive them.
+ * @param {String} file Absolute path.
+ * @returns {{line: Number, text: String}[]}
+ */
+export function findSelectorBlocks(file) {
+    const
+        lines  = fs.readFileSync(file, 'utf8').split('\n'),
+        blocks = [];
+
+    let depth     = 0,
+        inComment = false;
+
+    lines.forEach((raw, index) => {
+        let code      = raw,
+            opensHere = 0;
+
+        // Strip block comments (possibly spanning lines), then line comments and strings.
+        if (inComment) {
+            const end = code.indexOf('*/');
+
+            if (end === -1) return;
+
+            code      = code.slice(end + 2);
+            inComment = false
+        }
+
+        code = code.replace(/\/\*[\s\S]*?\*\//g, '');
+
+        const open = code.indexOf('/*');
+
+        if (open !== -1) {
+            inComment = true;
+            code      = code.slice(0, open)
+        }
+
+        code = code.replace(/\/\/.*$/, '').replace(/(['"])(?:\\.|(?!\1).)*\1/g, '');
+
+        // SCSS INTERPOLATION is not a block. `--button-border: #{$width} #{$style};` carries two
+        // `#{` openers, and counting them made a file this sweep had already cleaned report 34
+        // selectors. Stripped before the walk so the depth stays structural.
+        code = code.replace(/#\{[^{}]*\}/g, '');
+
+        const atRule = /^\s*@/.test(code);
+
+        for (const char of code) {
+            if (char === '{') {
+                // Depth 0 → the file's own theme wrapper. Depth ≥ 1 → a nested rule, unless this
+                // line is an at-rule: `@include`/`@if`/`@each` compose values and control flow,
+                // they do not decide which elements receive them.
+                depth > 0 && !atRule && opensHere++;
+                depth++
+            } else if (char === '}') {
+                depth = Math.max(0, depth - 1)
+            }
+        }
+
+        opensHere && blocks.push({line: index + 1, text: raw.trim()})
+    });
+
+    return blocks
+}
+
+/**
+ * @summary Every `resources/scss/theme-*` SCSS file, repo-relative.
+ * @returns {String[]}
+ */
+export function collectThemeFiles() {
+    const walk = dir => fs.readdirSync(dir, {withFileTypes: true}).flatMap(entry => {
+        const full = path.join(dir, entry.name);
+
+        return entry.isDirectory() ? walk(full) : entry.name.endsWith('.scss') ? [full] : []
+    });
+
+    return fs.readdirSync(themeRoot, {withFileTypes: true})
+        .filter(entry => entry.isDirectory() && entry.name.startsWith('theme-'))
+        .flatMap(entry => walk(path.join(themeRoot, entry.name)))
+        .map(file => path.relative(repoRoot, file))
+        .sort()
+}
+
+/**
+ * @summary Reads the baseline, treating a missing file as an empty one (its retired state).
+ * @returns {Map<String,Object>}
+ */
+export function readBaseline() {
+    if (!fs.existsSync(baselinePath)) return new Map();
+
+    return new Map(JSON.parse(fs.readFileSync(baselinePath, 'utf8')).map(entry => [entry.file, entry]))
+}
+
+/**
+ * @summary The guard. Returns the (possibly empty) list of failures.
+ * @returns {String[]}
+ */
+export function collectThemeValueFileFailures() {
+    const
+        baseline = readBaseline(),
+        failures = [],
+        seen     = new Set();
+
+    for (const file of collectThemeFiles()) {
+        const
+            blocks   = findSelectorBlocks(path.join(repoRoot, file)),
+            recorded = baseline.get(file);
+
+        recorded && seen.add(file);
+
+        if (!blocks.length) {
+            // A baselined file that is now clean must lose its entry in the same commit, or the
+            // record rots into a list of problems nobody has any more.
+            recorded && failures.push(
+                `[stale-baseline] ${file} declares no selectors any more — remove its baseline entry`
+            );
+            continue
+        }
+
+        if (!recorded) {
+            failures.push(
+                `[new-selector] ${file} declares ${blocks.length} selector block(s); a theme file ` +
+                `answers "what value", never "which elements". Move the selector to resources/scss/src ` +
+                `and add tokens: ` + blocks.map(block => `${file}:${block.line} ${block.text.trim()}`).join(' | ')
+            );
+            continue
+        }
+
+        if (blocks.length > recorded.blocks) {
+            failures.push(
+                `[grew] ${file} declares ${blocks.length} selector block(s), baselined at ${recorded.blocks}`
+            )
+        } else if (blocks.length < recorded.blocks) {
+            failures.push(
+                `[stale-baseline] ${file} is down to ${blocks.length} selector block(s) from ` +
+                `${recorded.blocks} — update its baseline entry in this commit`
+            )
+        }
+    }
+
+    for (const file of baseline.keys()) {
+        seen.has(file) || failures.push(`[stale-baseline] ${file} is baselined but no longer exists`)
+    }
+
+    return failures
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+    const
+        failures = collectThemeValueFileFailures(),
+        baseline = readBaseline(),
+        pending  = [...baseline.values()].filter(entry => entry.reason?.startsWith('pending')).length,
+        exempt   = [...baseline.values()].filter(entry => entry.reason?.startsWith('exempt')).length;
+
+    if (failures.length) {
+        console.error('✗ theme value files FAILED:\n');
+        failures.forEach(failure => console.error('    ' + failure));
+        process.exit(1)
+    }
+
+    console.log(
+        `✓ theme value files declare variables only — ${pending} file(s) pending sweep, ` +
+        `${exempt} exempt pending a decision.`
+    )
+}

--- a/package.json
+++ b/package.json
@@ -158,7 +158,8 @@
             "node ./buildScripts/util/check-engine-brain-boundary.mjs"
         ],
         "resources/scss/**/*.scss": [
-            "node ./buildScripts/util/check-theme-coverage.mjs"
+            "node ./buildScripts/util/check-theme-coverage.mjs",
+            "node ./buildScripts/util/check-theme-value-files.mjs"
         ],
         "resources/content/archive/**/*.md": [
             "node ./buildScripts/util/check-content-logical-identity.mjs"


### PR DESCRIPTION
## Summary

**#18145 AC-4.** The operator's rule now has enforcement, introduced *before* the sweep finishes rather than after:

> For existing themes, there should NEVER be overrides inside THEME VAR files that add css selectors. Such cases must get added to `scss/src`, and add new vars as needed.

## The baseline separates two things a flat list would conflate

| kind | meaning | entries |
|---|---|---|
| `pending` | ordinary sweep work; a later batch removes the entry | 5 (`Global.scss` × 5 themes) |
| `exempt` | **blocked on a decision**, naming the ticket that owns it | 4 |

The exempt four are `dialog/Base.scss` × 2 — a structural rule for a dialog header button must sit at (0,3,0) and would override a ui-variant background winning at (0,2,0) in themes that carry no such rule today, and CSS has no per-declaration opt-out — and `tab/header/Button.scss` × 2, whose block has never matched (#18171).

**Without the distinction those four read as unfinished work forever** and nobody can tell whether the sweep is done. That was the design note I raised when deferring this guard, and it is why the baseline carries a `reason` per entry rather than just a count.

A baselined file whose count **drops** also fails, so the batch that cleans a file shrinks the baseline in the same commit and the record cannot rot into a list of problems that no longer exist.

## Detection is structural, and getting there took three instruments

| attempt | result |
|---|---|
| regex — *indented, no colon, ends in `{`* | **14 blocks.** Blind to the one-liner (`&.neo-state-open { … }`, all over the portal palette) and to the pseudo-class (`&:not(.hljs) {`, whose colon it read as a declaration) |
| brace depth | **162 blocks.** Counted SCSS interpolation — `#{$width}` — as blocks, so a file this sweep had *already cleaned* reported 34 |
| brace depth, minus `#{…}` and at-rule bodies | **35 blocks across 9 files** |

The third number is the one to trust, and not because it is last: it independently reproduces **#18145's own census of 10 blocks each** in the neo `Global.scss` files. Two instruments disagreeing is a reason to distrust both; an instrument agreeing with a separately-taken census is evidence.

Mutation-testing is what exposed attempts one and two. A guard that silently misses the forms it exists to catch is worse than no guard, because its green is mistaken for coverage.

## Mutations — clean tree exits 0, each of these exits 1

- a **one-liner** selector added to a clean theme file
- a **pseudo-class** selector added to a clean theme file
- a baselined file that **grew**
- a baselined file **cleaned** without updating its entry

## Wiring

lint-staged beside `check-theme-coverage`, mirrored in CI because a pre-commit guard alone is bypassable with `--no-verify`. The workflow watches **every path the guard scans**, plus the baseline itself — a baseline edit changes the verdict, so it must re-read reality rather than let a file be blessed by editing the record of what exists.

**A separate script rather than a check inside `check-theme-surfaces`:** that guard owns the Workstation surface and its workflow filters on Workstation paths. Folding this in would either widen that filter — running Workstation parity/token-only/completeness on unrelated theme edits — or leave this rule silent for the files it most needs to watch. Two contracts, two scopes.

**Sunset:** the guard is permanent, it *is* the rule. The **baseline** retires: at zero entries the file is deleted, and the loader already treats a missing baseline as empty.

## Evidence

`check-theme-value-files` exit 0 on a clean tree, exit 1 on all four mutations. Guard runs in 0.07s, so it adds nothing meaningful to the pre-commit path.

Refs #18145.

Authored by Grace (Claude Opus 5, Claude Code). Session 8d936ec9-b816-4ded-a91e-6e91ef6a3325.
