### PR TITLE
feat(tab): a pressed tab's title and glyph get the contrast colour the themes always meant to give them (#18171)

### DIFF
--- a/buildScripts/util/check-theme-value-files-baseline.json
+++ b/buildScripts/util/check-theme-value-files-baseline.json
@@ -25,11 +25,6 @@
         "reason": "exempt #18145 — see the neo-light entry; same rule, same blocker."
     },
     {
-        "file": "resources/scss/theme-neo-dark/tab/header/Button.scss",
-        "blocks": 3,
-        "reason": "exempt #18171 — see the neo-light entry; same dead selector."
-    },
-    {
         "file": "resources/scss/theme-neo-light/Global.scss",
         "blocks": 10,
         "reason": "pending #18145 — Global.scss is the sweep last batch; the ticket expects it to graduate to its own ticket."
@@ -38,10 +33,5 @@
         "file": "resources/scss/theme-neo-light/dialog/Base.scss",
         "blocks": 3,
         "reason": "exempt #18145 — a structural rule for a dialog header button must sit at (0,3,0), which would override a ui-variant background winning at (0,2,0) in themes carrying no such rule today. CSS has no per-declaration opt-out, so this needs a design decision rather than a refactor."
-    },
-    {
-        "file": "resources/scss/theme-neo-light/tab/header/Button.scss",
-        "blocks": 3,
-        "reason": "exempt #18171 — the block writes .pressed as a DESCENDANT of a class that lands on the button itself, so it has never matched. Porting it reproduces a dead selector; fixing it repaints pressed tabs in two themes."
     }
 ]

--- a/resources/scss/src/tab/header/Button.scss
+++ b/resources/scss/src/tab/header/Button.scss
@@ -75,6 +75,10 @@
             color: var(--tab-button-glyph-color-pressed);
         }
 
+        .neo-button-text {
+            color: var(--tab-button-text-color-pressed, var(--tab-button-text-color));
+        }
+
         .neo-tab-button-indicator {
             animation-duration: 260ms;
             animation-name    : delaybgcolor;

--- a/resources/scss/theme-neo-dark/tab/header/Button.scss
+++ b/resources/scss/theme-neo-dark/tab/header/Button.scss
@@ -20,22 +20,14 @@
     --tab-button-glyph-color                    : var(--sem-color-fg-neutral-subdued);
     --tab-button-glyph-color-active             : inherit;
     --tab-button-glyph-color-hover              : inherit;
-    --tab-button-glyph-color-pressed            : inherit;
+    --tab-button-glyph-color-pressed            : var(--sem-color-fg-neutral-contrast);
     --tab-button-height                         : var(--cmp-tab-height);
     --tab-button-height-pressed                 : var(--cmp-tab-height);
     --tab-button-margin-bottom                  : 0;
     --tab-button-padding                        : 7px var(--cmp-tab-spacinghorizontal) 6px;
     --tab-button-text-color                     : var(--sem-color-fg-neutral-subdued);
+    --tab-button-text-color-pressed             : var(--sem-color-fg-neutral-contrast);
     --tab-button-text-font-size                 : var(--sem-typo-label-regular-fontSize);
     --tab-button-text-font-weight               : var(--button-text-font-weight);
     --tab-button-text-transform                 : uppercase;
-
-    // custom overrides
-    .neo-tab-header-button.neo-button {
-        .pressed {
-            .neo-button-glyph, .neo-button-text {
-                color: var(--sem-color-fg-neutral-contrast);
-            }
-        }
-    }
 }

--- a/resources/scss/theme-neo-light/tab/header/Button.scss
+++ b/resources/scss/theme-neo-light/tab/header/Button.scss
@@ -20,22 +20,14 @@
     --tab-button-glyph-color                    : var(--sem-color-fg-neutral-subdued);
     --tab-button-glyph-color-active             : inherit;
     --tab-button-glyph-color-hover              : inherit;
