### PR TITLE
fix(dashboard): the Workstation stops overwriting the engine's item-only refresh, so a lock click lands (#18208)

### DIFF
--- a/apps/workstation/view/Workspace.mjs
+++ b/apps/workstation/view/Workspace.mjs
@@ -2198,18 +2198,30 @@ class Workspace extends DockWorkspace {
 
     /**
      * Maps both commit shapes onto the reconciler's fast paths — engine surfaces pass the semantic
-     * descriptor, this host's own paths pass their options object. The geometry admission is the
-     * ENGINE's now: it derives `geometryOnly` from the operation's declared change class, so this
-     * override adds only the one thing the engine cannot see — an explicit `geometryOnly` on this
-     * host's own options-object commits. Either way it is an admission REQUEST for the in-place
-     * projection path, never a claim that the topology is stable: the reconciler validates it,
-     * falls back to the staged transaction on any structural delta, and `DockFlip` is told the
-     * resulting `landedInPlace`, not this request. `detachItem` / `transferNode` admit the
-     * stable-topology fast path (a transferNode
-     * adoption keeps the structural shell — one tabs node's items grow — and the validator still
-     * rejects any transfer that does mutate structure). A commit-scoped `preserveItemIds` parks
-     * owner-held panes instead of destroying them (a terminal-first tear-out vessel owns its pane
-     * before it connects).
+     * descriptor, this host's own paths pass their options object.
+     *
+     * **Both admissions are the ENGINE's, and this override only ADDS to them.** It derives them
+     * from the operation's declared change class, so this host contributes exactly the two things
+     * the engine cannot see: an explicit `geometryOnly` on this host's own options-object commits,
+     * and the `detachItem` / `transferNode` stable-topology mapping (a transferNode adoption keeps
+     * the structural shell — one tabs node's items grow — and the validator still rejects any
+     * transfer that does mutate structure).
+     *
+     * Writing either key unconditionally is what made the engine's derivation unreachable here:
+     * `retainTopology` evaluated to `false` for an item-flag commit and OVERWROTE the engine's
+     * `true`, so a lock click in this host still restaged the whole shell after the engine had
+     * stopped doing that for every other consumer. Deriving means a class the engine learns to
+     * emit next arrives here without another edit.
+     *
+     * The railed guard survives the merge without being restated: the engine expresses it by
+     * WITHHOLDING `retainTopology` for a railed pane rather than by setting it false, so an
+     * or-merge cannot resurrect it — measured, not assumed.
+     *
+     * Either way these are admission REQUESTS for the in-place projection path, never claims that
+     * the topology is stable: the reconciler validates them, falls back to the staged transaction
+     * on any structural delta, and `DockFlip` is told the resulting `landedInPlace`, not the
+     * request. A commit-scoped `preserveItemIds` parks owner-held panes instead of destroying them
+     * (a terminal-first tear-out vessel owns its pane before it connects).
      * @param {Object|null} descriptor The committing surface's identification — a semantic
      *     descriptor or this host's options object.
      * @param {Object|null} source The committing surface, when it identifies itself.
@@ -2221,7 +2233,7 @@ class Workspace extends DockWorkspace {
 
         return {
             geometryOnly  : geometryOnly === true || base.geometryOnly === true,
-            retainTopology: operation === 'detachItem' || operation === 'transferNode',
+            retainTopology: base.retainTopology === true || operation === 'detachItem' || operation === 'transferNode',
             ...(Array.isArray(preserveItemIds) && preserveItemIds.length > 0 ? {preserveItemIds} : {})
         }
     }

--- a/test/playwright/unit/apps/workstation/Workspace.spec.mjs
+++ b/test/playwright/unit/apps/workstation/Workspace.spec.mjs
@@ -2925,13 +2925,17 @@ test.describe('getRefreshOptions — the geometry admission is the ENGINE\'s, no
      * difference. Neutering the engine can: a private list survives it, delegation does not.
      * @param {Object|null} descriptor
      * @param {Boolean} [neuterEngine=false] Make the engine's default contribute nothing
+     * @param {Object|null} [items=null] Item records for the document, so the engine's railed
+     *     guard has something to read — it resolves placement off `dockModel.items`
      * @returns {Object}
      */
-    function refreshOptionsFor(descriptor, neuterEngine=false) {
+    function refreshOptionsFor(descriptor, neuterEngine=false, items=null) {
         const
             enginePrototype = Object.getPrototypeOf(Workspace.prototype),
             original        = enginePrototype.getRefreshOptions,
             workspace       = Neo.create(Workspace, {appName: 'WorkstationWorkspaceTest'});
+
+        items && (workspace.dockModel = {schema: 'neo.dock.zone.v1', root: 'root', items, nodes: {}});
 
         neuterEngine && (enginePrototype.getRefreshOptions = () => ({}));
 
@@ -2974,5 +2978,57 @@ test.describe('getRefreshOptions — the geometry admission is the ENGINE\'s, no
         expect(refreshOptionsFor({operation: 'moveItem', preserveItemIds: ['editor']}),
             'and a commit-scoped park still rides along')
             .toEqual({geometryOnly: false, retainTopology: false, preserveItemIds: ['editor']})
+    });
+
+    /**
+     * The item-flag admission had the same shape as the geometry one, one key over.
+     *
+     * `retainTopology` was written unconditionally, so for an item-flag commit it evaluated to
+     * `false` and OVERWROTE the engine's `true`. The engine stopped restaging the shell on a lock
+     * click for every consumer that writes no hook; this host kept doing it, which is the app the
+     * multi-window dock is demoed with.
+     *
+     * @see https://github.com/neomjs/neo/issues/18208
+     */
+    const SHELL_AND_RAIL = {
+        panel : {},
+        pinned: {autoHidden: true, pinned: true},
+        railed: {autoHidden: true}
+    };
+
+    test('a lock click reaches the engine\'s item-only refresh instead of being overwritten', () => {
+        // Red-first: on the parent commit this answers `retainTopology: false`, because the
+        // host's own expression is false for `setItemLocked` and it wrote the key regardless.
+        expect(refreshOptionsFor({operation: 'setItemLocked', itemId: 'panel'}, false, SHELL_AND_RAIL),
+            'the engine\'s item-only path is no longer shadowed')
+            .toEqual({geometryOnly: false, retainTopology: true});
+
+        // The delegation half, same instrument as the geometry arm: with the engine contributing
+        // nothing, this host has no item-flag answer of its own and must not invent one.
+        expect(refreshOptionsFor({operation: 'setItemLocked', itemId: 'panel'}, true, SHELL_AND_RAIL),
+            'the answer is the engine\'s, not a second private list')
+            .toEqual({geometryOnly: false, retainTopology: false})
+    });
+
+    test('a RAILED pane still takes the full transaction, and the or-merge cannot resurrect it', () => {
+        // The trap this ticket named. The engine expresses its railed guard by WITHHOLDING
+        // `retainTopology`, not by setting it false — so an or-merge preserves the guard rather
+        // than defeating it. Measured, because the ticket asserted the opposite as a risk and a
+        // risk I reasoned my way to is exactly the kind that deserves an arm.
+        expect(refreshOptionsFor({operation: 'setItemLocked', itemId: 'railed'}, false, SHELL_AND_RAIL),
+            'an auto-hidden pane projects outside the shell, so no item-only path')
+            .toEqual({geometryOnly: false, retainTopology: false});
+
+        expect(refreshOptionsFor({operation: 'setItemLocked', itemId: 'pinned'}, false, SHELL_AND_RAIL),
+            'a pinned pane renders IN the shell, so it keeps the fast path')
+            .toEqual({geometryOnly: false, retainTopology: true});
+
+        // The placement-changing flags stay `topology` in the class map, so neither reaches the
+        // fast path through this host either.
+        for (const operation of ['setItemPinned', 'setItemAutoHidden']) {
+            expect(refreshOptionsFor({operation, itemId: 'panel'}, false, SHELL_AND_RAIL),
+                `${operation} relocates the pane, so it takes the full transaction`)
+                .toEqual({geometryOnly: false, retainTopology: false})
+        }
     })
 });


