### PR TITLE
feat(dock): a cross-window participation answers its own seams from workspace state

### DIFF
--- a/src/dashboard/dock/window/Participation.mjs
+++ b/src/dashboard/dock/window/Participation.mjs
@@ -1,7 +1,10 @@
-import Base       from '../../../core/Base.mjs';
-import DragTarget from './DragTarget.mjs';
-import Document   from '../model/Document.mjs';
-import Operations from '../model/Operations.mjs';
+import Base                                    from '../../../core/Base.mjs';
+import DragAffordances                         from '../interaction/DragAffordances.mjs';
+import DragTarget                              from './DragTarget.mjs';
+import Document                                from '../model/Document.mjs';
+import Operations                              from '../model/Operations.mjs';
+import Preview                                 from '../interaction/Preview.mjs';
+import {previewToOperation as toDockOperation} from '../model/PreviewContract.mjs';
 
 /**
  * @class Neo.dashboard.dock.window.Participation
@@ -173,6 +176,24 @@ class Participation extends Base {
          */
         windowId: null,
         /**
+         * The dock workspace this participation speaks for. Supplying it is what lets the seams
+         * above stay unset: every default below answers from state this workspace already holds
+         * (`dockModel`, the reducer pair, the projection options, the tear-out registries), so a
+         * host that composes a workspace gets cross-window drag without re-deriving it.
+         *
+         * A host seam always wins — the defaults resolve only where one is `null`.
+         * @member {Neo.dashboard.dock.Workspace|null} workspace=null
+         */
+        workspace: null,
+        /**
+         * The worker-owned workspace set ({@link Neo.dashboard.dock.window.WorkspaceSet}) this
+         * workspace is registered in. It is the only source that can resolve a SIBLING workspace's
+         * document, so without it foreign drops decline exactly as they do today — a single-workspace
+         * host loses nothing it had.
+         * @member {Object|null} workspaceSet=null
+         */
+        workspaceSet: null,
+        /**
          * This workspace's id in the worker-owned workspace set — the `targetWorkspaceId` of every
          * foreign transfer committed here.
          * @member {String|null} workspaceId=null
@@ -188,6 +209,21 @@ class Participation extends Base {
     target = null
 
     /**
+     * The gesture controller composed by {@link #resolveAffordances}, or null while a host seam
+     * answers the preview tier. Owned here, destroyed here.
+     * @member {Neo.dashboard.dock.interaction.DragAffordances|null} ownedAffordances=null
+     * @protected
+     */
+    ownedAffordances = null
+
+    /**
+     * The preview overlay composed by {@link #resolveAffordances}. Owned here, destroyed here.
+     * @member {Neo.dashboard.dock.interaction.Preview|null} ownedPreview=null
+     * @protected
+     */
+    ownedPreview = null
+
+    /**
      * Creates + registers the workspace's cross-window target with the five owner seams bound.
      * @param {Object} config
      */
