### PR TITLE
test(buildScripts): restore the content-index rebuild spec its subject never left with

### DIFF
--- a/test/playwright/unit/buildScripts/docs/RebuildContentIndexesAndSeo.spec.mjs
+++ b/test/playwright/unit/buildScripts/docs/RebuildContentIndexesAndSeo.spec.mjs
@@ -1,0 +1,158 @@
+import {test, expect} from '@playwright/test';
+import fs             from 'fs/promises';
+import path           from 'path';
+
+import {
+    rebuildContentIndexesAndSeo
+} from '../../../../../buildScripts/docs/rebuildContentIndexesAndSeo.mjs';
+
+test.describe('rebuildContentIndexesAndSeo (#13260)', () => {
+    test('runs local content index builders before SEO generation and writes both SEO artifacts', async () => {
+        const
+            calls  = [],
+            writes = [];
+
+        const record = name => async (...args) => {
+            calls.push({name, args});
+            return `${name}-result`;
+        };
+
+        const result = await rebuildContentIndexesAndSeo({
+            root                    : '/repo',
+            baseUrl                 : 'https://example.test',
+            sitemapPath             : '/repo/apps/portal/sitemap.xml',
+            llmsPath                : '/repo/apps/portal/llms.txt',
+            createReleaseIndexFn    : record('releases'),
+            createPullRequestIndexFn: record('pulls'),
+            createDiscussionIndexFn : record('discussions'),
+            createTicketIndexFn     : record('tickets'),
+            getSitemapXmlFn         : record('sitemap'),
+            getLlmsTxtFn            : record('llms'),
+            writeFileSync           : (filePath, content) => writes.push({filePath, content}),
+            log                     : () => {}
+        });
+
+        expect(calls.map(call => call.name)).toEqual([
+            'releases',
+            'pulls',
+            'discussions',
+            'tickets',
+            'sitemap',
+            'llms'
+        ]);
+        expect(calls.find(call => call.name === 'sitemap').args[0]).toEqual({
+            baseUrl            : 'https://example.test',
+            existingSitemapPath: '/repo/apps/portal/sitemap.xml'
+        });
+        expect(calls.find(call => call.name === 'llms').args[0]).toEqual({
+            baseUrl: 'https://example.test'
+        });
+        expect(writes).toEqual([
+            {filePath: '/repo/apps/portal/sitemap.xml', content: 'sitemap-result'},
+            {filePath: '/repo/apps/portal/llms.txt', content: 'llms-result'}
+        ]);
+        expect(result).toEqual({
+            baseUrl    : 'https://example.test',
+            llmsPath   : '/repo/apps/portal/llms.txt',
+            sitemapPath: '/repo/apps/portal/sitemap.xml'
+        });
+    });
+
+    test('can explicitly include the remote GitHub label index for release and CI callers', async () => {
+        const calls = [];
+
+        const record = name => async () => {
+            calls.push(name);
+        };
+
+        await rebuildContentIndexesAndSeo({
+            includeLabelIndex       : true,
+            createLabelIndexFn      : record('labels'),
+            createReleaseIndexFn    : record('releases'),
+            createPullRequestIndexFn: record('pulls'),
+            createDiscussionIndexFn : record('discussions'),
+            createTicketIndexFn     : record('tickets'),
+            getSitemapXmlFn         : async () => '<xml />',
+            getLlmsTxtFn            : async () => 'llms',
+            writeFileSync           : () => {},
+            log                     : () => {}
+        });
+
+        expect(calls).toEqual(['labels', 'releases', 'pulls', 'discussions', 'tickets']);
+    });
+
+    test('imports nothing from ai/** — the corpus re-chunk belongs to the emitter, not this projection', async () => {
+        // The ordinal-100 re-chunk moved to `SyncService#emitGeneratedContentAndDerive` so the corpus
+        // WRITER leaves the layout canonical. This arm pins the boundary property at the module level,
+        // complementing the repo-wide `check-engine-brain-boundary` guard: a reintroduced `ai/` import
+        // fails here inside the unit suite, before the lint-staged/CI guard ever runs.
+        const source = await fs.readFile(
+            path.resolve(process.cwd(), 'buildScripts/docs/rebuildContentIndexesAndSeo.mjs'), 'utf8'
+        );
+
+        expect(source).not.toMatch(/from\s+'[^']*\bai\//);
+        expect(source).not.toMatch(/import\('[^']*\bai\//);
+
+        // This arm used to also pin the OTHER side of that boundary — that the emitter still carries
+        // the re-chunk pass, ordered before its own derive call — by reading
+        // `ai/services/github-workflow/SyncService.mjs`. That file left for `neomjs/neo-agent-brain`
+        // in the split, so the assertion is not merely red here, it is unstateable: this repository
+        // cannot read it, and a spec that reaches across the split would fail for the wrong reason.
+        //
+        // Restored deliberately without it rather than with it commented out. The half above is a
+        // property of a file that still lives here; the emitter's ordering is the Brain repository's
+        // to pin, and claiming it from this side would recreate the coupling the split removed.
+    });
+
+    test('fails closed when a derive step rejects before generated artifacts are written', async () => {
+        const writes = [];
+
+        await expect(rebuildContentIndexesAndSeo({
+            createLabelIndexFn      : async () => {},
+            createReleaseIndexFn    : async () => {},
+            createPullRequestIndexFn: async () => { throw new Error('pull index failed'); },
+            createDiscussionIndexFn : async () => { throw new Error('must not run'); },
+            createTicketIndexFn     : async () => { throw new Error('must not run'); },
+            getSitemapXmlFn         : async () => '<xml />',
+            getLlmsTxtFn            : async () => 'llms',
+            writeFileSync           : (filePath, content) => writes.push({filePath, content}),
+            log                     : () => {}
+        })).rejects.toThrow('pull index failed');
+
+        expect(writes).toEqual([]);
+    });
+
+    test('data-sync pipeline delegates to the shared helper instead of duplicating the seven derive commands', async () => {
+        const [workflow, publisher] = await Promise.all([
+            fs.readFile(path.resolve(process.cwd(), '.github/workflows/data-sync-pipeline.yml'), 'utf8'),
+            fs.readFile(path.resolve(process.cwd(), 'buildScripts/dataSyncPipeline.mjs'), 'utf8')
+        ]);
+        const delegatedPipeline = workflow + publisher;
+
+        expect(workflow).toContain('node ./buildScripts/dataSyncPipeline.mjs');
+        expect(publisher).toContain('./buildScripts/docs/rebuildContentIndexesAndSeo.mjs');
+        expect(delegatedPipeline).not.toContain('node ./buildScripts/docs/index/labels.mjs');
+        expect(delegatedPipeline).not.toContain('node ./buildScripts/docs/index/release.mjs');
+        expect(delegatedPipeline).not.toContain('node ./buildScripts/docs/index/pulls.mjs');
+        expect(delegatedPipeline).not.toContain('node ./buildScripts/docs/index/discussions.mjs');
+        expect(delegatedPipeline).not.toContain('node ./buildScripts/docs/index/tickets.mjs');
+        // The pipeline step receives SCOPED credentials and no ambient repository token. This
+        // previously pinned `GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}` — one token for the publish
+        // push AND for cross-repository intake reads, two different authorization contracts that the
+        // default token satisfies neither of.
+        //
+        // The intake half went with the DevIndex stages, so one scoped credential
+        // remains here. The property under test is unchanged: the step names what it is entitled to.
+        expect(workflow).not.toContain('DATA_SYNC_INTAKE_TOKEN');
+        expect(workflow).toContain('DATA_SYNC_PUBLISHER_TOKEN: ${{ steps.publisher-token.outputs.token }}');
+
+        // The assertion that matters: the ambient repository token is gone from the run step, so a
+        // future edit reinstating it would fail here rather than silently restoring the shared
+        // credential this split exists to remove.
+        expect(workflow).not.toContain('GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}');
+
+        // The publish push runs through the checkout credential, so it must be the publisher —
+        // the only identity permitted to bypass the ruleset.
+        expect(workflow).toContain('token: ${{ steps.publisher-token.outputs.token }}');
+    });
+});


### PR DESCRIPTION
Resolves #17922

The parent census listed 27 buildScripts guards whose specs were deleted by the split while their implementations stayed. Re-measured at `dev@274b63beac`, **25 have been restored** and two remain:

| remaining subject | disposition |
|---|---|
| `buildScripts/docs/rebuildContentIndexesAndSeo.mjs` | **restored here** |
| `.github/workflows/test.yml` concurrency / scope script | **belongs in `neo-agent-skills`**, not here — see below |

## Deltas

| File | Change |
|---|---|
| `test/…/unit/buildScripts/docs/RebuildContentIndexesAndSeo.spec.mjs` | **restored** from `c623b2f63c^`, 5 arms, two adaptations |
| everything else | untouched |

Two adaptations, both stated rather than silent:

1. **Import depth.** The spec lived at `unit/ai/buildScripts/docs/` and now lives at `unit/buildScripts/docs/`, so its relative import loses one level — matching the sibling `docs/index/PortalContentIndexes.spec.mjs` convention.
2. **Half of the `ai/**` boundary arm is unstateable here now.** It asserted two things: that `rebuildContentIndexesAndSeo.mjs` imports nothing from `ai/**` (a property of a file that still lives here — **kept**), and that the emitter still carries its re-chunk pass ordered before its derive call, by reading `ai/services/github-workflow/SyncService.mjs` (**dropped** — that file left for `neomjs/neo-agent-brain`). Restored without it rather than with it commented out: the emitter's ordering is the Brain repository's to pin, and reaching across the split from this side would recreate the coupling the split removed.

## Why the other remaining row is not in this PR

`WorkflowConcurrency.spec.mjs` covered three mechanisms in `test.yml`, not one: rerun isolation (`concurrency`), the head gate, and the mergeability controller. Restoring a 675-line neo-side spec would re-implement CI/governance guards in the engine because their old spec lived here — the placement error that cost #18228 a Drop+Supersede this session.

**But "superseded" overstates it, and #17922's ACs now say so.** `neo-agent-skills#41` owns all three and **all three of its ACs are open**; only the concurrency third has a script (`scripts/check-workflow-concurrency.mjs`, skills PR #42), and the reusable baseline offers none of them yet. So the row is **relocated and still owed there**, not discharged — closing #17922 must not read as those guards being covered anywhere.

#17922's AC-1 and AC-5 are restated accordingly: the close condition is **26 restored here + 1 dispositioned**, and AC-5's target moves 27 → 26. Caught by @neo-gpt-emmy in review.

## AC Evidence

| Verdict | Evidence: |
|---|---|
| the spec runs against the current implementation | `5 passed (461ms)`; every DI seam it exercises (`includeLabelIndex`, `createLabelIndexFn`, `getSitemapXmlFn`, `writeFileSync`) is still present at `rebuildContentIndexesAndSeo.mjs:47-62` |
| it is not vacuous | mutation matrix below |
| no regression | unit **3148 passed** (3147 + 1 restored file's 5 arms, net +1 spec file) |
| it lands in a tier CI runs | `unit` — the point of the parent ticket is that these guards run with no coverage, so coverage in a tier nothing executes would repeat the defect |

**Mutants:**

| mutant | result |
|---|---|
| derive order swapped (pulls before releases) | 2 failed |
| sitemap write removed | 1 failed |
| an `ai/` import reintroduced | **could not be constructed — see below** |

**I could not build the third mutant, and that is a finding rather than a gap I am glossing.** `ai/` here is a husk: `ai/config.mjs` survives but imports `ai/configBase.mjs`, which does not, so **no `ai/` module in this repository resolves**. Any real reintroduced import would fail at module load before the boundary arm ever asserted. I verified the arm's regex discriminates directly instead:

```
OK  matches  "import aiConfig from '../../ai/config.mjs';"
OK  matches  "const x = await import('../../ai/services/foo.mjs');"
OK  no match "import path from 'path';"
OK  no match "import x from './index/labels.mjs';"
```

So that arm is belt-and-braces over `check-engine-brain-boundary` rather than independently mutation-proven, and it is stated that way.

## Test Evidence

```
unit  RebuildContentIndexesAndSeo      5 passed (461ms)
unit  (full tier)                   3148 passed
```

Evidence: L2 (headless unit) → L2 required; the close-target AC is spec restoration. Residual: none for this row; the `WorkflowConcurrency` row stays open on #17922 with the disposition above.

## Post-Merge Validation

- The parent's count drops from 2 remaining to 1, and the survivor is a placement question rather than a restoration.
- The dropped half of the boundary arm is the one thing a future reader might try to "fix back in". The comment in its place names why it cannot be, so the next person does not spend the read.

Authored by Grace (Claude Opus 5, Claude Code). Session 118d8435-8d23-4745-a28a-8d22da918aac.

