### PR TITLE
docs(dock): the archaeology leaves the class docs, the invariants stay (#18234)

### DIFF
--- a/src/dashboard/dock/Workspace.mjs
+++ b/src/dashboard/dock/Workspace.mjs
@@ -788,12 +788,8 @@ class Workspace extends Container {
     /**
      * @summary Opens the tear-out vessel, defaulting to the engine's own connect vocabulary.
      *
-     * This hook used to return `null`, so pop-out and drag tear-out were both inert for any host
-     * that wrote no window code: the action rendered, the click opened nothing, and no signal said
-     * why. The engine was asking each consumer to re-implement a SENDER for a protocol only the
-     * engine defines — `onWindowConnect` parses `tearout`, the host param, `vesselFlow` and
-     * `vesselAdmission` off the vessel's own URL — from a specification that existed nowhere but
-     * one app's source.
+     * `onWindowConnect` parses `tearout`, the host param, `vesselFlow` and `vesselAdmission` off the
+     * vessel's own URL — a protocol only the engine defines, so only the engine can send it.
      *
      * Nothing in those four parameters is app-specific, so the default constructs them and reopens
      * the host's own document. A consumer that wants a dedicated vessel shell, its own routing or
@@ -1674,9 +1670,8 @@ class Workspace extends Container {
      *
      * `enableDockPopOutAction` alone is not sufficient: dispatch requires one effective
      * {@link #tearOutHandlers} bundle, whether base-owned or supplied by the host, AND a realm that
-     * can actually produce a vessel — see {@link #canOpenTearOutVessel}. An action a consumer
-     * enabled, the engine rendered, and the platform then refuses is the defect this whole seam
-     * exists to remove: the user clicks and nothing happens.
+     * can actually produce a vessel — see {@link #canOpenTearOutVessel}. Any one of the three
+     * missing renders a control that opens nothing.
      * @returns {Boolean}
      */
     get dockPopOutActionActive() {
@@ -1753,11 +1748,8 @@ class Workspace extends Container {
     /**
      * @summary Re-evaluates the retained pop-out action against current truth after every commit.
      *
-     * Pop-out was the one engine action with no sync. Its `hidden` is projected once as
-     * `!activeItemId || !dockPopOutActionAvailable` and then lives on a RETAINED action instance
-     * that survives re-projection, so nothing ever recomputed it: the control was correct at boot
-     * and silently gone after the first layout commit. For a consumer whose reason to be here is
-     * multi-window, the feature disappeared until reload.
+     * `hidden` is projected once and then lives on a RETAINED action instance that survives
+     * re-projection, so without this sync nothing recomputes it after a commit.
      *
      * Mirrors the projected expression from the same reader (`dockPopOutActionActive`), so the
      * projected and the synced answer cannot drift. Change-guarded like its siblings, so re-walking
@@ -3980,9 +3972,8 @@ class Workspace extends Container {
      * document is the repair — this is the caller-side half of the reject-then-re-diff contract that
      * `VdomLifecycle#executeVdomUpdate` provides.
      *
-     * Observability is the other half of the fix. Before this, the rejection escaped as an unhandled
-     * rejection: `onDockZoneDocumentChange` attaches its `.catch` to the PREVIOUS refresh, never the
-     * one it is starting, so nothing on the live path ever saw the failure.
+     * The failure must be caught HERE: `onDockZoneDocumentChange` attaches its `.catch` to the
+     * PREVIOUS refresh, never the one it is starting, so nothing else on the live path sees it.
      *
      * **Exactly one retry.** A deterministic failure must not hot-loop, so the re-projection carries
      * `isDockProjectionRetry` and a second failure surfaces without scheduling a third attempt. The


### PR DESCRIPTION
Resolves #18234

## What

Four docblocks lose their bug story and keep their mechanism. **Net −9 lines, zero executable lines touched.**

| block | removed | kept |
|---|---|---|
| `openTearOutVessel` | *"This hook used to return `null`, so pop-out and drag tear-out were both inert…"* | `onWindowConnect` parses `tearout`, host, `vesselFlow`, `vesselAdmission` off the vessel's URL — a protocol only the engine defines |
| `syncDockPopOutAction` | *"Pop-out was the one engine action with no sync… correct at boot and silently gone after the first layout commit"* | `hidden` is projected once onto a RETAINED instance, so nothing recomputes it after a commit |
| `dockPopOutActionActive` | *"…is the defect this whole seam exists to remove: the user clicks and nothing happens"* | any one of the three missing renders a control that opens nothing |
| `onDockProjectionFailed` | *"Before this, the rejection escaped as an unhandled rejection"* | `onDockZoneDocumentChange` attaches its `.catch` to the PREVIOUS refresh, so nothing else on the live path sees it |

## The ticket over-claimed, and the correction is the point

#18234 was filed on **393** merged comment lines. Applying the rule honestly yields **four blocks**. The rest is structural JSDoc the lint requires, or invariants unrecoverable from the code — one `SortZone` shared by every zone in a window; `previewId` carrying node *and* placement kind; the retained-vs-fresh `cls` asymmetry. Removing those would be the safety net that discards the work.

I over-claimed in the self-critical direction, which is the same failure wearing a hair shirt.

## The finding underneath, which outweighs the diff

`dock/Workspace.mjs`: **4317 → 4308 lines, 1773 → 1773 code. 59% not code, before and after.**

The ratio does not move because **almost every comment is individually defensible**. That is the mechanism: per-comment triage cannot bound a total. Each of those 2535 lines passed "is this justified?" when written, and the file is still 59% commentary. `§pr_diff_equals_pr_body`'s new *added comment lines > added code lines ⇒ cut* is a per-diff bound that stops accretion at the door — it does not shrink what is already there, and no per-comment review will.

Shrinking it is a question about what this class should be responsible for. That is D#18150's, and this PR deliberately does not widen into it.

## Green

`npm run test-unit` — **3143 passed**. No executable line changed; the diff is comment-only, verified by `git diff` carrying no `+`/`-` outside docblocks.

- **Origin Session ID:** 8d936ec9-b816-4ded-a91e-6e91ef6a3325

🖖 Grace, Claude Opus 5, Claude Code.
