### PR TITLE
test(portal): the click arm arrives, and its control names the harness (#18231)

### DIFF
--- a/test/playwright/e2e/portal/LearnLinkRoutingNL.spec.mjs
+++ b/test/playwright/e2e/portal/LearnLinkRoutingNL.spec.mjs
@@ -19,6 +19,9 @@ const GUIDE       = '/apps/portal/index.html#/learn/guides/uibuildingblocks/Dock
 /** The content component's own class, so the assertions cannot drift onto sidebar or chrome links. */
 const CONTENT = '.neo-app-content-component';
 
+/** The sidebar tree, whose navigation owes nothing to the rewrite — see the control arm below. */
+const TREE = '.neo-app-content-tree-list';
+
 test.describe('learn link routing', () => {
     test('a relative guide link is rendered as a route, not a file path', async ({page}) => {
         await page.goto(GUIDE);
@@ -47,16 +50,40 @@ test.describe('learn link routing', () => {
         ).toHaveCount(1)
     });
 
-});
+    /**
+     * Ordered before the click arm on purpose, and kept even though it asserts nothing about the
+     * rewrite: the sidebar tree is the app's own navigation. If a click stops working in this tier,
+     * this arm reddens too and names the harness as the subject. Without it a harness regression
+     * reads as "the rewrite is broken", which is the misreading that got an earlier click arm
+     * written and reverted.
+     */
+    test('control: the harness can click the app\'s own navigation', async ({page}) => {
+        await page.goto(GUIDE);
 
-/*
- * Not covered here, and deliberately not asserted: that CLICKING one of these links arrives at the
- * destination. A click arm was written and reverted, because its own control — clicking the sidebar
- * tree, which is the app's own navigation and owes nothing to this feature — failed in the same
- * harness. A red assertion whose control is also red measures the harness, not the subject, and
- * shipping it would have read as "routing is broken" on this evidence.
- *
- * So the arms above prove the href a reader is given, and stop there. What remains open is whether an
- * in-content route link re-renders on click in a real session; that needs the navigation question
- * settled in this tier first, and it is not something the rewrite can answer.
- */
+        const content = page.locator(CONTENT);
+        await expect(content.locator('h1')).toContainText('Dock');
+
+        await page.locator(`${TREE} .neo-list-item-leaf`).filter({hasText: 'Using These Topics'}).first().click();
+
+        await expect(content.locator('h1')).toContainText('Using These Topics')
+    });
+
+    /**
+     * The question the href arms structurally cannot answer: not "is the href well-formed" but
+     * "does clicking it arrive". Neutering `MainContainerController#onRouteLearnItem` leaves every
+     * href above correct and reddens only this arm.
+     */
+    test('clicking a rewritten link arrives at its destination', async ({page}) => {
+        await page.goto(GUIDE);
+
+        const content = page.locator(CONTENT);
+        await expect(content.locator('h1')).toContainText('Dock Layouts:');
+
+        await content.locator(`a[href="#/learn/${ADOPTION_ID}"]`).first().click();
+
+        // The source page is 'Dock Layouts: One Application, Many Windows', so the destination's own
+        // subtitle is the discriminator — 'Dock Layouts:' alone would pass without navigating.
+        await expect(content.locator('h1')).toContainText('Adopting in Your App')
+    });
+
+});

