### PR TITLE
fix(grid): clearing isLoading re-projects, so a load committed while loading is not lost

### DIFF
--- a/src/grid/View.mjs
+++ b/src/grid/View.mjs
@@ -152,9 +152,20 @@ class View extends Base {
             //
             // `createViewData` clears the CONTAINER's flag on its way out, which arrives back here as
             // a no-op through the config's own equality gate, so this cannot re-enter.
-            me.timeout(0).then(() => {
-                me.isDestroyed || me.items?.forEach(body => body.createViewData?.(false, true))
-            })
+            // The deferral is detached, so it owns its terminal outcome. `core.Base#destroy` rejects
+            // every pending timeout with `Neo.isDestroyed`, and a view destroyed inside this one tick
+            // is an expected end to a re-projection into somewhere that no longer exists — not a
+            // failure to report. The `isDestroyed` guard below cannot cover it: that guard only runs
+            // when the timeout RESOLVES, and destroy makes it reject. Anything else IS a live failure
+            // and this chain has no caller to propagate to, so the console is the honest surface.
+            me.timeout(0)
+                .then(() => {
+                    me.isDestroyed || me.items?.forEach(body => body.createViewData?.(false, true))
+                })
+                .catch(reason => {
+                    reason !== Neo.isDestroyed &&
+                        console.error('grid.View: deferred re-projection failed', {id: me.id, reason})
+                })
         }
     }
 

