### PR TITLE
test(dashboard): the one-construction arms carry their cause (#18275)

### DIFF
--- a/test/playwright/component/apps/dock-lazy-rail/LazyPane.mjs
+++ b/test/playwright/component/apps/dock-lazy-rail/LazyPane.mjs
@@ -20,11 +20,10 @@ class LazyPane extends Component {
      * `lazyPaneConstructionTrail`.
      *
      * A count says a second construction happened; it cannot say who caused it. Two callers may
-     * legitimately load this pane (`layout.Card#afterSetActiveIndex` on activation, and
-     * `container.Base#insert` when the inserted index is already active), so the identity of the
-     * second one is the whole diagnostic — and #18275's window only opens on a loaded CI runner,
-     * where nobody is attached to inspect it. Capturing the site at construction is what lets the
-     * next natural occurrence name its own cause instead of leaving it to be deduced from a tally.
+     * legitimately load this pane — `layout.Card#afterSetActiveIndex` on activation, and
+     * `container.Base#insert` when the inserted index is already active — so the identity of the
+     * second is the diagnostic. The duplicate only surfaces on a loaded runner, where nobody is
+     * attached, so the site is captured at construction rather than reconstructed from a tally.
      * @member {String[]} constructionTrail=[]
      * @static
      */

--- a/test/playwright/component/apps/dock-lazy-rail/LazyPane.mjs
+++ b/test/playwright/component/apps/dock-lazy-rail/LazyPane.mjs
@@ -15,6 +15,21 @@ class LazyPane extends Component {
      */
     static instances = 0
 
+    /**
+     * One captured call site per construction, in order — read through the fixture workspace's
+     * `lazyPaneConstructionTrail`.
+     *
+     * A count says a second construction happened; it cannot say who caused it. Two callers may
+     * legitimately load this pane (`layout.Card#afterSetActiveIndex` on activation, and
+     * `container.Base#insert` when the inserted index is already active), so the identity of the
+     * second one is the whole diagnostic — and #18275's window only opens on a loaded CI runner,
+     * where nobody is attached to inspect it. Capturing the site at construction is what lets the
+     * next natural occurrence name its own cause instead of leaving it to be deduced from a tally.
+     * @member {String[]} constructionTrail=[]
+     * @static
+     */
+    static constructionTrail = []
+
     static config = {
         /**
          * @member {String} className='Test.Playwright.Component.DockLazyRail.LazyPane'
@@ -37,7 +52,13 @@ class LazyPane extends Component {
      */
     construct(config) {
         super.construct(config);
-        this.constructor.instances++
+
+        let sCfg = this.constructor;
+
+        sCfg.instances++;
+        // The frames above `construct` are the caller chain that reached `Neo.create`, which is the
+        // only thing that distinguishes an activation-driven load from an insert-driven one.
+        sCfg.constructionTrail.push(new Error(`construction #${sCfg.instances}`).stack)
     }
 }
 

--- a/test/playwright/component/apps/dock-lazy-rail/LazyPane.mjs
+++ b/test/playwright/component/apps/dock-lazy-rail/LazyPane.mjs
@@ -15,19 +15,6 @@ class LazyPane extends Component {
      */
     static instances = 0
 
-    /**
-     * One captured call site per construction, in order — read through the fixture workspace's
-     * `lazyPaneConstructionTrail`.
-     *
-     * A count says a second construction happened; it cannot say who caused it. Two callers may
-     * legitimately load this pane — `layout.Card#afterSetActiveIndex` on activation, and
-     * `container.Base#insert` when the inserted index is already active — so the identity of the
-     * second is the diagnostic. The duplicate only surfaces on a loaded runner, where nobody is
-     * attached, so the site is captured at construction rather than reconstructed from a tally.
-     * @member {String[]} constructionTrail=[]
-     * @static
-     */
-    static constructionTrail = []
 
     static config = {
         /**
@@ -51,13 +38,7 @@ class LazyPane extends Component {
      */
     construct(config) {
         super.construct(config);
-
-        let sCfg = this.constructor;
-
-        sCfg.instances++;
-        // The frames above `construct` are the caller chain that reached `Neo.create`, which is the
-        // only thing that distinguishes an activation-driven load from an insert-driven one.
-        sCfg.constructionTrail.push(new Error(`construction #${sCfg.instances}`).stack)
+        this.constructor.instances++
     }
 }
 

--- a/test/playwright/component/apps/dock-lazy-rail/app.mjs
+++ b/test/playwright/component/apps/dock-lazy-rail/app.mjs
@@ -26,6 +26,14 @@ const fixtureDocument = {
  * @extends Neo.dashboard.dock.Workspace
  */
 class LazyRailFixtureWorkspace extends DockWorkspace {
+    /**
+     * One captured call site per lazy-load request, in order — read through
+     * {@link #lazyPaneConstructionTrail}.
+     * @member {String[]} raiseSites=[]
+     * @static
+     */
+    static raiseSites = []
+
     static config = {
         /**
          * @member {String} className='Test.Playwright.Component.DockLazyRail.Workspace'
@@ -84,15 +92,17 @@ class LazyRailFixtureWorkspace extends DockWorkspace {
     }
 
     /**
-     * Spec-readable cause witness: one captured call site per construction, in order.
+     * Spec-readable cause witness: one captured call site per load request, in order.
      *
-     * `lazyPaneInstances` reports THAT a duplicate happened; this reports WHO. The arms assert one
-     * construction, and when that assertion fails on CI there is no session to attach to, so the
-     * trail travels in the failure message instead.
+     * `lazyPaneInstances` reports THAT a duplicate happened; this reports WHO asked. Each entry is
+     * captured in the loader before the dynamic import is awaited, so it still carries the frame
+     * that names the route — `container.Base#insert` or `layout.Card#afterSetActiveIndex`. The arms
+     * assert one construction, and when that fails on CI there is no session to attach to, so the
+     * sites travel in the failure message instead.
      * @returns {String[]}
      */
     get lazyPaneConstructionTrail() {
-        return Neo.ns('Test.Playwright.Component.DockLazyRail.LazyPane')?.constructionTrail ?? []
+        return LazyRailFixtureWorkspace.raiseSites
     }
 
     /**
@@ -115,9 +125,23 @@ class LazyRailFixtureWorkspace extends DockWorkspace {
         if (itemId === 'lazy') {
             return {
                 // the lazy shape: loaded on activation — for a rail item, on its first reveal
-                module: () => import('./LazyPane.mjs'),
-                id    : 'dock-lazy-rail-pane-lazy',
-                text  : 'Lazy pane'
+                //
+                // The loader records its own call site, and the timing is the point: this runs
+                // BEFORE `#loadModuleOnce` awaits the import, so the caller chain is still on the
+                // stack. Capturing at construction instead yields three frames ending at
+                // `#loadModuleOnce` — the await starts a fresh microtask stack and severs the very
+                // frame that says which route asked. Here the two are plainly distinct:
+                // `container.Base#insert` on the already-active insert path, `afterSetActiveIndex`
+                // on activation.
+                module: () => {
+                    LazyRailFixtureWorkspace.raiseSites.push(
+                        (new Error('lazy module requested').stack || '').split('\n').slice(1, 7).join('\n')
+                    );
+
+                    return import('./LazyPane.mjs')
+                },
+                id  : 'dock-lazy-rail-pane-lazy',
+                text: 'Lazy pane'
             }
         }
 

--- a/test/playwright/component/apps/dock-lazy-rail/app.mjs
+++ b/test/playwright/component/apps/dock-lazy-rail/app.mjs
@@ -84,6 +84,18 @@ class LazyRailFixtureWorkspace extends DockWorkspace {
     }
 
     /**
+     * Spec-readable cause witness: one captured call site per construction, in order.
+     *
+     * `lazyPaneInstances` reports THAT a duplicate happened; this reports WHO. The arms below assert
+     * one construction, and when that assertion fails on CI there is no session to attach to — so the
+     * trail travels in the failure message instead. See #18275.
+     * @returns {String[]}
+     */
+    get lazyPaneConstructionTrail() {
+        return Neo.ns('Test.Playwright.Component.DockLazyRail.LazyPane')?.constructionTrail ?? []
+    }
+
+    /**
      * @param {Object} config
      */
     construct(config) {

--- a/test/playwright/component/apps/dock-lazy-rail/app.mjs
+++ b/test/playwright/component/apps/dock-lazy-rail/app.mjs
@@ -86,9 +86,9 @@ class LazyRailFixtureWorkspace extends DockWorkspace {
     /**
      * Spec-readable cause witness: one captured call site per construction, in order.
      *
-     * `lazyPaneInstances` reports THAT a duplicate happened; this reports WHO. The arms below assert
-     * one construction, and when that assertion fails on CI there is no session to attach to — so the
-     * trail travels in the failure message instead. See #18275.
+     * `lazyPaneInstances` reports THAT a duplicate happened; this reports WHO. The arms assert one
+     * construction, and when that assertion fails on CI there is no session to attach to, so the
+     * trail travels in the failure message instead.
      * @returns {String[]}
      */
     get lazyPaneConstructionTrail() {

--- a/test/playwright/component/dashboard/DockRailLazyModule.spec.mjs
+++ b/test/playwright/component/dashboard/DockRailLazyModule.spec.mjs
@@ -53,7 +53,13 @@ const expectOneConstruction = async (page, instances) => {
     if (instances !== 1) {
         const [trail] = await readWorkspace(page, ['lazyPaneConstructionTrail']);
 
-        expect(instances, `one construction — ${instances} recorded. Call sites:\n${(trail ?? ['(no trail captured)']).join('\n--- next construction ---\n')}`).toBe(1);
+        // `?? fallback` is not enough: an EMPTY array is not nullish, so a trail that captured
+        // nothing would join to `''` and render a blank message — the exact "renders empty on the
+        // failing path" outcome this witness exists to avoid, and the one a reader would take as
+        // "no second caller". Length is the predicate, not nullishness.
+        const sites = trail?.length ? trail.join('\n--- next request ---\n') : '(no call site captured — the witness itself failed)';
+
+        expect(instances, `one construction — ${instances} recorded. Load requested from:\n${sites}`).toBe(1);
 
         return
     }
@@ -164,5 +170,50 @@ test.describe('dock rail — a lazy module item loads on its first reveal', () =
 
         expect(loaded).toBe(true);
         await expectOneConstruction(page, instances)
+    });
+
+
+    /**
+     * The two arms below are the witness's own coverage, and they exist because without them the
+     * whole capture is deletable while every check stays green: every other read of the trail sits
+     * behind `instances !== 1`, a branch the suite never takes. They assert the property the
+     * diagnostic is FOR — that a call site identifies WHICH of the two legitimate routes asked —
+     * rather than that a string arrived.
+     */
+    test('the load request from the already-active insert route names that route', async ({page}) => {
+        await setWorkspace(page, {applyOperationJson: JSON.stringify({operation: 'setItemAutoHidden', itemId: 'pinned', autoHidden: true})});
+        await expect(page.locator('.neo-dashboard-dock-rail-tab', {hasText: 'Pinned'})).toHaveCount(1);
+        await setWorkspace(page, {applyOperationJson: JSON.stringify({operation: 'setItemAutoHidden', itemId: 'lazy', autoHidden: false})});
+
+        const tabsNode = page.locator('.neo-dashboard-dock-tabs', {has: page.locator('.neo-tab-header-button', {hasText: 'Lazy'})});
+
+        await expect(tabsNode.locator('.dock-lazy-rail-pane')).toBeVisible();
+
+        const [trail] = await readWorkspace(page, ['lazyPaneConstructionTrail']);
+
+        // Transport first: the capture happens in the app worker and is read through `getConfigs`,
+        // so a structured-clone failure would surface here as a missing array rather than as a
+        // silently empty message at the moment a real duplicate needs explaining.
+        expect(Array.isArray(trail), 'the trail survives the worker boundary as an array').toBe(true);
+        expect(trail, 'one load request, so one call site').toHaveLength(1);
+        expect(typeof trail[0], 'each entry is a string').toBe('string');
+        expect(trail[0], 'the insert route is named').toContain('insert');
+        expect(trail[0], 'and is not confused with the activation route').not.toContain('afterSetActiveIndex')
+    });
+
+    test('the load request from the activation route names that route instead', async ({page}) => {
+        await setWorkspace(page, {applyOperationJson: JSON.stringify({operation: 'setItemAutoHidden', itemId: 'lazy', autoHidden: false})});
+
+        const tabsNode = page.locator('.neo-dashboard-dock-tabs', {has: page.locator('.neo-tab-header-button', {hasText: 'Lazy'})});
+
+        await page.locator('.neo-tab-header-button', {hasText: 'Lazy'}).click();
+        await expect(tabsNode.locator('.dock-lazy-rail-pane')).toBeVisible();
+
+        const [trail] = await readWorkspace(page, ['lazyPaneConstructionTrail']);
+
+        expect(Array.isArray(trail), 'the trail survives the worker boundary as an array').toBe(true);
+        expect(trail, 'one load request, so one call site').toHaveLength(1);
+        expect(typeof trail[0], 'each entry is a string').toBe('string');
+        expect(trail[0], 'the activation route is named').toContain('afterSetActiveIndex')
     });
 });

--- a/test/playwright/component/dashboard/DockRailLazyModule.spec.mjs
+++ b/test/playwright/component/dashboard/DockRailLazyModule.spec.mjs
@@ -41,9 +41,9 @@ const visibleOverlay = page => page.locator('.neo-dashboard-dock-reveal-overlay:
  *
  * Two callers may legitimately load a parked pane — `layout.Card#afterSetActiveIndex` on activation,
  * and `container.Base#insert` when the inserted index is already active — so a tally of 2 does not
- * say which one arrived second. #18275 reds roughly once in a hundred runs and only on a loaded CI
- * runner, where there is no session to attach to afterwards; the failure message is the only channel
- * that reaches a reader, so the captured call sites travel in it.
+ * say which one arrived second. The duplicate is rare and surfaces only on a loaded runner, where
+ * there is no session to attach to afterwards; the failure message is the only channel that reaches
+ * a reader, so the captured call sites travel in it.
  *
  * The trail is read only on the failing path, so the green path keeps its single round-trip.
  * @param {Object} page

--- a/test/playwright/component/dashboard/DockRailLazyModule.spec.mjs
+++ b/test/playwright/component/dashboard/DockRailLazyModule.spec.mjs
@@ -36,6 +36,31 @@ const lazyTab = page => page.locator('.neo-dashboard-dock-rail-tab', {hasText: '
 
 const visibleOverlay = page => page.locator('.neo-dashboard-dock-reveal-overlay:not(.neo-dashboard-dock-reveal-overlay-hidden)');
 
+/**
+ * Asserts the one-construction contract, and on a break carries the CAUSE rather than only the count.
+ *
+ * Two callers may legitimately load a parked pane — `layout.Card#afterSetActiveIndex` on activation,
+ * and `container.Base#insert` when the inserted index is already active — so a tally of 2 does not
+ * say which one arrived second. #18275 reds roughly once in a hundred runs and only on a loaded CI
+ * runner, where there is no session to attach to afterwards; the failure message is the only channel
+ * that reaches a reader, so the captured call sites travel in it.
+ *
+ * The trail is read only on the failing path, so the green path keeps its single round-trip.
+ * @param {Object} page
+ * @param {Number} instances
+ */
+const expectOneConstruction = async (page, instances) => {
+    if (instances !== 1) {
+        const [trail] = await readWorkspace(page, ['lazyPaneConstructionTrail']);
+
+        expect(instances, `one construction — ${instances} recorded. Call sites:\n${(trail ?? ['(no trail captured)']).join('\n--- next construction ---\n')}`).toBe(1);
+
+        return
+    }
+
+    expect(instances, 'one construction').toBe(1)
+};
+
 test.beforeEach(async ({page}) => {
     await page.goto('test/playwright/component/apps/dock-lazy-rail/index.html');
     await page.waitForSelector(`#${WORKSPACE_ID}`,       {state: 'attached'});
@@ -115,7 +140,7 @@ test.describe('dock rail — a lazy module item loads on its first reveal', () =
         const [loadedAfter, instances] = await readWorkspace(page, ['lazyPaneModuleLoaded', 'lazyPaneInstances']);
 
         expect(loadedAfter).toBe(true);
-        expect(instances, 'one construction').toBe(1)
+        await expectOneConstruction(page, instances)
     });
 
     test('un-hidden as the only visible item of its tabs node, the lazy item is the active card and loads at once', async ({page}) => {
@@ -138,6 +163,6 @@ test.describe('dock rail — a lazy module item loads on its first reveal', () =
         const [loaded, instances] = await readWorkspace(page, ['lazyPaneModuleLoaded', 'lazyPaneInstances']);
 
         expect(loaded).toBe(true);
-        expect(instances, 'one construction').toBe(1)
+        await expectOneConstruction(page, instances)
     });
 });


### PR DESCRIPTION
Resolves #18286

Refs #18275

`DockRailLazyModule`'s one-construction arms now carry their **cause**, not just their count. When the duplicate recurs on CI, the failure message names the **lazy-load request sites** instead of leaving the second caller to be deduced from a tally of 2. The capture point is the loader request, not `Neo.create`; correlating those requests to the construction count is what the assertion does, not what the capture records.

**Close target split, so both are honest.** This delivers #18286 in full — the arms report no caller identity — and leaves #18275 open, because the duplicate is still unreproduced and AC-1 there is a reproduction this PR does not have. Ready for review on that basis rather than draft: the instrumentation's whole value is being in CI when the next natural occurrence lands, and every day it sits in draft is a lost occurrence.

Evidence: L2 (test-tier instrumentation, run locally against the component fixture) → L2 required (#18286's ACs are test-tier by construction; this PR ships no production-path behaviour). Residual: the duplicate itself, Residual-Owner: #18275.

## Why a tally was not enough

Two callers may legitimately load a parked pane — `layout.Card#afterSetActiveIndex` on activation, and `container.Base#insert` when the inserted index is already active. `instances === 2` cannot say which one arrived second, and #18275's window opens roughly once in a hundred runs and only on a loaded CI runner, where there is no session to attach to afterwards. The failure message is the only channel that reaches a reader, so the captured call sites travel in it.

Read only on the failing path, so the green path keeps its single round-trip.

## AC Evidence

One row per #18286 AC. #18275's own ACs are untouched by this PR and stay open there.

| AC | Evidence |
|---|---|
| AC-1 — a duplicate names its call sites | `LazyRailFixtureWorkspace.raiseSites` captures one site per **lazy-load request**, recorded in the fixture's loader before `#loadModuleOnce` awaits the import; `expectOneConstruction` carries them in the assertion message. `LazyPane.constructionTrail` is deleted — capturing at construction is post-await and severed |
| AC-2 — the witness is proven, not assumed | Two persistent arms assert route identity on BOTH paths (`insert` vs `afterSetActiveIndex`), plus array-ness, string-ness, cardinality and worker transport. Mutation-proven: deleting the capture reds 2/7; keeping it but slicing away the distinguishing frames also reds 2/7; restored 7/7 |
| AC-3 — green path unchanged | 5/5 on `playwright.config.component.mjs`; the trail is fetched only when the count is wrong |

## Deltas from ticket

#18275 listed three candidate approaches for its AC-1. This PR takes option 1 (instrument so the next natural occurrence is self-diagnosing) and deliberately does **not** take option 2 (run the component job under deliberate CI contention). At roughly one event per hundred runs, option 2 burns CI on a hope while option 1 makes the event that will happen anyway carry its own diagnosis.

One addition beyond the ticket's wording: the capture lives in the fixture app rather than the spec, because it happens inside the app worker while the spec runs in the main realm — a main-realm probe cannot see the class at all. It is held on `LazyRailFixtureWorkspace.raiseSites`, **not** on `LazyPane`: an earlier revision of this PR captured at construction on `LazyPane.constructionTrail`, and that member is deleted, because a stack taken after `await module()` has already lost the frame naming the route.

## Test Evidence

**The first witness did not work, and the control that said it did was a false positive.** @neo-gpt-emmy probed both construction routes live and found the insert-side stack carries only `LazyPane.construct → Neo.create → #loadModuleOnce` — neither `container.Base#insert` nor `afterSetActiveIndex`. My `/loadModule|insert|afterSetActiveIndex/` regex matched `loadModule`, a frame present on **both** routes, so it distinguished nothing. I verified her finding independently before acting on it; the insert trail is exactly those three frames.

Cause: `#loadModuleOnce` does `module = await module()`, and the continuation resumes on a fresh microtask stack. The frame naming the route is gone before `Neo.create` runs.

The capture now happens in the fixture's loader, invoked synchronously *before* that await, where the caller chain is intact. Measured, both routes self-identify:

```
insert      … Card.loadModule → BodyContainer.insert → Reconciler.mjs:795
activation  … Card.loadModule → Card.afterSetActiveIndex → tab/Container.mjs:183
```

**Mutation-proven, because "the arms pass" is not evidence the arms can fail:**

| mutation | result |
|---|---|
| delete the capture entirely | **2/7 red** |
| capture, but slice away the distinguishing frames | **2/7 red** |
| restored | **7/7 green** |

Before this, every read of the trail sat behind `instances !== 1` — a branch the suite never takes — so the whole witness was deletable with all checks green. That was Emmy's finding and it was right.

One instrument failure of my own, recorded so the green after it is not mistaken for proof: a first attempt to force a red called `Neo.ns(...)` from `page.evaluate`, which runs in the main realm where the worker-side class does not exist, and died with `Class undefined does not exist`.

**The mandated `agent-preflight` could not run, and I am saying so rather than omitting it.** `npm run agent-preflight` does not exist in this repository — `c623b2f63c` ("feat(engine): remove received Brain implementation") removed the whole `ai/` tree, and `git ls-files ai/` now returns 0. `ai:structure-map` and `ai:check-substrate-size` are absent for the same reason. Under `--silent` the call exits 1 with **no output at all**, so a deliberately-invalid control subject produces the identical empty failure; without checking `$?` this reads as a clean pass. Defect-note filed; the fix belongs in `neomjs/neo-agent-skills`, which mandates these org-wide while only the Brain ships them.

## Post-Merge Validation

- [ ] On the next natural occurrence of the duplicate in CI, the failure message names two call sites and identifies the second caller — the only check that exercises the failing path with a real race rather than a synthetic one.

## Commits

- `154f7e67e0` — capture one call site per construction; carry the trail in the assertion message.
- `4466d983c3` — the witness records who ASKED, captured before the await severs the caller; two persistent route-identity controls; length-aware empty sentinel.
- `550a99464d` — the JSDoc describes behaviour, not a tracking ref: `check-ticket-archaeology` red on three comments citing a ticket number, which rots when the ref closes. Removed rather than escaped with `ticket-ref-ok:`; verified by running the guard with a decoy to prove it still reds.

Authored by Ada (Claude Opus 5, Claude Code). Session 7596538d-5324-419a-b043-95c585d833ea.




