### PR TITLE
fix(dock): a refresh builds a stand-in only for an item of a new tabs node (#18274)

### DIFF
--- a/src/dashboard/dock/Workspace.mjs
+++ b/src/dashboard/dock/Workspace.mjs
@@ -1553,8 +1553,8 @@ class Workspace extends Container {
      * Creates the hidden stand-in the reconciler materializes a projected item through before the
      * live pane or its resolved config takes the slot. Asked only for an item inside a tabs node the
      * current shell does not render: a retained node's config is discarded whole, so its items
-     * project as placeholder configs and no instance is built for them. Override only to change the
-     * placeholder's shape; its header text rides {@link #getPaneHeaderText}.
+     * project as their `blueprint` or a placeholder config and no instance is built for them. Override
+     * only to change the placeholder's shape; its header text rides {@link #getPaneHeaderText}.
      * @param {String} itemId
      * @param {Object} item The persisted item record.
      * @param {String} componentRef

--- a/src/dashboard/dock/Workspace.mjs
+++ b/src/dashboard/dock/Workspace.mjs
@@ -4055,8 +4055,8 @@ class Workspace extends Container {
      * refusal below leaves the workspace exactly as it was. The docking record's user-triggered
      * recreate exception is conditioned on this phase — without a validated candidate the exception
      * does not apply and the never-destroyed guarantee stands unmodified.
-     * @see ADR 0029 §2.6 — ticket-ref-ok: the record IS this method's authority, not a tracking ref;
-     *      the contract is unreadable without it and an accepted ADR section does not close.
+     * @see learn/agentos/decisions/0029-docking-design.md §2.6 — the docking record is this method's
+     *      authority, not a tracking reference; the contract is unreadable without it.
      *
      * The three refusals are the ones a cache-backed resolver actually produces:
      *

--- a/src/dashboard/dock/Workspace.mjs
+++ b/src/dashboard/dock/Workspace.mjs
@@ -1551,8 +1551,10 @@ class Workspace extends Container {
 
     /**
      * Creates the hidden stand-in the reconciler materializes a projected item through before the
-     * live pane or its resolved config takes the slot. Override only to change the placeholder's
-     * shape; its header text rides {@link #getPaneHeaderText}.
+     * live pane or its resolved config takes the slot. Asked only for an item inside a tabs node the
+     * current shell does not render: a retained node's config is discarded whole, so its items
+     * project as placeholder configs and no instance is built for them. Override only to change the
+     * placeholder's shape; its header text rides {@link #getPaneHeaderText}.
      * @param {String} itemId
      * @param {Object} item The persisted item record.
      * @param {String} componentRef
@@ -3793,13 +3795,22 @@ class Workspace extends Container {
             return
         }
 
-        const nextConfig = me.projectDockModel(tabInsertDescriptor, (componentRef, item, itemId) => {
-            const placeholder = me.createProjectionPlaceholder(itemId, item, componentRef);
+        // The reconciler discards a retained tabs node's config whole, so a stand-in for one of its
+        // items never enters a parent; only an item inside a NEW tabs node needs one, for button pairing.
+        const
+            currentShell       = host.items?.[me.dockShellIndex],
+            retainedTabNodeIds = new Set(currentShell ? Reconciler.collectProjectedTabs(currentShell).keys() : []),
+            nextConfig         = me.projectDockModel(tabInsertDescriptor, (componentRef, item, itemId, nodeId) => {
+                if (retainedTabNodeIds.has(nodeId)) {
+                    return null
+                }
 
-            placeholders.set(itemId, placeholder);
+                const placeholder = me.createProjectionPlaceholder(itemId, item, componentRef);
 
-            return placeholder
-        }, document);
+                placeholders.set(itemId, placeholder);
+
+                return placeholder
+            }, document);
 
         // The hook extends the reconciler's SEAMS, never its identity: only the three sanctioned
         // keys are read off its result — a hostile or accidental override cannot displace the

--- a/src/dashboard/dock/projection/LayoutAdapter.mjs
+++ b/src/dashboard/dock/projection/LayoutAdapter.mjs
@@ -455,7 +455,8 @@ class LayoutAdapter extends Base {
      *     another owning lifecycle has already retired the same source vessel.
      * @param {Function} [options.resolveVesselConversionSourceRect] Synchronous owner resolver for
      *     the exact dragged vessel's live global inner rect; threaded through a clone-safe listener.
-     * @param {Function} [options.resolveComponentRef]
+     * @param {Function} [options.resolveComponentRef] `(componentRef, item, itemId, nodeId) => config
+     *     | instance | null`; a `null` answer projects a recoverable placeholder config.
      * @param {Function} [options.resolveRevealComponentRef] Durable resolver retained by edge rails.
      * @param {Function} [options.syncDockLockPane] Workspace-owned lock presentation for a resolved
      *     rail reveal pane: `(pane, itemId) => void`.
@@ -908,11 +909,13 @@ class LayoutAdapter extends Base {
      * Projects one dock item id into a Neo config or recoverable placeholder.
      * @param {String} itemId
      * @param {Object} context
+     * @param {String|null} [nodeId=null] The tabs node the item projects into; a resolver that declines
+     *     an item of a retained node gets it projected as a placeholder config instead.
      * @returns {*}
      * @protected
      * @static
      */
-    static projectItem(itemId, context) {
+    static projectItem(itemId, context, nodeId=null) {
         let item      = context.items[itemId],
             component = null;
 
@@ -920,7 +923,7 @@ class LayoutAdapter extends Base {
             return this.createPlaceholder(itemId, null)
         }
 
-        component = context.resolveComponentRef(item.componentRef, item, itemId);
+        component = context.resolveComponentRef(item.componentRef, item, itemId, nodeId);
 
         if (!component && item.blueprint) {
             component = this.cloneConfig(item.blueprint)
@@ -1046,7 +1049,7 @@ class LayoutAdapter extends Base {
         // root header (plain config OR live instance) with exact restoration on its next item-only
         // projection; no broad selector or committed-document mutation is used as a fallback.
         projectedItems = items.map((itemId, index) => this.decorateProjectedItem(
-            this.projectItem(itemId, context),
+            this.projectItem(itemId, context, nodeId),
             itemId,
             context.items[itemId],
             {

--- a/src/dashboard/dock/projection/LayoutAdapter.mjs
+++ b/src/dashboard/dock/projection/LayoutAdapter.mjs
@@ -456,7 +456,8 @@ class LayoutAdapter extends Base {
      * @param {Function} [options.resolveVesselConversionSourceRect] Synchronous owner resolver for
      *     the exact dragged vessel's live global inner rect; threaded through a clone-safe listener.
      * @param {Function} [options.resolveComponentRef] `(componentRef, item, itemId, nodeId) => config
-     *     | instance | null`; a `null` answer projects a recoverable placeholder config.
+     *     | instance | null`; a `null` answer falls through to the item's persisted `blueprint` when
+     *     present, otherwise to a recoverable placeholder config — neither constructs an instance.
      * @param {Function} [options.resolveRevealComponentRef] Durable resolver retained by edge rails.
      * @param {Function} [options.syncDockLockPane] Workspace-owned lock presentation for a resolved
      *     rail reveal pane: `(pane, itemId) => void`.
@@ -910,7 +911,7 @@ class LayoutAdapter extends Base {
      * @param {String} itemId
      * @param {Object} context
      * @param {String|null} [nodeId=null] The tabs node the item projects into; a resolver that declines
-     *     an item of a retained node gets it projected as a placeholder config instead.
+     *     an item of a retained node gets it projected as its `blueprint` or a placeholder config instead.
      * @returns {*}
      * @protected
      * @static

--- a/test/playwright/unit/dashboard/DockProjectionStandIns.spec.mjs
+++ b/test/playwright/unit/dashboard/DockProjectionStandIns.spec.mjs
@@ -1,0 +1,204 @@
+import {setup} from '../../setup.mjs';
+
+setup({
+    appConfig: {
+        name: 'NeoDashboardDockProjectionStandInsTest'
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../src/Neo.mjs';
+import * as core      from '../../../../src/core/_export.mjs';
+import Component      from '../../../../src/component/Base.mjs';
+import DockWorkspace  from '../../../../src/dashboard/dock/Workspace.mjs';
+import Operations     from '../../../../src/dashboard/dock/model/Operations.mjs';
+import Reconciler     from '../../../../src/dashboard/dock/projection/Reconciler.mjs';
+import '../../../../src/manager/Instance.mjs';
+import '../../../../src/tab/Container.mjs';
+
+/**
+ * A refresh materializes a hidden stand-in component per projected item. For an item whose tabs
+ * node the current shell already renders, that stand-in is discarded with the node's config and
+ * never enters a parent, so it must not be constructed at all. Only an item inside a NEW tabs node
+ * needs one: the staged container is built from the config, and the stand-in's index pairs the
+ * projected tab button with the live pane that replaces it.
+ *
+ * The arms count two things across the commit classes: stand-ins constructed (through the factory
+ * hook) and components destroyed (through the base destroy), and they read the header chrome ids
+ * before and after so instance permanence is asserted rather than assumed.
+ */
+const createDocument = () => ({
+    schema: 'neo.dock.zone.v1',
+    root  : 'root',
+    items : {
+        editor  : {componentRef: 'Editor',   title: 'Editor',   kind: 'panel'},
+        preview : {componentRef: 'Preview',  title: 'Preview',  kind: 'panel'},
+        terminal: {componentRef: 'Terminal', title: 'Terminal', kind: 'terminal'}
+    },
+    nodes: {
+        root         : {type: 'edge-zone', zones: {center: {nodeId: 'root-split'}}},
+        'root-split' : {type: 'split', orientation: 'horizontal', children: ['editor-tabs', 'side-tabs'], sizes: [0.6, 0.4]},
+        'editor-tabs': {type: 'tabs', items: ['editor'],              activeItemId: 'editor'},
+        'side-tabs'  : {type: 'tabs', items: ['preview', 'terminal'], activeItemId: 'preview'}
+    }
+});
+
+const standIns = [];
+
+class StandInWorkspace extends DockWorkspace {
+    static config = {
+        className           : 'Test.Unit.Dashboard.DockProjectionStandIns.Workspace',
+        enableDockLockAction: true,
+        layout              : {ntype: 'vbox', align: 'stretch'}
+    }
+
+    construct(config) {
+        super.construct(config);
+        this.add(this.projectDockModel())
+    }
+
+    /**
+     * Records every stand-in the refresh asks for, then builds it like the engine does.
+     * @param {String} itemId
+     * @param {Object} item
+     * @param {String} componentRef
+     * @returns {Neo.component.Base}
+     */
+    createProjectionPlaceholder(itemId, item, componentRef) {
+        standIns.push(itemId);
+        return super.createProjectionPlaceholder(itemId, item, componentRef)
+    }
+}
+
+StandInWorkspace = Neo.setupClass(StandInWorkspace);
+
+let destroyed       = 0,
+    originalDestroy = null;
+
+/**
+ * The header chrome of every projected tabs node: the ids permanence is asserted on.
+ * @param {Neo.dashboard.dock.Workspace} workspace
+ * @returns {Object}
+ */
+function chrome(workspace) {
+    const shell = workspace.getDockHost().items[workspace.dockShellIndex],
+          out   = {};
+
+    Reconciler.collectProjectedTabs(shell).forEach((tab, nodeId) => {
+        const bar = tab.getTabBar();
+
+        out[nodeId] = {
+            tab    : tab.id,
+            bar    : bar.id,
+            buttons: tab.getTabButtons().map(button => button.id),
+            actions: bar.getActionItems().map(action => `${action.action}:${action.id}`)
+        }
+    });
+
+    return out
+}
+
+/**
+ * Commits one operation the way a committing surface does and waits for its refresh to land.
+ * @param {Neo.dashboard.dock.Workspace} workspace
+ * @param {Object} descriptor
+ * @param {Object} [document=workspace.dockModel]
+ * @returns {Promise<{destroyed: Number, standIns: String[]}>}
+ */
+async function commit(workspace, descriptor, document=workspace.dockModel) {
+    const before = destroyed,
+          mark   = standIns.length,
+          result = Operations.applyOperation(document, descriptor);
+
+    expect(result.errors, `${descriptor.operation} must be accepted`).toEqual([]);
+
+    workspace.onDockZoneDocumentChange(result.document, descriptor, workspace);
+    // The refresh chain resolves once the projection has landed and the post-commit sweeps ran.
+    await workspace.refreshPromise;
+
+    return {destroyed: destroyed - before, standIns: standIns.slice(mark)}
+}
+
+test.describe('Neo.dashboard.dock.Workspace projection stand-ins (#18274)', () => {
+    let workspace;
+
+    test.beforeAll(() => {
+        originalDestroy = Component.prototype.destroy;
+        Component.prototype.destroy = function(...args) {
+            destroyed++;
+            return originalDestroy.apply(this, args)
+        }
+    });
+
+    test.afterAll(() => {
+        Component.prototype.destroy = originalDestroy
+    });
+
+    test.beforeEach(async () => {
+        standIns.length = 0;
+        workspace = Neo.create(StandInWorkspace, {dockModel: createDocument()});
+        await workspace.refreshPromise
+    });
+
+    test.afterEach(() => {
+        workspace?.destroy?.();
+        workspace = null
+    });
+
+    test('AC-1 an item-flag commit constructs nothing and destroys nothing', async () => {
+        const before = chrome(workspace),
+              lock   = await commit(workspace, {operation: 'setItemLocked', itemId: 'editor', locked: true});
+
+        expect(lock.standIns, 'no stand-in for a retained node').toEqual([]);
+        expect(lock.destroyed, 'the lock commit destroys no component').toBe(0);
+        expect(chrome(workspace), 'header chrome keeps every instance').toEqual(before)
+    });
+
+    test('AC-2/AC-3 topology commits on retained nodes construct no stand-in and keep the chrome', async () => {
+        const before = chrome(workspace);
+
+        const activate = await commit(workspace, {operation: 'setActiveItem', tabsNodeId: 'side-tabs', itemId: 'terminal'});
+        expect(activate.standIns, 'a tab click builds no stand-in').toEqual([]);
+        expect(chrome(workspace)).toEqual(before);
+
+        const withNotes = structuredClone(workspace.dockModel);
+        withNotes.items.notes = {componentRef: 'Notes', title: 'Notes', kind: 'panel'};
+
+        const add = await commit(workspace, {operation: 'addTab', itemId: 'notes', tabsNodeId: 'side-tabs', index: 2}, withNotes);
+        expect(add.standIns, 'a tab added to a retained node builds no stand-in').toEqual([]);
+
+        const afterAdd = chrome(workspace);
+        expect(afterAdd['editor-tabs']).toEqual(before['editor-tabs']);
+        expect(afterAdd['side-tabs'].tab).toBe(before['side-tabs'].tab);
+        expect(afterAdd['side-tabs'].bar).toBe(before['side-tabs'].bar);
+        expect(afterAdd['side-tabs'].actions).toEqual(before['side-tabs'].actions);
+        expect(afterAdd['side-tabs'].buttons.slice(0, 2), 'the existing tab buttons survive').toEqual(before['side-tabs'].buttons);
+        expect(afterAdd['side-tabs'].buttons.length, 'the added item renders its tab').toBe(3);
+
+        const close = await commit(workspace, {operation: 'closeItem', itemId: 'notes'});
+        expect(close.standIns, 'closing builds no stand-in').toEqual([]);
+        expect(chrome(workspace)).toEqual(before);
+
+        const noop = await commit(workspace, {operation: 'setActiveItem', tabsNodeId: 'side-tabs', itemId: 'terminal'});
+        expect(noop.standIns, 'a byte-identical re-commit builds no stand-in').toEqual([]);
+        expect(chrome(workspace)).toEqual(before)
+    });
+
+    test('AC-2 a NEW tabs node still receives exactly one stand-in per item, and pairing holds', async () => {
+        const before = chrome(workspace),
+              split  = await commit(workspace, {operation: 'splitNode', itemId: 'terminal', targetNodeId: 'editor-tabs', orientation: 'vertical', position: 'after'});
+
+        expect(split.standIns, 'only the new node\'s item gets a stand-in').toEqual(['terminal']);
+
+        const after = chrome(workspace);
+
+        expect(after['editor-tabs'], 'the retained split target keeps its chrome').toEqual(before['editor-tabs']);
+        expect(after['side-tabs'].tab).toBe(before['side-tabs'].tab);
+        expect(after['side-tabs'].buttons, 'the moved item left its old node').toEqual(before['side-tabs'].buttons.slice(0, 1));
+
+        const newNode = Object.keys(after).find(nodeId => !(nodeId in before));
+
+        expect(newNode, 'a new tabs node projected').toBeTruthy();
+        expect(after[newNode].buttons, 'the new node pairs one button with its one pane').toHaveLength(1)
+    });
+});


### PR DESCRIPTION
Resolves #18274

🌿 A dock commit can no longer build a hidden pane for an item the shell already shows, only to throw it away unseen.

The refresh resolver declined nothing: every commit constructed one hidden stand-in component per document item, and the reconciler destroyed the ones inside retained tabs nodes because it discards those nodes' configs whole. The adapter now passes the tabs node id into the item resolver, and the refresh declines a stand-in for an item whose node the current shell already renders; the item projects as its persisted `blueprint` when present, otherwise as a placeholder config, and the reconciler discards that config exactly as before.

## Contract Ledger
| Target surface | Source of authority | Proposed behavior | Fallback | Docs | Evidence |
|---|---|---|---|---|---|
| `LayoutAdapter.project({resolveComponentRef})` callback | `LayoutAdapter.projectItem` (`:915–930`) | Called as `(componentRef, item, itemId, nodeId)`; `nodeId` is the tabs node the item projects into and is `undefined` on the rail-reveal path. A 1–3-argument consumer is unchanged: the extra argument is ignored. A `null` answer falls through to `item.blueprint` when present, otherwise to `createPlaceholder(itemId, item)` — neither constructs an instance. | Today's behaviour for every existing consumer; `Workspace#resolveProjectedPane` still answers the default resolver | `LayoutAdapter.mjs` option and parameter JSDoc; `Workspace#createProjectionPlaceholder` docblock | `DockProjectionStandIns.spec.mjs`: zero stand-ins for retained nodes across four commit classes; exactly one for the single item of a `splitNode`-minted node | A new tabs node keeps its stand-ins, because the staged container is built from the config and the stand-in's index pairs the projected tab button with the live pane that replaces it. The reconciler is untouched; its retire sweeps remain its contract towards any caller that hands in a full map (`DockProjectionReconciler.spec.mjs:432` asserts it).

Evidence: unit tier (a `component.Base` construct/destroy census on a two-node fixture across five commit classes) achieved for AC-1–AC-4; AC-5 is no-regression against the exact base: the dock journeys ran in the Neural Link e2e tier against the Brain runtime — 9 of 10 arms green on both the branch and pristine `dev@205bc52f8a`, the tenth red on both (control run). Residual: the tenth arm asserts a retired reload contract, Residual-Owner: #18283.

## AC Evidence
| AC-1 | CI-covered: `test/playwright/unit/dashboard/DockProjectionStandIns.spec.mjs` — "an item-flag commit constructs nothing and destroys nothing" (destroy counter 0, was 3) |
| AC-2 | CI-covered: same spec — "topology commits on retained nodes construct no stand-in" and "a NEW tabs node still receives exactly one stand-in per item, and pairing holds" (`splitNode` → `['terminal']`) |
| AC-3 | CI-covered: same spec — every arm compares the header chrome census (tab container, toolbar, tab buttons, action buttons by id) before and after the commit |
| AC-4 | Diff: `Reconciler.mjs` unchanged; the delta is the resolver predicate in `Workspace#refreshDockWorkspace`, the `nodeId` parameter through `LayoutAdapter.projectItem`, and their docs — `git diff --stat dev` shows two source files |
| AC-5 | CI-covered: `unit/dashboard` 815 passed, `unit/examples/dashboard/crossWindow` + `unit/apps/workstation` + `unit/tab` + `unit/toolbar` 183 passed; outside CI (no-regression against exact base): e2e `DockLockActionNL`, `DockOperationsNL`, `DockReloadActionNL` 9/10 on the branch and 9/10 on pristine `dev@205bc52f8a` with this change stashed — the same arm red on both (`DockReloadActionNL.spec.mjs:72`), owned by #18283 |

## Deltas from ticket
The ticket's first AC-4 asked to delete the reconciler's "retire them now" block as dead code. It is dead on the workspace path after this change, but `DockProjectionReconciler.spec.mjs:379–436` drives the reconciler directly with a full placeholder map and asserts the sweep; deleting it would change a static utility's contract for one caller's convenience. AC-4 was corrected in the ticket body before this PR: the change is caller-side only.

## Test Evidence
Neural Link e2e tier, `NEO_AGENTOS_RUNTIME_ROOT` set to the Brain checkout, `--workers=1`: `DockLockActionNL` + `DockOperationsNL` + `DockReloadActionNL` → 9 passed, 1 failed. Control: the same arm fails identically on pristine `dev@205bc52f8a` (branch changes stashed). Its cause is dated, not inferred: the arm asserts the delegation-only reload contract of 2026-08-31, and `ce0634b62c` (2026-09-01) plus the always-`true` `hasDockRecreateFallback` made the action visible for every resolved pane — #18283 owns the arm and the vestigial predicate. Red-first: the new spec's three arms failed on the unchanged tree for the ticket's reasons (three stand-ins per commit; the split arm received three instead of one) before the change made them green.

`baseline / Source comment archaeology` was red at the first head on a line this PR did not change: `Workspace.mjs:4058` carried the repo's `ticket-ref-ok` escape on an accepted-ADR `@see`, which the local pre-commit hook honours and `neo-agent-skills@0.1.3` classifies as a legacy escape. The reviewer asked for touched-file cleanup; the line now cites the decision record by its stable file path, both checkers pass (packaged 0.1.3 run locally against the base: 0 violations), and the drift itself is a defect-note — 18 legacy markers remain across 12 engine files.

## Post-Merge Validation
None — every acceptance criterion is verified before merge, in the unit tier and the e2e receipt above.

Authored by Vega (Claude Fable 5.1, Claude Code). Session 4384828f-2650-4d28-b650-fac55eebec59.