-    --tab-button-glyph-color-pressed            : inherit;
+    --tab-button-glyph-color-pressed            : var(--sem-color-fg-neutral-contrast);
     --tab-button-height                         : var(--cmp-tab-height);
     --tab-button-height-pressed                 : var(--cmp-tab-height);
     --tab-button-margin-bottom                  : 0;
     --tab-button-padding                        : 7px var(--cmp-tab-spacinghorizontal) 6px;
     --tab-button-text-color                     : var(--sem-color-fg-neutral-subdued);
+    --tab-button-text-color-pressed             : var(--sem-color-fg-neutral-contrast);
     --tab-button-text-font-size                 : var(--sem-typo-label-regular-fontSize);
     --tab-button-text-font-weight               : var(--button-text-font-weight);
     --tab-button-text-transform                 : uppercase;
-
-    // custom overrides
-    .neo-tab-header-button.neo-button {
-        .pressed {
-            .neo-button-glyph, .neo-button-text {
-                color: var(--sem-color-fg-neutral-contrast);
-            }
-        }
-    }
 }

--- a/test/playwright/component/tab/ContainerUi.spec.mjs
+++ b/test/playwright/component/tab/ContainerUi.spec.mjs
@@ -16,35 +16,35 @@ const EXPECTED = {
         actionSize: '20px',
         // `flat`, not `none`: the family states its own header grey and carries no hairline. The
         // old name described the value it happened to have, which stopped being true.
-        band      : 'flat',
-        inline    : {fontSize: '11px', fontWeight: '400', height: '25px', padding: '7px 8px 6px',  radius: '0px'},
-        null      : {fontSize: '11px', fontWeight: '600', height: '25px', padding: '7px 12px 6px', radius: '0px'},
-        standalone: {fontSize: '11px', fontWeight: '600', height: '40px', padding: '7px 16px 6px', radius: '8px'},
-        textColor : 'rgb(43, 43, 43)'
+        band            : 'flat',
+        inline          : {fontSize: '11px', fontWeight: '400', height: '25px', padding: '7px 8px 6px',  radius: '0px'},
+        null            : {fontSize: '11px', fontWeight: '600', height: '25px', padding: '7px 12px 6px', radius: '0px'},
+        standalone      : {fontSize: '11px', fontWeight: '600', height: '40px', padding: '7px 16px 6px', radius: '8px'},
+        pressedTextColor: 'rgb(43, 43, 43)'
     },
     'neo-theme-dark': {
-        actionSize: '20px',
-        band      : 'flat',
-        inline    : {fontSize: '11px', fontWeight: '400', height: '25px', padding: '7px 8px 6px',  radius: '0px'},
-        null      : {fontSize: '11px', fontWeight: '600', height: '25px', padding: '7px 12px 6px', radius: '0px'},
-        standalone: {fontSize: '11px', fontWeight: '600', height: '40px', padding: '7px 16px 6px', radius: '8px'},
-        textColor : 'rgb(187, 187, 187)'
+        actionSize      : '20px',
+        band            : 'flat',
+        inline          : {fontSize: '11px', fontWeight: '400', height: '25px', padding: '7px 8px 6px',  radius: '0px'},
+        null            : {fontSize: '11px', fontWeight: '600', height: '25px', padding: '7px 12px 6px', radius: '0px'},
+        standalone      : {fontSize: '11px', fontWeight: '600', height: '40px', padding: '7px 16px 6px', radius: '8px'},
+        pressedTextColor: 'rgb(187, 187, 187)'
     },
     'neo-theme-neo-light': {
-        actionSize: '24px',
-        band      : 'surface',
-        inline    : {fontSize: '12px', fontWeight: '400', height: '32px', padding: '4px 8px 3px',  radius: '0px'},
-        null      : {fontSize: '16px', fontWeight: '600', height: '48px', padding: '7px 16px 6px', radius: '8px'},
-        standalone: {fontSize: '16px', fontWeight: '600', height: '48px', padding: '7px 16px 6px', radius: '8px'},
-        textColor : 'rgb(69, 75, 66)'
+        actionSize      : '24px',
+        band            : 'surface',
+        inline          : {fontSize: '12px', fontWeight: '400', height: '32px', padding: '4px 8px 3px',  radius: '0px'},
+        null            : {fontSize: '16px', fontWeight: '600', height: '48px', padding: '7px 16px 6px', radius: '8px'},
+        standalone      : {fontSize: '16px', fontWeight: '600', height: '48px', padding: '7px 16px 6px', radius: '8px'},
+        pressedTextColor: 'rgb(0, 0, 0)'
     },
     'neo-theme-neo-dark': {
-        actionSize: '24px',
-        band      : 'surface',
-        inline    : {fontSize: '12px', fontWeight: '400', height: '32px', padding: '4px 8px 3px',  radius: '0px'},
-        null      : {fontSize: '16px', fontWeight: '600', height: '48px', padding: '7px 16px 6px', radius: '8px'},
-        standalone: {fontSize: '16px', fontWeight: '600', height: '48px', padding: '7px 16px 6px', radius: '8px'},
-        textColor : 'rgb(153, 162, 149)'
+        actionSize      : '24px',
+        band            : 'surface',
+        inline          : {fontSize: '12px', fontWeight: '400', height: '32px', padding: '4px 8px 3px',  radius: '0px'},
+        null            : {fontSize: '16px', fontWeight: '600', height: '48px', padding: '7px 16px 6px', radius: '8px'},
+        standalone      : {fontSize: '16px', fontWeight: '600', height: '48px', padding: '7px 16px 6px', radius: '8px'},
+        pressedTextColor: 'rgb(255, 255, 255)'
     }
 };
 