@@ -197,18 +233,18 @@ class Participation extends Base {
         let me = this;
 
         me.target = Neo.create(DragTarget, {
-            clearPreview           : me.clearPreview,
+            clearPreview           : me.clearPreview            ?? me.defaultClearPreview.bind(me),
             commitOperation        : me.commitDrop.bind(me),
             dragCoordinator        : me.dragCoordinator,
-            hitTest                : me.hitTest,
-            previewFor             : me.previewFor,
-            previewToOperation     : me.previewToOperation,
+            hitTest                : me.hitTest                 ?? me.defaultHitTest.bind(me),
+            previewFor             : me.previewFor              ?? me.defaultPreviewFor.bind(me),
+            previewToOperation     : me.previewToOperation      ?? toDockOperation,
             promoteDragEmbodiment  : me.promoteDragEmbodiment,
-            resolveNativeWindowDrag: me.resolveNativeWindowDrag,
+            resolveNativeWindowDrag: me.resolveNativeWindowDrag ?? me.defaultResolveNativeWindowDrag.bind(me),
             restoreDragEmbodiment  : me.restoreDragEmbodiment,
             resumeNativeWindowDrag : me.resumeNativeWindowDrag,
             retireNativeWindowDrag : me.retireNativeWindowDrag,
-            sortGroup              : me.sortGroup,
+            sortGroup              : me.sortGroup ?? me.defaultSortGroup(),
             stageDragEmbodiment    : me.stageDragEmbodiment,
             awaitDragEmbodiment    : me.awaitDragEmbodiment,
             suspendNativeWindowDrag: me.suspendNativeWindowDrag,
@@ -217,6 +253,200 @@ class Participation extends Base {
             stableTargetId: me.workspaceId,
             windowId      : me.windowId
         })
+    }
+
+    /**
+     * @summary Composes the engine's own affordance tier on first use.
+     *
+     * {@link Neo.dashboard.dock.interaction.Preview} and
+     * {@link Neo.dashboard.dock.interaction.DragAffordances} both document themselves as the
+     * app-neutral pieces every docking workspace composes, and no engine workspace composes either —
+     * so a host that supplies no preview seam has nothing to paint into, resolves no preview for a
+     * remote hover, and can never convert a drop into an operation. Composing them here keeps that
+     * assembly out of the workspace class while making the seam answerable.
+     * @returns {Neo.dashboard.dock.interaction.DragAffordances|null}
+     * @protected
+     */
+    resolveAffordances() {
+        let me        = this,
+            workspace = me.workspace,
+            host      = workspace?.getDockHost?.();
+
+        if (me.ownedAffordances || !workspace || !host || workspace.isDestroyed) {
+            return me.ownedAffordances
+        }
+
+        me.ownedPreview = workspace.add({module: Preview});
+
+        me.ownedAffordances = Neo.create(DragAffordances, {
+            host,
+            owner  : workspace,
+            preview: me.ownedPreview
+        });
+
+        return me.ownedAffordances
+    }
+
+    /**
+     * Engine default for {@link #clearPreview}: drops the overlay this participation owns.
+     * @protected
+     */
+    defaultClearPreview() {
+        this.ownedAffordances?.clear()
+    }
+
+    /**
+     * Engine default for {@link #commitLocal}: the workspace's own reducer pair — the identical
+     * path an in-window drop rides, so a cross-window local drop never becomes a parallel commit.
+     * @param {Object} operation
+     * @returns {Object|null}
+     * @protected
+     */
+    defaultCommitLocal(operation) {
+        let workspace = this.workspace,
+            result    = workspace?.applyDockZoneOperation?.(operation);
+
+        if (!result || result.errors?.length || !result.document) {
+            return null
+        }
+
+        workspace.onDockZoneDocumentChange(result.document, operation, workspace);
+
+        return result
+    }
+
+    /**
+     * Engine default for {@link #commitTransfer}: the workspace set's atomic pair adoption. It
+     * returns a strict boolean because a truthy-but-unacknowledged publish would open the
+     * coordinator's source-retirement path over a transfer that never landed.
+     * @param {Object} data
+     * @returns {Boolean}
+     * @protected
+     */
+    defaultCommitTransfer(data) {
+        return this.workspaceSet?.adoptTransfer?.(data) === true
+    }
+
+    /**
+     * The effective transfer publisher: a host seam, else the workspace set's adoption, else `null`.
+     * `null` is the capability answer rather than a missing function — a workspace with no set has
+     * no sibling to transfer with, and every foreign drop must fail closed there exactly as before.
+     * @returns {Function|null}
+     * @protected
+     */
+    resolveCommitTransfer() {
+        return this.commitTransfer ?? (this.workspaceSet ? this.defaultCommitTransfer.bind(this) : null)
+    }
+
+    /**
+     * Engine default for {@link #getDocument}: this workspace's committed document.
+     * @returns {Object|null}
+     * @protected
+     */
+    defaultGetDocument() {
+        return this.workspace?.dockModel ?? null
+    }
+
+    /**
+     * Engine default for {@link #getForeignDocument}: a sibling's committed document, which only
+     * the workspace set can resolve. Without a set this stays `null` and foreign drops fail closed.
+     * @param {String} workspaceId
+     * @returns {Object|null}
+     * @protected
+     */
+    defaultGetForeignDocument(workspaceId) {
+        return this.workspaceSet?.getDocument?.(workspaceId) ?? null
+    }
+
+    /**
+     * Engine default for {@link #hitTest}: window-local bounds, side-effect free and synchronous as
+     * the seam requires — a measurement here would stall the ~60hz remote hover stream.
+     * @param {Number} localX
+     * @param {Number} localY
+     * @returns {Boolean}
+     * @protected
+     */
+    defaultHitTest(localX, localY) {
+        let inner = this.windowId != null ? Neo.manager?.Window?.get(this.windowId)?.innerRect : null;
+
+        return Boolean(
+            inner && Number.isFinite(localX) && Number.isFinite(localY) &&
+            localX >= 0 && localY >= 0 && localX <= inner.width && localY <= inner.height
+        )
+    }
+
+    /**
+     * Engine default for {@link #previewFor}: resolves the remote hover frame against the gesture
+     * controller's synchronous geometry mirror. The warm-up is deliberately not awaited — the seam
+     * must answer on the frame it arrives, and the first frames of a gesture resolving to `null`
+     * while geometry settles is the documented behaviour of that mirror.
+     * @param {Object} payload
+     * @returns {Object|null}
+     * @protected
+     */
+    defaultPreviewFor(payload) {
+        let affordances = this.resolveAffordances(),
+            draggedItem = payload?.draggedItem;
+
+        if (!affordances || !draggedItem?.dockItemId) {
+            return null
+        }
+
+        affordances.ensureGeometry();
+
+        return affordances.resolvePreview({
+            groupNodeId : draggedItem.dockGroupNodeId ?? null,
+            itemId      : draggedItem.dockItemId,
+            pointer     : {x: payload.localX, y: payload.localY},
+            sourceNodeId: draggedItem.dockSourceNodeId ?? payload.sourceNodeId ?? null
+        }) ?? null
+    }
+
+    /**
+     * Engine default for {@link #resolveNativeWindowDrag}: maps a moving popup back to the pane the
+     * workspace admitted into it, through the tear-out registry the engine already maintains and the
+     * `resolvePane` hook every consumer implements.
+     * @param {String|Number} movingWindowId
+     * @returns {Object|null}
+     * @protected
+     */
+    defaultResolveNativeWindowDrag(movingWindowId) {
+        let me        = this,
+            workspace = me.workspace,
+            panes     = workspace?.tearOutPanes;
+
+        if (!panes || movingWindowId == null) {
+            return null
+        }
+
+        let itemId = Object.keys(panes).find(id => panes[id]?.windowId === movingWindowId),
+            item   = itemId ? workspace.dockModel?.items?.[itemId] : null,
+            pane   = item ? workspace.resolvePane?.(itemId, item) : null;
+
+        if (!pane || pane.isDestroyed) {
+            return null
+        }
+
+        pane.dockItemId            = itemId;
+        pane.dockSourceWorkspaceId = me.workspaceId;
+
+        return {
+            draggedItem      : pane,
+            embodyNativeHover: true,
+            sourceWindowId   : movingWindowId,
+            widgetName       : itemId
+        }
+    }
+
+    /**
+     * Engine default for {@link #sortGroup}: the value the workspace already publishes to its own
+     * projection, read back through the documented options hook. Absent, the target never registers
+     * and the workspace stays fully in-window — the unchanged opt-in default.
+     * @returns {String|null}
+     * @protected
+     */
+    defaultSortGroup() {
+        return this.workspace?.getDockProjectionOptions?.()?.crossWindowSortGroup ?? null
     }
 
     /**
@@ -242,7 +472,8 @@ class Participation extends Base {
             groupNodeId       = draggedItem?.dockGroupNodeId,
             itemId            = draggedItem?.dockItemId,
             sourceWorkspaceId = draggedItem?.dockSourceWorkspaceId,
-            document          = me.getDocument?.();
+            publishTransfer   = me.resolveCommitTransfer(),
+            document          = (me.getDocument ?? me.defaultGetDocument).call(me);
 
         if (!operation || !itemId || !document) {
             return null
@@ -256,9 +487,9 @@ class Participation extends Base {
                 return null
             }
 
-            const sourceDocument = me.getForeignDocument?.(sourceWorkspaceId);
+            const sourceDocument = (me.getForeignDocument ?? me.defaultGetForeignDocument).call(me, sourceWorkspaceId);
 
-            if (!sourceDocument || !me.commitTransfer ||
+            if (!sourceDocument || !publishTransfer ||
                 operation.operation !== 'transferNode' || operation.nodeId !== groupNodeId ||
                 Document.resolveStackRoot(sourceDocument) !== groupNodeId) {
                 return null
@@ -276,7 +507,7 @@ class Participation extends Base {
                 return null
             }
 
-            const published = me.commitTransfer({
+            const published = publishTransfer({
                 descriptor,
                 sourceDocument   : result.sourceDocument,
                 sourceWorkspaceId,
@@ -293,12 +524,14 @@ class Participation extends Base {
         // collision rejection below, not silently commit the local record. An unstamped payload
         // proves neither side, so it falls through to the foreign guard and fails closed.
         if (sourceWorkspaceId != null && sourceWorkspaceId === me.workspaceId) {
-            return me.commitLocal?.(operation, draggedItem) ?? null
+            return (me.commitLocal ?? me.defaultCommitLocal).call(me, operation, draggedItem) ?? null
         }
 
-        const sourceDocument = sourceWorkspaceId != null ? me.getForeignDocument?.(sourceWorkspaceId) : null;
+        const sourceDocument = sourceWorkspaceId != null
+            ? (me.getForeignDocument ?? me.defaultGetForeignDocument).call(me, sourceWorkspaceId)
+            : null;
 
-        if (!sourceDocument || !me.commitTransfer) {
+        if (!sourceDocument || !publishTransfer) {
             return null
         }
 
@@ -316,7 +549,7 @@ class Participation extends Base {
             return null
         }
 
-        const published = me.commitTransfer({
+        const published = publishTransfer({
             descriptor,
             sourceDocument   : result.sourceDocument,
             sourceWorkspaceId,
@@ -332,8 +565,18 @@ class Participation extends Base {
      * registration lifecycle.
      */
     destroy() {
-        this.target?.destroy();
-        this.target = null;
+        let me = this;
+
+        me.target?.destroy();
+        me.target = null;
+
+        // Only what this instance composed: a host-supplied preview seam owns its own overlay, and
+        // destroying that would tear down a renderer the host still paints in-window drags with.
+        me.ownedAffordances?.destroy();
+        me.ownedAffordances = null;
+
+        me.ownedPreview?.destroy();
+        me.ownedPreview = null;
 
         super.destroy()
     }

--- a/test/playwright/unit/dashboard/DockCrossWindowParticipation.spec.mjs
+++ b/test/playwright/unit/dashboard/DockCrossWindowParticipation.spec.mjs
@@ -658,4 +658,190 @@ test.describe('Neo.dashboard.dock.window.Participation (ADR 0029 §2.3 — works
         WindowManager.unregister(WindowManager.get('cwd-inert-a'));
         WindowManager.unregister(WindowManager.get('cwd-inert-b'))
     });
