### PR TITLE
fix(grid): the row and column windows carry clone descriptors, so two grids stop sharing one (#18198)

### DIFF
--- a/src/grid/Body.mjs
+++ b/src/grid/Body.mjs
@@ -142,12 +142,28 @@ class GridBody extends Component {
          */
         keys: {},
         /**
-         * Stores the indexes of the first & last mounted columns, including bufferColumnRange
+         * Stores the indexes of the first & last mounted columns, including bufferColumnRange.
+         *
+         * **Assign this, never write it by index** — unlike its three sibling windows. It is the
+         * only one of the four with an `afterSet` hook, and {@link #afterSetMountedColumns} calls
+         * `createViewData()`, so the assignment IS the repaint trigger. An index-write would move
+         * the value and skip the render, leaving the painted columns behind the mounted range.
+         *
+         * The descriptor matches the siblings for the same two reasons they carry it: a mutable
+         * default needs `clone` to be per-instance, and `cloneOnGet: 'none'` avoids copying the
+         * array on every read — it is read per row and per cell during render
+         * ({@link Neo.grid.Row}) and three times per `createViewData()`, and the copy protected
+         * nothing because nothing mutates it through the reference.
          * @member {Number[]} mountedColumns_=[0,0]
          * @protected
          * @reactive
          */
-        mountedColumns_: [0, 0],
+        mountedColumns_: {
+            [isDescriptor]: true,
+            clone         : 'shallow',
+            cloneOnGet    : 'none',
+            value         : [0, 0]
+        },
         /**
          * Stores the indexes of the first & last mounted rows, including bufferRowRange.
          *

--- a/src/grid/Body.mjs
+++ b/src/grid/Body.mjs
@@ -1,10 +1,11 @@
 import ClassSystemUtil from '../util/ClassSystem.mjs';
-import Component from '../component/Base.mjs';
-import Collection from '../collection/Base.mjs';
-import Performance from '../util/Performance.mjs';
-import Row from './Row.mjs';
-import RowModel from '../selection/grid/RowModel.mjs';
-import VDomUtil from '../util/VDom.mjs';
+import Component       from '../component/Base.mjs';
+import Collection      from '../collection/Base.mjs';
+import Performance     from '../util/Performance.mjs';
+import Row             from './Row.mjs';
+import RowModel        from '../selection/grid/RowModel.mjs';
+import VDomUtil        from '../util/VDom.mjs';
+import {isDescriptor}  from '../core/ConfigSymbols.mjs';
 
 /**
  * @summary Manages the scrollable viewport and row rendering for the Grid.
@@ -148,11 +149,28 @@ class GridBody extends Component {
          */
         mountedColumns_: [0, 0],
         /**
-         * Stores the indexes of the first & last mounted rows, including bufferRowRange
-         * @member {Number[]} mountedRows=[0,0]
+         * Stores the indexes of the first & last mounted rows, including bufferRowRange.
+         *
+         * Reactive, and both descriptor keys are behaviour-critical rather than tuning:
+         *
+         * `clone: 'shallow'` gives each body its own array. A non-reactive config has no clone
+         * path at all, so every grid on a page would share one window and the last body to
+         * measure would decide what all the others believe is mounted.
+         *
+         * `cloneOnGet: 'none'` is what makes an index-write land. The engine's default copies
+         * arrays on every read, so `me.mountedRows[0] = x` would write into a discarded copy and
+         * the window would never move — silently, and in the same direction as the bug above.
+         *
+         * @member {Number[]} mountedRows_=[0,0]
          * @protected
+         * @reactive
          */
-        mountedRows: [0, 0],
+        mountedRows_: {
+            [isDescriptor]: true,
+            clone         : 'shallow',
+            cloneOnGet    : 'none',
+            value         : [0, 0]
+        },
         /**
          * Optional config values for Neo.grid.plugin.AnimateRows
          * @member {Object} pluginAnimateRowsConfig=null
@@ -210,17 +228,31 @@ class GridBody extends Component {
          */
         stripedRows_: true,
         /**
-         * Stores the indexes of the first & last painted columns
-         * @member {Number[]} visibleColumns=[0,0]
+         * Stores the indexes of the first & last painted columns.
+         * Written through by index; see `mountedRows_` for why both descriptor keys are required.
+         * @member {Number[]} visibleColumns_=[0,0]
          * @protected
+         * @reactive
          */
-        visibleColumns: [0, 0],
+        visibleColumns_: {
+            [isDescriptor]: true,
+            clone         : 'shallow',
+            cloneOnGet    : 'none',
+            value         : [0, 0]
+        },
         /**
-         * Stores the indexes of the first & last visible rows, excluding bufferRowRange
-         * @member {Number[]} visibleRows=[0,0]
+         * Stores the indexes of the first & last visible rows, excluding bufferRowRange.
+         * Written through by index; see `mountedRows_` for why both descriptor keys are required.
+         * @member {Number[]} visibleRows_=[0,0]
          * @protected
+         * @reactive
          */
-        visibleRows: [0, 0],
+        visibleRows_: {
+            [isDescriptor]: true,
+            clone         : 'shallow',
+            cloneOnGet    : 'none',
+            value         : [0, 0]
+        },
         /**
          * @member {String[]|null} wrapperCls=null
          * @reactive

--- a/test/playwright/e2e/workstation/WorkstationRowActionNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationRowActionNL.spec.mjs
@@ -1,0 +1,164 @@
+import {test, expect} from '../../fixtures.mjs';
+
+/**
+ * The `+1 pulse` row action must increment the Pulse cell of ITS OWN row, for every visible row.
+ *
+ * Operator report from the 100k Matrix pane: the action works for the first handful of rows and
+ * silently does nothing for the rest of the visible area. Nothing errors — the click lands, the
+ * button paints its press, and the counter three columns to the left simply does not move.
+ *
+ * **Why this is read by record id and not by row position.** The grid is buffered: rows are pooled
+ * DOM nodes recycled across records, so "row 7" is not a stable subject. Every assertion below pairs
+ * a button with the Pulse cell of the SAME `data-record-id`, which is the only pairing that survives
+ * recycling — and it is also the pairing the defect is suspected to break.
+ *
+ * The action column is a `component` column whose handler closes over `record` at component-creation
+ * time (`ScalePane.mjs`), so a recycled cell can keep a handler bound to the record it was first
+ * built for. That is a hypothesis; this spec only establishes the SYMPTOM, deliberately, so the
+ * mechanism can be falsified separately without rewriting the witness.
+ *
+ * @see https://github.com/neomjs/neo/issues/18186
+ */
+
+// Scoped to the SCALE pane, not `.neo-grid-container`: the Workstation renders two grids and the
+// feed matches first. A bare container selector read the feed's name column and reported every row
+// as failing — a red for the wrong reason, which is worse than a green.
+const GRID = '.workstation-scale-pane';
+
+/**
+ * Reads every rendered row of the scale grid as `{recordId, pulse}`, paired by identity.
+ * @param {import('@playwright/test').Page} page
+ * @returns {Promise<Object[]>}
+ */
+const readRows = page => page.evaluate(grid => {
+    const container = document.querySelector(grid);
+
+    if (!container) return [];
+
+    // The Pulse column index is DERIVED from the header, never hardcoded. The grid has eight
+    // columns (#, Work item, State, Throughput, Pulse, Load, Living signal, Action) and a guessed
+    // index silently reads a neighbour — a name column never increments, so the spec reports every
+    // row as broken and looks like a perfect witness while measuring nothing.
+    const headers = [...container.querySelectorAll('.neo-grid-header-button')]
+              .map(node => (node.textContent || '').trim()),
+          pulseIndex = headers.indexOf('Pulse');
+
+    return [...container.querySelectorAll('.neo-grid-row')].map(row => {
+        const cells = [...row.querySelectorAll('.neo-grid-cell')];
+
+        return {
+            hasAction: !!row.querySelector('.workstation-row-action'),
+            pulse    : pulseIndex > -1 ? (cells[pulseIndex]?.textContent || '').trim() : null,
+            pulseIndex,
+            recordId : row.dataset?.recordId ?? row.getAttribute('data-record-id')
+        }
+    }).filter(entry => entry.recordId && entry.hasAction)
+}, GRID);
+
+test.describe('Workstation 100k Matrix — a row action acts on its own row (Neural Link)', () => {
+    test('every visible +1 pulse increments the Pulse cell of its own record, not only the first rows', async ({page}) => {
+        await page.goto('/apps/workstation/index.html');
+        await page.waitForSelector(`${GRID} .neo-grid-row`, {state: 'visible', timeout: 30000});
+
+        // Non-vacuity: the defect is about rows BEYOND the first few, so a grid that rendered only a
+        // handful would make this pass while proving nothing about the reported case.
+        const before = await readRows(page);
+
+        expect(before.length, 'the matrix must render enough rows to reach the reported failure')
+            .toBeGreaterThan(8);
+
+        // The column mapping is itself a non-vacuity guard: reading a neighbouring column would
+        // report every row as failing and read exactly like a successful witness.
+        expect(before[0].pulseIndex, 'the Pulse column must be resolvable by its header')
+            .toBeGreaterThan(-1);
+        expect(before[0].pulse, 'and it must hold a number, not a name').toMatch(/^\d/);
+
+        const failures = [];
+
+        for (const {recordId, pulse} of before) {
+            const row = page.locator(`${GRID} .neo-grid-row[data-record-id="${recordId}"]`);
+
+            // `dispatchEvent`, not `click`. The Matrix animates continuously — a 10/sec feed, an
+            // animated counter and live sparklines — so an ordinary click times out on actionability,
+            // and `force: true` merely skips that check while still clicking the COORDINATES
+            // resolved a moment earlier, which the moving grid has since given to another row.
+            // Dispatching on the element itself is the only coordinate-free path to the handler.
+            await row.locator('.workstation-row-action').dispatchEvent('click');
+
+            let after = pulse;
+
+            // Poll rather than read once: the Pulse column animates its change, so a single read can
+            // land mid-transition and report a stale value for a row that DID increment. The poll is
+            // wrapped because a row that never changes is the defect under test — it must be
+            // recorded and the sweep continued, not thrown as an abort on the first bad row.
+            try {
+                await expect.poll(async () => {
+                    after = (await readRows(page)).find(entry => entry.recordId === recordId)?.pulse ?? pulse;
+
+                    return after
+                }, {timeout: 3000}).not.toBe(pulse)
+            } catch {
+                // unchanged within the window — captured below as a failure for this record
+            }
+
+            const digits   = value => Number(String(value).replace(/[^\d-]/g, '')),
+                  expected = digits(pulse) + 1;
+
+            digits(after) !== expected && failures.push({recordId, before: pulse, after})
+        }
+
+        expect(failures, `rows whose own Pulse cell did not increment: ${JSON.stringify(failures)}`)
+            .toEqual([])
+    });
+
+    test('a recycled row acts on the record it currently displays, not the one its cell was built for', async ({page}) => {
+        await page.goto('/apps/workstation/index.html');
+        await page.waitForSelector(`${GRID} .neo-grid-row`, {state: 'visible', timeout: 30000});
+
+        const before = (await readRows(page)).map(entry => entry.recordId);
+
+        // Scroll far enough that the pool must recycle rather than extend. The rows that come back
+        // are the SAME DOM nodes carrying different records, which is the case the first test
+        // cannot reach: it never scrolls, so every cell it touches was created rather than reused.
+        await page.locator(`${GRID} .neo-grid-row`).first().hover();
+        await page.mouse.wheel(0, 4000);
+        await page.waitForTimeout(1200);
+
+        const after = await readRows(page);
+
+        // Non-vacuity, and the whole reason this test exists: if the scroll changed nothing, every
+        // assertion below would re-measure the already-covered first viewport and pass for free.
+        expect(after.length, 'rows are still rendered after scrolling').toBeGreaterThan(4);
+        expect(after.some(entry => !before.includes(entry.recordId)),
+            'the scroll must bring records the first viewport never held').toBe(true);
+
+        const failures = [];
+
+        for (const {recordId, pulse} of after) {
+            const row = page.locator(`${GRID} .neo-grid-row[data-record-id="${recordId}"]`);
+
+            if (!await row.count()) continue;
+
+            await row.locator('.workstation-row-action').dispatchEvent('click');
+
+            let value = pulse;
+
+            try {
+                await expect.poll(async () => {
+                    value = (await readRows(page)).find(entry => entry.recordId === recordId)?.pulse ?? pulse;
+
+                    return value
+                }, {timeout: 3000}).not.toBe(pulse)
+            } catch {
+                // unchanged within the window — recorded below rather than aborting the sweep
+            }
+
+            const digits = input => Number(String(input).replace(/[^\d-]/g, ''));
+
+            digits(value) !== digits(pulse) + 1 && failures.push({recordId, before: pulse, after: value})
+        }
+
+        expect(failures, `recycled rows whose own Pulse cell did not increment: ${JSON.stringify(failures)}`)
+            .toEqual([])
+    })
+});

--- a/test/playwright/unit/grid/BodyWindowIsolation.spec.mjs
+++ b/test/playwright/unit/grid/BodyWindowIsolation.spec.mjs
@@ -119,18 +119,28 @@ test.describe('Neo.grid.Body — one grid cannot resize another grid\'s window (
         expect(feed.mountedRows,  'short grid, measured last').toEqual([0, 5])
     });
 
-    test('an index-write through the window is observable on the instance', () => {
-        // The other half of the descriptor, and the one with no visible symptom when it breaks.
-        // Both calculators write by index rather than reassigning, and the engine's default copies
-        // arrays on every read — so without `cloneOnGet: 'none'` this write lands in a discarded
-        // copy and the window silently never moves. That failure looks exactly like the sharing
-        // bug from the outside, so it needs its own arm rather than being covered by the ones above.
-        scale.mountedRows[0] = 3;
-        scale.mountedRows[1] = 9;
+    // The other half of the descriptor, and the one with no visible symptom when it breaks. Every
+    // window here is written BY INDEX rather than reassigned, and the engine's default copies
+    // arrays on every read — so without `cloneOnGet: 'none'` the write lands in a discarded copy
+    // and the window silently never moves. That failure looks exactly like the sharing bug from
+    // the outside, which is why it is armed rather than left to the arms above.
+    //
+    // One arm PER CONFIG, because a passing suite is not evidence that a config is covered: with
+    // `cloneOnGet` dropped from `visibleColumns_` alone, all 80 specs across `unit/grid` and
+    // `component/grid` stayed green. The writers that would have caught it live in other classes —
+    // `grid/Container.mjs` destructures `visibleColumns` off the body and does `+= step` through
+    // the reference, and `grid/View.mjs` index-writes `_body.visibleRows` — and neither path is
+    // exercised by those suites. Covering one config and inferring the rest is what left that hole.
+    for (const key of ['mountedRows', 'visibleRows', 'visibleColumns']) {
+        test(`an index-write through ${key} is observable on the instance`, () => {
+            scale[key][0] = 3;
+            scale[key][1] = 9;
 
-        expect(scale.mountedRows, 'the write reached the stored array').toEqual([3, 9]);
+            expect(scale[key], 'the write reached the stored array').toEqual([3, 9]);
 
-        // And it must not have reached anything else, which is what pairs it with `clone: 'shallow'`.
-        expect(feed.mountedRows, 'without touching the other body').toEqual([0, 0])
-    })
+            // And it must not have reached anything else, which is what pairs `cloneOnGet: 'none'`
+            // with `clone: 'shallow'`: a live reference per instance, not one shared live reference.
+            expect(feed[key], 'without touching the other body').toEqual([0, 0])
+        })
+    }
 });

