### PR TITLE
fix(workstation): the host adds to the engine's topology answer instead of replacing it (#18208)

### DIFF
--- a/apps/workstation/view/Workspace.mjs
+++ b/apps/workstation/view/Workspace.mjs
@@ -2198,18 +2198,23 @@ class Workspace extends DockWorkspace {
 
     /**
      * Maps both commit shapes onto the reconciler's fast paths — engine surfaces pass the semantic
-     * descriptor, this host's own paths pass their options object. The geometry admission is the
-     * ENGINE's now: it derives `geometryOnly` from the operation's declared change class, so this
-     * override adds only the one thing the engine cannot see — an explicit `geometryOnly` on this
-     * host's own options-object commits. Either way it is an admission REQUEST for the in-place
-     * projection path, never a claim that the topology is stable: the reconciler validates it,
-     * falls back to the staged transaction on any structural delta, and `DockFlip` is told the
-     * resulting `landedInPlace`, not this request. `detachItem` / `transferNode` admit the
-     * stable-topology fast path (a transferNode
+     * descriptor, this host's own paths pass their options object. BOTH admissions are the
+     * ENGINE's now: it derives `geometryOnly` and `retainTopology` from the operation's declared
+     * change class, so this override adds only what the engine cannot see — an explicit
+     * `geometryOnly` on this host's own options-object commits, and the two operations below.
+     * Neither key may be written unconditionally: an override that always answers `false` does not
+     * decline the engine's answer, it SHADOWS it, which is how `setItemLocked`'s item-only refresh
+     * stopped reaching this host while the engine derived it correctly. Either way it is an
+     * admission REQUEST for the in-place projection path, never a claim that the topology is
+     * stable: the reconciler validates it, falls back to the staged transaction on any structural
+     * delta, and `DockFlip` is told the resulting `landedInPlace`, not this request. `detachItem` /
+     * `transferNode` admit the stable-topology fast path (a transferNode
      * adoption keeps the structural shell — one tabs node's items grow — and the validator still
-     * rejects any transfer that does mutate structure). A commit-scoped `preserveItemIds` parks
-     * owner-held panes instead of destroying them (a terminal-first tear-out vessel owns its pane
-     * before it connects).
+     * rejects any transfer that does mutate structure). Adding them to the engine's answer rather
+     * than replacing it keeps the engine's railed-item guard intact: a railed pane projects outside
+     * the shell, the engine answers `{}` for it, and neither of these two operations resurrects it.
+     * A commit-scoped `preserveItemIds` parks owner-held panes instead of destroying them (a
+     * terminal-first tear-out vessel owns its pane before it connects).
      * @param {Object|null} descriptor The committing surface's identification — a semantic
      *     descriptor or this host's options object.
      * @param {Object|null} source The committing surface, when it identifies itself.
@@ -2221,7 +2226,7 @@ class Workspace extends DockWorkspace {
 
         return {
             geometryOnly  : geometryOnly === true || base.geometryOnly === true,
-            retainTopology: operation === 'detachItem' || operation === 'transferNode',
+            retainTopology: base.retainTopology === true || operation === 'detachItem' || operation === 'transferNode',
             ...(Array.isArray(preserveItemIds) && preserveItemIds.length > 0 ? {preserveItemIds} : {})
         }
     }

--- a/test/playwright/unit/apps/workstation/Workspace.spec.mjs
+++ b/test/playwright/unit/apps/workstation/Workspace.spec.mjs
@@ -2983,11 +2983,12 @@ test.describe('getRefreshOptions — BOTH admissions are the ENGINE\'s, not a li
             .toEqual({geometryOnly: false, retainTopology: false, preserveItemIds: ['editor']})
     });
 
-    // #18152 removed the lock flicker in the engine by deriving `{retainTopology: true}` for the
-    // item-flag class. It never reached this host, because the override wrote `retainTopology`
-    // unconditionally: for `setItemLocked` the operation test is `false`, and an unconditional
-    // `false` overwrites the engine's `true` instead of falling back to it. The host is where the
-    // operator demoed docking, so the flicker was still live exactly where it was reported.
+    // The engine derives `{retainTopology: true}` for the item-flag class, which is what keeps a
+    // lock click from restaging the shell. It cannot reach this host through an override that
+    // writes `retainTopology` unconditionally: for `setItemLocked` the operation test below is
+    // `false`, and an unconditional `false` overwrites the engine's `true` instead of falling back
+    // to it. So the arm that matters is not "does the engine derive it" but "does this host's
+    // return value preserve what the engine derived".
     test('a lock on a shell item reaches this host\'s item-only refresh', () => {
         const shellItem = {items: {editor: {locked: false}}};
 

--- a/test/playwright/unit/apps/workstation/Workspace.spec.mjs
+++ b/test/playwright/unit/apps/workstation/Workspace.spec.mjs
@@ -2914,7 +2914,7 @@ test.describe('Workspace — the theme toggle reveals from the pointer (#18125)'
     })
 });
 
-test.describe('getRefreshOptions — the geometry admission is the ENGINE\'s, not a list this host keeps', () => {
+test.describe('getRefreshOptions — BOTH admissions are the ENGINE\'s, not a list this host keeps', () => {
     /**
      * @summary Reads this host's refresh options, optionally with the engine's default neutered.
      *
@@ -2923,15 +2923,22 @@ test.describe('getRefreshOptions — the geometry admission is the ENGINE\'s, no
      * same list got the full staged transaction on every drag-resize. The VALUES below are
      * unchanged; only their source moved, and an arm that asserts values alone cannot tell the
      * difference. Neutering the engine can: a private list survives it, delegation does not.
+     * `dockModel` is what makes the railed arms real rather than stubbed: the engine's item-flag
+     * guard resolves placement through `isDockRailedItem`, which reads `dockModel.items[itemId]`.
+     * Passing a document exercises the engine's own predicate instead of replacing it with a
+     * hand-held boolean, so an arm still fails if that predicate changes underneath this host.
      * @param {Object|null} descriptor
      * @param {Boolean} [neuterEngine=false] Make the engine's default contribute nothing
+     * @param {Object|null} [dockModel=null] The pre-commit document the railed guard reads
      * @returns {Object}
      */
-    function refreshOptionsFor(descriptor, neuterEngine=false) {
+    function refreshOptionsFor(descriptor, neuterEngine=false, dockModel=null) {
         const
             enginePrototype = Object.getPrototypeOf(Workspace.prototype),
             original        = enginePrototype.getRefreshOptions,
             workspace       = Neo.create(Workspace, {appName: 'WorkstationWorkspaceTest'});
+
+        dockModel && (workspace.dockModel = dockModel);
 
         neuterEngine && (enginePrototype.getRefreshOptions = () => ({}));
 
@@ -2974,5 +2981,46 @@ test.describe('getRefreshOptions — the geometry admission is the ENGINE\'s, no
         expect(refreshOptionsFor({operation: 'moveItem', preserveItemIds: ['editor']}),
             'and a commit-scoped park still rides along')
             .toEqual({geometryOnly: false, retainTopology: false, preserveItemIds: ['editor']})
+    });
+
+    // #18152 removed the lock flicker in the engine by deriving `{retainTopology: true}` for the
+    // item-flag class. It never reached this host, because the override wrote `retainTopology`
+    // unconditionally: for `setItemLocked` the operation test is `false`, and an unconditional
+    // `false` overwrites the engine's `true` instead of falling back to it. The host is where the
+    // operator demoed docking, so the flicker was still live exactly where it was reported.
+    test('a lock on a shell item reaches this host\'s item-only refresh', () => {
+        const shellItem = {items: {editor: {locked: false}}};
+
+        expect(refreshOptionsFor({operation: 'setItemLocked', itemId: 'editor'}, false, shellItem),
+            'the engine derives the item-only path and this host no longer shadows it')
+            .toEqual({geometryOnly: false, retainTopology: true});
+
+        // The discriminating half, mirroring the geometry arm above. A host that still answered
+        // `retainTopology` from its own operation list would be unmoved by neutering the engine —
+        // and would answer `false` here either way, which is the bug this arm fails on.
+        expect(refreshOptionsFor({operation: 'setItemLocked', itemId: 'editor'}, true, shellItem),
+            'with the engine neutered this host has no item-flag answer of its own')
+            .toEqual({geometryOnly: false, retainTopology: false})
+    });
+
+    test('a railed item still takes the full transaction — delegation inherits the guard, a naive merge would not', () => {
+        // `isDockRailedItem` is `autoHidden === true && pinned !== true`: auto-hide is rail
+        // membership and pinning is the override that keeps the pane open in the shell. A railed
+        // pane projects OUTSIDE the shell, so an item-only refresh would leave a stale copy on the
+        // rail — worse than the slow path it replaces. The engine answers `{}` for it.
+        expect(refreshOptionsFor(
+            {operation: 'setItemLocked', itemId: 'editor'}, false,
+            {items: {editor: {autoHidden: true}}}
+        ), 'the engine declines, and adding two unrelated operations to a decline is still a decline')
+            .toEqual({geometryOnly: false, retainTopology: false});
+
+        // Control on the axis the guard actually turns on. Same operation, same item, one field
+        // different — an arm that only ever saw the railed case could not tell this delegation
+        // apart from a blanket `false`.
+        expect(refreshOptionsFor(
+            {operation: 'setItemLocked', itemId: 'editor'}, false,
+            {items: {editor: {autoHidden: true, pinned: true}}}
+        ), 'a pinned pane is open in the shell, so it is not railed and the fast path holds')
+            .toEqual({geometryOnly: false, retainTopology: true})
     })
 });


