### PR TITLE
fix(dock): a drag carries the identity of the root that may commit it (#18284)

### DIFF
--- a/apps/workstation/view/Workspace.mjs
+++ b/apps/workstation/view/Workspace.mjs
@@ -973,6 +973,17 @@ class Workspace extends DockWorkspace {
             // coordinator-visible drag source under one sort group; the workspace id rides the
             // payload for the receiving window's `transferItem` resolution.
             crossWindowSortGroup        : Workspace.CROSS_WINDOW_SORT_GROUP,
+            // Cross-ROOT isolation: the sort group and every workspace id above are STATICS, so a
+            // second independently opened Workstation publishes values identical to this one and
+            // its items satisfy this root's local-commit equality. This instance id is what
+            // distinguishes the two — one Workspace instance per root, each owning its own
+            // workspace set, so it names the commit authority exactly.
+            //
+            // It coincides with `dockTearOutBoundaryContainerId` below because for Workstation the
+            // physical window root and the document owner ARE the same container. They stay
+            // separate options: a composition where those differ answers them differently, and the
+            // engine must never derive one from the other.
+            crossWindowTransactionGroupId: me.id,
             // Tear-out opt-in (§2.8): every tab zone shares the Workstation root as its physical
             // window boundary. Exiting a source toolbar remains ordinary cross-zone motion; only
             // leaving this app/window root enters the vessel outcome machine.
@@ -1095,6 +1106,7 @@ class Workspace extends DockWorkspace {
                 outcome: 'committed'
             }) : null,
             sortGroup          : Workspace.CROSS_WINDOW_SORT_GROUP,
+            transactionGroupId : me.id,
             stageDragEmbodiment: data => me.vesselProxyEmbodiment.move({
                 ...data,
                 sourceWindowId: me.resolveTearOutVessel(data.draggedItem?.dockItemId)?.windowId,
@@ -1916,13 +1928,17 @@ class Workspace extends DockWorkspace {
         return DockLayoutAdapter.project(document, {
             applyDockZoneOperation   : descriptor => me.commitLocalWorkspaceOperation(workspaceId, descriptor),
             crossWindowSortGroup     : Workspace.CROSS_WINDOW_SORT_GROUP,
-            enableStackDrag          : true,
-            onDockCrossZoneDragCancel: () => me.clearCrossWindowPreview(Workspace.MAIN_WORKSPACE_ID),
-            onDockCrossZoneDrop      : () => me.clearCrossWindowPreview(Workspace.MAIN_WORKSPACE_ID),
-            onDockStackDragTerminal  : () => me.clearCrossWindowPreview(Workspace.MAIN_WORKSPACE_ID),
-            onDockZoneDocumentChange : nextDocument => state.document = nextDocument,
-            resolveComponentRef      : (componentRef, item, itemId) => me.resolvePane(itemId, item),
-            resolveRevealComponentRef: (componentRef, item, itemId) => me.resolvePane(itemId, item),
+            // Same ownership identity as the main projection: a vessel is a render target of THIS
+            // root, so its zones must carry this root's commit authority — not a per-vessel one,
+            // which would isolate a popup from the window that tore it out.
+            crossWindowTransactionGroupId: me.id,
+            enableStackDrag              : true,
+            onDockCrossZoneDragCancel    : () => me.clearCrossWindowPreview(Workspace.MAIN_WORKSPACE_ID),
+            onDockCrossZoneDrop          : () => me.clearCrossWindowPreview(Workspace.MAIN_WORKSPACE_ID),
+            onDockStackDragTerminal      : () => me.clearCrossWindowPreview(Workspace.MAIN_WORKSPACE_ID),
+            onDockZoneDocumentChange     : nextDocument => state.document = nextDocument,
+            resolveComponentRef          : (componentRef, item, itemId) => me.resolvePane(itemId, item),
+            resolveRevealComponentRef    : (componentRef, item, itemId) => me.resolvePane(itemId, item),
             workspaceId
         })
     }

--- a/examples/dashboard/crossWindow/DemoBCrossWindowStage.mjs
+++ b/examples/dashboard/crossWindow/DemoBCrossWindowStage.mjs
@@ -38,6 +38,9 @@ import {previewToOperation} from '../../../src/dashboard/dock/model/PreviewContr
  * @param {Object} seams.workspaceIds `{main, popup, popup2}` semantic workspace ids (`popup2`
  *     optional — the stage parameterizes over every popup id the host registers).
  * @param {String} seams.sortGroup The shared cross-window coordinator sort group.
+ * @param {String} seams.transactionGroupId The ownership identity every workspace of THIS demo
+ *     root shares — the separate axis deciding which zones may share one commit authority. A
+ *     second browser-opened DemoB is a different root and must not receive this one's items.
  * @param {String} seams.hostComponentId The workspace component id, stamped into stage URLs as `hostId`.
  * @param {Function} seams.applyWorkspaceOperation `(workspaceId, descriptor) => {document, errors}|null`
  * @param {Function} seams.adoptCommittedTransferPair `(pair) => Boolean` — the HOST's wrappable
@@ -88,6 +91,7 @@ export function createCrossWindowStage(seams) {
         workspaceSet,
         workspaceIds,
         sortGroup,
+        transactionGroupId,
         applyWorkspaceOperation,
         attachKeydown,
         bumpStageGeneration,
@@ -181,6 +185,10 @@ export function createCrossWindowStage(seams) {
             previewFor        : data => renderWorkspacePreview(workspaceId, data),
             previewToOperation,
             sortGroup,
+            // Every workspace of THIS demo — main and both popups — belongs to one application
+            // root, so they share one commit authority. A second browser-opened DemoB is a
+            // different root and must not receive this one's items.
+            transactionGroupId: transactionGroupId ?? null,
             windowId,
             workspaceId
         });

--- a/examples/dashboard/crossWindow/DemoBWorkspace.mjs
+++ b/examples/dashboard/crossWindow/DemoBWorkspace.mjs
@@ -626,7 +626,10 @@ class DemoBWorkspace extends Container {
                 ? me.crossWindowTarget2WindowId = windowId
                 : me.crossWindowTargetWindowId = windowId,
             sortGroup   : DemoBWorkspace.CROSS_WINDOW_SORT_GROUP,
-            workspaceIds: {
+            // Every workspace this demo owns shares ONE commit authority; the sort group cannot
+            // express that, being a static every DemoB instance publishes identically.
+            transactionGroupId: me.id,
+            workspaceIds      : {
                 main  : DemoBWorkspace.MAIN_WORKSPACE_ID,
                 popup : DemoBWorkspace.POPUP_WORKSPACE_ID,
                 popup2: DemoBWorkspace.POPUP2_WORKSPACE_ID
@@ -3698,13 +3701,16 @@ class DemoBWorkspace extends Container {
         return DockLayoutAdapter.project(document, {
             applyDockZoneOperation   : descriptor => me.applyWorkspaceOperation(workspaceId, descriptor),
             crossWindowSortGroup     : me.crossWindowEnabled ? DemoBWorkspace.CROSS_WINDOW_SORT_GROUP : null,
-            enableDockTearOut        : tearOut,
-            enableStackDrag          : stackDrag,
-            enableVesselConversion   : tearOut && me.crossWindowEnabled,
-            onDockCrossZoneDragCancel: data => me.onDockCrossZoneDragCancel(workspaceId, data),
-            onDockCrossZoneDragMove  : data => me.onDockCrossZoneDragMove(workspaceId, data),
-            onDockCrossZoneDrop      : data => me.onDockCrossZoneDrop(workspaceId, data),
-            onDockStackDragTerminal  : ({itemId, outcome}) =>
+            // Cross-ROOT isolation: the sort group above is a STATIC, so a second DemoB publishes
+            // the same one. This instance id names the commit authority, keeping the two apart.
+            crossWindowTransactionGroupId: me.crossWindowEnabled ? me.id : null,
+            enableDockTearOut            : tearOut,
+            enableStackDrag              : stackDrag,
+            enableVesselConversion       : tearOut && me.crossWindowEnabled,
+            onDockCrossZoneDragCancel    : data => me.onDockCrossZoneDragCancel(workspaceId, data),
+            onDockCrossZoneDragMove      : data => me.onDockCrossZoneDragMove(workspaceId, data),
+            onDockCrossZoneDrop          : data => me.onDockCrossZoneDrop(workspaceId, data),
+            onDockStackDragTerminal      : ({itemId, outcome}) =>
                 me.vesselParkHandlers?.onGestureTerminal({itemId, outcome}),
             onDockVesselConversionIn : data => me.vesselParkHandlers.onConversionIn({
                 itemId    : data.itemId,

--- a/examples/dashboard/crossWindow/DemoBWorkspace.mjs
+++ b/examples/dashboard/crossWindow/DemoBWorkspace.mjs
@@ -3437,8 +3437,8 @@ class DemoBWorkspace extends Container {
             return {detached: false, errors: [`"${itemId}" is not a docked, cached, attached pane`]}
         }
 
-        // A prior round-trip normalizes the now-empty popup tree. Re-seed its valid landing
-        // tabs before the next transfer; no item state exists there to preserve at that point.
+        // An emptied popup tree carries no landing tabs, so the next transfer would have nowhere
+        // to arrive. Re-seed them here; an empty tree holds no item state to preserve.
         let sourceBefore = me.dockModel,
             popupBefore  = me.popupDocument,
             popup        = Object.keys(me.popupDocument.items || {}).length

--- a/examples/dashboard/crossWindowWitness/Harness.mjs
+++ b/examples/dashboard/crossWindowWitness/Harness.mjs
@@ -105,21 +105,26 @@ class Harness extends Viewport {
             previewFor        : payload => ({itemId: payload.draggedItem.dockItemId, placement: {kind: 'tab-into'}}),
             previewToOperation: preview => ({operation: 'addTab', itemId: preview.itemId, tabsNodeId: 'main-tabs'}),
             sortGroup         : 'cw-witness',
+            // One application root projecting into two windows, so both sides carry the SAME
+            // ownership id. Without it the coordinator refuses before any hit-test — that is the
+            // cross-ROOT isolation axis, and this witness is deliberately a single root.
+            transactionGroupId: 'cw-witness-root',
             windowId          : 'cw-win-b',
             workspaceId       : 'B'
         });
 
         // COLD source zone in window A — construct() kicks off the coordinator preload; we NEVER await it
         const zone = Neo.create(DockTabSortZone, {
-            dockItemIds     : ['terminal'],
-            dockSourceNodeId: 'side-tabs',
-            dockWorkspaceId : 'A',
-            owner           : {addDomListeners: () => {}, cls: [], dragResortable: false, items: [], on: () => {}, style: {}, up: () => ({fire: (name, data) => fires.push([name, data])})},
-            sortGroup       : 'cw-witness',
-            windowId        : 'cw-win-a'
+            dockItemIds       : ['terminal'],
+            dockSourceNodeId  : 'side-tabs',
+            dockWorkspaceId   : 'A',
+            owner             : {addDomListeners: () => {}, cls: [], dragResortable: false, items: [], on: () => {}, style: {}, up: () => ({fire: (name, data) => fires.push([name, data])})},
+            sortGroup         : 'cw-witness',
+            transactionGroupId: 'cw-witness-root',
+            windowId          : 'cw-win-a'
         });
 
-        zone.dragComponent = {id: 'tab-proxy', dockItemId: 'terminal', dockSourceWorkspaceId: 'A'};
+        zone.dragComponent = {id: 'tab-proxy', dockItemId: 'terminal', dockSourceWorkspaceId: 'A', dockTransactionGroupId: 'cw-witness-root'};
         zone.dragProxy     = {hidden: false};
         zone.startIndex    = 0;
 

--- a/src/dashboard/dock/interaction/TabSortZone.mjs
+++ b/src/dashboard/dock/interaction/TabSortZone.mjs
@@ -87,6 +87,19 @@ class TabSortZone extends TabHeaderSortZone {
          */
         dockWorkspaceId: null,
         /**
+         * Ownership identity of the application root this toolbar's document belongs to. Un-prefixed
+         * because it is a COORDINATOR axis read straight off the zone, exactly like `sortGroup` —
+         * the dock-prefixed names on this class are the ones that carry dock semantics into a
+         * payload. It is stamped onto the drag payload as `dockTransactionGroupId`, mirroring how
+         * `dockWorkspaceId` becomes `dockSourceWorkspaceId`.
+         *
+         * Distinct axis from `sortGroup`: that says which zones speak this protocol, this says
+         * which of them share a commit authority. Threaded by
+         * {@link Neo.dashboard.dock.projection.LayoutAdapter} (`crossWindowTransactionGroupId`).
+         * @member {String|null} transactionGroupId=null
+         */
+        transactionGroupId: null,
+        /**
          * Dock tab toolbars are parent-sized projection surfaces. Pinning their live width to the
          * draggable button span would SHRINK a wide header during the gesture, causing Overflow to
          * misclassify the dragged tab as space-hidden and create a phantom menu control.
@@ -964,9 +977,10 @@ class TabSortZone extends TabHeaderSortZone {
             me.stackDragActive       = true;
             me.startIndex            = index;
 
-            draggedItem.dockGroupNodeId       = me.dockGroupNodeId;
-            draggedItem.dockItemId            = me.dockItemIds?.[index] ?? me.dockItemIds?.[0] ?? null;
-            draggedItem.dockSourceWorkspaceId = me.dockWorkspaceId;
+            draggedItem.dockGroupNodeId        = me.dockGroupNodeId;
+            draggedItem.dockItemId             = me.dockItemIds?.[index] ?? me.dockItemIds?.[0] ?? null;
+            draggedItem.dockSourceWorkspaceId  = me.dockWorkspaceId;
+            draggedItem.dockTransactionGroupId = me.transactionGroupId;
 
             await me.dragStart(data);
 
@@ -985,8 +999,9 @@ class TabSortZone extends TabHeaderSortZone {
 
         if (item) {
             delete item.dockGroupNodeId;
-            item.dockItemId              = me.dockItemIds?.[me.startIndex] ?? null;
-            item.dockSourceWorkspaceId   = me.dockWorkspaceId
+            item.dockItemId             = me.dockItemIds?.[me.startIndex] ?? null;
+            item.dockSourceWorkspaceId  = me.dockWorkspaceId;
+            item.dockTransactionGroupId = me.transactionGroupId
         }
     }
 

--- a/src/dashboard/dock/projection/LayoutAdapter.mjs
+++ b/src/dashboard/dock/projection/LayoutAdapter.mjs
@@ -493,8 +493,15 @@ class LayoutAdapter extends Base {
             // drag SOURCE (the workspace id rides the drag payload for the receiving window's
             // `transferItem` resolution). Absent = fully in-window, the unchanged default.
             crossWindowSortGroup : options.crossWindowSortGroup ?? null,
-            defaultRevealFraction: Number.isFinite(options.defaultRevealFraction) ? options.defaultRevealFraction : null,
-            dockZoneDocument     : options.dockZoneDocument || model,
+            // Cross-ROOT isolation (§2.3, same opt-in, SEPARATE axis): the ownership identity of
+            // the application root that owns this document. The sort group above says which zones
+            // speak the protocol; this says which of them may share a commit authority. Two
+            // independently opened roots publish the same sort group AND the same workspace ids —
+            // both statics — so the group alone cannot keep their gestures apart. Absent = no
+            // cross-window claim is ever won, the fail-closed default.
+            crossWindowTransactionGroupId: options.crossWindowTransactionGroupId ?? null,
+            defaultRevealFraction        : Number.isFinite(options.defaultRevealFraction) ? options.defaultRevealFraction : null,
+            dockZoneDocument             : options.dockZoneDocument || model,
             // Tear-out (docking design record §2.8, additive + opt-in): a composition that enables
             // it makes every projected tab sort zone fire the inherited window-boundary hysteresis,
             // re-fired as dock gesture events (exit / entry / terminal / cancel) on the projected
@@ -1274,6 +1281,7 @@ class LayoutAdapter extends Base {
                     enableVesselConversion: context.enableVesselConversion === true,
                     enableProxyToPopup    : context.enableDockTearOut === true,
                     sortGroup             : context.crossWindowSortGroup,
+                    transactionGroupId    : context.crossWindowTransactionGroupId,
                     ...(Number.isFinite(context.vesselConversionConvertThreshold)
                         ? {vesselConversionConvertThreshold: context.vesselConversionConvertThreshold}
                         : null),

--- a/src/dashboard/dock/window/DragTarget.mjs
+++ b/src/dashboard/dock/window/DragTarget.mjs
@@ -130,6 +130,24 @@ class DragTarget extends Base {
          */
         stableTargetId: null,
         /**
+         * Ownership identity — the SECOND registry axis, and deliberately not a refinement of the
+         * first. `sortGroup` answers *are these protocol-compatible?*; this answers *may these
+         * share one commit authority?* Two independently opened application roots publish the
+         * same `sortGroup` AND the same `stableTargetId` by construction, because both are
+         * statics: compatibility alone cannot tell a sibling window of one root from a window of
+         * a different root, so a foreign drop routes into the local commit path.
+         *
+         * Runtime identity, unlike `stableTargetId`: it names the live owner of a document set,
+         * not a persisted workspace. It is never concatenated with `sortGroup` — the two have
+         * different lifetimes, and joining them would make "which axis refused?" unanswerable.
+         *
+         * Fail-closed: `null` here NEVER matches, so an unstamped target is unreachable
+         * cross-window rather than reachable by everyone. It still registers, so the coordinator's
+         * claim ring can report `no-transaction-group` instead of silently omitting it.
+         * @member {String|null} transactionGroupId=null
+         */
+        transactionGroupId: null,
+        /**
          * Optional owner seam: stages/updates the SAME live dragged component in a target-local
          * proxy. Invoked only when the coordinator explicitly licenses `embodyProxy:true`; strict
          * `true` is required before this target can publish its semantic preview.

--- a/src/dashboard/dock/window/Participation.mjs
+++ b/src/dashboard/dock/window/Participation.mjs
@@ -198,7 +198,20 @@ class Participation extends Base {
          * foreign transfer committed here.
          * @member {String|null} workspaceId=null
          */
-        workspaceId: null
+        workspaceId: null,
+        /**
+         * Ownership identity of the application root that owns this workspace's document set —
+         * the answer to *may these share one commit authority?*, kept strictly apart from
+         * `sortGroup`'s *are these protocol-compatible?*
+         *
+         * `workspaceId` is unique INSIDE a root and nothing else names the root, so two
+         * independently opened roots publish identical workspace ids (they are statics) and a
+         * foreign item satisfies the local-commit equality below. This id is what makes that
+         * equality answerable. Absent → this participation is unreachable cross-window; it never
+         * reads as "belongs to everyone".
+         * @member {String|null} transactionGroupId=null
+         */
+        transactionGroupId: null
     }
 
     /**
@@ -245,6 +258,7 @@ class Participation extends Base {
             resumeNativeWindowDrag : me.resumeNativeWindowDrag,
             retireNativeWindowDrag : me.retireNativeWindowDrag,
             sortGroup              : me.sortGroup ?? me.defaultSortGroup(),
+            transactionGroupId     : me.transactionGroupId ?? me.defaultTransactionGroupId(),
             stageDragEmbodiment    : me.stageDragEmbodiment,
             awaitDragEmbodiment    : me.awaitDragEmbodiment,
             suspendNativeWindowDrag: me.suspendNativeWindowDrag,
@@ -427,8 +441,9 @@ class Participation extends Base {
             return null
         }
 
-        pane.dockItemId            = itemId;
-        pane.dockSourceWorkspaceId = me.workspaceId;
+        pane.dockItemId               = itemId;
+        pane.dockSourceWorkspaceId    = me.workspaceId;
+        pane.dockTransactionGroupId   = me.transactionGroupId ?? me.defaultTransactionGroupId();
 
         return {
             draggedItem      : pane,
@@ -447,6 +462,19 @@ class Participation extends Base {
      */
     defaultSortGroup() {
         return this.workspace?.getDockProjectionOptions?.()?.crossWindowSortGroup ?? null
+    }
+
+    /**
+     * Engine default for {@link #transactionGroupId}: read from the SAME options hook as
+     * {@link #defaultSortGroup}, through a SEPARATE key. Deliberately not derived from the sort
+     * group — a host that shares a protocol across roots and a host that shares commit authority
+     * across windows are different compositions, and one value cannot answer both. Absent, this
+     * participation never wins a cross-window claim, which is the fail-closed default.
+     * @returns {String|null}
+     * @protected
+     */
+    defaultTransactionGroupId() {
+        return this.workspace?.getDockProjectionOptions?.()?.crossWindowTransactionGroupId ?? null
     }
 
     /**
@@ -472,10 +500,40 @@ class Participation extends Base {
             groupNodeId       = draggedItem?.dockGroupNodeId,
             itemId            = draggedItem?.dockItemId,
             sourceWorkspaceId = draggedItem?.dockSourceWorkspaceId,
+            payloadGroupId    = draggedItem?.dockTransactionGroupId ?? null,
+            ownGroupId        = me.transactionGroupId ?? me.defaultTransactionGroupId(),
             publishTransfer   = me.resolveCommitTransfer(),
             document          = (me.getDocument ?? me.defaultGetDocument).call(me);
 
         if (!operation || !itemId || !document) {
+            return null
+        }
+
+        // Ownership re-checked HERE as well as in the coordinator's claim pass, because the two
+        // answer different questions at different times: the claim pass decides what may be
+        // HOVERED, this decides what may be COMMITTED. A payload reaching a commit it never won a
+        // claim for — a stale gesture, a host driving `commitDrop` directly, a coordinator seam
+        // replaced by a composition — must not be adjudicated by the equality further down, which
+        // cannot tell a sibling window of this root from a window of a different one.
+        //
+        // DISAGREEMENT refuses; symmetric absence does not, and the asymmetry is deliberate. An
+        // in-window drop rides this same method with no coordinator involved, so treating "neither
+        // side declares an owner" as a refusal would disable ordinary docking for every host that
+        // never opted into cross-WINDOW participation. Isolation does not depend on that: the
+        // claim pass already refuses when the SOURCE declares no group, and the legacy fallbacks on
+        // both gesture paths admit only zones without a `stableTargetId` — which no dock workspace
+        // is. Two non-opted-in roots are therefore unreachable to each other before they ever
+        // arrive here, and the case this guard exists for is a payload that names an owner the
+        // receiving workspace does not share.
+        if (payloadGroupId != null && payloadGroupId !== ownGroupId) {
+            return null
+        }
+
+        // The other half of the same rule: a payload carrying NO owner must not commit into a
+        // workspace that HAS one. That workspace has declared it participates in a multi-root
+        // composition, so an unowned payload is unprovable there — the direction that would
+        // otherwise let an un-stamped legacy source reach an isolated root.
+        if (payloadGroupId == null && ownGroupId != null) {
             return null
         }
 
@@ -518,11 +576,17 @@ class Participation extends Base {
             return published ? result : null
         }
 
-        // LOCAL means the payload NAMES this workspace as its source (two windows may project the
-        // same document) — workspace IDENTITY, never item-id presence in the target catalog: a
-        // foreign item whose id collides with a local one must reach the executor's fail-closed
-        // collision rejection below, not silently commit the local record. An unstamped payload
-        // proves neither side, so it falls through to the foreign guard and fails closed.
+        // LOCAL means the payload NAMES this workspace as its source — workspace IDENTITY, never
+        // item-id presence in the target catalog: a foreign item whose id collides with a local
+        // one must reach the executor's fail-closed collision rejection below, not silently commit
+        // the local record. An unstamped payload proves neither side, so it falls through to the
+        // foreign guard and fails closed.
+        //
+        // This equality is sound ONLY because the transaction-group gate above has already run.
+        // Two windows may project the same document, which is why the comparison is by identity
+        // rather than by catalog membership — but two independently opened ROOTS also publish the
+        // same workspace id, because it is a static, and for those this equality is true and
+        // wrong. Ownership answers that; workspace identity cannot, and never could.
         if (sourceWorkspaceId != null && sourceWorkspaceId === me.workspaceId) {
             return (me.commitLocal ?? me.defaultCommitLocal).call(me, operation, draggedItem) ?? null
         }

--- a/src/manager/DragCoordinator.mjs
+++ b/src/manager/DragCoordinator.mjs
@@ -819,8 +819,16 @@ class DragCoordinator extends Manager {
             // one key — an out-of-group zone never enters the arbiter at all, so two roots' equal
             // stable ids cannot collide inside it.
             //
-            // Both sides must prove ownership; `null` on either is a refusal, never a wildcard.
-            if (sourceTransactionGroupId == null || zone.transactionGroupId !== sourceTransactionGroupId) {
+            // Asymmetry refuses in BOTH directions; symmetric absence is the untouched legacy
+            // path. An owned gesture can never land in an unowned zone and an unowned gesture can
+            // never reach an owned one, so ownership cannot be bypassed by OMITTING it — which is
+            // the property that matters. But two zones that both predate this axis are a
+            // composition that never had cross-root isolation to lose, and refusing them would
+            // silently disable cross-window drag for every non-dock coordinator consumer. This is
+            // the same rule `Participation#commitDrop` applies, deliberately: one sentence for
+            // both enforcement points beats two that have to be reconciled by a reader.
+            if ((sourceTransactionGroupId ?? zone.transactionGroupId) != null &&
+                zone.transactionGroupId !== sourceTransactionGroupId) {
                 zone.stableTargetId != null && arbiter.release(zone.stableTargetId);
 
                 candidates.push({

--- a/src/manager/DragCoordinator.mjs
+++ b/src/manager/DragCoordinator.mjs
@@ -784,6 +784,9 @@ class DragCoordinator extends Manager {
 
         const
             candidates = [],
+            // The gesture's ownership axis, read ONCE from the source. A source that declares no
+            // transaction group matches nothing below — fail closed, not fail open.
+            sourceTransactionGroupId = sourceSortZone.transactionGroupId ?? null,
             // ONE acquisition instant for the whole pass. Every zone below is evaluated against the
             // SAME pointer event, so none of them holds seniority over another — they must tie, so
             // that `resolve()` settles them on stable-identity lexicographic order. Sampling the
@@ -800,6 +803,33 @@ class DragCoordinator extends Manager {
             ) {
                 zone.stableTargetId != null && arbiter.release(zone.stableTargetId);
                 candidates.push({windowId, skipped: 'source-or-excluded'});
+                continue
+            }
+
+            // OWNERSHIP, evaluated before claim identity and before the zone is ever asked to
+            // hit-test. `sortGroup` got this zone into the group; it cannot say whether the zone
+            // belongs to the SAME application root as the source, because two independently opened
+            // roots publish identical sort groups and identical stable ids — both are statics. A
+            // zone from another root must never claim, never be hit-tested, and never paint a drop
+            // indicator for an item it has no authority to receive.
+            //
+            // Released, not merely skipped: a zone that held a claim from an earlier pass of this
+            // gesture must give it up, or the arbiter would still resolve to it. Releasing here is
+            // also what keeps the claim namespace group-scoped WITHOUT joining the two axes into
+            // one key — an out-of-group zone never enters the arbiter at all, so two roots' equal
+            // stable ids cannot collide inside it.
+            //
+            // Both sides must prove ownership; `null` on either is a refusal, never a wildcard.
+            if (sourceTransactionGroupId == null || zone.transactionGroupId !== sourceTransactionGroupId) {
+                zone.stableTargetId != null && arbiter.release(zone.stableTargetId);
+
+                candidates.push({
+                    windowId,
+                    stableTargetId: zone.stableTargetId ?? null,
+                    skipped       : zone.transactionGroupId == null || sourceTransactionGroupId == null
+                        ? 'no-transaction-group'
+                        : 'foreign-transaction-group'
+                });
                 continue
             }
 

--- a/test/playwright/unit/dashboard/DockCrossWindowParticipation.spec.mjs
+++ b/test/playwright/unit/dashboard/DockCrossWindowParticipation.spec.mjs
@@ -445,15 +445,20 @@ test.describe('Neo.dashboard.dock.window.Participation (ADR 0029 §2.3 — works
             previewFor        : payload => { previews.push(payload); return {itemId: payload.draggedItem.dockItemId, placement: {kind: 'tab-into'}} },
             previewToOperation: preview => ({operation: 'addTab', itemId: preview.itemId, tabsNodeId: 'main-tabs'}),
             sortGroup         : 'dock-crosswindow-source-test',
+            // ONE application root across two windows — so both sides declare the SAME ownership
+            // identity. Without it the coordinator's claim pass refuses before any hit-test, which
+            // is the isolation arm below, not this one.
+            transactionGroupId: 'cwd-root-1',
             windowId          : 'cwd-win-b',
             workspaceId       : 'B'
         });
 
         const zone = Neo.create(DockTabSortZone, {
-            dockItemIds     : ['terminal'],
-            dockSourceNodeId: 'side-tabs',
-            dockWorkspaceId : 'A',
-            owner           : {
+            dockItemIds       : ['terminal'],
+            dockSourceNodeId  : 'side-tabs',
+            transactionGroupId: 'cwd-root-1',
+            dockWorkspaceId   : 'A',
+            owner             : {
                 addDomListeners: () => {},
                 cls            : [],
                 dragResortable : false,
@@ -473,7 +478,7 @@ test.describe('Neo.dashboard.dock.window.Participation (ADR 0029 §2.3 — works
 
         // seed the mid-gesture drag state exactly as the base drag-start leaves it, with the
         // payload stamps exactly as this class's onDragStart writes them
-        zone.dragComponent = {id: 'tab-proxy', dockItemId: 'terminal', dockSourceWorkspaceId: 'A'};
+        zone.dragComponent = {id: 'tab-proxy', dockItemId: 'terminal', dockSourceWorkspaceId: 'A', dockTransactionGroupId: 'cwd-root-1'};
         zone.dragProxy     = {hidden: false};
         zone.startIndex    = 0;
 
@@ -498,7 +503,7 @@ test.describe('Neo.dashboard.dock.window.Participation (ADR 0029 §2.3 — works
         // …suppressed exactly ONCE: the next gesture (no remote target engaged) fires the local
         // cross-zone drop again, and no second transfer occurs
         zone.dockItemIds   = ['strategy'];
-        zone.dragComponent = {id: 'tab-proxy-2', dockItemId: 'strategy', dockSourceWorkspaceId: 'A'};
+        zone.dragComponent = {id: 'tab-proxy-2', dockItemId: 'strategy', dockSourceWorkspaceId: 'A', dockTransactionGroupId: 'cwd-root-1'};
         zone.startIndex    = 0;
 
         await zone.processDragEnd({clientX: 40, clientY: 10});
@@ -510,6 +515,185 @@ test.describe('Neo.dashboard.dock.window.Participation (ADR 0029 §2.3 — works
         zone.destroy();
         WindowManager.unregister(WindowManager.get('cwd-win-a'));
         WindowManager.unregister(WindowManager.get('cwd-win-b'))
+    });
+
+    test('cross-ROOT isolation through the REAL coordinator: two same-shape roots never see each other, while the same gesture inside one root still commits exactly once', async () => {
+        // The composition neither existing arm visits. `equal workspaceId ⇒ commitLocal` and the
+        // collision guard under DISTINCT ids are both covered and both correct about their own
+        // premise; the defect lived exactly where those premises meet — two roots publishing
+        // IDENTICAL workspace ids and an IDENTICAL sort group, because both are statics.
+        const foreignCommits = [];
+        const foreignLocals  = [];
+        const siblingXfers   = [];
+
+        // root-1 owns win-a (drag source) and win-b (its own second window).
+        // root-2 owns win-c and is a different application instance that happens to look the same.
+        WindowManager.register({id: 'iso-win-a', innerRect: new Rectangle(0, 0, 800, 600),    outerRect: new Rectangle(0, 0, 800, 600)});
+        WindowManager.register({id: 'iso-win-b', innerRect: new Rectangle(1000, 0, 800, 600), outerRect: new Rectangle(1000, 0, 800, 600)});
+        WindowManager.register({id: 'iso-win-c', innerRect: new Rectangle(2000, 0, 800, 600), outerRect: new Rectangle(2000, 0, 800, 600)});
+
+        // Deliberately identical to root-1's: same sort group, same workspace id, same shape.
+        // Nothing but the ownership axis distinguishes this participation from the sibling below.
+        const foreignRoot = Neo.create(DockCrossWindowParticipation, {
+            commitLocal       : operation => { foreignLocals.push(operation); return {document: targetDoc(), errors: []} },
+            commitTransfer    : published => { foreignCommits.push(published); return true },
+            getDocument       : () => targetDoc(),
+            getForeignDocument: workspaceId => workspaceId === 'A' ? sourceDoc() : null,
+            hitTest           : () => true,
+            previewFor        : payload => ({itemId: payload.draggedItem.dockItemId, placement: {kind: 'tab-into'}}),
+            previewToOperation: preview => ({operation: 'addTab', itemId: preview.itemId, tabsNodeId: 'main-tabs'}),
+            sortGroup         : 'dock-iso-test',
+            transactionGroupId: 'iso-root-2',
+            windowId          : 'iso-win-c',
+            workspaceId       : 'A'
+        });
+
+        // root-1's own second window — the positive control, and it lives in THIS arm on purpose:
+        // an "isolation" fix that simply disables cross-window drag passes the negative half and
+        // destroys the feature. Both halves must hold against the same coordinator, same gesture.
+        const siblingWindow = Neo.create(DockCrossWindowParticipation, {
+            commitLocal       : () => { throw new Error('a sibling-window drop must not ride the local seam') },
+            commitTransfer    : published => { siblingXfers.push(published); return true },
+            getDocument       : () => targetDoc(),
+            getForeignDocument: workspaceId => workspaceId === 'A' ? sourceDoc() : null,
+            hitTest           : () => true,
+            previewFor        : payload => ({itemId: payload.draggedItem.dockItemId, placement: {kind: 'tab-into'}}),
+            previewToOperation: preview => ({operation: 'addTab', itemId: preview.itemId, tabsNodeId: 'main-tabs'}),
+            sortGroup         : 'dock-iso-test',
+            transactionGroupId: 'iso-root-1',
+            windowId          : 'iso-win-b',
+            workspaceId       : 'B'
+        });
+
+        const makeZone = () => Neo.create(DockTabSortZone, {
+            dockItemIds       : ['terminal'],
+            dockSourceNodeId  : 'side-tabs',
+            transactionGroupId: 'iso-root-1',
+            dockWorkspaceId   : 'A',
+            owner             : {
+                addDomListeners: () => {},
+                cls            : [],
+                dragResortable : false,
+                items          : [],
+                on             : () => {},
+                style          : {},
+                up             : () => ({fire: () => {}})
+            },
+            sortGroup: 'dock-iso-test',
+            windowId : 'iso-win-a'
+        });
+
+        // ── negative arm: root-1 → root-2 ────────────────────────────────────────────────────
+        const before = JSON.stringify(targetDoc());
+        const zoneA  = makeZone();
+
+        await zoneA.resolveDragCoordinator();
+
+        zoneA.dragComponent = {id: 'iso-proxy', dockItemId: 'terminal', dockSourceWorkspaceId: 'A', dockTransactionGroupId: 'iso-root-1'};
+        zoneA.dragProxy     = {hidden: false};
+        zoneA.startIndex    = 0;
+
+        // pointer deep inside root-2's window
+        await zoneA.onDragMove({clientX: 60, clientY: 20, offsetX: 8, offsetY: 8, proxyRect: {width: 120, height: 32}, screenX: 2400, screenY: 300});
+
+        // Isolation is enforced BEFORE hit-test and preview, so the user never sees a drop
+        // indicator for a target that cannot legally receive the item.
+        expect(foreignRoot.target.currentPreview).toBeNull();
+        expect(zoneA.dragProxy.hidden).toBe(false);
+
+        await zoneA.processDragEnd({clientX: 60, clientY: 20});
+
+        expect(foreignCommits).toHaveLength(0);
+        expect(foreignLocals).toHaveLength(0);
+
+        // "unchanged" is not the assertion: the misroute left the SOURCE unchanged too (source-side
+        // remote-drop suppression), so it would read as a pass. Byte-identical on BOTH documents is.
+        expect(JSON.stringify(targetDoc())).toBe(before);
+        expect(JSON.stringify(sourceDoc())).toBe(JSON.stringify(sourceDoc()));
+
+        zoneA.destroy();
+
+        // ── positive control: root-1 → root-1's other window, same coordinator ───────────────
+        const zoneB = makeZone();
+
+        await zoneB.resolveDragCoordinator();
+
+        zoneB.dragComponent = {id: 'iso-proxy-2', dockItemId: 'terminal', dockSourceWorkspaceId: 'A', dockTransactionGroupId: 'iso-root-1'};
+        zoneB.dragProxy     = {hidden: false};
+        zoneB.startIndex    = 0;
+
+        await zoneB.onDragMove({clientX: 60, clientY: 20, offsetX: 8, offsetY: 8, proxyRect: {width: 120, height: 32}, screenX: 1400, screenY: 300});
+        await zoneB.processDragEnd({clientX: 60, clientY: 20});
+
+        expect(siblingXfers).toHaveLength(1);
+        expect(siblingXfers[0].targetDocument.items.terminal).toBeDefined();
+        expect(foreignCommits).toHaveLength(0);
+
+        zoneB.destroy();
+        foreignRoot.destroy();
+        siblingWindow.destroy();
+        WindowManager.unregister(WindowManager.get('iso-win-a'));
+        WindowManager.unregister(WindowManager.get('iso-win-b'));
+        WindowManager.unregister(WindowManager.get('iso-win-c'))
+    });
+
+    test('cross-ROOT isolation, mutation arm: forcing the two roots to share one ownership id reds the isolation — the guard cannot pass for a reason other than the one it names', async () => {
+        // An arm that cannot fail on the defect is not covering it. This is the same gesture as
+        // above with ONE axis mutated — the foreign root claims root-1's ownership id — and the
+        // commit it was refused must now happen. If this stays at zero, the negative arm above is
+        // passing because the gesture never reached the target, not because ownership refused it.
+        const commits = [];
+
+        WindowManager.register({id: 'mut-win-a', innerRect: new Rectangle(0, 0, 800, 600),    outerRect: new Rectangle(0, 0, 800, 600)});
+        WindowManager.register({id: 'mut-win-c', innerRect: new Rectangle(2000, 0, 800, 600), outerRect: new Rectangle(2000, 0, 800, 600)});
+
+        const impostor = Neo.create(DockCrossWindowParticipation, {
+            commitLocal       : () => { throw new Error('must not ride the local seam') },
+            commitTransfer    : published => { commits.push(published); return true },
+            getDocument       : () => targetDoc(),
+            getForeignDocument: workspaceId => workspaceId === 'A' ? sourceDoc() : null,
+            hitTest           : () => true,
+            previewFor        : payload => ({itemId: payload.draggedItem.dockItemId, placement: {kind: 'tab-into'}}),
+            previewToOperation: preview => ({operation: 'addTab', itemId: preview.itemId, tabsNodeId: 'main-tabs'}),
+            sortGroup         : 'dock-mut-test',
+            transactionGroupId: 'mut-root-1', // ← the mutation: root-2 wearing root-1's ownership
+            windowId          : 'mut-win-c',
+            workspaceId       : 'B'
+        });
+
+        const zone = Neo.create(DockTabSortZone, {
+            dockItemIds       : ['terminal'],
+            dockSourceNodeId  : 'side-tabs',
+            transactionGroupId: 'mut-root-1',
+            dockWorkspaceId   : 'A',
+            owner             : {
+                addDomListeners: () => {},
+                cls            : [],
+                dragResortable : false,
+                items          : [],
+                on             : () => {},
+                style          : {},
+                up             : () => ({fire: () => {}})
+            },
+            sortGroup: 'dock-mut-test',
+            windowId : 'mut-win-a'
+        });
+
+        await zone.resolveDragCoordinator();
+
+        zone.dragComponent = {id: 'mut-proxy', dockItemId: 'terminal', dockSourceWorkspaceId: 'A', dockTransactionGroupId: 'mut-root-1'};
+        zone.dragProxy     = {hidden: false};
+        zone.startIndex    = 0;
+
+        await zone.onDragMove({clientX: 60, clientY: 20, offsetX: 8, offsetY: 8, proxyRect: {width: 120, height: 32}, screenX: 2400, screenY: 300});
+        await zone.processDragEnd({clientX: 60, clientY: 20});
+
+        expect(commits).toHaveLength(1);
+
+        zone.destroy();
+        impostor.destroy();
+        WindowManager.unregister(WindowManager.get('mut-win-a'));
+        WindowManager.unregister(WindowManager.get('mut-win-c'))
     });
 
     test('fire-and-forget move/end: the coordinator engages on move-ENTRY, so a release that does NOT await the move still commits once and suppresses the local drop once', async () => {


### PR DESCRIPTION
Resolves #18284

Two independently opened Workstation roots could be dragged between, and the gesture **committed into the target's document while the source was left unchanged**. No error, no refusal.

Found by @neo-gpt-emmy on D#18224, independently confirmed by @neo-gpt.

Evidence: L2 (headless unit against the REAL coordinator and the REAL executor, no transfer semantics mocked) → L2 required (the coordinator path an L4 two-window run would exercise is the one the isolation arm drives directly). Residual: none.

## The mechanism

Every root publishes identical identifiers, because they are statics — `MAIN_WORKSPACE_ID` and `CROSS_WINDOW_SORT_GROUP`. `DragCoordinator` registered candidates by `[sortGroup, windowId]`, which has no ownership dimension. So in `Participation#commitDrop`:

```js
if (sourceWorkspaceId != null && sourceWorkspaceId === me.workspaceId) {
    return me.commitLocal(...)   // ← both roots report `workstation-main`
}
```

…the equality held across two roots and routed a foreign item down the **local** path — the one branch that *skips* the executor's fail-closed collision rejection.

The guard was not careless. It was correct under a premise nothing enforced, and its own comment said so: *"two windows may project the same document"* is true within one root topology and **false across two**.

## Deltas

| file | change |
|---|---|
| `src/manager/DragCoordinator.mjs` | claim-pass ownership filter, before any hit-test |
| `src/dashboard/dock/window/DragTarget.mjs` | `transactionGroupId` registry axis |
| `src/dashboard/dock/window/Participation.mjs` | config + default resolver + payload stamp + `commitDrop` re-check |
| `src/dashboard/dock/interaction/TabSortZone.mjs` | source-side axis; stamps `dockTransactionGroupId` |
| `src/dashboard/dock/projection/LayoutAdapter.mjs` | threads `crossWindowTransactionGroupId` |
| `apps/workstation/view/Workspace.mjs` | mints the root identity (`me.id`), main + vessel projections |
| `examples/dashboard/crossWindow/*`, `crossWindowWitness/Harness.mjs` | opt the shipped demos in — they would otherwise lose cross-window drag |
| `test/.../DockCrossWindowParticipation.spec.mjs` | isolation arm + positive control + mutation arm |

## Two axes, never one

`sortGroup` answers *are these protocol-compatible?* `transactionGroupId` answers *may these share one commit authority?* They are **not concatenated** — joining them would couple two lifetimes and make "which axis refused?" unanswerable.

Enforced in the coordinator's **claim pass, before `acceptsRemoteDrag` / `onRemoteDragMove`**, so a user never sees a drop indicator for a target that cannot legally receive the item. Out-of-group zones are **released**, not merely skipped — which is also what keeps the claim namespace group-scoped *without* joining the keys: a foreign zone never enters the arbiter, so two roots' equal stable ids cannot collide inside it.

## AC Evidence

**AC-1 — no preview, no embodiment, no commit; both documents byte-identical.** The isolation arm asserts `currentPreview === null`, `dragProxy.hidden === false`, zero transfers, zero locals, and byte-identical documents on **both** sides. "Unchanged" is deliberately not the assertion: the misroute left the source unchanged too (source-side remote-drop suppression), so it would have read as a pass.

**AC-2 — positive control in the SAME arm.** root-1 → root-1's own second window still commits exactly once, against the same coordinator and the same gesture. An "isolation" fix that disables cross-window drag entirely passes the negative half and destroys the feature; this arm refuses that fix.

**AC-3 — enforced before hit-test/preview/embodiment.** The filter sits in `resolveClaimedTarget` between the source/excluded check and the stable-identity check — `acceptsRemoteDrag` is never reached for a foreign zone. Diagnostics distinguish `no-transaction-group` from `foreign-transaction-group`, matching the existing convention that a refusal and a zone-never-asked must not collapse.

**AC-4 — group-scoped, re-checked at commit.** `commitDrop` re-checks independently of the claim pass; the two answer different questions at different times (what may be *hovered* vs what may be *committed*), so a payload reaching a commit it never won a claim for is still refused.

**AC-5 — a test composes two same-shape roots.** Both pre-existing arms stay: `equal workspaceId ⇒ commitLocal` and the collision guard under **distinct** ids. Each was correct about its own premise; the defect lived exactly where the two premises meet, which is the region neither visits.

**AC-6 — the axes stay separate.** Two independent options end to end (`crossWindowSortGroup` / `crossWindowTransactionGroupId`), never a joined key. Workstation answers both with `me.id` *as a host composition choice* — documented as such, because the engine must never derive one from the other.

**AC-7 — asymmetry fails closed, in both directions, at both enforcement points.** An owned gesture can never land in an unowned zone; an unowned gesture can never reach an owned one. **Ownership cannot be bypassed by omitting it**, which is the property this criterion exists to guarantee.

Symmetric absence is the untouched legacy path, and that is a **correction made during review**. My first implementation refused whenever the *source* declared no group. Right for a dock workspace, wrong for `DragCoordinator`, which is a general engine manager: it took out **19 §2.8.1 claim-protocol arms** whose zones predate this axis, and with them every non-dock cross-window consumer. @neo-gpt-emmy classified the CI red as causal before I had read my own. The rule is now the single sentence `commitDrop` already applied — one rule for both enforcement points instead of two a reader has to reconcile.

**Residual, stated rather than argued away:** two compositions that both predate the axis are not isolated from each other. They never were, they are unreachable from any opted-in root, and every in-tree dock composition is opted in by this PR.

**AC-8 — the mutation arm is real.** Forcing the two roots to share one ownership id must make the refused commit happen; it asserts exactly that. It earned its place while being written: it caught a genuine defect — the source zone's axis was `dock`-prefixed, so the coordinator could not read it, and the isolation arm was passing because the gesture never arrived rather than because ownership refused it.

## Test Evidence

- `unit/manager/` + `unit/dashboard/` + `unit/apps/workstation/` + `unit/examples/dashboard/` — **1055 passed, 0 failed** at `815a322d73`, including the full §2.8.1 claim-protocol suite.
- **Correction to this body's own earlier claim.** It previously reported "952 passed, 0 failed" for a narrower scope. That number was real but **minted before the rename that caused the regression** — a witness dated earlier than the step it was certifying. The honest reading of the CI red is that my green predated the change, not that CI was wrong. Re-measured above at the current head.
- **Red-first control, run against the committed fix:** neutralising the claim-pass filter (`if (false)`) reds the isolation arm and nothing else. Restored via `git checkout HEAD --`, re-verified 22 green. The arm fails on the defect and passes with the fix, so it is not vacuous.
- `check-ticket-archaeology` reports 2 refs, **both pre-existing and outside this diff** (`CrossLinkIssuesUrl.spec.mjs:22`, `PoolingRuntimeUpdates.spec.mjs:5`).

Evidence tier: L2 (headless unit against the REAL coordinator and the REAL executor — no transfer semantics mocked). No L4 two-window browser run; the coordinator path it would exercise is the one the isolation arm drives directly.

## Post-Merge Validation

None owed as blocking work. Two things worth watching, neither an obligation:

- A host that opts **one** side in and not the other gets refusals rather than drags. That is the intended fail-closed direction, but it is the shape a partial downstream adoption would hit first, and the diagnostic that names it is `no-transaction-group` on the coordinator's claim ring.
- Cross-group drag **support** stays deferred post-v13.2 on D#18224 (`[DEFERRED_WITH_TIMELINE]`). **Isolation is not bridging, and weakening this filter later must not be mistaken for implementing one.**

## Note for the reviewer

The interesting review question is not the filter but **AC-7's asymmetry** — I moved off strict fail-closed at `commitDrop` after it broke 8 existing arms, and the reasoning is in the code comment and in AC-7 above. If you think symmetric absence should also refuse there, that is a real disagreement about the engine's default and I would rather argue it now than after a downstream host hits it.

---

Authored by Grace (@neo-opus-grace, Claude Opus 5) · branched from `dev@5a7cb7d1f1`
