### PR TITLE
feat(e2e): the config says how much of the tier it is not selecting (#18246)

### DIFF
--- a/test/playwright/e2e/dashboard/DockPinCollapseNL.spec.mjs
+++ b/test/playwright/e2e/dashboard/DockPinCollapseNL.spec.mjs
@@ -40,9 +40,8 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url)),
  * The runtime root is a PREREQUISITE, not a convenience: `playwright.config.e2e.mjs` builds its
  * `testIgnore` from `selectExternalBrainSpecs` whenever `NEO_AGENTOS_RUNTIME_ROOT` is unset, so a
  * run without it does not fail this spec — it never selects it, and reports "No tests found". The
- * config says so out loud at startup since #18246; before that it did not, and three readers took
- * the silence for a green tier. The port override isolates from any foreign dev-server squatting
- * on 8080.
+ * config announces that exclusion at startup, naming how many spec files it dropped. The port
+ * override isolates from any foreign dev-server squatting on 8080.
  */
 
 const bootDockExample = async ({ page, neuralLink, theme }) => {

--- a/test/playwright/e2e/dashboard/DockPinCollapseNL.spec.mjs
+++ b/test/playwright/e2e/dashboard/DockPinCollapseNL.spec.mjs
@@ -38,9 +38,11 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url)),
  *      DockPinCollapseNL -c test/playwright/playwright.config.e2e.mjs --workers=1
  *
  * The runtime root is a PREREQUISITE, not a convenience: `playwright.config.e2e.mjs` builds its
- * `testIgnore` from `discoverExternalBrainSpecs` whenever `NEO_AGENTOS_RUNTIME_ROOT` is unset, so a
+ * `testIgnore` from `selectExternalBrainSpecs` whenever `NEO_AGENTOS_RUNTIME_ROOT` is unset, so a
  * run without it does not fail this spec — it never selects it, and reports "No tests found". The
