### PR TITLE
fix(layout): loadModule honours the in-flight marker it already sets (#18201)

### DIFF
--- a/src/layout/Card.mjs
+++ b/src/layout/Card.mjs
@@ -69,6 +69,15 @@ class Card extends Base {
     }
 
     /**
+     * In-flight {@link #loadModule} calls, keyed by the parked item config so a second caller joins
+     * the first load instead of starting its own. Keyed by the config rather than stored on it,
+     * because the config itself is handed to `Neo.create` once the module resolves.
+     * @member {WeakMap<Object,Promise>} loadingModules=new WeakMap()
+     * @protected
+     */
+    loadingModules = new WeakMap()
+
+    /**
      * Modifies the CSS classes of the container items this layout is bound to.
      * Automatically gets triggered after changing the value of activeIndex.
      * Lazy loads items which use a module config containing a function.
@@ -189,12 +198,51 @@ class Card extends Base {
     }
 
     /**
-     * Loads a component.Base module which is defined via module: () => import('...')
+     * @summary Loads a component.Base module which is defined via module: () => import('...')
+     *
+     * **Idempotent per item, and the guard belongs here.** Two callers legitimately ask for the same
+     * parked item: a card layout loads it when its index activates, and `container.Base#insert`
+     * starts the load itself when the inserted index is already the active one. Both are correct,
+     * and neither can know about the other.
+     *
+     * `isLoading` below is NOT that guard. It is set for `form.Container` to read — its own comment
+     * says so — and this method never consulted it, so both callers crossed the `await` on the
+     * dynamic import and both reached `Neo.create`, the second overwriting the first instance and
+     * orphaning a live component. The window is exactly the import's duration, which is why it
+     * surfaced as an intermittent double construction under machine load rather than as a bug.
+     *
+     * A second call therefore joins the in-flight promise and settles on the same instance. The
+     * promise is keyed in a `WeakMap` by the parked config rather than stored on it, because that
+     * config is passed to `Neo.create` once it resolves.
      * @param {Object} item
      * @param {Number} [index]
-     * @returns {Neo.component.Base}
+     * @returns {Promise<Neo.component.Base>}
      */
-    async loadModule(item, index) {
+    loadModule(item, index) {
+        let me       = this,
+            inFlight = me.loadingModules.get(item);
+
+        if (inFlight) {
+            return inFlight
+        }
+
+        const load = me.#loadModuleOnce(item, index);
+
+        me.loadingModules.set(item, load);
+
+        // A rejected import must not leave the item unloadable: the entry goes whatever the outcome,
+        // so the next activation retries against a config that is still parked behind its placeholder.
+        return load.finally(() => me.loadingModules.delete(item))
+    }
+
+    /**
+     * The one-shot body of {@link #loadModule}, entered at most once per parked item at a time.
+     * @param {Object} item
+     * @param {Number} [index]
+     * @returns {Promise<Neo.component.Base>}
+     * @private
+     */
+    async #loadModuleOnce(item, index) {
         let me          = this,
             {container} = me,
             items       = container.items,

--- a/test/playwright/unit/container/InsertLazyModule.spec.mjs
+++ b/test/playwright/unit/container/InsertLazyModule.spec.mjs
@@ -30,6 +30,26 @@ import CardLayout     from '../../../../src/layout/Card.mjs';
 
 const lazyButton = text => ({module: () => Promise.resolve({default: Button}), text});
 
+/**
+ * A resolved module whose constructions are countable — the identity witness for the concurrent-load
+ * arms. A count is the only way to see a duplicate: the second instance replaced the first in
+ * `items`, so the container looked correct while a live component had been orphaned.
+ */
+class Counted extends Button {
+    static config = {
+        className: 'Test.Unit.Container.InsertLazyModule.Counted'
+    }
+
+    static constructions = 0
+
+    construct(config) {
+        super.construct(config);
+        Counted.constructions++
+    }
+}
+
+Neo.setupClass(Counted);
+
 const cardContainer = () => Neo.create(Container, {
     appName,
     layout: {ntype: 'card', activeIndex: 0},
@@ -165,4 +185,70 @@ test.describe('Neo.container.Base#insert — a lazy module config parks, then lo
         expect(container.vdom.cn[0].removeDom).toBe(true);
         expect(container.vdom.cn).toHaveLength(2)
     });
+
+    /**
+     * Two callers legitimately ask for the same parked item: a card layout loads it when its index
+     * activates, and `container.Base#insert` loads it itself when the inserted index is already
+     * active. `loadModule` sets `isLoading` for `form.Container` to read and never consulted it, so
+     * both crossed the `await` on the import and both reached `Neo.create` — the second overwriting
+     * the first instance and orphaning a live component.
+     *
+     * Driven with a DEFERRED loader rather than a microtask one, so the window is held open on
+     * purpose. That is what makes this deterministic: the defect was found as an intermittent red on
+     * unrelated PRs, because in the wild the window is only as wide as a dynamic import.
+     */
+    test('two concurrent loadModule calls for one parked item construct it once', async () => {
+        let resolveImport;
+
+        const deferred = new Promise(resolve => {resolveImport = resolve});
+
+        container = cardContainer();
+        container.add({module: () => deferred, text: 'lazy'});
+
+        const parked = container.items[1];
+
+        expect(parked, 'the config must be parked, not constructed').not.toBeInstanceOf(Neo.core.Base);
+
+        // Both calls enter before the import settles — the race the two owners produce.
+        const first  = container.layout.loadModule(parked, 1),
+              second = container.layout.loadModule(parked, 1);
+
+        resolveImport({default: Counted});
+
+        const [a, b] = await Promise.all([first, second]);
+
+        expect(Counted.constructions, 'exactly one construction').toBe(1);
+        expect(a, 'both callers settle on the SAME instance').toBe(b);
+
+        // The orphaning half: without the join, the second create replaced the first in `items`,
+        // leaving a live component nothing referenced. Asserted so the count alone cannot carry it.
+        expect(container.items[1], 'the container holds the instance both callers received').toBe(a)
+    });
+
+    test('a failed import leaves nothing in flight, so the next call retries', async () => {
+        const failing  = {module: () => Promise.reject(new Error('chunk gone')), text: 'lazy'},
+              original = console.error;
+
+        console.error = () => {};
+
+        try {
+            container = cardContainer();
+            container.add(failing);
+
+            const parked = container.items[1];
+
+            await container.layout.loadModule(parked, 1).catch(() => {});
+
+            // The retry must actually re-enter rather than join a settled promise the map still holds.
+            Counted.constructions = 0;
+            parked.module         = () => Promise.resolve({default: Counted});
+
+            const retried = await container.layout.loadModule(parked, 1);
+
+            expect(Counted.constructions, 'the retry constructs').toBe(1);
+            expect(retried).toBeInstanceOf(Counted)
+        } finally {
+            console.error = original
+        }
+    })
 });


### PR DESCRIPTION
Resolves #18201

`Card#loadModule` set `item.isLoading = true` and never read it, so two legitimate callers both crossed the `await` on the dynamic import, both reached `Neo.create`, and the second `items[index] = …` overwrote the first instance. A duplicate construction **and** a live component orphaned behind it. A second call now joins the in-flight promise.

Evidence: L2 (unit — the defect is a re-entrancy window inside one method; the deferred loader makes it deterministic, which the CI symptom never was) → L2 required (every AC is a per-call contract on `loadModule`). Residual: none.

## AC Evidence
| AC-1 | `InsertLazyModule.spec.mjs` — `two concurrent loadModule calls for one parked item construct it once`; a deferred loader holds the window open, both calls enter, `Counted.constructions` is 1 and both callers receive the same instance |
| AC-2 | red-first, see Test Evidence — with `src/layout/Card.mjs` reverted the arm reports 2 constructions; the arm also asserts `container.items[1]` is the instance both callers got, so the count alone cannot carry it |
| AC-3 | the six pre-existing arms in the same spec cover the single-call path unchanged — parked config, placeholder vnode, load on activation, `isLoading` cleared, instance referenced at its index |
| AC-4 | `a failed import leaves nothing in flight, so the next call retries` — the `WeakMap` entry is removed in a `finally`, and the arm proves a repaired loader constructs on the next call rather than joining a settled rejection |
| AC-5 | `item.isLoading` is still set before the await and deleted after; `form/Container.mjs:80` is its only reader and is untouched |
| AC-6 | consequence, not the instrument: `DockRailLazyModule.spec.mjs:121` is the symptom this was found through. AC-1 is the proof — it is deterministic, where the component arm was load-sensitive |
| AC-7 | `unit/container/` + `unit/layout/` + `unit/dashboard/` — **931 passed** |

## Deltas from ticket

**The ticket's first version proposed a caller-side single-flight guard, and that was a workaround.** The operator named it: a mutex leaves two owners each believing they must start the load and makes the duplicate survivable instead of impossible. The ticket body carries a dated correction rather than a silent rewrite, because the reasoning that produced the wrong fix is the reasoning to avoid.

**The ticket's fork is closed, by reading rather than by reproduction.** It offered "engine race versus fixture over-counting". The fixture's counter increments inside `construct()`, once per construction, with no path on which it over-counts — so `instances: 2` was always two constructions.

**A second finding, deliberately left out of scope.** `container.Base#insert` starts the load itself when `me.layout.activeIndex === index`, justified in its comment as *"an index that is already active fired that hook long before this insert"*. That is an assumption about ordering, not a fact, and it is wrong exactly when an un-hide both inserts an item and activates its index. It only becomes a defect because the owner did not defend itself; with `loadModule` idempotent, a caller that asks twice gets one construction and the heuristic stops mattering. Narrowing it is a separate change with its own evidence.

**Engine-general, not dock-specific.** Any container with a card layout and a parked lazy module had this. The dock is where it surfaced because #18086 added the second caller.

## Test Evidence

**Red-first, and deterministic where the symptom was not.** With `src/layout/Card.mjs` stashed:

```
Expected: 1
Received: 2
  220 |  expect(Counted.constructions, 'exactly one construction').toBe(1);
1 failed
6 passed
```

The pre-existing six arms pass without the fix, which is the point: they cover the single-call path, and only the concurrent arm reds. In the wild the window is as wide as a dynamic import, which is why this arrived as an intermittent CI red on unrelated PRs (#18176, #18200) rather than as a bug report.

Green with the fix: **931 passed** across `container/`, `layout/` and `dashboard/`.

## Post-Merge Validation
- [ ] `components` stops reddening on unrelated PRs. Two reviews were spent on attribution before this was root-caused; that cost is the measure, and it is only observable after a few merges.

Authored by Vega (Opus 5, Claude Code). Session e8ea32a2-b9a8-43ea-84ba-b83081ec4b3d.
