### PR TITLE
test(dock): the pop-out sweep arm witnesses the value, not just the call (#18159)

### DIFF
--- a/test/playwright/unit/dashboard/DockWorkspace.spec.mjs
+++ b/test/playwright/unit/dashboard/DockWorkspace.spec.mjs
@@ -3467,6 +3467,71 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
                 .toBeGreaterThan(0)
         });
 
+        /**
+         * The arm above witnesses that `syncDockHeaderActions` INVOKES the pop-out sync: it replaces
+         * the method with a logger, so it is blind to what the sync computes. An inverted guard, a
+         * wrong `getActionItem` key or a backwards `hidden` each keep it green while the control
+         * disappears from the header, which is the symptom users actually report.
+         *
+         * This arm reads the RETAINED action instance instead, because retention is where the
+         * staleness lives: `hidden` is stamped once at projection from `!activeItemId ||
+         * !dockPopOutActionActive` onto an instance that survives re-projection by design, so a
+         * capability arriving afterwards can only reach it through the sweep. Asserting the same
+         * instance across the commits is what makes that the claim — a freshly projected node would
+         * satisfy the visibility assertion without anything having recomputed the retained one.
+         *
+         * Shape follows the `reload` sibling's pin-back arm rather than the config-level pop-out arms.
+         */
+        test('the post-commit sweep RECOMPUTES pop-out on the retained instance, so a stale hidden is repaired', async () => {
+            workspace = Neo.create(PlainWorkspace, {dockModel: createDocument()});
+
+            const side   = tabsOf(workspace.items[0]).get('side-tabs'),
+                  popOut = side?.getActionItem('pop-out');
+
+            // Not a formality: `pop-out` is the registered action name while `popOut` is the tooltip
+            // key, so resolving the wrong one yields undefined and every assertion below would read
+            // `undefined?.hidden`. The arm states its subject exists before measuring it.
+            expect(popOut, 'the pop-out action projects onto the tabs node').toBeTruthy();
+
+            // Projected with no handler bundle, so `dockPopOutActionActive` was false and the action
+            // was stamped hidden ONCE. This is the stale value the defect could never repair.
+            expect(popOut.hidden, 'stamped hidden at projection time').toBe(true);
+
+            // The capability arrives after projection — a vessel opener registered on a live
+            // workspace. With the tear-out lifecycle off, `dockPopOutActionActive` reduces to "is
+            // there a handler bundle", which keeps the engine opener's platform gating out of a
+            // question about the sweep.
+            workspace.tearOutHandlers = {
+                onDockTearOutExit    : async () => undefined,
+                onDockTearOutTerminal: () => true
+            };
+
+            expect(workspace.dockPopOutActionActive, 'the workspace can now offer pop-out').toBe(true);
+            expect(popOut.hidden, 'but the RETAINED instance still carries the projection-time answer').toBe(true);
+
+            // Two commits, matching the reported reproduction: one addTab and one close, each a real
+            // reduction plus the refresh a host performs — never a direct sweep call.
+            for (const descriptor of [
+                {operation: 'addTab',    itemId: 'terminal', tabsNodeId: 'editor-tabs', index: null},
+                {operation: 'closeItem', itemId: 'terminal'}
+            ]) {
+                const result = workspace.applyDockZoneOperation(descriptor);
+
+                expect(result.errors, `${descriptor.operation} is a clean commit`).toEqual([]);
+
+                workspace.onDockZoneDocumentChange(result.document, descriptor);
+                await workspace.refreshPromise
+            }
+
+            // Asserting the same instance is what makes this a claim about the sweep: a freshly
+            // projected node would satisfy the visibility assertion without anything having
+            // recomputed the retained one.
+            expect(tabsOf(workspace.items[0]).get('side-tabs')?.getActionItem('pop-out'),
+                'the SAME action instance was retained across both commits').toBe(popOut);
+            expect(popOut.hidden, 'and the post-commit sweep recomputed it, so pop-out is offered again')
+                .toBe(false)
+        });
+
         test('a destroyed handle does not shadow the tree', () => {
             workspace = Neo.create(PlainWorkspace, {dockModel: createDocument()});
 


### PR DESCRIPTION
Resolves #18159
Related: #18151

`syncDockPopOutAction` already shipped in #18160 and is on `dev`. What did not ship is a witness for what it computes: the arm that came with it replaces the sync with a logger and asserts the sweep invoked it — the right claim for the missing-sibling defect it was written against, and blind to the value. This adds the arm the ticket's AC-1 asked for: the retained action instance, read after two real commits, red under three mutations the shipped arm cannot see.

Evidence: L3 (unit arms + mutation testing on the real subject in the repo harness) → L3 required (every close-target AC is unit-observable; the sweep, the retention and the recomputation all live in the app worker and need no browser or host). Residual: none.

## AC Evidence
| AC-1 | CI-covered: `DockWorkspace.spec.mjs` — *the post-commit sweep RECOMPUTES pop-out on the retained instance, so a stale hidden is repaired* |
| AC-2 | outside-CI: red-first mutation receipts below (a passing suite cannot show a red) |
| AC-3 | Met by construction, no arm added: `Neo.mjs:463` gates `afterSet` and subscriber notification behind `config.set(value)`, so assigning an unchanged reactive config fires nothing. This is the idiom #18245 established across the dock; a hand-rolled change guard here would re-add what that PR removed. |
| AC-4 | CI-covered: `Workspace.mjs:1774` early-returns on `!enableDockPopOutAction`; `DockWorkspace.spec.mjs` — *without the capability the pop-out action does not render, rather than rendering and declining* |
| AC-5 | Met by construction: `hidden = !itemId \|\| !this.dockPopOutActionActive` — the sync cannot pin the action visible, and the new arm's first two assertions read `hidden === true` for exactly that reason |
| AC-6 | CI-covered: full unit suite, 3169 passed, exit 0 |

## Deltas from ticket

Two corrections to the ticket body, both mine, both recorded on it:

1. It specified `getActionItem('popOut')`. The registered action name is `'pop-out'` (`LayoutAdapter:1183`); `popOut` is the tooltip key (`:1186`). #18160 used the right one. Had anyone implemented my spelling, the lookup returns `undefined` and `action && (…)` swallows it silently — a guard that never fires. That is now mutation 2 below.
2. AC-3 asked for an arm counting updates. It needs none: the engine already answers it, and the table above records why so the next reader does not build one.

## Test Evidence

Red-first, three mutations of `syncDockPopOutAction` on `origin/dev`, each reverted after measuring. The shipped arm runs as the control:

| mutation | this arm | shipped arm |
|---|---|---|
| `me.syncDockPopOutAction(tab)` removed from the sweep | **RED** | RED |
| `getActionItem('popOut')` instead of `'pop-out'` | **RED** | green |
| `hidden` computed backwards | **RED** | green |
| unmutated `dev` | green | green |

The bottom two rows are the coverage this PR adds — both reproduce the originally reported symptom (the control gone from the header) while the existing arm stays green.

**The first version of this arm passed under all three mutations.** It kept `preview` active on a node whose pop-out was available throughout, so the projected value never went stale and there was nothing for the sweep to restore — a passing oracle answering a different question. The arm was rewritten to project *without* a handler bundle, register one on the live workspace afterwards, and require the sweep to clear the now-stale `hidden`. The mutation matrix is what caught it; the arm title alone would not have.

## Post-Merge Validation

- [ ] None. The behaviour under test is fully exercised in the unit tier; nothing here depends on a merged head, a deployed host, or a browser.

## Evolution

The lane began as "close #18159, its fix already merged" — @neo-opus-grace's nightshift audit found #18160 contained the code and recommended closing as completed, and every claim in that audit held. Re-reading the ACs against what shipped is what moved it: the mechanism was delivered, the witness for it was not. The disposition and its reasoning are on the ticket at `IC_kwDODSospM8AAAABShuETA` rather than repeated here.

Authored by Ada (Claude Opus 5, Claude Code). Session 7596538d-5324-419a-b043-95c585d833ea.
