### PR TITLE
feat(dock): a workspace answers the multi-window restore seams, so a captured topology can reach it

### DIFF
--- a/docs/output/class-hierarchy.json
+++ b/docs/output/class-hierarchy.json
@@ -244,6 +244,7 @@
  "Neo.dashboard.dock.projection.Reconciler": "Neo.core.Base",
  "Neo.dashboard.dock.window.DragTarget": "Neo.core.Base",
  "Neo.dashboard.dock.window.Participation": "Neo.core.Base",
+ "Neo.dashboard.dock.window.TopologySeams": "Neo.core.Base",
  "Neo.data.Model": "Neo.core.Base",
  "Neo.data.Pipeline": "Neo.core.Base",
  "Neo.data.RecordFactory": "Neo.core.Base",

--- a/src/dashboard/dock/Workspace.mjs
+++ b/src/dashboard/dock/Workspace.mjs
@@ -10,6 +10,7 @@ import {createDockTearOutHandlers} from './window/TearOut.mjs';
 import Document                    from './model/Document.mjs';
 import Operations                  from './model/Operations.mjs';
 import {previewToOperation}        from './model/PreviewContract.mjs';
+import TopologySeams               from './window/TopologySeams.mjs';
 
 /**
  * @summary The engine-owned dock workspace host: the reducer-container that owns one committed
@@ -84,6 +85,12 @@ import {previewToOperation}        from './model/PreviewContract.mjs';
  */
 class Workspace extends Container {
     static config = {
+        /**
+         * A topology restore resolves its holder as the component carrying the dock document, so
+         * the seams must be here; their implementation is not.
+         * @member {Neo.core.Base[]} mixins=[TopologySeams]
+         */
+        mixins: [TopologySeams],
         /**
          * @member {String} className='Neo.dashboard.dock.Workspace'
          * @protected

--- a/src/dashboard/dock/window/TopologySeams.mjs
+++ b/src/dashboard/dock/window/TopologySeams.mjs
@@ -56,8 +56,11 @@ class TopologySeams extends Base {
     /**
      * @summary The atomic multi-document write: every slot adopts, or none does.
      *
-     * A refusal returns its reason rather than throwing, because the service treats an empty or
-     * missing `errors` as success — a thrown commit would read as one.
+     * A refusal returns its reason rather than throwing because the caller reads a structured
+     * result: `restoreTopologyPerspective` branches on `commit?.errors?.length` and does not wrap
+     * this call, so a throw would escape the refusal shape entirely and surface as an RPC crash
+     * instead of a declared refusal — the same distinction `executeDockOperation` draws for the
+     * single-document path.
      * @param {Object[]} documents Slot-ordered committed documents, primary first.
      * @returns {Object} `{errors}` — empty when every slot committed.
      */
@@ -93,9 +96,18 @@ class TopologySeams extends Base {
             return {errors: [`topology commit rolled back: ${error.message}`]}
         }
 
-        // The set writes each slot through its registered `setDocument`, which for the primary
-        // assigns `dockModel` directly — the view would keep projecting the pre-restore document
-        // without this. Sibling workspaces re-project through their own registered writer.
+        // The set writes each slot through its registered `setDocument`, and every such writer in
+        // the codebase is a plain assignment — `me.dockModel = document`, `me.popupDocument =
+        // document`, `targetState.document = document`. `dockModel` is not a reactive config, so
+        // nothing projects off the write; the document advances only inside
+        // `onDockZoneDocumentChange`, which is why the primary needs this call.
+        //
+        // ONLY the primary converges here. A sibling slot's document is written and never
+        // projected: the `register` contract carries no projection seam, and no consumer has a
+        // vessel-side projection to hand it — `targetState.document` is written in five places and
+        // read only by its own `getDocument`. So this restores N documents and one view. Making the
+        // second window visibly converge is a missing layer, not a missing call, and it is owed
+        // beyond this seam.
         me.onDockZoneDocumentChange(me.dockModel, null, me);
 
         return {errors: []}

--- a/src/dashboard/dock/window/TopologySeams.mjs
+++ b/src/dashboard/dock/window/TopologySeams.mjs
@@ -1,0 +1,105 @@
+import Base from '../../../core/Base.mjs';
+
+/**
+ * @class Neo.dashboard.dock.window.TopologySeams
+ * @extends Neo.core.Base
+ *
+ * @summary The holder seam pair a multi-window perspective restore reaches an app through.
+ *
+ * `Neo.ai.client.DockService` routes a topology-scope record through
+ * {@link Neo.dashboard.dock.model.TopologyReconciler} and then commits every resulting document
+ * through the holder — but only when the holder answers BOTH `getDockTopologyDocuments()` and
+ * `commitDockTopologyDocuments()`. It resolves that holder as the component carrying the dock
+ * document, so the seams have to be instance methods on the workspace itself; the service refuses
+ * a topology record outright when either is absent, which is why an unimplemented pair reports
+ * nothing and simply never restores.
+ *
+ * They live in a mixin rather than in `dashboard/dock/Workspace.mjs` because that file is under a
+ * standing directive to stop growing, and this is a whole responsibility rather than a method.
+ *
+ * **Slot order is registration order.** A host registers its primary workspace into the set first
+ * (`register(MAIN, {getDocument: () => me.dockModel, …})`) and vessel workspaces as they commit, so
+ * `ids()` yields primary-first — the order `Persistence.captureTopologyPerspective()` captured and
+ * the reconciler restores by index. Nothing here re-derives an order; re-deriving one is how slots
+ * drift apart between capture and restore.
+ *
+ * **A workspace with no set is not a failure case.** It answers a single-slot topology, which
+ * `Persistence` documents as structurally identical to a window-scope record. What it must never do
+ * is accept a multi-slot record and silently drop the slots it cannot hold.
+ */
+class TopologySeams extends Base {
+    static config = {
+        /**
+         * @member {String} className='Neo.dashboard.dock.window.TopologySeams'
+         * @protected
+         */
+        className: 'Neo.dashboard.dock.window.TopologySeams'
+    }
+
+    /**
+     * @summary The ordered live committed documents, primary first — the read seam that topology
+     * CAPTURE and topology RESTORE share.
+     * @returns {Object[]}
+     */
+    getDockTopologyDocuments() {
+        let me  = this,
+            set = me.workspaceSet,
+            ids = typeof set?.ids === 'function' ? set.ids() : [];
+
+        if (!ids.length) {
+            return me.dockModel ? [me.dockModel] : []
+        }
+
+        return ids.map(workspaceId => set.getDocument(workspaceId))
+    }
+
+    /**
+     * @summary The atomic multi-document write: every slot adopts, or none does.
+     *
+     * A refusal returns its reason rather than throwing, because the service treats an empty or
+     * missing `errors` as success — a thrown commit would read as one.
+     * @param {Object[]} documents Slot-ordered committed documents, primary first.
+     * @returns {Object} `{errors}` — empty when every slot committed.
+     */
+    commitDockTopologyDocuments(documents) {
+        let me  = this,
+            set = me.workspaceSet;
+
+        if (!Array.isArray(documents) || !documents.length || documents.some(document => !document)) {
+            return {errors: ['a topology commit needs one committed document per registered workspace']}
+        }
+
+        if (typeof set?.adoptAll !== 'function') {
+            if (documents.length !== 1) {
+                return {errors: [
+                    `this workspace holds a single document and the record carries ${documents.length} — ` +
+                    'a topology restore commits every slot or none'
+                ]}
+            }
+
+            me.onDockZoneDocumentChange(documents[0], null, me);
+
+            return {errors: []}
+        }
+
+        try {
+            if (!set.adoptAll(documents)) {
+                return {errors: [
+                    'the workspace set refused the topology: the slot count does not match the registered ' +
+                    'workspaces, a slot carried no document, or a workspace is read-only'
+                ]}
+            }
+        } catch (error) {
+            return {errors: [`topology commit rolled back: ${error.message}`]}
+        }
+
+        // The set writes each slot through its registered `setDocument`, which for the primary
+        // assigns `dockModel` directly — the view would keep projecting the pre-restore document
+        // without this. Sibling workspaces re-project through their own registered writer.
+        me.onDockZoneDocumentChange(me.dockModel, null, me);
+
+        return {errors: []}
+    }
+}
+
+export default Neo.setupClass(TopologySeams);

--- a/src/dashboard/dock/window/WorkspaceSet.mjs
+++ b/src/dashboard/dock/window/WorkspaceSet.mjs
@@ -114,6 +114,55 @@ export function createDockWorkspaceSet() {
         },
 
         /**
+         * Adopts one committed document per registered workspace, in `ids()` order — the slot
+         * order a topology perspective was captured in.
+         *
+         * All-or-nothing, like {@link #adoptTransfer} one arity up: a slot count that does not
+         * match the registry, a missing document, or a read-only entry refuses before anything is
+         * written, and a throw mid-write rolls every earlier slot back to the document it replaced.
+         * A partially adopted topology is a composition no capture could have produced.
+         * @param {Object[]} documents Slot-ordered committed documents, primary first.
+         * @returns {Boolean} true when every slot adopted
+         */
+        adoptAll(documents) {
+            const ids = [...entries.keys()];
+
+            if (
+                !Array.isArray(documents) || documents.length !== ids.length ||
+                documents.some(document => !document) ||
+                ids.some(workspaceId => !entries.get(workspaceId).setDocument)
+            ) {
+                return false
+            }
+
+            const written = [];
+
+            for (let index = 0; index < ids.length; index++) {
+                const entry = entries.get(ids[index]);
+
+                written.push([entry, entry.getDocument()]);
+
+                try {
+                    entry.setDocument(documents[index])
+                } catch (error) {
+                    written.reverse().forEach(([slot, previous]) => {
+                        try {
+                            slot.setDocument(previous)
+                        } catch (compensationError) {
+                            // best-effort by construction, exactly as `adoptTransfer` documents:
+                            // the original failure below still propagates, and a writer failing its
+                            // own compensation is the documented double-breach residual
+                        }
+                    });
+
+                    throw error
+                }
+            }
+
+            return true
+        },
+
+        /**
          * @param {String} workspaceId
          * @returns {Object|null} the entry's current document, or null (fail closed)
          */

--- a/test/playwright/unit/dashboard/DockTopologySeams.spec.mjs
+++ b/test/playwright/unit/dashboard/DockTopologySeams.spec.mjs
@@ -166,12 +166,12 @@ test.describe('Neo.dashboard.dock.window.TopologySeams — the multi-window rest
 
         expect(result.errors).toEqual([]);
         expect(result.documents).toHaveLength(2);
-        // The gap this arm was written to pin is CLOSED, and the arm is why we know it: #18257 gave
-        // `TopologyDiff` an `activeItemChanges` bucket and `RestorePlanner` a `setActiveItem` step,
-        // and `TopologyReconciler` reaches both through `RestorePlanner.restoreToward()`. Capture
-        // kept `activeItemId` all along (asserted above); now the restore carries it too, so the
-        // captured value wins over the live one. The arm stays, inverted: it now pins the restore.
-        expect(result.documents[0].nodes['main-tabs'].activeItemId, 'captured value restores (#18257)').toBe('strategy');
+        // Which tab was active is restored, not merely which tabs exist: `TopologyDiff` reports an
+        // `activeItemChanges` bucket and `RestorePlanner` emits a `setActiveItem` step for it, both
+        // reached here through `RestorePlanner.restoreToward()`. Capture keeps `activeItemId`
+        // (asserted above) and the restore now carries it, so the CAPTURED value wins over the live
+        // one — this arm is what fails if that stops being true.
+        expect(result.documents[0].nodes['main-tabs'].activeItemId, 'captured active tab wins over live').toBe('strategy');
 
         const commit = workspace.commitDockTopologyDocuments(result.documents, {operation: 'restorePerspective'});
 

--- a/test/playwright/unit/dashboard/DockTopologySeams.spec.mjs
+++ b/test/playwright/unit/dashboard/DockTopologySeams.spec.mjs
@@ -1,0 +1,199 @@
+import {setup} from '../../setup.mjs';
+
+setup({
+    appConfig: {
+        name: 'DashboardDockTopologySeamsTest'
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../src/Neo.mjs';
+import * as core      from '../../../../src/core/_export.mjs';
+import '../../../../src/manager/Instance.mjs'; // defines Neo.get — the container child-add path resolves parents through it
+import '../../../../src/tab/Container.mjs';    // registers the `tab-container` ntype the projection emits
+import DockWorkspace            from '../../../../src/dashboard/dock/Workspace.mjs';
+import Persistence              from '../../../../src/dashboard/dock/model/Persistence.mjs';
+import TopologyReconciler       from '../../../../src/dashboard/dock/model/TopologyReconciler.mjs';
+import {createDockWorkspaceSet} from '../../../../src/dashboard/dock/window/WorkspaceSet.mjs';
+
+/**
+ * @summary The holder seam pair a multi-window perspective restore reaches an app through.
+ *
+ * `DockService` refuses a topology record unless the holder answers BOTH seams, and it resolves the
+ * holder as the component carrying the dock document — so these have to be real methods on a real
+ * workspace. Before this pair existed the whole capture/restore chain was exercised only against
+ * stub objects in `DockService`'s own spec, which is why an unreachable capability stayed green.
+ *
+ * The round-trip below therefore runs the REAL capture producer, the REAL topology reconciler and a
+ * REAL workspace + workspace set — nothing about the restore path is mocked.
+ */
+
+/** Primary-window fixture. */
+function primaryDoc() {
+    return {
+        schema: 'neo.dock.zone.v1',
+        root  : 'root',
+        items : {
+            strategy: {componentRef: 'strategy', title: 'Strategy', kind: 'panel'},
+            swarm   : {componentRef: 'swarm',    title: 'Swarm',    kind: 'panel'}
+        },
+        nodes: {
+            root       : {type: 'edge-zone', zones: {center: {nodeId: 'main-tabs'}}},
+            'main-tabs': {type: 'tabs', items: ['strategy', 'swarm'], activeItemId: 'strategy'}
+        }
+    }
+}
+
+/** Item-disjoint second-window fixture — the reconciler validates disjointness across windows. */
+function vesselDoc() {
+    return {
+        schema: 'neo.dock.zone.v1',
+        root  : 'root',
+        items : {terminal: {componentRef: 'terminal', title: 'Terminal', kind: 'terminal'}},
+        nodes : {
+            root         : {type: 'edge-zone', zones: {center: {nodeId: 'vessel-tabs'}}},
+            'vessel-tabs': {type: 'tabs', items: ['terminal'], activeItemId: 'terminal'}
+        }
+    }
+}
+
+/** The primary, rearranged — a different composition to restore AWAY from. */
+function primaryRearranged() {
+    const document = primaryDoc();
+
+    document.nodes['main-tabs'].items        = ['swarm', 'strategy'];
+    document.nodes['main-tabs'].activeItemId = 'swarm';
+
+    return document
+}
+
+/**
+ * A workspace that has actually projected: the commit seam ends in the view-sync contract, and an
+ * unprojected shell would exercise the seams without ever exercising that.
+ */
+class TopologyWorkspace extends DockWorkspace {
+    static config = {
+        className: 'Test.Unit.Dashboard.DockTopologySeams.Workspace',
+        layout   : {ntype: 'vbox', align: 'stretch'}
+    }
+
+    construct(config) {
+        super.construct(config);
+        this.add(this.projectDockModel())
+    }
+}
+
+Neo.setupClass(TopologyWorkspace);
+
+test.describe('Neo.dashboard.dock.window.TopologySeams — the multi-window restore seams', () => {
+    let workspace;
+
+    test.afterEach(() => {
+        workspace?.isDestroyed === false && workspace.destroy();
+        workspace = null
+    });
+
+    /**
+     * Registers the primary first, exactly as a host does — `ids()` order IS slot order, and the
+     * capture/restore pair index by it.
+     * @returns {Object} `{set, vessel}` — the live set plus a mutable second-slot handle
+     */
+    function createSet(host) {
+        const
+            vessel = {document: vesselDoc()},
+            set    = createDockWorkspaceSet();
+
+        set.register('main', {
+            getDocument: () => host.dockModel,
+            setDocument: document => host.dockModel = document
+        });
+
+        set.register('vessel', {
+            getDocument: () => vessel.document,
+            setDocument: document => vessel.document = document
+        });
+
+        return {set, vessel}
+    }
+
+    test('a workspace with no set answers a single-slot topology', () => {
+        workspace = Neo.create(TopologyWorkspace, {dockModel: primaryDoc()});
+
+        const documents = workspace.getDockTopologyDocuments();
+
+        expect(documents).toHaveLength(1);
+        expect(documents[0]).toBe(workspace.dockModel)
+    });
+
+    test('a workspace with a set answers every slot, primary first', () => {
+        workspace = Neo.create(TopologyWorkspace, {dockModel: primaryDoc()});
+
+        const {set, vessel} = createSet(workspace);
+
+        workspace.workspaceSet = set;
+
+        const documents = workspace.getDockTopologyDocuments();
+
+        expect(documents).toHaveLength(2);
+        expect(documents[0]).toBe(workspace.dockModel);
+        expect(documents[1]).toBe(vessel.document)
+    });
+
+    test('a multi-window capture restores the whole composition through the real reconciler', async () => {
+        workspace = Neo.create(TopologyWorkspace, {dockModel: primaryDoc()});
+
+        const {set, vessel} = createSet(workspace);
+
+        workspace.workspaceSet = set;
+
+        // CAPTURE the composition through the seam the service uses
+        const captured = Persistence.captureTopologyPerspective(workspace.getDockTopologyDocuments(), {
+            layoutId: 'topo-1', perspectiveName: 'Everything', title: 'Everything'
+        });
+
+        expect(captured.errors).toEqual([]);
+        expect(captured.layout.captureScope).toBe('topology');
+        // where the active tab lives at each hop — capture, reconcile, commit
+        expect(captured.layout.dockZone.nodes['main-tabs'].activeItemId, 'capture keeps it').toBe('strategy');
+
+        // the live composition MOVES ON: the primary is rearranged
+        workspace.dockModel = primaryRearranged();
+
+        expect(workspace.dockModel.nodes['main-tabs'].items).toEqual(['swarm', 'strategy']);
+
+        // RESTORE: real reconciler over the live slots, then the atomic write seam
+        const result = TopologyReconciler.reconcile(captured.layout, workspace.getDockTopologyDocuments());
+
+        expect(result.errors).toEqual([]);
+        expect(result.documents).toHaveLength(2);
+        // KNOWN GAP, pinned rather than wished away: capture keeps `activeItemId` (asserted above)
+        // and the reconciler leaves the LIVE value standing — the string appears nowhere in
+        // `TopologyReconciler` or `RestorePlanner`. Tab membership and order restore; which tab was
+        // active does not. Flagged separately; this arm exists so the gap cannot close silently.
+        expect(result.documents[0].nodes['main-tabs'].activeItemId, 'live value survives today').toBe('swarm');
+
+        const commit = workspace.commitDockTopologyDocuments(result.documents, {operation: 'restorePerspective'});
+
+        expect(commit.errors).toEqual([]);
+
+        // the captured composition is back on BOTH slots
+        expect(workspace.dockModel.nodes['main-tabs'].items).toEqual(['strategy', 'swarm']);
+        expect(Object.keys(vessel.document.items)).toEqual(['terminal']);
+
+        await workspace.refreshPromise
+    });
+
+    test('a commit refuses rather than dropping slots it cannot hold', () => {
+        workspace = Neo.create(TopologyWorkspace, {dockModel: primaryDoc()});
+
+        // no set: a single-document workspace must never silently swallow a two-window record
+        const refused = workspace.commitDockTopologyDocuments([primaryDoc(), vesselDoc()]);
+
+        expect(refused.errors).toHaveLength(1);
+        expect(refused.errors[0]).toContain('commits every slot or none');
+
+        expect(workspace.commitDockTopologyDocuments([]).errors).toHaveLength(1);
+        expect(workspace.commitDockTopologyDocuments([null]).errors).toHaveLength(1);
+        expect(workspace.commitDockTopologyDocuments(null).errors).toHaveLength(1)
+    })
+});

--- a/test/playwright/unit/dashboard/DockTopologySeams.spec.mjs
+++ b/test/playwright/unit/dashboard/DockTopologySeams.spec.mjs
@@ -166,11 +166,12 @@ test.describe('Neo.dashboard.dock.window.TopologySeams — the multi-window rest
 
         expect(result.errors).toEqual([]);
         expect(result.documents).toHaveLength(2);
-        // KNOWN GAP, pinned rather than wished away: capture keeps `activeItemId` (asserted above)
-        // and the reconciler leaves the LIVE value standing — the string appears nowhere in
-        // `TopologyReconciler` or `RestorePlanner`. Tab membership and order restore; which tab was
-        // active does not. Flagged separately; this arm exists so the gap cannot close silently.
-        expect(result.documents[0].nodes['main-tabs'].activeItemId, 'live value survives today').toBe('swarm');
+        // The gap this arm was written to pin is CLOSED, and the arm is why we know it: #18257 gave
+        // `TopologyDiff` an `activeItemChanges` bucket and `RestorePlanner` a `setActiveItem` step,
+        // and `TopologyReconciler` reaches both through `RestorePlanner.restoreToward()`. Capture
+        // kept `activeItemId` all along (asserted above); now the restore carries it too, so the
+        // captured value wins over the live one. The arm stays, inverted: it now pins the restore.
+        expect(result.documents[0].nodes['main-tabs'].activeItemId, 'captured value restores (#18257)').toBe('strategy');
 
         const commit = workspace.commitDockTopologyDocuments(result.documents, {operation: 'restorePerspective'});
 

--- a/test/playwright/unit/dashboard/DockWorkspaceSet.spec.mjs
+++ b/test/playwright/unit/dashboard/DockWorkspaceSet.spec.mjs
@@ -268,5 +268,72 @@ test.describe('Neo.dashboard.dock.window.WorkspaceSet — the workspace-set regi
 
         expect(set.getDocument('main')).toEqual(before);
         expect(set.ids()).toEqual(['main'])
+    });
+
+    /**
+     * `adoptAll` is `adoptTransfer` one arity up — the write half of a multi-window perspective
+     * restore. A partially adopted topology is a composition no capture could have produced, so
+     * every refusal path is asserted alongside the success one.
+     */
+    test.describe('adoptAll — slot-ordered, all-or-nothing', () => {
+        test('adopts one document per registered workspace in ids() order', () => {
+            const
+                main   = createHolder({rootId: 'main-before', items: []}),
+                vessel = createHolder({rootId: 'vessel-before', items: []});
+
+            set.register('main', main.seams);
+            set.register('vessel', vessel.seams);
+
+            expect(set.adoptAll([{rootId: 'main-after', items: []}, {rootId: 'vessel-after', items: []}])).toBe(true);
+            expect(main.document.rootId).toBe('main-after');
+            expect(vessel.document.rootId).toBe('vessel-after')
+        });
+
+        test('refuses a slot count that does not match the registry, writing nothing', () => {
+            const main = createHolder({rootId: 'untouched', items: []});
+
+            set.register('main', main.seams);
+
+            expect(set.adoptAll([{rootId: 'a', items: []}, {rootId: 'b', items: []}])).toBe(false);
+            expect(set.adoptAll([])).toBe(false);
+            expect(set.adoptAll(null)).toBe(false);
+            expect(main.document.rootId).toBe('untouched')
+        });
+
+        test('refuses a missing slot document and a read-only workspace, writing nothing', () => {
+            const
+                main   = createHolder({rootId: 'untouched', items: []}),
+                vessel = createHolder({rootId: 'also-untouched', items: []});
+
+            set.register('main', main.seams);
+            set.register('vessel', vessel.seams);
+
+            expect(set.adoptAll([{rootId: 'a', items: []}, null]), 'a null slot').toBe(false);
+
+            // a read-only entry cannot adopt, so neither may its siblings
+            set.register('vessel', {getDocument: vessel.seams.getDocument});
+
+            expect(set.adoptAll([{rootId: 'a', items: []}, {rootId: 'b', items: []}])).toBe(false);
+            expect(main.document.rootId).toBe('untouched');
+            expect(vessel.document.rootId).toBe('also-untouched')
+        });
+
+        test('a throw mid-write rolls every earlier slot back to the document it replaced', () => {
+            const
+                main    = createHolder({rootId: 'main-before', items: []}),
+                failure = new Error('the second writer refuses');
+
+            set.register('main', main.seams);
+            set.register('vessel', {
+                getDocument: () => ({rootId: 'vessel-before', items: []}),
+                setDocument: () => {throw failure}
+            });
+
+            expect(() => set.adoptAll([{rootId: 'main-after', items: []}, {rootId: 'vessel-after', items: []}]))
+                .toThrow('the second writer refuses');
+
+            // the primary was written first and must not survive the failure
+            expect(main.document.rootId).toBe('main-before')
+        })
     })
 });


### PR DESCRIPTION
Resolves #18252

The operator's prio-zero for dock layouts is: save the layout, reload the multi-window app, get the same setup back — and *"i am 99% sure this is not the case."*

He was right, and nothing was missing. `Persistence.captureTopologyPerspective()`, a 712-line `TopologyReconciler`, `RestorePlanner` and the `DockService` routing are all built and unit-tested. They reach a live app through exactly two holder seams, and **those seams had zero implementations anywhere** — the only definitions in the repo were stub objects inside `DockService`'s own spec. The service even handles their absence gracefully, which is why an unreachable capability never surfaced as an error.

A workspace now answers both. Nothing about the capture format, the reconciler or the planner changed; this connects them.

## Deltas

| File | Change |
|---|---|
| `src/dashboard/dock/window/TopologySeams.mjs` | **new** — the seam pair as a mixin: `getDockTopologyDocuments()` (slot-ordered, primary first) and `commitDockTopologyDocuments()` (atomic, or a stated refusal) |
| `src/dashboard/dock/window/WorkspaceSet.mjs` | `adoptAll(documents)` — `adoptTransfer` one arity up: slot-ordered, all-or-nothing, with the same compensation on a mid-write throw |
| `src/dashboard/dock/Workspace.mjs` | **+7** — one import and the `mixins` entry. See AC-2 |
| `test/…/DockTopologySeams.spec.mjs` | **new** — the capture→reconcile→commit round-trip on a REAL workspace, REAL set, REAL producer and REAL reconciler |
| `test/…/DockWorkspaceSet.spec.mjs` | `adoptAll`: success, three refusal paths, and rollback on a throw |

## AC Evidence

| AC | Verdict | Evidence: |
|---|---|---|
| AC-1 a host can capture a multi-window topology and restore the same composition | met at unit scope | the round-trip arm: capture two slots, rearrange the primary live, reconcile, commit — both slots come back. Real machinery end to end. The live browser-reload witness still needs the harness in #17844 |
| AC-2 implemented outside `dock/Workspace.mjs`, that file unchanged | **partially — and my AC was wrong** | the implementation is a separate 105-line module, but that file gains **7 lines** (an import and the `mixins` entry). Not zero, and it cannot be: `DockService.resolveHolder()` requires the holder to be the component carrying the dock document, so the seams must be instance methods on the workspace. I wrote AC-2 before verifying that. 7 lines is the floor, and no responsibility logic landed there |
| AC-3 restore applies a composition state, never replays history | met | `TopologyReconciler.reconcile()` returns documents; the commit adopts them in one atomic write. No operation replay anywhere in the path |
| AC-4 a host implementing neither seam is unaffected | **superseded, deliberately** | every dock workspace now has both, which is the capability delivery. The safety this AC was protecting is kept by the refusal arm: a single-document workspace handed a two-slot record refuses with a stated reason rather than dropping slots |
| AC-5 mutation-verified | met | matrix below |
| AC-6 `windowFingerprint` stays shape-only | met | untouched — no capture-format change is in this diff |

**AC-5 — mutants:**

| mutant | result |
|---|---|
| `getDockTopologyDocuments` returns `[]` | 2 failed |
| `commitDockTopologyDocuments` returns `{errors: []}` without writing | 1 failed |
| `adoptAll` skips its rollback | 1 failed |

## Test Evidence

```
unit (full tier)                 3151 passed   ← 3143 + 8 new arms
unit DockTopologySeams              4 passed
unit DockWorkspaceSet              17 passed
```

### ~~A second, independent gap~~ → **CLOSED, and the arm is how we know**

An earlier revision of this body pinned an open gap: a topology restore reordered tabs but did not restore which tab was active, and `activeItemId` appeared nowhere in `TopologyReconciler.mjs` or `RestorePlanner.mjs`.

**That gap is closed and this section is withdrawn.** #18257 gave `TopologyDiff` an `activeItemChanges` bucket and `RestorePlanner` a `setActiveItem` step; `TopologyReconciler` reaches both through `RestorePlanner.restoreToward()` at `TopologyReconciler.mjs:606`. Verified as a chain, not inferred from the commit title.

| hop | `activeItemId` |
|---|---|
| capture | `strategy` — kept |
| live composition moves on | `swarm` |
| after reconcile | **`strategy` — the captured value restores** |

The round-trip arm was written to fail loudly if the gap ever closed, and that is exactly what happened: rebasing onto a dev carrying #18257 turned it red, which is how the change was found at all. The arm stays and is inverted — it pinned the gap, it now pins the restore.

## Post-Merge Validation

- A host that already builds a workspace set (`apps/workstation`, `examples/dashboard/crossWindow`) gains topology capture and restore with no code of its own; a host without a set answers a single-slot topology, which `Persistence` documents as structurally identical to a window-scope record.
- The refusal path is the guard worth watching: a multi-slot record must never reach a single-document workspace and lose slots quietly.
- **What stands between this and the operator's actual sentence is #18272, not the active-tab gap.** This PR restores N documents and one view: `commitDockTopologyDocuments` converges the primary projection only, because all seven `workspaceSet.register` sites supply plain-assignment writers and no consumer has a vessel-side projection to call. That is a missing layer, and it is owned by #18272 (blocked on D#18224), not folded in here.

## Acceptance-criteria disposition

#18252's ACs were restated after review — the model half closes here, the view half moves to #18272, and AC-2 now measures concern growth rather than raw line count, since "line count unchanged" forbids the mixin composition the architecture review endorsed. #18252 also gains a **Contract Ledger** for the three methods this PR puts under contract: `getDockTopologyDocuments`, `commitDockTopologyDocuments`, and the consumed `workspaceSet.adoptAll`.

**Evidence:** L2 (headless unit) — 21/21 on the dock specs, `check-ticket-archaeology` 0 violations, exact head. AC-1's runtime witness is explicitly **not** claimed here; it is open under #18272 with a named owner.

Authored by Grace (Claude Opus 5, Claude Code). Session 118d8435-8d23-4745-a28a-8d22da918aac.

