### PR TITLE
feat(dashboard): the engine emits the geometry class, so a resize is a fast path for every consumer (#18206)

### DIFF
--- a/apps/workstation/view/Workspace.mjs
+++ b/apps/workstation/view/Workspace.mjs
@@ -2198,11 +2198,14 @@ class Workspace extends DockWorkspace {
 
     /**
      * Maps both commit shapes onto the reconciler's fast paths — engine surfaces pass the semantic
-     * descriptor, this host's own paths pass their options object. `resizeSplit` (or an explicit
-     * `geometryOnly`) is an admission REQUEST for the in-place projection path, never a claim that
-     * the topology is stable: the reconciler validates it, falls back to the staged transaction on
-     * any structural delta, and `DockFlip` is told the resulting `landedInPlace`, not this
-     * request. `detachItem` / `transferNode` admit the stable-topology fast path (a transferNode
+     * descriptor, this host's own paths pass their options object. The geometry admission is the
+     * ENGINE's now: it derives `geometryOnly` from the operation's declared change class, so this
+     * override adds only the one thing the engine cannot see — an explicit `geometryOnly` on this
+     * host's own options-object commits. Either way it is an admission REQUEST for the in-place
+     * projection path, never a claim that the topology is stable: the reconciler validates it,
+     * falls back to the staged transaction on any structural delta, and `DockFlip` is told the
+     * resulting `landedInPlace`, not this request. `detachItem` / `transferNode` admit the
+     * stable-topology fast path (a transferNode
      * adoption keeps the structural shell — one tabs node's items grow — and the validator still
      * rejects any transfer that does mutate structure). A commit-scoped `preserveItemIds` parks
      * owner-held panes instead of destroying them (a terminal-first tear-out vessel owns its pane
@@ -2213,10 +2216,11 @@ class Workspace extends DockWorkspace {
      * @returns {Object}
      */
     getRefreshOptions(descriptor, source) {
-        let {geometryOnly = false, operation = null, preserveItemIds} = descriptor || {};
+        let {geometryOnly = false, operation = null, preserveItemIds} = descriptor || {},
+            base = super.getRefreshOptions(descriptor, source);
 
         return {
-            geometryOnly  : geometryOnly === true || ['resizeEdgeZone', 'resizeSplit'].includes(operation),
+            geometryOnly  : geometryOnly === true || base.geometryOnly === true,
             retainTopology: operation === 'detachItem' || operation === 'transferNode',
             ...(Array.isArray(preserveItemIds) && preserveItemIds.length > 0 ? {preserveItemIds} : {})
         }

--- a/src/dashboard/dock/Workspace.mjs
+++ b/src/dashboard/dock/Workspace.mjs
@@ -3460,10 +3460,11 @@ class Workspace extends Container {
 
     /**
      * Hook: the reconciler's fast-path options for the refresh a commit schedules —
-     * `{geometryOnly}` for a pure `resizeSplit`, `{retainTopology}` for item-only deltas on a
+     * `{geometryOnly}` for a pure boundary move, `{retainTopology}` for item-only deltas on a
      * proven-identical shell, `{preserveItemIds}` for owner-held ids known only at THIS commit (a
      * pane parked by the operation itself), merged with the standing {@link #getPreservedItemIds}
-     * set. The default takes the full staged transaction every time. The committing surface passes
+     * set. The default derives both fast paths from the operation's declared change class, so a
+     * consumer that overrides nothing already gets them. The committing surface passes
      * `descriptor` as it identifies the operation — engine surfaces pass the semantic descriptor;
      * a host's own paths may pass their options object — and the override maps whatever shapes its
      * commit sites produce.
@@ -3481,13 +3482,27 @@ class Workspace extends Container {
         //
         // An operation with no declared class falls through to `topology`, i.e. exactly the old
         // behaviour, so a vocabulary that outgrows the map degrades to slow rather than to wrong.
-        // Only the item-flag class is wired. `geometry` is declared honestly in the class map but
-        // deliberately NOT emitted yet: on `dev` a resize takes the full transaction, this ticket
-        // measured only the lock flicker, and its AC-4 requires resize to keep its current
-        // behaviour. Putting every drag-resize on an unmeasured fast path is a separate change with
-        // its own evidence, not a free rider on this one.
-        if (Operations.changeClassFor(descriptor?.operation) === 'itemFlags') {
-            return this.isDockRailedItem(descriptor?.itemId) ? {} : {retainTopology: true}
+        // `topology` is the one class with nothing to emit, because it IS the full transaction.
+        //
+        // Both emitted values are admission REQUESTS, never claims: `reconcileStableTopology`
+        // returns null on any node/type/ancestry/order/orientation delta and the caller falls
+        // through to the staged transaction, with `landedInPlace` reporting the path actually
+        // taken. A class that were ever wrong would therefore cost one refused validation pass,
+        // not a wrong projection — which is why the fast path can be derived at all.
+        switch (Operations.changeClassFor(descriptor?.operation)) {
+            // Both resize reducers clone the document and write exactly one field —
+            // `nodes[id].sizes`, `nodes[id].zones[edge].extent` — and survive `Document.commit`,
+            // normalization included, with the node tree, the node id set and `items` all
+            // byte-identical. Nothing moved but the boundary, so nothing needs restaging.
+            case 'geometry':
+                return {geometryOnly: true};
+
+            // The item-flag reducers write one `items[id]` field and touch `nodes` nowhere, so the
+            // shell is stable and only items reconcile. A railed item is the exception: pin and
+            // auto-hide project OUTSIDE the shell, so their placement change cannot ride an
+            // item-only refresh.
+            case 'itemFlags':
+                return this.isDockRailedItem(descriptor?.itemId) ? {} : {retainTopology: true}
         }
 
         return {}

--- a/test/playwright/unit/apps/workstation/Workspace.spec.mjs
+++ b/test/playwright/unit/apps/workstation/Workspace.spec.mjs
@@ -2913,3 +2913,66 @@ test.describe('Workspace — the theme toggle reveals from the pointer (#18125)'
         expect(themeAfter, 'and the flip still happens').toBe('neo-theme-neo-dark')
     })
 });
+
+test.describe('getRefreshOptions — the geometry admission is the ENGINE\'s, not a list this host keeps', () => {
+    /**
+     * @summary Reads this host's refresh options, optionally with the engine's default neutered.
+     *
+     * The host used to hand-list `['resizeEdgeZone', 'resizeSplit']` — a verbatim restatement of
+     * `Operations.operationChangeClass`, which is why a consumer that did not know to write the
+     * same list got the full staged transaction on every drag-resize. The VALUES below are
+     * unchanged; only their source moved, and an arm that asserts values alone cannot tell the
+     * difference. Neutering the engine can: a private list survives it, delegation does not.
+     * @param {Object|null} descriptor
+     * @param {Boolean} [neuterEngine=false] Make the engine's default contribute nothing
+     * @returns {Object}
+     */
+    function refreshOptionsFor(descriptor, neuterEngine=false) {
+        const
+            enginePrototype = Object.getPrototypeOf(Workspace.prototype),
+            original        = enginePrototype.getRefreshOptions,
+            workspace       = Neo.create(Workspace, {appName: 'WorkstationWorkspaceTest'});
+
+        neuterEngine && (enginePrototype.getRefreshOptions = () => ({}));
+
+        try {
+            return workspace.getRefreshOptions(descriptor, null)
+        } finally {
+            enginePrototype.getRefreshOptions = original;
+            workspace.destroy()
+        }
+    }
+
+    test('a resize still admits the in-place path, and it now comes from the change class', () => {
+        expect(refreshOptionsFor({operation: 'resizeSplit'}),
+            'a split boundary move is unchanged for this host')
+            .toEqual({geometryOnly: true, retainTopology: false});
+
+        expect(refreshOptionsFor({operation: 'resizeEdgeZone'}),
+            'and so is an edge-zone extent')
+            .toEqual({geometryOnly: true, retainTopology: false});
+
+        // The discriminating half. With the engine contributing nothing, a host that still kept
+        // its own operation list would answer `true` here.
+        expect(refreshOptionsFor({operation: 'resizeSplit'}, true),
+            'with the engine neutered the host has no geometry answer of its own')
+            .toEqual({geometryOnly: false, retainTopology: false})
+    });
+
+    test('the two jobs that are genuinely this host\'s survive the delegation', () => {
+        // This host's own paths commit with an options object rather than a semantic descriptor,
+        // so an explicit `geometryOnly` carries no operation the engine could classify. It must
+        // still be honoured — with the engine neutered, to prove the host answers it alone.
+        expect(refreshOptionsFor({geometryOnly: true}, true),
+            'an explicit request on an options-object commit is the host\'s to answer')
+            .toEqual({geometryOnly: true, retainTopology: false});
+
+        expect(refreshOptionsFor({operation: 'detachItem'}),
+            'the stable-topology mapping is untouched by this change')
+            .toEqual({geometryOnly: false, retainTopology: true});
+
+        expect(refreshOptionsFor({operation: 'moveItem', preserveItemIds: ['editor']}),
+            'and a commit-scoped park still rides along')
+            .toEqual({geometryOnly: false, retainTopology: false, preserveItemIds: ['editor']})
+    })
+});

--- a/test/playwright/unit/dashboard/DockOperationChangeClass.spec.mjs
+++ b/test/playwright/unit/dashboard/DockOperationChangeClass.spec.mjs
@@ -27,7 +27,12 @@ import Operations    from '../../../../src/dashboard/dock/model/Operations.mjs';
  * overrides `getRefreshOptions`, which is why the derived default needs its own witness — an arm on
  * an overriding workspace would pass whether or not a default exists.
  *
+ * The `geometry` class joined `itemFlags` afterwards: a resize used to take the full transaction
+ * for every consumer that wrote no hook, while one host escaped it by hand-listing the two resize
+ * operations — the engine's own map, restated in an app.
+ *
  * @see https://github.com/neomjs/neo/issues/18152
+ * @see https://github.com/neomjs/neo/issues/18206
  */
 
 /**
@@ -109,11 +114,15 @@ test.describe('Neo.dashboard.dock.Workspace — getRefreshOptions derives from t
             expect(workspace.getRefreshOptions({operation: 'setItemLocked', itemId: 'panel'}),
                 'an item-flag delta reconciles items in place').toEqual({retainTopology: true});
 
-            // `geometry` is declared in the class map but deliberately not wired yet: on `dev` a
-            // resize takes the full transaction, and this ticket measured only the lock flicker.
-            // Emitting `geometryOnly` here would put every drag-resize on an unmeasured fast path.
+            // Both resize reducers clone the document and write exactly one field, and survive
+            // `Document.commit` — normalization included — with the node tree, the node id set and
+            // `items` byte-identical. Nothing moved but the boundary, so nothing needs restaging.
             expect(workspace.getRefreshOptions({operation: 'resizeSplit'}),
-                'a boundary move keeps its current full transaction').toEqual({});
+                'a split boundary move reconciles in place').toEqual({geometryOnly: true});
+
+            expect(workspace.getRefreshOptions({operation: 'resizeEdgeZone'}),
+                'and so does an edge-zone extent — the class decides, not the operation name')
+                .toEqual({geometryOnly: true});
 
             expect(workspace.getRefreshOptions({operation: 'moveItem', itemId: 'panel'}),
                 'a restructuring operation still takes the full transaction').toEqual({});

--- a/test/playwright/unit/dashboard/DockProjectionReconciler.spec.mjs
+++ b/test/playwright/unit/dashboard/DockProjectionReconciler.spec.mjs
@@ -13,6 +13,7 @@ import Component                from '../../../../src/component/Base.mjs';
 import Container                from '../../../../src/container/Base.mjs';
 import DockLayoutAdapter        from '../../../../src/dashboard/dock/projection/LayoutAdapter.mjs';
 import DockProjectionReconciler from '../../../../src/dashboard/dock/projection/Reconciler.mjs';
+import DockWorkspace            from '../../../../src/dashboard/dock/Workspace.mjs';
 import '../../../../src/manager/Instance.mjs';
 import '../../../../src/button/Base.mjs';
 import '../../../../src/tab/Container.mjs';
@@ -431,6 +432,47 @@ test.describe('Neo.dashboard.dock.projection.Reconciler', () => {
             expect(placeholders.size).toBe(0)
         } finally {
             host.destroy()
+        }
+    });
+
+    test('the option the ENGINE derives for a resize is one this reconciler grants', async () => {
+        // The arms around this one hand `reconcileProjection` a `geometryOnly` the test author
+        // chose, which proves the reconciler honours the request but says nothing about whether
+        // anything ever makes it. The workspace's derived default is the other half of that loop:
+        // a consumer writing no hook gets whatever `getRefreshOptions` returns, so if the two ends
+        // disagree the fast path is dead code that every arm here still passes over.
+        //
+        // Taking the engine's ACTUAL output rather than restating it is what closes the loop —
+        // this goes red if the engine stops emitting the class, and red if the reconciler stops
+        // granting it.
+        const workspace = Neo.create(DockWorkspace, {});
+
+        let options;
+
+        try {
+            options = workspace.getRefreshOptions({operation: 'resizeSplit'}, null)
+        } finally {
+            workspace.destroy()
+        }
+
+        expect(options, 'the engine asks for the in-place path').toEqual({geometryOnly: true});
+
+        const receipt = await reconcileModel(createSplitModel(), nextModel => {
+            nextModel.nodes['root-split'].sizes = [0.7, 0.3]
+        }, options);
+
+        try {
+            // `landedInPlace` is the OUTCOME, not the request — the one read that distinguishes a
+            // granted fast path from a refused one that quietly took the staged transaction.
+            expect(receipt.result.landedInPlace, 'and the reconciler grants it').toBe(true);
+            expect(receipt.result.nextShell, 'the live shell was kept, not swapped').toBe(receipt.oldShell);
+
+            const currentTabs = DockProjectionReconciler.collectProjectedTabs(receipt.oldShell);
+
+            expect(currentTabs.get('alpha-tabs').flex, 'and the new boundary actually landed').toBe(0.7);
+            expect(currentTabs.get('beta-tabs').flex).toBe(0.3)
+        } finally {
+            receipt.host.destroy()
         }
     });
 


### PR DESCRIPTION
Resolves #18206 · Epic #18151 row 1

## What

`operationChangeClass` declared `resizeSplit`/`resizeEdgeZone` as `geometry`; the engine never emitted it. So `getRefreshOptions` returned `{}` for both and **every drag-resize in a consumer that writes no hook took the full staged transaction** — the same restage #18152 removed for lock. One host escaped it by hand-listing the engine's own map:

```js
['resizeEdgeZone', 'resizeSplit'].includes(operation)
```

That line is gone. `apps/workstation` now delegates, and the value it produces is unchanged.

This is the successor #18152 named in its own comment — *"a separate change with its own evidence, not a free rider on this one"* — so the evidence is below rather than the assertion.

## The class is measured, not asserted

Both reducers, driven through the real `Document.commit` (`normalizeTree` + `validate` — the path that could restructure behind a reducer's back):

| | `resizeSplit` | `resizeEdgeZone` |
|---|---|---|
| errors empty | ✅ | ✅ |
| **the write actually happened** | ✅ `[0.5,0.5]` → `[0.8,0.2]` | ✅ `0.25` → `0.4` |
| node tree identical | ✅ | ✅ |
| node id set identical | ✅ | ✅ |
| `items` byte-identical | ✅ | ✅ |

**Every row is conditioned on the write having landed**, because my first probe reported *"node tree identical: true"* for an operation that had errored and returned the document untouched — a refusal reading as a pass. The same comparison is armed against `moveItem`, where it correctly goes red, so the greens discriminate rather than blindly agree.

## Why this is safe by construction, not by my reading

`geometryOnly` is an admission **request**. `reconcileStableTopology` returns `null` on any node/type/ancestry/order/orientation delta and the caller falls through to the staged transaction, with `landedInPlace` reporting the path actually taken (#18188). A wrong class costs one refused validation pass, never a wrong projection. The measurement is what makes this a *fast* path; the reconciler is what makes it a *safe* one.

## Arms, and what each one would catch

Three arms, each mutation-verified — I reverted the change and watched them, rather than reporting that they exist.

**1. `DockOperationChangeClass` — the engine emits it.** The pre-existing arm asserting `resizeSplit → {}` (with the deferral comment) is inverted; `resizeEdgeZone` joins it, because the class decides and not the operation name.

**2. `DockProjectionReconciler` — the loop closes.** The arms around it hand `reconcileProjection` a `geometryOnly` the *test author* chose, which proves the reconciler honours a request but says nothing about whether one ever arrives. This arm takes the engine's **actual output** and feeds it in, then reads `landedInPlace` — the outcome, not the request. It goes red if either end stops holding up its half; without it, a fast path that nothing emits stays dead code every existing arm passes over.

**3. `apps/workstation` — the host delegates rather than keeping a private list.** The values here are identical before and after, so an arm asserting values alone cannot tell the two apart. It neuters the engine's default and asserts the host then has no geometry answer of its own. Verified discriminating: reintroducing the hand-list turns **only** that assertion red while the value assertions stay green.

Mutation results: disabling the engine's `geometry` case turns **exactly** those first two arms red (`2 failed / 56 passed`) and nothing else. Reintroducing the host's list turns **only** the neuter assertion red (`1 failed / 50 passed`).

## Green

- `npm run test-unit` — **3123 passed**
- `npm run test-components` — **233 passed**

## Two things I did NOT change, and why they are separate

**`detachItem` / `transferNode`.** This host requests `retainTopology` for both while the map declares them `topology`. Not a contradiction — different axis, and the map is deliberately conservative — but the host plainly knows something the engine does not. It needs its own measurement.

**This host's `retainTopology` line shadows the engine's `itemFlags` derivation entirely**, which means #18152's lock fast path does not currently reach `apps/workstation`. I noticed it while writing arm 3 and left it alone: it is the same class of finding, it is not a regression from this PR, and folding it in would make the resize evidence carry a lock change it never measured. Worth its own ticket — happy to file it, or leave it to whoever takes the `detachItem` lane.

## Review

@neo-opus-ada — this is your #18152's named successor, so you are the natural seat.

- **Origin Session ID:** 8d936ec9-b816-4ded-a91e-6e91ef6a3325

🖖 Grace, Claude Opus 5, Claude Code.
