### PR TITLE
fix(tab): the classic families give the inline dock header its own ground (#18181)

### DIFF
--- a/resources/scss/theme-dark/tab/Container.scss
+++ b/resources/scss/theme-dark/tab/Container.scss
@@ -7,9 +7,17 @@
     --tab-header-action-glyph-color-active         : #fff;
     --tab-header-action-glyph-color-hover          : #fff;
     --tab-header-action-size                       : 20px;
-    // Classic chrome is intentionally flat, stated rather than omitted: an omitted custom property
-    // inherits the enclosing theme's value instead of resetting. Separation is the content border.
-    --tab-header-inline-background-color           : transparent;
+    // Classic chrome stays FLAT — no gradient, no hairline — but flat is not groundless. `transparent`
+    // left the header borrowing whatever sat behind it, so beside white pane content it read as an
+    // undefined grey rather than as chrome, and every consumer re-declared the token to fix it. That
+    // projection lands at the SAME (0,2,0) weight as this line, so which one wins is decided by sheet
+    // fetch order, which a consumer cannot control. Stating the value here is what removes the race.
+    //
+    // `#3c3f41` is the family's own header grey rather than a new one: it already carries
+    // `--calendar-settings-header-background-color`, `component.Splitter`, and the even-row banding
+    // that separates rows from white. A `--sem-color-*` token would be wrong here — the classic
+    // families declare none, so it would resolve against whatever theme was previously in scope.
+    --tab-header-inline-background-color           : #3c3f41;
     --tab-header-inline-background-image           : none;
     --tab-header-inline-box-shadow                 : none;
 

--- a/resources/scss/theme-light/tab/Container.scss
+++ b/resources/scss/theme-light/tab/Container.scss
@@ -7,9 +7,17 @@
     --tab-header-action-glyph-color-active         : #1c60a0;
     --tab-header-action-glyph-color-hover          : #1c60a0;
     --tab-header-action-size                       : 20px;
-    // Classic chrome is intentionally flat, stated rather than omitted: an omitted custom property
-    // inherits the enclosing theme's value instead of resetting. Separation is the content border.
-    --tab-header-inline-background-color           : transparent;
+    // Classic chrome stays FLAT — no gradient, no hairline — but flat is not groundless. `transparent`
+    // left the header borrowing whatever sat behind it, so beside white pane content it read as an
+    // undefined grey rather than as chrome, and every consumer re-declared the token to fix it. That
+    // projection lands at the SAME (0,2,0) weight as this line, so which one wins is decided by sheet
+    // fetch order, which a consumer cannot control. Stating the value here is what removes the race.
+    //
+    // `#f2f2f2` is the family's own header grey rather than a new one: it already carries
+    // `--calendar-settings-header-background-color`, `component.Splitter`, and the even-row banding
+    // that separates rows from white. A `--sem-color-*` token would be wrong here — the classic
+    // families declare none, so it would resolve against whatever theme was previously in scope.
+    --tab-header-inline-background-color           : #f2f2f2;
     --tab-header-inline-background-image           : none;
     --tab-header-inline-box-shadow                 : none;
 

--- a/test/playwright/component/dashboard/DockInlineHeaderPaint.spec.mjs
+++ b/test/playwright/component/dashboard/DockInlineHeaderPaint.spec.mjs
@@ -99,6 +99,63 @@ const measure = (page, controlId) => page.evaluate(id => {
     }
 }, controlId);
 
