### PR TITLE
fix(build): the alarm body names the axis that fired, not a fixed sentence (#18229)

### DIFF
--- a/buildScripts/dataSyncWatchdog.mjs
+++ b/buildScripts/dataSyncWatchdog.mjs
@@ -414,7 +414,9 @@ export function buildAlarmBody({consecutiveFailures, lastSuccess, latestFailure,
         '',
         breachedAxes.length > 0
             ? `**Breached axes:** ${breachedAxes.join('; and ')}. The two are measured separately and neither implies the other.`
-            : 'The pipeline is degrading silently and nothing else surfaces it.',
+            : forced
+                ? '**Breached axes:** none — neither axis measured a breach.'
+                : 'The pipeline is degrading silently and nothing else surfaces it.',
         'Root-cause work (if any) is tracked elsewhere; this issue only carries the alarm.',
         forced ? '\n> This alarm was opened by a forced `workflow_dispatch` dry run — close it manually if the pipeline is in fact healthy.' : ''
     ].filter(line => line !== '').join('\n')

--- a/buildScripts/dataSyncWatchdog.mjs
+++ b/buildScripts/dataSyncWatchdog.mjs
@@ -385,6 +385,19 @@ export function buildAlarmBody({consecutiveFailures, lastSuccess, latestFailure,
         ].join('\n')
         : `**Corpus axis:** last \`resources/content/**\` commit on \`${branch}\`: ${corpusLastCommitAt ? `${corpusLastCommitAt} (${corpusAgeHours}h old)` : 'not measured'}. Deploys, fresh clones, CI, and container KB ingestion all build from committed \`${branch}\` — a green pipeline cannot attest to this backlog.`;
 
+    // The two axes breach independently, so the closing line is derived from the ones that fired
+    // rather than asserted. A sentence claiming failing runs describes the wrong outage whenever
+    // the corpus axis breaches alone: a zero streak reading above prose about failing runs sends
+    // the reader after a broken workflow instead of a dead producer.
+    //
+    // Read from the structured inputs, never by matching `reasons` prose — a containment check over
+    // sentences is a coincidence of wording standing in for a measurement.
+    const staleFacets  = (corpusFacets ?? []).filter(({stale}) => stale).map(({facet}) => `\`${facet}\``),
+          breachedAxes = [
+              consecutiveFailures > 0 && `runs are failing on schedule (${consecutiveFailures} consecutive)`,
+              staleFacets.length  > 0 && `the committed corpus is frozen (${staleFacets.join(', ')})`
+          ].filter(Boolean);
+
     return [
         ALARM_MARKER,
         '',
@@ -399,7 +412,9 @@ export function buildAlarmBody({consecutiveFailures, lastSuccess, latestFailure,
         '**Breach reasons:**',
         ...reasons.map(reason => `- ${reason}`),
         '',
-        'The pipeline is degrading silently: runs fail on schedule and nothing else surfaces it.',
+        breachedAxes.length > 0
+            ? `**Breached axes:** ${breachedAxes.join('; and ')}. The two are measured separately and neither implies the other.`
+            : 'The pipeline is degrading silently and nothing else surfaces it.',
         'Root-cause work (if any) is tracked elsewhere; this issue only carries the alarm.',
         forced ? '\n> This alarm was opened by a forced `workflow_dispatch` dry run — close it manually if the pipeline is in fact healthy.' : ''
     ].filter(line => line !== '').join('\n')

--- a/test/playwright/unit/buildScripts/DataSyncWatchdog.spec.mjs
+++ b/test/playwright/unit/buildScripts/DataSyncWatchdog.spec.mjs
@@ -492,7 +492,21 @@ test.describe('dataSyncWatchdog (#15948)', () => {
         });
 
         expect(both).toContain('runs are failing on schedule (18 consecutive)');
-        expect(both).toContain('the committed corpus is frozen')
+        expect(both).toContain('the committed corpus is frozen');
+
+        // Neither axis: a forced `workflow_dispatch` dry run on a healthy pipeline. Reachable and
+        // intentional, and the one quadrant where claiming degradation asserts what neither axis read.
+        const neither = buildAlarmBody({
+            consecutiveFailures: 0,
+            lastSuccess        : run('success', '2026-07-26T18:00:00Z'),
+            latestFailure      : null,
+            reasons            : ['forced breach evaluation (workflow_dispatch dry run)'],
+            corpusFacets       : [{facet: 'issues', lastCommitAt: '2026-07-26T10:00:00Z', ageHours: 2.0, stale: false}],
+            forced             : true
+        });
+
+        expect(neither).toContain('none — neither axis measured a breach');
+        expect(neither).not.toContain('degrading silently')
     });
 
     test('forced dispatch dry-run alarm body discloses its own provenance', () => {

--- a/test/playwright/unit/buildScripts/DataSyncWatchdog.spec.mjs
+++ b/test/playwright/unit/buildScripts/DataSyncWatchdog.spec.mjs
@@ -443,6 +443,58 @@ test.describe('dataSyncWatchdog (#15948)', () => {
         expect(body).toContain('| `discussions` | none visible | — | **STALE** |')
     });
 
+    test('buildAlarmBody: the closing line names the axes that fired, and never asserts failing runs on a zero streak (#17920)', () => {
+        // The corpus-only breach: a zero streak, and a frozen producer. The streak is the
+        // instrument, and the prose must not contradict it — a reader who trusts a sentence about
+        // failing runs goes looking for a broken workflow that is in fact green.
+        const corpusOnly = buildAlarmBody({
+            consecutiveFailures: 0,
+            lastSuccess        : run('success', '2026-07-26T00:17:01Z'),
+            latestFailure      : null,
+            reasons            : ['corpus facet `issues` is 190.9h old (threshold 48h)'],
+            corpusFacets       : [
+                {facet: 'issues', lastCommitAt: '2026-07-18T05:13:29Z', ageHours: 190.9, stale: true},
+                {facet: 'pulls', lastCommitAt: '2026-07-26T10:00:00Z', ageHours: 2.0, stale: false}
+            ]
+        });
+
+        // The shipped sentence is named literally, not paraphrased. A negative arm written only
+        // against the NEW wording goes green on the old source by wording mismatch rather than by
+        // axis-correctness — red for the wrong reason, and no guard against the regression at all.
+        expect(corpusOnly).not.toContain('runs fail on schedule');
+        expect(corpusOnly).not.toContain('runs are failing on schedule');
+        expect(corpusOnly).toContain('the committed corpus is frozen');
+        // Named, not merely counted: a fresh facet must not be swept into the breach.
+        expect(corpusOnly).toContain('`issues`');
+        expect(corpusOnly).not.toContain('frozen (`issues`, `pulls`)');
+
+        // The run-only breach. The mirror case, and the one the fixed sentence used to get right by
+        // luck: no corpus axis fired, so nothing may claim the corpus is frozen.
+        const runOnly = buildAlarmBody({
+            consecutiveFailures: 18,
+            lastSuccess        : run('success', '2026-07-26T00:17:01Z'),
+            latestFailure      : run('failure', '2026-07-26T18:26:19Z', 33790494207),
+            reasons            : ['18 consecutive failures (threshold 3)'],
+            corpusFacets       : [{facet: 'issues', lastCommitAt: '2026-07-26T10:00:00Z', ageHours: 2.0, stale: false}]
+        });
+
+        expect(runOnly).toContain('runs are failing on schedule (18 consecutive)');
+        expect(runOnly).not.toContain('the committed corpus is frozen');
+
+        // Both axes. They are measured separately and neither implies the other, so both must
+        // survive into the body rather than one standing in for the pair.
+        const both = buildAlarmBody({
+            consecutiveFailures: 18,
+            lastSuccess        : run('success', '2026-07-18T00:17:01Z'),
+            latestFailure      : run('failure', '2026-07-26T18:26:19Z', 33790494207),
+            reasons            : ['18 consecutive failures (threshold 3)', 'corpus facet `issues` is 190.9h old (threshold 48h)'],
+            corpusFacets       : [{facet: 'issues', lastCommitAt: '2026-07-18T05:13:29Z', ageHours: 190.9, stale: true}]
+        });
+
+        expect(both).toContain('runs are failing on schedule (18 consecutive)');
+        expect(both).toContain('the committed corpus is frozen')
+    });
+
     test('forced dispatch dry-run alarm body discloses its own provenance', () => {
         const body = buildAlarmBody({
             consecutiveFailures: 0,


### PR DESCRIPTION
Resolves #18229

The Data Sync alarm closed every breach with one hardcoded sentence — *"The pipeline is degrading silently: runs fail on schedule and nothing else surfaces it."* — a claim about the run axis, printed without consulting it. When only the corpus axis breached, the alarm asserted failing runs directly beneath its own contradicting measurement (`Streak: 0 consecutive failures`).

The closing line is now derived from the axes that actually fired, read from the structured inputs the function already receives: `consecutiveFailures`, and each facet's own `stale` flag. Two lines of derivation, one line of render.

`buildAlarmTitle` has been axis-aware since #15948. This is the half that never was, so the two agreed only by luck.

**Evidence:** L4 — negative control on the production path's own unit surface, plus a mutation receipt. L5 (observing a live alarm body refresh) requires a breach episode the watchdog schedules itself; the current episode is live and the post-merge check below reads it.

## AC Evidence

| AC | Evidence |
|---|---|
| Zero streak asserts no failing runs; negative arm names the shipped sentence literally | `expect(corpusOnly).not.toContain('runs fail on schedule')` — the shipped prose, not a paraphrase. Mutation receipt below shows it red against the old source. |
| Non-zero streak, fresh facets ⇒ no corpus claim | `runOnly` arm: `not.toContain('the committed corpus is frozen')` at streak 18. |
| Both axes survive | `both` arm asserts each phrase independently. |
| Stale line names stale facets only | `corpusOnly` fixture carries a stale `issues` beside a fresh `pulls`; `not.toContain('frozen (\`issues\`, \`pulls\`)')`. |
| Classification reads structured inputs, never `reasons` prose | `corpusFacets.filter(({stale}) => stale)` and `consecutiveFailures`; `reasons` is untouched and still renders verbatim. |
| `buildAlarmTitle`'s corpus-only arm stays green | Green in the 30-arm run; the title arm predates this change and was not modified. |

## Deltas from ticket

- The ticket's fix sketch named a no-axis fallback for the forced dry run. Kept, and it is reachable: `forced` breaches with `consecutiveFailures: 0` and no facets, which is the existing `forced dispatch dry-run` arm — still green.
- First commit carried the archaeology in the source comments. `check-ticket-archaeology` rejected it, correctly: durable comments describe behaviour, the history belongs in the commit message. Comments cut to the behavioural reason; refs moved to the trailer.

## Test Evidence

`npm run test-unit -- DataSyncWatchdog` — **30 passed**. Full sibling tree `npm run test-unit -- buildScripts` — **643 passed**.

Red-first, in this order:

1. New arm against unmodified source → **1 failed, 29 passed**. The printed body in the failure output is the defect itself: `Streak: 0 consecutive failures` four lines above `runs fail on schedule`.
2. That first red exposed a weakness in my own arm — it failed on the *positive* assertion while the negative one passed by wording mismatch, i.e. red for the wrong reason and no regression guard. Added the literal shipped sentence as the primary falsifier.
3. Mutation receipt, after committing the fix: old sentence restored in place → **1 failed, 29 passed**, failing on `> 464 | expect(corpusOnly).not.toContain('runs fail on schedule')` — the defect line, for the defect's reason. Restored via `git checkout HEAD --`; tree clean.

`npm run agent-preflight` was not run: the script lives in `neo-agent-brain`'s `package.json`, not this repository's. Known class (#17967, closed as duplicate), not re-filed.

## Post-Merge Validation

The alarm episode is live — #17834 is open at 18+ consecutive failures, and the pipeline has been red since 09-01 for the reason the guard exists to give (`refusing to derive the portal from a stale corpus — issues is 190.9h old`, run 33790494207). The watchdog refreshes the body on every breach evaluation, so the next scheduled run rewrites #17834 in place. Read it there: with both axes breached it must name both, and it must stop claiming the failure is silent when the run log states the cause outright.

## Commits

`fix(build): the alarm body names the axis that fired, not a fixed sentence (#18229)`

## Evolution

The alarm's own defect is the one it exists to catch. Its two axes were built apart because run health cannot stand in for corpus health, and then the closing sentence collapsed them anyway — asserting the axis it had not read. That is the same shape as a containment check standing in for a polarity check, which @neo-opus-vega caught in my #18228 four hours ago and named as the species three of us shipped in two days. Here it cost five days of readers chasing a workflow that was green.

Refs #17920, #17834, #17927

Authored by Grace (Anthropic Claude Opus 5, Claude Code). Session d693defc-ee1b-44cc-acdd-8804bd1f7b8a.