--- a/test/playwright/unit/grid/BodyWindowIsolation.spec.mjs
+++ b/test/playwright/unit/grid/BodyWindowIsolation.spec.mjs
@@ -1,0 +1,136 @@
+/**
+ * @file test/playwright/unit/grid/BodyWindowIsolation.spec.mjs
+ * @summary Each Neo.grid.Body owns its virtualization windows, so one grid cannot resize another's.
+ *
+ * `mountedRows`, `visibleRows` and `visibleColumns` are declared in `static config` as array
+ * literals, and the two window calculators write through them BY INDEX rather than reassigning
+ * (`me.mountedRows[0] = …` — "update the array inline"). A non-reactive config holding an array
+ * hands every instance the same object, so before the fix every grid body on a page shared one
+ * window and the last body to measure decided what all the others believed was mounted.
+ *
+ * Nothing reports that. `onStoreRecordChange()` and `getRow()` both treat an index outside the
+ * window as "nothing to do" — no row update, no warning — so on a page with two grids, a record
+ * change beyond the borrowed window reaches the store and never reaches the DOM. The store stays
+ * correct, which is what makes it hard to see: only the paint is missing.
+ *
+ * Observed on a page holding a tall grid and a short one, where the short grid clamped the tall
+ * grid to six mounted rows and every row below the sixth stopped repainting.
+ *
+ * @see Neo.grid.Body
+ * @see https://github.com/neomjs/neo/issues/18198
+ */
+
+import {setup} from '../../setup.mjs';
+
+setup({
+    neoConfig: {
+        allowVdomUpdatesInTests: true,
+        unitTestMode           : true,
+        useDomApiRenderer      : true,
+        useVdomWorker          : false
+    },
+    appConfig: {
+        name             : 'GridBodyWindowIsolationTest',
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../src/Neo.mjs';
+import * as core      from '../../../../src/core/_export.mjs';
+import GridBody       from '../../../../src/grid/Body.mjs';
+import Store          from '../../../../src/data/Store.mjs';
+
+/**
+ * A body with just enough state for the window calculator: it reads `availableRows`,
+ * `bufferRowRange`, `startIndex` and `store.count`, and nothing else.
+ * @param {Object} config
+ * @returns {Neo.grid.Body}
+ */
+const createBody = config => Neo.create(GridBody, {
+    appName: 'GridBodyWindowIsolationTest',
+    store  : Neo.create(Store, {
+        data: Array.from({length: 500}, (_, i) => ({id: i + 1, name: 'row ' + (i + 1)}))
+    }),
+    ...config
+});
+
+test.describe('Neo.grid.Body — one grid cannot resize another grid\'s window (#18198)', () => {
+    // Deliberately NO `test.skip(!!process.env.NEO_TEST_SKIP_CI, …)` guard, which several specs in
+    // this directory carry. The `unit` CI job sets that variable, so a guarded regression arm is
+    // green in CI by not running — indistinguishable from green by passing, and useless as the
+    // thing that stops this defect coming back. Nothing here needs more than the engine the
+    // unguarded specs in this directory already use: two `Neo.grid.Body` instances and a store,
+    // no mount, no render, no DOM.
+
+    let feed, scale;
+
+    test.beforeEach(() => {
+        // Deliberately unequal geometries, mirroring the Workstation: a tall grid and a short one.
+        // Equal geometries would produce equal windows and the arm would pass while sharing.
+        scale = createBody({availableRows: 7, bufferRowRange: 10, startIndex: 0});
+        feed  = createBody({availableRows: 1, bufferRowRange: 2,  startIndex: 0})
+    });
+
+    test.afterEach(() => {
+        scale?.destroy?.();
+        feed?.destroy?.()
+    });
+
+    test('two bodies do not share the array objects their windows are written through', () => {
+        // Identity, asserted directly. The inline writes mean sharing the object IS the defect —
+        // every behavioural symptom below is downstream of this one fact.
+        expect(scale.mountedRows,    'mountedRows is per instance').not.toBe(feed.mountedRows);
+        expect(scale.visibleRows,    'visibleRows is per instance').not.toBe(feed.visibleRows);
+        expect(scale.visibleColumns, 'visibleColumns is per instance').not.toBe(feed.visibleColumns)
+    });
+
+    test('recomputing the tall grid\'s window leaves the short grid\'s window untouched', () => {
+        feed.updateMountedAndVisibleRows();
+
+        const feedWindow  = [...feed.mountedRows],
+              feedVisible = [...feed.visibleRows];
+
+        // The short grid's own geometry can only ever produce a 5-row window
+        // (availableRows 1 + 2 * bufferRowRange 2). Stating it makes the arm non-vacuous: if the
+        // calculator ever stops running, the assertions below would compare two untouched
+        // defaults and pass without measuring anything.
+        expect(feedWindow, 'the short grid measured its own geometry').toEqual([0, 5]);
+
+        scale.updateMountedAndVisibleRows();
+
+        // The tall grid reaches a window the short one cannot produce: availableRows 7 puts the
+        // visible end at 7, and bufferRowRange 10 extends the mounted end to 27.
+        expect(scale.mountedRows, 'the tall grid measured its own geometry').toEqual([0, 27]);
+        expect(scale.visibleRows, 'and its own visible range').toEqual([0, 7]);
+
+        // The point of the file: measuring one grid must not move the other.
+        expect(feed.mountedRows, 'the short grid keeps its window').toEqual(feedWindow);
+        expect(feed.visibleRows, 'and its visible range').toEqual(feedVisible)
+    });
+
+    test('the order the grids measure in does not decide what either believes is mounted', () => {
+        // The defect was order-dependent, so asserting one order proves only that order. Whichever
+        // measures last, both must end on their own numbers.
+        scale.updateMountedAndVisibleRows();
+        feed.updateMountedAndVisibleRows();
+
+        expect(scale.mountedRows, 'tall grid, measured first').toEqual([0, 27]);
+        expect(feed.mountedRows,  'short grid, measured last').toEqual([0, 5])
+    });
+
+    test('an index-write through the window is observable on the instance', () => {
+        // The other half of the descriptor, and the one with no visible symptom when it breaks.
+        // Both calculators write by index rather than reassigning, and the engine's default copies
+        // arrays on every read — so without `cloneOnGet: 'none'` this write lands in a discarded
+        // copy and the window silently never moves. That failure looks exactly like the sharing
+        // bug from the outside, so it needs its own arm rather than being covered by the ones above.
+        scale.mountedRows[0] = 3;
+        scale.mountedRows[1] = 9;
+
+        expect(scale.mountedRows, 'the write reached the stored array').toEqual([3, 9]);
+
+        // And it must not have reached anything else, which is what pairs it with `clone: 'shallow'`.
+        expect(feed.mountedRows, 'without touching the other body').toEqual([0, 0])
+    })
+});

--- a/test/playwright/unit/grid/BodyWindowIsolation.spec.mjs
+++ b/test/playwright/unit/grid/BodyWindowIsolation.spec.mjs
@@ -143,4 +143,38 @@ test.describe('Neo.grid.Body — one grid cannot resize another grid\'s window (
             expect(feed[key], 'without touching the other body').toEqual([0, 0])
         })
     }
+
+    // `mountedColumns` is the fourth window and it is deliberately NOT in the loop above, because
+    // it is the only one of the four with an `afterSet` hook: `afterSetMountedColumns` calls
+    // `createViewData()`, so the assignment IS the horizontal repaint trigger. Its contract is
+    // therefore assign-only, and the property worth guarding is the opposite one — that a whole
+    // assignment still reaches the hook. It carries the same descriptor as its siblings for the
+    // other two reasons (per-instance default, and no array copy on a read that happens per row
+    // and per cell during render), and those must not have cost it the notification.
+    test('mountedColumns is per instance, like its three siblings', () => {
+        expect(scale.mountedColumns, 'not the same array as the other body').not.toBe(feed.mountedColumns);
+
+        scale.mountedColumns = [2, 8];
+
+        expect(feed.mountedColumns, 'the sibling keeps its own').toEqual([0, 0])
+    });
+
+    test('assigning mountedColumns still reaches afterSetMountedColumns, which drives the repaint', () => {
+        let renders = 0;
+
+        scale.createViewData = () => {renders++};
+
+        // A fresh array with different values: the setter's equality check must see a change.
+        scale.mountedColumns = [1, 6];
+
+        expect(scale.mountedColumns, 'the assignment landed').toEqual([1, 6]);
+        expect(renders, 'and it triggered the render the hook owns').toBe(1);
+
+        // The negative half, and the reason this config is excluded from the index-write loop: a
+        // write that does not go through the setter moves the value without repainting. Asserted
+        // so the assign-only contract is enforced by the suite rather than only by a comment.
+        scale.mountedColumns[0] = 4;
+
+        expect(renders, 'an index-write does NOT repaint — assign, never index-write').toBe(1)
+    })
 });


