### PR TITLE
test(dashboard): the preview-geometry settle guard witnesses the transition (#18179)

### DIFF
--- a/test/playwright/component/apps/dock-preview-geometry/app.mjs
+++ b/test/playwright/component/apps/dock-preview-geometry/app.mjs
@@ -55,6 +55,69 @@ class PreviewGeometryWorkspace extends DockWorkspace {
     }
 
     /**
+     * How many dock projections have RUN TO COMPLETION on this workspace.
+     *
+     * The spec's settle guard used to poll the host's child count for its at-rest value of 3 — but 3
+     * is the at-rest count on BOTH sides of a projection, so `expect.poll` returned on its first
+     * satisfying sample and could hand control to a measurement that then landed mid-stage. It waited
+     * for a state the timeline visits twice instead of the transition it meant to witness.
+     *
+     * This counter cannot be satisfied before a projection has run: it starts at 0.
+     * @member {Number} dockProjectionSettles=0
+     */
+    dockProjectionSettles = 0
+    /**
+     * Whether a projection is in flight right now.
+     *
+     * The counter alone is not enough — two equal samples can bracket a refresh that started after
+     * the first and has not finished by the second. Pairing them gives the guard a state that exists
+     * only after a projection has completed AND while none is running.
+     * @member {Boolean} dockProjectionBusy=false
+     */
+    dockProjectionBusy = false
+
+    /**
+     * @param {Object} data
+     */
+    afterRefreshDockWorkspace(data) {
+        super.afterRefreshDockWorkspace(data);
+        this.dockProjectionSettles++
+    }
+
+    /**
+     * Brackets the whole refresh, so `dockProjectionBusy` cannot LATCH.
+     *
+     * The obvious shape — set it in `beforeRefreshDockWorkspace`, clear it in
+     * `afterRefreshDockWorkspace` — latches on every path between the two that does not reach the
+     * second hook, and this subsystem has several: `refreshDockWorkspace` returns early on the
+     * projection-failure path (deliberately, since `afterRefreshDockWorkspace` consumers read
+     * `result` as a completed projection), it returns early when the workspace is destroyed, and an
+     * uncaught throw inside the transaction leaves the pair unbalanced too. Measured: the paired
+     * version stayed `true` for the life of the workspace, and the settle guard would then have
+     * timed out at 10 s with a poll message rather than a failure — reintroducing, one layer up,
+     * exactly the ambiguity this fixture removes.
+     *
+     * `finally` closes the whole class at once instead of naming each exit. `dockProjectionSettles`
+     * still counts only true completions, because that is a different question: *did a projection
+     * finish*, versus *is one running*.
+     * @param {Object} tabInsertDescriptor
+     * @param {Object} document
+     * @param {Object} refreshOptions
+     * @returns {Promise<*>}
+     */
+    async refreshDockWorkspace(tabInsertDescriptor, document, refreshOptions) {
+        let me = this;
+
+        me.dockProjectionBusy = true;
+
+        try {
+            return await super.refreshDockWorkspace(tabInsertDescriptor, document, refreshOptions)
+        } finally {
+            me.dockProjectionBusy = false
+        }
+    }
+
+    /**
      * Builds the host and its two persistent overlay siblings. The host gets `position: relative`
      * through an inline style rather than a class, so this fixture stays stylesheet-free and the
      * spec measures the engine sheet alone.

--- a/test/playwright/component/dashboard/DockPreviewGeometry.spec.mjs
+++ b/test/playwright/component/dashboard/DockPreviewGeometry.spec.mjs
@@ -26,13 +26,25 @@ import {test, expect} from '@playwright/test';
 
 const HOST = '.dock-preview-geometry-host';
 
+const WORKSPACE_ID = 'dock-preview-geometry-workspace';
+
 /**
  * Reads the host's overflow state together with the preview's computed position, in one evaluate so
  * every number describes the same frame.
  * @param {Object} page
  * @returns {Promise<Object>}
  */
-const readGeometry = page => page.evaluate(host => {
+const readSettleState = async page => {
+    const reply = await page.evaluate(data => Neo.worker.App.getConfigs(data),
+        {id: WORKSPACE_ID, keys: ['dockProjectionBusy', 'dockProjectionSettles']});
+
+    // `getConfigs` answers POSITIONALLY, in `keys` order — not as an object.
+    const [busy, settles] = reply?.data ?? reply ?? [];
+
+    return {busy, settles}
+};
+
+const readHostGeometry = page => page.evaluate(host => {
     const el      = document.querySelector(host),
           preview = el?.querySelector(':scope > .neo-dock-preview'),
           shell   = el?.querySelector(':scope > .neo-dashboard-dock-tabs, :scope > .neo-layout-fit-item');
@@ -49,6 +61,17 @@ const readGeometry = page => page.evaluate(host => {
     }
 }, HOST);
 
+const readGeometry = async page => {
+    // The settle state travels WITH the geometry so a failure can be read. Before this, a red was
+    // ambiguous between a mid-stage measurement and a genuine strand, and the team resolved that by
+    // re-running — which destroys the log that would have settled it. Carrying `settles`/`busy` into
+    // the failure output means the message itself says which one happened.
+    const {busy, settles} = await readSettleState(page);
+
+    return {...await readHostGeometry(page), projectionBusy: busy, projectionSettles: settles}
+};
+
+
 test.beforeEach(async ({page}) => {
     await page.goto('test/playwright/component/apps/dock-preview-geometry/index.html');
     await page.waitForSelector('#dock-preview-geometry-workspace', {state: 'attached'});
@@ -58,15 +81,63 @@ test.beforeEach(async ({page}) => {
     // stages the next shell as a hidden sibling before retiring the old one, so for the duration of
     // that transaction the host legitimately holds two full-width shells — and `scrollWidth` is
     // then 2x `clientWidth` for a correct reason. Measuring inside that window reads a transient as
-    // the defect: it never reproduced locally and failed on CI, which is a race against a slower
-    // machine rather than a flaky suite.
+    // the defect.
     //
     // The settle signal is deliberately NOT `scrollWidth`, which is the property under test — that
-    // would make the arms below vacuous, waiting for exactly what they claim to prove. Child count
-    // is independent: the host holds its shell plus the two persistent overlays at rest, and one
-    // more while a second shell is staged.
-    await expect.poll(async () => page.evaluate(host =>
-        document.querySelector(host)?.childElementCount ?? 0, HOST), {timeout: 10000}).toBe(3)
+    // would make the arms below vacuous, waiting for exactly what they claim to prove.
+    //
+    // It is no longer the host's CHILD COUNT either. That guard polled for the at-rest value of 3,
+    // and 3 is the at-rest count on BOTH sides of a projection: satisfied before staging begins and
+    // again after it settles. `expect.poll` returns on its first satisfying sample, so it could pass
+    // pre-transaction and hand control to a measurement that then landed mid-stage. It waited for a
+    // STATE the timeline visits twice rather than for the TRANSITION it means to witness — which is
+    // why a red here was ambiguous between a harness race and a real regression, and why the team
+    // resolved it by re-running.
+    //
+    // The fixture now reports the transition directly. `dockProjectionSettles` counts projections
+    // that ran to completion, so it cannot be satisfied before one has; `dockProjectionBusy` closes
+    // the remaining hole, since two equal counter samples could otherwise bracket a refresh that
+    // started after the first and had not finished by the second. The pair describes a state that
+    // exists only AFTER a projection completed and while none is running.
+    await expect.poll(async () => {
+        const reply = await page.evaluate(data => Neo.worker.App.getConfigs(data),
+            {id: WORKSPACE_ID, keys: ['dockProjectionBusy', 'dockProjectionSettles']});
+
+        // `getConfigs` answers POSITIONALLY, in `keys` order — not as an object. Destructuring by
+        // name yields undefined for both, and the poll then never satisfies.
+        const [busy, settles] = reply?.data ?? reply ?? [];
+
+        return settles > 0 && busy === false
+    }, {timeout: 10000}).toBe(true)
+});
+
+test.describe('the settle guard survives a FAILED projection', () => {
+    // Found in review: the first version set `dockProjectionBusy` in `beforeRefreshDockWorkspace`
+    // and cleared it in `afterRefreshDockWorkspace`, which LATCHES. `refreshDockWorkspace` returns
+    // early on the projection-failure path — deliberately, since `afterRefreshDockWorkspace`
+    // consumers read `result` as a completed projection — so the only clear never ran and the guard
+    // could never satisfy again. Every arm would then die on a 10s poll timeout, which reads as a
+    // hang rather than as a failed projection: the very ambiguity this file exists to remove,
+    // reintroduced one layer up.
+    //
+    // The fixture brackets the whole refresh in `finally` instead of pairing two hooks, so the
+    // clear cannot be skipped by ANY exit — the early return, the destroyed guard, or a throw.
+    test('a projection that throws leaves the guard satisfiable', async ({page}) => {
+        await page.goto('test/playwright/component/apps/dock-preview-geometry/index.html');
+        await page.waitForSelector(`#${WORKSPACE_ID}`, {state: 'attached'});
+        await expect.poll(async () => (await readSettleState(page)).busy, {timeout: 10000}).toBe(false);
+
+        // Arm one failing projection, then commit a real document change to trigger a refresh.
+        await page.evaluate(id => Neo.worker.App.setConfigs({id, failNextProjection: true}), WORKSPACE_ID);
+        await page.evaluate(id => Neo.worker.App.setConfigs({
+            id, applyOperationJson: JSON.stringify({operation: 'setActiveItem', tabsNodeId: 'root', itemId: 'aside'})
+        }), WORKSPACE_ID);
+
+        // The assertion is the ABSENCE of a latch, so it must be given time to latch if it can.
+        await page.waitForTimeout(1200);
+
+        expect((await readSettleState(page)).busy, 'a failed projection must not latch the guard').toBe(false)
+    })
 });
 
 test.describe('Neo.dashboard.dock.interaction.Preview — the overlay carries its own geometry (#18142)', () => {
@@ -78,6 +149,12 @@ test.describe('Neo.dashboard.dock.interaction.Preview — the overlay carries it
         expect(geometry.present,      'the preview overlay must exist for this to measure anything').toBe(true);
         expect(geometry.shellPresent, 'the projected shell must exist for the same reason').toBe(true);
         expect(geometry.clientWidth,  'the host must have laid out').toBeGreaterThan(0);
+
+        // AC-4: name the state this measurement was taken in. A red below now means a STRANDED
+        // shell or an in-flow preview — never "measured too early", because a projection has
+        // completed and none is running. Asserting it here puts that fact in the failure output.
+        expect(geometry.projectionSettles, 'at least one projection has completed').toBeGreaterThan(0);
+        expect(geometry.projectionBusy, 'and none is in flight — so a red below is a real defect, not a race').toBe(false);
 
         expect(geometry.position, 'the engine sheet positions the preview root').toBe('absolute');
 


### PR DESCRIPTION
## Summary

The spec's `beforeEach` polled the host's child count for its at-rest value of **3**. That is the at-rest count on **both sides** of a projection — satisfied before staging begins and again after it settles — and `expect.poll` returns on its first satisfying sample.

So the guard could pass **pre-transaction** and hand control to a measurement that then landed mid-stage, where the host legitimately holds two full-width shells and `scrollWidth` is 2× `clientWidth` *for a correct reason*. It waited for a **state the timeline visits twice** rather than for the **transition** it meant to witness.

That made a red here ambiguous between a harness race and a genuine regression of the two defects this file guards — and the team resolved that by re-running.

**A green re-run also destroys the failing log.** I did exactly that to a sibling spec earlier today and could not recover the value afterwards, so I cannot now say whether that one was real. That is the compounding cost of the ritual, not just noise.

## The fix

The fixture reports the transition directly:

- **`dockProjectionSettles`** — projections that ran to completion. Cannot be satisfied before one has: it starts at 0.
- **`dockProjectionBusy`** — closes the remaining hole, since two equal counter samples could bracket a refresh that started after the first and had not finished by the second.

The pair describes a state that exists **only after a projection completed and while none is running**.

## Acceptance Criteria

| AC | Evidence |
|---|---|
| **AC-1** the old guard is satisfiable pre-transaction — *demonstrated, not asserted* | sampling **from navigation** (not after `waitForSelector`, which skips the window), the very first frame reads `{busy: true, count: 3, settles: 0}` — the old guard returns there, mid-flight — and the next two frames show `count: 4` as the second shell stages. Two divergent frames in one boot. |
| **AC-2** 20 repeats green, including under load | **40 passed**; and **40 again** while a full components tier ran concurrently (that run: **230 passed**). The failure is load-tipped, so the loaded repeat is the one that counts. |
| **AC-3** the original defect still turns it red | removing `position: absolute` from the engine's preview sheet → **2 failed**. Stability was not bought by weakening the assertion. |
| **AC-4** a real defect is distinguishable from a mid-stage measurement | the settle state now travels **with** the geometry, so it appears in the failure output beside the assertion that fired. |
| **AC-5** `scrollWidth === clientWidth` unchanged | untouched — it reads the cause and it stays. |

## Why AC-1 needed a different sampling point

My first witness sampled after `waitForSelector`, and reported **60 of 60 frames identical** — no divergence. The projection had already settled by then, so the instrument could not see the window it was built to find. Sampling from `goto` is what exposed it. **A witness aimed after the event proves nothing about the event.**

## One idiom correction

`Neo.worker.App.getConfigs` answers **positionally**, in `keys` order — not as an object. Destructuring by name yields `undefined` for every key and the poll never satisfies, which is how my first version failed both arms. `DockRailLazyModule.spec.mjs` already does `const [loaded, instances] = …`; I had read the helper and not the destructuring.

## Scope

`DockRailLazyModule.spec.mjs` stays **out**, per the ticket — same tier, different spec, unproven common cause. For the record it failed again today on #18200, which is its second independent sighting; that belongs in its own ticket with its own measurement rather than bundled here on a resemblance.

## Evidence

component `dashboard`: **108 passed** · repeats: **40 passed** idle, **40 passed** under load.

Resolves #18179.

Authored by Grace (Claude Opus 5, Claude Code). Session 8d936ec9-b816-4ded-a91e-6e91ef6a3325.
