### PR TITLE
fix(grid): a row forwards windowId to its pooled cell components (#18291)

### DIFF
--- a/src/grid/Row.mjs
+++ b/src/grid/Row.mjs
@@ -83,12 +83,7 @@ class Row extends Component {
      */
     afterSetMounted(value, oldValue) {
         super.afterSetMounted(value, oldValue);
-
-        if (this.components) {
-            for (const key in this.components) {
-                this.components[key].mounted = value
-            }
-        }
+        this.forwardToCells('mounted', value)
     }
 
     /**
@@ -99,10 +94,36 @@ class Row extends Component {
      */
     afterSetTheme(value, oldValue) {
         super.afterSetTheme(value, oldValue);
+        this.forwardToCells('theme', value)
+    }
 
-        if (this.components) {
-            for (const key in this.components) {
-                this.components[key].theme = value
+    /**
+     * Triggered after the windowId config got changed. A pooled cell that was created in one
+     * window must follow the row into the next one: a canvas cell re-transfers its node to the
+     * main thread of the window it believes it is in, and only the current id reaches a node.
+     * @param {String|null} value
+     * @param {String|null} oldValue
+     * @protected
+     */
+    afterSetWindowId(value, oldValue) {
+        super.afterSetWindowId(value, oldValue);
+        value && this.forwardToCells('windowId', value)
+    }
+
+    /**
+     * Relays one lifecycle config to every cell component this row owns. A row is a component,
+     * not a container, so the cascade `container.Base` performs for its items is done here by hand
+     * for the configs a pooled cell depends on: `mounted`, `theme` and `windowId`.
+     * @param {String} key
+     * @param {*} value
+     * @protected
+     */
+    forwardToCells(key, value) {
+        const {components} = this;
+
+        if (components) {
+            for (const cellKey in components) {
+                components[cellKey][key] = value
             }
         }
     }

--- a/test/playwright/e2e/utils/pngPixels.mjs
+++ b/test/playwright/e2e/utils/pngPixels.mjs
@@ -1,0 +1,149 @@
+import {inflateSync} from 'node:zlib';
+
+/**
+ * @summary Reads what a screenshot shows, for canvases whose pixels no page script can see.
+ *
+ * A canvas whose control was transferred to a worker (`transferControlToOffscreen`) displays the
+ * worker's frames, but reads as blank from the page: `drawImage(placeholder)` copies nothing and
+ * `getContext` is refused. The compositor still paints it, so an element screenshot is the one
+ * truthful read of "drawn or blank" — and Playwright hands that back as PNG bytes. This decodes
+ * the 8-bit, non-interlaced RGB/RGBA PNGs Playwright produces and counts how many pixels differ
+ * from the dominant colour, which on a cell canvas is its background.
+ */
+
+const SIGNATURE = [137, 80, 78, 71, 13, 10, 26, 10];
+
+/**
+ * @summary Decodes an 8-bit non-interlaced RGB or RGBA PNG into raw pixel bytes.
+ * @param {Buffer} buffer PNG bytes.
+ * @returns {{width: Number, height: Number, channels: Number, pixels: Buffer}}
+ */
+export function decodePng(buffer) {
+    SIGNATURE.forEach((byte, index) => {
+        if (buffer[index] !== byte) {
+            throw new Error('not a PNG')
+        }
+    });
+
+    let offset = 8,
+        bitDepth, colorType, height, interlace, width;
+
+    const idat = [];
+
+    while (offset < buffer.length) {
+        const
+            length = buffer.readUInt32BE(offset),
+            type   = buffer.toString('ascii', offset + 4, offset + 8),
+            data   = buffer.subarray(offset + 8, offset + 8 + length);
+
+        if (type === 'IHDR') {
+            width     = data.readUInt32BE(0);
+            height    = data.readUInt32BE(4);
+            bitDepth  = data[8];
+            colorType = data[9];
+            interlace = data[12]
+        } else if (type === 'IDAT') {
+            idat.push(data)
+        } else if (type === 'IEND') {
+            break
+        }
+
+        offset += 12 + length
+    }
+
+    if (bitDepth !== 8 || interlace !== 0 || (colorType !== 2 && colorType !== 6)) {
+        throw new Error(`unsupported PNG: bit depth ${bitDepth}, colour type ${colorType}, interlace ${interlace}`)
+    }
+
+    const
+        channels = colorType === 6 ? 4 : 3,
+        stride   = width * channels,
+        raw      = inflateSync(Buffer.concat(idat)),
+        pixels   = Buffer.alloc(stride * height);
+
+    let inPos = 0;
+
+    for (let y = 0; y < height; y++) {
+        const
+            filter    = raw[inPos++],
+            rowStart  = y * stride,
+            prevStart = (y - 1) * stride;
+
+        for (let x = 0; x < stride; x++) {
+            const
+                rawByte = raw[inPos++],
+                a       = x >= channels ? pixels[rowStart + x - channels] : 0,
+                b       = y > 0 ? pixels[prevStart + x] : 0,
+                c       = y > 0 && x >= channels ? pixels[prevStart + x - channels] : 0;
+
+            let value;
+
+            switch (filter) {
+                case 0: value = rawByte; break;
+                case 1: value = rawByte + a; break;
+                case 2: value = rawByte + b; break;
+                case 3: value = rawByte + ((a + b) >> 1); break;
+                case 4: {
+                    const
+                        p  = a + b - c,
+                        pa = Math.abs(p - a),
+                        pb = Math.abs(p - b),
+                        pc = Math.abs(p - c);
+
+                    value = rawByte + (pa <= pb && pa <= pc ? a : pb <= pc ? b : c);
+                    break
+                }
+                default: throw new Error(`unknown PNG filter ${filter}`)
+            }
+
+            pixels[rowStart + x] = value & 255
+        }
+    }
+
+    return {width, height, channels, pixels}
+}
+
+/**
+ * @summary Counts the pixels that differ from the screenshot's dominant colour.
+ *
+ * On a cell canvas the dominant colour is the background; anything drawn on it — a sparkline's
+ * polyline, its anti-aliased edges — counts as unlike. A blank canvas counts zero.
+ * @param {Buffer} buffer PNG bytes from `locator.screenshot()`.
+ * @param {Number} [tolerance=8] Per-channel distance below which a pixel still counts as the background.
+ * @returns {{width: Number, height: Number, total: Number, unlike: Number}}
+ */
+export function countPixelsUnlikeDominant(buffer, tolerance=8) {
+    const
+        {width, height, channels, pixels} = decodePng(buffer),
+        counts                            = new Map();
+
+    for (let i = 0; i < pixels.length; i += channels) {
+        const key = (pixels[i] << 16) | (pixels[i + 1] << 8) | pixels[i + 2];
+
+        counts.set(key, (counts.get(key) || 0) + 1)
+    }
+
+    let best = -1, dominant = 0;
+
+    counts.forEach((count, key) => {
+        if (count > best) {
+            best     = count;
+            dominant = key
+        }
+    });
+
+    const
+        dr = (dominant >> 16) & 255,
+        dg = (dominant >> 8)  & 255,
+        db = dominant & 255;
+
+    let unlike = 0;
+
+    for (let i = 0; i < pixels.length; i += channels) {
+        if (Math.abs(pixels[i] - dr) > tolerance || Math.abs(pixels[i + 1] - dg) > tolerance || Math.abs(pixels[i + 2] - db) > tolerance) {
+            unlike++
+        }
+    }
+
+    return {width, height, total: width * height, unlike}
+}

--- a/test/playwright/e2e/workstation/WorkstationPopOutSparklinesNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationPopOutSparklinesNL.spec.mjs
@@ -1,4 +1,5 @@
-import {test, expect} from '../../fixtures.mjs';
+import {test, expect}              from '../../fixtures.mjs';
+import {countPixelsUnlikeDominant} from '../utils/pngPixels.mjs';
 
 /**
  * @summary Whitebox E2E witness: the sparkline cells of a popped-out grid follow the grid into the
@@ -13,9 +14,15 @@ import {test, expect} from '../../fixtures.mjs';
  * created after the hop were stamped with the popup's id at creation and drew at once — which is why
  * this arm reads the cells that existed BEFORE the gesture, not only the ones present after it.
  *
- * Read through the Neural Link, not the DOM: a blank canvas and a drawn one are the same element to
- * a locator. `offscreenRegistered` is the App Worker's own record that the canvas worker owns the
- * node in the window the component believes it is in.
+ * Two boundaries, read separately. Ownership is read through the Neural Link: `offscreenRegistered`
+ * is the App Worker's own record that the canvas worker owns the node in the window the component
+ * believes it is in. Drawing is read from the popup page as an element screenshot of each travelled
+ * canvas, decoded and counted as pixels unlike the cell's background — a canvas whose control lives
+ * in a worker reads as blank from page script, a blank canvas and a drawn one are the same element
+ * to a locator, and the renderer records nothing the App Worker can be asked about.
+ *
+ * Runs in Playwright's default headless mode of the local Chrome channel the e2e config selects; no
+ * `--headed` is passed. The popup is a real second window either way.
  *
  * Run: NEO_AGENTOS_RUNTIME_ROOT=<abs path to neo-agent-brain> NEO_E2E_PORT=8152 \
  *      npx playwright test workstation/WorkstationPopOutSparklinesNL -c test/playwright/playwright.config.e2e.mjs --workers=1
@@ -27,9 +34,12 @@ const
     ACTION     = '.neo-toolbar-action',
     FEED_TITLE = 'Live Event Stream', // the Feed pane's tab title in the Workstation's boot document
     HEADER     = '.neo-tab-header-toolbar',
-    POP_OUT    = 'window-restore',
-    SPARKLINE  = 'Neo.component.Sparkline',
-    TAB        = '.neo-tab-header-button';
+    // A sparkline's polyline crosses a ~139px-wide cell; a blank canvas counts zero. Well below
+    // any drawn count, well above a stray border pixel.
+    MIN_DRAWN_PIXELS = 40,
+    POP_OUT          = 'window-restore',
+    SPARKLINE        = 'Neo.component.Sparkline',
+    TAB              = '.neo-tab-header-button';
 
 /** One record per live sparkline, in the shape the fixture returns for either wrapper. */
 const readSparklines = async app => {
@@ -76,6 +86,13 @@ test.describe('Workstation pop-out — sparkline cells follow the grid into the 
         const travelling = (await readSparklines(app)).filter(cell => cell.windowId === openerId).map(cell => cell.id),
               popOut     = header.locator(`${ACTION}:has(span[class*="${POP_OUT}"])`).first();
 
+        // The drawing instrument, validated on cells the opener visibly draws before the gesture: if
+        // the screenshot read cannot see a drawn sparkline here, it cannot certify one in the popup.
+        const drawnInOpener = countPixelsUnlikeDominant(await page.locator(`#${travelling[0]}`).screenshot());
+
+        expect(drawnInOpener.unlike, `the screenshot read sees a drawn sparkline in the opener (${drawnInOpener.width}×${drawnInOpener.height})`)
+            .toBeGreaterThanOrEqual(MIN_DRAWN_PIXELS);
+
         await expect(popOut, 'the Feed pane offers the pop-out action').toBeVisible({timeout: 10000});
 
         // Subscribed before the click: the vessel can open faster than the next await.
@@ -108,6 +125,26 @@ test.describe('Workstation pop-out — sparkline cells follow the grid into the 
         const strangers = (await readSparklines(app)).filter(cell => inVessel.has(cell.id) && cell.windowId !== popupId);
 
         expect(strangers, 'no canvas in the vessel still believes it is in the opener').toEqual([]);
+
+        // Registration is ownership, not drawing: the renderer's register/updateData/updateSize run
+        // in the Canvas worker afterwards and record nothing the App Worker can be asked about. The
+        // drawn result is observed where it lands — the pixels the popup DISPLAYS for each travelled
+        // canvas, read from an element screenshot, because a canvas whose control lives in a worker
+        // reads as blank from page script. Drawn = pixels unlike the cell's background.
+        await expect.poll(async () => {
+            const blank = [];
+
+            for (const id of travelled) {
+                const {unlike} = countPixelsUnlikeDominant(await vessel.locator(`#${id}`).screenshot());
+
+                unlike < MIN_DRAWN_PIXELS && blank.push(`${id}:${unlike}`)
+            }
+
+            return blank
+        }, {
+            message: 'every travelled sparkline is drawn in the popup — the Live column is not blank',
+            timeout: 15000
+        }).toEqual([]);
 
         await vessel.close({runBeforeUnload: true})
     })

--- a/test/playwright/e2e/workstation/WorkstationPopOutSparklinesNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationPopOutSparklinesNL.spec.mjs
@@ -1,0 +1,114 @@
+import {test, expect} from '../../fixtures.mjs';
+
+/**
+ * @summary Whitebox E2E witness: the sparkline cells of a popped-out grid follow the grid into the
+ * popup window and draw there.
+ *
+ * Measured against the running Workstation before the fix: the Feed pane — a `grid.Container` with a
+ * `sparkline` column — moved into a real popup as the same instance, every descendant in the items
+ * tree took the popup's `windowId`, and every sparkline canvas that travelled with the grid went
+ * blank. A grid row is a component, not a container, so the `windowId` cascade never reached the
+ * cell components a row pools; the travelled canvases kept the opener's id, re-transferred their
+ * nodes to the opener's main thread on remount, and never registered again. The cells the grid
+ * created after the hop were stamped with the popup's id at creation and drew at once — which is why
+ * this arm reads the cells that existed BEFORE the gesture, not only the ones present after it.
+ *
+ * Read through the Neural Link, not the DOM: a blank canvas and a drawn one are the same element to
+ * a locator. `offscreenRegistered` is the App Worker's own record that the canvas worker owns the
+ * node in the window the component believes it is in.
+ *
+ * Run: NEO_AGENTOS_RUNTIME_ROOT=<abs path to neo-agent-brain> NEO_E2E_PORT=8152 \
+ *      npx playwright test workstation/WorkstationPopOutSparklinesNL -c test/playwright/playwright.config.e2e.mjs --workers=1
+ *
+ * The runtime root is not optional: `playwright.config.e2e.mjs` ignores every neuralLink-fixture
+ * spec without it, so the command selects ZERO tests and reports success.
+ */
+const
+    ACTION     = '.neo-toolbar-action',
+    FEED_TITLE = 'Live Event Stream', // the Feed pane's tab title in the Workstation's boot document
+    HEADER     = '.neo-tab-header-toolbar',
+    POP_OUT    = 'window-restore',
+    SPARKLINE  = 'Neo.component.Sparkline',
+    TAB        = '.neo-tab-header-button';
+
+/** One record per live sparkline, in the shape the fixture returns for either wrapper. */
+const readSparklines = async app => {
+    const records = await app.findInstances({className: SPARKLINE}, ['id', 'windowId', 'offscreenRegistered', 'mounted']);
+
+    return (Array.isArray(records) ? records : [records]).filter(Boolean).map(record => record.properties ?? record)
+};
+
+/**
+ * Clicks a pane's tab by its title, which is how a user gives that pane focus, and returns the tab
+ * header toolbar that carries it — the surface the focus-gated action set renders into.
+ */
+const focusPane = async (page, title) => {
+    const header = page.locator(HEADER).filter({has: page.locator(TAB, {hasText: title})}).first();
+
+    await expect(header, `${title} must have a projected tab header`).toBeVisible({timeout: 30000});
+    await header.locator(TAB, {hasText: title}).first().click();
+
+    return header
+};
+
+test.describe('Workstation pop-out — sparkline cells follow the grid into the popup (Neural Link)', () => {
+    test.setTimeout(120000);
+    test.use({viewport: {width: 1600, height: 900}});
+
+    test('every sparkline that travelled with the Feed pane registers under the popup windowId and draws', async ({page, context, neuralLink}) => {
+        await page.goto('/apps/workstation/index.html');
+        await page.waitForSelector('.workstation-dock-host',            {timeout: 60000});
+        await page.waitForSelector('.neo-tab-header-button.neo-draggable', {timeout: 60000});
+
+        // A window's id lives on the main thread's worker manager, the same place `Main.mjs` reads
+        // it from when it hands a popup its native route.
+        const app      = await neuralLink.connectToApp('Workstation'),
+              openerId = await page.evaluate(() => Neo.worker.Manager.windowId);
+
+        expect(openerId, 'the opener knows its own window id').toBeTruthy();
+
+        // The cells that exist BEFORE the gesture are the ones the defect blanked; record them.
+        const header = await focusPane(page, FEED_TITLE);
+
+        await expect.poll(async () => (await readSparklines(app)).filter(cell => cell.windowId === openerId && cell.offscreenRegistered).length,
+            {message: 'the Feed pane draws its sparklines in the opener before the gesture', timeout: 15000}).toBeGreaterThan(0);
+
+        const travelling = (await readSparklines(app)).filter(cell => cell.windowId === openerId).map(cell => cell.id),
+              popOut     = header.locator(`${ACTION}:has(span[class*="${POP_OUT}"])`).first();
+
+        await expect(popOut, 'the Feed pane offers the pop-out action').toBeVisible({timeout: 10000});
+
+        // Subscribed before the click: the vessel can open faster than the next await.
+        const vesselPromise = context.waitForEvent('page', {timeout: 45000});
+
+        await popOut.click();
+
+        const vessel = await vesselPromise;
+
+        await vessel.waitForLoadState('domcontentloaded');
+        await vessel.waitForSelector('canvas', {timeout: 45000});
+
+        const popupId   = await vessel.evaluate(() => Neo.worker.Manager.windowId),
+              inVessel  = new Set(await vessel.evaluate(() => [...document.querySelectorAll('canvas')].map(canvas => canvas.id))),
+              travelled = travelling.filter(id => inVessel.has(id));
+
+        expect(popupId, 'the vessel is its own window').not.toBe(openerId);
+        expect(travelled.length, 'at least one pre-existing sparkline cell travelled into the vessel').toBeGreaterThan(0);
+
+        // The witness: a canvas that travelled belongs to the popup's window in the App Worker's
+        // own record and has re-registered there. Before the fix every travelled cell kept the
+        // opener's id and `offscreenRegistered` stayed false for good.
+        await expect.poll(async () => {
+            const cells = (await readSparklines(app)).filter(cell => travelled.includes(cell.id));
+
+            return cells.length === travelled.length && cells.every(cell => cell.windowId === popupId && cell.offscreenRegistered === true && cell.mounted === true)
+        }, {message: 'every travelled sparkline carries the popup windowId, is mounted and registered', timeout: 10000}).toBe(true);
+
+        // And every canvas the vessel shows, travelled or created after the hop, belongs to it.
+        const strangers = (await readSparklines(app)).filter(cell => inVessel.has(cell.id) && cell.windowId !== popupId);
+
+        expect(strangers, 'no canvas in the vessel still believes it is in the opener').toEqual([]);
+
+        await vessel.close({runBeforeUnload: true})
+    })
+});

--- a/test/playwright/unit/grid/RowWindowIdForwarding.spec.mjs
+++ b/test/playwright/unit/grid/RowWindowIdForwarding.spec.mjs
@@ -1,0 +1,90 @@
+import {setup} from '../../setup.mjs';
+
+setup({
+    appConfig: {
+        name: 'NeoGridRowWindowIdForwardingTest'
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../src/Neo.mjs';
+import * as core      from '../../../../src/core/_export.mjs';
+import Canvas         from '../../../../src/component/Canvas.mjs';
+import Component      from '../../../../src/component/Base.mjs';
+import Row            from '../../../../src/grid/Row.mjs';
+import '../../../../src/manager/Instance.mjs';
+
+/**
+ * A grid row is a component, not a container, so the `windowId` cascade `container.Base` performs
+ * for its items does not reach the cell components a row owns in `components`. After a cross-window
+ * move every row carries the new id and every pooled cell keeps the old one; a canvas cell then
+ * re-transfers its node to the opener's main thread on remount, where the node no longer exists,
+ * and never registers again. The row already relays `mounted` and `theme` by hand; `windowId` is
+ * the third config the same relay must carry.
+ */
+const APP = 'NeoGridRowWindowIdForwardingTest';
+
+test.describe('Neo.grid.Row forwards windowId to its cell components', () => {
+    let cell, row;
+
+    test.afterEach(() => {
+        cell?.destroy?.();
+        row?.destroy?.();
+        cell = row = null
+    });
+
+    test('a component cell takes the row\'s new windowId, as it already takes its theme', () => {
+        row  = Neo.create(Row,       {appName: APP, windowId: 'w1'});
+        cell = Neo.create(Component, {appName: APP, windowId: 'w1', parentComponent: row});
+
+        row.components = {live: cell};
+
+        row.windowId = 'w2';
+        expect(cell.windowId, 'the pooled cell follows the row into the new window').toBe('w2');
+
+        // The sibling relay, as the control: theme has forwarded since the pool existed.
+        row.theme = 'neo-theme-dark';
+        expect(cell.theme).toBe('neo-theme-dark')
+    });
+
+    test('a canvas cell drops its registration on the id change and re-registers with the new windowId on remount', async () => {
+        const transfers      = [],
+              mainThread     = Neo.main ??= {},
+              workers        = Neo.worker ??= {},
+              originalAccess = mainThread.DomAccess,
+              originalCanvas = workers.Canvas;
+
+        // The single-thread unit run has neither a main thread nor a canvas worker: record the
+        // transfer and answer it the way the addon does, by resolving the component's registration
+        // callback for that node; accept the unregister a registered canvas issues on teardown.
+        mainThread.DomAccess = {
+            transferCanvasToWorker(opts) {
+                transfers.push(opts);
+                Neo.getComponent(opts.componentId)?.registerCanvasCallbacks?.[opts.nodeId]?.()
+            }
+        };
+        workers.Canvas = {unregisterCanvas() {}};
+
+        try {
+            row  = Neo.create(Row,    {appName: APP, windowId: 'w1'});
+            cell = Neo.create(Canvas, {appName: APP, windowId: 'w1', monitorSize: false, offscreenRegistered: true, parentComponent: row});
+
+            row.components = {live: cell};
+
+            row.windowId = 'w2';
+            expect(cell.windowId).toBe('w2');
+            expect(cell.offscreenRegistered, 'a new window invalidates the old registration').toBe(false);
+
+            cell.mounted = true;
+
+            await expect.poll(() => transfers.length, {message: 'the remount transfers the canvas once'}).toBe(1);
+            expect(transfers[0].windowId, 'to the new window, not the opener').toBe('w2');
+            await expect.poll(() => cell.offscreenRegistered, {message: 'and the registration completes'}).toBe(true)
+        } finally {
+            cell?.destroy?.();
+            cell = null;
+            mainThread.DomAccess = originalAccess;
+            workers.Canvas       = originalCanvas
+        }
+    });
+});


### PR DESCRIPTION
Resolves #18291

🌿 A grid can no longer leave its sparklines behind in the window it came from.

A grid row is a component, not a container, so the `windowId` cascade `container.Base` performs for its items never reached the cell components a row pools. After a cross-window move every row carried the new id and every pooled cell kept the old one; a canvas cell then re-transferred its node to the opener's main thread on remount, where the node no longer existed, and never registered again — every sparkline that travelled with a popped-out grid went blank while the cells created after the hop drew. The row already relayed `mounted` and `theme` by hand; `windowId` is now the third config on the same relay, and the three loops fold into one `forwardToCells(key, value)` helper.

Evidence: unit tier for AC-1, AC-2 and AC-4 in CI; AC-3 is a Neural Link journey outside CI, run locally against the Brain runtime — red against the dev row, green with the relay. Residual: none.

## Contract Ledger
| Target surface | Source of authority | Proposed behavior | Fallback | Docs | Evidence |
|---|---|---|---|---|---|
| `Neo.grid.Row#afterSetWindowId` (new) | `container.Base#afterSetWindowId` cascade contract (`src/container/Base.mjs:319`); the row's own `mounted` relay | Every component in `row.components` takes the row's new `windowId` when one is set; the row's `mounted` and `theme` relays are unchanged and share the helper | None needed — a cell without window-scoped main-thread state ignores the write | `Row.mjs` hook and helper docblocks | `unit/grid/RowWindowIdForwarding.spec.mjs` (component cell follows; canvas cell re-registers with the new id); `e2e/workstation/WorkstationPopOutSparklinesNL.spec.mjs` |

## AC Evidence
| AC-1 | CI-covered: `test/playwright/unit/grid/RowWindowIdForwarding.spec.mjs` — "a component cell takes the row's new windowId, as it already takes its theme" (red on the unchanged row: `w1`; green: `w2`) |
| AC-2 | CI-covered: same spec — "a canvas cell drops its registration on the id change and re-registers with the new windowId on remount" (`transferCanvasToWorker` stub receives `windowId: 'w2'` once; `offscreenRegistered` false after the id change, true after the remount) |
| AC-3 | Outside CI (headless Chrome channel, `--headed` not passed): `NEO_AGENTOS_RUNTIME_ROOT=<brain> npx playwright test -c test/playwright/playwright.config.e2e.mjs e2e/workstation/WorkstationPopOutSparklinesNL --workers=1` → 1 passed at head, with BOTH boundaries asserted — ownership (`windowId`, `mounted`, `offscreenRegistered` through the Neural Link) and drawing (each travelled canvas's displayed bitmap has painted pixels, read from the popup page); with `src/grid/Row.mjs` checked out from `origin/dev` the arm fails at the ownership poll and the travelled bitmaps stay blank |
| AC-4 | CI-covered: `unit/grid` 92 passed (the `mounted`/`theme` relays now run through the shared helper); `component/grid` + `component/container/CardGridContainment` 11 passed |

## Deltas from ticket
The ticket's headed AC pointed at an untracked popup-birth spec on another seat's host. A permanent Neural Link e2e arm on the Workstation's Feed pane replaces it, so the evidence lives in the tree. Two instrument facts it cost runs to learn: the main thread exposes the window id on `Neo.worker.Manager.windowId`, not on `Neo.config`; and a canvas whose control lives in a worker reads as blank from page script (`drawImage` of the placeholder copies nothing), so the draw side is read from element screenshots decoded by a new small helper, `test/playwright/e2e/utils/pngPixels.mjs` (8-bit non-interlaced RGB/RGBA, pixels unlike the dominant colour), and the arm validates that instrument on the opener's drawn cells before it judges the popup — a blind read fails there instead of passing.

## Test Evidence
Neural Link e2e tier in Playwright's default headless mode of the local Chrome channel (`--headed` not passed; the popup is a real second window either way), Brain runtime bound, `--workers=1`: the arm records the `Neo.component.Sparkline` cells that exist before the gesture, pops the Feed pane out through the production `window-restore` action, and reads two boundaries — ownership through the Neural Link (`windowId`, `mounted`, `offscreenRegistered` in the App Worker's own record) and drawing from the popup page (an element screenshot of each travelled canvas, decoded by `pngPixels.mjs` and counted as pixels unlike the cell's background; a canvas whose control lives in a worker reads as blank from page script, so no scratch-canvas copy can see it). Control at the same head with the dev row: the pre-gesture cells that appear in the popup keep the opener's `windowId`, `offscreenRegistered` stays false for the full 10 s poll, and their bitmaps stay blank. With the relay: every such cell carries the popup's id, is mounted and registered, and has painted pixels; no canvas in the popup still believes it is in the opener.

## Post-Merge Validation
None — every acceptance criterion is verified before merge.

## Commits (if multi-commit)
- `efc13470a6` — the relay and the two unit arms
- `b1e2c390e0` — the headed Workstation witness

Authored by Vega (Claude Fable 5.1, Claude Code). Session 4384828f-2650-4d28-b650-fac55eebec59.