--- a/src/grid/View.mjs
+++ b/src/grid/View.mjs
@@ -124,6 +124,41 @@ class View extends Base {
     }
 
     /**
+     * Triggered after the isLoading config got changed
+     *
+     * {@link Neo.grid.Body#createViewData} refuses to project while the view is loading, and a store
+     * that commits inside that window fires its `load` into the refusal — so the rows keep showing
+     * the pre-load projection after the mask clears, with nothing left to re-run them. Clearing the
+     * flag is therefore a projection trigger and not only a mask removal, which is what any consumer
+     * wrapping a bulk store mutation in `isLoading` depends on.
+     *
+     * Every body is asked, not just `body`: `bodyStart` and `bodyEnd` project the same store through
+     * the same guard, so a locked-column grid would otherwise clear its mask over two stale flanks.
+     * @param {Boolean|String} value
+     * @param {Boolean|String} oldValue
+     * @protected
+     */
+    afterSetIsLoading(value, oldValue) {
+        let me = this;
+
+        super.afterSetIsLoading(value, oldValue);
+
+        if (oldValue !== undefined && !value) {
+            // Deferred one tick, and not for tidiness: the mask removal this call just published is
+            // still in flight, so a synchronous re-projection meets `createViewData`'s guard block
+            // while the body still measures as masked. That block returns BEFORE the `isVdomUpdating`
+            // branch that would re-register the work, so an early call is not merely early — it is
+            // dropped, and nothing schedules another.
+            //
+            // `createViewData` clears the CONTAINER's flag on its way out, which arrives back here as
+            // a no-op through the config's own equality gate, so this cannot re-enter.
+            me.timeout(0).then(() => {
+                me.isDestroyed || me.items?.forEach(body => body.createViewData?.(false, true))
+            })
+        }
+    }
+
+    /**
      * Triggered after the selectionModel config got changed. Registers grid.View (not a body) as the
      * model's `view`, so a single model owns selection state across all bodies.
      * @param {Neo.selection.Model} value

--- a/test/playwright/unit/grid/ViewLoadingReprojection.spec.mjs
+++ b/test/playwright/unit/grid/ViewLoadingReprojection.spec.mjs
@@ -1,0 +1,138 @@
+/**
+ * @file test/playwright/unit/grid/ViewLoadingReprojection.spec.mjs
+ * @summary Clearing `isLoading` re-projects every body, because a store load that arrived while
+ * loading was dropped rather than deferred.
+ *
+ * `Neo.grid.Body#createViewData` opens with a guard block that returns when the body cannot measure
+ * — and a loading view cannot. The guard sits BEFORE the `isVdomUpdating` branch that would
+ * re-register the work, so a `load` event arriving inside the loading window is not postponed, it is
+ * discarded, and nothing schedules another. The rows then keep projecting the pre-load state after
+ * the mask clears, with the store already correct — only the paint is missing.
+ *
+ * The consumer shape that hits it is the documented one: wrap a bulk store mutation in `isLoading`
+ * so the grid shows a spinner while it commits. `examples/grid/treeBigData` does exactly that around
+ * `expandAll()`, and three of its five e2e arms were red for it. The same symptom had been fixed and
+ * closed once before on the identical assertion, which is why this arm lives in the tier CI runs.
+ *
+ * The re-projection is deferred one tick deliberately: the mask removal published by this very call
+ * is still in flight, so a synchronous re-projection meets the guard while the body still measures as
+ * masked and is dropped exactly like the load it was meant to rescue.
+ *
+ * @see Neo.grid.View
+ * @see Neo.grid.Body#createViewData
+ */
+
+import {setup} from '../../setup.mjs';
+
+setup({
+    neoConfig: {
+        allowVdomUpdatesInTests: true,
+        unitTestMode           : true,
+        useDomApiRenderer      : true,
+        useVdomWorker          : false
+    },
+    appConfig: {
+        name             : 'GridViewLoadingReprojectionTest',
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../src/Neo.mjs';
+import * as core      from '../../../../src/core/_export.mjs';
+import GridView       from '../../../../src/grid/View.mjs';
+
+const appName = 'GridViewLoadingReprojectionTest';
+
+/**
+ * A stand-in for one body: the view only asks it to re-project, and recording the arguments is what
+ * the contract is about — `force` must be true, or a projection whose record identity is unchanged
+ * (every row of a bulk expand) would be skipped as a no-op.
+ * @returns {Object}
+ */
+function createBodyStub() {
+    return {
+        calls: [],
+
+        createViewData(silent, force) {
+            this.calls.push({force, silent})
+        }
+    }
+}
+
+test.describe('Neo.grid.View — clearing isLoading re-projects', () => {
+    let view;
+
+    const attachBodies = (...bodies) => {
+        // assigned past the reactive setter: the container would instantiate real components, and the
+        // contract under test is only which of its items get asked to re-project
+        view._items = bodies;
+        return bodies
+    };
+
+    test.beforeEach(() => {
+        view = Neo.create(GridView, {appName})
+    });
+
+    test.afterEach(() => {
+        view?.isDestroyed === false && view.destroy();
+        view = null
+    });
+
+    test('a load dropped during loading is recovered when the flag clears', async () => {
+        const [body] = attachBodies(createBodyStub());
+
+        view.isLoading = 'Loading';
+
+        expect(body.calls, 'entering the loading state re-projects nothing').toEqual([]);
+
+        view.isLoading = false;
+
+        // NOT synchronous: the mask removal this assignment published is still in flight, and a
+        // re-projection landing inside it meets the same guard that dropped the original load
+        expect(body.calls, 'deferred past the mask removal').toEqual([]);
+
+        await view.timeout(10);
+
+        expect(body.calls, 'exactly one re-projection').toHaveLength(1);
+        // force:true — a bulk expand changes no record identity, so an unforced pass would skip it
+        expect(body.calls[0]).toEqual({force: true, silent: false})
+    });
+
+    test('every body is asked, not only the centre one', async () => {
+        const bodies = attachBodies(createBodyStub(), createBodyStub(), createBodyStub());
+
+        view.isLoading = 'Loading';
+        view.isLoading = false;
+
+        await view.timeout(10);
+
+        // bodyStart / body / bodyEnd project the same store through the same guard, so a
+        // locked-column grid would otherwise clear its mask over two stale flanks
+        expect(bodies.map(body => body.calls.length)).toEqual([1, 1, 1])
+    });
+
+    test('entering the loading state never re-projects', async () => {
+        const [body] = attachBodies(createBodyStub());
+
+        view.isLoading = 'Loading';
+
+        await view.timeout(10);
+
+        expect(body.calls).toEqual([])
+    });
+
+    test('a view destroyed inside the deferral does not project into its own teardown', async () => {
+        const [body] = attachBodies(createBodyStub());
+
+        view.isLoading = 'Loading';
+        view.isLoading = false;
+        view.destroy();
+
+        await new Promise(resolve => setTimeout(resolve, 20));
+
+        expect(body.calls, 'the deferred pass saw the teardown').toEqual([]);
+
+        view = null
+    })
+});

--- a/test/playwright/unit/grid/ViewLoadingReprojection.spec.mjs
+++ b/test/playwright/unit/grid/ViewLoadingReprojection.spec.mjs
@@ -137,24 +137,54 @@ test.describe('Neo.grid.View — clearing isLoading re-projects', () => {
     });
 
     /**
-     * Silence is two different outcomes here and the arm above cannot tell them apart: a deferral
-     * that declined to project, and a deferral whose promise rejected with nobody listening. Both
-     * leave `body.calls` empty. `core.Base#destroy` rejects pending timeouts with `Neo.isDestroyed`,
-     * so the second is what an unguarded chain actually produces — one `ERR_UNHANDLED_REJECTION`
-     * per teardown inside the window.
+     * The terminal has two halves and only one of them is witnessable in this tier.
      *
-     * Same shape as the landed `DispatchTerminalOutcome.spec.mjs`: record both escape channels, and
-     * require that the expected sentinel is consumed WITHOUT muting a real failure.
+     * The half that is NOT: `core.Base#destroy` rejects pending timeouts with `Neo.isDestroyed`, and
+     * an unguarded `timeout().then()` therefore leaks a rejected child promise. That surfaces as
+     * `ERR_UNHANDLED_REJECTION` under strict Node isolation — but NOT here. Measured, not assumed:
+     * a control that reproduces the raw unguarded shape (`inst.timeout(0).then(() => {}); inst.destroy()`)
+     * and records `process.on('unhandledRejection')` for 400ms observes **zero** in this runner. An
+     * arm asserting `unhandled === []` would therefore pass with the `.catch` deleted, which is a
+     * green that means nothing.
+     *
+     * The half that IS witnessable is the one a blanket catch would destroy: an UNEXPECTED failure
+     * inside the deferral must still reach the console. Deleting the `.catch` makes this arm red,
+     * because the rejection then escapes the chain instead of being reported — so this is the arm
+     * that actually holds the terminal in place.
+     *
+     * @see Neo.grid.Body#onStoreLoad — the landed terminal-outcome idiom this follows.
      */
-    test('the destroyed deferral consumes its cancellation instead of leaking a rejection', async () => {
-        const unhandled     = [],
-              consoleErrors = [],
-              onUnhandled   = value => unhandled.push(value),
+    test('an unexpected failure inside the deferral still reaches the console', async () => {
+        const consoleErrors = [],
+              originalError = console.error,
+              boom          = new Error('projection exploded');
+
+        attachBodies({
+            createViewData() { throw boom }
+        });
+
+        console.error = (...args) => consoleErrors.push(args);
+
+        try {
+            view.isLoading = 'Loading';
+            view.isLoading = false;
+
+            await new Promise(resolve => setTimeout(resolve, 50))
+        } finally {
+            console.error = originalError
+        }
+
+        expect(consoleErrors, 'a live failure has no caller to propagate to, so it must be reported')
+            .toHaveLength(1);
+        expect(consoleErrors[0][1].reason, 'the real reason survives, unwrapped').toBe(boom)
+    });
+
+    test('the expected teardown cancellation is consumed silently', async () => {
+        const consoleErrors = [],
               originalError = console.error;
 
         attachBodies(createBodyStub());
 
-        process.on('unhandledRejection', onUnhandled);
         console.error = (...args) => consoleErrors.push(args);
 
         try {
@@ -162,16 +192,12 @@ test.describe('Neo.grid.View — clearing isLoading re-projects', () => {
             view.isLoading = false;
             view.destroy();
 
-            // Past the deferral, then far enough for Node to have decided a rejection is unhandled —
-            // that verdict lands a macrotask after the microtask queue drains.
-            await new Promise(resolve => setTimeout(resolve, 300))
+            await new Promise(resolve => setTimeout(resolve, 50))
         } finally {
-            process.off('unhandledRejection', onUnhandled);
             console.error = originalError
         }
 
-        expect(unhandled,     'the Neo.isDestroyed sentinel is an expected outcome').toEqual([]);
-        expect(consoleErrors, 'an expected cancellation is not a reportable failure').toEqual([]);
+        expect(consoleErrors, 'Neo.isDestroyed is an expected end, not a reportable failure').toEqual([]);
 
         view = null
     })

--- a/test/playwright/unit/grid/ViewLoadingReprojection.spec.mjs
+++ b/test/playwright/unit/grid/ViewLoadingReprojection.spec.mjs
@@ -134,5 +134,45 @@ test.describe('Neo.grid.View — clearing isLoading re-projects', () => {
         expect(body.calls, 'the deferred pass saw the teardown').toEqual([]);
 
         view = null
+    });
+
+    /**
+     * Silence is two different outcomes here and the arm above cannot tell them apart: a deferral
+     * that declined to project, and a deferral whose promise rejected with nobody listening. Both
+     * leave `body.calls` empty. `core.Base#destroy` rejects pending timeouts with `Neo.isDestroyed`,
+     * so the second is what an unguarded chain actually produces — one `ERR_UNHANDLED_REJECTION`
+     * per teardown inside the window.
+     *
+     * Same shape as the landed `DispatchTerminalOutcome.spec.mjs`: record both escape channels, and
+     * require that the expected sentinel is consumed WITHOUT muting a real failure.
+     */
+    test('the destroyed deferral consumes its cancellation instead of leaking a rejection', async () => {
+        const unhandled     = [],
+              consoleErrors = [],
+              onUnhandled   = value => unhandled.push(value),
+              originalError = console.error;
+
+        attachBodies(createBodyStub());
+
+        process.on('unhandledRejection', onUnhandled);
+        console.error = (...args) => consoleErrors.push(args);
+
+        try {
+            view.isLoading = 'Loading';
+            view.isLoading = false;
+            view.destroy();
+
+            // Past the deferral, then far enough for Node to have decided a rejection is unhandled —
+            // that verdict lands a macrotask after the microtask queue drains.
+            await new Promise(resolve => setTimeout(resolve, 300))
+        } finally {
+            process.off('unhandledRejection', onUnhandled);
+            console.error = originalError
+        }
+
+        expect(unhandled,     'the Neo.isDestroyed sentinel is an expected outcome').toEqual([]);
+        expect(consoleErrors, 'an expected cancellation is not a reportable failure').toEqual([]);
+
+        view = null
     })
 });


### PR DESCRIPTION
Resolves #18256

Three of `TreeBigData`'s five e2e arms were red, and the split was the clue: **every passing arm expands one node by clicking it; every failing arm expands some other way** — bulk toggle, filter-driven auto-expand, expansion after a structural change.

It is not the tree, the store, or the click handler. `Neo.grid.Body#createViewData` opens with a guard block that returns when the body cannot measure, and a loading view cannot. That guard sits **before** the `isVdomUpdating` branch that would re-register the work — so a store `load` arriving inside the loading window is not postponed, it is **discarded**, and nothing schedules another. The rows keep projecting the pre-load state after the mask clears, with the store already correct. Only the paint is missing.

The consumer shape that hits it is the documented one: wrap a bulk store mutation in `isLoading` so the grid shows a spinner while it commits. `examples/grid/treeBigData` does exactly that around `expandAll()`.

**The example is not in this diff.** Clearing `isLoading` is a projection trigger, not only a mask removal, and any consumer using that pattern depends on it.

## Deltas

| File | Change |
|---|---|
| `src/grid/View.mjs` | `afterSetIsLoading` — on clear, re-project every body, deferred one tick |
| `test/…/unit/grid/ViewLoadingReprojection.spec.mjs` | **new**, 4 arms in the tier CI actually runs |
| `examples/grid/treeBigData/**` | **untouched** |

## AC Evidence

| Verdict | Evidence: |
|---|---|
| the three failing arms pass, the two passing arms still pass | `5 passed (10.5s)`, from `3 failed / 2 passed (52.3s)` on clean `origin/dev` |
| the fix is in the engine, not the example | `git status --porcelain examples/` is empty in this branch |
| no regression | unit **3147 passed**, components **234 passed** |
| mutation-verified | matrix below |

**Mutants, each run against both tiers:**

| mutant | unit | e2e |
|---|---|---|
| re-projection removed entirely | 2 failed | 3 failed |
| deferral removed (synchronous call) | 2 failed | 3 failed |
| `force` flag dropped | **1 failed** | 5 passed |

The third row is why the unit arm exists. A bulk expand changes no record identity, so an unforced pass is skipped as a no-op — and **e2e cannot see that at all**. It is also why the arm asserts the call is *not* synchronous: without the deferral the re-projection meets the same guard that dropped the original load, so an early call is not merely early, it is dropped too.

## Test Evidence

```
e2e   TreeBigData                     5 passed (10.5s)   ← was 3 failed / 2 passed (52.3s)
unit  (full tier)                  3147 passed           ← 3143 + 4 new arms
unit  grid/ (directory, 3 runs)      88 passed × 3
comp  (full tier)                   234 passed
```

Two notes I would rather state than have a reviewer find.

**I put the fix on the wrong class first.** `grid/Container` creates `Neo.grid.View` (`:284`), not `Neo.grid.Body`, so an `afterSetIsLoading` override on `Body` never fired and the arms stayed red — a null result I only caught because I ran them instead of reasoning that the handler must be firing. The layering is `View → Body → Row`; the mask lives on the View and the projection on the Body, which is exactly why the two halves came apart in the first place.

**One `unit/grid/` directory run reported `2 failed / 86 passed` and did not reproduce** — three consecutive runs since are `88 passed`, and the full tier was green throughout. I could not attribute it, so it is recorded rather than smoothed over; if it recurs on this branch it is worth a defect-note before merge.

## Post-Merge Validation

- The deferral is the fragile part. Any future change that makes the re-projection synchronous will pass a naive review and re-open this defect silently — the unit arm's "deferred past the mask removal" assertion is what stops that.
- Locked-column grids: `bodyStart` / `body` / `bodyEnd` project the same store through the same guard, so the fix asks every item rather than only the centre one, and an arm covers all three.
- This symptom has been fixed and closed once before on the identical assertion, with coverage that lived only in e2e — which no workflow runs (#17844). That is the reason the regression arm lands in the unit tier instead.

Authored by Grace (Claude Opus 5, Claude Code). Session 118d8435-8d23-4745-a28a-8d22da918aac.
