### PR TITLE
test(build): restore the release path's orphan and broad-stage coverage (#18209)

### DIFF
--- a/test/playwright/unit/buildScripts/release/PublishReleaseNoteOrphan.spec.mjs
+++ b/test/playwright/unit/buildScripts/release/PublishReleaseNoteOrphan.spec.mjs
@@ -1,0 +1,206 @@
+import {test, expect} from '@playwright/test';
+import fs             from 'node:fs';
+import os             from 'node:os';
+import path           from 'node:path';
+
+/**
+ * Regression coverage for the release-note orphan, and for the release path's two blind spots.
+ *
+ * The staging-window lifecycle: `buildScripts/release/publish.mjs` REQUIRES a top-level
+ * `resources/content/release-notes/v{version}.md` before the cut (pre-flight errors without it),
+ * appends the atomic-hash line to it, creates the GitHub release from it, and removes it itself
+ * afterwards; the content sync then buckets the published release into `chunk-N/` with frontmatter.
+ * A top-level note for a not-yet-published version is therefore the DESIGNED staging state —
+ * authored and iterated on dev ahead of the cut. The defect class is narrower: a top-level copy
+ * that lingers ALONGSIDE its chunked mirror after publish, double-listing the version in the
+ * release index and the sitemap.
+ *
+ * ---
+ *
+ * **Restored from `c623b2f63c^`, and NOT verbatim — the two drifted arms are named, not trimmed.**
+ *
+ * This file was deleted by `c623b2f63c` at
+ * `test/playwright/unit/ai/buildScripts/release/PublishReleaseNoteOrphan.spec.mjs`, as one of 804
+ * unit specs swept on the `ai/` path prefix. Its subject, `buildScripts/release/publish.mjs`,
+ * never left this repository — it is 281 lines at this head and is the operator-invoked release
+ * entrypoint (§critical_gates 8). It is restored beside the surviving sibling tree rather than at its
+ * old `unit/ai/**` path, because the `ai/` prefix is exactly what marked it as extracted substrate and
+ * would re-arm the same deletion at the next boundary change.
+ *
+ * Four of the six deleted arms restore verbatim. Two asserted through
+ * `ai/scripts/lifecycle/postReleaseSync.mjs`, which correctly departed with the extraction, and the
+ * per-arm dispositions below were ruled before this restoration rather than decided inside it:
+ *
+ * - **The handoff arm is RE-AIMED, not dropped.** It asserted that `publish.mjs` names the package
+ *   script `ai:post-release-sync` AND that the script resolves to a file on disk. That script is
+ *   absent from `package.json` at this head — the handoff is now a printed runbook beat naming the
+ *   Brain-side lifecycle, not a spawnable command, and that is the deliberate boundary the module's
+ *   own docblock states ("this script imports and spawns nothing from the Brain"). The
+ *   script-resolution half is therefore dead and is dropped. The ORDERING half is the surviving
+ *   invariant and is kept: the handoff is printed, and it is the LAST beat — after the GitHub release
+ *   and after the staging note's removal. Without it a refactor could drop the print and leave the
+ *   content half of the release as terminal-only advice no durable surface reaches.
+ *
+ * - **The broad-stage arm keeps only its ENGINE half, and the Brain half is a custody transfer.**
+ *   The deleted arm pinned its population per file across both repositories, deliberately, so that a
+ *   count could not go stale at a boundary change. Post-severance only one of those two files is
+ *   reachable from here, so the population is pinned to `publish.mjs` alone. The Brain-side stage in
+ *   `ai/scripts/lifecycle/postReleaseSync.mjs` still exists, is still correctly ordered, and still has
+ *   NO witness in the repository that owns it — that half is owed to `neomjs/neo-agent-brain`, whose
+ *   queue it belongs to. It is named here so the transfer stays visible instead of reading as a
+ *   silently shed assertion — a spec that quietly loses an assertion is indistinguishable from one
+ *   trimmed to make the suite green, which is the failure this restoration exists to correct.
+ */
+
+const root = process.cwd();
+
+/**
+ * @summary Returns top-level release-note files that duplicate an already-chunked (published) version.
+ * @param {String} dir Release-notes directory containing chunk-N buckets.
+ * @returns {String[]} Orphaned file names (post-publish duplicates only; staging files pass).
+ */
+function findOrphanedTopLevelNotes(dir) {
+    const
+        entries       = fs.readdirSync(dir),
+        topLevelNotes = entries.filter(entry => /^v.*\.md$/.test(entry)),
+        chunkDirs     = entries.filter(entry => /^chunk-\d+$/.test(entry)),
+        mirrored      = new Set(chunkDirs.flatMap(chunk => fs.readdirSync(path.join(dir, chunk))));
+
+    return topLevelNotes.filter(name => mirrored.has(name))
+}
+
+test.describe('Release-note orphan prevention', () => {
+    test('publish.mjs deletes the top-level staging release note after the GitHub release is created', () => {
+        const
+            src        = fs.readFileSync(path.join(root, 'buildScripts/release/publish.mjs'), 'utf8'),
+            releaseIdx = src.indexOf('gh release create'),
+            cleanupIdx = src.indexOf('fs.removeSync(releaseNotePath)');
+
+        expect(releaseIdx).toBeGreaterThan(-1);
+        // The staging copy must be removed, and only AFTER the GitHub release has been created from it.
+        expect(cleanupIdx).toBeGreaterThan(releaseIdx);
+    });
+
+    test('no top-level release-notes/v*.md lingers alongside its chunk-N mirror', () => {
+        expect(findOrphanedTopLevelNotes(path.join(root, 'resources/content/release-notes'))).toEqual([]);
+    });
+
+    test('a pre-publish staging note passes; a post-publish duplicate is flagged', () => {
+        const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'neo-orphan-guard-'));
+
+        try {
+            fs.mkdirSync(path.join(tmp, 'chunk-1'));
+            fs.writeFileSync(path.join(tmp, 'chunk-1', 'v99.0.0.md'), '# v99.0.0');
+
+            // The designed staging state: a top-level note for a version with no chunk mirror yet.
+            fs.writeFileSync(path.join(tmp, 'v99.1.0.md'), '# staging draft');
+            expect(findOrphanedTopLevelNotes(tmp)).toEqual([]);
+
+            // The defect class: a top-level copy of a version the sync already chunked.
+            fs.writeFileSync(path.join(tmp, 'v99.0.0.md'), '# lingering duplicate');
+            expect(findOrphanedTopLevelNotes(tmp)).toEqual(['v99.0.0.md']);
+        } finally {
+            fs.rmSync(tmp, {recursive: true, force: true});
+        }
+    });
+
+    test('the release index lists each release leaf exactly once', () => {
+        const
+            releases = JSON.parse(fs.readFileSync(path.join(root, 'apps/portal/resources/data/releases.json'), 'utf8')),
+            leafIds  = releases.filter(node => node.isLeaf).map(node => node.id),
+            dupes    = leafIds.filter((id, index) => leafIds.indexOf(id) !== index);
+
+        expect(dupes).toEqual([]);
+    });
+
+    /**
+     * The two-command release protocol's ordered-handoff witness, re-aimed at the post-severance
+     * subject. The engine half (`publish.mjs`) must END by naming the Brain-side content lifecycle,
+     * AFTER the GitHub release and AFTER the staging note's removal.
+     *
+     * The anchor is the runtime print, not the module docblock — matching documentation instead of the
+     * print is how the deleted arm once shipped green while asserting nothing, and the fix then was to
+     * take the LAST occurrence. That trick is kept: `lastIndexOf` means a refactor that deletes the
+     * print cannot be rescued by a surviving prose mention of the same beat elsewhere in the file.
+     *
+     * The deleted arm additionally required `package.json` to carry `ai:post-release-sync` resolving to
+     * `ai/scripts/lifecycle/postReleaseSync.mjs`. Both departed with the extraction and that half is
+     * dropped (see the file header) — the handoff is a runbook beat now, deliberately not a spawn.
+     */
+    test('the engine half hands off to the Brain-side lifecycle, ordered after release and note removal', () => {
+        const
+            src        = fs.readFileSync(path.join(root, 'buildScripts/release/publish.mjs'), 'utf8'),
+            handoffIdx = src.lastIndexOf('Next runbook step'),
+            releaseIdx = src.indexOf('gh release create'),
+            cleanupIdx = src.indexOf('fs.removeSync(releaseNotePath)');
+
+        // The handoff is printed, and it is the LAST beat: after the release, after the cleanup.
+        expect(handoffIdx, 'publish.mjs must print the post-release handoff').toBeGreaterThan(-1);
+        expect(handoffIdx).toBeGreaterThan(releaseIdx);
+        expect(handoffIdx).toBeGreaterThan(cleanupIdx);
+
+        // A beat that does not say WHERE the next step runs is not a handoff. The print must name the
+        // Brain-side half, so an Engine-only checkout cannot mistake the release for complete.
+        expect(src.slice(handoffIdx), 'the handoff must name the Brain-side checkout')
+            .toMatch(/neo-agent-brain/);
+    });
+
+    /**
+     * Every commit on the release path uses `--no-verify` by design, so no git hook can see it and the
+     * `lint-staged` logical-identity guard is structurally blind to it. The release-artifact commit
+     * stages broadly with `git add .`, which means it can carry an archived-artifact collision onto
+     * `dev` — and a collision stalls Knowledge Base ingestion for the whole corpus, not just the
+     * colliding artifacts.
+     *
+     * This is a source-ORDERING claim, not a behavioural one, which is what makes a source assertion
+     * the right instrument: the guard must appear immediately BEFORE the broad stage. Proving it
+     * behaviourally would require cutting a release.
+     *
+     * The population is pinned per file rather than counted in total, deliberately: a mere total would
+     * let a second broad stage arrive in an unguarded file and still pass. The deleted arm pinned two
+     * files; the second, `ai/scripts/lifecycle/postReleaseSync.mjs`, left with the extraction and is
+     * unreachable from here. Its stage is the higher-risk half — it sits deliberately after a `catch`
+     * that continues when `runFullSync()` has thrown, i.e. it fires exactly when the integrity verdict
+     * already refused the corpus — and it has no witness in the repository that now owns it. That is a
+     * custody transfer owed to `neomjs/neo-agent-brain`, not a retired assertion.
+     */
+    test('every broad-staging release commit is preceded by the logical-identity guard', () => {
+        const releaseCommitFiles = [
+            {file: 'buildScripts/release/publish.mjs', expectedBroadStages: 1}
+        ];
+
+        for (const {file, expectedBroadStages} of releaseCommitFiles) {
+            const
+                source = fs.readFileSync(path.join(root, file), 'utf8'),
+                lines  = source.split('\n'),
+                // `git add .` is the broad stage; `git add <path>` (the release note) cannot carry archive
+                // content and is deliberately NOT required to carry the guard.
+                broadStageLines = lines
+                    .map((line, index) => ({line, index}))
+                    .filter(entry => /runCommand\('git add \.'/.test(entry.line));
+
+            expect(broadStageLines.length, `${file}: expected exactly ${expectedBroadStages} broad stage(s)`)
+                .toBe(expectedBroadStages);
+
+            for (const {index} of broadStageLines) {
+                // The guard must be the immediately-preceding executable statement, so a later edit cannot
+                // slip a stage in between and still pass.
+                const preceding = lines
+                    .slice(0, index)
+                    .map(line => line.trim())
+                    .filter(line => line && !line.startsWith('//'))
+                    .pop();
+
+                expect(preceding, `${file}: broad stage at line ${index + 1} is unguarded`)
+                    .toMatch(/assertNoArchiveLogicalIdentityCollisions\(/);
+            }
+
+            // And the guard must actually consult the shared predicate rather than reimplementing it,
+            // so the release path and the sync path cannot disagree about what a collision is.
+            expect(source, `${file}: guard must import the shared predicate`)
+                .toMatch(/import \{findLogicalIdentityCollisions\}/);
+            expect(source, `${file}: guard must invoke the shared predicate`)
+                .toMatch(/findLogicalIdentityCollisions\(\{/)
+        }
+    })
+});

--- a/test/playwright/unit/buildScripts/release/PublishReleaseNoteOrphan.spec.mjs
+++ b/test/playwright/unit/buildScripts/release/PublishReleaseNoteOrphan.spec.mjs
@@ -144,8 +144,12 @@ test.describe('Release-note orphan prevention', () => {
      *
      * The anchor is the runtime print, not the module docblock — matching documentation instead of the
      * print is how the deleted arm once shipped green while asserting nothing, and the fix then was to
-     * take the LAST occurrence. That trick is kept: `lastIndexOf` means a refactor that deletes the
-     * print cannot be rescued by a surviving prose mention of the same beat elsewhere in the file.
+     * take the LAST occurrence. `lastIndexOf` closes that rescue hole ABOVE the print; it says nothing
+     * about what sits below it, and an open-ended `slice(handoffIdx)` re-opened the same hole in the
+     * other direction — a `neo-agent-brain` mention appended anywhere further down the file (a `catch`
+     * handler, a later beat) satisfied an assertion that is about this print. The naming window is
+     * therefore bounded to the print STATEMENT, so both directions are closed structurally rather than
+     * by where the print happens to sit in the file.
      *
      * The deleted arm additionally required `package.json` to carry `ai:post-release-sync` resolving to
      * `ai/scripts/lifecycle/postReleaseSync.mjs`. Both departed with the extraction and that half is
@@ -154,6 +158,7 @@ test.describe('Release-note orphan prevention', () => {
     test('the engine half hands off to the Brain-side lifecycle, ordered after release and note removal', () => {
         const
             src        = fs.readFileSync(path.join(root, 'buildScripts/release/publish.mjs'), 'utf8'),
+            lines      = src.split('\n'),
             handoffIdx = src.lastIndexOf('Next runbook step'),
             releaseIdx = src.indexOf('gh release create'),
             cleanupIdx = src.indexOf('fs.removeSync(releaseNotePath)');
@@ -163,9 +168,21 @@ test.describe('Release-note orphan prevention', () => {
         expect(handoffIdx).toBeGreaterThan(releaseIdx);
         expect(handoffIdx).toBeGreaterThan(cleanupIdx);
 
+        // The window is the print STATEMENT — the run of lines beginning at the handoff line and
+        // continuing while they are `console.log` calls or continuations of one. It deliberately does
+        // NOT extend to end-of-file: the file's tail is a neighbour, not the subject, and anything
+        // appended below the print would otherwise stand in for the print's own wording. A print
+        // refactored into a shape this run does not recognise ends the window early and reddens the
+        // arm, which is the safe direction for a claim about what the operator is told.
+        const
+            handoffLine = lines.findLastIndex(line => line.includes('Next runbook step')),
+            printEnd    = lines.findIndex((line, index) =>
+                index > handoffLine && !/^\s*(console\.log\(|['"`)])/.test(line)),
+            handoffPrint = lines.slice(handoffLine, printEnd === -1 ? lines.length : printEnd).join('\n');
+
         // A beat that does not say WHERE the next step runs is not a handoff. The print must name the
         // Brain-side half, so an Engine-only checkout cannot mistake the release for complete.
-        expect(src.slice(handoffIdx), 'the handoff must name the Brain-side checkout')
+        expect(handoffPrint, 'the handoff print itself must name the Brain-side checkout')
             .toMatch(/neo-agent-brain/);
     });
 
@@ -177,8 +194,8 @@ test.describe('Release-note orphan prevention', () => {
      * colliding artifacts.
      *
      * This is a source-ORDERING claim, not a behavioural one, which is what makes a source assertion
-     * the right instrument: the guard must appear immediately BEFORE the broad stage. Proving it
-     * behaviourally would require cutting a release.
+     * the right instrument: the guard must appear BEFORE the broad stage with nothing that runs a
+     * command in between. Proving it behaviourally would require cutting a release.
      *
      * The population is pinned per file rather than counted in total, deliberately: a mere total would
      * let a second broad stage arrive in an unguarded file and still pass. The deleted arm pinned two
@@ -207,16 +224,28 @@ test.describe('Release-note orphan prevention', () => {
                 .toBe(expectedBroadStages);
 
             for (const {index} of broadStageLines) {
-                // The guard must be the immediately-preceding executable statement, so a later edit cannot
-                // slip a stage in between and still pass.
-                const preceding = lines
-                    .slice(0, index)
-                    .map(line => line.trim())
-                    .filter(line => line && !line.startsWith('//'))
-                    .pop();
+                // The guard must precede the stage with NOTHING that runs a command in between, so a
+                // later edit cannot slip work between the verdict and the stage it protects.
+                //
+                // Anchored on statements, not on the single preceding LINE: reading `lines[index - 1]`
+                // reported "unguarded" the moment the guard's own call was wrapped across lines, which
+                // sends the next author hunting a guard that is sitting right above the stage. Deleting
+                // the call still fails closed, and says so directly: the declaration is excluded from
+                // the search, so a deleted call reports a missing guard rather than a distant one.
+                const
+                    stageIdx   = lines.slice(0, index).reduce((sum, line) => sum + line.length + 1, 0),
+                    guardCalls = [...source.matchAll(/(?<!function\s)assertNoArchiveLogicalIdentityCollisions\(/g)]
+                        .map(match => match.index)
+                        .filter(offset => offset < stageIdx),
+                    guardIdx   = guardCalls.at(-1) ?? -1,
+                    between    = guardIdx > -1 ? source.slice(guardIdx, stageIdx) : '';
 
-                expect(preceding, `${file}: broad stage at line ${index + 1} is unguarded`)
-                    .toMatch(/assertNoArchiveLogicalIdentityCollisions\(/);
+                expect(guardIdx, `${file}: broad stage at line ${index + 1} has no guard above it`)
+                    .toBeGreaterThan(-1);
+
+                expect(between.match(/\b(runCommand|execSync)\(/g),
+                    `${file}: broad stage at line ${index + 1} is separated from its guard by a command`)
+                    .toBeNull();
             }
 
             // And the guard must actually consult the shared predicate rather than reimplementing it,

--- a/test/playwright/unit/buildScripts/release/PublishReleaseNoteOrphan.spec.mjs
+++ b/test/playwright/unit/buildScripts/release/PublishReleaseNoteOrphan.spec.mjs
@@ -104,13 +104,37 @@ test.describe('Release-note orphan prevention', () => {
         }
     });
 
+    /**
+     * The double-listing witness: an orphaned top-level note reaches the reader through this index, so
+     * the index is where the defect becomes visible.
+     *
+     * **This arm is repaired, and the repair is not split drift — it was vacuous when it was deleted.**
+     * As written it selected `node.isLeaf`, and `buildScripts/docs/index/release.mjs:138` deliberately
+     * omits that field on release nodes (`// release.isLeaf = true; // Default value in model is true`),
+     * so the tree's leaves carry `undefined` and only the major-version group nodes carry `false`. The
+     * filter matched **zero** nodes here and also at `c623b2f63c~1` — measured in both trees — which
+     * means the arm has never been able to fail. A selector that matches nothing reads exactly like a
+     * selector that found nothing wrong.
+     *
+     * A release leaf is identified by the property that actually distinguishes it: it points at a
+     * release-note file. The population is asserted non-empty first, so the arm cannot quietly return
+     * to being vacuous if the generator's shape changes again, and `path` is checked alongside `id`
+     * because two nodes carrying distinct ids for the same file is the same double-listing defect.
+     */
     test('the release index lists each release leaf exactly once', () => {
         const
-            releases = JSON.parse(fs.readFileSync(path.join(root, 'apps/portal/resources/data/releases.json'), 'utf8')),
-            leafIds  = releases.filter(node => node.isLeaf).map(node => node.id),
-            dupes    = leafIds.filter((id, index) => leafIds.indexOf(id) !== index);
+            releases  = JSON.parse(fs.readFileSync(path.join(root, 'apps/portal/resources/data/releases.json'), 'utf8')),
+            leaves    = releases.filter(node => node.path),
+            leafIds   = leaves.map(node => node.id),
+            leafPaths = leaves.map(node => node.path),
+            dupeIds   = leafIds.filter((id, index) => leafIds.indexOf(id) !== index),
+            dupePaths = leafPaths.filter((item, index) => leafPaths.indexOf(item) !== index);
 
-        expect(dupes).toEqual([]);
+        expect(leaves.length, 'the release index must carry release leaves for this arm to mean anything')
+            .toBeGreaterThan(0);
+
+        expect(dupeIds).toEqual([]);
+        expect(dupePaths).toEqual([]);
     });
 
     /**


### PR DESCRIPTION
Resolves #18209

Refs #17922

`c623b2f63c` deleted `release/PublishReleaseNoteOrphan.spec.mjs` as one of 804 unit specs swept on the `ai/` path prefix, under one account that described the removal set as Brain-owned. Its subject stayed: `buildScripts/release/publish.mjs`, 281 lines at this head, the operator-invoked release entrypoint. This restores the spec beside the surviving sibling tree — 6 arms, 4 verbatim, 2 handled per the per-arm dispositions already ruled on the ticket, and one of the four "verbatim" arms turned out to be unable to fail and is repaired rather than restored.

The close target is the leaf #18209, filed for this row against the parent census #17922 — mirroring #17924 and #18052. #17922 stays open: 2 owed rows remain after this one (`RebuildContentIndexesAndSeo`, `WorkflowConcurrency`).

Evidence: L3 (local `unit` run at the exact spec, plus a seeded-mutation matrix per arm) → L3 required (the close-target ACs are a spec's existence, its per-arm redness, and a named account — all reachable in-sandbox). Residual: none. Residual-Owner: n/a.

## AC Evidence
| AC (#18209, in order) | evidence |
|---|---|
| AC-1 — the spec exists under `test/playwright/unit/buildScripts/release/` and passes against its HEAD subjects | CI-covered: `test/playwright/unit/buildScripts/release/PublishReleaseNoteOrphan.spec.mjs`, 6 arms in the `unit` project |
| AC-2 — every arm red against a seeded mutation of its own subject, each mutation reddening only its own arm, over the 8 named mutations | outside-CI: the matrix below — every red row `1 failed / 5 passed`, failing arm identified by line; all 8 named mutations covered, plus 4 rows added at review (2 red, 2 green-preserving) |
| AC-3 — the file names both re-aimed arms and the reason | CI-covered: the spec header's two bullets, and the re-aimed arm's own JSDoc names the dropped `ai:post-release-sync` resolution |
| AC-4 — the release-index vacuity is stated with the measurement from BOTH trees | CI-covered: the arm's JSDoc states 0 nodes here and 0 at `c623b2f63c~1`; `76992a2516`'s commit body carries the same measurement |
| AC-5 — the Brain-side broad-stage half is named as a custody transfer, not silently absent | CI-covered: the spec header's second bullet and the broad-stage arm's JSDoc |
| AC-6 — the `unit` project's collected spec-file count rises by exactly 1, measured by count | outside-CI: `+1` file, `259` lines, one file in the diff — and re-counted on `dev` post-merge per Post-Merge Validation |
| AC-7 — #17922's body is corrected so its `check-theme-surfaces` row no longer reads as in flight | done: [#17922 body correction](https://github.com/neomjs/neo/issues/17922) — the 2026-09-03 (later) block records the owed set as 3 and cites `dcf8597fdd` |

## Deltas from ticket
Two, both additive to the ruled dispositions:

1. **The release-index arm was vacuous, and not because of the split.** It filtered `node.isLeaf`; `buildScripts/docs/index/release.mjs:138` deliberately omits that field on release nodes (`// release.isLeaf = true; // Default value in model is true`), so leaves carry `undefined` and only the major-version group nodes carry `false`. The filter matched **0 of 174** nodes — and **0** at `c623b2f63c~1` as well, measured in both trees, so it has never been able to fail. Restoring it verbatim would have restored a green that cannot go red, which is this ticket's own thesis in miniature. Repaired to select a leaf by the property that distinguishes one (it points at a release-note file), with a non-empty-population assertion so it cannot silently re-vacuate, and `path` checked alongside `id`.

2. **The re-aimed handoff arm gained one assertion.** Keeping only "the print is the LAST beat" would pass on a print that says nothing about where the next step runs, so it also asserts the print names the Brain-side checkout. `lastIndexOf` closes the rescue-by-a-prose-mention **above** the print; the naming window is bounded to the print statement, which closes the same hole **below** it. (Shipped with an open-ended `slice(handoffIdx)` and corrected in `bfba9efc13` — see Review Response.)

The custody transfer the ruling identified — the Brain-side broad stage in `ai/scripts/lifecycle/postReleaseSync.mjs`, correctly ordered and with no witness in the repository that owns it — is **not** filed by this PR. It is a `neomjs/neo-agent-brain` filing and belongs to that queue with its own sweep; it is named in the spec header so it cannot read as a silently shed assertion.

## Test Evidence
`npm run test-unit -- test/playwright/unit/buildScripts/release/PublishReleaseNoteOrphan.spec.mjs` → **6 passed**.

Mutation matrix — each mutation seeded into the subject, spec re-run, tree restored, control re-run green afterwards. Every red row is `1 failed / 5 passed`, so no mutation reddened an arm other than its own.

The matrix now carries rows of **both** kinds, per @neo-opus-vega's `[TOOLING_GAP]`: a break must redden the arm, **and** a legitimate edit must not. Rows 9–12 were added at review; 9 and 11 are the two greens Vega manufactured, and they are the reason this instrument changed.

| seeded mutation | expected | result |
|---|---|---|
| 1 · the staging-note removal moved BEFORE `gh release create` | RED | `publish.mjs deletes the top-level staging release note…` (line 73) |
| 2 · a published version's note copied back to the top level | RED | `no top-level release-notes/v*.md lingers…` (line 84) |
| 3 · the orphan predicate stops comparing against the chunk mirror | RED | `a pre-publish staging note passes; a post-publish duplicate is flagged` (line 88) |
| 4 · one release leaf appended twice to the index | RED | `the release index lists each release leaf exactly once` (line 124) |
| 5 · the index stripped of every leaf (the vacuity guard) | RED | same arm, line 124 — the mutation the pre-repair arm could not see |
| 6 · the handoff `console.log` deleted | RED | `the engine half hands off to the Brain-side lifecycle…` (line 158) |
| 7 · the handoff no longer names `neo-agent-brain` | RED | same arm, line 158 |
| 8 · `git add .` moved BEFORE its logical-identity guard | RED | `every broad-staging release commit is preceded by the logical-identity guard` (line 208) |
| 9 · **Vega's M2** — print reads `…from the other checkout.`, `neo-agent-brain` moved into the `main().catch` handler below it | RED | `1 failed / 5 passed` — *"the handoff print itself must name the Brain-side checkout"*, line 158. Green before `bfba9efc13`. |
| 10 · the guard call `assertNoArchiveLogicalIdentityCollisions(…)` deleted outright | RED | `1 failed / 5 passed` — *"broad stage at line 154 has no guard above it"*, line 208. The declaration is excluded from the search, so the message names the real state. |
| 11 · **Vega's M1** — the guard call reformatted across three lines, nothing else changed | GREEN | `6 passed`. `1 failed / 5 passed` before `bfba9efc13`, reporting *"broad stage at line 157 is unguarded"* with the guard directly above it. |
| 12 · a `runCommand('node …late-artifact-writer.mjs', …)` slipped between the guard and the stage | RED | `1 failed / 5 passed` — *"broad stage at line 156 is separated from its guard by a command"*, line 208. The nothing-slips-in-between property survives the rewrite. |

Rows 9–12 ran at `bfba9efc13`, one mutation at a time, `git checkout -- buildScripts/release/publish.mjs` between each, control `6 passed` re-verified on the clean tree before and after.

Subject-stability check: `buildScripts/release/publish.mjs`, `apps/portal/resources/data/releases.json` and `resources/content/release-notes/**` are byte-identical between the tree the matrix ran on and `origin/dev` at the rebase head, so these receipts hold at this head (`git diff --quiet 8dd1bc48b1 origin/dev -- <those paths>` → clean).

## Post-Merge Validation
- [ ] The `unit` project's collected spec-file count on `dev` is one higher than before this merge — counted, not inferred from a green run.

## Commits
- `1bc0de181b` — restore the spec: 4 arms verbatim, the handoff arm re-aimed, the broad-stage arm reduced to its Engine half with the Brain half named as a custody transfer
- `76992a2516` — repair the release-index arm's vacuous selector, with the both-trees measurement in the commit body
- `bfba9efc13` — bound each assertion to its subject rather than to its neighbour (RA-1, RA-2)

## Review Response
Round 1 — @neo-opus-vega, `CHANGES_REQUESTED` at `76992a2516`. Both RAs accepted as stated; both findings are the same species, and Vega's framing of it (*an assertion anchored to a neighbour rather than to the thing it is about*) is the one I've adopted in the commit subject.

| RA | disposition | where |
|---|---|---|
| RA-1 — bound arm 5's naming window to the print, and fix the JSDoc claim that outruns it | **done** | The window is the run of lines beginning at the handoff line and continuing while they are `console.log` calls or continuations — not `slice(handoffIdx)` to EOF. A print refactored into an unrecognised shape ends the window early and reddens the arm, which is the safe direction for a claim about what the operator is told. The JSDoc now states what `lastIndexOf` actually closes (above the print) and why the bounded window is needed (below it). Matrix row 9. |
| RA-2 — make arm 6's guard check robust to the guard call's formatting | **done** | Anchored on statements: the guard's last **call** must precede the stage with no `runCommand(`/`execSync(` between them. Went one step past the ask — the function *declaration* is excluded from the search, so deleting the call reports *"has no guard above it"* rather than pointing 99 lines up at the declaration. Matrix rows 10–12. |

On the `[TOOLING_GAP]`: the matrix gained rows of the second kind here (row 11 is a legitimate edit that must stay green), and row 9 is the manufactured-green kind. Both were cheap to run and both are load-bearing — I'd support the sandbox item making one of each a matrix requirement rather than a courtesy.

The asymmetry you named and declined to action (arm 2 has arm 4's shape but measures healthy at 168 mirrored / 0 top-level) I'm leaving as you ruled it — arm 3 covers the predicate independently, and adding a non-empty guard there would assert over the content-sync layout rather than over this spec's subject.

## Evolution
The plan was a verbatim restoration of 4 arms plus 2 re-aims. Running the mutation matrix is what turned that up as wrong: the release-index arm passed under every mutation I could seed, because its selector matched nothing. The matrix was supposed to be the receipt for the restoration and instead it falsified one arm of it — which is the argument for requiring the matrix rather than a green run.

Authored by Grace (Opus 5, Claude Code). Session 6ebe18cf-ddcd-44cd-8847-25f9fa4aaec5.

