### PR TITLE
fix(grid): hover-sync suspend and resume carry the windowId they are routed on (#18295)

### DIFF
--- a/src/grid/ScrollManager.mjs
+++ b/src/grid/ScrollManager.mjs
@@ -221,29 +221,39 @@ class ScrollManager extends Base {
     }
 
     /**
-     * @param {String|null} [windowId=this.windowId]
+     * Calls one method of the row-hover-sync addon in the window this manager renders in. The
+     * payload carries `windowId` because a remote method call is routed on it: without the key the
+     * message falls back to the first connected port, which in a popup is the opener — an addon
+     * that holds no registration for this grid, while the one that does is never told.
+     * @param {String} method `'suspendHover'` | `'resumeHover'`
+     * @param {String|null} windowId
      * @returns {Promise<void>}
+     * @protected
      */
-    async resumeGridRowHoverSyncAddon(windowId = this.windowId) {
-        let me = this,
+    async callGridRowHoverSyncAddon(method, windowId) {
+        let me    = this,
             addon = await Neo.currentWorker.getAddon('GridRowHoverSync', windowId);
 
-        addon.resumeHover({
-            id: me.id
-        });
+        addon[method]({
+            id: me.id,
+            windowId
+        })
     }
 
     /**
      * @param {String|null} [windowId=this.windowId]
      * @returns {Promise<void>}
      */
-    async suspendGridRowHoverSyncAddon(windowId = this.windowId) {
-        let me = this,
-            addon = await Neo.currentWorker.getAddon('GridRowHoverSync', windowId);
+    resumeGridRowHoverSyncAddon(windowId = this.windowId) {
+        return this.callGridRowHoverSyncAddon('resumeHover', windowId)
+    }
 
-        addon.suspendHover({
-            id: me.id
-        });
+    /**
+     * @param {String|null} [windowId=this.windowId]
+     * @returns {Promise<void>}
+     */
+    suspendGridRowHoverSyncAddon(windowId = this.windowId) {
+        return this.callGridRowHoverSyncAddon('suspendHover', windowId)
     }
 
     /**

--- a/test/playwright/e2e/workstation/WorkstationPopOutHoverSyncNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationPopOutHoverSyncNL.spec.mjs
@@ -9,7 +9,9 @@ import {test, expect} from '../../fixtures.mjs';
  * scroll manager resolved the hover-sync addon for its own window but called it without the key, so
  * a scroll in the popup reached the opener's addon — which holds no registration for that grid —
  * while the popup's addon, which does, heard nothing. In one window the misroute is invisible
- * beyond a deprecation warning; two windows make it observable, which is what this arm does.
+ * beyond a deprecation warning; two windows make it observable, which is what this arm does. The
+ * warning is App Worker console output, which the Neural Link session forwards, so the arm also reads
+ * its count for the addon before and after the judged scroll.
  *
  * The addon keeps no "suspended" flag to ask about, so the arm counts the two calls where they land:
  * the main-thread addon instance in each window has its `suspendHover` / `resumeHover` wrapped with a
@@ -31,7 +33,8 @@ const
     HEADER     = '.neo-tab-header-toolbar',
     POP_OUT    = 'window-restore',
     TAB        = '.neo-tab-header-button',
-    VIEW       = '.neo-grid-view';
+    VIEW       = '.neo-grid-view',
+    WARNING    = 'destination "main" is deprecated'; // worker/Base#sendMessage, on a call it routes to the first port
 
 /**
  * Wraps the window's hover-sync addon so every suspend and resume it receives is counted; the
@@ -60,6 +63,16 @@ const countAddonCalls = (page, addonName) => page.evaluate(name => {
 
 const readAddonCalls = (page, addonName) => page.evaluate(name => Neo.main?.addon?.[name]?.__hoverSyncCalls ?? null, addonName);
 
+/**
+ * Counts the worker's deprecated-destination warnings that name the addon: the warning's second
+ * argument is the routed payload, stringified, so the addon's class name is in the message.
+ */
+const countHoverSyncWarnings = async (app, addonName) => {
+    const logs = await app.getConsoleLogs('warn', addonName);
+
+    return logs.filter(log => log.message.includes(WARNING)).length
+};
+
 /** Clicks a pane's tab by its title and returns the tab header toolbar that carries it. */
 const focusPane = async (page, title) => {
     const header = page.locator(HEADER).filter({has: page.locator(TAB, {hasText: title})}).first();
@@ -79,7 +92,7 @@ test.describe('Workstation pop-out — hover sync follows the grid into the popu
         await page.waitForSelector('.workstation-dock-host',            {timeout: 60000});
         await page.waitForSelector('.neo-tab-header-button.neo-draggable', {timeout: 60000});
 
-        await neuralLink.connectToApp('Workstation');
+        const app = await neuralLink.connectToApp('Workstation');
 
         const header = await focusPane(page, FEED_TITLE),
               popOut = header.locator(`${ACTION}:has(span[class*="${POP_OUT}"])`).first();
@@ -130,6 +143,11 @@ test.describe('Workstation pop-out — hover sync follows the grid into the popu
         expect(await countAddonCalls(page,   ADDON), 'the opener addon is counted').toBe(true);
         expect(await countAddonCalls(vessel, ADDON), 'the popup addon is counted').toBe(true);
 
+        // Both warm-up scrolls carried the routing key, so no hover-sync warning has been logged yet.
+        const warningsBefore = await countHoverSyncWarnings(app, ADDON);
+
+        expect(warningsBefore, 'the warm-up scrolls log no deprecated-destination warning for the hover-sync addon').toBe(0);
+
         // The judged scroll: one real wheel scroll over the popup's grid view.
         await vessel.mouse.wheel(0, 240);
 
@@ -140,6 +158,11 @@ test.describe('Workstation pop-out — hover sync follows the grid into the popu
             .toEqual(expect.arrayContaining(['suspendHover', 'resumeHover']));
 
         expect(await readAddonCalls(page, ADDON), 'the opener addon hears nothing about the popup\'s scroll').toEqual([]);
+
+        // A worker round-trip on the session's connection orders this read after the scroll's console output.
+        await app.checkNamespace('Neo.grid.ScrollManager');
+
+        expect(await countHoverSyncWarnings(app, ADDON), 'the judged scroll logs no deprecated-destination warning for the hover-sync addon').toBe(warningsBefore);
 
         await vessel.close({runBeforeUnload: true})
     })

--- a/test/playwright/e2e/workstation/WorkstationPopOutHoverSyncNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationPopOutHoverSyncNL.spec.mjs
@@ -1,0 +1,146 @@
+import {test, expect} from '../../fixtures.mjs';
+
+/**
+ * @summary Whitebox E2E witness: a scroll inside a popped-out grid suspends and resumes hover sync
+ * in the popup's window, and the opener's addon is never told.
+ *
+ * A remote method call to a main-thread addon is routed on the payload's `windowId`; without one the
+ * App Worker falls back to the first connected port, which after a pop-out is the opener. The grid's
+ * scroll manager resolved the hover-sync addon for its own window but called it without the key, so
+ * a scroll in the popup reached the opener's addon — which holds no registration for that grid —
+ * while the popup's addon, which does, heard nothing. In one window the misroute is invisible
+ * beyond a deprecation warning; two windows make it observable, which is what this arm does.
+ *
+ * The addon keeps no "suspended" flag to ask about, so the arm counts the two calls where they land:
+ * the main-thread addon instance in each window has its `suspendHover` / `resumeHover` wrapped with a
+ * counter before the popup grid is scrolled. Nothing else is patched, and the wrappers call through.
+ *
+ * Runs in Playwright's default headless mode of the local Chrome channel the e2e config selects; no
+ * `--headed` is passed. The popup is a real second window either way.
+ *
+ * Run: NEO_AGENTOS_RUNTIME_ROOT=<abs path to neo-agent-brain> NEO_E2E_PORT=8153 \
+ *      npx playwright test workstation/WorkstationPopOutHoverSyncNL -c test/playwright/playwright.config.e2e.mjs --workers=1
+ *
+ * The runtime root is not optional: `playwright.config.e2e.mjs` ignores every neuralLink-fixture
+ * spec without it, so the command selects ZERO tests and reports success.
+ */
+const
+    ACTION     = '.neo-toolbar-action',
+    ADDON      = 'GridRowHoverSync',
+    FEED_TITLE = 'Live Event Stream', // the Feed pane's tab title in the Workstation's boot document
+    HEADER     = '.neo-tab-header-toolbar',
+    POP_OUT    = 'window-restore',
+    TAB        = '.neo-tab-header-button',
+    VIEW       = '.neo-grid-view';
+
+/**
+ * Wraps the window's hover-sync addon so every suspend and resume it receives is counted; the
+ * wrappers call through, so the addon's behaviour is unchanged. Returns whether the addon existed.
+ */
+const countAddonCalls = (page, addonName) => page.evaluate(name => {
+    const addon = Neo.main?.addon?.[name];
+
+    if (!addon) {
+        return false
+    }
+
+    addon.__hoverSyncCalls = [];
+
+    ['resumeHover', 'suspendHover'].forEach(method => {
+        const original = addon[method].bind(addon);
+
+        addon[method] = payload => {
+            addon.__hoverSyncCalls.push(method);
+            return original(payload)
+        }
+    });
+
+    return true
+}, addonName);
+
+const readAddonCalls = (page, addonName) => page.evaluate(name => Neo.main?.addon?.[name]?.__hoverSyncCalls ?? null, addonName);
+
+/** Clicks a pane's tab by its title and returns the tab header toolbar that carries it. */
+const focusPane = async (page, title) => {
+    const header = page.locator(HEADER).filter({has: page.locator(TAB, {hasText: title})}).first();
+
+    await expect(header, `${title} must have a projected tab header`).toBeVisible({timeout: 30000});
+    await header.locator(TAB, {hasText: title}).first().click();
+
+    return header
+};
+
+test.describe('Workstation pop-out — hover sync follows the grid into the popup (Neural Link)', () => {
+    test.setTimeout(120000);
+    test.use({viewport: {width: 1600, height: 900}});
+
+    test('a scroll in the popped-out Feed grid suspends and resumes hover sync in the popup, and the opener hears nothing', async ({page, context, neuralLink}) => {
+        await page.goto('/apps/workstation/index.html');
+        await page.waitForSelector('.workstation-dock-host',            {timeout: 60000});
+        await page.waitForSelector('.neo-tab-header-button.neo-draggable', {timeout: 60000});
+
+        await neuralLink.connectToApp('Workstation');
+
+        const header = await focusPane(page, FEED_TITLE),
+              popOut = header.locator(`${ACTION}:has(span[class*="${POP_OUT}"])`).first();
+
+        await expect(popOut, 'the Feed pane offers the pop-out action').toBeVisible({timeout: 10000});
+
+        // A main-thread addon is imported into a window the first time the App Worker resolves it
+        // for that window (`worker.App#getAddon` → `Main.importAddon`); a grid without locked
+        // columns never resolves hover sync at mount, so the opener's addon exists only once a
+        // scroll asks for it. One warm-up scroll in the opener loads it, so the opener side of the
+        // witness can be counted rather than merely absent.
+        const openerView = page.locator(HEADER).filter({has: page.locator(TAB, {hasText: FEED_TITLE})}).locator('xpath=ancestor::*[contains(@class,"neo-dashboard-dock-tabs")][1]').locator(VIEW).first(),
+              openerBox  = await openerView.boundingBox();
+
+        expect(openerBox, 'the opener renders the Feed grid view').toBeTruthy();
+
+        await page.mouse.move(openerBox.x + openerBox.width / 2, openerBox.y + openerBox.height / 2);
+        await page.mouse.wheel(0, 120);
+
+        await expect.poll(() => page.evaluate(name => !!Neo.main?.addon?.[name], ADDON),
+            {message: 'the warm-up scroll imports the hover-sync addon into the opener window', timeout: 15000}).toBe(true);
+
+        // Subscribed before the click: the vessel can open faster than the next await.
+        const vesselPromise = context.waitForEvent('page', {timeout: 45000});
+
+        await popOut.click();
+
+        const vessel = await vesselPromise;
+
+        await vessel.waitForLoadState('domcontentloaded');
+        await vessel.waitForSelector(VIEW, {timeout: 45000});
+
+        const view = vessel.locator(VIEW).first(),
+              box  = await view.boundingBox();
+
+        expect(box, 'the popup renders the grid view').toBeTruthy();
+
+        // A main-thread addon is imported into a window the first time the App Worker resolves it
+        // for that window (`worker.App#getAddon` → `Main.importAddon`), so the popup's hover-sync
+        // addon does not exist until a scroll asks for it. One warm-up scroll loads it; the counters
+        // go on afterwards, and only the second scroll is judged.
+        await vessel.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+        await vessel.mouse.wheel(0, 120);
+
+        await expect.poll(() => vessel.evaluate(name => !!Neo.main?.addon?.[name], ADDON),
+            {message: 'the first scroll imports the hover-sync addon into the popup window', timeout: 15000}).toBe(true);
+
+        expect(await countAddonCalls(page,   ADDON), 'the opener addon is counted').toBe(true);
+        expect(await countAddonCalls(vessel, ADDON), 'the popup addon is counted').toBe(true);
+
+        // The judged scroll: one real wheel scroll over the popup's grid view.
+        await vessel.mouse.wheel(0, 240);
+
+        // The witness: the popup's addon is suspended and resumed; the opener's addon receives nothing.
+        // Before the fix every call fell back to the first connected port — the opener — so the
+        // counts were exactly reversed.
+        await expect.poll(() => readAddonCalls(vessel, ADDON), {message: 'the popup addon receives suspend and resume', timeout: 10000})
+            .toEqual(expect.arrayContaining(['suspendHover', 'resumeHover']));
+
+        expect(await readAddonCalls(page, ADDON), 'the opener addon hears nothing about the popup\'s scroll').toEqual([]);
+
+        await vessel.close({runBeforeUnload: true})
+    })
+});

--- a/test/playwright/unit/grid/ScrollManagerHoverSyncRouting.spec.mjs
+++ b/test/playwright/unit/grid/ScrollManagerHoverSyncRouting.spec.mjs
@@ -1,0 +1,86 @@
+import {setup} from '../../setup.mjs';
+
+setup({
+    appConfig: {
+        name: 'NeoGridScrollManagerHoverSyncRoutingTest'
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../src/Neo.mjs';
+import * as core      from '../../../../src/core/_export.mjs';
+import ScrollManager  from '../../../../src/grid/ScrollManager.mjs';
+
+/**
+ * A remote method call to a main-thread addon is routed on the payload's `windowId`; without one the
+ * worker falls back to the first connected port. In one window that is the same window, and only a
+ * deprecation warning shows. With the grid in a popup the first port is the opener, whose hover-sync
+ * addon holds no registration for the grid — while the popup's addon, which does, is never told. The
+ * scroll manager already resolves the addon for its own window and already routes its horizontal
+ * scroll sync with the key; suspend and resume of hover sync must carry the same key.
+ */
+const APP = 'NeoGridScrollManagerHoverSyncRoutingTest';
+
+test.describe('Neo.grid.ScrollManager routes hover-sync suspend and resume to its own window', () => {
+    const
+        calls    = [],
+        resolved = [],
+        addon    = {
+            register()      {},
+            resumeHover(payload)  { calls.push({method: 'resumeHover',  payload}) },
+            suspendHover(payload) { calls.push({method: 'suspendHover', payload}) },
+            unregister()    {}
+        };
+
+    let manager, originalGetAddon;
+
+    test.beforeAll(() => {
+        originalGetAddon = Neo.currentWorker.getAddon;
+
+        // The single-thread unit run has no main thread: resolve every addon to one recorder and
+        // note which window it was resolved for.
+        Neo.currentWorker.getAddon = async (name, windowId) => {
+            resolved.push({name, windowId});
+            return addon
+        }
+    });
+
+    test.afterAll(() => {
+        Neo.currentWorker.getAddon = originalGetAddon
+    });
+
+    test.afterEach(() => {
+        manager?.destroy?.();
+        manager = null;
+        calls.length = resolved.length = 0
+    });
+
+    test('a scroll on a manager bound to window w2 suspends and resumes hover sync with windowId w2 in the payload', async () => {
+        const
+            gridBody      = {addCls() {}, removeCls() {}},
+            gridContainer = {
+                body               : {isScrolling: false},
+                bodyEnd            : null,
+                bodyStart          : null,
+                headerToolbar      : null,
+                horizontalScrollbar: null,
+                syncBodies()       {},
+                view               : {id: 'hover-sync-routing-view'}
+            };
+
+        manager = Neo.create(ScrollManager, {appName: APP, gridBody, gridContainer, windowId: 'w2'});
+
+        // One scroll of the view: the manager suspends hover sync as scrolling starts and resumes it
+        // when the scroll settles — both through the addon it resolves for its own window.
+        manager.onContainerScroll({scrollLeft: 0, scrollTop: 24, target: {id: 'hover-sync-routing-view'}});
+
+        await expect.poll(() => calls.map(call => call.method), {message: 'suspend, then resume'})
+            .toEqual(['suspendHover', 'resumeHover']);
+
+        expect(resolved.filter(entry => entry.name === 'GridRowHoverSync').map(entry => entry.windowId),
+            'the hover-sync addon is resolved for the manager\'s window, both times').toEqual(['w2', 'w2']);
+
+        expect(calls[0].payload, 'suspend carries the routing key').toEqual({id: manager.id, windowId: 'w2'});
+        expect(calls[1].payload, 'resume carries the routing key').toEqual({id: manager.id, windowId: 'w2'})
+    });
+});


### PR DESCRIPTION
Resolves #18295

🌿 A scroll in a popped-out grid can no longer tell the wrong window to stop hovering.

A remote method call to a main-thread addon is routed on the payload's `windowId`; without one the App Worker falls back to the first connected port. The grid's scroll manager resolved the hover-sync addon for its own window and then called `suspendHover` and `resumeHover` with `{id}` only, so every scroll logged the deprecated-destination warning and, with the grid in a popup, the calls reached the opener's addon — which holds no registration for that grid — while the popup's addon, which does, was never told. The horizontal scroll sync in the same class already carries the key. Both hover-sync calls now go through one helper that passes `{id, windowId}`; a red-first unit arm drives a real scroll on a manager bound to window `w2` against a recording addon resolver, and a permanent Neural Link journey counts the calls where they land in two real windows and reads the worker's warning count around the judged scroll.

Evidence: L3 achieved (the rendered two-window Neural Link gesture at the exact head, Brain runtime bound, red-first against the dev scroll manager) → L3 required (AC-2, AC-3); AC-1 is CI-covered; AC-2 is read where the warning is emitted — the App Worker's console, forwarded over the Neural Link session and counted by the same arm. Residual: none.

## Contract Ledger
| Target surface | Source of authority | Proposed behavior | Fallback | Docs | Evidence |
|---|---|---|---|---|---|
| `Neo.grid.ScrollManager#suspendGridRowHoverSyncAddon` / `#resumeGridRowHoverSyncAddon` | `worker/Base#sendMessage` routing contract (`:478–484`); the sibling `updateGridHorizontalScrollSyncAddon` (`:340–350`) | Both calls pass `{id, windowId}` through one protected helper, `callGridRowHoverSyncAddon(method, windowId)`; the addon's `suspendHover({id})` / `resumeHover({id})` ignore the extra key | None needed — signatures, defaults and callers unchanged | Helper docblock on `ScrollManager.mjs` | `unit/grid/ScrollManagerHoverSyncRouting.spec.mjs`; `e2e/workstation/WorkstationPopOutHoverSyncNL.spec.mjs` |

## AC Evidence
| AC-1 | CI-covered: `test/playwright/unit/grid/ScrollManagerHoverSyncRouting.spec.mjs` — a scroll on a manager with `windowId: 'w2'` resolves the addon for `w2` twice and calls `suspendHover` then `resumeHover` with `{id, windowId: 'w2'}` (red on the unchanged manager: the payloads carried `{id}` only) |
| AC-2 | Outside CI, in the AC-3 run: the arm reads the App Worker's `warn` entries through the Neural Link app handle (`app.getConsoleLogs('warn', 'GridRowHoverSync')`, then the deprecated-destination sentence) — 0 after the two warm-up scrolls and 0 after the judged popup scroll at head; with `src/grid/ScrollManager.mjs` checked out from `origin/dev` the first read already counts 3 and the arm reds there |
| AC-3 | Outside CI (headless Chrome channel, `--headed` not passed): `NEO_AGENTOS_RUNTIME_ROOT=<brain> npx playwright test -c test/playwright/playwright.config.e2e.mjs e2e/workstation/WorkstationPopOutHoverSyncNL --workers=1` → 1 passed at head: after a pop-out of the Feed pane, a wheel scroll in the popup delivers `suspendHover` and `resumeHover` to the popup window's addon and none to the opener's; with `src/grid/ScrollManager.mjs` checked out from `origin/dev` the popup's addon receives nothing (measured at `47f79251fd`; at this head that control reds at the AC-2 warning read first) |

## Deltas from ticket
The ticket's two-line fix became a small helper, as it suggested. Two harness facts shaped the headed arm: a main-thread addon is imported into a window only when the App Worker first resolves it for that window (`worker.App#getAddon` → `Main.importAddon`), and a grid without locked columns never resolves hover sync at mount — so each window receives one warm-up scroll before its call counter goes on, and only the second popup scroll is judged. AC-2 is read in that same two-window journey rather than in a single-window one: every scroll in it is a Feed-grid scroll.

## Test Evidence
Neural Link e2e tier in Playwright's default headless mode of the local Chrome channel, Brain runtime bound, `--workers=1`. The arm wraps `suspendHover` / `resumeHover` on the main-thread addon instance of each window with a counter that calls through (nothing else is patched), then scrolls the popup grid once. Head: the popup's counter reads suspend and resume, the opener's reads nothing. The same run reads the worker's console over the Neural Link app handle — `warn` entries filtered to `GridRowHoverSync` and the deprecated-destination sentence — once after the warm-up scrolls and once after the judged scroll, behind a worker round-trip on the session's connection that orders the read after the scroll's output: 0 and 0 at head. Control with the dev scroll manager at the same head: the first warning read counts 3 and the arm reds there. At the head before the warning read (`47f79251fd`) the same control ran through to the call counters: the popup's stayed empty for the full 10 s poll — the calls went to the first connected port. Red-first on the unit arm as well.

## Post-Merge Validation
None — every acceptance criterion is verified before merge.

## Commits (if multi-commit)
- `a3896c5738` — the routing key through one helper, and the unit arm
- `47f79251fd` — the two-window headed witness
- `7f5c548001` — the witness reads the worker's warning count over the Neural Link

Authored by Vega (Claude Fable 5.1, Claude Code). Session 4384828f-2650-4d28-b650-fac55eebec59.