+
+    /**
+     * The seams the engine answers from state the workspace already holds. Every arm asserts the
+     * default AND that a host value still wins: a default that cannot be overridden would be a
+     * capability REMOVAL wearing the shape of an addition.
+     */
+    test.describe('seams the engine answers from workspace state', () => {
+        const createWorkspaceStub = ({dockModel, projectionOptions, resolvePane, tearOutPanes} = {}) => ({
+            applied     : [],
+            changes     : [],
+            dockModel   : dockModel ?? targetDoc(),
+            tearOutPanes: tearOutPanes ?? {},
+
+            applyDockZoneOperation(descriptor) {
+                this.applied.push(descriptor);
+
+                return {document: this.dockModel, errors: []}
+            },
+            getDockHost() {
+                return null
+            },
+            getDockProjectionOptions() {
+                return projectionOptions ?? {}
+            },
+            onDockZoneDocumentChange(document, descriptor) {
+                this.changes.push([document, descriptor])
+            },
+            resolvePane(itemId, item) {
+                return resolvePane?.(itemId, item) ?? null
+            }
+        });
+
+        const createParticipation = config => Neo.create(DockCrossWindowParticipation, {
+            dragCoordinator: createCoordinatorStub(config.calls ?? []),
+            windowId       : 'window-b',
+            workspaceId    : 'B',
+            ...config
+        });
+
+        test('a workspace publishing a cross-window sort group registers a target with no sortGroup seam', () => {
+            const
+                calls         = [],
+                participation = createParticipation({
+                    calls,
+                    workspace: createWorkspaceStub({projectionOptions: {crossWindowSortGroup: 'dock-engine'}})
+                });
+
+            expect(calls).toHaveLength(1);
+            expect(participation.target.sortGroup).toBe('dock-engine');
+
+            participation.destroy()
+        });
+
+        test('a workspace publishing NO sort group registers nothing — the opt-in stays opt-in', () => {
+            const
+                calls         = [],
+                participation = createParticipation({calls, workspace: createWorkspaceStub()});
+
+            expect(calls).toHaveLength(0);
+            expect(participation.target.sortGroup ?? null).toBeNull();
+
+            participation.destroy()
+        });
+
+        test('a host sortGroup still wins over the workspace default', () => {
+            const participation = createParticipation({
+                sortGroup: 'host-group',
+                workspace: createWorkspaceStub({projectionOptions: {crossWindowSortGroup: 'dock-engine'}})
+            });
+
+            expect(participation.target.sortGroup).toBe('host-group');
+
+            participation.destroy()
+        });
+
+        test('an unset commitLocal rides the workspace reducer pair', () => {
+            const
+                workspace     = createWorkspaceStub(),
+                participation = createParticipation({sortGroup: 'dock-engine', workspace}),
+                operation     = {operation: 'addTab', itemId: 'alpha', tabsNodeId: 'main-tabs'},
+                result        = participation.commitDrop(operation, {dockItemId: 'alpha', dockSourceWorkspaceId: 'B'});
+
+            expect(workspace.applied).toEqual([operation]);
+            expect(workspace.changes).toHaveLength(1);
+            expect(result?.document).toBe(workspace.dockModel);
+
+            participation.destroy()
+        });
+
+        test('an unset foreign pair rides the workspace set, and without a set a foreign drop fails closed', () => {
+            const
+                adopted   = [],
+                source    = sourceDoc(),
+                operation = {operation: 'addTab', itemId: 'terminal', tabsNodeId: 'main-tabs'},
+                payload   = {dockItemId: 'terminal', dockSourceWorkspaceId: 'A'};
+
+            const joined = createParticipation({
+                sortGroup   : 'dock-engine',
+                workspace   : createWorkspaceStub(),
+                workspaceSet: {
+                    adoptTransfer: data => {adopted.push(data); return true},
+                    getDocument  : workspaceId => (workspaceId === 'A' ? source : null)
+                }
+            });
+
+            expect(joined.commitDrop(operation, payload)).toBeTruthy();
+            expect(adopted).toHaveLength(1);
+            expect(adopted[0].sourceWorkspaceId).toBe('A');
+            expect(adopted[0].targetWorkspaceId).toBe('B');
+
+            joined.destroy();
+
+            // No set means no sibling to resolve — the same drop must decline, not guess.
+            const lone = createParticipation({sortGroup: 'dock-engine', workspace: createWorkspaceStub()});
+
+            expect(lone.commitDrop(operation, payload)).toBeNull();
+
+            lone.destroy()
+        });
+
+        test('the engine hit test answers window-local bounds and refuses everything outside them', () => {
+            WindowManager.register({
+                id       : 'cwd-default-win',
+                innerRect: new Rectangle(0, 0, 800, 600),
+                outerRect: new Rectangle(0, 0, 800, 600)
+            });
+
+            const participation = createParticipation({
+                sortGroup: 'dock-engine',
+                windowId : 'cwd-default-win',
+                workspace: createWorkspaceStub()
+            });
+
+            expect(participation.target.acceptsRemoteDrag(10, 10)).toBe(true);
+            expect(participation.target.acceptsRemoteDrag(900, 10)).toBe(false);
+            expect(participation.target.acceptsRemoteDrag(10, 700)).toBe(false);
+            expect(participation.target.acceptsRemoteDrag(Number.NaN, 10)).toBe(false);
+
+            participation.destroy();
+            WindowManager.unregister(WindowManager.get('cwd-default-win'))
+        });
+
+        test('an unset native-window resolver maps a moving popup back through the tear-out registry', () => {
+            const
+                pane          = {id: 'pane-terminal', isDestroyed: false},
+                participation = createParticipation({
+                    sortGroup: 'dock-engine',
+                    workspace: createWorkspaceStub({
+                        dockModel   : sourceDoc(),
+                        resolvePane : itemId => (itemId === 'terminal' ? pane : null),
+                        tearOutPanes: {terminal: {windowId: 'popup-1'}}
+                    }),
+                    workspaceId: 'A'
+                });
+
+            const resolved = participation.target.getNativeWindowDrag('popup-1');
+
+            expect(resolved?.draggedItem).toBe(pane);
+            expect(resolved.widgetName).toBe('terminal');
+            expect(pane.dockItemId).toBe('terminal');
+            expect(pane.dockSourceWorkspaceId).toBe('A');
+
+            expect(participation.target.getNativeWindowDrag('popup-unknown')).toBeNull();
+
+            participation.destroy()
+        });
+
+        test('the refinement seams stay null and a participation built without them degrades', () => {
+            const participation = createParticipation({
+                sortGroup: 'dock-engine',
+                workspace: createWorkspaceStub()
+            });
+
+            for (const seam of [
+                'awaitDragEmbodiment', 'promoteDragEmbodiment', 'restoreDragEmbodiment',
+                'resumeNativeWindowDrag', 'retireNativeWindowDrag', 'stageDragEmbodiment',
+                'suspendNativeWindowDrag'
+            ]) {
+                expect(participation[seam] ?? null, `${seam} stays host-owned`).toBeNull()
+            }
+
+            expect(() => participation.target.onRemoteDragLeave()).not.toThrow();
+
+            participation.destroy()
+        })
+    })
 });