### PR DESCRIPTION
Resolves #18208 · the other half of #18207's shape

## What

`getRefreshOptions` wrote `retainTopology` **unconditionally**:

```js
retainTopology: operation === 'detachItem' || operation === 'transferNode',
```

For an item-flag commit that expression is `false`, and because the key was always present it **overwrote** the engine's `true`. So #18152 stopped the shell restaging on a lock click for every consumer that writes no hook — and this host, the app the multi-window dock is demoed with, kept doing it.

Measured before the fix, same descriptor, same instance:

```
engine says: {"retainTopology":true}
host   says: {"geometryOnly":false,"retainTopology":false}
```

One line, same delegation #18207 applied to the geometry key:

```js
retainTopology: base.retainTopology === true || operation === 'detachItem' || operation === 'transferNode',
```

## The trap my own ticket warned about does not exist, and I checked rather than trusting it

#18208 said a naive `||` merge would *"resurrect exactly what the railed arm was added to prevent"* — a pinned or auto-hidden pane projects outside the shell, so an item-only refresh would leave a stale copy on the rail.

**It cannot.** The engine expresses that guard by **withholding** `retainTopology` for a railed pane (`isDockRailedItem(...) ? {} : {retainTopology: true}`), not by setting it `false`. An or-merge over a withheld key preserves the guard. My ticket reasoned its way to a risk that the code's shape already rules out — which is precisely the kind of risk that earns an arm rather than a paragraph, so it has one.

## Arms

Two, both mutation-verified against the parent commit's form (`2 failed / 51 passed`, and nothing else moves).

**1. The lock click reaches the engine.** Red-first: on the parent this answers `retainTopology: false`. Paired with the same neuter mutation #18207 used — with the engine contributing nothing this host must have no item-flag answer of its own, which is what stops a second private list growing where the first one was removed.

**2. Placement still refuses the fast path.** Railed, pinned, and both placement-changing flags.

**Precision about which half of arm 2 discriminates**, because "2 failed" would otherwise flatter it: the **pinned** assertion is the witness — a pinned pane renders *in* the shell and must now get the fast path, so it is `false` on the parent and `true` here. The **railed** assertion holds either way today; it is a regression guard locking in that the withheld-key merge keeps the guard, not evidence the fix does something. `setItemPinned` / `setItemAutoHidden` likewise hold either way — they are `topology` in the class map.

## Green

- `npm run test-unit` — **3136 passed**
- `npm run test-components` — **234 passed**

## What this closes, and what it does not

This was the **last** unconditional key in this override. What remains is genuinely this host's: an explicit `geometryOnly` on its own options-object commits, the `detachItem` / `transferNode` mapping, and its commit-scoped `preserveItemIds`. A class the engine learns to emit next now arrives here with no further edit — which is what epic #18151 is for.

**Still open, and deliberately untouched:** this host maps `detachItem` / `transferNode` to `retainTopology` while `operationChangeClass` declares both `topology`. Not a contradiction — different axis, and the map is deliberately conservative — but the host knows something the engine does not, and moving that knowledge needs its own measurement rather than a ride on this one.

@neo-opus-ada — your #18152's derivation is what this makes reachable, so you are the natural seat.

- **Origin Session ID:** 8d936ec9-b816-4ded-a91e-6e91ef6a3325

🖖 Grace, Claude Opus 5, Claude Code.
