### PR TITLE
test(workstation): two arms assert their subject, not the whole structure (#18243)

### DIFF
--- a/test/playwright/e2e/workstation/WorkstationNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationNL.spec.mjs
@@ -2187,8 +2187,11 @@ test.describe('Workstation — dense living-data composition', () => {
         for (const [nodeId, receipt] of Object.entries(openingChrome)) {
             const {headerActions} = await app.getComponent(receipt.containerId, ['headerActions']);
 
-            expect(headerActions.map(action => action.action), `${nodeId} owns the complete default vector`)
-                .toEqual(['reload', 'pin', 'pop-out', 'maximize', 'close']);
+            // Containment, not equality: this arm is about every default action being OFFERED, and
+            // an exact vector additionally forbids the engine from ever growing the default set —
+            // which is a consumer spec vetoing an engine decision. A missing action still fails.
+            expect(headerActions.map(action => action.action), `${nodeId} offers every default action`)
+                .toEqual(expect.arrayContaining(['reload', 'pin', 'pop-out', 'maximize', 'close']));
             expect(headerActions.find(action => action.action === 'pop-out').hidden,
                 `${nodeId} sees Workstation's handler bundle on first projection`).toBe(false)
         }
@@ -2520,7 +2523,10 @@ test.describe('Workstation — dense living-data composition', () => {
                     height: Math.max(Math.round(beforeRect.height), 240),
                     width : Math.max(Math.round(beforeRect.width), 320)
                 },
-                placement: {index: 0, tabsNodeId: 'right-bottom-tabs'},
+                // The subject is WHERE the pane is recorded, so the two fields that say so are
+                // asserted exactly. The record is allowed to carry more — it gained a rebuildable
+                // `home` the moment restoration stopped depending on the node still existing.
+                placement: expect.objectContaining({index: 0, tabsNodeId: 'right-bottom-tabs'}),
                 stage    : 'granted',
                 windowId : expect.any(String)
             });


### PR DESCRIPTION
Resolves #18243

## What

Two arms in `WorkstationNL.spec.mjs` asserted whole structures with `toEqual`, so extending what they observe reddened them. Both fired today against correct, reviewed engine commits.

```diff
- .toEqual(['reload', 'pin', 'pop-out', 'maximize', 'close']);
+ .toEqual(expect.arrayContaining(['reload', 'pin', 'pop-out', 'maximize', 'close']));

- placement: {index: 0, tabsNodeId: 'right-bottom-tabs'},
+ placement: expect.objectContaining({index: 0, tabsNodeId: 'right-bottom-tabs'}),
```

**No engine file is touched.** Neither commit that reddened these is at fault:

| arm | reddened by | why |
|---|---|---|
| `:2158` pin round-trip | `f8432c1ccb` (#18185) | puts `lock` into the default engine action set — **by design**; the spec froze the vector |
| `:2474` pop-out | `5e67e5e486` (#18165) | adds a rebuildable `home` to `tearOutPlacements` — **the fix's whole mechanism**; the spec froze the object |

Both failure diffs were `Expected − 0 / Received + N`. Pure additions. **A whole-object `toEqual` over a growing structure is a consumer spec vetoing an engine decision.**

## How the culprits were found

Two full workstation e2e runs, same command and env, each with its own server, provenance confirmed via the webpack `served from` line:

```
dev @274b63beac    18 failed / 41 passed / 5 skipped   (64 arms)
3c432c50f3 (base)  18 failed / 39 passed / 5 skipped   (62 arms)
```

`18 → 18` hides it — per-arm it is **2 fixed, 2 newly red**. Then two `git bisect run` passes over `3c432c50f3..274b63beac`, selecting by test **title** (line numbers shift across the range), each exiting 125 — skip, do not judge — when the expected arm count did not run.

The first pass short-circuited on "either arm fails", which found `:2474`'s culprit and left `:2158` unexplored above the midpoint; the second pass covered that region for the pin arm alone. **One bisect answering two questions gives one answer and hides the other.**

⚠️ Requires `NEO_AGENTOS_RUNTIME_ROOT`. Without it, `testIgnore: externalBrainTestIgnore` silently drops every `neuralLink` spec and **8 of 64 arms run while the summary still looks clean**.

## Evidence

Evidence: L2 (e2e arms exercised at head with seeded-mutation receipts) → L2 required (the close-target ACs are assertion behaviour, fully observable in the suite). Residual: none.

| check | result |
|---|---|
| AC-1 — both arms at `dev` head | **2 passed** |
| AC-2/AC-3 — seeded `seeded-absent-action` into the vector | **red** — `Expected: ArrayContaining [… "seeded-absent-action"]`, so a **missing default action is still caught** |
| AC-2 — seeded `tabsNodeId: 'seeded-wrong-node'` | **red** — the placement fields are still asserted exactly |
| restored, re-run as the final action | **2 passed**, zero seeds remaining |

The mutation receipts are the point: loosening an assertion until it cannot fail is worse than the brittle one it replaced. `arrayContaining` fails on a **missing** element and tolerates an **added** one, which is exactly the asymmetry `:2158` wants — it stays sensitive to the neighbouring defect class where an action disappears (#18159, #18039).

## AC evidence

| AC (#18243) | disposition |
|---|---|
| AC-1 — both arms green at head | **met** |
| AC-2 — each rewritten assertion still fails when its subject breaks | **met** — two seeded receipts above |
| AC-3 — `:2191` stays sensitive to a *missing* default action | **met** — the seeded absent action reds it |
| AC-4 — no engine file changes | **met** — one file, `+9 −3`, tests only |

## Out of scope

The **15** arms red at both heads (PaletteBridge ×3, EdgeSplitter, DockPreviewSymmetry, Perspectives, StarvedGeometry, TabDragLabelOverlap, TabOverflowCap, TabRestore, TearOutSourceContinuity, `WorkstationNL` ×5) — pre-existing, unattributed, and deliberately untouched. Filed as a `defect-note` so the population is named rather than rediscovered; nothing here should be read as "the suite is fine".

- **Origin Session ID:** 7596538d-5324-419a-b043-95c585d833ea

⚖️ **Ada** · `@neo-opus-ada` · Claude Opus 5 · Claude Code
