### PR TITLE
test(menu): the spawn re-arm arm measures the entrance, and names what is absent (#18215)

### DIFF
--- a/test/playwright/component/menu/SpawnAnimation.spec.mjs
+++ b/test/playwright/component/menu/SpawnAnimation.spec.mjs
@@ -202,11 +202,29 @@ test.describe('Neo.menu.List spawn animation', () => {
 
         // Positive match on purpose, above: `.not.toBeNull()` is satisfied by `undefined`, so against
         // an absent node it passes instantly and waits for nothing — a poll that cannot poll.
-        const animationName = await page.evaluate(
-            id => getComputedStyle(document.getElementById(id)).animationName, menuId
-        );
 
-        expect(animationName).not.toBe('none')
+        // The entrance is polled on its OWN state, not inferred from the alignment above.
+        //
+        // `List.scss` keys the animation on TWO classes at once — `.neo-animate-spawn` and a
+        // specific `.neo-aligned-*` — so alignment landing is necessary and not sufficient. Reading
+        // `animationName` once, after a poll that gated on the other settlement, meant the read
+        // could land in the window between them and see `none`. That is what made this arm fail
+        // about one run in eight while the feature was working.
+        //
+        // Polling this value is legitimate where polling a count was not: the transition is
+        // one-way. `animation-fill-mode: both` holds the end state, and `DomAccess` swaps the
+        // aligned class only on a REAL zone change behind a `contains()` guard, so the name does
+        // not return to `none` once resolved.
+        //
+        // Matched POSITIVELY against the four keyframe names the stylesheet can produce, rather
+        // than `not.toBe('none')` — which any string satisfies, including a `neo-aligned-` class
+        // the stylesheet has no rule for. Same reasoning as the note above, one assertion over.
+        await expect.poll(async () => page.evaluate(id => {
+            const node = document.getElementById(id);
+
+            return node ? getComputedStyle(node).animationName : '';
+        }, menuId), {message: 'the entrance animation is armed on the reopened instance'})
+            .toMatch(/^neo-menu-spawn-from-(top|bottom|left|right)$/)
     });
 
     test('propagates a later animateSpawn change to an already-cached submenu, both ways', async ({page}) => {

--- a/test/playwright/component/menu/SpawnAnimation.spec.mjs
+++ b/test/playwright/component/menu/SpawnAnimation.spec.mjs
@@ -194,11 +194,21 @@ test.describe('Neo.menu.List spawn animation', () => {
         await expect.poll(async () => page.evaluate(id => !!document.getElementById(id), menuId)).toBe(false);
 
         await page.evaluate(id => Neo.worker.App.setConfigs({id, hidden: false}), menuId);
+
+        // The sentinel distinguishes ABSENT from UNALIGNED, because those are different failures
+        // with different causes and the previous `''` returned the same value for both. Measured
+        // while diagnosing the intermittency this arm carries: at the failure the node is
+        // `absent` — `document.querySelectorAll('.neo-menu-list').length` is 0 — so the reopened
+        // menu has left the DOM rather than arrived unaligned. Three diagnostic passes read that
+        // as an alignment problem because the sentinel could not say otherwise.
         await expect.poll(async () => page.evaluate(id => {
             const node = document.getElementById(id);
 
-            return node ? [...node.classList].find(cls => cls.startsWith('neo-aligned-')) ?? '' : '';
-        }, menuId)).toMatch(/^neo-aligned-/);
+            if (!node) return 'absent';
+
+            return [...node.classList].find(cls => cls.startsWith('neo-aligned-')) ?? 'unaligned';
+        }, menuId), {message: 'the reopened menu is mounted and has resolved a zone'})
+            .toMatch(/^neo-aligned-/);
 
         // Positive match on purpose, above: `.not.toBeNull()` is satisfied by `undefined`, so against
         // an absent node it passes instantly and waits for nothing — a poll that cannot poll.

--- a/test/playwright/component/menu/SpawnAnimation.spec.mjs
+++ b/test/playwright/component/menu/SpawnAnimation.spec.mjs
@@ -232,7 +232,12 @@ test.describe('Neo.menu.List spawn animation', () => {
         await expect.poll(async () => page.evaluate(id => {
             const node = document.getElementById(id);
 
-            return node ? getComputedStyle(node).animationName : '';
+            // Three separable states, for the same reason the alignment sentinel above names two:
+            // `absent` (no node), `none` (mounted but unarmed) and a keyframe name. Reporting
+            // absence as `''` here would have undone this file's own fix one assertion later — and
+            // it is the likeliest failure, because absence is what the remaining intermittency
+            // actually produces.
+            return node ? getComputedStyle(node).animationName : 'absent';
         }, menuId), {message: 'the entrance animation is armed on the reopened instance'})
             .toMatch(/^neo-menu-spawn-from-(top|bottom|left|right)$/)
     });


### PR DESCRIPTION
## Summary

`Refs #18215` — deliberately **not** `Resolves`. **This does not fix the flake.**

Two real defects in the arm are fixed, and the intermittency the ticket was filed for is still live at 1 failure in 30. The ticket's own AC-3 is what caught that, and it stays open.

## What I got wrong

I filed #18215 naming the cause: the arm polls for a resolved-zone class and then reads `animationName` once, outside any poll — two different settlements, so the read could land between them and see `none`. That defect is **real**, it is fixed here, and it is **not the cause**.

Measured at the failure instead of reasoned about:

```
DIAG-ALIGN {"nodePresent":false,"classes":null,"inDom":false,"menuCount":0}
```

The arm reddens at the **alignment** poll, not the animation read — and the reopened menu is **not in the DOM at all**. Not unaligned. Absent.

Three of my own diagnostic passes read this as an alignment problem, because the poll's sentinel returned `''` for *node absent* and for *node present but unaligned* alike. **A sentinel that collapses two states cannot tell you which one you are in**, and that is the second defect fixed here.

## What is fixed

**The entrance is polled on its own state.** `List.scss` keys the animation on two classes at once — `.neo-animate-spawn` **and** a specific `.neo-aligned-*` — so alignment landing is necessary and not sufficient. Polling this is legitimate where polling a count was not, and the difference matters: the transition is **one-way**. `animation-fill-mode: both` holds the end state, and `DomAccess` swaps the aligned class only on a real zone change behind a `contains()` guard, so the name does not return to `none`. A poll for a value the timeline visits twice would have been the same bug in a new place.

**Matched positively** against the four keyframe names the stylesheet can produce, rather than `not.toBe('none')` — which any string satisfies, including a `neo-aligned-*` class the stylesheet has no rule for. Checked while diagnosing: `Rectangle.mjs` derives zone names from `['top','right','bottom','left']` and `List.scss` carries a rule for each, so nothing reachable is excluded today. The positive match is what keeps that true if either list grows.

**The alignment sentinel now names `absent` and `unaligned` separately**, so the next failure is legible without instrumenting it again.

## Test Evidence

| AC | state |
|---|---|
| **AC-2** — red-first, by suppressing the mechanism rather than waiting for the flake | **met.** Stripping only `.neo-animate-spawn` at runtime, alignment left intact, fails the new poll: `Expected pattern: /^neo-menu-spawn-from-(top\|bottom\|left\|right)$/ · Received "none"`, under its own named message. The assertion witnesses the animation specifically. |
| **AC-3** — 30 serial repeats, zero failures | **NOT met. 1 failure in 30.** |
| **AC-1** — the sentinel distinguishes absent from unaligned | met |

Full spec: `8 passed`.

## What remains, and why it is not guessed at here

`src/menu/List.mjs` documents that a floating menu *"listens on its own app main view so outside pointer input can dismiss it even when a non-focusable target produces no focus transition"*. This arm's own comment reports the consequence:

> *"the reopened menu takes focus, and a locator count that momentarily matches can be followed by a focus-driven dismissal before the read lands"*

The author met this hazard and responded by observing the subject **id** rather than the `.neo-menu-list` locator. That changes what is read; it does not stop the dismissal. The fixture also aligns to a zero-size **point** target, so the interaction island has no element to anchor on.

Whether that post-reopen dismissal is legitimate behaviour the arm must wait out, or a defect in the `hidden: false` remount path, is **AC-6 on the ticket and unresolved**. `DomAccess.mjs:305` already carries a guard added because this remount path is fragile — a hidden menu *"remounts as a fresh element, so it comes back classless"* — which is adjacent but not the same failure.

I am not shipping a guess at it. If it is an engine defect, it needs its own ticket and its own evidence; if it is legitimate, the arm needs to settle on *open* before reading anything.

## Note for reviewers

The useful thing here is the shape, not the diff. I had a plausible mechanism, proved it red-first, and would have closed the ticket on it — with the flake still live and a green PR body saying otherwise. **AC-3 is the only reason that did not happen**, and I set it at 30 repeats when filing because the arm measured 1-in-8. A smaller number would have passed and I would have shipped a false cure.

⚖️ **Ada** · `@neo-opus-ada` · Claude Opus 5 · Claude Code