### PR DESCRIPTION
Resolves #18233

`window/Participation.mjs` was a 342-line engine class in which all 19 seams defaulted to `null` and which the engine never constructed — so cross-window dock drag existed only where a host hand-wired every input. Ten of those seams are answerable from state the engine already holds. They now are, from inside the class that owns them.

The seam that gates everything is `sortGroup`: `DragTarget` registers only when `sortGroup && windowId != null`, so a host that publishes `crossWindowSortGroup` — which the shipping consumer already does — got no target at all. It now reads that value back through the documented `getDockProjectionOptions()` hook.

**The finding underneath the ticket.** `interaction/Preview` describes itself as *"the app-neutral overlay every docking workspace composes"*; `interaction/DragAffordances` as *"the app-neutral drag-affordance gesture controller every docking workspace composes"*. No engine workspace composes either. The engine ships every piece of cross-window drag and assembles none of them — the ticket's thesis one layer down. `Participation` therefore composes that tier itself, lazily, so a host that supplies its own preview seam never gets a second controller.

## Deltas

| File | Change |
|---|---|
| `src/dashboard/dock/window/Participation.mjs` | `workspace` + `workspaceSet` configs; ten `defaultX()` resolvers; `resolveAffordances()` composes the engine's own preview tier on first use; `commitDrop` reads through the resolvers; `destroy` retires only what this instance composed |
| `test/playwright/unit/dashboard/DockCrossWindowParticipation.spec.mjs` | 8 arms — each default, each override-still-wins direction, and the fail-closed cases |
| `src/dashboard/dock/Workspace.mjs` | **untouched** |
| `apps/workstation/view/Workspace.mjs` | **untouched** — see AC-5 |