### PR DESCRIPTION
Resolves #18208

#18152 removed the lock flicker the operator reported: `setItemLocked` assigns one boolean on one item and touches `document.nodes` nowhere, so the engine derives `{retainTopology: true}` for it instead of restaging the shell. It never reached `apps/workstation` — the host the operator actually demoed multi-window docking with.

The override wrote the key unconditionally:

```js
retainTopology: operation === 'detachItem' || operation === 'transferNode',
```

For `setItemLocked` that expression is `false`. An unconditional `false` does not *decline* the engine's answer, it **shadows** it — so the host answered `{retainTopology: false}` while the engine one frame away had derived `true`, and a lock click still took the full staged transaction. The clause shadowed the whole `itemFlags` class, and would have shadowed whatever the engine derived next.

The fix is the one #18206 already applied to the geometry half: add to the engine's answer rather than replace it. That inherits the engine's railed-item guard for free — a railed pane projects outside the shell, the engine answers `{}` for it, and neither of this host's two operations resurrects it. This was the **last** unconditional key here, so `getRefreshOptions` now contributes only what is genuinely its own: an explicit `geometryOnly` on options-object commits, and its commit-scoped `preserveItemIds`. Which is what epic #18151 is for.

## Deltas

| File | Change |
|---|---|
| `apps/workstation/view/Workspace.mjs` | `retainTopology` delegates — `base.retainTopology === true \|\| detachItem \|\| transferNode`; docblock states that BOTH admissions are the engine's, and why an unconditional key shadows rather than declines |
| `test/playwright/unit/apps/workstation/Workspace.spec.mjs` | `refreshOptionsFor` takes a `dockModel` so the railed arms drive the engine's real `isDockRailedItem`; two new tests — the shell arm and the railed/pinned pair; describe renamed to *BOTH admissions* |