### PR DESCRIPTION
## Summary

Resolves #18198.

The `+1 pulse` button in the Workstation's 100k Matrix incremented the record and never repainted the cell, for every row below the sixth. This is the fix, done through the config system rather than around it — the fourth attempt at this defect, and the first that uses the engine's own machinery.

### The defect

`mountedRows`, `visibleRows` and `visibleColumns` were non-reactive `static config` array literals, and both window calculators write through them **by index** rather than reassigning (`me.mountedRows[0] = mountedStart`, and the source says `// update the array inline`). A non-reactive key has no clone path at all, so every grid body on a page held the same array.

The Workstation renders two grids. The feed grid (`availableRows 1`, buffer 2) wrote a 5-row window into the array the scale grid (`availableRows 7`, buffer 10) was reading, so the scale grid believed 6 of its 27 painted rows were mounted. Both repaint paths gate on that window and treat anything outside it as nothing to do — `onStoreRecordChange()` skips, `getRow()` returns `null`, `AnimatedChange` no-ops under `if (row)`. No warning anywhere on that path, and the store stays correct, so only the paint is missing.

Measured before the fix, on the running app: calling `updateMountedAndVisibleRows()` on the **scale** body alone moved the **feed** body's window from `[0,5]` to `[0,27]` — a window its own geometry cannot produce.

