### PR TITLE
fix(worker): a window joining a running SharedWorker receives the replayed remotes (#18265)

### DIFF
--- a/src/worker/Base.mjs
+++ b/src/worker/Base.mjs
@@ -206,8 +206,10 @@ class Worker extends Base {
 
         me.sendMessage(id, {action: 'workerConstructed', port: id})
 
+        // Addressed to `main`, because the receiving thread accepts a registration only when the
+        // destination names it; routed to exactly the new port through `opts.port`.
         me.remotesToRegister.forEach(remote => {
-            me.sendMessage(id, {action : 'registerRemote', ...remote})
+            me.sendMessage('main', {action: 'registerRemote', port: id, ...remote})
         });
 
         me.afterConnect()

--- a/src/worker/Base.mjs
+++ b/src/worker/Base.mjs
@@ -183,7 +183,12 @@ class Worker extends Base {
     }
 
     /**
-     * Only relevant for SharedWorkers
+     * Binds one freshly connected SharedWorker port: registers it, announces `workerConstructed`, and
+     * replays every stored `registerRemote` so a window that joins a running worker holds the same remote
+     * proxies as the first. The replay is addressed to `main` — the receiving thread accepts a registration
+     * only when the destination names it — and routed to exactly this port through `opts.port`; the port
+     * has no `windowId` yet, so the port id is the only routing key that exists.
+     * Only relevant for SharedWorkers.
      * @param {Object} e
      */
     onConnected(e) {
@@ -206,8 +211,6 @@ class Worker extends Base {
 
         me.sendMessage(id, {action: 'workerConstructed', port: id})
 
-        // Addressed to `main`, because the receiving thread accepts a registration only when the
-        // destination names it; routed to exactly the new port through `opts.port`.
         me.remotesToRegister.forEach(remote => {
             me.sendMessage('main', {action: 'registerRemote', port: id, ...remote})
         });

--- a/src/worker/mixin/RemoteMethodAccess.mjs
+++ b/src/worker/mixin/RemoteMethodAccess.mjs
@@ -136,13 +136,14 @@ class RemoteMethodAccess extends Base {
      *
      * @param {Object} remote The remote configuration object.
      * @param {String} method The name of the method to generate a proxy for.
-     * @returns {function(*=, *=): Promise<any>} The proxy function.
+     * @returns {function(*=, *=): Promise<any>} The proxy function, carrying `remoteProvenance`
+     *     (`{className, origin}`) so {@link #onRegisterRemote} can tell a replay of this exact endpoint from a collision.
      */
     generateRemote(remote, method) {
         let me       = this,
             {origin} = remote;
 
-        return function(data, buffer) {
+        const proxy = function(data, buffer) {
             let opts = {
                 action         : 'remoteMethod',
                 data,
@@ -162,7 +163,11 @@ class RemoteMethodAccess extends Base {
             me.isSharedWorker && me.assignPort(data, opts);
 
             return me.promiseMessage(opts.destination, opts, buffer)
-        }
+        };
+
+        proxy.remoteProvenance = {className: remote.className, origin};
+
+        return proxy
     }
 
     /**
@@ -170,10 +175,12 @@ class RemoteMethodAccess extends Base {
      * It iterates over the list of methods provided in the remote config and generates local proxy functions
      * for them in the appropriate namespace. This makes the remote methods available to be called as if they were local.
      *
-     * Idempotent: the same registration can reach a thread twice — a SharedWorker replays every stored
-     * registration to each newly connected port, and the singleton's own startup registration also
-     * addresses the first window. The namespace is the class's own, so a second arrival keeps the existing
-     * proxy and is never a conflict.
+     * A registration of the SAME endpoint — `className`, `method` and `origin` all equal — arriving again
+     * is a no-op that keeps the existing proxy: a SharedWorker replays every stored registration to each
+     * newly connected port, and the singleton's own startup registration also addresses the first window,
+     * so that window legitimately sees one endpoint twice. Anything else already occupying the slot — a
+     * proxy for a different origin, or a local member — is a collision and throws, so a wrong binding is
+     * never retained in silence.
      *
      * @param {Object} remote The remote configuration object containing className and methods list.
      */
@@ -184,10 +191,19 @@ class RemoteMethodAccess extends Base {
                 pkg                  = Neo.ns(className, true);
 
             methods.forEach(method => {
-                pkg[method] ??= me.generateRemote({
-                    className: remote.className,
-                    origin   : remote.origin
-                }, method)
+                const existing = pkg[method],
+                      repeat   = existing?.remoteProvenance?.className === className
+                              && existing.remoteProvenance.origin === remote.origin;
+
+                if (existing && !repeat) {
+                    throw new Error(
+                        `Remote method collision: ${className}.${method} is already bound to ` +
+                        (existing.remoteProvenance ? `origin "${existing.remoteProvenance.origin}"` : 'a local member') +
+                        `; a registration from "${remote.origin}" cannot replace it`
+                    )
+                }
+
+                pkg[method] ??= me.generateRemote({className, origin: remote.origin}, method)
             });
 
             if (remote.id) {

--- a/src/worker/mixin/RemoteMethodAccess.mjs
+++ b/src/worker/mixin/RemoteMethodAccess.mjs
@@ -170,6 +170,11 @@ class RemoteMethodAccess extends Base {
      * It iterates over the list of methods provided in the remote config and generates local proxy functions
      * for them in the appropriate namespace. This makes the remote methods available to be called as if they were local.
      *
+     * Idempotent: the same registration can reach a thread twice — a SharedWorker replays every stored
+     * registration to each newly connected port, and the singleton's own startup registration also
+     * addresses the first window. The namespace is the class's own, so a second arrival keeps the existing
+     * proxy and is never a conflict.
+     *
      * @param {Object} remote The remote configuration object containing className and methods list.
      */
     onRegisterRemote(remote) {
@@ -179,10 +184,6 @@ class RemoteMethodAccess extends Base {
                 pkg                  = Neo.ns(className, true);
 
             methods.forEach(method => {
-                if (remote.origin !== 'main' && pkg[method]) {
-                    throw new Error('Duplicate remote method definition ' + className + '.' + method)
-                }
-
                 pkg[method] ??= me.generateRemote({
                     className: remote.className,
                     origin   : remote.origin

--- a/test/playwright/e2e/core/SharedWorkerRemoteReplay.spec.mjs
+++ b/test/playwright/e2e/core/SharedWorkerRemoteReplay.spec.mjs
@@ -1,0 +1,85 @@
+import {test, expect} from '@playwright/test';
+
+/**
+ * A window that connects to an already-running SharedWorker receives the App worker's remote methods.
+ *
+ * The first window gets `Neo.worker.App.*` through the singleton's startup registration. Every later
+ * window — a second tab on the same origin, or the first window after a reload while another window
+ * keeps the worker alive — depends on the per-connection replay of the stored registrations. This arm
+ * drives both of those windows against a real SharedWorker app and reads the namespace the main thread
+ * ends up with; the unit arms pin the message envelope, this one pins the outcome a user's window sees.
+ *
+ * The negative half matters as much: the first window must not report a duplicate registration when
+ * the replay and the startup path both reach it, and the replay must not trip the deprecated-`main`
+ * warning — a window with the proxies but a console full of throws would pass a namespace check.
+ */
+const
+    APP      = '/apps/colors/index.html',
+    VIEWPORT = '.neo-viewport',
+    REMOTE   = 'moveComponent';
+
+const remoteState = page => page.evaluate(remote => ({
+    shared : globalThis.Neo?.config?.useSharedWorkers === true,
+    remotes: Object.keys(globalThis.Neo?.worker?.App || {}),
+    has    : typeof globalThis.Neo?.worker?.App?.[remote] === 'function'
+}), REMOTE);
+
+const watch = page => {
+    const problems = [];
+
+    page.on('pageerror', error => problems.push(`pageerror: ${error?.message || error}`));
+    page.on('console', message => {
+        const text = message.text();
+
+        if (/Duplicate remote method definition|destination "main" is deprecated/.test(text)) {
+            problems.push(`${message.type()}: ${text}`)
+        }
+    });
+
+    return problems
+};
+
+const boot = async page => {
+    await page.goto(APP);
+    await page.locator(VIEWPORT).first().waitFor({state: 'attached', timeout: 60000});
+    // the registrations ride the connect handshake; give the main thread one frame past first paint
+    await page.waitForTimeout(500)
+};
+
+test.describe('SharedWorker remote registration reaches every window', () => {
+    test.setTimeout(120000);
+
+    test('a second window and a reloaded window both receive the App worker remotes, without duplicate or deprecation noise', async ({page, context}) => {
+        const firstProblems = watch(page);
+
+        await boot(page);
+
+        const first = await remoteState(page);
+
+        expect(first.shared, 'the subject app must run on a SharedWorker').toBe(true);
+        expect(first.has, 'the first window gets the remotes through the startup registration').toBe(true);
+
+        // A second window on the same origin joins the RUNNING worker: only the replay can serve it.
+        const second         = await context.newPage(),
+              secondProblems = watch(second);
+
+        await boot(second);
+
+        const late = await remoteState(second);
+
+        expect(late.has, 'a window connecting to a running SharedWorker receives the remotes').toBe(true);
+        expect(late.remotes, 'and the same set the first window received').toEqual(first.remotes);
+
+        // The first window reloads while the second keeps the worker alive — the F5 case.
+        await page.reload();
+        await page.locator(VIEWPORT).first().waitFor({state: 'attached', timeout: 60000});
+        await page.waitForTimeout(500);
+
+        const reloaded = await remoteState(page);
+
+        expect(reloaded.has, 'a reloaded window receives the remotes again').toBe(true);
+
+        expect(firstProblems, 'no duplicate-registration throw and no deprecation warning in the first window').toEqual([]);
+        expect(secondProblems, 'nor in the second').toEqual([])
+    })
+});

--- a/test/playwright/e2e/core/SharedWorkerRemoteReplay.spec.mjs
+++ b/test/playwright/e2e/core/SharedWorkerRemoteReplay.spec.mjs
@@ -39,11 +39,17 @@ const watch = page => {
     return problems
 };
 
+// The registrations ride the connect handshake and nothing in the DOM marks their arrival, so readiness is
+// the proxy itself: wait for it with a bound and let the assertion read whatever is there afterwards — a
+// window that never receives it fails on the value, not on a clock.
+const awaitRemotes = page => page
+    .waitForFunction(remote => typeof globalThis.Neo?.worker?.App?.[remote] === 'function', REMOTE, {timeout: 20000})
+    .then(() => true, () => false);
+
 const boot = async page => {
     await page.goto(APP);
     await page.locator(VIEWPORT).first().waitFor({state: 'attached', timeout: 60000});
-    // the registrations ride the connect handshake; give the main thread one frame past first paint
-    await page.waitForTimeout(500)
+    await awaitRemotes(page)
 };
 
 test.describe('SharedWorker remote registration reaches every window', () => {
@@ -73,7 +79,7 @@ test.describe('SharedWorker remote registration reaches every window', () => {
         // The first window reloads while the second keeps the worker alive — the F5 case.
         await page.reload();
         await page.locator(VIEWPORT).first().waitFor({state: 'attached', timeout: 60000});
-        await page.waitForTimeout(500);
+        await awaitRemotes(page);
 
         const reloaded = await remoteState(page);
 

--- a/test/playwright/unit/worker/RemoteReplay.spec.mjs
+++ b/test/playwright/unit/worker/RemoteReplay.spec.mjs
@@ -1,0 +1,131 @@
+import {setup} from '../../setup.mjs';
+
+setup({
+    appConfig: {
+        name: 'RemoteReplayTest'
+    }
+});
+
+import {test, expect}     from '@playwright/test';
+import Neo                from '../../../../src/Neo.mjs';
+import * as core          from '../../../../src/core/_export.mjs';
+import RemoteMethodAccess from '../../../../src/worker/mixin/RemoteMethodAccess.mjs';
+import WorkerBase         from '../../../../src/worker/Base.mjs';
+
+/**
+ * @summary A window connecting to a running SharedWorker receives the worker's remote methods.
+ *
+ * Every singleton's `registerRemote` is stored on the worker and replayed to each newly connected
+ * port, so a second window — or the first window after a reload — gets the same proxies the first
+ * window got through the startup path. Two contracts make that replay land:
+ *
+ * 1. The replayed message is addressed to `main` and routed to exactly the new port. The receiving
+ *    thread accepts a registration only when its destination names that thread, so a message whose
+ *    destination is the port id is delivered and dropped — the window ends up with no proxies and no
+ *    error. Routing through `opts.port` keeps the message out of every other window's port.
+ * 2. Receiving the same registration twice is a no-op. The first window can legitimately see a
+ *    registration through the replay and again through the singleton's own startup registration;
+ *    the existing proxy is kept, never re-minted, never reported as a conflict.
+ */
+class ReplayWorker extends WorkerBase {
+    static config = {
+        className: 'Test.Unit.Worker.RemoteReplayWorker'
+    }
+
+    construct(config) {
+        super.construct(config);
+        // The SharedWorker branch, decided before onConstructed() runs, so the dedicated-worker
+        // announcement (which needs a main thread) never fires inside the single-threaded unit env.
+        this.isSharedWorker = true
+    }
+}
+Neo.setupClass(ReplayWorker);
+
+class ReplayReceiver extends Neo.core.Base {
+    static config = {
+        className: 'Test.Unit.Worker.RemoteReplayReceiver',
+        mixins   : [RemoteMethodAccess]
+    }
+
+    /**
+     * Every reply the mixin's `resolve()` hands to `sendMessage()`, captured instead of posted.
+     * @member {Object[]} replies=[]
+     */
+    replies = []
+
+    promiseMessage(destination, opts) {
+        return Promise.resolve(opts)
+    }
+
+    sendMessage(destination, opts) {
+        this.replies.push(opts);
+        return opts
+    }
+}
+Neo.setupClass(ReplayReceiver);
+
+const createCapturingPort = () => {
+    const sent = [];
+
+    return {
+        sent,
+        port: {
+            postMessage(message) {
+                sent.push(message)
+            }
+        }
+    }
+};
+
+const createWorker = () => Neo.create(ReplayWorker, {workerId: 'remote-replay-test'});
+
+test.describe('SharedWorker remote registration replay', () => {
+    test('onConnected: the replayed registerRemote is addressed to main and routed to the new port', () => {
+        const worker       = createWorker(),
+              {port, sent} = createCapturingPort();
+
+        worker.remotesToRegister.push({className: 'Test.Unit.Worker.ReplayedSingleton', methods: ['ping', 'pong']});
+
+        worker.onConnected({ports: [port]});
+
+        const registration = sent.find(message => message.action === 'registerRemote'),
+              newPortId    = worker.ports[worker.ports.length - 1].id;
+
+        expect(sent.map(message => message.action)).toEqual(['workerConstructed', 'registerRemote']);
+        expect(registration.destination).toBe('main');
+        expect(registration.port).toBe(newPortId);
+        expect(registration.className).toBe('Test.Unit.Worker.ReplayedSingleton');
+        expect(registration.methods).toEqual(['ping', 'pong'])
+    });
+
+    test('onConnected: an already-connected window receives nothing from the replay', () => {
+        const worker = createWorker(),
+              first  = createCapturingPort(),
+              second = createCapturingPort();
+
+        worker.ports.push({appNames: new Set(['RemoteReplayTest']), id: 'port-first', port: first.port, windowId: 'win-first'});
+        worker.remotesToRegister.push({className: 'Test.Unit.Worker.ReplayedSingleton', methods: ['ping']});
+
+        worker.onConnected({ports: [second.port]});
+
+        expect(first.sent.length).toBe(0);
+        expect(second.sent.filter(message => message.action === 'registerRemote').length).toBe(1)
+    });
+
+    test('onRegisterRemote: the same registration arriving twice keeps the existing proxy and still replies', () => {
+        const receiver  = Neo.create(ReplayReceiver),
+              className = 'Test.Unit.Worker.TwiceRegistered',
+              remote    = {className, destination: Neo.workerId, methods: ['ping'], origin: 'app'};
+
+        receiver.onRegisterRemote({...remote, id: 'registration-1'});
+
+        const proxy = Neo.ns(className).ping;
+
+        expect(typeof proxy).toBe('function');
+
+        expect(() => receiver.onRegisterRemote({...remote, id: 'registration-2'})).not.toThrow();
+
+        expect(Neo.ns(className).ping).toBe(proxy);
+        expect(receiver.replies.map(reply => reply.replyId)).toEqual(['registration-1', 'registration-2'])
+    })
+});

--- a/test/playwright/unit/worker/RemoteReplay.spec.mjs
+++ b/test/playwright/unit/worker/RemoteReplay.spec.mjs
@@ -112,7 +112,7 @@ test.describe('SharedWorker remote registration replay', () => {
         expect(second.sent.filter(message => message.action === 'registerRemote').length).toBe(1)
     });
 
-    test('onRegisterRemote: the same registration arriving twice keeps the existing proxy and still replies', () => {
+    test('onRegisterRemote: the same endpoint arriving twice keeps the existing proxy, still replies, and still routes to its origin', async () => {
         const receiver  = Neo.create(ReplayReceiver),
               className = 'Test.Unit.Worker.TwiceRegistered',
               remote    = {className, destination: Neo.workerId, methods: ['ping'], origin: 'app'};
@@ -126,6 +126,38 @@ test.describe('SharedWorker remote registration replay', () => {
         expect(() => receiver.onRegisterRemote({...remote, id: 'registration-2'})).not.toThrow();
 
         expect(Neo.ns(className).ping).toBe(proxy);
-        expect(receiver.replies.map(reply => reply.replyId)).toEqual(['registration-1', 'registration-2'])
+        expect(receiver.replies.map(reply => reply.replyId)).toEqual(['registration-1', 'registration-2']);
+
+        // the retained proxy still addresses the origin that registered it
+        expect((await proxy({})).destination).toBe('app')
+    });
+
+    test('onRegisterRemote: the same method from a DIFFERENT origin is a collision — it throws and the first binding stays', async () => {
+        const receiver  = Neo.create(ReplayReceiver),
+              className = 'Test.Unit.Worker.ConflictingOrigins',
+              methods   = ['ping'];
+
+        receiver.onRegisterRemote({className, destination: Neo.workerId, methods, origin: 'app'});
+
+        const proxy = Neo.ns(className).ping;
+
+        expect(() => receiver.onRegisterRemote({className, destination: Neo.workerId, methods, origin: 'data'}))
+            .toThrow(/collision/);
+
+        expect(Neo.ns(className).ping).toBe(proxy);
+        expect((await proxy({})).destination).toBe('app')
+    });
+
+    test('onRegisterRemote: a namespace slot already holding a local member is a collision, and the local member stays', () => {
+        const receiver  = Neo.create(ReplayReceiver),
+              className = 'Test.Unit.Worker.LocallyBound',
+              local     = () => 'local';
+
+        Neo.ns(className, true).ping = local;
+
+        expect(() => receiver.onRegisterRemote({className, destination: Neo.workerId, methods: ['ping'], origin: 'app'}))
+            .toThrow(/collision/);
+
+        expect(Neo.ns(className).ping).toBe(local)
     })
 });


### PR DESCRIPTION
Resolves #18265

🌿 A registration replayed to a new window was delivered and dropped in silence; now every window that joins a running SharedWorker holds the same remotes as the first, and a missing proxy can no longer be mistaken for a window that never asked.

Evidence: L3 (an e2e arm on a real SharedWorker app, red at `dev@35d468b51f` and green at head, plus a live two-window receipt on the dev server) → L3 required (AC-2 names an outcome a window sees, not a unit property). No residuals.

## What was wrong

`#8339` stored every singleton's `registerRemote` and replayed the list to each newly connected port (`worker/Base.mjs:209–210`). The replay was sent with the **port id** as destination; `sendMessage` stamps `opts.destination = dest` (`:449`), and the receiving thread's `onRegisterRemote` accepts a registration only when `remote.destination === Neo.workerId`, which is `'main'` (`RemoteMethodAccess.mjs:176`). So the message reached the right port and the guard discarded it. The first window got its proxies through the startup path (`promiseRemotes` → destination `'main'`); every later window — a second tab, or the first window after a reload while another window kept the worker alive — had `Neo.worker.App` undefined, with no error. `worker/Manager.mjs:693` calls `Neo.worker.App.setGlobalConfig` unguarded on exactly those windows.

## What changed

- `worker/Base.mjs` — the replay is addressed to `main` and routed to the new port through `opts.port`: `sendMessage('main', {action: 'registerRemote', port: id, ...remote})`. The routing cascade resolves the explicit key, so the last-resort first-port fallback never runs and a registration never lands in a foreign window; the `registerRemote` exemption at `:445` keeps the deprecated-`main` warning silent. `destination` here is the receiver's identity check, never a routing decision.
- `worker/mixin/RemoteMethodAccess.mjs` — every generated proxy carries `remoteProvenance` (`{className, origin}`), and `onRegisterRemote` uses it to admit exactly one kind of repeat: the SAME endpoint (`className`, `method`, `origin` all equal) arriving again is a no-op that keeps the existing proxy. With a valid replay the first window legitimately receives one endpoint twice (the replay at connect, the startup path a tick later); the previous `Duplicate remote method definition` throw would have fired there and left the startup promise unsettled. Anything else already in the slot — a proxy for a different origin, or a local member — is still a collision and throws, so the provenance guard of `59a2a4010ce` (#698) is narrowed, not removed. The destination guard stays — it is what isolates windows.

Tracked `src/`: +33 / −11.

## AC Evidence

| AC | Verdict | Evidence |
|---|---|---|
| AC-1 | met | `test/playwright/unit/worker/RemoteReplay.spec.mjs` — a second `onConnected` posts one `registerRemote` with `destination: 'main'` and `port: <new port id>` to that port alone; an already-connected port receives nothing. Red-first: `Received: "neo-port-1"` before the change. |
| AC-2 | met, outside CI | `test/playwright/e2e/core/SharedWorkerRemoteReplay.spec.mjs` (Brain-independent, subject `apps/colors`): a second tab on the running worker and the first tab after `reload()` both have `typeof Neo.worker.App.moveComponent === 'function'`. **1 failed** with the two source files stashed (`Received: false` on the second window), **1 passed** at head. Live: two tabs on the dev server, both listing the nine remotes. |
| AC-3 | met | unit arm 3: the same endpoint arriving twice keeps the identical proxy object, replies to both ids, and the retained proxy still routes to `app`; two red-first negative controls: the same method from a different origin **throws** and the first binding stays, a slot holding a local member **throws** and the local member stays; the e2e arm's `pageerror` / console watch is empty in both windows; both live consoles empty. |
| AC-4 | met | the e2e arm asserts no `destination "main" is deprecated` line in either window; both live consoles empty. |
| AC-5 | met | reverting the envelope change reds AC-1 (2 unit arms) and AC-2 (the e2e arm) — the red halves above are that mutation. |

## Deltas from ticket

The ticket's fix was the envelope alone. Implementing it surfaced that the receiver's duplicate throw becomes reachable on the first window once the replay is valid (replay + startup path). The first head made the receiver idempotent for any occupant of the slot; review (Euclid, RA1) falsified that at exact head — a different-origin registration and a pre-seeded local member were both retained in silence — so the head now stamps provenance on every proxy and admits only the identical endpoint, keeping `59a2a4010ce`'s collision boundary. The ticket's Contract Ledger gained that row; the e2e arm waits on the proxy instead of a fixed 500 ms (RA3). The destination identity check the ticket's Avoided Traps protect is untouched.

## Test Evidence

- e2e `core/SharedWorkerRemoteReplay`: source stashed → `1 failed` (second window `has: false`); source restored → `1 passed`; with the proxy-driven wait → `1 passed (7.9s)`.
- Live, dev server at head: first tab `typeof Neo.worker.App === 'object'` with 9 remotes; second tab the same 9; `read_console_messages` empty on both.
- Unit red-first, twice: `RemoteReplay.spec.mjs` 2 failed / 1 passed before the envelope change; the two collision controls failed (`Received function did not throw`) before the provenance guard; `test/playwright/unit/worker` 26 / 26 after.

## Post-Merge Validation

- Any main-thread caller of `Neo.worker.App.*` on a second or reloaded window — `worker/Manager.mjs:693`'s `setGlobalConfig` is the one in the engine — stops throwing `Cannot read properties of undefined`; a report of that error on a multi-window app after this lands is a different defect.
- The downstream multi-window consumer's reload rig can drive `moveComponent` from the reloaded main page instead of through the Neural Link; D#18224's rebind design is the consumer of that route.

## Commits

- `fdde91a068` fix(worker): a window joining a running SharedWorker receives the replayed remotes — the envelope, the first receiver change, both arms
- `d24ee734a2` fix(worker): a repeated registration is a no-op only for the same endpoint — provenance-stamped proxies, the narrowed guard, two collision controls (review RA1 / RA2)
- `c89d55f465` test(e2e): the replay arm waits on the proxy, not a clock (review RA3)

Authored by Vega (Fable 5.1, Claude Code). Session 3464d658-9b64-4f10-a951-6a4836e12ca1.