## One correction to the ticket's own AC-3 wording

AC-3 asks that a lock on a **"pinned or auto-hidden"** item not take the item-only path. The engine's predicate disagrees, and I implemented the engine rather than the prose:

```js
isDockRailedItem(itemId) { const item = ...; return item?.autoHidden === true && item?.pinned !== true }
```

Auto-hide is rail membership; **pinning is the override that keeps the pane open in the shell**. So a pinned item is *not* railed and the engine admits it to the fast path today. Widening the host's guard to cover pinned items would have contradicted the engine and slowed a case the engine deliberately admits. Flagging it here rather than silently narrowing or widening — if the intended semantics really are "pinned is also railed", that is an engine-side change to `isDockRailedItem` and a separate ticket, not a host override.

## AC Evidence

| AC | Verdict | Evidence |
|---|---|---|
| AC-1 derives from the engine, contributes only `detachItem`/`transferNode`, no unconditional key | met | the delegation above; `geometryOnly` was already delegated, `retainTopology` was the last unconditional key in the method |
| AC-2 red-first arm: a lock on a **shell** item returns `retainTopology: true`, failing on today's code | met | fails on the unfixed line — `Expected true, Received false` at spec `:2996`. Full red output below |
| AC-3 railed arm: a railed item does **not** take the item-only path | met, with the correction above | see the honesty note below on which half of this arm is red |
| AC-4 the `detachItem`/`transferNode` mapping and the `geometryOnly` passthrough are unchanged — measured | met | the four pre-existing arms in this describe are untouched and green in the same run that showed the new ones red, including both `neuterEngine` discriminators |
| AC-5 extend the component-tier witness, or record why the unit arms suffice | met, by recording | rationale below |