### The fix, and why both descriptor keys are load-bearing

All four window configs now carry a descriptor on the reactive path, which is where the clone machinery already lives:

```javascript
mountedRows_: {
    [isDescriptor]: true,
    clone         : 'shallow',
    cloneOnGet    : 'none',
    value         : [0, 0]
},
```

Measured at `core.Base` with a probe class before being applied here:

| descriptor | same-instance identity | two instances | after `a[0] = 99` |
|---|---|---|---|
| `clone:'none', cloneOnGet:'none'` | stable | **shared** | sibling `[99,0]`, class default `[99,0]` |
| `clone:'deep', cloneOnGet:'none'` | stable | isolated | sibling `[0,0]` |
| **`clone:'shallow', cloneOnGet:'none'`** | **stable** | **isolated** | `a` `[99,0]`, sibling `[0,0]`, default clean |

- **`clone: 'shallow'`** gives each body its own array. `'deep'` behaves identically for an array of two numbers and costs more; `'none'` reproduces the defect exactly.
- **`cloneOnGet: 'none'`** is what makes an index-write land. The engine's default copies arrays on **every read**, so without it `me.mountedRows[0] = x` writes into a discarded copy and the window never moves — silently, and in the same direction as the original bug. It has its own arm for that reason.

### The fourth window

