### PR TITLE
fix(dashboard): resolveFreshPane delegates, so the engine can be its own recreate fallback (#18169)

### DIFF
--- a/src/dashboard/dock/Workspace.mjs
+++ b/src/dashboard/dock/Workspace.mjs
@@ -1017,12 +1017,8 @@ class Workspace extends Container {
      *   only excludes the button.
      *
      * The placeholder is the dangerous one, and not as an edge case: a placeholder exists exactly
-     * when a pane could not be materialized, and for a host that writes no {@link #resolvePane}
-     * that is the ORDINARY state — the engine's own default resolves a labelled placeholder.
-     * Tearing one out would open a vessel holding a titled blank and lose the pane, silently.
-     *
-     * The hook named here is `resolvePane`, not `resolveFreshPane`: the latter now delegates to the
-     * former, so writing no recreate hook no longer implies an unresolvable pane.
+     * when a pane could not be materialized, which is the ordinary state for a host that writes no
+     * {@link #resolvePane}. Tearing one out would open a vessel holding a titled blank.
      * @param {Neo.component.Base} component
      * @returns {Boolean}
      * @protected
@@ -1708,15 +1704,9 @@ class Workspace extends Container {
      * a vessel without one, and demanding the config from it would withhold an action that works.
      *
      * So the default asks whether the engine's own opener is the one that will run. That is a
-     * prototype comparison, and the cost of one is on record in this file's own history:
-     * `hasDockRecreateFallback` used to compare `resolveFreshPane` against the prototype, which
-     * made it answer always-false the moment the base gained a default — the engine could not be
-     * its own fallback, because a base class cannot override itself. That comparison is gone; the
-     * lesson is not.
-     *
-     * It is sound *here* for the opposite reason: the base already HAS a working implementation, so
-     * "is it still the base one" is a stable question rather than a proxy for "did anyone implement
-     * this". A host may still override this getter directly when its answer is neither.
+     * prototype comparison, sound here because the base already has a working implementation — so
+     * it asks "is it still the base one", not "did anyone implement this". Override this getter
+     * directly when the answer is neither.
      * @returns {Boolean}
      * @protected
      */
@@ -4093,24 +4083,11 @@ class Workspace extends Container {
     /**
      * Hook: produces a **fresh** candidate pane for an item, bypassing any live-instance cache.
      *
-     * Deliberately a separate **hook** rather than an option on {@link #resolvePane}: a consumer
-     * that resolves from a live-instance cache needs somewhere to mint a replacement that its cache
-     * does not answer, and an option such a consumer never implemented would be silently ignored.
-     * `apps/workstation` is exactly that shape.
+     * Defaults to {@link #resolvePane} — only the consumer knows how to build its own pane. A
+     * cache-backed `resolvePane` is safe here: {@link #prepareRecreateCandidate} compares by
+     * identity and refuses with `live-instance`, leaving the live pane untouched.
      *
-     * Its **default delegates** to {@link #resolvePane}, because only the consumer knows how to
-     * build its own pane — the engine knows how to build a placeholder, which for any host that
-     * resolves real panes would be a downgrade rather than a recreate. Delegation therefore serves
-     * the host's own shape where one exists, and the engine's labelled placeholder where nothing
-     * else does.
-     *
-     * Delegation is safe even against a cache-backed `resolvePane`, which is why it can be the
-     * default at all: {@link #prepareRecreateCandidate} compares the candidate to the live pane by
-     * **identity** and reports `live-instance` with the live pane untouched. The worst case is a
-     * named refusal behind a visible action, never a swap of a pane for itself.
-     *
-     * Returning `null` stays a legitimate answer — it declines for that item, reported as
-     * `declined` with the live pane untouched.
+     * `null` declines for that item.
      * @param {String} itemId The stable workspace identity from the item catalog.
      * @param {Object} item The persisted item record.
      * @returns {Object|Neo.component.Base|null}
@@ -4120,22 +4097,12 @@ class Workspace extends Container {
     }
 
     /**
-     * Whether this workspace can serve a recreate at all.
+     * Whether a recreate path is wired — not whether a given item will succeed.
      *
-     * **Never calls the factory.** {@link #syncDockReloadAction} consults this on every active-item
-     * change, so a visibility sync must not have side effects: invoking a resolver to decide whether
-     * to show a button would mint panes nobody asked for.
+     * Never calls the factory: {@link #syncDockReloadAction} consults this on every active-item
+     * change, and minting a pane to decide whether to show a button would be a side effect.
      *
-     * It answers "is a recreate path wired", not "will this particular item succeed" — and since
-     * {@link #resolveFreshPane} now delegates to {@link #resolvePane}, which every workspace answers,
-     * a path always is. An item that cannot be served still gets a **visible** action settling with a
-     * named refusal, which is the honest outcome: hiding it leaves a wedged pane with no affordance
-     * and no explanation.
-     *
-     * This used to compare `this.resolveFreshPane` against the prototype, which asked "did a consumer
-     * override the hook?" — so the engine could never be its own fallback, because a base class
-     * cannot override itself. Overriding this method to return `false` is the remaining way for a host
-     * to declare it does not serve recreate at all.
+     * Override to `false` to declare this host serves no recreate.
      * @returns {Boolean}
      */
     hasDockRecreateFallback() {

--- a/src/dashboard/dock/Workspace.mjs
+++ b/src/dashboard/dock/Workspace.mjs
@@ -1017,9 +1017,12 @@ class Workspace extends Container {
      *   only excludes the button.
      *
      * The placeholder is the dangerous one, and not as an edge case: a placeholder exists exactly
-     * when a pane could not be materialized, and for a host that writes no `resolveFreshPane` that
-     * is the ORDINARY state — the same epic's row 2. Tearing one out would open a vessel holding a
-     * titled blank and lose the pane, silently.
+     * when a pane could not be materialized, and for a host that writes no {@link #resolvePane}
+     * that is the ORDINARY state — the engine's own default resolves a labelled placeholder.
+     * Tearing one out would open a vessel holding a titled blank and lose the pane, silently.
+     *
+     * The hook named here is `resolvePane`, not `resolveFreshPane`: the latter now delegates to the
+     * former, so writing no recreate hook no longer implies an unresolvable pane.
      * @param {Neo.component.Base} component
      * @returns {Boolean}
      * @protected
@@ -1705,11 +1708,15 @@ class Workspace extends Container {
      * a vessel without one, and demanding the config from it would withhold an action that works.
      *
      * So the default asks whether the engine's own opener is the one that will run. That is a
-     * prototype comparison, which this file elsewhere shows the cost of (`hasDockRecreateFallback`
-     * inverts to always-false the moment its base gains a default). It is sound *here* for the
-     * opposite reason: the base already HAS a working implementation, so "is it still the base one"
-     * is a stable question rather than a proxy for "did anyone implement this". A host may still
-     * override this getter directly when its answer is neither.
+     * prototype comparison, and the cost of one is on record in this file's own history:
+     * `hasDockRecreateFallback` used to compare `resolveFreshPane` against the prototype, which
+     * made it answer always-false the moment the base gained a default — the engine could not be
+     * its own fallback, because a base class cannot override itself. That comparison is gone; the
+     * lesson is not.
+     *
+     * It is sound *here* for the opposite reason: the base already HAS a working implementation, so
+     * "is it still the base one" is a stable question rather than a proxy for "did anyone implement
+     * this". A host may still override this getter directly when its answer is neither.
      * @returns {Boolean}
      * @protected
      */

--- a/src/dashboard/dock/Workspace.mjs
+++ b/src/dashboard/dock/Workspace.mjs
@@ -4086,41 +4086,53 @@ class Workspace extends Container {
     /**
      * Hook: produces a **fresh** candidate pane for an item, bypassing any live-instance cache.
      *
-     * Deliberately a separate hook rather than an option on {@link #resolvePane}. Real consumers
-     * resolve panes from live-instance caches and mint replacements only after observing
-     * `pane.isDestroyed`; an option those consumers do not implement would be silently ignored and
-     * hand back **the very instance the recreate is meant to replace**. A distinct hook cannot be
-     * accidentally satisfied by a cache, and its default says the honest thing: this consumer does
-     * not support recreate.
+     * Deliberately a separate **hook** rather than an option on {@link #resolvePane}: a consumer
+     * that resolves from a live-instance cache needs somewhere to mint a replacement that its cache
+     * does not answer, and an option such a consumer never implemented would be silently ignored.
+     * `apps/workstation` is exactly that shape.
      *
-     * Returning `null` is a legitimate answer, not a failure of contract — it declines the
-     * capability, and {@link #prepareRecreateCandidate} reports that as a named refusal with the
-     * live pane untouched.
+     * Its **default delegates** to {@link #resolvePane}, because only the consumer knows how to
+     * build its own pane — the engine knows how to build a placeholder, which for any host that
+     * resolves real panes would be a downgrade rather than a recreate. Delegation therefore serves
+     * the host's own shape where one exists, and the engine's labelled placeholder where nothing
+     * else does.
+     *
+     * Delegation is safe even against a cache-backed `resolvePane`, which is why it can be the
+     * default at all: {@link #prepareRecreateCandidate} compares the candidate to the live pane by
+     * **identity** and reports `live-instance` with the live pane untouched. The worst case is a
+     * named refusal behind a visible action, never a swap of a pane for itself.
+     *
+     * Returning `null` stays a legitimate answer — it declines for that item, reported as
+     * `declined` with the live pane untouched.
      * @param {String} itemId The stable workspace identity from the item catalog.
      * @param {Object} item The persisted item record.
      * @returns {Object|Neo.component.Base|null}
      */
     resolveFreshPane(itemId, item) {
-        return null
+        return this.resolvePane(itemId, item)
     }
 
     /**
-     * Whether this workspace can serve a recreate at all — i.e. whether a consumer overrode
-     * {@link #resolveFreshPane}.
+     * Whether this workspace can serve a recreate at all.
      *
-     * Derived from the prototype rather than by calling the factory, because this is consulted by
-     * {@link #syncDockReloadAction} on every active-item change and a visibility sync must not have
-     * side effects: invoking a consumer factory to decide whether to show a button would mint panes
-     * nobody asked for.
+     * **Never calls the factory.** {@link #syncDockReloadAction} consults this on every active-item
+     * change, so a visibility sync must not have side effects: invoking a resolver to decide whether
+     * to show a button would mint panes nobody asked for.
      *
-     * It answers "is the capability wired", not "will this particular item succeed". A consumer that
-     * overrides the hook and then declines a specific item still gets a **visible** action that
-     * settles with a named refusal — which is the honest behaviour: hiding it would leave a wedged
-     * pane with no affordance and no explanation.
+     * It answers "is a recreate path wired", not "will this particular item succeed" — and since
+     * {@link #resolveFreshPane} now delegates to {@link #resolvePane}, which every workspace answers,
+     * a path always is. An item that cannot be served still gets a **visible** action settling with a
+     * named refusal, which is the honest outcome: hiding it leaves a wedged pane with no affordance
+     * and no explanation.
+     *
+     * This used to compare `this.resolveFreshPane` against the prototype, which asked "did a consumer
+     * override the hook?" — so the engine could never be its own fallback, because a base class
+     * cannot override itself. Overriding this method to return `false` is the remaining way for a host
+     * to declare it does not serve recreate at all.
      * @returns {Boolean}
      */
     hasDockRecreateFallback() {
-        return this.resolveFreshPane !== Workspace.prototype.resolveFreshPane
+        return true
     }
 
     /**

--- a/test/playwright/component/dashboard/DockReload.spec.mjs
+++ b/test/playwright/component/dashboard/DockReload.spec.mjs
@@ -69,6 +69,33 @@ const soleAction = async (locator, subject) => {
     return locator
 };
 
+/**
+ * Asserts a locator's node count in its SETTLED state, by requiring two consecutive reads to agree.
+ *
+ * A plain `toHaveCount(n)` retries until it sees `n` once, so it is satisfied by a value the
+ * timeline merely passes THROUGH. That is not hypothetical here: switching to a contract-free pane
+ * leaves the reload action briefly mounted before the visibility sync settles it, so
+ * `toHaveCount(1)` succeeds on the transient while `toHaveCount(0)` succeeds on the settled state —
+ * both "pass", and only one describes the app. This caught a false green on my own arm.
+ * @param {Object} locator
+ * @param {Number} expected
+ * @param {String} subject for the failure message
+ * @returns {Promise<void>}
+ */
+const settledCount = async (locator, expected, subject) => {
+    let previous = -1;
+
+    await expect.poll(async () => {
+        const now    = await locator.count(),
+              stable = now === previous;
+
+        previous = now;
+
+        // -1 is never an expected count, so an unstable sample can never satisfy the assertion.
+        return stable ? now : -1
+    }, {message: `${subject}: settled node count`}).toBe(expected)
+};
+
 test.beforeEach(async ({page}) => {
     await page.goto('test/playwright/component/apps/dock-maximize/index.html');
     await page.waitForSelector('#dock-maximize-workspace', {state: 'attached'});
@@ -236,21 +263,43 @@ test.describe('dock reload — delegation-only, settled, single-flight', () => {
         expect((await readInstance(page, WORKSPACE_ID, ['docJson']))[0]).toBe(docBefore)
     });
 
-    test('a pane without the contract hides the action — pure probe, no resolver call', async ({page}) => {
+    test('a pane without the contract is OFFERED the action, because the engine serves the recreate', async ({page}) => {
+        // This arm asserted the opposite until the engine gained its own recreate fallback: a
+        // contract-free pane hid its action, and `frame` existed in the fixture as that hiding
+        // witness. The hiding was a construction artefact, not a policy — the capability used to
+        // be derived by comparing
+        // `resolveFreshPane` against the prototype, so the engine could never be its own fallback
+        // and the action vanished for exactly the panes whose only recovery is a recreate.
+        // `syncDockReloadAction`'s own comment already stated the intended rule: "hidden only when
+        // NEITHER path can serve the item."
+        //
+        // The probe is still pure — `hasDockRecreateFallback()` returns without touching a
+        // resolver, which is what keeps a visibility sync from minting panes nobody asked for.
+        // That property is asserted where it can be isolated from the projection's own legitimate
+        // resolver calls, in `unit/dashboard/DockRecreateCandidate.spec.mjs`.
         const side   = tabsNodeWith(page, 'Frame'),
               reload = actionButton(side, 'fa-rotate-right');
 
-        // gamma (contract, throwing or not) active: present in the DOM.
+        // Every count here is a SETTLED count. A plain `toHaveCount(1)` passes on this fixture
+        // whether or not the engine change is present, because switching to a contract-free pane
+        // leaves the action briefly mounted before the sync settles it — so the transient satisfies
+        // the assertion and the arm reports green against `dev`. That false green was this arm's
+        // first draft.
         await tabButton(side, 'Gamma').click();
-        await expect(reload).toHaveCount(1);
+        await settledCount(reload, 1, 'gamma owns the contract');
 
-        // frame (contract-free) active: hidden means removeDom — the control leaves entirely.
+        // frame is contract-free, and the engine's delegated `resolveFreshPane` can serve it — the
+        // fixture resolves `frame` as a real iframe, so a recreate rebuilds THAT rather than
+        // downgrading it to a placeholder. The action belongs on screen, and stays.
         await tabButton(side, 'Frame').click();
-        await expect(reload).toHaveCount(0);
+        await settledCount(reload, 1, 'frame is served by the engine fallback');
+        await expect(reload).toBeEnabled();
 
-        // and returns with gamma.
+        // and it survives the round trip rather than appearing once.
         await tabButton(side, 'Gamma').click();
-        await expect(reload).toHaveCount(1)
+        await settledCount(reload, 1, 'gamma again');
+        await tabButton(side, 'Frame').click();
+        await settledCount(reload, 1, 'frame again')
     });
 
     test('single-flight is per item: switching panes re-derives both axes from the active item', async ({page}) => {

--- a/test/playwright/unit/dashboard/DockRecreateCandidate.spec.mjs
+++ b/test/playwright/unit/dashboard/DockRecreateCandidate.spec.mjs
@@ -68,16 +68,47 @@ test.describe('dock recreate — Phase 1 validates a candidate before anything i
         workspace = livePane = null
     });
 
-    test('the default hook declines, so recreate is opt-in rather than assumed', () => {
-        // A consumer that has not implemented the factory must not silently get a destructive
-        // capability. `null` is a legitimate answer — "this surface does not support recreate".
-        expect(workspace.resolveFreshPane('editor', null)).toBeNull();
+    test('the default hook delegates, and for a placeholder host that is not a downgrade', () => {
+        // This arm used to assert `null` — "recreate is opt-in rather than assumed" — on the
+        // reasoning that a consumer which implemented no factory must not silently get a
+        // DESTRUCTIVE capability. That fear was right and the mechanism was inverted: because the
+        // capability was derived from whether the hook was overridden, the engine could never be
+        // its own fallback, and the reload action was hidden for exactly the panes whose only
+        // recovery is a recreate.
+        //
+        // The default now delegates to `resolvePane`, which is what keeps it non-destructive.
+        // Minting the engine placeholder UNCONDITIONALLY would have been destructive — a host
+        // resolving a real pane would have had it replaced by a labelled box. Delegation instead
+        // returns whatever that host already resolves: here the engine placeholder, which is the
+        // pane this workspace is already showing, so the recreate swaps a placeholder for an
+        // equivalent placeholder and downgrades nothing.
+        const candidate = workspace.resolveFreshPane('editor', null);
+
+        expect(candidate, 'the default answers with a config').toBeTruthy();
+        expect(candidate.cls, 'and it is the engine placeholder this host already resolves')
+            .toContain('neo-dock-workspace-placeholder');
+
+        // Not the live pane, so the identity guard passes and phase 1 admits it.
+        const result = workspace.prepareRecreateCandidate('editor', livePane);
+
+        expect(result.ok).toBe(true);
+        expect(result.reason).toBeNull();
+        expect(result.candidate, 'the candidate is a config, never the mounted instance')
+            .not.toBe(livePane)
+    });
+
+    test('a host that declines for an item still declines, with the live pane untouched', () => {
+        // Delegation does not remove the refusal path, it just stops it being the default. A host
+        // whose resolver answers `null` for a particular item is the case AC-6 names, and the
+        // action stays visible so the refusal can be reported rather than hidden.
+        workspace.resolveFreshPane = () => null;
 
         const result = workspace.prepareRecreateCandidate('editor', livePane);
 
         expect(result.ok).toBe(false);
         expect(result.reason).toBe('declined');
-        expect(result.candidate).toBeNull()
+        expect(result.candidate).toBeNull();
+        expect(livePane.isDestroyed, 'the live pane is untouched by a refusal').toBeFalsy()
     });
 
     test('a factory that throws refuses with the error carried, never swallowed', () => {
@@ -539,14 +570,24 @@ test.describe('dock reload — the fallback the ticket exists to provide', () =>
         tabContainer.getActionItem  = () => action;
         workspace.getActiveDockItemId = () => 'editor';
 
-        // No fallback wired: hiding is correct — the item has no recovery at all.
+        // "No fallback" is no longer a state a workspace reaches by writing nothing — the default
+        // delegates, so a path is always wired. It is now reached only by a host declaring it
+        // outright, which is the remaining purpose of overriding this predicate. Stated explicitly
+        // rather than relying on the base default, which is what this half used to lean on.
+        workspace.hasDockRecreateFallback = () => false;
         workspace.syncDockReloadAction(tabContainer);
-        expect(action.hidden, 'no delegation, no fallback → hidden').toBe(true);
+        expect(action.hidden, 'no delegation, and recreate declared unavailable → hidden').toBe(true);
 
-        // Fallback wired: the action must appear, because it is now the pane's ONLY recovery.
+        // The engine's own default is enough on its own: no host factory, no declared refusal.
+        delete workspace.hasDockRecreateFallback;
+        workspace.syncDockReloadAction(tabContainer);
+        expect(action.hidden, 'the engine default alone un-hides it').toBe(false);
+
+        // And a host factory on top is still honoured — the original half of this arm, now the
+        // third state rather than the second.
         workspace.resolveFreshPane = () => ({module: Component});
         workspace.syncDockReloadAction(tabContainer);
-        expect(action.hidden, 'no delegation but a fallback → visible').toBe(false)
+        expect(action.hidden, 'no delegation but a host fallback → visible').toBe(false)
     })
 });
 

--- a/test/playwright/unit/dashboard/DockRecreateCandidate.spec.mjs
+++ b/test/playwright/unit/dashboard/DockRecreateCandidate.spec.mjs
@@ -97,6 +97,30 @@ test.describe('dock recreate — Phase 1 validates a candidate before anything i
             .not.toBe(livePane)
     });
 
+    test('hasDockRecreateFallback constructs nothing, however often it is consulted', () => {
+        // AC-3, and the reason the old implementation compared prototypes rather than calling the
+        // factory: `syncDockReloadAction` consults this on every active-item change, so a
+        // visibility sync that invoked a resolver would mint panes nobody asked for. Delegation
+        // changed what `resolveFreshPane` returns; it must not have changed WHEN it runs.
+        let resolverCalls = 0;
+
+        workspace.resolvePane = (itemId, item) => {
+            resolverCalls++;
+            return {ntype: 'component'}
+        };
+
+        for (let i = 0; i < 5; i++) {
+            expect(workspace.hasDockRecreateFallback(), 'a path is wired').toBe(true)
+        }
+
+        expect(resolverCalls, 'consulting the predicate never reached the resolver').toBe(0);
+
+        // Non-vacuity: the counter can move, so zero above is a measurement rather than a
+        // resolver that was never wired up.
+        workspace.resolveFreshPane('editor', null);
+        expect(resolverCalls, 'and the resolver is genuinely reachable').toBe(1)
+    });
+
     test('a host that declines for an item still declines, with the live pane untouched', () => {
         // Delegation does not remove the refusal path, it just stops it being the default. A host
         // whose resolver answers `null` for a particular item is the case AC-6 names, and the

--- a/test/playwright/unit/dashboard/DockWorkspace.spec.mjs
+++ b/test/playwright/unit/dashboard/DockWorkspace.spec.mjs
@@ -2150,9 +2150,20 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
         // could fix it without changing refresh sequencing for every consumer. What AC-3 actually
         // claims is that no group was ever rebuilt behind them — every signal, before and after
         // reconciliation, came from the one retained instance.
-        expect(new Set(signalSources).size, 'one emitter across every signal, not a rebuilt group')
+        // Scoped to the PIN action's own signals. The claim is about pin's instance surviving
+        // reconciliation, and an unscoped emitter set silently also asserted that pin is the only
+        // action in this fixture whose visibility ever moves — which it is not: `reload` is enabled
+        // here and the engine now derives a recreate fallback for it, so it legitimately un-hides
+        // during the same refreshes. Measured: the two emitters are `pin` and `reload`, both
+        // visible. Counting them together turned another action's correct behaviour into a failure
+        // of this one.
+        const pinSources = signalSources.filter(component => component === pinAction);
+
+        expect(pinSources.length, 'pin did emit, so the assertion below is not vacuous')
+            .toBeGreaterThan(0);
+        expect(new Set(pinSources).size, 'one emitter across every pin signal, not a rebuilt group')
             .toBe(1);
-        expect(signalSources[0], 'and it is the instance the assertions above held').toBe(pinAction)
+        expect(pinSources[0], 'and it is the instance the assertions above held').toBe(pinAction)
     });
 
     /**

--- a/test/playwright/unit/dashboard/DockWorkspace.spec.mjs
+++ b/test/playwright/unit/dashboard/DockWorkspace.spec.mjs
@@ -3369,8 +3369,10 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
             // LayoutAdapter.createPlaceholder mints ntype 'dashboard-panel' carrying the same
             // dockItemId, so it passes an exclusion that only names the header button. A placeholder
             // exists exactly when a pane could NOT be materialized — the ordinary state for a host
-            // that writes no resolveFreshPane — so tearing one out opens a vessel holding a titled
-            // blank and loses the pane, silently.
+            // that writes no resolvePane — so tearing one out opens a vessel holding a titled
+            // blank and loses the pane, silently. The hook is `resolvePane`, not `resolveFreshPane`:
+            // the recreate hook now delegates to it, so writing no recreate hook no longer implies
+            // an unresolvable pane.
             expect(workspace.isDockTearOutCandidate({cls: ['neo-dashboard-dock-placeholder'], ntype: 'dashboard-panel'}),
                 'a placeholder is not a tear-out candidate').toBe(false);
 


### PR DESCRIPTION
## Summary

Resolves #18169 — epic #18151 row 2, the last of its seams.

`hasDockRecreateFallback()` asked *"did a consumer override the hook?"* by comparing `this.resolveFreshPane` against the prototype. So **the engine could never be its own fallback by construction** — a base class cannot override itself — and `syncDockReloadAction` therefore hid the reload action for every pane with no `dockReload()`, i.e. exactly the panes whose only recovery is a recreate.

## The fix this ticket prescribed was wrong

Worth stating plainly, because I wrote the prescription and it would have shipped a **destructive** affordance.

It called for a default that mints a fresh config from the persisted record. The engine's record-minting is `resolvePane`'s default: `{cls: ['neo-dock-workspace-placeholder'], ntype: 'component', text}` — a labelled box. The `dock-maximize` fixture resolves `frame` as a real `iframe`, and its own comment calls `frame` *"contract-free — the hidden witness"*. Under the prescription, that pane's reload button becomes visible and clicking it replaces a working browsing context with a text box. **The ticket's own AC-1 would have gone green on exactly that.**

A hidden recovery affordance is bad. One that silently downgrades a real pane is worse. So the prototype predicate was encoding something true I had not credited when filing: **only the consumer knows how to build its own pane.** Wrong mechanism, right idea.

## What landed instead

```js
resolveFreshPane(itemId, item) {
    return this.resolvePane(itemId, item)
}
```

This reverses `resolveFreshPane`'s own JSDoc, which argued a distinct hook was needed because *"real consumers resolve panes from live-instance caches"* and delegation would *"hand back the very instance the recreate is meant to replace"*. That hazard is real and it is **not a correctness hazard**, because `prepareRecreateCandidate` already catches it:

```js
if (livePane && candidate === livePane) {
    return {ok: false, candidate: null, reason: 'live-instance', error: null}
}
```

Identity, not equality, and the live pane is untouched. So the worst case is a named refusal behind a visible action — which is what AC-6 asks for, arriving from a guard that already existed.

Three host shapes, three correct outcomes, no new minting code:

| host | delegated default returns | outcome |
|---|---|---|
| resolves nothing | the engine placeholder | swaps a placeholder for an equivalent one — the pane already on screen, so nothing is downgraded |
| resolves fresh configs (`dock-maximize`) | the host's own shape — an `iframe` for `frame` | the recreate serves the **right** pane |
| cache-backed, **no `resolveFreshPane` override** — hypothetical, no in-tree host | the cached live instance | `live-instance` refusal, pane untouched, action visible with a named reason |

**No in-tree host exercises row 3.** `apps/workstation` is cache-backed but overrides `resolveFreshPane` (`apps/workstation/view/Workspace.mjs:2415`), so it mints fresh and never reaches the delegated default — the first version of this table named it as row 3's subject, which was wrong and would have been mined from the graph as "workstation takes the delegated path". Row 3 describes the shape a third-party consumer could have, and it is the reason the `live-instance` guard matters even though nothing here trips it.

`hasDockRecreateFallback()` keeps its no-side-effect contract — a visibility sync must not mint panes to decide whether to show a button — and becomes structurally true, surviving as the seam a host overrides to declare it serves no recreate at all.

Evidence: L2 (mutation-verified unit and component arms, run locally) → L2 required. Residual: none.

## Test Evidence

Red-first at both tiers, with **only the engine file** reverted to `dev` and its absence verified by `grep` rather than assumed:

| | fix applied | engine file reverted |
|---|---|---|
| `unit/dashboard/` | `791 passed` | `3 failed` |
| `component/dashboard/DockReload.spec.mjs` | `11 passed` | `1 failed` — `Expected: 1 / Received: 0` |

Full unit suite: **`3136 passed`**. Full component dashboard suite: **`112 passed`**.

### The component arm's first draft was a false green

The most useful thing in this PR. `toHaveCount(1)` retries until it sees `1` **once**, and switching to a contract-free pane leaves the action briefly mounted before the visibility sync settles it. So the transient satisfied the assertion and the arm passed **against `dev`, with the engine change reverted and the served tree verified**. `toHaveCount(0)` and `toHaveCount(1)` both "passed" on the same subject — only possible when one of them reads mid-transition.

Every count is now a settled count. `settledCount` requires two consecutive reads to agree and returns a sentinel for an unstable sample, so a value the timeline merely passes through can never satisfy it. That is the same defect class as #18179's settle guard, one tier out: **a retrying assertion for a value the timeline visits twice is not a settle.**

## Three flipped arms, none a defect in the change

- **`DockRecreateCandidate` "the default hook declines"** — its comment feared a consumer with no factory getting a "destructive capability". Right fear, inverted mechanism; delegation is what makes the default non-destructive. Rewritten, with a companion arm keeping the refusal path delegation does not remove.
- **`DockRecreateCandidate` "no longer hides the action"** — leaned on the base default to produce a no-fallback state, which is no longer reachable by writing nothing. Now declared outright, and the arm gained the state between: the engine default alone un-hides the action.
- **`DockWorkspace` "the pin action refuses fail-closed"** — this one **looked** like a regression and is not. It asserted one emitter across every `actionVisibilityChange` and got two, which reads as a rebuilt action group, the exact thing it guards. Measured: the emitters are `pin` and `reload`, both visible — `reload` is enabled in that fixture and now derives a fallback, so it legitimately un-hides during the same refreshes. The unscoped emitter set was silently also asserting that pin is the only action in the fixture whose visibility moves. Scoped to pin's own signals, with a non-vacuity check.

## AC dispositions

AC-5 was **revised on the ticket before implementing**: it required the default to return "a config, never a live instance", which forbids the safe design — a cache-backed host reaching the delegated default correctly returns its live instance and correctly settles as a refusal. AC-7 (no automatic recreation) holds by construction: the diff changes what two methods return, never when either is called.

## Not in scope

`apps/workstation`'s override discards the engine's `retainTopology` — the `itemFlags` half of the same shape. That is #18208, authored and self-assigned by @neo-opus-grace, with a trap I did not have (a naive `||` merge resurrects the bug the railed arm prevents). No file overlap: that lane is in `apps/workstation`, this one is in `src/`.

⚖️ **Ada** · `@neo-opus-ada` · Claude Opus 5 · Claude Code