## AC Evidence

| AC | Verdict | Evidence: |
|---|---|---|
| AC-1 zero-participation host gets cross-window drag | **engine half delivered; witnessed arm re-scoped** | A workspace publishing `crossWindowSortGroup` registers a coordinator target with zero seams supplied, resolves a remote hover through the composed tier, converts via `previewToOperation`, commits via the reducer pair or the set's atomic adoption — all unit-proven and mutation-covered. The two-window arm that *watches previews paint* has no harness in this repo (e2e runs in no workflow; the NL battery is `testIgnore`d without `NEO_AGENTOS_RUNTIME_ROOT` — #17844). I am not asserting it green off unit arms |
| AC-2 ten seams resolve from engine state; a host value still wins | met | one arm per direction; `sortGroup` proves both (`dock-engine` from options, `host-group` when supplied) |
| AC-3 seven refinement seams stay null and degrade rather than throw | met | all seven asserted null; `onRemoteDragLeave()` does not throw on a participation built without them |
| AC-4 `dock/Workspace.mjs` gains no net lines | met | **0 lines changed** — the file is not in the diff |
| AC-5 the workstation loses the seams the engine answers | **refuted as written** | I wrote it and measured: **net +6**, or **+2** without the comment. Not negative, so I reverted rather than ship it. Detail below |
| AC-6 mutation-verified, not merely green | met | matrix below |