`mountedColumns_` was originally left alone on the grounds that it is already reactive and always assigned a fresh array. That is true — it is never index-written anywhere in `src/` — and it was the wrong call. It is one of four siblings, it read differently from the other three for no reason visible to a reader, and it paid the engine's copy-on-read at `grid/Row.mjs:411` and `:502` (per row and per cell during render) plus three times per `createViewData()`, for a defensive copy that protected nothing.

It **is** genuinely different, and the difference is worth stating rather than eliding: it is the only one of the four with an `afterSet` hook, and `afterSetMountedColumns` calls `createViewData()`. **The assignment is the horizontal repaint trigger**, so its contract is assign-only — an index-write would move the value and skip the render.

So it carries the same descriptor for the two reasons the siblings do (per-instance default, no array copy on a hot read), and it stays out of the index-write loop in the spec, which would have asserted the opposite of its contract. It gets two arms instead: that it is per-instance like its siblings, and that a whole assignment still reaches the hook — verified to discriminate by forcing the setter's equality check to always report equal, which turns it red. The negative half is asserted in the same arm: an index-write does **not** repaint, so the assign-only contract lives in the suite rather than in a comment.

### Why `cloneOnGet: 'none'` is safe *here* specifically

@neo-opus-grace established on D#18195 that `cloneOnGet: 'none'` carries a real hazard: with a live read, the read-modify-write-back idiom mutates the stored value and then compares it to itself, so `Config.set()` returns `false` and **both `afterSet` and `notify` are skipped** — the mutation lands and the notification does not. That is why `container/Base`, `selection/Model` and `tab/Container` all pair it with `isEqual: () => false`.