+test.describe('Neo.tab.Container — the CLASSIC families give the inline header its own ground', () => {
+    // The themes previously stated `transparent` here, deliberately: an omitted custom property inherits the
+    // enclosing theme's value instead of resetting, so the token had to be SAID. What it said turned
+    // out to be wrong — flat is not groundless, and beside white pane content a transparent header
+    // read as undefined grey. Every consumer then re-declared the token at the SAME (0,2,0) weight
+    // as the theme's own line, a race decided by sheet fetch order rather than by intent.
+    //
+    // Measured on the rendered element, because the sheet cannot answer which declaration won.
+    const GROUND = {'neo-theme-dark': 'rgb(60, 63, 65)', 'neo-theme-light': 'rgb(242, 242, 242)'};
+
+    for (const [theme, expected] of Object.entries(GROUND)) {
+        test(`${theme}: the header paints its family's own header grey, and stays flat`, async ({page}) => {
+            await applyTheme(page, theme);
+
+            const measured = await measure(page, controlId);
+
+            expect(measured.inline, 'an inline dock header must be rendered').toBeTruthy();
+
+            // AC-1 / AC-2 — the ground itself.
+            expect(measured.inline.backgroundColor, `${theme} states its own header grey`).toBe(expected);
+
+            // The classic families stay FLAT: this ticket gives them a ground, not chrome. Asserting
+            // it here is what stops a later "make it look like neo" from arriving unnoticed.
+            expect(measured.inline.backgroundImage, 'no gradient band').toBe('none');
+            expect(measured.inline.boxShadow, 'no hairline — separation stays the content border').toBe('none');
+
+            // AC-4 — the contrast that actually carries the bar is header-vs-ACTIVE-TAB, not
+            // header-vs-page: in classic light the active tab is white. Read as a computed
+            // difference so the arm cannot pass on two shades nobody can tell apart.
+            const activeTab = await page.evaluate(() => {
+                const button = document.querySelector('.neo-tab-container-inline .neo-tab-header-button.pressed')
+                    || document.querySelector('.neo-tab-container-inline .neo-tab-header-button');
+
+                return button && getComputedStyle(button).backgroundColor
+            });
+
+            expect(activeTab, 'an active tab button must be rendered').toBeTruthy();
+            expect(measured.inline.backgroundColor,
+                'the header must not be the same colour as the tab it frames').not.toBe(activeTab)
+        })
+    }
+
+    test('AC-3 the neo families are untouched — they still resolve their semantic surface', async ({page}) => {
+        // The regression this ticket could plausibly cause: editing the classic pair while reaching
+        // for a shared token would move the neo pair too. Cheap to assert, and it is the only arm
+        // here that would notice.
+        for (const theme of ['neo-theme-neo-light', 'neo-theme-neo-dark']) {
+            await applyTheme(page, theme);
+
+            const measured = await measure(page, controlId);
+
+            expect(measured.surfaceToken, `${theme} still values the highlighted neutral surface`).toMatch(/^rgb/);
+            expect(measured.inline.backgroundColor, `${theme} still paints that surface`).toBe(measured.surfaceToken)
+        }
+    })
+});
+
 test.describe('Neo.tab.Container — the inline header paints a flat surface with a hairline', () => {
     for (const theme of THEMES) {
         test(`${theme}: flat semantic surface, hairline, no gradient — and the standalone control keeps its paint`, async ({page}) => {
@@ -175,7 +232,18 @@ test.describe('Neo.tab.Container — the inline header paints a flat surface wit
             // this, an inner reset and an inner nothing are indistinguishable.
             expect(measured.surfaceToken, 'the outer neo scope still values the highlighted surface').toMatch(/^rgb/);
 
-            expect(measured.inline.backgroundColor, `${classic} paints no surface inside a neo scope`).toBe('rgba(0, 0, 0, 0)');
+            // The property under test is the RESET, not the value: an inner classic scope must stop
+            // showing the outer neo surface. It used to reset to `transparent` because that is what
+            // the classic families stated; they now state their own header grey, so the reset lands
+            // on that instead. The assertion follows the value rather than pinning the old one —
+            // what would break this arm is the inner scope rendering the OUTER surface, which is
+            // still exactly what it fails on.
+            const CLASSIC_GROUND = {'neo-theme-dark': 'rgb(60, 63, 65)', 'neo-theme-light': 'rgb(242, 242, 242)'};
+
+            expect(measured.inline.backgroundColor, `${classic} paints its OWN ground inside a neo scope`)
+                .toBe(CLASSIC_GROUND[classic]);
+            expect(measured.inline.backgroundColor, `${classic} does not inherit the outer neo surface`)
+                .not.toBe(measured.surfaceToken);
             expect(measured.inline.backgroundImage, `${classic} paints no image inside a neo scope`).toBe('none');
             expect(measured.inline.boxShadow, `${classic} carries no hairline inside a neo scope`).toBe('none')
         })

--- a/test/playwright/component/tab/ContainerUi.spec.mjs
+++ b/test/playwright/component/tab/ContainerUi.spec.mjs
@@ -14,7 +14,9 @@ const THEMES = [
 const EXPECTED = {
     'neo-theme-light': {
         actionSize: '20px',
-        band      : 'none',
+        // `flat`, not `none`: the family states its own header grey and carries no hairline. The
+        // old name described the value it happened to have, which stopped being true.
+        band      : 'flat',
         inline    : {fontSize: '11px', fontWeight: '400', height: '25px', padding: '7px 8px 6px',  radius: '0px'},
         null      : {fontSize: '11px', fontWeight: '600', height: '25px', padding: '7px 12px 6px', radius: '0px'},
         standalone: {fontSize: '11px', fontWeight: '600', height: '40px', padding: '7px 16px 6px', radius: '8px'},
@@ -22,7 +24,7 @@ const EXPECTED = {
     },
     'neo-theme-dark': {
         actionSize: '20px',
-        band      : 'none',
+        band      : 'flat',
         inline    : {fontSize: '11px', fontWeight: '400', height: '25px', padding: '7px 8px 6px',  radius: '0px'},
         null      : {fontSize: '11px', fontWeight: '600', height: '25px', padding: '7px 12px 6px', radius: '0px'},
         standalone: {fontSize: '11px', fontWeight: '600', height: '40px', padding: '7px 16px 6px', radius: '8px'},
@@ -341,16 +343,20 @@ test.describe('Neo.tab.Container — ui variants', () => {
                 .not.toBe('0px');
 
             // The inline header's band. The neo themes paint a flat semantic surface with an inset
-            // hairline and value the public image hook `none`; the legacy themes value none of the
-            // inline hooks and keep a transparent header. Neither paints a gradient any more.
+            // hairline; the classic families paint their own header grey and carry no hairline, so
+            // separation there stays the content border. Neither paints a gradient any more.
+            //
+            // The classic branch used to assert `transparent`, which was the VALUE those families
+            // happened to state rather than the property this arm exists for. `flat` is the property
+            // — a ground, no hairline — and it is what still distinguishes the two families.
             expect(measured.inline.backgroundImage, 'no theme paints the inline header as a gradient').toBe('none');
 
             if (EXPECTED[theme].band === 'surface') {
                 expect(measured.inline.backgroundColor, 'the inline header is a theme surface').not.toBe('rgba(0, 0, 0, 0)');
                 expect(measured.inline.boxShadow, 'with a hairline under it').toContain('inset')
             } else {
-                expect(measured.inline.backgroundColor, 'a theme without inline hooks keeps the header transparent').toBe('rgba(0, 0, 0, 0)');
-                expect(measured.inline.boxShadow).toBe('none')
+                expect(measured.inline.backgroundColor, 'a classic family gives the header its own ground').not.toBe('rgba(0, 0, 0, 0)');
+                expect(measured.inline.boxShadow, 'and no hairline — the content border carries the separation').toBe('none')
             }
 
             expect(measured.null.boxShadow, 'the hairline belongs to the inline variant alone').toBe('none');


### PR DESCRIPTION
## Summary

Reported by @neo-opus-vega; the operator decided the values live — `#f2f2f2` light, `#3c3f41` dark, preferred over the `#eee` a consumer had been using.

#18144 stated `transparent` here, and **stating something was right**: an omitted custom property inherits the enclosing theme's value instead of resetting, so silence was never an option. **The value it chose was wrong.** Flat is not groundless — beside white pane content a transparent header read as undefined grey rather than as chrome, and every consumer re-declared the token.

## Why a consumer could not fix this for itself

Those projections land at the **same (0,2,0) weight** as the theme's own line:

```
engine    :root .neo-theme-light { --tab-header-inline-background-color: transparent }
consumer  :root .neo-theme-light { --tab-header-inline-background-color: … }
```

Equal weight, so the winner is sheet fetch order — and theme files load per class as each class first appears, which a consumer cannot control. Measured on a consumer host at current `dev`, the engine's declaration won and the header rendered transparent: **the exact symptom the projection existed to fix.** Stating the value here removes the race rather than winning it.

Both greys are ones the families already spend — `#f2f2f2` carries the calendar settings header, `component.Splitter`, and the even-row banding; `#3c3f41` is the dark twin. A `--sem-color-*` token would be wrong: the classic families declare none, so it would resolve against whatever theme was previously in scope, which is how the symptom first appeared on a theme **switch**.

## Arms measure the rendered element

A sheet cannot answer which declaration won, so every assertion reads computed values. AC-4 asserts the contrast that actually carries the bar is **header-vs-active-tab**, not header-vs-page — the active tab is white in classic light.

**Red-first:** restoring both value files to `dev` turns 4 of the 8 arms red.

## Two pre-existing specs changed, and the property they test did not

Both had encoded `transparent` — the **value** those families happened to state — rather than the property the arm exists for.

- `DockInlineHeaderPaint`'s nested-theme arms asserted a classic scope inside a neo scope paints `rgba(0,0,0,0)`. The property is the **reset**: an inner classic scope must stop showing the outer neo surface. They now assert the classic ground **and, explicitly, that it differs from the outer surface token** — so what breaks them is still an inner scope rendering the outer surface.
- `ContainerUi`'s band branch asserted `transparent` + no shadow for the classic families, keyed `band: 'none'`. The distinguishing property is **flat vs surface** — a ground with no hairline, versus a semantic surface with one. Renamed to `band: 'flat'` and the assertion is now "its own ground, no hairline".

Renaming the key mattered: `'none'` described the value, and the value is what moved.

## A failure of mine worth recording, because the tests caught it

The first push contained **only the spec**. During the red-first control I ran `git checkout HEAD -- <scss>` to restore my values — but that commit had *failed* the pre-commit hook, so `HEAD` was still `dev`, and the restore **reverted the fix instead of returning it**. Four arms went red asserting a value the source no longer had.

The tell was in my own output: I printed `git log --oneline -1` immediately after the failed commit and it showed dev's head. I read past it. **`HEAD` is only a safe restore point once the commit has actually landed** — after a failed commit it is the thing you were committing *onto*.

## Evidence

component `tab` + `dashboard`: **129 passed** · unit: **3117 passed**, 0 failed, 0 skipped · themes rebuilt and `dist` verified to carry both values.

Resolves #18181.

Authored by Grace (Claude Opus 5, Claude Code). Session 8d936ec9-b816-4ded-a91e-6e91ef6a3325.
