### PR TITLE
test(dashboard): the dock lock NL arms compare against the baseline, not a fixture literal (#17844)

### DIFF
--- a/test/playwright/e2e/dashboard/DockLockActionNL.spec.mjs
+++ b/test/playwright/e2e/dashboard/DockLockActionNL.spec.mjs
@@ -73,7 +73,15 @@ test.describe('dock lock action — Whitebox gesture contract', () => {
         await app.getDragTrace(true);
         await dragAfter(page, tabButton(main, 'Alpha'), tabButton(main, 'Beta'));
 
-        expect((await readDocument()).nodes['main-tabs'].items).toEqual(['alpha', 'beta']);
+        // Compared against the captured baseline rather than a literal, exactly as the close
+        // refusal above is. A hardcoded `['alpha', 'beta']` is what rotted here: the fixture gained
+        // a third pane (`delegated`, the lock-delegation host) and this arm started failing on the
+        // fixture rather than on the gesture — while the property it names, "a locked header
+        // refuses the drag", was never violated. The invariant is that the drag changed NOTHING,
+        // and only the baseline states that.
+        expect((await readDocument()).nodes['main-tabs'].items,
+            'a locked header refuses the drag, so the tabs node is untouched')
+            .toEqual(before.nodes['main-tabs'].items);
         expect((await app.getDragTrace()).traces || [],
             'a locked header never arms the SortZone').toEqual([]);
 
@@ -106,8 +114,16 @@ test.describe('dock lock action — Whitebox gesture contract', () => {
 
         expect(unlockedEnd.noop).not.toBe(true);
 
+        // Derived from the baseline and the reorder the trace above just asserted (`from: 0, to: 1`)
+        // rather than hardcoded, for the same reason as the refusal arm: a literal states the
+        // fixture, and the invariant is "the SortZone moved slot 0 to slot 1 and touched nothing
+        // else". Any pane the fixture gains rides along untouched instead of reddening the arm.
+        const expectedOrder = [...before.nodes['main-tabs'].items];
+
+        [expectedOrder[0], expectedOrder[1]] = [expectedOrder[1], expectedOrder[0]];
+
         await expect.poll(async () => (await readDocument()).nodes['main-tabs'].items)
-            .toEqual(['beta', 'alpha']);
+            .toEqual(expectedOrder);
         await awaitRefresh(1);
 
         await actionButton(main, 'fa-times').click();


### PR DESCRIPTION
Part of #17844 (AC-5, fixed forward) · one of the four reds from that ticket's first census

## What

`DockLockActionNL` has been red since the repo split, and nobody saw it: every NL spec is config-ignored unless `NEO_AGENTOS_RUNTIME_ROOT` is set, nothing sets it, and the ignored run reports `✅ Passed: 0 ❌ Failed: 0` — a clean-looking green over an empty selection.

Two assertions hardcoded the fixture's item list. The `dock-lock` fixture later gained a third pane (`delegated`, the lock-delegation host), so both arms failed on the **fixture** while the properties they name were never violated:

```
- Expected  ['alpha', 'beta']            - Expected  ['beta', 'alpha']
+ Received  ['alpha', 'beta', 'delegated'] + Received  ['beta', 'alpha', 'delegated']
```

## The fix is the file's own idiom, one assertion up

The close-refusal half already does it right — `expect(await readDocument()).toEqual(before)` against a captured baseline. Only the drag halves reached for literals, and that is exactly why they rotted: **a literal states the fixture; the baseline states the invariant.**

- **Refusal arm** → `toEqual(before.nodes['main-tabs'].items)`. The property is "the drag changed nothing".
- **Restored arm** → derived from the baseline by swapping slots 0 and 1, which is the reorder the trace assertion immediately above already pins as `{from: 0, to: 1}`. The property is "the SortZone moved one slot and touched nothing else".

Any pane the fixture gains now rides along untouched instead of reddening the arms. **`1 passed`** at this head with the runtime root set.

## What I did NOT prove, stated plainly

I seeded the model-level guard — deleting the locked check in `Operations.moveItem` (`Operations.mjs:235`) — and the spec **still passed**. That is not a coverage hole, and I checked rather than assuming:

- This arm asserts `traces == []` — *"a locked header never arms the SortZone"*. The gesture is refused at **arming**, so it never reaches the reducer, so removing the reducer's guard cannot change the outcome.
- The reducer's guard has its own witness: `DockZoneModel.spec.mjs:1734` puts `moveItem` on a locked item into an `attempts` array and `:1743-1747` asserts each returns the same document with an error containing `locked`.

Two layers, two witnesses. But it means **these arms are not mutation-proven by me** — I mutated the wrong layer for them, and locating the SortZone arming guard to seed it properly was more than this fix warranted. Recording that rather than presenting a passing mutation as if it validated something.

The spec's own comment — *"the model remains the boundary"* — is what sent me at the reducer. It is true of the close path and misleading for the drag path, which is refused earlier. Not changed here; noted for whoever touches it next.

## Scope

Assertion shape only. No fixture change, no engine change, and the other three reds from the census are untouched: `DockAutoHideRevealNL:90` and `:293` are a live engine defect filed as **#18216**, and `DockSplitterProxyPaintNL:29` is still unclassified — I am not guessing at it.

## Green

- The spec: **1 passed** (`NEO_AGENTOS_RUNTIME_ROOT` set to the sibling Brain checkout)
- Test-only change; `unit` and `components` untouched by it

Worth knowing for review: you need `NEO_AGENTOS_RUNTIME_ROOT=/path/to/neo-agent-brain` to run this spec at all. Without it the file is ignored and the run reports zero of zero.

- **Origin Session ID:** 8d936ec9-b816-4ded-a91e-6e91ef6a3325

🖖 Grace, Claude Opus 5, Claude Code.
