### PR TITLE
fix(collection): the unfiltered projection mirrors inside the mutation, and an eager store hydrates before the splice (#18269)

### DIFF
--- a/src/collection/Base.mjs
+++ b/src/collection/Base.mjs
@@ -811,15 +811,6 @@ class Collection extends Base {
         } else {
             me.calcValueBands();
 
-            // The unfiltered projection is PART of the mutation, never a subscriber racing the
-            // other subscribers for it: mirror before `mutate` fires, so every listener — the
-            // store's own synchronous `load` included — sees `allItems` holding the batch, and a
-            // record hydrated inside a listener lands in both collections.
-            me.allItems?.onMutate({
-                addedItems  : me[toAddArray],
-                removedItems: me[toRemoveArray]
-            });
-
             me.fire('mutate', {
                 addedItems  : me[toAddArray],
                 removedItems: me[toRemoveArray]
@@ -913,18 +904,14 @@ class Collection extends Base {
                 // which stores the unfiltered data. It is crucial to use `me.constructor` here.
                 // If we hardcode `Collection`, subclasses like `data.Store` would lose their specific
                 // functionalities (e.g., lazy record instantiation on `get()`) for the `allItems` collection.
+                // Not a `sourceId` collection: that would subscribe it to `mutate` as one listener
+                // among others, ordered by registration. `splice` writes into it inline instead —
+                // see `mirrorMutation` — so the projection needs neither a subscription nor a source.
                 me.allItems = me.createAllItems({
                     ...Neo.clone(config, true, true),
                     id         : me.id + '-all',
-                    keyProperty: me.keyProperty,
-                    sourceId   : me.id
+                    keyProperty: me.keyProperty
                 });
-
-                // `sourceId` subscribed the projection to this collection's `mutate` — one listener
-                // among others, ordered by registration. `splice` and `endUpdate` mirror into it
-                // inline instead, before the event, so the subscription would only replay an
-                // already-applied mutation.
-                me.un({mutate: me.allItems.onMutate, scope: me.allItems});
 
                 me.allItems.items = me._items.slice();
             }
@@ -1376,6 +1363,19 @@ class Collection extends Base {
     }
 
     /**
+     * @summary The unfiltered projection's write: the rows its collection's `splice` just applied,
+     * applied here without an event. The projection holds what the collection holds before any
+     * listener runs, and fires nothing of its own — it is part of the mutation, not an observer of it.
+     * @param {Object}   opts
+     * @param {Object[]} [opts.addedItems]
+     * @param {Object[]} [opts.removedItems]
+     * @protected
+     */
+    mirrorMutation({addedItems, removedItems}) {
+        this.splice(null, removedItems, addedItems, true)
+    }
+
+    /**
      * @param {Object} opts
      * @protected
      */
@@ -1469,9 +1469,11 @@ class Collection extends Base {
      * @param {Number|null} index
      * @param {Number|Object[]} [removeCountOrToRemoveArray]
      * @param {Object|Object[]} [toAddArray]
+     * @param {Boolean} [silent=false] Applies the mutation without firing `mutate` — the write path of
+     *     the unfiltered projection, which is part of its collection's mutation, never an observer of it
      * @returns {Object} An object containing the addedItems & removedItems arrays
      */
-    splice(index, removeCountOrToRemoveArray, toAddArray) {
+    splice(index, removeCountOrToRemoveArray, toAddArray, silent=false) {
         let me                 = this,
             {keyProperty, map} = me,
             source             = me.getSource(),
@@ -1615,22 +1617,20 @@ class Collection extends Base {
             me[countMutations]++
         }
 
+        // The unfiltered projection is PART of the mutation, never a subscriber racing the other
+        // subscribers for it and never an event consumer: it is written here, on every splice —
+        // batched and silent ones included — before anything can observe the mutation, so a listener
+        // (the store's own synchronous `load` included) sees `allItems` holding the batch, and a
+        // record hydrated inside a listener lands in both collections. The payload is the input
+        // rows, because the projection filters nothing itself.
+        me.allItems?.mirrorMutation({addedItems: toAddArray, removedItems});
+
         if (me[updatingIndex] === 0) {
             me.count = me._items.length;
 
             me.calcValueBands(index || 0);
 
-            // The unfiltered projection is PART of the mutation, never a subscriber racing the
-            // other subscribers for it: mirror before `mutate` fires, so every listener — the
-            // store's own synchronous `load` included — sees `allItems` holding the batch, and a
-            // record hydrated inside a listener lands in both collections. The payload is the
-            // event's own: the INPUT items, because the projection filters nothing itself.
-            me.allItems?.onMutate({
-                addedItems  : toAddArray,
-                removedItems: removedItems
-            });
-
-            me.fire('mutate', {
+            !silent && me.fire('mutate', {
                 addedItems     : toAddArray,
                 preventBubbleUp: me.preventBubbleUp,
                 // Always emit actual removed objects, not input keys. `removedItems` (local) is built

--- a/src/collection/Base.mjs
+++ b/src/collection/Base.mjs
@@ -811,6 +811,15 @@ class Collection extends Base {
         } else {
             me.calcValueBands();
 
+            // The unfiltered projection is PART of the mutation, never a subscriber racing the
+            // other subscribers for it: mirror before `mutate` fires, so every listener — the
+            // store's own synchronous `load` included — sees `allItems` holding the batch, and a
+            // record hydrated inside a listener lands in both collections.
+            me.allItems?.onMutate({
+                addedItems  : me[toAddArray],
+                removedItems: me[toRemoveArray]
+            });
+
             me.fire('mutate', {
                 addedItems  : me[toAddArray],
                 removedItems: me[toRemoveArray]
@@ -910,6 +919,12 @@ class Collection extends Base {
                     keyProperty: me.keyProperty,
                     sourceId   : me.id
                 });
+
+                // `sourceId` subscribed the projection to this collection's `mutate` — one listener
+                // among others, ordered by registration. `splice` and `endUpdate` mirror into it
+                // inline instead, before the event, so the subscription would only replay an
+                // already-applied mutation.
+                me.un({mutate: me.allItems.onMutate, scope: me.allItems});
 
                 me.allItems.items = me._items.slice();
             }
@@ -1605,6 +1620,16 @@ class Collection extends Base {
 
             me.calcValueBands(index || 0);
 
+            // The unfiltered projection is PART of the mutation, never a subscriber racing the
+            // other subscribers for it: mirror before `mutate` fires, so every listener — the
+            // store's own synchronous `load` included — sees `allItems` holding the batch, and a
+            // record hydrated inside a listener lands in both collections. The payload is the
+            // event's own: the INPUT items, because the projection filters nothing itself.
+            me.allItems?.onMutate({
+                addedItems  : toAddArray,
+                removedItems: removedItems
+            });
+
             me.fire('mutate', {
                 addedItems     : toAddArray,
                 preventBubbleUp: me.preventBubbleUp,
@@ -1613,10 +1638,10 @@ class Collection extends Base {
                 // The legacy `toRemoveArray || removedItems` fallback emitted the INPUT array, which
                 // contained STRING IDs when remove-by-key was used. Rollback at Database.mjs:451
                 // (`store.add(mutation.removedItems)`) then attempted Symbol-assignment on primitive
-                // strings → TypeError (#11595 surface failure).
+                // strings → TypeError (the transaction-rollback surface failure).
                 //
-                // Consumer-impact V-B-A 2026-05-18 (corrected scope per @neo-gpt PR #11611 Cycle 1
-                // review using `rg -n "mutate:|on(['\"]mutate" src ai`):
+                // Consumer-impact V-B-A 2026-05-18 (scope corrected in cross-family review, using
+                // `rg -n "mutate:|on(['\"]mutate" src ai`):
                 //   1. `Database.onNodesMutate` (ai/graph/Database.mjs:378) — consumes via
                 //      `storage.removeNodes` → SQLite.mjs:280 `node.id` extraction. REQUIRES object.
                 //   2. `Database.onEdgesMutate` (ai/graph/Database.mjs:358) — symmetric edge path.
@@ -1632,7 +1657,7 @@ class Collection extends Base {
                 // Net: 2 consumers strictly require object-shape (and previously silently broke or
                 // loudly broke when fed strings); 3 are payload-compatible with either shape. Fix
                 // is structurally narrow-blast — no consumer breaks, 2 previously-silent bugs also
-                // fixed. (#11595)
+                // fixed.
                 removedItems   : removedItems
             })
         } else if (!me[silentUpdateMode]) {

--- a/src/data/Store.mjs
+++ b/src/data/Store.mjs
@@ -274,11 +274,15 @@ class Store extends Collection {
             threshold = me.initialChunkSize;
 
         if (init) {
-            super.add(items);
+            const prepared = me.prepareAddedItems(items);
+
+            super.add(prepared);
 
             me.isLoaded = true;
 
-            return items.map(i => me.get(me.getKey(i)))
+            // the VISIBLE instance per key: the existing record for a duplicate, null for a row an
+            // active filter hides
+            return prepared.map(i => me.get(me.getKey(i)))
         }
 
         if (threshold > 0 && items.length > threshold) {
@@ -778,6 +782,26 @@ class Store extends Collection {
     }
 
     /**
+     * @summary What an eager-mode `add` / `insert` hands to the splice: records, created BEFORE the
+     * mutation runs.
+     *
+     * The mutation — and the unfiltered projection (`allItems`) mirrored inside it — then carries
+     * the record instances every listener will see, so no listener can observe a raw/record split:
+     * a filter on a calculated field evaluates records, and a mounted list that renders inside the
+     * store's own `load` holds the same instances the projection does. The caller's array stays
+     * raw (a copy is converted).
+     *
+     * Overridable: a store whose structural layer annotates raw rows before records exist (see
+     * {@link Neo.data.TreeStore#prepareAddedItems}) hands the rows through and hydrates lazily.
+     * @param {Object[]} items The raw rows (or records) passed to `add` / `insert`
+     * @returns {Object[]} The items to splice
+     * @protected
+     */
+    prepareAddedItems(items) {
+        return this.createRecord([...items])
+    }
+
+    /**
      * Lazily instantiates a raw data object into a Record instance and updates all internal maps.
      * This acts as the Single Source of Truth for "Soft Hydration" in Turbo Mode.
      * @param {Object} item The raw data object or Record
@@ -869,7 +893,7 @@ class Store extends Collection {
      */
     insert(index, item, init=this.autoInitRecords) {
         let me    = this,
-            items = super.insert(index, item);
+            items = super.insert(index, init ? me.prepareAddedItems(Array.isArray(item) ? item : [item]) : item);
 
         if (init) {
             return items.map(i => me.get(me.getKey(i)))

--- a/src/data/TreeStore.mjs
+++ b/src/data/TreeStore.mjs
@@ -1285,8 +1285,9 @@ class TreeStore extends Store {
         if (me[isFiltered]) {
             me.filter();
 
-            // Collection fires mutate if added or removed items > 0
-            if (toAddArray || removeCountOrToRemoveArray) {
+            // Collection fires mutate if added or removed items > 0 — unless this is the
+            // projection's own event-free write
+            if (!silent && (toAddArray || removeCountOrToRemoveArray)) {
                 me.fire('mutate', {
                     addedItems     : toAddArray || [],
                     preventBubbleUp: me.preventBubbleUp,
@@ -1306,7 +1307,8 @@ class TreeStore extends Store {
 
         // Fallback Mutation Event: If we added/removed hidden nodes, the visible array didn't change,
         // so we skipped super.splice(). We must manually fire 'mutate' to keep systems like Store.count in sync.
-        if (toAddArray || removeCountOrToRemoveArray) {
+        // The projection's own write (`silent`) fires nothing on this exit either.
+        if (!silent && (toAddArray || removeCountOrToRemoveArray)) {
             me.fire('mutate', {
                 addedItems     : toAddArray,
                 preventBubbleUp: me.preventBubbleUp,

--- a/src/data/TreeStore.mjs
+++ b/src/data/TreeStore.mjs
@@ -834,6 +834,20 @@ class TreeStore extends Store {
     }
 
     /**
+     * @summary The tree ingests RAW rows: its structural layer annotates `depth`, `isLeaf`,
+     * `childCount` and `collapsed` inside {@link #splice} before a record exists, and
+     * {@link #hydrateRecord} materializes records lazily with those annotations in place. The base
+     * store's eager pre-splice hydration would freeze a record before the annotation and leave the
+     * hierarchy fields at their defaults, so the rows pass through untouched here.
+     * @param {Object[]} items The raw rows (or records) passed to `add` / `insert`
+     * @returns {Object[]} The same rows
+     * @protected
+     */
+    prepareAddedItems(items) {
+        return items
+    }
+
+    /**
      * Extends the base Store's hydrateRecord to also update the TreeStore's internal maps.
      * This acts as the Single Source of Truth for "Soft Hydration" in Turbo Mode, ensuring
      * that when a raw data object becomes a Record, the TreeStore doesn't suffer from a split-brain.

--- a/src/data/TreeStore.mjs
+++ b/src/data/TreeStore.mjs
@@ -1081,9 +1081,10 @@ class TreeStore extends Store {
      * @param {Number|null} index
      * @param {Number|Object[]} [removeCountOrToRemoveArray]
      * @param {Object|Object[]} [toAddArray]
+     * @param {Boolean} [silent=false] The unfiltered projection's event-free write, forwarded to the Collection
      * @returns {Object} An object containing the addedItems & removedItems arrays
      */
-    splice(index, removeCountOrToRemoveArray, toAddArray) {
+    splice(index, removeCountOrToRemoveArray, toAddArray, silent=false) {
         let me              = this,
             affectedParents = new Set(),
             visibleToRemove = [],
@@ -1300,7 +1301,7 @@ class TreeStore extends Store {
 
         // Delegate to super.splice ONLY if the Projection Layer (visible items) actually changed.
         if (visibleToRemove.length > 0 || visibleToAdd.length > 0 || index === 0 && removeCountOrToRemoveArray === me.count) {
-            return super.splice(insertIndex, visibleToRemove, visibleToAdd)
+            return super.splice(insertIndex, visibleToRemove, visibleToAdd, silent)
         }
 
         // Fallback Mutation Event: If we added/removed hidden nodes, the visible array didn't change,

--- a/src/menu/Model.mjs
+++ b/src/menu/Model.mjs
@@ -43,8 +43,7 @@ class Model extends BaseModel {
             name: 'iconCls',
             type: 'String'
         }, {
-            name: 'id',
-            type: 'Integer'
+            name: 'id' // untyped: menus key by strings (`file-open`); a typed conversion would rewrite the key
         }, {
             name: 'items', // optional
             type: 'Array'

--- a/test/playwright/unit/collection/AllItemsMirror.spec.mjs
+++ b/test/playwright/unit/collection/AllItemsMirror.spec.mjs
@@ -149,5 +149,76 @@ test.describe('Neo.collection.Base — allItems mirrors inside the mutation', ()
         // the calculated field is readable through the projection — the filter saw records
         expect(store.allItems.get('b').tier).toBe(1);
         expect(store.items.map(item => item.id)).toEqual(['seed', 'a', 'd'])
+    });
+
+    // The mirror is per splice, not per event: a batch — ordinary or silent — reaches the projection
+    // while the batch is still open, and the projection ends with the primary's row set.
+    for (const silent of [false, true]) {
+        test(`a${silent ? ' silent' : 'n ordinary'} batch — startUpdate(${silent}) … endUpdate(${silent}) — lands in the projection with the primary`, () => {
+            const collection = Neo.create(Collection, {
+                keyProperty: 'id',
+                items      : [{id: 'seed', state: 'ok'}]
+            });
+
+            created.push(collection);
+
+            collection.filters = [{disabled: true, property: 'state', filterBy: ({item}) => item.state === 'idle'}];
+
+            collection.startUpdate(silent);
+            collection.add({id: 'batched', state: 'ok'});
+
+            // inside the open batch: the primary holds the row, and so does the projection
+            expect(collection.map.has('batched')).toBe(true);
+            expect(collection.allItems.get('batched')?.id).toBe('batched');
+
+            collection.endUpdate(silent);
+
+            expect(collection.items.map(item => item.id)).toEqual(['seed', 'batched']);
+            expect(collection.allItems.items.map(item => item.id)).toEqual(['seed', 'batched'])
+        })
+    }
+
+    test('the projection fires nothing of its own — the primary\'s `mutate` is the one event', () => {
+        const collection = Neo.create(Collection, {
+            keyProperty: 'id',
+            items      : [{id: 'seed', state: 'ok'}]
+        });
+
+        created.push(collection);
+
+        collection.filters = [{disabled: true, property: 'state', filterBy: ({item}) => item.state === 'idle'}];
+
+        const events = {primary: 0, projection: 0};
+
+        collection.on('mutate', () => events.primary++);
+        collection.allItems.on('mutate', () => events.projection++);
+
+        collection.add(rows());
+
+        expect(events).toEqual({primary: 1, projection: 0});
+        expect(collection.allItems.count).toBe(5);
+        // the projection is not a derived collection either: no source, no subscription
+        expect(collection.allItems.sourceId).toBeNull()
+    });
+
+    test('a `sourceId` collection keeps receiving its source\'s mutations — that contract is untouched', () => {
+        const source = Neo.create(Collection, {
+            keyProperty: 'id',
+            items      : [{id: 'seed', state: 'ok'}]
+        });
+
+        const derived = Neo.create(Collection, {
+            keyProperty: 'id',
+            sourceId   : source.id
+        });
+
+        created.push(source, derived);
+
+        source.filters = [{disabled: true, property: 'state', filterBy: ({item}) => item.state === 'idle'}];
+
+        source.add(rows());
+
+        expect(['a', 'b', 'c', 'd'].map(id => derived.map.has(id))).toEqual([true, true, true, true]);
+        expect(source.allItems.count).toBe(5)
     })
 });

--- a/test/playwright/unit/collection/AllItemsMirror.spec.mjs
+++ b/test/playwright/unit/collection/AllItemsMirror.spec.mjs
@@ -14,6 +14,7 @@ import * as core       from '../../../../src/core/_export.mjs';
 import Collection      from '../../../../src/collection/Base.mjs';
 import Model           from '../../../../src/data/Model.mjs';
 import Store           from '../../../../src/data/Store.mjs';
+import TreeStore       from '../../../../src/data/TreeStore.mjs';
 import InstanceManager from '../../../../src/manager/Instance.mjs';
 
 /**
@@ -220,5 +221,40 @@ test.describe('Neo.collection.Base — allItems mirrors inside the mutation', ()
 
         expect(['a', 'b', 'c', 'd'].map(id => derived.map.has(id))).toEqual([true, true, true, true]);
         expect(source.allItems.count).toBe(5)
-    })
+    });
+
+    // A tree store's projection write is event-free on EVERY exit of `TreeStore#splice`: the
+    // visible-delta exit reaches the Collection's `splice`; the two exits that do not — a node added
+    // under a collapsed parent (no visible delta) and a store with an active filter — fire their own
+    // `mutate`, and honor `silent` there too. The same exit without `silent` keeps its one event.
+    const treeRows = () => [
+        {id: 'file',      text: 'File',  isLeaf: false, collapsed: true},
+        {id: 'file-open', text: 'Open',  isLeaf: true,  parentId: 'file'},
+        {id: 'about',     text: 'About', isLeaf: true}
+    ];
+
+    for (const [label, filters, row] of [
+        ['a node under a collapsed parent — the hidden-node exit', null, {id: 'file-save', text: 'Save', isLeaf: true, parentId: 'file'}],
+        ['a store with an active filter — the filtered exit', [{property: 'id', operator: 'like', value: 'o'}], {id: 'help', text: 'Help', isLeaf: true}]
+    ]) {
+        test(`a tree store's silent splice fires nothing: ${label}`, () => {
+            const store = Neo.create(TreeStore, {data: treeRows()});
+
+            created.push(store);
+
+            // assigned after construction, the consumer's shape: the filter pass runs on the
+            // populated tree and the store takes its filtered exit from here on
+            filters && (store.filters = filters);
+
+            let events = 0;
+
+            store.on('mutate', () => events++);
+
+            store.splice(null, [], [row], true);
+            expect(events).toBe(0);
+
+            store.splice(null, [], [{...row, id: row.id + '-2'}]);
+            expect(events).toBe(1)
+        })
+    }
 });

--- a/test/playwright/unit/collection/AllItemsMirror.spec.mjs
+++ b/test/playwright/unit/collection/AllItemsMirror.spec.mjs
@@ -1,0 +1,153 @@
+import {setup} from '../../setup.mjs';
+
+const appName = 'CollectionAllItemsMirrorTest';
+
+setup({
+    appConfig: {
+        name: appName
+    }
+});
+
+import {test, expect}  from '@playwright/test';
+import Neo             from '../../../../src/Neo.mjs';
+import * as core       from '../../../../src/core/_export.mjs';
+import Collection      from '../../../../src/collection/Base.mjs';
+import Model           from '../../../../src/data/Model.mjs';
+import Store           from '../../../../src/data/Store.mjs';
+import InstanceManager from '../../../../src/manager/Instance.mjs';
+
+/**
+ * @summary The unfiltered projection (`allItems`) is part of the mutation, never a subscriber
+ * racing the other subscribers for it.
+ *
+ * Two facets, measured on a live consumer before they were understood in source:
+ * 1. `splice` / `endUpdate` used to fire `mutate` and let the projection catch up as ONE of the
+ *    listeners — registered after the store's own, which fires `load` synchronously. A filter
+ *    toggled inside that `load` rebuilt the view from an `allItems` the batch had not reached:
+ *    every row being added vanished, and `add` answered nulls.
+ * 2. The projection received the rows as they were at splice time. A listener that hydrated a row
+ *    first (a mounted list rendering inside `load`) left the projection with a stale raw reference
+ *    of a resident the store already held as a record — two representations of one row, and a
+ *    filter on a calculated field saw `undefined` on the projected one.
+ *
+ * The mirror now runs inside the mutation, before `mutate` fires. These arms are the contract:
+ * every listener sees the projection holding the batch, and a hydration inside a listener lands
+ * in both collections. The filters are assigned AFTER construction, the consumer's own shape —
+ * the projection is created by the first filter pass, not by the config.
+ */
+test.describe('Neo.collection.Base — allItems mirrors inside the mutation', () => {
+    const
+        rows    = () => [
+            {id: 'a', state: 'ok'},
+            {id: 'b', state: 'idle'},
+            {id: 'c', state: 'idle'},
+            {id: 'd', state: 'off'}
+        ],
+        tierModel = () => ({
+            module: Model,
+            fields: [
+                {name: 'id',    type: 'String'},
+                {name: 'state', type: 'String'},
+                {name: 'tier',  calculate: data => data.state === 'idle' ? 1 : 0}
+            ]
+        }),
+        created = [];
+
+    test.afterEach(() => {
+        created.splice(0).forEach(instance => instance.destroy())
+    });
+
+    test('a filter enabled inside a mutate listener keeps the rows the same mutation added', () => {
+        const collection = Neo.create(Collection, {
+            keyProperty: 'id',
+            items      : [{id: 'seed', state: 'ok'}]
+        });
+
+        created.push(collection);
+
+        // the consumer's shape — and the store's: a `mutate` listener registered BEFORE the
+        // projection subscribes (the store registers its own `load`-firing listener at construct,
+        // the projection only on the first filter pass), flipping the filter on inside the mutation
+        collection.on('mutate', () => {
+            collection.getFilter('state').disabled = false
+        });
+
+        collection.filters = [{disabled: true, property: 'state', filterBy: ({item}) => item.state === 'idle'}];
+
+        // the projection exists once a filter pass ran, and holds the seed
+        expect(collection.allItems.count).toBe(1);
+
+        const added = collection.add(rows());
+
+        expect(added.map(item => item.id)).toEqual(['a', 'b', 'c', 'd']);
+        // the projection held the batch BEFORE the listener re-filtered from it
+        expect(collection.allItems.count).toBe(5);
+        expect(collection.allItems.map.has('a')).toBe(true);
+        // the view kept every row the filter does not target — nothing was lost to the toggle
+        expect(collection.items.map(item => item.id)).toEqual(['seed', 'a', 'd']);
+        expect(collection.count).toBe(3)
+    });
+
+    test('a store filter on a calculated field, enabled inside `load`, folds the batch it was added with', () => {
+        const store = Neo.create(Store, {
+            keyProperty: 'id',
+            model      : tierModel(),
+            data       : [{id: 'seed', state: 'ok'}]
+        });
+
+        created.push(store);
+
+        store.filters = [{disabled: true, property: 'tier', filterBy: ({item}) => item.tier === 1}];
+
+        // the store's own `load` fires synchronously inside the mutation — the consumer's fold
+        store.on('load', () => {
+            store.count >= 3 && (store.getFilter('tier').disabled = false)
+        });
+
+        const added = store.add(rows());
+
+        // `add` resolves the VISIBLE instance per key: the rows the fold now hides answer null
+        // (the contract for a filtered row), the visible ones answer their record — none was
+        // dropped by the toggle, the projection holds every one
+        expect(added.map(item => item?.isRecord ? item.id : null)).toEqual(['a', null, null, 'd']);
+        // the whole batch lives in the projection, the folded view keeps the non-idle rows
+        expect(store.allItems.count).toBe(5);
+        expect(store.allItems.get('b').isRecord).toBe(true);
+        expect(store.items.map(item => item.id)).toEqual(['seed', 'a', 'd']);
+        expect(store.count).toBe(3)
+    });
+
+    test('a record hydrated inside `load` is the same instance in the store and its projection', () => {
+        const store = Neo.create(Store, {
+            keyProperty: 'id',
+            model      : tierModel(),
+            data       : [{id: 'seed', state: 'ok'}]
+        });
+
+        created.push(store);
+
+        store.filters = [{disabled: true, property: 'tier', filterBy: ({item}) => item.tier === 1}];
+
+        // a mounted list rendering inside `load` hydrates rows before anything else runs; the
+        // toggle then re-filters the view from the projection
+        store.on('load', () => {
+            if (store.count >= 3) {
+                store.get('b');
+                store.getFilter('tier').disabled = false
+            }
+        });
+
+        store.add(rows());
+
+        for (const id of ['a', 'b', 'c', 'd']) {
+            const record = store.allItems.get(id);
+
+            expect(record?.isRecord, `${id} is a record in the projection`).toBe(true);
+            expect(store.get(id) ?? store.allItems.get(id), `${id} resolves to one instance`).toBe(record)
+        }
+
+        // the calculated field is readable through the projection — the filter saw records
+        expect(store.allItems.get('b').tier).toBe(1);
+        expect(store.items.map(item => item.id)).toEqual(['seed', 'a', 'd'])
+    })
+});


### PR DESCRIPTION
Resolves #18269

Related: neomjs/neo-agent-institution#78 / neomjs/neo-agent-institution PR #95 (the consumer witness and the measurement) · the 2026-01-30 `allItems` shadow-instance regression (prior art on the same class)

The unfiltered projection (`allItems`) becomes part of the mutation instead of a subscriber racing the other subscribers for it, and an eager store hands the mutation records instead of raw rows. Two facets, one root — a collection with filters kept two representations of its rows and let listener registration order decide which one a consumer saw.

- **`collection/Base.mjs`** — every `splice` writes into `allItems` through `mirrorMutation`, an event-free write (`splice(…, silent=true)`), before anything can observe the mutation: ordinary and silent batches included, because the write is per splice, not per event. The projection is no longer a `sourceId` collection — no subscription, no source — and fires nothing of its own. A filter toggled inside a `mutate`/`load` listener rebuilds the view from a projection that already holds the batch.
- **`data/Store.mjs`** — eager mode (`autoInitRecords: true`, the default) hydrates **before** the splice through one named override point, `prepareAddedItems` (used by `add` and `insert`): the mutation, the projection and every listener see the same record instances, so a filter on a calculated field evaluates records and a mounted list holds the instances the projection does. `hydrateRecord` stays the lazy path for turbo mode. The caller's array stays raw (a copy is converted); `add`'s return keeps its contract — the visible instance per key, `null` for a row an active filter hides.
- **`data/TreeStore.mjs`** — overrides `prepareAddedItems` to hand raw rows through: the tree's structural layer annotates `depth` / `isLeaf` / `childCount` / `collapsed` inside its own `splice` before records exist, and its `hydrateRecord` materializes them lazily with those annotations in place. The override says why in its own JSDoc. Its `splice` forwards the `silent` parameter, so a tree store's projection write is event-free too.
- **`menu/Model.mjs`** — the `id` field loses its `Integer` type. Every shipped menu keys by strings (`file-open`, `view-zoom`), and the lazy path hid the mismatch: it keyed the map by the raw value and hydrated in place under it, so the record's `id` (NaN after `parseInt('file-open')`) never reached the map. With records hydrated before the splice the map is keyed by the record's key — the coherent state every dedupe in `splice` already assumes — and the menu's own tree (`ListTreeStore.spec.mjs`) collapsed two rows into one NaN key. An untyped key is the engine default: the key is whatever the consumer keys by.

Witness: `test/playwright/unit/collection/AllItemsMirror.spec.mjs`, three arms — a plain collection whose `mutate` listener (registered ahead of the projection, the store's own shape) enables a filter and keeps the batch; a store whose synchronous `load` enables a filter on a calculated field and folds the batch it was added with; a store whose `load` hydrates a row through `get` and then toggles — `allItems.get(key) === store.get(key)` for every added row, the calculated field readable through the projection. **Red-first: 3 of 3 fail on `dev` with the fix stashed, 3 of 3 pass with it.** Cycle 2 adds four arms from the review: an ordinary batch and a silent batch (`startUpdate(silent)` … `endUpdate(silent)`) land in the projection while the batch is still open and end with the primary's row set; the event-order arm (the primary's `mutate` fires once, the projection's never, and the projection has no `sourceId`); and a `sourceId` preservation arm (a derived collection keeps receiving its source's mutations). The two batch arms and the event arm are red on the Cycle-1 head. Cycle 2b adds two tree-store arms — a node under a collapsed parent (the hidden-node exit) and a store with an active filter (the filtered exit): `splice(…, true)` fires nothing, the same exit without `silent` fires once; both red on the Cycle-2 head.

Evidence: L2 (engine unit witnesses, red-first; the collection + data trees green) → L2 required (AC-1/AC-2/AC-4 are engine-internal; AC-3 names the downstream falsifier). Residual: none. The consumer proof lands with the next Agent Institution pin: `FleetGridScaleNL` (neomjs/neo-agent-institution#78) currently fails its DOM half on exactly this class — 12 cards for 6 rows — and its store half already passes with the consumer discipline in PR #95.

## AC Evidence

| AC | Evidence |
| --- | --- |
| AC-1 — a filter enabled inside a `load` listener keeps the non-matching rows of the same `add`; `add` returns their records; matching rows in `allItems` only | `AllItemsMirror.spec.mjs` arms 1 and 2: view `['seed', 'a', 'd']`, `allItems.count` 5, `add` → `['a', null, null, 'd']` (null = hidden by the filter the listener enabled, the pre-existing `get` contract). Red on `dev`: the view loses the batch (arm 1: count 1; arm 2: `add` answers nulls for every row). |
| AC-2 — collection/store semantics unchanged for every other consumer; `sourceId`-derived collections keep receiving their source's mutations | `test/playwright/unit/collection` + `test/playwright/unit/data`: **158 passed** in Cycle 1, **202 passed** with `menu` in Cycle 2 (`MassiveData` and the TreeStore trees included; the `sourceId` contract has its own arm now — the earlier claim that these suites already carried one was false, there was none). Full unit tree: **3177 passed, 0 failed** (18.6s) at `6594a3f` (3175 at `42af4e8`, 3171 at `4009f19`) — the two `menu/ListTreeStore.spec.mjs` arms the eager key exposed (`getCount` 2 → 1, `get('empty')` null: two string ids folded into one NaN key) are green with the untyped menu key. |
| AC-3 — the Agent Institution witness named as the downstream falsifier; the consumer deferral becomes removable | neomjs/neo-agent-institution#78 / PR #95: the witness's DOM half (`.fm-fleet-cards .fm-agent-card` expected 6, received 12) is this class; PR #95's `onRosterStoreLoad` microtask carries a "removable once the Engine mirrors inside the mutation" note. The next pin retires it. |
| AC-4 — the projection and the store hold the same record instances at every listener; a hydration inside a listener lands in both | Arm 3: `allItems.get(id).isRecord` for a–d, `store.get(id) === allItems.get(id)` for the visible rows, `allItems.get('b').tier === 1` readable through the projection, view `['seed', 'a', 'd']`. Red on `dev`: `c` stays raw in the projection and survives the fold (view `['seed', 'a', 'c', 'd']`). |

## Deltas from ticket

- The ticket's facet-2 fix sketch ("hydrate before `fire('mutate')`, or hydrate inside the mirror splice") landed as the cleaner cut: hydrate before the **splice**, once, in the eager store — the mirror then carries records by construction. The `allItems`-only hydration alternative in `Store#filter` would have fixed filters and left the list-identity split in place.
- `prepareAddedItems` is a new protected override point rather than a TreeStore-specific branch in `Store#add`: the tree's raw-first ingestion is a design, and it now says so at its own seam.
- Not in the ticket: the eager store now keys the map by the **record's** key, where the lazy path keyed by the raw value and hydrated under it. For a model whose key field converts (`Integer` fed a string) the two paths disagree, and the lazy one was the incoherent one — `splice`'s add/remove dedupe compares `item[keyProperty]` against map keys, so a converted record key never matched its own raw map entry. The one consumer that fed strings into an `Integer` key is `Neo.menu.Model`; its `id` is untyped now (the bullet above). No other unit arm in the tree touched this class.
- Hygiene on touched lines in `collection/Base.mjs`: three durable-comment ticket refs in the `removedItems` narrative (a prior fix's `#11595` / PR `#11611`) are rewritten as behavior descriptions — the pre-commit archaeology gate is whole-touched-file, and the numbers live in `git log`.
- Cycle 2 (from the review): the mirror moved from the two fire sites into `splice` itself and became event-free. `cacheUpdate` is a disabled no-op on `dev`, so an ordinary batch's `endUpdate` fires `mutate` with empty aggregates — pre-existing and outside this ticket; the projection no longer depends on that event at all. The ticket carries a Contract Ledger for every consumed surface now (`allItems` order, `splice(…, silent)`, `mirrorMutation`, `prepareAddedItems`, the eager payload and key, the TreeStore overrides, the menu key).

- Cycle 2b (the Round-2 hold): `TreeStore#splice` has three exits, and only the visible-delta one reached the Collection's `splice` with `silent`; the hidden-node fallback (a node under a collapsed parent) and the filtered exit fired their own `mutate` regardless. Both honor `silent` now; two arms mirror the reviewer's controls per exit (0 events with `silent`, 1 without). The ticket's TreeStore ledger row says "on every exit".

## Test Evidence

- `AllItemsMirror.spec.mjs` against `dev` with the fix stashed: **3 failed** — against the fix: **3 passed**.
- `test/playwright/unit/collection` + `test/playwright/unit/data`: **158 passed**.
- Full `npm run test-unit`: **3177 passed, 0 failed** (18.6s) at `6594a3f` (3175 at `42af4e8`, 3171 at `4009f19`) — the two `menu/ListTreeStore.spec.mjs` arms the eager key exposed (`getCount` 2 → 1, `get('empty')` null: two string ids folded into one NaN key) are green with the untyped menu key.
- Live origin of the measurement (before the fix): neomjs/neo-agent-institution#78's ticket trail — `add` of a 20-row fixture answering 20 nulls, `count` unchanged, `allItems` 31; the fold threshold pushed out of reach makes the same `add` answer the record.

## Post-Merge Validation

- [ ] The next Agent Institution pin (after this lands on `dev`): `FleetGridScaleNL` green in full, and PR #95's microtask deferral retired.

## Commits

- `4009f19` — the mirror inside the mutation at both fire sites, `prepareAddedItems` (Store, and TreeStore's raw-first override), the menu key untyped, the three-arm witness, the archaeology hygiene on touched lines.
- `42af4e8` — Cycle 2: the per-splice event-free write (`mirrorMutation`, `splice(…, silent)`), the projection without `sourceId`, TreeStore forwarding `silent`, the four review arms.
- `6594a3f` — Cycle 2b: the two `TreeStore#splice` exits without a visible delta honor `silent`; the two tree-store arms (red-first 2/2 against `42af4e8`).

Authored by Clio (Claude Fable 5.1, Claude Code). Session e1f9d3cb-6f4f-423c-9e42-6f20d9cba9b3 · 📜 @neo-fable-clio