**AC-3, stated precisely rather than claimed as red.** The railed *decline* (`{autoHidden: true}` → `retainTopology: false`) passes both before and after this change — it was already `false`, because the old code was `false` for everything in this class. A control that cannot change is not evidence, so the discriminating half is the **pinned control** (`{autoHidden: true, pinned: true}` → `true`), which *is* red on the unfixed line. The pair is what makes the arm meaningful: same operation, same item, one field different, opposite verdicts. An arm that only ever saw the railed case could not tell this delegation apart from a blanket `false`.

**AC-5, why the unit arms are sufficient here.** The component-tier witness `DockLock.spec.mjs` measures *repaint scope* — mutations outside the locked pane's own header. That is the right instrument for #18152, where the question was whether the engine's derivation actually suppresses restaging. It is the wrong instrument for this defect, which is a pure option-resolution bug one call earlier: the engine already derives correctly, and the only question is whether the host's return value preserves or overwrites it. `getRefreshOptions` is synchronous, takes a descriptor and returns an object, and the `neuterEngine` helper can distinguish delegation from a private list — which a repaint-scope assertion cannot. Extending the component tier to `apps/workstation` would also mean standing up the Workstation host in the component config, which is a materially larger change than the one-line fix it would witness. Recording the reason, per the AC's own second branch.

## Test Evidence

**Red, against the unfixed line with the new arms in place** (`-g "getRefreshOptions"`):

```
2 failed
  › a lock on a shell item reaches this host's item-only refresh
      Error: the engine derives the item-only path and this host no longer shadows it
      - "retainTopology": true
      + "retainTopology": false
  › a railed item still takes the full transaction
      Error: a pinned pane is open in the shell, so it is not railed and the fast path holds
      - "retainTopology": true
      + "retainTopology": false
2 passed          ← the pre-existing geometry arms, unmoved
```

**Green, with the fix:**

```
unit  test/playwright/unit/apps/workstation/Workspace.spec.mjs      53 passed
unit  test/playwright/unit/dashboard + unit/apps                   881 passed
unit  full tier (npm run test-unit)                               3145 passed, exit 0
```

The scoped run is reported separately from the full tier on purpose: on #18250 a dashboard-scoped green hid a defect the full tier caught, so a subset is no longer offered here as the evidence.

## Review

`getRefreshOptions` is the seam epic #18151 is closing, so the question worth a reviewer's attention is not the one-line merge but the AC-3 correction above — whether `isDockRailedItem`'s `autoHidden && !pinned` is the intended railed predicate, or whether the ticket's "pinned or auto-hidden" describes an engine-side gap that this PR should be leaving behind it.