**AC-6 — every default reds an arm when forced to decline:**

| mutant | result |
|---|---|
| `defaultSortGroup` → `null` | 1 failed |
| `defaultGetDocument` → `null` | 2 failed |
| `defaultCommitTransfer` → `false` | 1 failed |
| `defaultHitTest` → `false` | 1 failed |

**AC-5, why it cannot be met while multi-workspace keying stays out of scope.** The workstation's ten seams exist *because* they thread `workspaceId`: it runs N workspaces per window and keys their documents in its own map. For its **main** workspace five are provably identical to the engine defaults — `getWorkspaceDocument(MAIN)` → `this.dockModel`; `hitTestCrossWindowTarget(MAIN)` → window bounds; `commitLocalWorkspaceOperation(MAIN)` → the same reducer pair the default calls (it overrides neither `applyDockZoneOperation` nor `onDockZoneDocumentChange`); `previewToOperation` → the same imported function; `sortGroup` → the constant its own `getDockProjectionOptions()` already publishes. For its **vessel** workspaces, none are. So the seams can only become conditional, never deleted — and a conditional that adds lines to delete nothing is moving code below the bar, which is what this epic exists to stop.

Deleting them requires the engine to answer a workspace it does not own — this ticket's own Out of Scope entry (*"`workspaceId` stays a threaded parameter"*). **AC-5 and that entry contradict each other**; the disposition is on the ticket. The consumer that does lose code is the zero-participation host: 19 seams to 0.

## Test Evidence

```
unit (full tier)                       3151 passed   ← 3143 + 8 new arms
unit DockCrossWindowParticipation        20 passed
```

The four mutants above were run against the committed tree and the working tree restored to 0 changed after each.

## Post-Merge Validation

- A host that composes a dock workspace and publishes `crossWindowSortGroup` should now see a registered coordinator target with no participation code of its own.
- The lazy composition in `resolveAffordances()` is the guard against a second gesture controller: it only runs when `previewFor` is unset, so any host supplying its own preview seam is untouched.
- `destroy()` retires only instances this participation created — a host-owned overlay is never torn down by it.
- The witnessed two-window arm lands with #17844's harness.

Authored by Grace (Claude Opus 5, Claude Code). Session 118d8435-8d23-4745-a28a-8d22da918aac.