- * port override isolates from any foreign dev-server squatting on 8080.
+ * config says so out loud at startup since #18246; before that it did not, and three readers took
+ * the silence for a green tier. The port override isolates from any foreign dev-server squatting
+ * on 8080.
  */
 
 const bootDockExample = async ({ page, neuralLink, theme }) => {

--- a/test/playwright/externalBrainSelection.mjs
+++ b/test/playwright/externalBrainSelection.mjs
@@ -1,0 +1,76 @@
+import fs   from 'node:fs';
+import path from 'node:path';
+
+/**
+ * @summary Splits an e2e spec tree into the specs that need an external neo-agent-brain checkout and
+ * everything an Engine-only seat can run, in a single walk.
+ *
+ * Why the split exists: the whitebox specs drive a live Brain through the `neuralLink` fixture, which
+ * throws unless `NEO_AGENTOS_RUNTIME_ROOT` names an absolute checkout root. A contributor cloning this
+ * repo must still get a usable run from `npm ci` alone — a suite that requires infrastructure only
+ * maintainers possess is a suite the community is locked out of — so those specs leave the selection
+ * instead of failing.
+ *
+ * Why the total is returned alongside the matchers: Playwright's `testIgnore` removes files from
+ * SELECTION rather than skipping them, so no reporter, summary line or `--list` output can ever
+ * mention them — a run missing four fifths of the tier prints `Skipped: 0`. This walk is the only
+ * place both numbers exist, and returning one without the other is what made the gap inaudible.
+ *
+ * @param {String} root Absolute directory to walk; recursion passes subdirectories.
+ * @param {String} [base=root] Absolute directory the emitted matchers are relative to. Held constant
+ *        across the recursion so a nested spec still matches by its full path from the e2e root.
+ * @returns {{ignore: RegExp[], total: Number}} Exact-file matchers for the Engine-only project's
+ *          ignore set, and every `*.spec.mjs` seen — excluded or not.
+ */
+export function selectExternalBrainSpecs(root, base = root) {
+    const ignore = [];
+
+    let total = 0;
+
+    for (const entry of fs.readdirSync(root, {withFileTypes: true})) {
+        const file = path.join(root, entry.name);
+
+        if (entry.isDirectory()) {
+            const nested = selectExternalBrainSpecs(file, base);
+
+            ignore.push(...nested.ignore);
+            total += nested.total
+        } else if (entry.name.endsWith('.spec.mjs')) {
+            total++;
+
+            if (/\bneuralLink\b/.test(fs.readFileSync(file, 'utf8'))) {
+                const relative = path.relative(base, file)
+                    .split(path.sep)
+                    .map(part => part.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
+                    .join('[\\\\/]');
+
+                ignore.push(new RegExp(`[\\\\/]${relative}$`))
+            }
+        }
+    }
+
+    return {ignore, total}
+}
+
+/**
+ * @summary States how much of the tier a run will not select, for the one moment the count is knowable.
+ *
+ * Emitted at config-evaluation time rather than from the reporter, because that is the only seam every
+ * entry point crosses: a reporter never learns about unselected files, and `--list` constructs no
+ * reporter at all — a bare `--list` matching almost nothing is exactly the signal that sent three
+ * separate readers off to re-derive this from scratch (#18246).
+ *
+ * @param {{ignore: RegExp[], total: Number}} selection From {@link selectExternalBrainSpecs}.
+ * @returns {String|null} The notice, or `null` when the run selects the whole tier and has nothing to
+ *          disclose — a caller printing unconditionally would otherwise announce an exclusion of zero.
+ */
+export function excludedSpecNotice({ignore, total}) {
+    if (!ignore.length) {
+        return null
+    }
+
+    return `e2e: NEO_AGENTOS_RUNTIME_ROOT is unset — ${ignore.length} of ${total} spec files are ` +
+        `EXCLUDED from selection, not skipped, so nothing below this line reports them. This run ` +
+        `covers ${total - ignore.length}. Set NEO_AGENTOS_RUNTIME_ROOT to an absolute ` +
+        `neo-agent-brain checkout root to select all ${total}.`
+}

--- a/test/playwright/externalBrainSelection.mjs
+++ b/test/playwright/externalBrainSelection.mjs
@@ -57,8 +57,8 @@ export function selectExternalBrainSpecs(root, base = root) {
  *
  * Emitted at config-evaluation time rather than from the reporter, because that is the only seam every
  * entry point crosses: a reporter never learns about unselected files, and `--list` constructs no
- * reporter at all — a bare `--list` matching almost nothing is exactly the signal that sent three
- * separate readers off to re-derive this from scratch (#18246).
+ * reporter at all — a bare `--list` matching almost nothing looks identical to a tier that ran and
+ * found nothing wrong.
  *
  * @param {{ignore: RegExp[], total: Number}} selection From {@link selectExternalBrainSpecs}.
  * @returns {String|null} The notice, or `null` when the run selects the whole tier and has nothing to

--- a/test/playwright/playwright.config.e2e.mjs
+++ b/test/playwright/playwright.config.e2e.mjs
@@ -1,9 +1,12 @@
 
 import {defineConfig, devices}             from '@playwright/test';
-import fs                                  from 'node:fs';
 import path                                from 'node:path';
 import {resolveFreePortSync}               from './resolveFreePort.mjs';
 import {activeLaunchArgs, requiresGlProbe} from './e2e/utils/gpuIntent.mjs';
+import {
+    excludedSpecNotice,
+    selectExternalBrainSpecs
+} from './externalBrainSelection.mjs';
 import {
     DEFAULT_BROWSER_LIFECYCLE_RECEIPT_LIMIT,
     resolveBrowserLifecycleReceipt
@@ -41,35 +44,21 @@ const RUN_ID        = process.env.NEO_E2E_RUN_ID || null,
 
 process.env.NEO_E2E_LIFECYCLE_RUN_ID = LIFECYCLE_RECEIPT.runId;
 
-/**
- * @summary Finds whitebox specs that request the external Brain fixture.
- * @param {String} root Absolute e2e directory.
- * @returns {RegExp[]} Exact file matchers for the Engine-only project's ignore set.
- */
-export function discoverExternalBrainSpecs(root) {
-    const files = [];
+// Only walked when the variable is absent: with a Brain checkout the whole tier is selected and there
+// is nothing to disclose, so the set arm keeps doing no I/O at all.
+const externalBrainSelection = process.env.NEO_AGENTOS_RUNTIME_ROOT
+    ? null
+    : selectExternalBrainSpecs(path.resolve(import.meta.dirname, 'e2e'));
 
-    for (const entry of fs.readdirSync(root, {withFileTypes: true})) {
-        const file = path.join(root, entry.name);
+const externalBrainTestIgnore = externalBrainSelection?.ignore ?? [];
 
-        if (entry.isDirectory()) {
-            files.push(...discoverExternalBrainSpecs(file));
-        } else if (entry.name.endsWith('.spec.mjs') && /\bneuralLink\b/.test(fs.readFileSync(file, 'utf8'))) {
-            const relative = path.relative(path.resolve(import.meta.dirname, 'e2e'), file)
-                .split(path.sep)
-                .map(part => part.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
-                .join('[\\\\/]');
+// Pinned like NEO_E2E_PORT above, for the same reason: Playwright re-imports this config in the
+// webServer and in every worker, so an unguarded notice prints once per process. Children inherit it.
+if (externalBrainSelection && !process.env.NEO_E2E_EXCLUSION_NOTICE) {
+    process.env.NEO_E2E_EXCLUSION_NOTICE = '1';
 
-            files.push(new RegExp(`[\\\\/]${relative}$`))
-        }
-    }
-
-    return files
+    console.warn(excludedSpecNotice(externalBrainSelection))
 }
-
-const externalBrainTestIgnore = process.env.NEO_AGENTOS_RUNTIME_ROOT
-    ? []
-    : discoverExternalBrainSpecs(path.resolve(import.meta.dirname, 'e2e'));
 
 const
     launchArgs     = activeLaunchArgs(),

--- a/test/playwright/unit/test/externalBrainSelection.spec.mjs
+++ b/test/playwright/unit/test/externalBrainSelection.spec.mjs
@@ -1,0 +1,125 @@
+import {test, expect}                                 from '@playwright/test';
+import fs                                             from 'node:fs';
+import os                                             from 'node:os';
+import path                                           from 'node:path';
+import {excludedSpecNotice, selectExternalBrainSpecs} from '../../externalBrainSelection.mjs';
+
+/**
+ * Coverage for the e2e tier's selection split and the notice that discloses it.
+ *
+ * The contract worth pinning is not "which specs are excluded" — that is a grep, and it changes every
+ * time a spec gains or loses the fixture. It is that the two numbers a reader needs can never drift
+ * apart: `testIgnore` deletes files from selection rather than skipping them, so a run missing four
+ * fifths of the tier still prints `Skipped: 0`, and the only honest moment is the walk itself. A
+ * selection that reports its exclusions and a total that came from somewhere else would be the same
+ * silence wearing a number.
+ *
+ * The tree fixtures are synthetic on purpose: a suite that asserted counts against the real `e2e`
+ * directory would go red on any unrelated spec being added, which is how a guard gets deleted rather
+ * than fixed. One arm does read the real tree — for the invariant, never for the figures.
+ */
+test.describe('test/playwright/externalBrainSelection — the e2e selection split and its disclosure', () => {
+    const makeTree = layout => {
+        const root = fs.mkdtempSync(path.join(os.tmpdir(), 'neo-e2e-selection-'));
+
+        for (const [relative, contents] of Object.entries(layout)) {
+            const file = path.join(root, relative);
+
+            fs.mkdirSync(path.dirname(file), {recursive: true});
+            fs.writeFileSync(file, contents)
+        }
+
+        return root
+    };
+
+    test('a spec requesting the neuralLink fixture is excluded; its siblings are not', () => {
+        const root = makeTree({
+            'dashboard/DockPinNL.spec.mjs': 'import {neuralLink} from "../fixtures.mjs";',
+            'dashboard/DockPin.spec.mjs'  : 'plain engine spec, no fixture',
+            'grid/Tree.spec.mjs'          : 'plain engine spec, no fixture'
+        });
+
+        const {ignore, total} = selectExternalBrainSpecs(root);
+
+        expect(total).toBe(3);
+        expect(ignore).toHaveLength(1);
+        expect(ignore[0].test('/any/prefix/dashboard/DockPinNL.spec.mjs')).toBe(true);
+        expect(ignore[0].test('/any/prefix/dashboard/DockPin.spec.mjs')).toBe(false)
+    });
+
+    test('the total counts every spec file, excluded or not — the two numbers come from one walk', () => {
+        const root = makeTree({
+            'a/OneNL.spec.mjs': 'neuralLink',
+            'a/TwoNL.spec.mjs': 'neuralLink',
+            'b/c/Deep.spec.mjs': 'engine only',
+            'b/notes.md'       : 'neuralLink appears here but this is not a spec',
+            'helper.mjs'       : 'neuralLink appears here too'
+        });
+
+        const {ignore, total} = selectExternalBrainSpecs(root);
+
+        // Three spec files, of which two need a Brain. The two non-spec files mention the fixture and
+        // must not be counted by either number — the walk keys on `.spec.mjs`, never on the match.
+        expect(total).toBe(3);
+        expect(ignore).toHaveLength(2)
+    });
+
+    test('a nested spec matches by its full path from the root, not by its basename', () => {
+        const root = makeTree({
+            'workstation/deep/TabRestoreNL.spec.mjs': 'neuralLink',
+            'other/TabRestoreNL.spec.mjs'           : 'engine only'
+        });
+
+        const [matcher] = selectExternalBrainSpecs(root).ignore;
+
+        expect(matcher.test('/repo/e2e/workstation/deep/TabRestoreNL.spec.mjs')).toBe(true);
+        // Same basename, different directory: a basename-keyed matcher would drop this one too, which
+        // is how an exclusion set quietly grows past what it was allowed to remove.
+        expect(matcher.test('/repo/e2e/other/TabRestoreNL.spec.mjs')).toBe(false)
+    });
+
+    test('regex metacharacters in a path are escaped, not interpreted', () => {
+        const root = makeTree({'a+b/Dock(1).spec.mjs': 'neuralLink'});
+
+        const [matcher] = selectExternalBrainSpecs(root).ignore;
+
+        expect(matcher.test('/repo/e2e/a+b/Dock(1).spec.mjs')).toBe(true);
+        expect(matcher.test('/repo/e2e/aab/Dock1.spec.mjs')).toBe(false)
+    });
+
+    test('the notice names both counts, the survivors and the variable that restores them', () => {
+        const notice = excludedSpecNotice({ignore: new Array(78), total: 95});
+
+        expect(notice).toContain('NEO_AGENTOS_RUNTIME_ROOT');
+        expect(notice).toContain('78 of 95');
+        // The survivor count is the number a reader is about to mistake for the whole tier.
+        expect(notice).toContain('covers 17');
+        // "not skipped" is load-bearing prose, not decoration: `Skipped: 0` is what the summary will
+        // say a few lines below, and this sentence is the only thing that contradicts it.
+        expect(notice).toContain('not skipped')
+    });
+
+    test('nothing excluded means nothing announced — no exclusion-of-zero notice', () => {
+        expect(excludedSpecNotice({ignore: [], total: 95})).toBeNull();
+        expect(excludedSpecNotice(selectExternalBrainSpecs(makeTree({'a/Plain.spec.mjs': 'engine only'}))))
+            .toBeNull()
+    });
+
+    test('against the real e2e tree: the total matches an independent walk, and both counts are real', () => {
+        const root = path.resolve(import.meta.dirname, '../../e2e');
+
+        // Counted by a second instrument rather than by the function under test — a total the walk
+        // reports about itself proves only that it is self-consistent.
+        const countSpecs = dir => fs.readdirSync(dir, {withFileTypes: true}).reduce((sum, entry) => sum +
+            (entry.isDirectory() ? countSpecs(path.join(dir, entry.name)) : Number(entry.name.endsWith('.spec.mjs'))), 0);
+
+        const {ignore, total} = selectExternalBrainSpecs(root);
+
+        expect(total).toBe(countSpecs(root));
+        // No figures pinned: the invariant is that the tier is genuinely split, so an unset seat is
+        // running a strict subset and the notice has something true to say.
+        expect(ignore.length).toBeGreaterThan(0);
+        expect(ignore.length).toBeLessThan(total);
+        expect(excludedSpecNotice({ignore, total})).toContain(`${ignore.length} of ${total}`)
+    })
+});


### PR DESCRIPTION
## Summary

Resolves #18246

Evidence: L3 (both selection arms driven through real Playwright and matched against the `origin/dev` config, one live e2e run, a four-mutation battery) → L3 required (every AC on #18246 verifies by invoking the config; none needs an operator-gated handoff). No residuals.

`testIgnore` removes files from **selection** rather than skipping them, so an e2e run without a `neo-agent-brain` checkout dropped 78 of 95 spec files and still printed `Skipped: 0`. Nothing downstream could correct that: a reporter never learns about unselected files, and `--list` builds no reporter at all. The count existed inside one ternary in the config and was thrown away there.

The config now says it out loud, once, before anything runs:

```
e2e: NEO_AGENTOS_RUNTIME_ROOT is unset — 78 of 95 spec files are EXCLUDED from selection,
not skipped, so nothing below this line reports them. This run covers 17. Set
NEO_AGENTOS_RUNTIME_ROOT to an absolute neo-agent-brain checkout root to select all 95.
```

**This changes no execution policy.** Whether e2e belongs in CI is a separate question that has been declined three times — #14685 (outside-CI by design), #15110, #17853 — and re-proposing it is out of scope by construction. The exclusion itself stays exactly as wide as it was; an Engine-only contributor with no Brain checkout gets the same run they got yesterday, plus one line telling them what it is.

## Changes

- **`test/playwright/externalBrainSelection.mjs`** (new) — the walk, lifted out of the config beside `resolveFreePort.mjs`, which is the established shape here: the config delegates a decision to an importable helper and keeps `defineConfig` thin. `selectExternalBrainSpecs` now returns `{ignore, total}` from one traversal, and `excludedSpecNotice` formats the disclosure, returning `null` when nothing is excluded.
- **`test/playwright/playwright.config.e2e.mjs`** — imports both, prints the notice, and drops its now-unused `fs` import. The emit is pinned through `NEO_E2E_EXCLUSION_NOTICE` for the same reason the file already pins `NEO_E2E_PORT`: Playwright re-imports this config in the webServer and in every worker. With the variable set the tree is not walked at all, so that arm still does no I/O.
- **`test/playwright/unit/test/externalBrainSelection.spec.mjs`** (new) — 7 tests over synthetic trees, plus one arm against the real `e2e` directory that pins the invariant and no figures.
- **`test/playwright/e2e/dashboard/DockPinCollapseNL.spec.mjs`** — its header documented the old symbol name; both sides of that contract now agree.

## Evidence

Evidence ladder: **executed**. Every number below is a run in this checkout at `d8f5acb0a0`, against `dev@274b63beac`.

**Matched baseline — selection is untouched.** The `origin/dev` config was extracted to a sibling file and listed side by side with this branch's:

| arm | baseline (`origin/dev`) | this branch | notices emitted |
|---|---|---|---|
| `NEO_AGENTOS_RUNTIME_ROOT` unset | 47 tests in **17** files | 47 tests in **17** files | 0 → **1** |
| set to a real checkout root | 229 tests in **95** files | 229 tests in **95** files | 0 → **0** |

Playwright's own `Total:` line is the instrument, not the helper being tested — and it independently corroborates the notice's `78 of 95` and `covers 17`.

**The once-per-process guard, measured rather than reasoned.** A real run (`e2e/grid/ThumbDragPause.spec.mjs`, `--workers=1`, variable unset) boots the webServer and a worker, so the config is genuinely re-imported: **1 occurrence** of the notice across the whole log, spec passed, exit 0.

**Mutation battery.** Control 7/7 green; each mutation reverted from the committed baseline (tree clean after each):

| mutation | expected red | result |
|---|---|---|
| M1 — `total` counts only excluded files | the two-numbers-one-walk arms | **3 failed**, incl. the real-tree arm |
| M2 — notice returned even when nothing is excluded | the exclusion-of-zero arm | **1 failed** (that arm) |
| M3 — matcher keyed on basename, not full path | the nested-path arm | **1 failed** (that arm) |
| M4 — delete the `console.warn` from the config | unset arm goes silent | notice count **1 → 0** |

M4 is the one that matters for the wiring: it proves the disclosure comes from this diff and not from something already in the tier.

## AC Evidence

| AC-1 | notice before any test executes, naming excluded + total — printed above `Listing tests:` and above the run's first spec line; see the matched-baseline table |
| AC-2 | also under `--list` — both `--list` arms above. This is why the emit sits at config-evaluation time, where no reporter exists |
| AC-3 | set arm silent, selection unchanged — 0 notices, 229 tests in 95 files, identical to baseline |
| AC-4 | counts derived from one walk, never hardcoded — `selectExternalBrainSpecs` returns both; mutation M1 and the real-tree spec arm go red if they ever diverge |
| AC-5 | exit code + selection identical, notice the only difference — matched-baseline table, both arms; real e2e run exit 0 |
| AC-6 | mutation evidence both directions — M1–M4 above: three red on the helper, one red on the config wiring |

## Deltas from ticket

Two, both stated rather than absorbed.

1. **The ticket prescribed the notice "in `playwright.config.e2e.mjs`"; the walk moved to a helper instead.** Written in place it would have been untestable without importing a Playwright config — which resolves a free port, pins two env vars and constructs a lifecycle receipt on import. AC-6 asks for mutation evidence in both directions, and that is not reachable through a module with those side effects. The seam is the config's own existing idiom, and the config got shorter, not longer.
2. **A fresh `git worktree` cannot run the unit tier**, and says so only as a module-resolution error: `dist/parse5.mjs` is gitignored, so the tier dies before producing any summary — and the wrapper I ran it through reported `exit 0` while the tier had exited `1`. Unrelated to this diff, and an independent second instance of the fresh-worktree class @neo-opus-ada sighted tonight on the portal tier. Sent as a defect-note; not filed, not fixed here.

## Test Evidence

Outside-CI receipts only; the mutation battery and both `--list` arms are in **Evidence** above and not restated.

- Full unit tier at `d8f5acb0a0`: **3150 passed**, exit 0 (`npm run test-unit`, after copying the gitignored `dist/parse5.mjs` in — see delta 2).
- Real e2e run, unset arm: 1 passed in 14.7 s, exit 0, notice emitted exactly once.

## Post-Merge Validation

None. Every AC is verifiable in the diff by running the config, and both arms are measured above.

## Notes for the reviewer

The thing worth pushing on is the **boundary**, not the code. This is deliberately the narrow half of a two-part sighting: the half with no predecessor decline. If the review wants the notice to escalate — fail the run, gate CI, reinstate a scheduler — that is the half three prior dispositions have already declined, and it should arrive as a challenge to #17853's close comment rather than as a Required Action here.

Second: I did not verify the scheduler side today. #17853 records it as retired in both repos as of 2026-08-29 (Brain #190 / PR #203); I re-measured only the workflow side, where the answer is still zero.

Related: #17853, #15110, #14685 · #17844 owns whether the 78 excluded specs pass · #18243 / #18244 is where the truncated-run cost surfaced again tonight.

Authored by Grace (Claude Opus 5, Claude Code). Session d52546bc-3057-45d9-8e49-9a8eb88b85a0.
