### PR TITLE
fix(dock): the pre-projection sweep awaits the rail's own in-flight reveal release

### DIFF
--- a/src/dashboard/dock/Workspace.mjs
+++ b/src/dashboard/dock/Workspace.mjs
@@ -2004,6 +2004,12 @@ class Workspace extends Container {
         const pending = [];
 
         this.forEachDockRail(rail => {
+            // A rail leave path (the pin escape, a reconciled leaver) starts its release without
+            // awaiting it, and the release clears the cache below on its first tick — without the
+            // lease this sweep would find nothing left to await and stage the projection into a
+            // removal still in flight.
+            pending.push(...Object.values(rail.revealPaneReleases || {}));
+
             Object.keys(rail.revealPaneCache || {}).forEach(itemId => {
                 if (document?.items?.[itemId]?.autoHidden !== true) {
                     pending.push(rail.releaseRevealPane(itemId));

--- a/src/dashboard/dock/interaction/Rail.mjs
+++ b/src/dashboard/dock/interaction/Rail.mjs
@@ -164,6 +164,15 @@ class Rail extends Container {
      */
     revealPaneLoads = {}
     /**
+     * In-flight {@link #releaseRevealPane} calls, keyed by dock item id. The rail's own leave paths
+     * start a release without awaiting it, and the release clears {@link #revealPaneCache} on its
+     * first tick — so without this lease the workspace's pre-projection sweep sees an empty cache
+     * and stages the projection while the removal is still landing.
+     * @member {Object} revealPaneReleases={}
+     * @protected
+     */
+    revealPaneReleases = {}
+    /**
      * The reveal/dismiss timing brain. Runtime-only; created per instance, torn down in `destroy()`.
      * @member {RevealStateMachine|null} revealMachine=null
      * @protected
@@ -411,46 +420,56 @@ class Rail extends Container {
      * dismissal parks the pane, so a revealed pane leaves through its slot in the one update the
      * dismissal would otherwise spend on parking it — its DOM node and its registration retire
      * together, ahead of the refresh that mints the flow pane. The workspace's pre-projection sweep
-     * ({@link Neo.dashboard.dock.Workspace#releaseStaleRevealPanes}) covers the leave paths that
-     * never pass through this rail (a restored perspective, a transfer) and AWAITS the result: the
-     * slot's removal has to land before a staged projection inserts a node under the same id, and a
-     * destroy must never race an in-flight update that still diffs the pane's vnode — either one
-     * wedges the refresh (measured: a reconcile whose `promiseUpdate` never settles).
+     * ({@link Neo.dashboard.dock.Workspace#releaseStaleRevealPanes}) AWAITS the result — both for
+     * the leave paths that never pass through this rail (a restored perspective, a transfer) and,
+     * through {@link #revealPaneReleases}, for the ones that do: the slot's removal has to land
+     * before a staged projection inserts a node under the same id, and a destroy must never race an
+     * in-flight update that still diffs the pane's vnode — either one wedges the refresh (measured:
+     * a reconcile whose `promiseUpdate` never settles).
      * @param {String} itemId
      * @returns {Promise<void>} Settles once the pane is gone from the DOM and the registry.
      * @protected
      */
     async releaseRevealPane(itemId) {
-        let me   = this,
+        let me = this,
+            parent, pane, resolveRelease;
+
+        me.revealPaneReleases[itemId] = new Promise(resolve => {resolveRelease = resolve});
+
+        try {
             pane = me.revealPaneCache[itemId];
 
-        // an import still in flight for a released item must not land a pane afterwards
-        delete me.revealPaneLoads[itemId];
+            // an import still in flight for a released item must not land a pane afterwards
+            delete me.revealPaneLoads[itemId];
 
-        if (!pane) {
-            return
-        }
+            if (!pane) {
+                return
+            }
 
-        delete me.revealPaneCache[itemId];
+            delete me.revealPaneCache[itemId];
 
-        if (pane.isDestroyed) {
-            return
-        }
+            if (pane.isDestroyed) {
+                return
+            }
 
-        const parent = pane.parent;
+            parent = pane.parent;
 
-        // A parked pane keeps its `parentId` after `removeAt(index, false)`, so `parent` can
-        // resolve a slot that no longer lists it — go through the parent only while it does.
-        if (parent?.items?.includes(pane)) {
-            // `removeAt` splices the vdom BEFORE the payload is built and destroys the pane, so the
-            // removal it publishes never references the instance; hand its landing back.
-            parent.remove(pane, true);
-            await parent.promiseUpdate()
-        } else {
-            // Parked: the dismissal already spliced it out, but that update may still be in flight
-            // with the pane's vnode in its diff — let it land before the instance goes.
-            await parent?.promiseUpdate?.();
-            pane.isDestroyed || pane.destroy()
+            // A parked pane keeps its `parentId` after `removeAt(index, false)`, so `parent` can
+            // resolve a slot that no longer lists it — go through the parent only while it does.
+            if (parent?.items?.includes(pane)) {
+                // `removeAt` splices the vdom BEFORE the payload is built and destroys the pane, so
+                // the removal it publishes never references the instance; hand its landing back.
+                parent.remove(pane, true);
+                await parent.promiseUpdate()
+            } else {
+                // Parked: the dismissal already spliced it out, but that update may still be in
+                // flight with the pane's vnode in its diff — let it land before the instance goes.
+                await parent?.promiseUpdate?.();
+                pane.isDestroyed || pane.destroy()
+            }
+        } finally {
+            delete me.revealPaneReleases[itemId];
+            resolveRelease()
         }
     }
 

--- a/src/dashboard/dock/interaction/Rail.mjs
+++ b/src/dashboard/dock/interaction/Rail.mjs
@@ -468,7 +468,10 @@ class Rail extends Container {
                 pane.isDestroyed || pane.destroy()
             }
         } finally {
-            delete me.revealPaneReleases[itemId];
+            // `destroy()` deletes own properties, so a rail torn down across the awaits above has no
+            // map left to clear — but the lease must settle either way, or the sweep holding it waits
+            // on a promise nobody resolves.
+            me.revealPaneReleases && delete me.revealPaneReleases[itemId];
             resolveRelease()
         }
     }

--- a/test/playwright/unit/dashboard/DockWorkspace.spec.mjs
+++ b/test/playwright/unit/dashboard/DockWorkspace.spec.mjs
@@ -2015,6 +2015,30 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
         expect(returned.getActionItem('reload')?.hidden, 'and the post-settle sweep ran on the returned node').toBe(false)
     });
 
+    test('a pin retires only its own item — a rail still holding another auto-hidden item survives', async () => {
+        const
+            document   = createEdgeDocument(),
+            railTabIds = rail => (rail?.items || []).filter(item => item.dockItemId != null).map(item => item.dockItemId);
+
+        document.items.logs = {componentRef: 'Logs', title: 'Logs', kind: 'panel'};
+        document.nodes['inspector-tabs'].items.push('logs');
+
+        document.items.inspector.autoHidden = true;
+        document.items.logs.autoHidden      = true;
+
+        workspace = Neo.create(FixedIdWorkspace, {dockModel: document});
+
+        expect(railTabIds(railOf(workspace.items[0])), 'both auto-hidden items rail').toEqual(['inspector', 'logs']);
+
+        expect(railOf(workspace.items[0]).onRevealPinRequested({itemId: 'inspector'}).errors).toEqual([]);
+
+        await workspace.refreshPromise;
+
+        // Awaiting the rail's in-flight release must not make teardown unconditional: the edge
+        // still hosts an auto-hidden item, so the rail stays and loses only the pinned tab.
+        expect(railTabIds(railOf(workspace.items[0])), 'the rail keeps the item that stayed').toEqual(['logs'])
+    });
+
     /**
      * The leave paths that bypass the rail (a restored perspective, a transfer) reach the reveal pane
      * only through the workspace's pre-projection sweep. The state machine's contract names those


### PR DESCRIPTION
Resolves #18216

`releaseRevealPane` clears `revealPaneCache` on its first tick, and the rail's own leave paths start it without awaiting it. `releaseStaleRevealPanes` — the pre-projection sweep whose whole job is to await that removal — iterates exactly that cache, so by the time the refresh swept it there was nothing left to await. The projection staged into a removal still in flight, and the retired rail affordance survived every later commit.

The requirement was already written down, one docblock over: *the slot's removal has to land before a staged projection inserts a node under the same id*. The sweep could not enforce it, because the cache was the only handle it had and the pin escape had already emptied it. `revealPaneReleases` gives it a second handle — a lease registered on entry, cleared in `finally` — so both rail leave paths become awaitable without changing a signature or losing the immediate dismissal the reveal contract needs.

## Deltas

| File | Change |
|---|---|
| `src/dashboard/dock/interaction/Rail.mjs` | `revealPaneReleases` lease; `releaseRevealPane` registers on entry and settles in `finally` — including when the rail is destroyed across the await and the map is gone; docblock corrected — the sweep awaits both leave-path families, not only the ones that bypass the rail |
| `src/dashboard/dock/Workspace.mjs` | `releaseStaleRevealPanes` pushes the rail's in-flight leases into the same `Promise.all` |
| `test/playwright/unit/dashboard/DockWorkspace.spec.mjs` | AC-5 control: a pin retires its own item only; a rail still holding another auto-hidden item survives |

## AC Evidence

| AC | Verdict | Evidence: |
|---|---|---|
| AC-1 no `Rail` in worker truth, no `.neo-dashboard-dock-rail-tab` in the DOM | met | both arms green — `DockAutoHideRevealNL:90` and `:293`, red at `ca83102346` |
| AC-2 mechanism named before the fix, measured not inferred | met | five perturbations, below. It is **none of the ticket's three candidates** — not instance teardown, DOM removal or adapter input, but the sweep losing its handle |
| AC-3 the `getVnode` errors disappear or are shown independent | met, via the independence branch | shown independent by four measurements; captured as a defect-note (ticket-create §1e). See below |
| AC-4 onset banded, or why not | met | `git log -S` puts the unawaited pin-path call **and** the cache-iterating sweep in the same commit — `c5aa0d2c11`, `fix(dock): a pane returns from the rail with its reload action (#18039) (#18041)`. The sweep was written to await; the same change made the cache empty by the time it ran |
| AC-5 control — teardown must not become unconditional | met | new unit test, mutation-verified (fails when the rail is made to collect nothing) |

**AC-2, the five perturbations** (each seeded on a detached `origin/dev`, tree restored to 0 changed after):

| seed | result | eliminates |
|---|---|---|
| `releaseStaleRevealPanes` → no-op | still fails | that await as the site |
| chain broken (`tail = Promise.resolve()`) | still fails | `refreshPromise` serialization |
| chained refresh made argument-free | still fails | the arguments |
| release moved earlier, still unawaited | still fails | start ≠ completion |
| release **awaited** before the commit | **passes** | names ordering as the mechanism |

A 500 ms delay on the chain also passes, which is what first showed this was a race and not the stall I had been chasing: waiting after the fact never helped because the losing write had already landed.

**AC-3, why the `getVnode` throws are independent.** They are real page errors, all for one component id, and they are caused by destroying the reveal pane while the dismissal's update still references it — a different mechanism from the projection race this PR fixes:

| measurement | count |
|---|---|
| single pin spec, clean `origin/dev` | 9 |
| single pin spec, this branch | 8 |
| full spec, before and after this fix | 16 / 16 |
| destroy skipped (`parent.remove(pane, false)`) | 0 |
| pin path does not fire `revealMachine.itemCleared` | 0 |
| reveal-only path, never pins | 0 |

Unmoved by this fix, and the rail retires with them present. Captured as a defect-note rather than promoted to an issue: §1e reserves promotion for a production-down signal, an independent second occurrence, or a triage decision, and this has none yet.

## Test Evidence

```
unit       (full tier)                        3144 passed   ← 3143 + the AC-5 control
components (playwright.config.component.mjs)   234 passed
e2e        DockAutoHideRevealNL                  4 passed
e2e        DockPinCollapseNL                     5 passed, 2 failed
```

The first push was CI-red on `unit`, and the cause is worth stating rather than squashing away: I had verified locally against the **dashboard-scoped** subset, which is green on a defect the full tier catches. `Neo.core.Base#destroy` deletes own properties, so a rail torn down *across* the release's awaits reaches `finally` with no map — `delete me.revealPaneReleases[itemId]` then threw. The neighbouring lines that look like the same pattern are safe only because they run before any await; mine does not. Guarded, and the lease still settles so the sweep cannot wait on a promise nobody resolves.

The two `DockPinCollapseNL` failures are `neo-theme-neo-dark` / `neo-theme-neo-light` and are **pre-existing**: stashing this branch's `src/dashboard/dock` reproduces the identical 2 failed / 2 passed on clean `origin/dev`. Not touched here.

AC-5 mutation control: seeding `LayoutAdapter:588` so the rail collects nothing turns the new test red (`- Expected 4 / + Received 1`). It fails on the hazard it guards.

e2e runs need `NEO_AGENTOS_RUNTIME_ROOT`; no workflow sets it, so CI covers `unit` + `components` only (#17844).

## Post-Merge Validation

- `apps/workstation`: pin an auto-hidden pane from its reveal overlay — the rail tab must leave, and a second auto-hidden item on the same edge must keep its rail.
- The lease is keyed per item id and cleared in `finally`, so a release that throws cannot wedge the sweep; a destroyed rail has no map, matching `revealPaneLoads`.
- If the `getVnode` throws gain a second independent sighting, the defect-note promotes under the full ceremony.

Authored by Grace (Claude Opus 5, Claude Code). Session 118d8435-8d23-4745-a28a-8d22da918aac.