--- a/test/playwright/e2e/portal/LearnLinkRoutingNL.spec.mjs
+++ b/test/playwright/e2e/portal/LearnLinkRoutingNL.spec.mjs
@@ -70,8 +70,9 @@ test.describe('learn link routing', () => {
 
     /**
      * The question the href arms structurally cannot answer: not "is the href well-formed" but
-     * "does clicking it arrive". Neutering `MainContainerController#onRouteLearnItem` leaves every
-     * href above correct and reddens only this arm.
+     * "does clicking it arrive". Measured: dropping every re-navigation in
+     * `MainContainerController#onRouteLearnItem` leaves both href arms green and reddens this arm
+     * and the control, each at its destination assertion rather than at setup.
      */
     test('clicking a rewritten link arrives at its destination', async ({page}) => {
         await page.goto(GUIDE);


### PR DESCRIPTION
## Summary

Resolves #18231. The ticket says no portal e2e arm can assert that clicking anything arrives, and asks for a harness investigation first. **The blocking precondition does not reproduce at `dev`** — so this PR is the arm, not the investigation.

Measured against `274b63beac` through `playwright.config.e2e.mjs`, driving the real Portal app:

| | ticket's premise | measured now |
|---|---|---|
| click the sidebar tree control | exceeds the 90 000 ms ceiling | **succeeds**, navigates, 1.6 s |
| click a rewritten in-content link | never satisfies actionability | **succeeds**, arrives, 1.3 s |
| tree settle time | assumed unstable | 273–296 ms, 17–18 frames |

No `force`, no `dispatchEvent`, no raised timeout — the arms exercise what a reader's pointer does.

I have **not** isolated why @neo-opus-ada's 2026-08-30 run differed, and I am not claiming a fix I did not make. What the ticket asked for was the click arm gated on a passing control; the control passes, so the arm ships.

## Changes

- `test/playwright/e2e/portal/LearnLinkRoutingNL.spec.mjs`
  - **control arm** — clicks the sidebar tree, the app's own navigation. Ordered before the click arm and kept deliberately: if a click stops working in this tier it reddens too and names the harness as the subject. That misreading is what got the earlier click arm written and reverted.
  - **click arm** — clicks the rewritten `#/learn/…/DockLayoutsAdoption` anchor and asserts the destination `h1`.
  - the deliberate-gap comment at `:51-61` is deleted in the same commit; the arms now cover what it described.

## Evidence

Evidence ladder: **executed** — every claim below is a run in this checkout, not a reading of the code.

**Green baseline** (post-restore, `b196c0a88c`): 4/4 passed in 8.1 s.

**Non-vacuity.** Dropping every re-navigation in `MainContainerController#onRouteLearnItem` (`if (this._probeSeen) return; this._probeSeen = true;`):

| arm | result |
|---|---|
| 1 — relative link rendered as a route | ✅ green (survives) |
| 2 — fragment-bearing link | ✅ green (survives) |
| 3 — control | ❌ red at `:68`, the destination assertion |
| 4 — click arrives | ❌ red at `:86`, the destination assertion |

Both href arms survive it and both navigation arms catch it, so the new arms are not restatements of the old ones. Both reds land on the **arrival** assertion, not on setup.

**A first mutation was rejected as red-for-the-wrong-reason.** `if (oldValue !== undefined) return` also suppressed the *initial* route, so all four arms failed at `toContainText('Dock')` — element not found, before any click. A red whose control is red for a setup reason is the exact class of evidence this ticket exists to avoid, so it was narrowed rather than reported.

**One docblock was wrong and is fixed in `b196c0a88c`.** The first commit claimed the mutation "reddens only this arm". It reddens the control too — correctly, since routing genuinely broke. The note now states the measured outcome.

## Acceptance Criteria

- [x] **AC-1** — the failing actionability check is named rather than inferred: at `dev` **none of them fails**. `isVisible` true, the box settles in 273–296 ms, and the click completes. The one real motion is `expandAndScrollToItem`'s easing smooth-scroll (12 unique boxes in 12 consecutive rAFs, deltas 19→5 px, converging), which `stable` is satisfied by once it lands.
- [x] **AC-2** — the control passes first: clicking the sidebar tree navigates to `#/learn/UsingTheseTopics`, `h1` "Using These Topics".
- [x] **AC-3** — a click on a rewritten in-content link arrives; destination `h1` "Dock Layouts: Adopting in Your App" asserted; the `:51-61` gap comment deleted in the same PR.
- [x] **AC-4** — proven able to fail, with the href arms surviving the mutation that reddens it.
- [x] **AC-5** — no `force: true`, no `dispatchEvent`, no raised timeout.
- [x] **AC-6** — no shared helper added: a helper under `test/playwright/util/` was the remedy *if* the cause were general to the tier. There is no cause to remedy, so adding one would be machinery with no defect under it.

## Notes for the reviewer

The sharpest question here is whether AC-1 is honestly discharged. The ticket asked *which* check fails; the answer is that none does, which is a different shape of answer than it anticipated. If you think that leaves the ticket open rather than resolved — because the difference from Ada's run is unexplained — say so and I will reopen it as a narrower environment question rather than argue the arm covers it.

Second: the control arm asserts nothing about the rewrite, and a future reader may read it as dead weight. Its docblock says why it stays. If you find that unconvincing, that is the line to push on.

🖖 **Grace** · `@neo-opus-grace` · Claude Opus 5 · Claude Code
