### PR TITLE
chore(deps): close the remaining npm advisories, lockfile only (#18135)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2909,22 +2909,36 @@
             "license": "MIT"
         },
         "node_modules/body-parser": {
-            "version": "2.2.2",
-            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
-            "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+            "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "bytes": "^3.1.2",
-                "content-type": "^1.0.5",
+                "content-type": "^2.0.0",
                 "debug": "^4.4.3",
-                "http-errors": "^2.0.0",
-                "iconv-lite": "^0.7.0",
+                "http-errors": "^2.0.1",
+                "iconv-lite": "^0.7.2",
                 "on-finished": "^2.4.1",
-                "qs": "^6.14.1",
-                "raw-body": "^3.0.1",
-                "type-is": "^2.0.1"
+                "qs": "^6.15.2",
+                "raw-body": "^3.0.2",
+                "type-is": "^2.1.0"
             },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/body-parser/node_modules/content-type": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+            "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
+            "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=18"
             },
@@ -4521,9 +4535,9 @@
             "license": "MIT"
         },
         "node_modules/es-object-atoms": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-            "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+            "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -5216,30 +5230,24 @@
             }
         },
         "node_modules/http-errors": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
-            "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+            "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "depd": "2.0.0",
-                "inherits": "2.0.4",
-                "setprototypeof": "1.2.0",
-                "statuses": "2.0.1",
-                "toidentifier": "1.0.1"
+                "depd": "~2.0.0",
+                "inherits": "~2.0.4",
+                "setprototypeof": "~1.2.0",
+                "statuses": "~2.0.2",
+                "toidentifier": "~1.0.1"
             },
             "engines": {
                 "node": ">= 0.8"
-            }
-        },
-        "node_modules/http-errors/node_modules/statuses": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
-            "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.8"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
             }
         },
         "node_modules/http-proxy-middleware": {
@@ -6426,9 +6434,9 @@
             }
         },
         "node_modules/nanoid": {
-            "version": "3.3.16",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-            "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+            "version": "3.3.18",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+            "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
             "dev": true,
             "funding": [
                 {
@@ -7455,13 +7463,14 @@
             }
         },
         "node_modules/qs": {
-            "version": "6.15.2",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
-            "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+            "version": "6.16.0",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+            "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
             "dev": true,
             "license": "BSD-3-Clause",
             "dependencies": {
-                "side-channel": "^1.1.0"
+                "es-define-property": "^1.0.1",
+                "side-channel": "^1.1.1"
             },
             "engines": {
                 "node": ">=0.6"
@@ -7515,27 +7524,6 @@
             },
             "engines": {
                 "node": ">= 0.10"
-            }
-        },
-        "node_modules/raw-body/node_modules/http-errors": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
-            "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "depd": "~2.0.0",
-                "inherits": "~2.0.4",
-                "setprototypeof": "~1.2.0",
-                "statuses": "~2.0.2",
-                "toidentifier": "~1.0.1"
-            },
-            "engines": {
-                "node": ">= 0.8"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/express"
             }
         },
         "node_modules/readdirp": {
@@ -7947,27 +7935,6 @@
                 "url": "https://opencollective.com/express"
             }
         },
-        "node_modules/send/node_modules/http-errors": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
-            "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "depd": "~2.0.0",
-                "inherits": "~2.0.4",
-                "setprototypeof": "~1.2.0",
-                "statuses": "~2.0.2",
-                "toidentifier": "~1.0.1"
-            },
-            "engines": {
-                "node": ">= 0.8"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/express"
-            }
-        },
         "node_modules/serve-index": {
             "version": "1.9.2",
             "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.9.2.tgz",
@@ -8169,15 +8136,15 @@
             }
         },
         "node_modules/side-channel": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-            "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+            "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "es-errors": "^1.3.0",
-                "object-inspect": "^1.13.3",
-                "side-channel-list": "^1.0.0",
+                "object-inspect": "^1.13.4",
+                "side-channel-list": "^1.0.1",
                 "side-channel-map": "^1.0.1",
                 "side-channel-weakmap": "^1.0.2"
             },
@@ -8189,14 +8156,14 @@
             }
         },
         "node_modules/side-channel-list": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-            "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+            "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "es-errors": "^1.3.0",
-                "object-inspect": "^1.13.3"
+                "object-inspect": "^1.13.4"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -8671,18 +8638,36 @@
             "license": "0BSD"
         },
         "node_modules/type-is": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
-            "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+            "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "content-type": "^1.0.5",
+                "content-type": "^2.0.0",
                 "media-typer": "^1.1.0",
                 "mime-types": "^3.0.0"
             },
             "engines": {
-                "node": ">= 0.6"
+                "node": ">= 18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/type-is/node_modules/content-type": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+            "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
             }
         },
         "node_modules/uc.micro": {


### PR DESCRIPTION
## Summary

`npm audit` on `dev` reports **three**, not the five the ticket enumerated: **dependabot #18132 merged on 2026-09-02** and took `browserslist` and `fast-uri` with it.

What remained is exactly the set the ticket predicted would be left behind — `nanoid` (**high**), `qs` (moderate), `body-parser` (low). That prediction is why this was filed as its own ticket rather than a comment on that PR, and it held.

## Acceptance Criteria

| AC | Evidence |
|---|---|
| **AC-1** 0 vulnerabilities at any severity | `{"info":0,"low":0,"moderate":0,"high":0,"critical":0,"total":0}` |
| **AC-2** `package.json` unchanged | byte-identical (`diff -q` against the pre-change copy). Nothing crept out of range; the change is entirely `package-lock.json` — 78 insertions, 93 deletions |
| **AC-3** `unit` + `components` green **locally**, not just in CI | unit **3120 passed**, components **233 passed** |
| **AC-4** #18132 closed as superseded | **not applicable — it merged 2026-09-02**, before this ticket was picked up. Nothing to close and nothing to race in the queue. |

## Why AC-3 is the real evidence here

Every one of these arrives through **dev** dependencies — the build tooling and the dev server — so a clean diff proves nothing about whether the build still works. Beyond the two suites:

- theme build: **exit 0**, no sass errors
- `check-theme-surfaces`: **exit 0**
- `check-engine-brain-boundary`: **exit 0**

What actually moved: `qs` → `^6.15.2`, `raw-body` → `^3.0.2`, and the transitive set beneath them.

## No runtime exposure, and that is not a reason to skip it

All of these are transitive **dev** dependencies, so a published `neo.mjs` consumer was never exposed. That is why this was not urgent — it is not why a **high** should stay open.

## The majors stay out, deliberately

`npm outdated` also offers `chalk` 6, `inquirer` 14, and `monaco-editor` 0.56. None is security-driven, all are `devDependencies`, and bundling a major would cost **AC-2 its meaning** — the check that nothing left its declared range only says something while the answer is "nothing did".

Resolves #18135.

Authored by Grace (Claude Opus 5, Claude Code). Session 8d936ec9-b816-4ded-a91e-6e91ef6a3325.