@@ -201,8 +201,9 @@ const readVariant = (page, id) => page.evaluate(componentId => {
         fontWeight     : text.fontWeight,
         height         : style.height,
         padding        : style.padding,
-        radius         : style.borderRadius,
-        textColor      : text.color
+        pressed  : button.classList.contains('pressed'),
+        radius   : style.borderRadius,
+        textColor: text.color
     }
 }, id);
 
@@ -311,16 +312,20 @@ test.describe('Neo.tab.Container — ui variants', () => {
             expect(measured.inline.cls).toContain('neo-tab-container-inline');
             expect(measured.standalone.cls).toContain('neo-tab-container-standalone');
 
+            for (const variant of ['default', 'inline', 'null', 'standalone']) {
+                expect(measured[variant].pressed, `${variant}'s first tab button is the active one`).toBe(true)
+            }
+
             for (const variant of ['inline', 'null', 'standalone']) {
                 expect(measured[variant]).toMatchObject({
                     ...EXPECTED[theme][variant],
-                    textColor: EXPECTED[theme].textColor
+                    textColor: EXPECTED[theme].pressedTextColor
                 })
             }
 
             expect(measured.default).toMatchObject({
                 ...EXPECTED[theme].null,
-                textColor: EXPECTED[theme].textColor
+                textColor: EXPECTED[theme].pressedTextColor
             });
             expect(await readDomSignature(page, 'tab-ui-null'))
                 .toEqual(await readDomSignature(page, 'tab-ui-default'));


### PR DESCRIPTION
Resolves #18171

## What

Both neo theme sheets carried a block meant to give a pressed tab's glyph and title the contrast colour:

```scss
.neo-tab-header-button.neo-button { .pressed { .neo-button-glyph, .neo-button-text { … } } }
```

`pressed` is toggled onto the **button itself** (`button/Base.mjs` → `NeoArray.toggle(cls, 'pressed', …)`), never onto a descendant, so the rule addressed an element no code path creates. **It has never matched.**

The operator chose *deliver the intent* over *delete as dead* — @tobiu, in-session on 2026-09-03: *"deliver the full intent"*. That ruling now has a public artifact: [#18171's decision comment](https://github.com/neomjs/neo/issues/18171#issuecomment-5528040486), and #18171's body no longer presents the fork as live. The reason it is delivery rather than new design is that **the classic themes already have this**:

| theme | `--tab-button-glyph-color-pressed` before |
|---|---|
| `theme-light` | `#1c60a0` |
| `theme-dark` | `#bbb` |
| `theme-neo-light` | **`inherit`** |
| `theme-neo-dark` | **`inherit`** |

The neo themes were the only ones with no pressed treatment, which is exactly what the dead block was written to fix.

### `inherit` is the residue of a failed move, not a decision

`inherit` is a written value, so reading it as "the intent was never delivered" owes the token's history. It says so in one commit:

- `47b59bf9fc` created `theme-neo-light` with `--tab-button-glyph-color-pressed: **#1c60a0**` — the concrete value `theme-light` still carries.
- `6b270a2302` (*Added token variables for tab component*, 2023-11-29) flipped **all three** glyph state tokens — `-active`, `-hover`, `-pressed` — to `inherit` in one stroke **and, in the same diff, added the dead `.pressed` block**.

So the token was neutralised and the pressed contrast intent re-expressed one layer up, in a selector that has never matched. The two are halves of one move, and the half carrying the colour is the half that failed silently — nothing in the uniform flip singles `pressed` out as wanting to inherit. (#5446 / `3c248814b7` later dropped the `!important` and re-nested the block, preserving the defect rather than introducing it.)

## Measured, and it is worse than "a colour was missing"

The active tab's label painted **the same colour as an inactive one** in both neo themes — `--tab-button-text-color` is `--sem-color-fg-neutral-subdued`, and pressed fell straight through to it. `ContainerUi.spec.mjs` had one `textColor` expectation applied to every variant, and every variant it measures **is** the active tab, which is how the sameness stayed invisible.

Repaint, read off computed style:

| theme | active tab title before | after |
|---|---|---|
| `neo-theme-neo-light` | `rgb(69, 75, 66)` | `rgb(0, 0, 0)` |
| `neo-theme-neo-dark` | `rgb(153, 162, 149)` | `rgb(255, 255, 255)` |
| `neo-theme-light` | `rgb(43, 43, 43)` | unchanged |
| `neo-theme-dark` | `rgb(187, 187, 187)` | unchanged |

## The classic themes are protected by construction, not by care

`--tab-button-text-color-pressed` is new, so a theme that declares nothing must keep today's paint. An undefined custom property would invalidate the declaration and hand the title the button's inherited colour instead — a silent regression in two shipped themes plus cyberpunk. The fix is the idiom this same file already documents for `font-weight`:

```scss
color: var(--tab-button-text-color-pressed, var(--tab-button-text-color));
```

**Verified as an outcome, not an intention:** the classic themes emit **zero** `--tab-button-text-color-pressed` declarations and their pressed glyph values are byte-identical (`#1c60a0`, `#bbb`).

## Arms

Extended `ContainerUi.spec.mjs`, which already sweeps all four themes — so the neo repaint and the classic non-regression are asserted by the same arm rather than by separate ones I would have to keep in step.

Two honesty fixes to that spec while I was in it:

- The expectation is renamed `pressedTextColor`. The old name said "the tab's text colour" while measuring specifically the active tab's, and a name that describes the wrong thing is how the original bug survived review.
- **Non-vacuity:** the arm now asserts each measured button actually carries `pressed`. Without it the colour assertion would keep passing while measuring an unpressed button — the same shape as the defect it covers.

Mutation-verified: dropping the new rule turns **exactly the two neo themes red and leaves both classic themes green**, which is simultaneously proof the arm is load-bearing and proof the fallback works.

## Ratchet

#18196's guard caught this itself at pre-commit — both files were baselined `exempt #18171`, waiting on this decision. Their entries are removed: the baseline goes **9 files / 35 blocks → 7 / 29**.

## Green

- `npm run test-unit` — **3131 passed**
- `npm run test-components` — **234 passed**
- `check-theme-value-files` — ✓ (5 pending sweep, 2 exempt pending a decision)

Themes rebuilt across `esm`, `development` and `production`; the rule and both token values verified in the emitted CSS, and the dead descendant selector is gone (0 occurrences).

## Deliberately NOT folded in

**`apps/portal`'s own `--portal-tab-text-color-pressed` is redundant in mechanism but NOT in value.** It resolves to `#3E63DD` (light) and `--sem-color-text-primary-default` (dark) — a blue, not the engine's neutral contrast. Retiring it would repaint the portal's tabs a different colour, which is a second visual decision and not this ticket's. Worth its own ticket now that the engine token exists; happy to file it.

- **Origin Session ID:** 8d936ec9-b816-4ded-a91e-6e91ef6a3325

🖖 Grace, Claude Opus 5, Claude Code.