That hazard **cannot fire on these three configs**: they are written by index, never assigned after construction, and nothing subscribes to them. `isEqual` is never reached, so the compensator is not needed. The distinction is the reason this PR does not carry a fourth descriptor key it does not use.

Evidence: L2 (mutation-verified unit arms plus an e2e witness on the running app, run locally) → L2 required. Residual: none.

## Test Evidence

Every arm red-first, with the fix's absence asserted by `grep` rather than assumed from a `git stash`:

| arm | fix applied | fix absent |
|---|---|---|
| `unit/grid/BodyWindowIsolation.spec.mjs` (8 arms) | `8 passed` | `3 failed` |
| `e2e/workstation/WorkstationRowActionNL.spec.mjs` (2 arms) | `2 passed` | `2 failed` |

Each config has its own index-write arm, and each was verified to discriminate by dropping **only that config's** `cloneOnGet: 'none'` while leaving `clone: 'shallow'` in place:

| `cloneOnGet` dropped from | arms failing |
|---|---|
| `mountedRows_` | 3 |
| `visibleRows_` | 2 |
| `visibleColumns_` | 1 |

*Corrected after review.* The first version of this body claimed the single-key drop verified "the index-write arm" without saying which config it was run against. It was `mountedRows_` only, and @neo-opus-grace found that dropping `cloneOnGet` from `visibleColumns_` alone left **all 80 specs** across `unit/grid` and `component/grid` green — one config armed, two inferred. The writers that would have caught it are in other classes: `grid/Container.mjs` destructures `visibleColumns` off the body and does `+= step` through the reference, and `grid/View.mjs` index-writes `_body.visibleRows`. Neither path is exercised by those suites, so the key was load-bearing and unguarded. There is now one arm per config.

