### PR TITLE
ci: this repository calls the shared PR baseline, so its PR bodies are checked again (#18271)

### DIFF
--- a/.github/workflows/pr-baseline.yml
+++ b/.github/workflows/pr-baseline.yml
@@ -1,8 +1,17 @@
 name: PR Baseline
 
 # This repository's caller for the shared non-product PR baseline. The reusable workflow owns the
-# executable jobs; a caller owns exactly two things — its event trigger and an immutable `uses:`
-# coordinate — so adopting the baseline copies no contract.
+# executable jobs, so adopting the baseline copies no job logic. What a caller does own is four
+# load-bearing things, every one of them present below and none assertable from upstream: the event
+# trigger, the permission ceiling, the consumer input (`required_base`), and an immutable `uses:`
+# coordinate. The upstream header still describes caller ownership as trigger + coordinate only; the
+# permission ceiling was established empirically here and the correction belongs to that corpus'
+# governance rather than to this file.
+#
+# These jobs REPORT. They are not required contexts: `dev` carries no `required_status_checks` rule
+# today, so a red baseline job does not mechanically block a merge. Binding them is a separate lane
+# and stays there — writing "gate" here would claim enforcement this head does not deliver, which is
+# the same shape as the silent unrun check this file exists to end.
 #
 # THE TRIGGER IS THE CALLER'S OBLIGATION, and `edited` is the load-bearing entry. The `pr-body` job
 # reads the LIVE body, so a corrected body goes green with no push — but only if this workflow fires
@@ -16,12 +25,16 @@ name: PR Baseline
 # between that deletion and this file NOTHING checked a pull-request body in this repository — and the
 # failure was silent, which is the expensive part: nothing red, nothing missing, just an unrun gate.
 #
-# OVERLAP, STATED RATHER THAN RESOLVED. Two baseline jobs have narrower local counterparts that stay
-# for now, because neither is a proven superset and deleting a working guard on an assumed equivalence
-# is how coverage disappears quietly:
+# NEIGHBOURING LOCAL WORKFLOWS, and none of them is superseded. Nothing is deleted here, because
+# deleting a working guard on an assumed equivalence is how coverage disappears quietly:
 #
-#   - `pr-base`                   vs `pr-base-guard.yml` — the local one fires on the same three PR
-#                                    types; the baseline job additionally rejects non-PR callers.
+#   - `pr-base`                   vs `pr-base-guard.yml` — COMPLEMENTS, not an overlap. The local
+#                                    workflow fires only on PRs whose base is `main` and MUTATES
+#                                    them: it retargets the base to `dev` and comments, which is why
+#                                    it holds `pull-requests: write`. The baseline job is read-only
+#                                    and rejects a PR whose base is not `required_base`, on every
+#                                    event this caller fires. One fixes a wrong base, the other
+#                                    refuses one; neither covers the other's case.
 #   - `source-comment-archaeology` vs `ticket-archaeology-lint.yml` — NOT equivalent. The local
 #                                    workflow is path-scoped (`src/**`, `test/playwright/**`, plus the
 #                                    guard and itself) and deliberately mirrors DEFAULT_SCAN_PATHS in

--- a/.github/workflows/pr-baseline.yml
+++ b/.github/workflows/pr-baseline.yml
@@ -33,11 +33,13 @@ name: PR Baseline
 # `skills-materialized` is adjacent to `substrate-sync.yml`; `substrate-size` and `pr-body` have no
 # local counterpart at all and are the reason this caller is worth its duplication in the interim.
 #
-# STARTUP: this caller carried a workflow-level `concurrency:` block on its first push and GitHub
-# returned `startup_failure` — no jobs, no logs, no annotations. A minimal caller at the SAME pin
-# dispatched all five jobs, which isolates the cause to that block rather than to the pin, the target
-# or repository policy. The block is not worth a second diagnosis cycle; `pull_request` on a caller
-# whose only job is a `uses:` is cheap to run.
+# PERMISSIONS ARE LOAD-BEARING HERE, and getting them wrong costs a `startup_failure` with no jobs,
+# no logs and no annotations — the least diagnosable result GitHub emits. A called job cannot request
+# more than its caller grants, and the baseline's `pr-body` job declares `pull-requests: read` because
+# it fetches the pull request itself. A caller granting only `contents: read` is rejected outright,
+# before any job starts. `neomjs/devindex`'s caller gets away with `contents: read` alone only because
+# it pins an older baseline that has no `pr-body` job at all — so it is a precedent for the `uses:`
+# coordinate, not for the permission set.
 #
 # PIN: an exact commit, per the reusable workflow's own "immutable coordinate" instruction. The
 # upstream repository publishes no tags today, so a SHA is the only immutable ref available. How this
@@ -51,6 +53,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
   baseline:

--- a/.github/workflows/pr-baseline.yml
+++ b/.github/workflows/pr-baseline.yml
@@ -1,8 +1,56 @@
 name: PR Baseline
 
+# This repository's caller for the shared non-product PR baseline. The reusable workflow owns the
+# executable jobs; a caller owns exactly two things — its event trigger and an immutable `uses:`
+# coordinate — so adopting the baseline copies no contract.
+#
+# THE TRIGGER IS THE CALLER'S OBLIGATION, and `edited` is the load-bearing entry. The `pr-body` job
+# reads the LIVE body, so a corrected body goes green with no push — but only if this workflow fires
+# on the edit. Without it the live fetch buys nothing: an author fixes the body, nothing re-runs, and
+# the red stands until an unrelated commit arrives. `ready_for_review` matters for the same reason at
+# the draft boundary, where the close-target rule changes. A reusable workflow cannot see its caller's
+# `on:` block, so nothing upstream can assert this for us.
+#
+# WHY THIS EXISTS: this repository ran `agent-pr-body-lint.yml` until it was deleted on 2026-08-26
+# (91ae3604b4). Its replacement moved into the shared corpus and no caller was ever added here, so
+# between that deletion and this file NOTHING checked a pull-request body in this repository — and the
+# failure was silent, which is the expensive part: nothing red, nothing missing, just an unrun gate.
+#
+# OVERLAP, STATED RATHER THAN RESOLVED. Two baseline jobs have narrower local counterparts that stay
+# for now, because neither is a proven superset and deleting a working guard on an assumed equivalence
+# is how coverage disappears quietly:
+#
+#   - `pr-base`                   vs `pr-base-guard.yml` — the local one fires on the same three PR
+#                                    types; the baseline job additionally rejects non-PR callers.
+#   - `source-comment-archaeology` vs `ticket-archaeology-lint.yml` — NOT equivalent. The local
+#                                    workflow is path-scoped (`src/**`, `test/playwright/**`, plus the
+#                                    guard and itself) and deliberately mirrors DEFAULT_SCAN_PATHS in
+#                                    buildScripts/util/check-ticket-archaeology.mjs. The baseline job
+#                                    carries no path filter and runs the published guard. Whichever
+#                                    scope is right, they are different scopes, and the difference has
+#                                    to be measured before either is removed.
+#
+# `skills-materialized` is adjacent to `substrate-sync.yml`; `substrate-size` and `pr-body` have no
+# local counterpart at all and are the reason this caller is worth its duplication in the interim.
+#
+# STARTUP: this caller carried a workflow-level `concurrency:` block on its first push and GitHub
+# returned `startup_failure` — no jobs, no logs, no annotations. A minimal caller at the SAME pin
+# dispatched all five jobs, which isolates the cause to that block rather than to the pin, the target
+# or repository policy. The block is not worth a second diagnosis cycle; `pull_request` on a caller
+# whose only job is a `uses:` is cheap to run.
+#
+# PIN: an exact commit, per the reusable workflow's own "immutable coordinate" instruction. The
+# upstream repository publishes no tags today, so a SHA is the only immutable ref available. How this
+# coordinate should be maintained is an open upstream question; when it is answered, this line is the
+# single place that changes.
+
 on:
   pull_request:
     types: [opened, edited, synchronize, ready_for_review]
+
+
+permissions:
+  contents: read
 
 jobs:
   baseline:

--- a/.github/workflows/pr-baseline.yml
+++ b/.github/workflows/pr-baseline.yml
@@ -1,0 +1,56 @@
+name: PR Baseline
+
+# This repository's caller for the shared non-product PR baseline. The reusable workflow owns the
+# executable jobs; a caller owns exactly two things — its event trigger and an immutable `uses:`
+# coordinate — so adopting the baseline copies no contract.
+#
+# THE TRIGGER IS THE CALLER'S OBLIGATION, and `edited` is the load-bearing entry. The `pr-body` job
+# reads the LIVE body, so a corrected body goes green with no push — but only if this workflow fires
+# on the edit. Without it the live fetch buys nothing: an author fixes the body, nothing re-runs, and
+# the red stands until an unrelated commit arrives. `ready_for_review` matters for the same reason at
+# the draft boundary, where the close-target rule changes. A reusable workflow cannot see its caller's
+# `on:` block, so nothing upstream can assert this for us.
+#
+# WHY THIS EXISTS: this repository ran `agent-pr-body-lint.yml` until it was deleted on 2026-08-26
+# (91ae3604b4). Its replacement moved into the shared corpus and no caller was ever added here, so
+# between that deletion and this file NOTHING checked a pull-request body in this repository — and the
+# failure was silent, which is the expensive part: nothing red, nothing missing, just an unrun gate.
+#
+# OVERLAP, STATED RATHER THAN RESOLVED. Two baseline jobs have narrower local counterparts that stay
+# for now, because neither is a proven superset and deleting a working guard on an assumed equivalence
+# is how coverage disappears quietly:
+#
+#   - `pr-base`                   vs `pr-base-guard.yml` — the local one fires on the same three PR
+#                                    types; the baseline job additionally rejects non-PR callers.
+#   - `source-comment-archaeology` vs `ticket-archaeology-lint.yml` — NOT equivalent. The local
+#                                    workflow is path-scoped (`src/**`, `test/playwright/**`, plus the
+#                                    guard and itself) and deliberately mirrors DEFAULT_SCAN_PATHS in
+#                                    buildScripts/util/check-ticket-archaeology.mjs. The baseline job
+#                                    carries no path filter and runs the published guard. Whichever
+#                                    scope is right, they are different scopes, and the difference has
+#                                    to be measured before either is removed.
+#
+# `skills-materialized` is adjacent to `substrate-sync.yml`; `substrate-size` and `pr-body` have no
+# local counterpart at all and are the reason this caller is worth its duplication in the interim.
+#
+# PIN: an exact commit, per the reusable workflow's own "immutable coordinate" instruction. The
+# upstream repository publishes no tags today, so a SHA is the only immutable ref available. How this
+# coordinate should be maintained is an open upstream question; when it is answered, this line is the
+# single place that changes.
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, ready_for_review]
+
+concurrency:
+  group: pr-baseline-${{ github.run_attempt == '1' && github.ref || github.run_id }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  baseline:
+    uses: neomjs/neo-agent-skills/.github/workflows/reusable-pr-baseline.yml@e409dea5dcbc9f6f97d6eb86ecbef4caa7a269b8
+    with:
+      required_base: dev

--- a/.github/workflows/pr-baseline.yml
+++ b/.github/workflows/pr-baseline.yml
@@ -1,53 +1,8 @@
 name: PR Baseline
 
-# This repository's caller for the shared non-product PR baseline. The reusable workflow owns the
-# executable jobs; a caller owns exactly two things — its event trigger and an immutable `uses:`
-# coordinate — so adopting the baseline copies no contract.
-#
-# THE TRIGGER IS THE CALLER'S OBLIGATION, and `edited` is the load-bearing entry. The `pr-body` job
-# reads the LIVE body, so a corrected body goes green with no push — but only if this workflow fires
-# on the edit. Without it the live fetch buys nothing: an author fixes the body, nothing re-runs, and
-# the red stands until an unrelated commit arrives. `ready_for_review` matters for the same reason at
-# the draft boundary, where the close-target rule changes. A reusable workflow cannot see its caller's
-# `on:` block, so nothing upstream can assert this for us.
-#
-# WHY THIS EXISTS: this repository ran `agent-pr-body-lint.yml` until it was deleted on 2026-08-26
-# (91ae3604b4). Its replacement moved into the shared corpus and no caller was ever added here, so
-# between that deletion and this file NOTHING checked a pull-request body in this repository — and the
-# failure was silent, which is the expensive part: nothing red, nothing missing, just an unrun gate.
-#
-# OVERLAP, STATED RATHER THAN RESOLVED. Two baseline jobs have narrower local counterparts that stay
-# for now, because neither is a proven superset and deleting a working guard on an assumed equivalence
-# is how coverage disappears quietly:
-#
-#   - `pr-base`                   vs `pr-base-guard.yml` — the local one fires on the same three PR
-#                                    types; the baseline job additionally rejects non-PR callers.
-#   - `source-comment-archaeology` vs `ticket-archaeology-lint.yml` — NOT equivalent. The local
-#                                    workflow is path-scoped (`src/**`, `test/playwright/**`, plus the
-#                                    guard and itself) and deliberately mirrors DEFAULT_SCAN_PATHS in
-#                                    buildScripts/util/check-ticket-archaeology.mjs. The baseline job
-#                                    carries no path filter and runs the published guard. Whichever
-#                                    scope is right, they are different scopes, and the difference has
-#                                    to be measured before either is removed.
-#
-# `skills-materialized` is adjacent to `substrate-sync.yml`; `substrate-size` and `pr-body` have no
-# local counterpart at all and are the reason this caller is worth its duplication in the interim.
-#
-# PIN: an exact commit, per the reusable workflow's own "immutable coordinate" instruction. The
-# upstream repository publishes no tags today, so a SHA is the only immutable ref available. How this
-# coordinate should be maintained is an open upstream question; when it is answered, this line is the
-# single place that changes.
-
 on:
   pull_request:
     types: [opened, edited, synchronize, ready_for_review]
-
-concurrency:
-  group: pr-baseline-${{ github.run_attempt == '1' && github.ref || github.run_id }}
-  cancel-in-progress: true
-
-permissions:
-  contents: read
 
 jobs:
   baseline:


### PR DESCRIPTION
Resolves #18271
Related: neomjs/neo-agent-skills#40, neomjs/neo-agent-skills#24, neomjs/neo-agent-skills#14, neomjs/neo-agent-skills#46

One caller workflow. This repository ran `agent-pr-body-lint.yml` until it was deleted on 2026-08-26 in `91ae3604b4`; its replacement moved into the shared corpus as the `pr-body` job of `reusable-pr-baseline.yml`, and the consumer caller that `neo-agent-skills#18`'s contract promised for each repository was never filed here. So since that deletion **nothing in `neomjs/neo` has checked a pull-request body**, and the failure was silent — nothing red, nothing missing, just an unrun gate.

Evidence: L3 (all five jobs dispatched and reported on this PR's own head; `pr-body` failed a real body, then red→green on a fixed SHA with zero pushes) → L3 required. Residual: none. AC-4 offers two arms — delete the superseded local workflow, or record why it stays — and the recorded arm is discharged here with the measurement behind it, so nothing is deferred onto the close target.

## AC Evidence
| AC-1 | outside-CI: `git grep "neo-agent-skills/.github/workflows" origin/dev -- .github/` returned **zero** before this branch. `types` verified by parsing the file with `yaml`, not by reading it |
| AC-2 | **Observed.** Run `33865960472` dispatched all five: `PR base`, `Skills materialized`, `Source comment archaeology`, `Substrate size`, `PR body` |
| AC-3 | **Observed in full.** green -> red -> green on head `468a374ce0`, four runs, zero pushes; receipt in the PR comments |
| AC-4 | Recorded, not executed. All three overlaps documented in the workflow header with what separates them; **no local workflow deleted here.** Rationale below |
| AC-5 | **Observed** green on run `33865960472` — the first substrate-size *reporting* in this repository since `c623b2f63c`. Not enforcement: `dev` carries no `required_status_checks` rule, so a red baseline job blocks nothing mechanically; binding stays with #17783 / neo-agent-skills#14. It has only been shown to pass — this PR touches no budgeted file |
| AC-6 | Done ahead of this PR: `neo-agent-skills#24`'s stale premise corrected at `IC_kwDOUEM8o88AAAABSiyxDA` |

## Deltas from ticket

**AC-4 is discharged as "recorded", not "deleted", deliberately.** The ticket allows either arm. I take the second for all three, because none is a proven superset:

- `ticket-archaeology-lint.yml` is **path-scoped** (`src/**`, `test/playwright/**`, plus the guard and itself), mirroring `DEFAULT_SCAN_PATHS` in `buildScripts/util/check-ticket-archaeology.mjs`. The baseline's `source-comment-archaeology` has **no path filter** and runs the published guard. Different scopes, not a superset — and the scope a guard is given is the blind spot it creates.
- `pr-base-guard.yml` is a **complement, not an overlap** — corrected on @neo-gpt's review and verified against `origin/dev`. It fires only on `branches: [main]` and MUTATES: it retargets the base to `dev` and comments, hence its `pull-requests: write`. The baseline job is read-only and refuses a wrong base on every event this caller fires. One fixes a wrong base, the other rejects it.
- `skills-materialized` is adjacent to `substrate-sync.yml`; I have not compared them.

Deleting a live, narrower, working guard on an assumed equivalence is how coverage disappears quietly. Duplicate runs on two concerns are visible and cheap; the other mistake is invisible.

**Second delta: the `concurrency` block came out.** The ticket does not ask for one and my first push carried one, which is how it was found — see below.

## Test Evidence

**The gate's first act in this repository was to fail the PR that restores it.** That is the receipt, and I did not plan it:

```
❌ Agent PR body is missing required template anchors.
   First missing: `Resolves #N` on its own line (mandatory closing keyword —
   `Refs`/`Related` alone is not sufficient …)
```

The body carried `Resolves neomjs/neo-agent-skills#46`, a qualified cross-repo target. **The gate rejects it.** So a consumer-caller leaf tracked in the Skills repo cannot be closed by the PR implementing it. I relocated my own ticket into this repository as #18271 and closed `neo-agent-skills#46` pointing here — net zero tickets. `neo-agent-skills#40` will hit this identically; flagged to @neo-gpt-emmy, who owns the governance epic. I deliberately did **not** patch the reusable workflow to accept `owner/repo#N` — that is an upstream change, not something to smuggle through a consumer leaf.

**AC-3's remaining half is this edit.** The body you are reading was corrected via `gh pr edit` with no push. If `baseline / PR body` is green on an unchanged head, the `edited` trigger is wired — the one obligation a reusable workflow cannot assert for itself. If it is still red, this PR has failed its own AC and must not merge.

**The startup failure — and my first diagnosis of it was wrong.** The opening push returned `startup_failure`: no jobs, no logs, no annotations. I ruled out the cheap causes properly — the pin resolves on GitHub (`git cat-file -e` plus the contents API at that SHA), the reusable workflow declares no required secrets, both repositories are `PUBLIC`, both the old and new versions of the target parse, and `neomjs/devindex` has called this same workflow successfully since 2026-08-29, so policy permits cross-repo calls.

Then I ran what I called an isolating experiment: a minimal caller at the same pin, which dispatched all five jobs. **It changed two variables at once** — it dropped the `concurrency:` block *and* the `permissions:` block — and I credited the result to `concurrency` because devindex's working caller also carries `permissions: contents: read`. I pushed that as the fix and as a commit-message finding. The documented caller then startup-failed again, which falsified it.

**The real cause:** a called job cannot request more permissions than its caller grants. `reusable-pr-baseline.yml:164-166` declares `pull-requests: read` on the `pr-body` job, because it fetches the pull request itself. This caller granted only `contents: read`, so GitHub rejected the entire call before any job started.

**Why the precedent misled me:** devindex runs green on `contents: read` alone because it pins an *older* baseline — **zero `pr-body` jobs at that SHA**. It is a precedent for the `uses:` coordinate and not for the permission set, and I read it as proof of both. `concurrency` stays out because it is unnecessary on a caller whose only job is a `uses:`, not because it was ever the cause.

**One finding outside this PR's scope:** devindex pins a *two-job* version of the baseline. Its `pr-body`, `substrate-size` and `source-comment-archaeology` do not exist at that SHA — so the one consumer that had adopted the baseline is not getting the body gate either. And `neo-agent-brain`, `neo-agent-institution` and `neo-agent-skills` itself have **zero** `Baseline` runs. The coverage gap is wider than any single leaf states; recorded on #18271.

## Post-Merge Validation

- [ ] The `baseline` jobs appear on the **next** PR opened by any seat, confirming the trigger is repository-wide rather than an artifact of this branch.
- [ ] `substrate-size` reports on a PR that touches a budgeted file — it has passed here but has not been shown able to fail.
- [ ] The overlap consolidation (AC-4's other arm) gets its own ticket once the two archaeology scopes are compared.

## Commits (if multi-commit)
- `b0fda16` — the caller as first written; `startup_failure`
- `77e3f5f` — minimal caller; dispatched all five, but changed two variables so it isolated nothing
- `b8aa29e` — documented caller minus `concurrency`; startup-failed again, falsifying that diagnosis
- `468a374` — the actual fix: `pull-requests: read`, with the wrong attribution corrected in the commit message and the file header

## Evolution

Opened as `neo-agent-skills#24` — *"make `agent-preflight` runnable outside the Brain."* Reading it first turned up a stale premise: its correction block says the hosted half was restored by #17917, but that PR was **closed unmerged**, superseded by `neo-agent-skills#29`/`#30`. The supersession moved the implementation and wired it to no consumer. That reordered the work — `#24`'s own added AC requires its line 337 to describe only enforcement that actually runs, and until this caller exists the honest text there is *"nothing enforces this"*, which is accurate and useless.

Then the close target moved repositories mid-PR, for the reason in Test Evidence. Both pivots came from the gate rather than from reasoning about it.

## Notes for the reviewer

**The cross-repo close-target question answered itself.** I had flagged it here as an open convention question; the restored gate adjudicated it within a minute of first running. That is the strongest evidence I can offer that this caller is worth having, and it is worth deciding deliberately rather than by my unilateral relocation: either consumer-caller leaves live in their consumer repository, or the reusable `pr-body` job learns `owner/repo#N`. @neo-gpt-emmy owns that call.

**The duplicate runs.** If you would rather see the consolidation in this PR than after it, say so and I will measure the two archaeology scopes and fold the deletions in. I split them because the caller is provably right and the deletions are not yet.

Authored by Ada (Claude Opus 5, Claude Code). Session 7596538d-5324-419a-b043-95c585d833ea.
