### PR TITLE
test(workstation): the splitter preview arms drag where the band has headroom

### DIFF
--- a/test/playwright/e2e/workstation/WorkstationEdgeSplitterNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationEdgeSplitterNL.spec.mjs
@@ -9,6 +9,18 @@ import {test, expect} from '../../fixtures.mjs';
  * projection lands on the same final geometry, and Escape restores the prior presentation without a
  * document write. A non-first tab remains selected through both axes and the cancelled gesture.
  *
+ * **Drag direction is load-bearing, and it is why this spec was red.** Both preview drags used to
+ * SHRINK their band, and at this pinned 1440x900 viewport a band cannot shrink: measured on the left
+ * edge it renders at ratio 0.1271 while its committed extent is 0.11 — already held above its own
+ * committed value by the intrinsic width of the tab header it contains, which flex will not shrink
+ * past. So the gesture armed, the addon took ownership, it named the correct target, and the band
+ * did not move, because there was nowhere for it to go. The assertion was unsatisfiable rather than
+ * failing, and it read as a live-preview regression for as long as nobody measured the geometry.
+ *
+ * Both preview drags therefore GROW their band, where the headroom is. Whether a band SHOULD be
+ * clamped by its content width is a separate question this spec deliberately does not pin: asserting
+ * the clamp here would cement behaviour nobody has ruled on.
+ *
  * Run: NEO_AGENTOS_RUNTIME_ROOT=/path/to/neo-agent-brain npx playwright test
  * test/playwright/e2e/workstation/WorkstationEdgeSplitterNL.spec.mjs
  * -c test/playwright/playwright.config.e2e.mjs --workers=1
@@ -301,11 +313,12 @@ test.describe('Workstation edge splitters — runtime pixels commit once as docu
             return after
         };
 
-        await dragEdge({edge: 'left', dx: -70});
+        // grows the band: the shrink direction has no headroom at this viewport (see the header)
+        await dragEdge({edge: 'left', dx: 70});
         expect((await readDocument()).nodes['right-top-tabs'].activeItemId).toBe('audit');
         expect((await readActiveTabs()).activeIndex).toBe(1);
 
-        await dragEdge({edge: 'bottom', dy: 70});
+        await dragEdge({edge: 'bottom', dy: -70});
         expect((await readDocument()).nodes['right-top-tabs'].activeItemId).toBe('audit');
         expect((await readActiveTabs()).activeIndex).toBe(1);
 


### PR DESCRIPTION
Resolves #18221

The spec was red because its assertion was **unsatisfiable, not failing** — and I am the one who filed it as a live-preview regression without measuring the geometry that separated the two.

Both preview drags shrank their band. At this spec's pinned `1440x900` viewport a band cannot shrink:

```
[PROBE] left dx=-70  beforeRatio=0.1271186440677966  duringRatio=0.1271186440677966
                     committedExtent={"nodeId":"left-tabs","extent":0.11,"resizable":true}
```

It renders at **0.1271** while its committed extent is **0.11** — already held above its own committed value by the intrinsic width of the tab header inside it, which flex will not shrink past. So the gesture armed, the addon took ownership, it named the correct target, and the band did not move because there was nowhere for it to go.

The live preview works on both axes. Flipping both drags to GROW turns the spec green.

## Deltas

| File | Change |
|---|---|
| `test/…/e2e/workstation/WorkstationEdgeSplitterNL.spec.mjs` | both preview drags reversed to the direction with headroom; the header records the measurement and why direction is load-bearing |
| everything else | **untouched** — no engine change, and none is warranted |

## AC Evidence

| Verdict | Evidence: |
|---|---|
| the arm passes | `1 passed (4.6s)`, three consecutive runs at 7.4s / 6.8s / 6.8s |
| the failure was the spec, not the engine | the probe above: `beforeRatio === duringRatio` at a ratio already above the committed extent. Reversing direction alone turns it green with zero source changes |
| no engine change smuggled in | `git diff --numstat` is one test file, `15 / 2` |
| onset | not established, and now cheap to skip: the arm has been unrunnable since the split, and the corrected reading is that it was never green at this viewport rather than that it regressed |

**What this PR deliberately does NOT do.** It does not assert the clamp. Whether an edge band *should* be floored by its content width is a real question nobody has ruled on — `DockSplitter:353` passes `minSize: 1` and `LayoutAdapter:991` sets `minWidth: 0`, so the floor is not a dock-level decision but a flex consequence. Pinning it in a spec would cement behaviour that has never been decided. It is recorded in the header instead, where whoever decides it will find the number.

## Test Evidence

```
e2e  WorkstationEdgeSplitterNL     1 passed (4.6s)  ← was 1 failed
     re-runs                       1 passed × 3
```

Evidence: L2 (headless e2e with the Neural Link runtime) → L2 required; the close-target AC is the arm itself. Residual: none.

The wider suite is untouched by this change; it is one spec file and no source.

## Post-Merge Validation

- The header comment is the guard against this recurring: the next person to adjust these drags will see why the direction is not arbitrary before flipping one back.
- If the content-width floor is later ruled a defect, this spec is the natural place to add the clamped-direction arm — deliberately left absent rather than asserted.
- I corrected the ticket body in the same pass. It carried "the live preview does not move the band on any edge" as a finding, which is false, and a ticket that states a wrong mechanism costs the next reader more than an empty one.

Authored by Grace (Claude Opus 5, Claude Code). Session 118d8435-8d23-4745-a28a-8d22da918aac.