Full unit suite: **`3121 passed`**. Component grid specs: **`7 passed`**.

No `NEO_TEST_SKIP_CI` guard on the new arms — the `unit` job sets that variable, so a guarded regression arm is green in CI by not running. Verified with it set.

The isolation arms use **unequal** geometries (`7`/`10` against `1`/`2`) deliberately: two grids of the same size produce the same window and would pass while still sharing the array. A third arm reverses the measurement order, because the defect was order-dependent.

## Relationship to D#18195

This does **not** depend on that fork and does not pre-empt it. The open question there is what should happen to a *non-reactive* key that declares a clone descriptor — silently inert today. This PR moves these three keys onto the **reactive** path, where descriptors already work, so it is correct under every option on that matrix.

If the descriptor defaults later change (Option F′), the explicit `clone: 'shallow'` here becomes redundant and can be dropped; `cloneOnGet: 'none'` stays either way, since F′ does not touch it.

## Predecessors

#18186, #18190 and #18191 were all dropped by @tobiu, correctly. The first two fixed a consumer while asserting things about a layer I had not tested; the third left the config system entirely by moving to instance fields. His ruling — *"if the [config system] does not honor NEO BEST PRACTISES, like core.Config and config descriptors ... it is a failure. using config descriptors e.g. inside grid body => that is fine"* — is what this shape follows.

⚖️ **Ada** · `@neo-opus-ada` · Claude Opus 5 · Claude Code


