### PR TITLE
fix(core): functions compare by identity, so a header can survive its own re-projection (#18236)

### DIFF
--- a/src/core/Compare.mjs
+++ b/src/core/Compare.mjs
@@ -46,16 +46,19 @@ class Compare {
     }
 
     /**
+     * @summary Functions compare by reference, because source text cannot see captured state.
+     *
+     * Two functions built from one source are routinely NOT interchangeable: `fn.bind({id: 1})` and
+     * `fn.bind({id: 2})` share a `name` and a `toString()`, as do two closures from one factory.
+     * Comparing those two properties therefore answers "equal" for functions that behave
+     * differently, so a reactive config carrying handlers would drop a genuine replacement without
+     * ever firing its change hooks.
      * @param {Function} item1
      * @param {Function} item2
      * @returns {Boolean}
      */
     static compareFunctions(item1, item2) {
-        if (item1.name !== item2.name) {
-            return false
-        }
-
-        return item1.toString() === item2.toString()
+        return item1 === item2
     }
 
     /**

--- a/src/tab/Container.mjs
+++ b/src/tab/Container.mjs
@@ -99,7 +99,6 @@ class Container extends BaseContainer {
             [isDescriptor]: true,
             clone         : 'shallow',
             cloneOnGet    : 'none',
-            isEqual       : () => false,
             value         : null
         },
         /**

--- a/test/playwright/unit/core/CompareFunctionIdentity.spec.mjs
+++ b/test/playwright/unit/core/CompareFunctionIdentity.spec.mjs
@@ -1,0 +1,85 @@
+import {setup} from '../../setup.mjs';
+
+setup({
+    appConfig: {
+        name: 'CompareFunctionIdentityTest'
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../src/Neo.mjs';
+import * as core      from '../../../../src/core/_export.mjs';
+
+/**
+ * @summary `Neo.core.Compare.isEqual` on functions.
+ *
+ * Behavioural equivalence is not decidable from a function's source text, so the only sound answer
+ * is reference identity. Comparing `name` + `toString()` instead reports two functions carrying
+ * DIFFERENT captured state as equal, and a reactive config whose change detection answers "equal"
+ * silently drops the replacement.
+ */
+test.describe('Neo.core.Compare — functions compare by identity', () => {
+    test('two bound functions from one target are not equal, though name and source are identical', () => {
+        function handler() { return this.id }
+
+        const first  = handler.bind({id: 1}),
+              second = handler.bind({id: 2});
+
+        // Non-vacuity: the two properties the old implementation compared really are identical here,
+        // so this arm fails against name+toString rather than passing for an unrelated reason.
+        expect(first.name).toBe(second.name);
+        expect(first.toString()).toBe(second.toString());
+        expect(first(), 'and yet they behave differently').toBe(1);
+        expect(second()).toBe(2);
+
+        expect(Neo.core.Compare.isEqual(first, second)).toBe(false)
+    });
+
+    test('two closures from one factory are not equal, though their source text is identical', () => {
+        const make   = x => () => x,
+              first  = make(1),
+              second = make(2);
+
+        expect(first.toString()).toBe(second.toString());
+        expect(first()).toBe(1);
+        expect(second()).toBe(2);
+
+        expect(Neo.core.Compare.isEqual(first, second)).toBe(false)
+    });
+
+    test('the same reference is equal — the comparison is identity, not a blanket false', () => {
+        const fn = () => 'stable';
+
+        // The control that stops the two arms above from being satisfied by an always-false rule.
+        expect(Neo.core.Compare.isEqual(fn, fn)).toBe(true);
+        expect(Neo.core.Compare.isEqual({handler: fn}, {handler: fn})).toBe(true);
+        expect(Neo.core.Compare.isEqual([{handler: fn}], [{handler: fn}])).toBe(true)
+    });
+
+    test('the rule reaches functions nested in the list shapes reactive configs actually carry', () => {
+        function handler() { return this.id }
+
+        const bound = handler.bind({id: 1});
+
+        expect(Neo.core.Compare.isEqual(
+            [{action: 'lock', handler: bound}],
+            [{action: 'lock', handler: handler.bind({id: 2})}]
+        )).toBe(false);
+
+        // Same list, same reference: the no-op case an identical re-projection must produce.
+        expect(Neo.core.Compare.isEqual(
+            [{action: 'lock', handler: bound}],
+            [{action: 'lock', handler: bound}]
+        )).toBe(true)
+    });
+
+    test('non-function comparison is untouched', () => {
+        // Scope control: identity applies to functions only. A structural change here would show up
+        // as these arms flipping, so they pin what the change must NOT do.
+        expect(Neo.core.Compare.isEqual({a: 1, b: [2, 3]}, {a: 1, b: [2, 3]})).toBe(true);
+        expect(Neo.core.Compare.isEqual({a: 1}, {a: 2})).toBe(false);
+        expect(Neo.core.Compare.isEqual([1, 2], [1, 2])).toBe(true);
+        expect(Neo.core.Compare.isEqual(new Date(0), new Date(0))).toBe(true);
+        expect(Neo.core.Compare.isEqual(/x/g, /x/g)).toBe(true)
+    })
+});

--- a/test/playwright/unit/core/CompareFunctionIdentity.spec.mjs
+++ b/test/playwright/unit/core/CompareFunctionIdentity.spec.mjs
@@ -35,6 +35,28 @@ test.describe('Neo.core.Compare — functions compare by identity', () => {
         expect(Neo.core.Compare.isEqual(first, second)).toBe(false)
     });
 
+    test('one method bound to two different owners is not equal — it compares equal ACROSS INSTANCES', () => {
+        // The sharpest case, and the one a real consumer hits: `me.fireAction.bind(me)` from two
+        // owners shares `name` and `toString()`, so a config whose handlers were re-bound to a
+        // different owner reports unchanged and drops the update while pointing at the old owner.
+        class Owner {
+            constructor(id) { this.id = id }
+            fireAction() { return this.id }
+        }
+
+        const first       = new Owner('first'),
+              second      = new Owner('second'),
+              boundFirst  = first.fireAction.bind(first),
+              boundSecond = second.fireAction.bind(second);
+
+        expect(boundFirst.name).toBe(boundSecond.name);
+        expect(boundFirst.toString()).toBe(boundSecond.toString());
+        expect(boundFirst()).toBe('first');
+        expect(boundSecond(), 'they answer for different owners').toBe('second');
+
+        expect(Neo.core.Compare.isEqual(boundFirst, boundSecond)).toBe(false)
+    });
+
     test('two closures from one factory are not equal, though their source text is identical', () => {
         const make   = x => () => x,
               first  = make(1),

--- a/test/playwright/unit/tab/HeaderActions.spec.mjs
+++ b/test/playwright/unit/tab/HeaderActions.spec.mjs
@@ -11,6 +11,7 @@ setup({
 import {test, expect} from '@playwright/test';
 import Neo            from '../../../../src/Neo.mjs';
 import * as core      from '../../../../src/core/_export.mjs';
+import Button         from '../../../../src/button/Base.mjs';
 import Component      from '../../../../src/component/Base.mjs';
 import BaseContainer  from '../../../../src/container/Base.mjs';
 import DialogToolbar  from '../../../../src/dialog/header/Toolbar.mjs';
@@ -339,6 +340,42 @@ test.describe.serial('Neo tab header actions', () => {
 
         expect(secondBoundAction).not.toBe(firstBoundAction);
         expect(secondBoundAction.handler()).toBe(2)
+    });
+
+    test('an identical re-projection constructs nothing; a real change still rebuilds', () => {
+        const tabs = own(Neo.create(TabContainer, {
+                  headerActions: [{action: 'lock', iconCls: 'fa fa-lock'}],
+                  items        : [{module: Component, header: {text: 'One'}}]
+              })),
+              first = tabs.getActionItems()[0];
+
+        // Counting constructions rather than inferring them from instance identity: a rebuild that
+        // happened to land in the same slot is still work the projection paid for, and `toBe` alone
+        // cannot see it. `button.Base` owns `construct`, so save/restore by assignment is exact.
+        const constructed       = [],
+              originalConstruct = Button.prototype.construct;
+
+        Button.prototype.construct = function(config) {
+            constructed.push(this);
+            return originalConstruct.call(this, config)
+        };
+
+        try {
+            // A structurally identical action set delivered as a FRESH array — the shape every dock
+            // re-projection produces. Nothing differs, so nothing may be rebuilt.
+            tabs.headerActions = [{action: 'lock', iconCls: 'fa fa-lock'}];
+
+            expect(tabs.getActionItems()[0], 'the instance survives an identical projection').toBe(first);
+            expect(constructed, 'an identical projection constructs no buttons').toHaveLength(0);
+
+            // Control: the counter must be ABLE to fire, or the zero above witnesses nothing.
+            tabs.headerActions = [{action: 'unlock', iconCls: 'fa fa-lock-open'}];
+
+            expect(constructed.length, 'a genuine action change still rebuilds').toBeGreaterThan(0);
+            expect(tabs.getActionItems()[0], 'and it is a different instance').not.toBe(first)
+        } finally {
+            Button.prototype.construct = originalConstruct
+        }
     });
 
     test('tab SortZone admits only tab buttons, including after runtime action replacement', async () => {


### PR DESCRIPTION
Refs #18236 (AC-0, AC-1, AC-2, AC-3 — `Refs` rather than `Resolves`: the reported symptom, one lock click repainting every header, is not reproduced end-to-end here. A mechanism proved red-first is still only a candidate.)

## What

Two deletions. `Neo.core.Compare.compareFunctions` stops guessing at function equivalence from source text, and `tab.Container#headerActions_` stops opting out of change detection.

```js
// before — name + toString()
if (item1.name !== item2.name) { return false }
return item1.toString() === item2.toString()

// after
return item1 === item2
```

## Why the second change needs the first

`headerActions_` carried `isEqual: () => false`, so every dock re-projection counted as a change: `syncActions` tore down and rebuilt the action buttons, `actionsChange` fired, and `tab.plugin.Overflow` (1,209 lines) re-measured and re-split.

**The opt-out was load-bearing, not a reflex** — which is the opposite of what the ticket originally claimed, and the correction is the substance of this PR. `fn.bind({id: 1})` and `fn.bind({id: 2})` share a `name` (`"bound fn"`) and a `toString()` (`"function () { [native code] }"`). Two closures from one factory are likewise identical in both. So deep equality was **blind to captured state**, and removing the opt-out alone silently dropped genuine handler swaps:

```
expect(secondBoundAction.handler()).toBe(2)
  Expected: 2
  Received: 1     ← the old handler stayed live
```

Any config carrying handlers therefore *had* to opt out or lose replacements. With identity comparison both properties hold at once: an identical re-projection matches and is a no-op (**object permanence**), a real handler change differs and fires.

## How the original diagnosis went wrong

Worth stating, because the failure mode is reusable. The first measurement removed the opt-out and read the one failing assertion:

```js
expect(secondBoundAction).not.toBe(firstBoundAction);   // :340 — failed, reported as "the spec pins the teardown"
expect(secondBoundAction.handler()).toBe(2)             // :341 — NEVER EXECUTED, the run aborted above
```

**A failing assertion aborts the arm.** `:340` is only the instance-level *proxy*; `:341` is the contract. Reordering them produced the result above and inverted the conclusion — the arm is the **guard**, not the defect. It is kept, unchanged.

## Evidence

Evidence: L2 (unit + component suites, plus a matched-set e2e delta on a detached `origin/dev` worktree) → L2 required (close-target ACs are mechanism-level and fully covered by specs). Residual: AC-4, Residual-Owner: #18150.

| suite | result |
|---|---|
| `npm run test-unit` | **3143 passed / 0 failed** |
| `npm run test-components` | **234 passed / 0 failed** |
| `npm run test-e2e -- .../workstation/` — this branch | 5 failed / 3 passed |
| same command on a detached `origin/dev` worktree | **5 failed / 3 passed — the identical five specs** |

**Zero e2e delta**, including `WorkstationTabOverflowCapNL`, the one spec inside this change's blast radius: it fails identically on clean `dev`. Both runs verified via the webpack `served from` line, so neither read a foreign tree.

⚠️ **What that e2e number is NOT.** `NEO_AGENTOS_RUNTIME_ROOT` is unset in this seat, so `testIgnore: externalBrainTestIgnore` drops the Brain-dependent specs: **only 8 of the workstation set are runnable here**, not the ~59 a fully-provisioned seat sees. This is a matched-set delta, not a workstation green.

**AC-0 red-first.** `Neo.core.Compare` had **no test coverage at all**. Against the old implementation the new spec is red on exactly its three non-equality arms (`Expected: false, Received: true`), while the identity control and the non-function scope control stay green — so the red is the property under test, not a blanket failure.

**AC-3** counts `Neo.button.Base` constructions rather than inferring them from instance identity, because a rebuild landing in the same slot is still work the projection paid for. An identical action set delivered as a fresh array constructs **zero**; the control immediately after proves the counter can fire.

## AC evidence

| AC (#18236) | disposition |
|---|---|
| AC-0 — `compareFunctions` compares by identity, red-first | **met** |
| AC-1 — `headerActions_` uses the default `isEqual` | **met** (depends on AC-0) |
| AC-2 — the `:340` arm is kept; a sibling asserts the other direction | **met** — the original AC, which called for inverting it, was withdrawn as premise-false |
| AC-3 — construction count across an identical re-projection: zero, with a firing control | **met** |
| AC-4 — re-test the flaky tab-header click | **open** — needs a seat where the Brain-dependent specs run |
| AC-5 — the other three `() => false` configs untouched | **met** — and now justified by mechanism: `container.Base#items_` holds component configs that legitimately carry handlers, so its opt-out is honest for the same reason. Each needs its own sweep once this lands. |

## Reviewer note — the risk I cannot bound with tests

`core.Compare` is engine-wide. Identity comparison makes a **freshly-built inline closure compare unequal** where the old form said equal, so some paths will now fire an update they previously skipped. 3377 green tests bound that risk; **none of them measures re-render frequency**, and that is the axis where a regression would hide. If you want a different shape here — restricting identity semantics to the config layer rather than to `Compare` itself — that is the argument worth making, and it is easier to make now than after this lands.

The `name` + `toString()` form arrived in **#6130**, a mechanical refactor that lifted the branch out of a `switch`. No rationale was stated then or since, so there is no prior decision being overturned — but absence of a stated reason is not proof there was none, and that is exactly what I got wrong about the four `isEqual` descriptors.

- **Origin Session ID:** 7596538d-5324-419a-b043-95c585d833ea

⚖️ **Ada** · `@neo-opus-ada` · Claude Opus 5 · Claude Code
