### PR TITLE
test(dock): the reload journey witnesses the engine recreate for a pane without the contract (#18283)

### DIFF
--- a/examples/dashboard/dock/MainContainer.mjs
+++ b/examples/dashboard/dock/MainContainer.mjs
@@ -128,10 +128,10 @@ class MainContainer extends DockWorkspace {
          */
         enableDockPinAction: true,
         /**
-         * And into the engine-owned, delegation-only reload action. The Strategy pane implements
-         * the `dockReload()` contract below, so the example shows both halves of the policy: the
-         * action appears on the pane that owns a reload meaning and stays hidden on every pane
-         * that does not.
+         * And into the engine-owned reload action, which delegates to a pane's `dockReload()` when
+         * it has one and otherwise recreates the pane through the engine. The Strategy pane
+         * implements the contract below, so the example shows both halves of the policy: a
+         * delegated reload that counts, and an engine recreate on every pane that does not.
          * @member {Boolean} enableDockReloadAction=true
          */
         enableDockReloadAction: true,

--- a/src/dashboard/dock/Workspace.mjs
+++ b/src/dashboard/dock/Workspace.mjs
@@ -175,19 +175,19 @@ class Workspace extends Container {
          */
         enableDockPinAction: true,
         /**
-         * Projects one engine-owned, delegation-only reload action into each Dock tab header —
-         * runtime only: no operation is committed and the document never changes. A pane
-         * implementing `dockReload(): void | Promise<*>` owns what reload means (its stores,
-         * caches, re-render — the author's decision, opted into by implementing the method); a
-         * pane without the contract simply hides the action, decided by a pure `typeof` probe on
-         * the live card, never a resolver call. One invocation per item may be in flight (the
-         * action disables for the window), and every completion — sync throw, async rejection,
-         * async success — settles exactly once through the `dockReloadSettled` event
+         * Projects one engine-owned reload action into each Dock tab header — runtime only: no
+         * operation is committed and the document never changes. A pane implementing
+         * `dockReload(): void | Promise<*>` owns what reload means (its stores, caches, re-render —
+         * the author's decision, opted into by implementing the method), decided by a pure `typeof`
+         * probe on the live card, never a resolver call; a pane without the contract keeps the
+         * action and is served by the engine's recreate — the two-phase transaction that replaces
+         * the live pane only after a validated fresh candidate exists (docking design record §2.6,
+         * as amended). The action hides only where the host declared no recreate through
+         * {@link #hasDockRecreateFallback}. One invocation per item may be in flight (the action
+         * disables for the window), and every completion — sync throw, async rejection, async
+         * success — settles exactly once through the `dockReloadSettled` event
          * (`{dockNodeId, itemId, errors}`); a failing `dockReload()` keeps the pane, always.
-         * Destroy-and-recreate is deliberately NOT here: resolved panes are moved, never
-         * destroyed (docking design record §2.6) — the recreate capability lives with the
-         * two-phase transaction that can honestly promise rollback. Enabled by default; explicit
-         * `false` removes the action.
+         * Enabled by default; explicit `false` removes the action.
          * @member {Boolean} enableDockReloadAction=true
          */
         enableDockReloadAction: true,
@@ -2549,9 +2549,10 @@ class Workspace extends Container {
     }
 
     /**
-     * Runs the engine-owned, delegation-only reload for the active pane: `dockReload()` when the
-     * pane implements the contract — the author owns what reload means, and the method is
-     * explicitly promise-aware (`void | Promise<*>`). Runtime-only by contract: no operation is
+     * Runs the engine-owned reload for the active pane: `dockReload()` when the pane implements
+     * the contract — the author owns what reload means, and the method is explicitly
+     * promise-aware (`void | Promise<*>`) — and the engine's recreate ({@link #recreateDockPane})
+     * when it does not. Runtime-only by contract: no operation is
      * committed and the document never changes. Every completion — sync throw, async rejection,
      * async success — settles exactly once through the `dockReloadSettled` event
      * (`{dockNodeId, itemId, errors}`), because the action wire has no result channel
@@ -2653,9 +2654,10 @@ class Workspace extends Container {
 
     /**
      * Synchronizes one retained reload action against the live active pane, owning BOTH state
-     * axes: `hidden` while no active item resolves OR the active card does not carry the
-     * `dockReload()` contract; `disabled` while the ACTIVE item — not whichever item started a
-     * flight — has an invocation in flight. Deriving both here (called at the flight edges and
+     * axes: `hidden` while no active item resolves, or while neither path can serve it — no
+     * `dockReload()` contract on the active card AND the host declared no recreate through
+     * {@link #hasDockRecreateFallback}; `disabled` while the ACTIVE item — not whichever item started
+     * a flight — has a reload or recreate in flight. Deriving both here (called at the flight edges and
      * on every active-item change) is what keeps per-item single-flight and the one node-level
      * action instance consistent when the active item changes mid-flight. The contract probe is
      * pure — a `typeof` on the card instance, or on its config's `module` prototype while the
@@ -4035,12 +4037,15 @@ class Workspace extends Container {
     }
 
     /**
-     * Whether a recreate path is wired — not whether a given item will succeed.
+     * Whether a recreate path is wired — not whether a given item will succeed. The engine always
+     * wires one: {@link #resolveFreshPane} delegates to {@link #resolvePane}, so the default answers
+     * `true` and a pane without `dockReload()` keeps its reload action.
      *
      * Never calls the factory: {@link #syncDockReloadAction} consults this on every active-item
      * change, and minting a pane to decide whether to show a button would be a side effect.
      *
-     * Override to `false` to declare this host serves no recreate.
+     * Override to `false` to declare this host serves no recreate; the action then hides for every
+     * pane without the contract.
      * @returns {Boolean}
      */
     hasDockRecreateFallback() {

--- a/test/playwright/component/dashboard/DockReload.spec.mjs
+++ b/test/playwright/component/dashboard/DockReload.spec.mjs
@@ -1,7 +1,8 @@
 import {test, expect} from '@playwright/test';
 
 /**
- * The engine-owned, delegation-only dock reload action
+ * The engine-owned dock reload action — delegation when the pane carries the contract, an engine
+ * recreate when it does not
  * (`Neo.dashboard.dock.Workspace#enableDockReloadAction`), witnessed on a rendered workspace:
  *
  * - **Delegation:** a pane implementing `dockReload()` is asked — invocation counted, instance
@@ -102,7 +103,7 @@ test.beforeEach(async ({page}) => {
     await page.waitForSelector('.neo-tab-header-button',   {state: 'visible'})
 });
 
-test.describe('dock reload — delegation-only, settled, single-flight', () => {
+test.describe('dock reload — delegation or engine recreate, settled, single-flight', () => {
     test('reload leads the engine set, focus-gated like its siblings', async ({page}) => {
         const main     = tabsNodeWith(page, 'Alpha'),
               reload   = actionButton(main, 'fa-rotate-right'),

--- a/test/playwright/e2e/dashboard/DockReloadActionNL.spec.mjs
+++ b/test/playwright/e2e/dashboard/DockReloadActionNL.spec.mjs
@@ -71,7 +71,7 @@ test.describe('Dock reload action — delegation into the pane (Neural Link)', (
     test.setTimeout(90000);
     test.use({ viewport: { width: 1600, height: 900 } });
 
-    test('the reload action asks the contract-bearing pane, commits nothing, and hides without the contract', async ({ page, neuralLink }) => {
+    test('the reload action asks the contract-bearing pane, commits nothing, and recreates the pane without the contract', async ({ page, neuralLink }) => {
         const { app, readModel } = await bootDockExample({ page, neuralLink }),
               before             = await readModel(),
               mainTabsId         = await tabsNodeId(app, 'main-tabs');

--- a/test/playwright/e2e/dashboard/DockReloadActionNL.spec.mjs
+++ b/test/playwright/e2e/dashboard/DockReloadActionNL.spec.mjs
@@ -1,7 +1,8 @@
 import { test, expect } from '../../fixtures.mjs';
 
 /**
- * Whitebox-e2e: the gesture proof for the engine-owned, delegation-only reload action.
+ * Whitebox-e2e: the gesture proof for the engine-owned reload action — delegation when the pane
+ * carries the contract, an engine recreate when it does not.
  *
  * The component battery proves the mechanics on a fixture; the product truths only this spec can
  * certify are
@@ -11,9 +12,10 @@ import { test, expect } from '../../fixtures.mjs';
  *      is a visible refresh counter),
  *   2. pressing it delegates INTO the pane — the counter advances where a user can read it — and
  *      commits nothing: the App Worker's dock document is byte-identical after the gesture,
- *   3. availability is the contract, not the flag: the very same node's header hides the action
- *      the moment a pane WITHOUT `dockReload()` holds the active slot, with the always-visible
- *      close action as the control arm proving the header itself is live.
+ *   3. availability is either path: the very same node's header keeps the action when a pane
+ *      WITHOUT `dockReload()` holds the active slot, and pressing it recreates that pane — a new
+ *      instance holds the slot, the document stays byte-identical — with the always-visible close
+ *      action as the control arm proving the header itself is live.
  *
  * Paradigm (whitebox-e2e protocol): Playwright drives the native clicks; the Neural Link fixture
  * reads the holder's committed `dockModel` and the pane's counter. Nothing here is committed
@@ -96,7 +98,7 @@ test.describe('Dock reload action — delegation into the pane (Neural Link)', (
         // The focus consequence, as its own settle surface: the engine set ungates in the DOM.
         await expect(page.locator(`#${reloadAction.id}`)).not.toHaveClass(/neo-toolbar-action-context-inactive/);
 
-        // Product truth #2: the gesture delegates into the pane — the counter is USER-VISIBLE.
+        // Product truth 2: the gesture delegates into the pane — the counter is USER-VISIBLE.
         await page.locator(`#${reloadAction.id}`).click();
         await expect(page.getByText('Strategy · reloaded 1×')).toBeVisible();
 
@@ -106,15 +108,33 @@ test.describe('Dock reload action — delegation into the pane (Neural Link)', (
         // …and commits nothing: the committed document is byte-identical after two gestures.
         expect(JSON.stringify(await readModel())).toBe(JSON.stringify(before));
 
-        // Product truth #3: availability is the contract, not the flag. Swarm implements no
-        // dockReload(), so the SAME header hides the action for it — while close (the gating
+        // Product truth 3: availability is either path. Swarm implements no dockReload(), so the
+        // SAME header keeps the action — the engine serves the recreate — while close (the gating
         // opt-out) stays visible on that focused header, proving the header itself is live.
         await focusPane(app, page, 'swarm');
 
         await expect.poll(async () => (await app.callMethod(mainTabsId, 'getActionItem', ['reload']))?.hidden, {
-            message: 'a pane without the contract hides the reload action',
+            message: 'a pane without the contract keeps the reload action',
             timeout: 10000
-        }).toBe(true);
+        }).toBe(false);
+
+        // The gesture recreates the pane: a NEW instance takes the active slot, and the committed
+        // document is still byte-identical — a recreate is presentation, never topology. The
+        // baseline is read AFTER the focus click: activating the Swarm tab was itself a committed
+        // `setActiveItem`, and that change belongs to the click, not to the recreate.
+        const swarmBefore = await app.callMethod(mainTabsId, 'getActiveCard', []),
+              swarmDoc    = JSON.stringify(await readModel());
+
+        expect(swarmBefore?.id, 'the Swarm pane holds the active slot').toBeTruthy();
+
+        await page.locator(`#${reloadAction.id}`).click();
+
+        await expect.poll(async () => (await app.callMethod(mainTabsId, 'getActiveCard', []))?.id, {
+            message: 'the recreate replaces the active pane instance',
+            timeout: 10000
+        }).not.toBe(swarmBefore.id);
+
+        expect(JSON.stringify(await readModel()), 'a recreate commits nothing').toBe(swarmDoc);
 
         const closeAction = await app.callMethod(mainTabsId, 'getActionItem', ['close']);
 


### PR DESCRIPTION
Resolves #18283

🌿 The reload journey can no longer certify a rule the engine retired, and three comments can no longer describe a pane as hidden that the engine has shown for three days.

The whitebox journey's third product truth asserted the delegation-only reload contract of 2026-08-31: a pane without `dockReload()` hides the action. `ce0634b62c` (#17996) amended the rule one day later — a pane without the contract keeps the action when a recreate path is wired, and the engine's default always wires one — so the arm has been red on `dev` with nothing in the spec changed. The arm now certifies the amended rule: the action stays visible on the contract-free Swarm pane, pressing it replaces the active pane instance while the committed document stays byte-identical, and close remains the control arm. The baseline document is read after the focus click, whose own `setActiveItem` commit belongs to the click, not to the recreate. Three durable comments that still described the retired rule now state the current one; `hasDockRecreateFallback` stays as the documented host opt-out, witnessed by `DockRecreateCandidate.spec.mjs:587–615`. No behaviour changes.

Evidence: L3 achieved (the rendered Neural Link gesture at the exact head, Brain runtime bound, red-first on the unchanged arm) → L3 required (AC-1); AC-2 is a diff-and-census claim; AC-3 is CI-covered. Residual: none.

## AC Evidence
| AC-1 | Outside CI: `NEO_AGENTOS_RUNTIME_ROOT=<brain> npx playwright test -c test/playwright/playwright.config.e2e.mjs e2e/dashboard/DockReloadActionNL --workers=1` → 1 passed at head; the same arm failed on the unchanged spec ("a pane without the contract hides the reload action") |
| AC-2 | Diff: the `enableDockReloadAction` config docblock, `Workspace#syncDockReloadAction`, `Workspace#handleDockReloadAction` and `Workspace#hasDockRecreateFallback` docblocks, `examples/dashboard/dock/MainContainer.mjs`'s `enableDockReloadAction` comment, the e2e spec header and test title, and the component spec's header and describe title all describe the amended rule. Census over `src examples apps test/playwright` for the token `delegation-only` AND the semantic counterphrases (`hides without the contract`, `hides the reload action`, `hidden on every pane that does not`, `without … dockReload … hid`) returns nothing — the first census was path-limited and token-only and missed three anchors the reviewer and the widened sweep found |
| AC-3 | CI-covered: `unit/dashboard/DockRecreateCandidate` + `unit/dashboard/DockWorkspace` 144 passed (the opt-out arm at `:587` included); `component/dashboard/DockReload` 11 passed |

## Deltas from ticket
The ticket's first body called `hasDockRecreateFallback` "a predicate that cannot answer `false`" and prescribed deleting it. `DockRecreateCandidate.spec.mjs:587–615` falsified that before any code moved: the predicate is the host's documented opt-out (declared refusal → hidden; engine default → visible; host factory → visible). The ticket body was corrected 14:40Z and the deletion dropped; this PR is a test rewrite plus doc truth-sync, no behaviour change.

## Test Evidence
Red-first: the unchanged arm fails at the `hidden === true` poll on pristine `dev@205bc52f8a` and on the branch base alike. Green at head: 1/1 with the Brain runtime bound; the recreate poll observed the active card's instance id change and the post-recreate document equal to the post-focus document. A first draft compared against the boot document and failed on exactly one field, `nodes.main-tabs.activeItemId: strategy → swarm` — the focus click's own commit — which is why the baseline moved after the click.

## Post-Merge Validation
None — every acceptance criterion is verified before merge.

Authored by Vega (Claude Fable 5.1, Claude Code). Session 4384828f-2650-4d28-b650-fac55eebec59.
