### PR TITLE
test(workstation): the split-chrome census counts containers, not every tab-header toolbar (#17844)

### DIFF
--- a/test/playwright/e2e/workstation/WorkstationDockSplitChromeNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationDockSplitChromeNL.spec.mjs
@@ -34,8 +34,10 @@ import {test, expect} from '../../fixtures.mjs';
  */
 
 /** Rendered chrome per tab container: its three config-derived classes, header density, and forensic counts. */
-const readChrome = page => page.evaluate(() => [...document.querySelectorAll('.neo-tab-header-toolbar')].map(bar => {
-    const container = bar.closest('[class*="neo-tab-container"]'),
+const readChrome = page => page.evaluate(() => [...document.querySelectorAll('.neo-tab-header-toolbar')].filter(bar => {
+    return !!bar.closest('.neo-tab-container')
+}).map(bar => {
+    const container = bar.closest('.neo-tab-container'),
           buttons   = [...bar.querySelectorAll('.neo-tab-header-button')],
           ids       = [...bar.querySelectorAll('[id]')].map(node => node.id);
 


### PR DESCRIPTION
Part of #17844 (AC-5, fixed forward) · one of the 19 deterministic reds from that ticket's Workstation census

## What

`WorkstationDockSplitChromeNL` failed on its own **precondition**, before its subject was ever exercised — so the property it exists to guard (*"docking a tab to a grid edge leaves every other header alone"*) has been unmeasured, on top of being red.

The census walked every `.neo-tab-header-toolbar` and resolved each one's container with a **substring** match:

```js
bar.closest('[class*="neo-tab-container"]')
```

## Why that stopped being true

A tab-header toolbar does not imply a tab container. The dock reveal overlay's header is a runtime-only toolbar that carries `neo-tab-container-inline` **deliberately** — `interaction/RevealOverlay.mjs:198-200` says why:

> The self-scoped variant class lets every theme resolve the same compact tokens as an inline TabContainer, even though this runtime-only toolbar has **no container owner**.

So `[class*="neo-tab-container"]` matched the overlay's **own bar** and returned it as its container. It was then counted as a violation for lacking `plain` and a position — two things a toolbar never has and was never supposed to have.

**The engine is behaving exactly as documented.** The class reuse is intentional and the comment states the ownerless-ness outright; the census simply asked a substring question and got a substring answer.

## The fix, and how I know it is the right one

Match the base class and drop bars with no container owner. This census is about what **containers** derive from their configs, so an ownerless runtime toolbar is outside its subject rather than a violation of it.

Tightening the selector alone was not enough, and that intermediate step is what proved the diagnosis: with `.neo-tab-container`, the two violators came back as `containerId: null` — *no container ancestor at all*, which is the overlay headers identifying themselves.

**No defect underneath.** With the census asking the right question the whole spec passes — `1 passed (12.3s)`, and the subject runs for the first time since the split.

## Non-vacuity is already in the file and still holds

The spec guards itself against exactly the failure my change could have introduced:

```js
expect(before.length, 'the workspace must project several tab containers').toBeGreaterThan(2);
```

A filter that removed too much would trip that rather than pass quietly. It passes, so the census still covers the real containers — six of them, each with all three config-derived classes.

## Scope — one file, deliberately

`WorkstationTabRestoreNL.spec.mjs:49` carries the **identical** loose selector, and I reverted my change to it before committing. Its red is a *different* precondition (*"every committed tabs node must have a rendered header before the gesture"*) that my fix does not resolve — the line number moved only because my edit shifted it. Shipping an unrelated instrument tweak inside a still-red spec would leave that file's status ambiguous for whoever takes its red. Flagged on #17844 instead.

The other 17 reds from the census are untouched and triaged there.

## Green

`NEO_AGENTOS_RUNTIME_ROOT=<neo-agent-brain> npx playwright test workstation/WorkstationDockSplitChromeNL -c test/playwright/playwright.config.e2e.mjs --workers=1` → **1 passed**

Reviewer note: without that variable the file is `testIgnore`d and the run reports `Passed: 0 / Failed: 0` — green over an empty selection. The spec's own docblock says so at its top, which is how I knew to look.

- **Origin Session ID:** 8d936ec9-b816-4ded-a91e-6e91ef6a3325

🖖 Grace, Claude Opus 5, Claude Code.
