### PR TITLE
feat(dock): a projection refuses a context that dropped the tear-out opt-ins (#18197)

### DIFF
--- a/src/dashboard/dock/Workspace.mjs
+++ b/src/dashboard/dock/Workspace.mjs
@@ -1645,6 +1645,18 @@ class Workspace extends Container {
      * {@link #dockPopOutActionActive}; both violations throw at projection rather than silently
      * unaddressing an action. Their intent surfaces on the `dockHeaderAction` event — see
      * {@link #onDockHeaderAction}.
+     *
+     * **An override MUST spread `super.getDockProjectionOptions()`.** This method is the only
+     * carrier of the tear-out opt-ins into the projection context: `enableDockTearOut` is what
+     * arms `allowOverdrag` and `enableProxyToPopup` on every tab sort zone, and the handler bundle
+     * rides beside it. A host that returns its own object instead of extending this one drops both,
+     * so dragging a tab out of the dock becomes unreachable and a dragged popup finds no target.
+     *
+     * **The pop-out action is not evidence the options arrived.** `dockPopOutActionActive` derives
+     * from `tearOutHandlers` on the instance rather than from the context, so the button renders,
+     * the vessel opens and the pane comes home while both drag gestures are dead — the failure hides
+     * behind a working sibling. `projectDockModel` therefore refuses a projection whose context
+     * lacks `enableDockTearOut` while the lifecycle is on, rather than trusting a host to notice.
      * @returns {Object}
      */
     getDockProjectionOptions() {
@@ -3684,14 +3696,33 @@ class Workspace extends Container {
      */
     projectDockModel(tabInsertDescriptor=null, itemResolver=null, document=this.dockModel) {
         let me = this,
-            config;
+            config, options;
 
         if (!document) {
             config = {ntype: 'container', cls: ['neo-dashboard'], items: []}
         } else {
+            options = me.getDockProjectionOptions();
+
+            // A host override that returns its own object without spreading `super` drops the
+            // tear-out opt-ins, and nothing downstream can tell. The projection succeeds, the dock
+            // renders, and the pop-out ACTION still appears — `dockPopOutActionActive` reads
+            // `tearOutHandlers` on the INSTANCE, not this context — so two gestures die behind a
+            // working button: dragging a tab out becomes unreachable (without `allowOverdrag` the
+            // proxy stays clamped to its strip, so the boundary exit can never fire) and a dragged
+            // popup finds no target (without a `sortGroup` the zone never registers with the
+            // coordinator). Measured on a consumer whose multi-window dock looked finished.
+            //
+            // Refusing here is the discipline the reserved-name violations already apply: a host
+            // that meant to enable tear-out learns at once, and one that meant to disable it turns
+            // the lifecycle off rather than silently dropping what the lifecycle promised. The
+            // action rendering is not evidence the options arrived.
+            if (me.enableDockTearOutLifecycle && options?.enableDockTearOut !== true) {
+                throw new Error(`Workspace ${me.id}: getDockProjectionOptions() returned no enableDockTearOut while enableDockTearOutLifecycle is on — an override must spread super.getDockProjectionOptions()`)
+            }
+
             config = LayoutAdapter.project(document, {
                 onDockCrossZoneDrop: me.onDockCrossZoneDrop.bind(me),
-                ...me.getDockProjectionOptions(),
+                ...options,
                 // The Workspace component is the DOM-root authority for ordinary cross-zone tab
                 // motion. An explicit dockTearOutBoundaryContainerId from the hook still wins in
                 // LayoutAdapter; direct adapter consumers must supply this field themselves.

--- a/src/dashboard/dock/Workspace.mjs
+++ b/src/dashboard/dock/Workspace.mjs
@@ -3716,8 +3716,21 @@ class Workspace extends Container {
             // that meant to enable tear-out learns at once, and one that meant to disable it turns
             // the lifecycle off rather than silently dropping what the lifecycle promised. The
             // action rendering is not evidence the options arrived.
-            if (me.enableDockTearOutLifecycle && options?.enableDockTearOut !== true) {
-                throw new Error(`Workspace ${me.id}: getDockProjectionOptions() returned no enableDockTearOut while enableDockTearOutLifecycle is on — an override must spread super.getDockProjectionOptions()`)
+            //
+            // The check compares against the WHOLE bundle, not against `enableDockTearOut` alone.
+            // The flag is one of eight keys `super` contributes — the rest are the tear-out gesture
+            // handlers `LayoutAdapter.project` reads — so testing the flag would make it a proxy for
+            // the bundle, and a host that writes the flag by hand (which `apps/workstation` does)
+            // would pass with none of the handlers present. That is this same failure one key
+            // deeper, and asking what `super` would have contributed keeps the check true as the
+            // bundle grows. It also lets the error name what was dropped.
+            if (me.enableDockTearOutLifecycle) {
+                const base = Workspace.prototype.getDockProjectionOptions.call(me),
+                      lost = Object.keys(base).filter(key => !(key in options));
+
+                if (lost.length) {
+                    throw new Error(`Workspace ${me.id}: getDockProjectionOptions() dropped ${lost.join(', ')} while enableDockTearOutLifecycle is on — an override must spread super.getDockProjectionOptions()`)
+                }
             }
 
             config = LayoutAdapter.project(document, {

--- a/test/playwright/unit/dashboard/DockWorkspace.spec.mjs
+++ b/test/playwright/unit/dashboard/DockWorkspace.spec.mjs
@@ -146,6 +146,71 @@ class PlainWorkspace extends DockWorkspace {
 }
 
 /**
+ * The mistake this guard exists for: the tear-out lifecycle on, and `getDockProjectionOptions`
+ * replaced rather than extended. Every real host writes this shape by accident, because returning
+ * an object literal is the obvious way to answer a hook.
+ */
+class DroppedOptInsWorkspace extends DockWorkspace {
+    static config = {
+        className                 : 'Test.Unit.Dashboard.DockWorkspace.DroppedOptInsWorkspace',
+        enableDockTearOutLifecycle: true,
+        layout                    : {ntype: 'vbox', align: 'stretch'}
+    }
+
+    construct(config) {
+        super.construct(config);
+        this.add(this.projectDockModel())
+    }
+
+    getDockProjectionOptions() {
+        return {onDockActiveIndexChange: () => {}}
+    }
+}
+
+/**
+ * The same override with the lifecycle OFF. Nothing was promised, so nothing was dropped and the
+ * guard must stay silent — a host that never wanted tear-out is not misconfigured.
+ */
+class NoLifecycleWorkspace extends DockWorkspace {
+    static config = {
+        className: 'Test.Unit.Dashboard.DockWorkspace.NoLifecycleWorkspace',
+        layout   : {ntype: 'vbox', align: 'stretch'}
+    }
+
+    construct(config) {
+        super.construct(config);
+        this.add(this.projectDockModel())
+    }
+
+    getDockProjectionOptions() {
+        return {onDockActiveIndexChange: () => {}}
+    }
+}
+
+/**
+ * The correct shape: `super` first, then the host's own additions.
+ */
+class KeptOptInsWorkspace extends DockWorkspace {
+    static config = {
+        className                 : 'Test.Unit.Dashboard.DockWorkspace.KeptOptInsWorkspace',
+        enableDockTearOutLifecycle: true,
+        layout                    : {ntype: 'vbox', align: 'stretch'}
+    }
+
+    construct(config) {
+        super.construct(config);
+        this.add(this.projectDockModel())
+    }
+
+    getDockProjectionOptions() {
+        return {
+            ...super.getDockProjectionOptions(),
+            crossWindowSortGroup: 'test-cross-window'
+        }
+    }
+}
+
+/**
  * A consumer with app chrome ahead of the shell and every hook overridden.
  */
 class ChromeWorkspace extends DockWorkspace {
@@ -287,6 +352,9 @@ class TearOutWorkspace extends DockWorkspace {
     }
 }
 
+Neo.setupClass(DroppedOptInsWorkspace);
+Neo.setupClass(NoLifecycleWorkspace);
+Neo.setupClass(KeptOptInsWorkspace);
 Neo.setupClass(PlainWorkspace);
 Neo.setupClass(ChromeWorkspace);
 Neo.setupClass(HostedWorkspace);
@@ -652,6 +720,36 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
                 boundaryContainerId: workspace.id,
                 enableProxyToPopup : false
             })
+        })
+    });
+
+    test('an override that drops the tear-out opt-ins is refused at projection', () => {
+        // The failure this guard replaces was silent AND masked. `dockPopOutActionActive` reads
+        // `tearOutHandlers` on the instance rather than the projection context, so a host that
+        // dropped the options still saw the pop-out button render, the vessel open and the pane
+        // come home — while dragging a tab out was unreachable and a dragged popup lit nothing.
+        // Measured on a real consumer before this arm existed.
+        expect(() => Neo.create(DroppedOptInsWorkspace, {dockModel: createDocument()}))
+            .toThrow(/returned no enableDockTearOut while enableDockTearOutLifecycle is on/);
+
+        // The guard must not fire on a host that never asked for tear-out; the same override with
+        // the lifecycle off promised nothing.
+        workspace = Neo.create(NoLifecycleWorkspace, {dockModel: createDocument()});
+        expect(workspace.enableDockTearOutLifecycle).toBe(false);
+        workspace.destroy();
+
+        // And the correct shape projects, with the opt-ins reaching the zone rather than merely
+        // surviving the guard — `allowOverdrag` is what lets the proxy leave its strip at all, and
+        // `sortGroup` is what registers the zone with the coordinator.
+        workspace = Neo.create(KeptOptInsWorkspace, {dockModel: createDocument()});
+
+        const tabs = collect(workspace.projectDockModel(), config => config.dockNodeType === 'tabs')[0];
+
+        expect(tabs, 'the fixture must project a tabs node, or these assertions prove nothing').toBeTruthy();
+        expect(tabs.headerToolbar.sortZoneConfig).toMatchObject({
+            allowOverdrag     : true,
+            enableProxyToPopup: true,
+            sortGroup         : 'test-cross-window'
         })
     });
 

--- a/test/playwright/unit/dashboard/DockWorkspace.spec.mjs
+++ b/test/playwright/unit/dashboard/DockWorkspace.spec.mjs
@@ -168,6 +168,29 @@ class DroppedOptInsWorkspace extends DockWorkspace {
 }
 
 /**
+ * The subtler mistake, and the one a flag-only check would certify: the host writes
+ * `enableDockTearOut` by hand, so the obvious predicate is satisfied while none of the gesture
+ * handlers `super` contributes are present. `apps/workstation` writes the flag by hand, so this is
+ * a shape the codebase already contains rather than an invented one.
+ */
+class HandWrittenFlagWorkspace extends DockWorkspace {
+    static config = {
+        className                 : 'Test.Unit.Dashboard.DockWorkspace.HandWrittenFlagWorkspace',
+        enableDockTearOutLifecycle: true,
+        layout                    : {ntype: 'vbox', align: 'stretch'}
+    }
+
+    construct(config) {
+        super.construct(config);
+        this.add(this.projectDockModel())
+    }
+
+    getDockProjectionOptions() {
+        return {enableDockTearOut: true}
+    }
+}
+
+/**
  * The same override with the lifecycle OFF. Nothing was promised, so nothing was dropped and the
  * guard must stay silent — a host that never wanted tear-out is not misconfigured.
  */
@@ -353,6 +376,7 @@ class TearOutWorkspace extends DockWorkspace {
 }
 
 Neo.setupClass(DroppedOptInsWorkspace);
+Neo.setupClass(HandWrittenFlagWorkspace);
 Neo.setupClass(NoLifecycleWorkspace);
 Neo.setupClass(KeptOptInsWorkspace);
 Neo.setupClass(PlainWorkspace);
@@ -730,7 +754,17 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
         // come home — while dragging a tab out was unreachable and a dragged popup lit nothing.
         // Measured on a real consumer before this arm existed.
         expect(() => Neo.create(DroppedOptInsWorkspace, {dockModel: createDocument()}))
-            .toThrow(/returned no enableDockTearOut while enableDockTearOutLifecycle is on/);
+            .toThrow(/dropped .*enableDockTearOut.* while enableDockTearOutLifecycle is on/);
+
+        // The subtler shape, and the one a flag-only predicate would have certified: the flag is
+        // written by hand, so `enableDockTearOut === true` holds while none of the gesture handlers
+        // `super` contributes are present. `apps/workstation` writes the flag by hand, so this is a
+        // shape the codebase contains — the check therefore asks what `super` WOULD have given.
+        // The message must NAME what was dropped, which a flag-only predicate could not do: it knew
+        // only one key. Asserted on a handler rather than on the flag, because the flag is the one
+        // thing this host DID supply.
+        expect(() => Neo.create(HandWrittenFlagWorkspace, {dockModel: createDocument()}))
+            .toThrow(/onDockTearOutCancel/);
 
         // The guard must not fire on a host that never asked for tear-out; the same override with
         // the lifecycle off promised nothing.


### PR DESCRIPTION
Resolves #18197

A projection whose context lost `enableDockTearOut` while the tear-out lifecycle is on is now refused. The loss used to be silent *and* masked: `dockPopOutActionActive` reads `tearOutHandlers` on the instance rather than the context, so the pop-out button rendered, the vessel opened and the pane came home while dragging a tab out was unreachable and a dragged popup lit nothing.

Evidence: L2 (unit — the defect is a context value going missing between a hook and a projector, with no rendered surface that distinguishes it; the masking sibling is exactly why a rendered check cannot see it) → L2 required (every AC is a projection-time claim). Residual: none.

## AC Evidence
| AC-1 | `DockWorkspace.spec.mjs` — `an override that drops the tear-out opt-ins is refused at projection`, over **two** super-less overrides with the lifecycle on. `DroppedOptInsWorkspace` returns an unrelated key and throws matching `/dropped .*enableDockTearOut.* while enableDockTearOutLifecycle is on/`; `HandWrittenFlagWorkspace` returns `{enableDockTearOut: true}` and nothing else, and throws matching `/onDockTearOutCancel/` — the message names all seven missing keys, so "naming the dropped option" is satisfied for the bundle rather than for one flag |
| AC-2 | same arm — `NoLifecycleWorkspace` carries the identical override with the lifecycle OFF and projects silently; asserted, because a host that never wanted tear-out is not misconfigured |
| AC-3 | same arm — `KeptOptInsWorkspace` spreads `super` and its projected zone carries `allowOverdrag: true`, `enableProxyToPopup: true`, `sortGroup: 'test-cross-window'`. Asserted on the zone, not on the guard passing: surviving the check is not the same as the opt-ins arriving |
| AC-4 | red-first, see Test Evidence — with the guard reverted the arm fails alone, 1 of 112 |
| AC-5 | `getDockProjectionOptions`' JSDoc states that an override MUST spread `super`, and that the pop-out action rendering is not evidence it did — the masking sibling named where a host reads the contract |
| AC-6 | dashboard unit family **889 passed** with the guard in place |

## Deltas from ticket

**I measured the guard's blast radius before writing it, not after.** The ticket did not ask for that and it was the thing most likely to sink the change: a throw on a widely-used hook could red unrelated arms. Every override in the repo:

| override | spreads `super` | lifecycle on | guard fires |
|---|---|---|---|
| `apps/workstation/view/Workspace.mjs` | no | no — supplies `enableDockTearOut` directly | no |
| `examples/dashboard/choreography/DemoAWorkspace.mjs` | no | no | no |
| `test/…/dock-hostreload/app.mjs` | yes | no | no |
| three fixtures in `DockWorkspace.spec.mjs` | no | no | no |
| inline stubs in `DockFlip` / `DockTabEnterButton` | n/a | no | no |

Nothing existing combines the lifecycle with a super-less override, so the guard fires on zero current code. That is what made the throw safe rather than a judgement call.

**The ticket's alternative — applying the base wiring outside the overridable hook — is not taken.** It would make the hook's return no longer the whole context, which is a larger contract change than the guard, and it removes the diagnostic: a host that drops `super` should learn that it did, not have it quietly repaired.

**AC-3 grew a second assertion.** The ticket asked that a correct override "projects unchanged". Asserting only that would pass if the guard let it through while the values still failed to reach the zone, so the arm reads `allowOverdrag`, `enableProxyToPopup` and `sortGroup` off the projected `sortZoneConfig`.

**The predicate widened from one flag to the whole bundle, per review.** `super.getDockProjectionOptions()` contributes eight keys — the flag plus `activeVessel`, `retireActiveVessel`, `onVesselRetired` and the four `onDockTearOut*` handlers `LayoutAdapter.project` reads. Testing the flag made it a proxy for the bundle, which is this guard's own failure mode one key deeper: a host writing `enableDockTearOut: true` by hand — and `apps/workstation` writes it by hand — passed with none of the handlers present. The check now asks what `super` *would* have contributed and refuses on any missing key, so it stays true as the bundle grows and the error can name what was dropped.

That widening earned its own two checks rather than inheriting the narrow version's:

- **A red control for exactly the missed case.** Reverting to the flag-only predicate fails the new arm alone, 1 of 112 — so the gap is covered by a test rather than by my assertion that it is closed.
- **Blast radius re-measured for the wider predicate.** `apps/workstation` and `DemoAWorkspace` still cannot trip it: neither sets `enableDockTearOutLifecycle` (0 occurrences each) and the guard is gated on it. Their suites 140 passed; dashboard family 889 passed.

## Test Evidence

**Red-first, mutation-checked.** With `src/dashboard/dock/Workspace.mjs` stashed and the arm in place:

```
1 failed
  [unit-engine] › DockWorkspace.spec.mjs › an override that drops the tear-out opt-ins is refused at projection
111 passed
```

It fails alone, so the arm witnesses the guard and nothing else moved. Green with the guard restored: `dashboard/` **889 passed**.

**A second red control, for the widening rather than for the guard.** Removing the guard proves the arm needs *a* guard; it does not prove the predicate is wide enough. So I also reverted only the predicate — back to `options?.enableDockTearOut !== true`, keeping everything else — and the arm fails alone again, 1 of 112. That is what establishes the flag-only version as insufficient, rather than my argument that it is.

Also verified by reading rather than assumed: the guard's thrown message and the arm's regexes are consistent with what it emits. Worth recording that this is where I slipped — the first version of the new assertion looked for `/dropped onDockTearOut/` while the message lists `activeVessel` first, so the arm reported red against a correct guard. The guard was right and the pattern was too literal, which is the second anchored-pattern miss of the day for me.

## Post-Merge Validation
- [ ] A host that currently drops `super` starts throwing at projection. That is the intent, and no such host exists in this repo — but a downstream consumer might, and the fix is one spread.

Authored by Vega (Opus 5, Claude Code). Session e8ea32a2-b9a8-43ea-84ba-b83081ec4b3d.

