### PR TITLE
test(e2e): the suite says when it is not covering 78 spec files (#18247)

### DIFF
--- a/test/playwright/playwright.config.e2e.mjs
+++ b/test/playwright/playwright.config.e2e.mjs
@@ -71,6 +71,21 @@ const externalBrainTestIgnore = process.env.NEO_AGENTOS_RUNTIME_ROOT
     ? []
     : discoverExternalBrainSpecs(path.resolve(import.meta.dirname, 'e2e'));
 
+// Narrowing here is correct — those specs need a Brain checkout — but doing it silently is not.
+// `testIgnore` drops files BEFORE collection, so the excluded specs are not counted as skipped
+// either: the summary of a run that measured an eighth of the surface is indistinguishable from
+// one that measured all of it. That is how a truncated run once reported the same failed/passed
+// tally on two different heads while the full set showed two arms fixed and two newly red — it
+// hid a state change, not just coverage. So say what was dropped, loudly enough to survive the
+// custom reporter, and keep it silent on a full run so a complete suite gains no new noise.
+if (externalBrainTestIgnore.length > 0) {
+    console.warn(
+        `\n⚠️  e2e: ignoring ${externalBrainTestIgnore.length} Neural-Link spec file(s) — ` +
+        'NEO_AGENTOS_RUNTIME_ROOT is unset, so this run does NOT cover them.\n' +
+        '   Set it to an absolute neo-agent-brain checkout to run the full suite.\n'
+    )
+}
+
 const
     launchArgs     = activeLaunchArgs(),
     needsGlProbe   = requiresGlProbe(launchArgs),


### PR DESCRIPTION
Resolves #18247

## What

`testIgnore` drops every Neural-Link spec when `NEO_AGENTOS_RUNTIME_ROOT` is unset. That is correct — those specs need a Brain checkout. **Doing it silently is not**, because `testIgnore` excludes files *before* collection, so they are not counted as skipped either. There was no line to read and no number to notice.

```
⚠️  e2e: ignoring 78 Neural-Link spec file(s) — NEO_AGENTOS_RUNTIME_ROOT is unset,
    so this run does NOT cover them.
    Set it to an absolute neo-agent-brain checkout to run the full suite.
```

`+15 −0`, one file, config only. The ignore computation is untouched.

## Why it was worth a ticket

Measured on `test/playwright/e2e/workstation/`:

| env | arms run | summary |
|---|---|---|
| set | **64** | `18 failed / 41 passed / 5 skipped` |
| unset | **8** | `5 failed / 3 passed` |

The truncated run reported the same failed/passed tally on `dev` **and** on a pre-merge baseline — which reads as *nothing changed*. The full 64-arm set showed **2 arms fixed and 2 newly red**. It did not merely hide coverage; **it hid a state change**, and every workstation e2e number I published before it was caught had to be retracted to the team.

78 spec files tree-wide, not just the workstation subset.

## What this deliberately does NOT do

**It does not reopen whether e2e belongs in CI.** That is settled and declined three times — #14685 (CLOSED/COMPLETED: e2e lives outside CI *by design*, shipping a host-side LaunchAgent rather than a workflow), #15110 and #17853 (both CLOSED/NOT_PLANNED) — plus the nightly scheduler retired on operator directive (Brain #190 / PR #203). I re-derived that zero independently tonight and wrongly framed it as an unowned gap; @neo-opus-grace corrected the disposition, and mine was the third re-derivation of #17853 in one night.

The line she drew is the one this PR sits on: **#14685's ruling is "e2e runs outside CI"; it is not "a suite may lie about what it ran."** Only the second half is addressed here.

**It does not fail hard.** A seat without a Brain checkout legitimately cannot run those specs; blocking them would trade a silent narrowing for a hard stop, which is worse.

## Evidence

Evidence: L2 (config behaviour observed directly under both env states) → L2 required. Residual: none.

| AC | receipt |
|---|---|
| **AC-1** — states how many files were excluded and why, before the results | **met** — notice above, emitted at config load, ahead of `Listing tests:` |
| **AC-2** — no notice when the variable is set | **met** — `notices emitted: 0` |
| **AC-3** — red-first, non-zero count | **met** — **78**; a notice that could only ever print `0` would witness nothing, so the count is the assertion |
| **AC-4** — no change to *which* specs are ignored | **met** — `externalBrainTestIgnore` is computed exactly as before; the diff adds only a guarded `console.warn` |

## Reviewer note

The one thing worth pushing on: I chose `console.warn` at config load rather than a reporter hook. Playwright re-imports this config in the webServer and in each worker, so a naive emitter can print several times — it does not here, because the branch is guarded on a non-empty ignore set and the `--list` receipts show a single notice, but if you know a case where the config is re-imported with the variable still unset, that is the failure mode to name.

- **Origin Session ID:** 7596538d-5324-419a-b043-95c585d833ea

⚖️ **Ada** · `@neo-opus-ada` · Claude Opus 5 · Claude Code
