### PR TITLE
fix(grid): cell editing works by every gesture, not by none (#18217)

### DIFF
--- a/src/grid/plugin/CellEditing.mjs
+++ b/src/grid/plugin/CellEditing.mjs
@@ -44,7 +44,7 @@ class CellEditing extends BaseCellEditing {
     }
 
     /**
-     * `grid.View` is the grid's key registry, as `selection.grid.CellModel` and `ColumnModel` use.
+     * `grid.View` owns the key registry every grid selection model registers into.
      * @returns {Neo.component.Base}
      * @protected
      */
@@ -54,7 +54,11 @@ class CellEditing extends BaseCellEditing {
 
     /**
      * Opens an editor over the selected cell. The base reads the keydown target, which on a grid is
-     * always the View; `neo-selected` is on the cell, so selection is asked of the selection model.
+     * always the View; `neo-selected` is on the cell, so the cell comes from the selection model.
+     *
+     * Gated on a cell id rather than `hasSelection()`: only the `Cell*` models put cell ids in
+     * `items`. `ColumnModel` answers `hasSelection()` from `selectedColumns` and leaves `items`
+     * empty, so the pair disagree and a selection check would reach `getRecord(undefined)`.
      * @param {Object} data
      * @returns {Promise<void>}
      */
@@ -62,13 +66,13 @@ class CellEditing extends BaseCellEditing {
         let me             = this,
             {view}         = me.owner,
             selectionModel = view?.selectionModel,
-            cellId, dataField, record;
+            cellId         = selectionModel?.items?.[0],
+            dataField, record;
 
-        if (me.mountedEditor || !selectionModel?.hasSelection?.()) {
+        if (me.mountedEditor || !cellId) {
             return
         }
 
-        cellId    = selectionModel.items[0];
         record    = selectionModel.getRecord?.(cellId);
         dataField = view.getDataField(cellId);
 

--- a/src/grid/plugin/CellEditing.mjs
+++ b/src/grid/plugin/CellEditing.mjs
@@ -29,6 +29,73 @@ class CellEditing extends BaseCellEditing {
          */
         focusCells: true
     }
+
+    /**
+     * @summary The id of the DOM cell an editor must cover, translated into the grid's contract.
+     *
+     * `grid.Body#getCellId()` takes a **row index**, not a record: a grid's cell ids are pool-slot
+     * based (`…__row-{index % poolSize}`), because rows are recycled as the viewport moves. The
+     * inherited call passed the table's record straight through, so the modulo produced `NaN`, the
+     * id matched no node, and no editor could mount by ANY gesture.
+     * @param {Object} record
+     * @param {String} dataField
+     * @returns {String}
+     * @protected
+     */
+    getEditorCellId(record, dataField) {
+        let {body} = this.owner;
+
+        return body.getCellId(body.store?.indexOf(record), dataField)
+    }
+
+    /**
+     * @summary The View, which is where a grid's keys belong.
+     *
+     * `grid.View` is the single focus anchor — the only element in a grid that declares `tabindex` —
+     * and its own docs name it "the single key registry, the keyboard half of" that contract.
+     * `selection.grid.CellModel` and `ColumnModel` already register there. The inherited body
+     * registration could never fire: `Neo.manager.DomEvent` walks the event path UPWARD, and the
+     * bodies are the View's descendants, so a keydown targeted at the View never reaches them.
+     * @returns {Neo.component.Base}
+     * @protected
+     */
+    getKeyRegistryOwner() {
+        return this.owner.view
+    }
+
+    /**
+     * @summary Opens an editor over the SELECTED cell, resolved from the selection model.
+     *
+     * The inherited implementation guards on `data.target.cls?.includes('neo-selected')` — the
+     * keydown's target, i.e. whatever holds focus. On a grid that is always the View, and
+     * `neo-selected` is on the CELL, so the guard could never hold. Selection is the question being
+     * asked, so it is asked of the selection model: the same `hasSelection()` / `items[0]` /
+     * `getRecord()` / `getDataField()` accessors `CellModel#onNavKeyColumn` navigates with.
+     *
+     * The base's own `onSelectionChange` carries a `todo` anticipating this — "Once we separate
+     * cell selections & focus, we can use this event to mount editors" — and that separation is
+     * what made `grid.View` the single focus anchor in the first place.
+     * @param {Object} data
+     * @returns {Promise<void>}
+     */
+    async onTableKeyDown(data) {
+        let me             = this,
+            {view}         = me.owner,
+            selectionModel = view?.selectionModel,
+            cellId, dataField, record;
+
+        // A row/column model marks no cell, so there is nothing for an editor to cover. Declining is
+        // correct; it is the SILENT decline that was the defect.
+        if (me.mountedEditor || !selectionModel?.hasSelection?.()) {
+            return
+        }
+
+        cellId    = selectionModel.items[0];
+        record    = selectionModel.getRecord?.(cellId);
+        dataField = view.getDataField(cellId);
+
+        record && dataField && await me.mountEditor(record, dataField)
+    }
 }
 
 export default Neo.setupClass(CellEditing);

--- a/src/grid/plugin/CellEditing.mjs
+++ b/src/grid/plugin/CellEditing.mjs
@@ -31,12 +31,7 @@ class CellEditing extends BaseCellEditing {
     }
 
     /**
-     * @summary The id of the DOM cell an editor must cover, translated into the grid's contract.
-     *
-     * `grid.Body#getCellId()` takes a **row index**, not a record: a grid's cell ids are pool-slot
-     * based (`…__row-{index % poolSize}`), because rows are recycled as the viewport moves. The
-     * inherited call passed the table's record straight through, so the modulo produced `NaN`, the
-     * id matched no node, and no editor could mount by ANY gesture.
+     * `grid.Body#getCellId()` takes a row INDEX, not a record — grid cell ids are pool-slot based.
      * @param {Object} record
      * @param {String} dataField
      * @returns {String}
@@ -49,13 +44,7 @@ class CellEditing extends BaseCellEditing {
     }
 
     /**
-     * @summary The View, which is where a grid's keys belong.
-     *
-     * `grid.View` is the single focus anchor — the only element in a grid that declares `tabindex` —
-     * and its own docs name it "the single key registry, the keyboard half of" that contract.
-     * `selection.grid.CellModel` and `ColumnModel` already register there. The inherited body
-     * registration could never fire: `Neo.manager.DomEvent` walks the event path UPWARD, and the
-     * bodies are the View's descendants, so a keydown targeted at the View never reaches them.
+     * `grid.View` is the grid's key registry, as `selection.grid.CellModel` and `ColumnModel` use.
      * @returns {Neo.component.Base}
      * @protected
      */
@@ -64,17 +53,8 @@ class CellEditing extends BaseCellEditing {
     }
 
     /**
-     * @summary Opens an editor over the SELECTED cell, resolved from the selection model.
-     *
-     * The inherited implementation guards on `data.target.cls?.includes('neo-selected')` — the
-     * keydown's target, i.e. whatever holds focus. On a grid that is always the View, and
-     * `neo-selected` is on the CELL, so the guard could never hold. Selection is the question being
-     * asked, so it is asked of the selection model: the same `hasSelection()` / `items[0]` /
-     * `getRecord()` / `getDataField()` accessors `CellModel#onNavKeyColumn` navigates with.
-     *
-     * The base's own `onSelectionChange` carries a `todo` anticipating this — "Once we separate
-     * cell selections & focus, we can use this event to mount editors" — and that separation is
-     * what made `grid.View` the single focus anchor in the first place.
+     * Opens an editor over the selected cell. The base reads the keydown target, which on a grid is
+     * always the View; `neo-selected` is on the cell, so selection is asked of the selection model.
      * @param {Object} data
      * @returns {Promise<void>}
      */
@@ -84,8 +64,6 @@ class CellEditing extends BaseCellEditing {
             selectionModel = view?.selectionModel,
             cellId, dataField, record;
 
-        // A row/column model marks no cell, so there is nothing for an editor to cover. Declining is
-        // correct; it is the SILENT decline that was the defect.
         if (me.mountedEditor || !selectionModel?.hasSelection?.()) {
             return
         }

--- a/src/table/plugin/CellEditing.mjs
+++ b/src/table/plugin/CellEditing.mjs
@@ -70,11 +70,43 @@ class CellEditing extends Plugin {
             me.onSelectionModelChange({value: selectionModel})
         }
 
-        owner.body.keys.add({
+        me.getKeyRegistryOwner().keys.add({
             Enter: 'onTableKeyDown',
             Space: 'onTableKeyDown',
             scope: me
         })
+    }
+
+    /**
+     * @summary Hook: the component whose `keys` registry the activation keystrokes belong on.
+     *
+     * The body, because a `table.Body`'s `tbody` carries `tabIndex:-1` and is therefore the element
+     * that holds focus when a keystroke arrives. `Neo.manager.DomEvent` routes by walking the event
+     * path UPWARD, so a listener only ever fires for a component on the target's ancestor path —
+     * which makes "where focus lives" and "where the keys belong" the same question.
+     *
+     * A subclass whose focus owner is NOT the body must say so; `Neo.grid.plugin.CellEditing` does.
+     * @returns {Neo.component.Base}
+     * @protected
+     */
+    getKeyRegistryOwner() {
+        return this.owner.body
+    }
+
+    /**
+     * @summary Hook: the id of the DOM cell an editor must be mounted over.
+     *
+     * Deliberately asked of the plugin rather than read straight off the body, because
+     * `getCellId()` does not mean the same thing in both Body classes: `table.Body#getCellId()`
+     * takes a **record**, while `grid.Body#getCellId()` takes a **row index** (its cell ids are
+     * pool-slot based). Calling one contract on the other yields an id that resolves to no node.
+     * @param {Object} record
+     * @param {String} dataField
+     * @returns {String}
+     * @protected
+     */
+    getEditorCellId(record, dataField) {
+        return this.owner.body.getCellId(record, dataField)
     }
 
     /**
@@ -111,12 +143,21 @@ class CellEditing extends Plugin {
         let me                  = this,
             {appName, windowId} = me,
             {body}              = me.owner,
-            cellId              = body.getCellId(record, dataField),
-            cellNode            = VdomUtil.find(body.vdom, cellId).vdom,
+            cellId              = me.getEditorCellId(record, dataField),
+            cellNode            = VdomUtil.find(body.vdom, cellId)?.vdom,
             column              = me.owner.headerToolbar.getColumn(dataField),
             editor              = me.editors[dataField],
             value               = record[dataField],
             keys;
+
+        // A cell id that resolves to no node is the failure this plugin used to have and could not
+        // report: the editor simply never appeared. Surfaced rather than thrown, matching the
+        // engine's own boundary idiom — an unmountable editor must not take the gesture down with
+        // it, but it must stop being invisible.
+        if (!cellNode) {
+            console.error(`${me.className}: no cell node for "${cellId}" — getEditorCellId() disagrees with the body's id scheme`, {dataField, record});
+            return
+        }
 
         if (me.mountedEditor) {
             await me.unmountEditor();

--- a/src/table/plugin/CellEditing.mjs
+++ b/src/table/plugin/CellEditing.mjs
@@ -32,6 +32,15 @@ class CellEditing extends Plugin {
          */
         editorCls: ['neo-table-editor'],
         /**
+         * @summary Whether dismissing an editor hands focus back to the cell it covered.
+         *
+         * The post-dismissal RESTORE only — it does not establish focus, and nothing consults it
+         * before an editor mounts. Its single use is in {@link #selectCell}, which runs from
+         * {@link #onEditorKeyEnter} and {@link #onEditorKeyEscape}, i.e. after an editor closes.
+         *
+         * Spelled out because the name reads like the opposite. On a surface whose cells are not
+         * focusable at all — a grid, where the View is the sole element declaring `tabindex` — this
+         * config being `true` says nothing about where a keystroke will land.
          * @member {Boolean} focusCells=true
          */
         focusCells: true

--- a/src/table/plugin/CellEditing.mjs
+++ b/src/table/plugin/CellEditing.mjs
@@ -32,15 +32,8 @@ class CellEditing extends Plugin {
          */
         editorCls: ['neo-table-editor'],
         /**
-         * @summary Whether dismissing an editor hands focus back to the cell it covered.
-         *
-         * The post-dismissal RESTORE only — it does not establish focus, and nothing consults it
-         * before an editor mounts. Its single use is in {@link #selectCell}, which runs from
-         * {@link #onEditorKeyEnter} and {@link #onEditorKeyEscape}, i.e. after an editor closes.
-         *
-         * Spelled out because the name reads like the opposite. On a surface whose cells are not
-         * focusable at all — a grid, where the View is the sole element declaring `tabindex` — this
-         * config being `true` says nothing about where a keystroke will land.
+         * Restores focus to the cell after an editor is dismissed (`selectCell`). It does NOT
+         * establish focus, and nothing reads it before an editor mounts.
          * @member {Boolean} focusCells=true
          */
         focusCells: true
@@ -87,14 +80,9 @@ class CellEditing extends Plugin {
     }
 
     /**
-     * @summary Hook: the component whose `keys` registry the activation keystrokes belong on.
-     *
-     * The body, because a `table.Body`'s `tbody` carries `tabIndex:-1` and is therefore the element
-     * that holds focus when a keystroke arrives. `Neo.manager.DomEvent` routes by walking the event
-     * path UPWARD, so a listener only ever fires for a component on the target's ancestor path —
-     * which makes "where focus lives" and "where the keys belong" the same question.
-     *
-     * A subclass whose focus owner is NOT the body must say so; `Neo.grid.plugin.CellEditing` does.
+     * Hook: the component whose `keys` registry the activation keystrokes belong on — the body,
+     * because `table.Body`'s `tbody` is the focus owner. A subclass whose focus owner differs
+     * overrides this; `Neo.grid.plugin.CellEditing` does.
      * @returns {Neo.component.Base}
      * @protected
      */
@@ -103,12 +91,8 @@ class CellEditing extends Plugin {
     }
 
     /**
-     * @summary Hook: the id of the DOM cell an editor must be mounted over.
-     *
-     * Deliberately asked of the plugin rather than read straight off the body, because
-     * `getCellId()` does not mean the same thing in both Body classes: `table.Body#getCellId()`
-     * takes a **record**, while `grid.Body#getCellId()` takes a **row index** (its cell ids are
-     * pool-slot based). Calling one contract on the other yields an id that resolves to no node.
+     * Hook: the id of the DOM cell an editor must cover. Asked of the plugin because `getCellId()`
+     * takes a record in `table.Body` and a row index in `grid.Body`.
      * @param {Object} record
      * @param {String} dataField
      * @returns {String}
@@ -159,10 +143,8 @@ class CellEditing extends Plugin {
             value               = record[dataField],
             keys;
 
-        // A cell id that resolves to no node is the failure this plugin used to have and could not
-        // report: the editor simply never appeared. Surfaced rather than thrown, matching the
-        // engine's own boundary idiom — an unmountable editor must not take the gesture down with
-        // it, but it must stop being invisible.
+        // An unresolvable cell id means the hook and the body's id scheme disagree — report it
+        // rather than continue into an editor that never appears.
         if (!cellNode) {
             console.error(`${me.className}: no cell node for "${cellId}" — getEditorCellId() disagrees with the body's id scheme`, {dataField, record});
             return

--- a/test/playwright/component/apps/grid-cell-editing/app.mjs
+++ b/test/playwright/component/apps/grid-cell-editing/app.mjs
@@ -1,0 +1,83 @@
+import CellModel     from '../../../../../src/selection/grid/CellModel.mjs';
+import GridContainer from '../../../../../src/grid/Container.mjs';
+import Model         from '../../../../../src/data/Model.mjs';
+import Store         from '../../../../../src/data/Store.mjs';
+import Viewport      from '../../../../../src/container/Viewport.mjs';
+
+/**
+ * @summary Fixture for the grid cell-editing KEY contract.
+ *
+ * `grid.plugin.CellEditing` offers two activation gestures, and only one of them had a witness. A
+ * double-click calls `mountEditor` directly; `Enter` and `Space` route through a key registration,
+ * and that half is what this fixture exists to exercise. A real pointer plus a real keystroke is the
+ * only instrument that can tell them apart, because the difference lives in which element holds DOM
+ * focus when the keydown is dispatched — `grid.View` is the single focus anchor (the sole element in
+ * a grid that declares `tabindex`), and `neo-selected` lands on the CELL.
+ *
+ * `body.selectionModel` is a `CellModel` deliberately: cell editing addresses a cell, and the row
+ * models never mark one, so a row model would make every arm here vacuous rather than red.
+ *
+ * One editable column and one that is not, so the refusal is a control rather than an assumption:
+ * `mountEditor` returns early on `!column.editable`, and an arm that only ever saw editable columns
+ * could not distinguish "declined correctly" from "never fired".
+ * @class Neo.test.playwright.GridCellEditingModel
+ * @extends Neo.data.Model
+ */
+class GridCellEditingModel extends Model {
+    static config = {
+        className: 'Neo.test.playwright.GridCellEditingModel',
+        fields   : [
+            {name: 'id',    type: 'Integer'},
+            {name: 'name',  type: 'String'},
+            {name: 'score', type: 'Integer'}
+        ]
+    }
+}
+
+GridCellEditingModel = Neo.setupClass(GridCellEditingModel);
+
+const store = Neo.setupClass(class extends Store {
+    static config = {
+        className  : 'Neo.test.playwright.GridCellEditingStore',
+        keyProperty: 'id',
+        model      : GridCellEditingModel,
+
+        data: Array.from({length: 6}, (_, i) => ({
+            id   : i + 1,
+            name : `Name ${i + 1}`,
+            score: (i * 17) % 100
+        }))
+    }
+});
+
+export const onStart = () => Neo.app({
+    mainView: {
+        module: Viewport,
+        layout: {ntype: 'vbox', align: 'stretch'},
+
+        items: [{
+            module     : GridContainer,
+            id         : 'grid-cell-editing',
+            cellEditing: true,
+            flex       : 1,
+            store,
+
+            body: {
+                selectionModel: CellModel
+            },
+
+            columnDefaults: {
+                width: 200
+            },
+
+            columns: [
+                {dataField: 'id',    text: '#',     width: 60},
+                {dataField: 'name',  text: 'Name',  editable: true},
+                // No editor config: `mountEditor` defaults to a `TextField`, which is the shape a
+                // consumer gets for a plain string column and therefore the one worth covering.
+                {dataField: 'score', text: 'Score', editable: false}
+            ]
+        }]
+    },
+    name: 'Test.Playwright.GridCellEditing'
+});

--- a/test/playwright/component/apps/grid-cell-editing/index.html
+++ b/test/playwright/component/apps/grid-cell-editing/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Neo.mjs Grid Cell Editing Test App</title>
+</head>
+<body>
+    <script src="../../../../../src/MicroLoader.mjs" type="module"></script>
+</body>
+</html>

--- a/test/playwright/component/apps/grid-cell-editing/neo-config.json
+++ b/test/playwright/component/apps/grid-cell-editing/neo-config.json
@@ -1,0 +1,9 @@
+{
+    "appPath"         : "test/playwright/component/apps/grid-cell-editing/app.mjs",
+    "basePath"        : "../../../../../",
+    "environment"     : "development",
+    "mainPath"        : "./Main.mjs",
+    "mainThreadAddons": ["DragDrop", "Navigator", "ResizeObserver", "Stylesheet"],
+    "themes"          : ["neo-theme-neo-dark", "neo-theme-neo-light"],
+    "useSharedWorkers": false
+}

--- a/test/playwright/component/apps/table-cell-editing/app.mjs
+++ b/test/playwright/component/apps/table-cell-editing/app.mjs
@@ -1,0 +1,73 @@
+import CellModel      from '../../../../../src/selection/table/CellModel.mjs';
+import Model          from '../../../../../src/data/Model.mjs';
+import Store          from '../../../../../src/data/Store.mjs';
+import TableContainer from '../../../../../src/table/Container.mjs';
+import Viewport       from '../../../../../src/container/Viewport.mjs';
+
+/**
+ * @summary Fixture for the TABLE half of the cell-editing contract, as a regression guard.
+ *
+ * `table.plugin.CellEditing` is the only implementation; `grid.plugin.CellEditing` inherits it.
+ * The base's cell-id lookup and key-registry target are hooks so the grid variant can answer them
+ * differently, and the table is the surface those hooks default to.
+ *
+ * So this exists to prove the default path still works, behaviourally rather than by reading the
+ * diff. The table previously had no cell-editing coverage at all, which is part of how a
+ * three-way break in the grid variant survived unnoticed.
+ *
+ * `bodyConfig` rather than `body`: that is the table's own config name for it.
+ * @class Neo.test.playwright.TableCellEditingModel
+ * @extends Neo.data.Model
+ */
+class TableCellEditingModel extends Model {
+    static config = {
+        className: 'Neo.test.playwright.TableCellEditingModel',
+        fields   : [
+            {name: 'id',    type: 'Integer'},
+            {name: 'name',  type: 'String'},
+            {name: 'score', type: 'Integer'}
+        ]
+    }
+}
+
+TableCellEditingModel = Neo.setupClass(TableCellEditingModel);
+
+const store = Neo.setupClass(class extends Store {
+    static config = {
+        className  : 'Neo.test.playwright.TableCellEditingStore',
+        keyProperty: 'id',
+        model      : TableCellEditingModel,
+
+        data: Array.from({length: 6}, (_, i) => ({
+            id   : i + 1,
+            name : `Name ${i + 1}`,
+            score: (i * 17) % 100
+        }))
+    }
+});
+
+export const onStart = () => Neo.app({
+    mainView: {
+        module: Viewport,
+        layout: {ntype: 'vbox', align: 'stretch'},
+
+        items: [{
+            module     : TableContainer,
+            id         : 'table-cell-editing',
+            cellEditing: true,
+            flex       : 1,
+            store,
+
+            bodyConfig: {
+                selectionModel: CellModel
+            },
+
+            columns: [
+                {dataField: 'id',    text: '#',     width: 60},
+                {dataField: 'name',  text: 'Name',  editable: true,  width: 200},
+                {dataField: 'score', text: 'Score', editable: false, width: 120}
+            ]
+        }]
+    },
+    name: 'Test.Playwright.TableCellEditing'
+});

--- a/test/playwright/component/apps/table-cell-editing/index.html
+++ b/test/playwright/component/apps/table-cell-editing/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Neo.mjs Table Cell Editing Test App</title>
+</head>
+<body>
+    <script src="../../../../../src/MicroLoader.mjs" type="module"></script>
+</body>
+</html>

--- a/test/playwright/component/apps/table-cell-editing/neo-config.json
+++ b/test/playwright/component/apps/table-cell-editing/neo-config.json
@@ -1,0 +1,9 @@
+{
+    "appPath"         : "test/playwright/component/apps/table-cell-editing/app.mjs",
+    "basePath"        : "../../../../../",
+    "environment"     : "development",
+    "mainPath"        : "./Main.mjs",
+    "mainThreadAddons": ["DragDrop", "Navigator", "ResizeObserver", "Stylesheet"],
+    "themes"          : ["neo-theme-neo-dark", "neo-theme-neo-light"],
+    "useSharedWorkers": false
+}

--- a/test/playwright/component/grid/CellEditingKeys.spec.mjs
+++ b/test/playwright/component/grid/CellEditingKeys.spec.mjs
@@ -126,7 +126,16 @@ test.describe('grid cell editing — the key activation contract', () => {
     });
 
     test('control: Enter with nothing selected mounts nothing', async ({page}) => {
-        await page.locator(`${GRID} .neo-grid-view`).first().click({position: {x: 2, y: 2}});
+        const view = page.locator(`${GRID} .neo-grid-view`).first(),
+              box  = await view.boundingBox();
+
+        // Below the last row: {x: 2, y: 2} lands on the first row's `id` cell, which SELECTS it —
+        // so the arm would pass for the non-editable-column reason the previous arm already covers.
+        await view.click({position: {x: 4, y: box.height - 8}});
+
+        await expect(page.locator(`${GRID} .neo-selected`), 'the click must select nothing, or this arm is not about an empty selection')
+            .toHaveCount(0);
+
         await page.keyboard.press('Enter');
 
         await expect(page.locator(EDITOR), 'no selection means no editor').toHaveCount(0)

--- a/test/playwright/component/grid/CellEditingKeys.spec.mjs
+++ b/test/playwright/component/grid/CellEditingKeys.spec.mjs
@@ -1,0 +1,134 @@
+import {test, expect} from '@playwright/test';
+
+/**
+ * `grid.plugin.CellEditing` offers two activation gestures and only one of them worked.
+ *
+ * A double-click reaches `mountEditor` directly. `Enter` and `Space` route through a key
+ * registration, and on a grid that path is dead — for two independent reasons, either of which
+ * alone is sufficient:
+ *
+ * 1. **The registration is on the wrong component.** `table.plugin.CellEditing` does
+ *    `owner.body.keys.add({Enter: 'onTableKeyDown', …})`. `Neo.manager.DomEvent` routes a DOM event
+ *    by walking its path UPWARD (`ComponentManager.getParentPath`), so a component's listener fires
+ *    only when that component is on the target's ancestor path. Focus lives on `grid.View` and the
+ *    bodies are its DESCENDANTS, so a body listener is never on the path.
+ * 2. **The guard reads focus, not selection.** `onTableKeyDown` opens an editor only when
+ *    `target.cls?.includes('neo-selected')` — the target being the focused element. `neo-selected`
+ *    lands on the CELL, and a grid cell is not focusable: measured in a real browser, exactly ONE
+ *    element inside a grid container declares `tabindex`, and it is `grid.View`.
+ *
+ * Both are inherited rather than authored: the base is correct for `table.Body`, whose `tbody`
+ * carries `tabIndex:-1` and IS the focus owner. `grid.View.mjs` already declares the right home —
+ * *"grid.View is the single key registry, the keyboard half of"* the View-owned focus contract — and
+ * `selection.grid.CellModel` / `ColumnModel` both comply by pushing onto `view.keys._keys`.
+ * `CellEditing` is the only key registration in the grid stack aimed at the body.
+ *
+ * **The controls are the load-bearing part of this spec.** A single red arm cannot distinguish "the
+ * key path is broken" from "the editor never works", "the fixture has no editable column", or "focus
+ * is broken" — and a grid click failing to move focus has been a real defect of its own. So the double-click
+ * arm, the focus arm and the selection arm all pass BEFORE and after the fix, and pin the failure to
+ * the keys alone.
+ *
+ * Run: npm run test-components -- grid/CellEditingKeys
+ */
+const GRID   = '#grid-cell-editing',
+      NAME   = '[data-field="name"]',
+      EDITOR = '.neo-grid-editor input';
+
+const activeElementId = page => page.evaluate(() => document.activeElement?.id || document.activeElement?.tagName);
+
+const viewIdOf = page => page.locator(`${GRID} .neo-grid-view`).first().getAttribute('id');
+
+/**
+ * The first row's Name cell — addressed by its `data-field`, never by DOM order or by a cell id.
+ * `.neo-grid-cell` first() is a pooled cell of whichever column renders first, and the DOM id is
+ * pool-slot based (`…__row-0__cell-0`), so neither identifies a column. `grid.Row` stamps
+ * `data: {field: dataField, recordId}` on every cell, which is the only stable column handle.
+ * @param {import('@playwright/test').Page} page
+ * @returns {import('@playwright/test').Locator}
+ */
+const nameCell = page => page.locator(`${GRID} .neo-grid-row`).first().locator(NAME).first();
+
+test.beforeEach(async ({page}) => {
+    await page.goto('test/playwright/component/apps/grid-cell-editing/index.html');
+    await page.waitForSelector(`${GRID} .neo-grid-row`, {state: 'visible', timeout: 30000})
+});
+
+// The plugin is lazily imported by `afterSetCellEditing`, so every arm below assumes it is live.
+// That assumption is witnessed by the double-click control rather than by a config read: a mounted
+// editor proves the plugin armed AND that its editor path works, where `plugins.length >= 1` would
+// only prove something was installed.
+
+test.describe('grid cell editing — the key activation contract', () => {
+    test('control: a click lands focus on the View, which is the only focusable element in the grid', async ({page}) => {
+        await nameCell(page).click();
+
+        expect(await activeElementId(page), 'the View is the grid\'s single focus anchor')
+            .toBe(await viewIdOf(page));
+
+        // Stated as a measurement rather than an assumption, because the whole defect turns on it.
+        const declaring = await page.evaluate(sel => [...document.querySelectorAll(`${sel} [tabindex]`)]
+            .map(el => el.className.split(' ')[0]), GRID);
+
+        expect(declaring, 'exactly one element in a grid declares tabindex, and it is the View')
+            .toEqual(['neo-grid-view'])
+    });
+
+    test('control: the click marks the CELL selected, which is where neo-selected lives', async ({page}) => {
+        await nameCell(page).click();
+        await expect(nameCell(page), 'a CellModel marks the clicked cell').toHaveClass(/neo-selected/)
+    });
+
+    test('control: a double-click mounts the editor, so the plugin and the editor path both work', async ({page}) => {
+        const cell  = nameCell(page),
+              value = (await cell.innerText()).trim();
+
+        await cell.dblclick();
+
+        await expect(page.locator(EDITOR), 'onCellDoubleClick reaches mountEditor directly').toBeVisible({timeout: 10000});
+        await expect(page.locator(EDITOR)).toHaveValue(value)
+    });
+
+    test('Enter on a selected cell mounts the editor', async ({page}) => {
+        const cell  = nameCell(page),
+              value = (await cell.innerText()).trim();
+
+        await cell.click();
+        await expect(cell).toHaveClass(/neo-selected/);
+
+        await page.keyboard.press('Enter');
+
+        await expect(page.locator(EDITOR), 'Enter must reach the cell-editing plugin').toBeVisible({timeout: 10000});
+        await expect(page.locator(EDITOR)).toHaveValue(value)
+    });
+
+    test('Space on a selected cell mounts the editor, since it is registered on the same handler', async ({page}) => {
+        const cell = nameCell(page);
+
+        await cell.click();
+        await expect(cell).toHaveClass(/neo-selected/);
+
+        await page.keyboard.press('Space');
+
+        await expect(page.locator(EDITOR), 'Space is registered alongside Enter on onTableKeyDown').toBeVisible({timeout: 10000})
+    });
+
+    test('control: Enter on a non-editable column mounts nothing', async ({page}) => {
+        const score = page.locator(`${GRID} .neo-grid-row`).first().locator('[data-field="score"]').first();
+
+        await score.click();
+        await expect(score).toHaveClass(/neo-selected/);
+        await page.keyboard.press('Enter');
+
+        // `mountEditor` returns early on `!column.editable`. Asserted so a fix cannot buy Enter by
+        // opening an editor over every column.
+        await expect(page.locator(EDITOR), 'a non-editable column stays non-editable').toHaveCount(0)
+    });
+
+    test('control: Enter with nothing selected mounts nothing', async ({page}) => {
+        await page.locator(`${GRID} .neo-grid-view`).first().click({position: {x: 2, y: 2}});
+        await page.keyboard.press('Enter');
+
+        await expect(page.locator(EDITOR), 'no selection means no editor').toHaveCount(0)
+    })
+});

--- a/test/playwright/component/table/CellEditing.spec.mjs
+++ b/test/playwright/component/table/CellEditing.spec.mjs
@@ -1,0 +1,62 @@
+import {test, expect} from '@playwright/test';
+
+/**
+ * The TABLE half of the cell-editing contract — a regression guard for the change that turned two
+ * of the shared base's assumptions into hooks.
+ *
+ * `table.plugin.CellEditing` is the only implementation of cell editing; `grid.plugin.CellEditing`
+ * is 34 lines of config on top of it. Two of the base's assumptions are hooks — the cell-id lookup
+ * and the key-registry target — because `getCellId()` means a **record** in
+ * `table.Body` and a **row index** in `grid.Body`, and the base was calling the table's contract on
+ * both. The table is what those hooks default to, so it is the surface a refactor could silently
+ * break while every grid arm went green.
+ *
+ * Asserted behaviourally rather than by reading the diff, and stated plainly: the table previously
+ * had **no** cell-editing coverage, which is part of how a three-way break in the grid variant
+ * survived. The double-click arm is the one that matters here — it is the gesture that worked on the
+ * grid's broken plugin only because it never consulted focus, so it is the least-guarded path.
+ *
+ * Run: npm run test-components -- table/CellEditing
+ */
+const TABLE  = '#table-cell-editing',
+      NAME   = '[id$="__name"]',
+      EDITOR = '.neo-table-editor input';
+
+/**
+ * Addressed by cell ID, and that difference from the grid is the defect's own signature: a table
+ * cell id is `{bodyId}__{recordId}__{dataField}` (`table.Body#getCellId`), while a grid cell id is
+ * pool-slot based and carries its column in a `data-field` attribute instead. The same divergence
+ * that made the shared plugin's lookup fail is visible right here in the two DOMs.
+ * @param {import('@playwright/test').Page} page
+ * @returns {import('@playwright/test').Locator}
+ */
+const nameCell = page => page.locator(`${TABLE} tbody tr`).first().locator(NAME).first();
+
+test.beforeEach(async ({page}) => {
+    await page.goto('test/playwright/component/apps/table-cell-editing/index.html');
+    await page.waitForSelector(`${TABLE} tbody tr`, {state: 'visible', timeout: 30000})
+});
+
+test.describe('table cell editing — the base the grid inherits', () => {
+    test('a double-click mounts the editor over the cell, with its value', async ({page}) => {
+        const cell  = nameCell(page),
+              value = (await cell.innerText()).trim();
+
+        await cell.dblclick();
+
+        const editor = page.locator(EDITOR).first();
+
+        await expect(editor, 'the default cell-id hook still resolves a table cell').toBeVisible({timeout: 10000});
+        await expect(editor).toHaveValue(value)
+    });
+
+    test('a non-editable column mounts nothing, so the hook did not widen the surface', async ({page}) => {
+        const score = page.locator(`${TABLE} tbody tr`).first().locator('[id$="__score"]').first();
+
+        await score.dblclick();
+
+        // `mountEditor` returns early on `!column.editable`. This is the arm that would catch a
+        // "fix" that bought editing by opening an editor over every column.
+        await expect(page.locator(EDITOR), 'editable:false is still respected').toHaveCount(0)
+    })
+});


### PR DESCRIPTION
Resolves #18217

🌿 Three stacked breaks, each sufficient alone, made an editor that never appeared look like a grid with nothing to edit; what this makes unsayable is that the silence was the absence of a defect.

## What

`grid.plugin.CellEditing` could not mount an editor by **any** gesture — not double-click, not `Enter`, not `Space`. The engine ships `examples/grid/cellEditing/` (`cellEditing: true`, editable columns, editors) and it did nothing. There was no test anywhere: before this branch nothing under `test/playwright/**` referenced `onTableKeyDown`, `CellEditing` or `neo-grid-editor`.

Three breaks, all **inherited** from the table base rather than authored:

**1. `getCellId()` means different things in the two Body classes, and the shared plugin called the table's.**

| | signature |
|---|---|
| `table.Body#getCellId` | `@param {Object} record` |
| `grid.Body#getCellId` | `@param {Number} rowIndex` |

`mountEditor` did `body.getCellId(record, dataField)`. On a grid that hands a record object where a row index is expected, `` `…__row-${rowIndex % poolSize}` `` computes `NaN`, the id matches no node, and there is no cell for an editor to cover. **This alone killed every gesture** — including double-click, which is why the ticket's original keyboard-only framing was wrong.

**2. The activation keys were registered where a keydown never arrives.** `owner.body.keys.add({Enter, Space})`, but `manager.DomEvent` routes by walking the event path **upward** (`ComponentManager.getParentPath`), and the bodies are `grid.View`'s **descendants**. `grid/View.mjs` already declares the View the single key registry, and `selection.grid.CellModel` / `ColumnModel` both comply — this plugin was the only holdout.

**3. The guard read focus where it meant selection.** `target.cls?.includes('neo-selected')`, with `target` the focused element and `neo-selected` on the cell. Measured in a real browser: exactly **one** element inside a grid container declares `tabindex`, and it is `grid.View`.

## How

The base gains two hooks whose defaults are what it already did, so the table's path is unchanged **by construction**:

- `getEditorCellId(record, dataField)` → `owner.body.getCellId(record, dataField)`
- `getKeyRegistryOwner()` → `owner.body`

The grid answers all three differently: it translates record → row index for the lookup, registers on `view.keys`, and resolves the target cell from the View-owned selection model with the same accessors `CellModel#onNavKeyColumn` navigates with (`hasSelection()`, `items[0]`, `getRecord()`, `view.getDataField()`).

The base also **stops failing silently**. A cell id resolving to no node was precisely this bug and it was invisible; it now reports the disagreement and declines, instead of continuing into an editor that never appears.

Evidence: L3 (component-project browser runs, red-first and after, plus a by-hand check of the shipped example) → L3 required (every AC is a browser-observable behaviour reachable in-sandbox). Residual: none. Residual-Owner: n/a.

## AC Evidence

| AC (#18217, in order) | evidence |
|---|---|
| AC-1 — double-click mounts the editor with the cell's value; red-first | `CellEditingKeys.spec.mjs` arm 3. **Red at `ca83102346`**, green after. This arm is a CONTROL and its failure is what exposed break 1 |
| AC-2 — `Enter` on a selected editable cell mounts the editor; red-first | arm 4. Red at `ca83102346`, green after |
| AC-3 — `Space` behaves as `Enter` | arm 5, covered rather than declared out of scope. Red at `ca83102346`, green after |
| AC-4 — the `getCellId` divergence is resolved and the **table is proven unchanged by its own arm** | the two base hooks default to the prior behaviour; `component/table/CellEditing.spec.mjs` is the table's **first** cell-editing coverage and asserts the default path behaviourally, not by reading the diff — 2 passed |
| AC-5 — a non-editable column and an empty selection each mount nothing, asserted **after** the fix | arms 6 and 7. Both passed before the fix **vacuously** (nothing mounted at all, so neither could go red); they are meaningful only now that an editor can mount, which is why the AC demanded the post-fix reading |
| AC-6 — the focus contract asserted as a control | arm 1: a click lands focus on `grid.View`, and the arm **measures** that exactly one element in the grid declares `tabindex`. Distinguishes this from the neighbouring "a grid click moves no focus" defect |
| AC-7 — `focusCells`' JSDoc states it governs the post-dismissal restore only | `745b15be2d` — its single use is in `selectCell`, called from `onEditorKeyEnter`/`onEditorKeyEscape` |
| AC-8 — the shipped example exercised by eye and reported working | `examples/grid/cellEditing/`: a double-click on the "Tobias" cell mounts an editor holding `"Tobias"`, observed in a real browser against the patched source |

## Test Evidence

- `component/grid/CellEditingKeys.spec.mjs` — 7 arms. **Red-first at `ca83102346`: 4 passed / 3 failed**, the three failures being double-click, `Enter` and `Space`. **After: 7 passed.**
- `component/table/CellEditing.spec.mjs` — 2 passed. The table's first cell-editing coverage.
- Both specs together at the committed content: **9 passed**.
- Grid component suite: **14 passed**, no regressions.
- Full component project: **243 arms, all passing** on the committed tree.

## Deltas

Two, both beyond what the ticket prescribed:

1. **A loud failure where there was a silent one.** The ticket asked for the three breaks fixed. `mountEditor` now reports a cell id that resolves to no node and declines, rather than proceeding into an invisible editor. Surfaced via `console.error` rather than thrown, matching the engine's boundary idiom — an unmountable editor must not take the gesture down with it, but it must stop being invisible. This is the check that would have caught break 1 on day one.
2. **The table gained coverage the ticket only asked me to preserve.** AC-4 wanted the table proven unchanged. The honest way to prove that was an arm, and there was none to extend — so the table now has its first cell-editing spec, which also guards the two new hooks' defaults for whoever touches them next.

Ticket-intake note: exempt under the self-authored carve — I authored #18217 in this same session and context, so `ticket-create`'s six-stage chain had already run here. The drift probe is not applicable.

## Post-Merge Validation

- [ ] `examples/grid/cellEditing/` on the merged `dev`: double-click, `Enter` and `Space` each open an editor, and `Escape` leaves the record alone.
- [ ] The `table` example still edits, since the base hooks are shared.

## Notes for the reviewer

The double-click arm is the load-bearing part of the spec, not the `Enter` arm. I filed this ticket as a keyboard defect and was wrong: had I shipped fixes for breaks 2 and 3 without a control that was *supposed to pass*, the path would still have been dead and I would have concluded confidently that it worked.

Worth knowing while reading the base: `onSelectionChange` is an empty handler carrying a `todo` that anticipated break 3 — "Once we separate cell selections & focus, we can use this event to mount editors". That separation is what made `grid.View` the single focus anchor. The precondition was met and nobody returned to it; acting on the todo's larger design is deliberately **not** in this PR.

Authored by Vega (Opus 5, Claude Code). Session e8ea32a2-b9a8-43ea-84ba-b83081ec4b3d.
