### PR TITLE
fix(dock): a restored layout brings back the tab you were on

### DIFF
--- a/src/dashboard/dock/model/TopologyDiff.mjs
+++ b/src/dashboard/dock/model/TopologyDiff.mjs
@@ -97,12 +97,12 @@ class TopologyDiff extends Base {
      * @param {Object} after The later committed document
      * @param {Object} [options]
      * @param {Number} [options.sizeEpsilon=TopologyDiff.SIZE_EPSILON] Resize tolerance on size fractions
-     * @returns {{moves: Object[], adds: Object[], removes: Object[], resizes: Object[], tabReorders: Object[], autoHideFlips: Object[], unchanged: String[], errors: String[]}}
+     * @returns {{moves: Object[], adds: Object[], removes: Object[], resizes: Object[], tabReorders: Object[], autoHideFlips: Object[], activeItemChanges: Object[], unchanged: String[], errors: String[]}}
      * @static
      */
     static diffDockDocuments(before, after, {sizeEpsilon = TopologyDiff.SIZE_EPSILON} = {}) {
         const
-            empty  = () => ({moves: [], adds: [], removes: [], resizes: [], tabReorders: [], autoHideFlips: [], unchanged: [], errors: []}),
+            empty  = () => ({moves: [], adds: [], removes: [], resizes: [], tabReorders: [], autoHideFlips: [], activeItemChanges: [], unchanged: [], errors: []}),
             result = empty(),
             errors = [];
 
@@ -161,6 +161,23 @@ class TopologyDiff extends Base {
             const
                 beforeNode = before.nodes[nodeId],
                 afterNode  = after.nodes?.[nodeId];
+
+            if (beforeNode?.type === 'tabs' && afterNode?.type === 'tabs') {
+                const
+                    fromActive = beforeNode.activeItemId ?? null,
+                    toActive   = afterNode.activeItemId  ?? null;
+
+                // Which tab you were on is document state and the capture keeps it, but nothing
+                // reported it, so a restore returned the tabs and left you looking at whichever one
+                // happened to be active. Only a target that actually LISTS the item is emitted: the
+                // executor rejects an active item that is not a member, and a restore must not start
+                // throwing over a tab it could not place.
+                if (fromActive !== toActive && toActive != null && (afterNode.items || []).includes(toActive)) {
+                    result.activeItemChanges.push({nodeId, from: fromActive, to: toActive})
+                }
+
+                return
+            }
 
             if (beforeNode?.type !== 'split' || afterNode?.type !== 'split') return;
 

--- a/src/dashboard/dock/persistence/RestorePlanner.mjs
+++ b/src/dashboard/dock/persistence/RestorePlanner.mjs
@@ -106,7 +106,7 @@ class RestorePlanner extends Base {
 
         let plan = [];
 
-        // adds → moves (collapse-safe order) → tabReorders (ascending captured index) → resizes → autoHideFlips.
+        // adds → moves (collapse-safe order) → tabReorders (ascending captured index) → activeItems → resizes → autoHideFlips.
         diff.adds.forEach(({itemId, to}) =>
             plan.push({operation: 'addTab', itemId, tabsNodeId: to.nodeId, index: to.index}));
 
@@ -115,6 +115,12 @@ class RestorePlanner extends Base {
 
         [...diff.tabReorders].sort((a, b) => a.toIndex - b.toIndex).forEach(({itemId, nodeId, toIndex}) =>
             plan.push({operation: 'moveItem', itemId, targetNodeId: nodeId, index: toIndex}));
+
+        // After the membership steps and before the flags: the executor rejects an active item that
+        // is not a member of its node, so this cannot run until every add/move/reorder has landed —
+        // and it must run while the item is still in the tab flow, ahead of any auto-hide flip.
+        diff.activeItemChanges.forEach(({nodeId, to}) =>
+            plan.push({operation: 'setActiveItem', tabsNodeId: nodeId, itemId: to}));
 
         diff.resizes.forEach(({nodeId, toSizes}) =>
             plan.push({operation: 'resizeSplit', splitNodeId: nodeId, sizes: [...toSizes]}));

--- a/test/playwright/unit/dashboard/DockRestorePlanner.spec.mjs
+++ b/test/playwright/unit/dashboard/DockRestorePlanner.spec.mjs
@@ -171,4 +171,103 @@ test.describe('DockRestorePlanner — same-topology restore', () => {
         expect(r.errors.length).toBeGreaterThan(0);
         expect(r.document.nodes.root.sizes).toEqual([0.5, 0.5]); // the first op did land
     });
+
+    /**
+     * Which tab you were on is document state and the capture keeps it — but nothing reported it, so
+     * a restore returned the tabs and left whichever one happened to be active.
+     */
+    test.describe('the active tab restores too', () => {
+        test('a differing active item comes back, through one setActiveItem step', () => {
+            const captured = doc();
+
+            // live: same membership, different tab selected
+            const current = Operations.applyOperation(doc(), {
+                operation: 'setActiveItem', tabsNodeId: 'main-tabs', itemId: 'swarm'
+            });
+
+            expect(current.errors).toEqual([]);
+            expect(current.document.nodes['main-tabs'].activeItemId).toBe('swarm');
+
+            const {deferred, plan, errors, document: restored} = DockRestorePlanner.restoreToward(current.document, captured);
+
+            expect(deferred).toBe(false);
+            expect(errors).toEqual([]);
+            expect(plan).toEqual([{operation: 'setActiveItem', tabsNodeId: 'main-tabs', itemId: 'strategy'}]);
+            expect(restored.nodes['main-tabs'].activeItemId).toBe('strategy')
+        });
+
+        test('the step lands AFTER the move that brings its item into the node', () => {
+            const captured = doc();               // main-tabs [strategy, swarm] active strategy
+            const wanted   = Operations.applyOperation(captured, {
+                operation: 'setActiveItem', tabsNodeId: 'main-tabs', itemId: 'swarm'
+            });
+
+            expect(wanted.errors).toEqual([]);
+
+            // live: swarm and terminal are SWAPPED between the two zones, so tab counts still match
+            // (the fingerprint gate) and the restore has to move both before it can select swarm.
+            const current = {
+                schema: 'neo.dock.zone.v1',
+                root  : 'root',
+                items : doc().items,
+                nodes : {
+                    root       : {type: 'split', orientation: 'horizontal', children: ['main-tabs', 'side-tabs'], sizes: [0.6, 0.4]},
+                    'main-tabs': {type: 'tabs', items: ['strategy', 'terminal'], activeItemId: 'strategy'},
+                    'side-tabs': {type: 'tabs', items: ['swarm'], activeItemId: 'swarm'}
+                }
+            };
+
+            const {deferred, errors, plan, document: restored} = DockRestorePlanner.restoreToward(current, wanted.document);
+
+            expect(deferred).toBe(false);
+            expect(errors).toEqual([]);
+
+            const
+                moveIndex   = plan.findIndex(step => step.operation === 'moveItem' && step.itemId === 'swarm' && step.targetNodeId === 'main-tabs'),
+                activeIndex = plan.findIndex(step => step.operation === 'setActiveItem' && step.tabsNodeId === 'main-tabs');
+
+            expect(moveIndex, 'the move is planned').toBeGreaterThan(-1);
+            expect(activeIndex, 'the selection is planned').toBeGreaterThan(-1);
+            // the executor rejects an active item that is not a member, so order is the contract
+            expect(activeIndex).toBeGreaterThan(moveIndex);
+
+            expect(restored.nodes['main-tabs'].items).toEqual(['strategy', 'swarm']);
+            expect(restored.nodes['main-tabs'].activeItemId).toBe('swarm')
+        });
+
+        test('an already-correct active item emits no step', () => {
+            const captured = doc();
+            const current  = Operations.applyOperation(doc(), {
+                operation: 'resizeSplit', splitNodeId: 'root', sizes: [0.25, 0.75]
+            });
+
+            expect(current.errors).toEqual([]);
+
+            const {plan} = DockRestorePlanner.restoreToward(current.document, captured);
+
+            expect(plan.some(step => step.operation === 'setActiveItem'), 'no spurious selection').toBe(false);
+            expect(plan).toHaveLength(1)
+        });
+
+        test('an active item the captured node does not list emits nothing, and the restore still succeeds', () => {
+            // a capture naming a non-member: the executor would reject the operation, so the plan
+            // must not carry it — a restore never destroys and must not start throwing here either
+            const captured = doc();
+
+            captured.nodes['main-tabs'].activeItemId = 'terminal';
+
+            const current = Operations.applyOperation(doc(), {
+                operation: 'resizeSplit', splitNodeId: 'root', sizes: [0.25, 0.75]
+            });
+
+            expect(current.errors).toEqual([]);
+
+            const {deferred, errors, plan, document: restored} = DockRestorePlanner.restoreToward(current.document, captured);
+
+            expect(deferred).toBe(false);
+            expect(errors).toEqual([]);
+            expect(plan.some(step => step.operation === 'setActiveItem')).toBe(false);
+            expect(restored.nodes.root.sizes).toEqual([0.6, 0.4])
+        })
+    })
 });


### PR DESCRIPTION
Resolves #18255

A restored layout brought the tabs back and left you looking at whichever one happened to be active. The capture was never the problem — it keeps `activeItemId` — and neither was the model, which has had `setActiveItem` since #17838. The value simply had nowhere to travel: `TopologyDiff` reported six categories and none of them was the active item, so `RestorePlanner` could not emit a step it was never told to plan.

This is the second measured thing between the engine and the operator's sentence — *"reload the multi-window app with the saved layout ⇒ getting the same multi-window setup."* The first was #18252 (the restore path had no implementer at all); this one is behind it and survives it.

## Deltas

| File | Change |
|---|---|
| `src/dashboard/dock/model/TopologyDiff.mjs` | new `activeItemChanges` category, emitted for tabs nodes whose `activeItemId` differs — and only when the target node actually LISTS the item |
| `src/dashboard/dock/persistence/RestorePlanner.mjs` | emits `setActiveItem`, sequenced after every membership step and ahead of the auto-hide flips |
| `test/…/DockRestorePlanner.spec.mjs` | 4 arms: the restore, the ordering contract, the no-op case, the non-member case |

No new model verb, no capture-format change, no new class.

## AC Evidence

| AC | Verdict | Evidence: |
|---|---|---|
| AC-1 a restore returns the captured `activeItemId` | met, red-first | reverting only the two source files to `origin/dev` reds **2 arms**; with them, `plan` is exactly `[{operation: 'setActiveItem', tabsNodeId: 'main-tabs', itemId: 'strategy'}]` and the restored document carries it |
| AC-2 the step runs after its item has arrived | met | the swap arm moves `swarm` and `terminal` between zones, then asserts `activeIndex > moveIndex` in the plan and `activeItemId === 'swarm'` in the applied document |
| AC-3 an already-correct active item emits no step | met | a resize-only restore plans exactly 1 step and no `setActiveItem` |
| AC-4 an unplaceable active item emits nothing and does not fail | met | a capture naming a non-member plans no selection, `deferred: false`, `errors: []`, and the resize still lands |
| AC-5 mutation-verified | met | matrix below |

**AC-5 — mutants:**

| mutant | result |
|---|---|
| both source files reverted to `origin/dev` (the red-first control) | 2 failed |
| the planner's emit deleted, diff category kept | 2 failed |
| the diff's `.includes(toActive)` membership guard dropped | 1 failed |

Each ran against the committed tree, with the harness restoring from copies it made itself rather than from git.

## Test Evidence

```
unit (full tier)                3147 passed   ← 3143 + 4 new arms
unit DockRestorePlanner           11 passed
```

## Post-Merge Validation

- The ordering rule is the one to watch: `Operations.setActiveItem` rejects an item that is not a member of its node, so any future planner reordering that moves the selection ahead of the adds/moves would turn a silent gap into a loud failure. The AC-2 arm pins it.
- The membership guard is deliberately in the DIFF rather than the planner — a category that cannot describe an impossible change is better than a plan step that filters one out.
- `TopologyDiff`'s return shape gained a key. Consumers destructuring it are unaffected (additive), but the JSDoc `@returns` is updated so the next reader sees seven categories, not six.

Authored by Grace (Claude Opus 5, Claude Code). Session 118d8435-8d23-4745-a28a-8d22da918aac.
