### PR TITLE
docs(themes): the exempt-state count is measured from the file that holds them (#18292)

### DIFF
--- a/buildScripts/util/check-theme-value-files-baseline.json
+++ b/buildScripts/util/check-theme-value-files-baseline.json
@@ -32,6 +32,6 @@
     {
         "file": "resources/scss/theme-neo-light/dialog/Base.scss",
         "blocks": 3,
-        "reason": "exempt #18145 — the structural rule outweighs 13 of the 16 button background states; the other 3 win on !important and need no token. Tokenising the 13 would close an open extension point. Measurement: #18145."
+        "reason": "exempt #18145 — of the 15 button background states in resources/scss/src/button/Base.scss, the structural rule outweighs 12; the other 3 (ghost/secondary/tertiary :active) win on !important and need no token. Tokenising the 12 would close an open extension point. Measurement: #18145."
     }
 ]


### PR DESCRIPTION
Resolves #18292

The dialog exemption's recorded state count did not match the file it describes. The exemption itself is unchanged.

Evidence: L2 (source enumeration + JSON parse + unchanged guard output) → L2 required (a baseline `reason` string has no runtime path to exercise). Residual: none.

## Deltas

| file | change |
|---|---|
| `buildScripts/util/check-theme-value-files-baseline.json` | one `reason` string: `13 of the 16` → `12` of `the 15 button background states in resources/scss/src/button/Base.scss`, and the three `!important` states named rather than counted |

One line. No code, no guard, no SCSS.

## AC Evidence

**AC-1 — the count matches a mechanical enumeration, and the reason names the file it runs against.** Rule blocks parsed out of the emitted `dist/esm/css/src/button/Base.css`, keeping only rules whose subject is the button itself (dropping `.neo-button-badge`, `-ripple`, `-glyph`, `-text`, which paint child elements):

```
button-own background-color states: 15
  winning on !important: 3
  decided by weight    : 12
```

Recorded was 16 / 13 / 3.

The reason now names **`resources/scss/src/button/Base.scss`** — the full path, checked to resolve rather than assumed:

```
path in reason: resources/scss/src/button/Base.scss
resolves from repo root: YES
```

The first revision of this PR wrote `src/button/Base.scss`, the shorthand that reads correctly from inside `resources/scss/` and **resolves nowhere from the repository root**. @neo-gpt caught it. A coordinate that does not resolve recreates precisely the ambiguity this change exists to remove, so the address is now verified with `git cat-file -e` rather than eyeballed.

**AC-2 — the three `!important` states are named, not counted.** `.neo-button.neo-button-{ghost,secondary,tertiary}:active`, at `resources/scss/src/button/Base.scss:205, 258, 317`.

**AC-3 — conclusion and guard output unchanged.** The structural rule is `:root .neo-theme-neo-light .neo-dialog .neo-header-toolbar .neo-button` = `(0,5,0)`; the heaviest of the 12 is `(0,3,0)`. It outweighs all of them, so the exemption stands.

**AC-4 — no re-expansion.** Previous reason ~1200 chars (cut after the verbosity challenge on #18264), current ~250, this one ~280. The correction did not buy its accuracy back in prose.

## Test Evidence

`buildScripts/util/check-theme-value-files.mjs` — identical before and after:

```
✓ theme value files declare variables only — 5 file(s) pending sweep, 2 exempt pending a decision.
exit=0
```

JSON parse check passes. No spec covers a `reason` string's contents and none should — the guard reads `file` and `blocks`, never the prose, so a spec asserting this text would test the fixture rather than the rule.

## Post-Merge Validation

**None owed.** Nothing about this change depends on the merge to become true: the count is measured, the path is verified to resolve, and the guard output is unchanged before and after.

The two decay observations that stood here previously were future revalidation triggers, not merge-dependent work, and leaving them as unchecked items made the residual posture ambiguous. They belong to #18292's own rationale rather than to this PR, and they are recorded there: if a future button variant adds a background state the count moves, which is the intended failure — the record now points at the file, so drift is one command from visible.

## One thing found in passing, deliberately not fixed

`--button-ghost-background-color-disabled` is declared in **both** neo theme value files and consumed by **nothing**. Ghost is the only variant with no disabled background rule; primary, secondary and tertiary all have one. Dangling token, unowned, claimable — out of scope here.

## Note for the reviewer

A local `dist/esm/css/theme-neo-light/dialog/Base.css` may show the **tokenised attempt** from #18264 — variables only, no selector block — while the source still carries the selector. It is a stale build artifact, not a source-vs-emit disagreement; it cost me a wrong read before I checked the mtime. Read the SCSS for the dialog side. The button side of the measurement is unaffected: nothing in this lane ever touched `resources/scss/src/button/`.

Refs #18145 — the parent sweep stays open, 3 files pending.

---

Authored by Grace (@neo-opus-grace, Claude Opus 5) · measured 2026-09-04 · branched from `dev@5a7cb7d1f1`
