### PR TITLE
feat(dock): a headless Workspace projects on first binding (#18276)

### DIFF
--- a/examples/dashboard/dock/MainContainer.mjs
+++ b/examples/dashboard/dock/MainContainer.mjs
@@ -144,8 +144,6 @@ class MainContainer extends DockWorkspace {
          * @member {Object} layout={ntype:'vbox', align:'stretch'}
          */
         layout: {ntype: 'vbox', align: 'stretch'}
-        // `items` is built in construct() — not here — so each projection can carry the instance-bound
-        // reducer and view-sync callbacks the commit loop needs.
     }
 
     /**
@@ -173,6 +171,7 @@ class MainContainer extends DockWorkspace {
     savedPerspectiveCount = 0
 
     /**
+     * @summary Creates example-owned perspective state and toolbar; the engine mounts the first shell.
      * @param {Object} config
      */
     construct(config) {
@@ -183,7 +182,7 @@ class MainContainer extends DockWorkspace {
         me.layoutCollection = me.createDefaultLayoutCollection();
         me.dockModel        = PerspectiveLibrary.restoreActiveSavedLayout(me.layoutCollection).document || Document.clone(initialDockModel);
 
-        me.add(me.buildWorkspaceItems());
+        me.add(me.createPerspectiveToolbar());
         me.layoutCollectionLoadPromise = me.loadLayoutCollectionFromStorage()
     }
 
@@ -296,19 +295,6 @@ class MainContainer extends DockWorkspace {
         }
 
         return collection
-    }
-
-    /**
-     * Creates the persistent top-level toolbar plus the initial dock projection.
-     * @param {Object|null} [tabInsertDescriptor=null] One-use normalized `addTab` correlation
-     * captured by the committing refresh; omitted for boot, restore, and unrelated projections.
-     * @returns {Object[]}
-     */
-    buildWorkspaceItems(tabInsertDescriptor=null) {
-        return [
-            this.createPerspectiveToolbar(),
-            this.projectDockModel(tabInsertDescriptor)
-        ]
     }
 
     /**

--- a/src/dashboard/dock/Workspace.mjs
+++ b/src/dashboard/dock/Workspace.mjs
@@ -518,6 +518,16 @@ class Workspace extends Container {
     dockMaximizePlay = null
 
     /**
+     * The render target whose geometry stream this Workspace has already armed. This is a
+     * duplicate-call guard, not ownership of the realm-global WindowPosition observation: moving
+     * away never disables a stream another Workspace may still consume.
+     * @member {String|null} observedWindowGeometryId=null
+     * @protected
+     */
+    observedWindowGeometryId = null
+
+    /**
+     * @summary Initializes dock-owned services and arms geometry only when already window-bound.
      * @param {Object} config
      */
     construct(config) {
@@ -548,11 +558,12 @@ class Workspace extends Container {
 
         // Cross-window hit testing reads manager.Window as its one geometry authority, and the
         // manager only learns what the Main realm publishes. The host's own render target publishes
-        // live extents from construction — the same stream every admitted vessel opens on connect —
-        // so a moved or resized main window never claims with a stale frame. Not gated on the
-        // engine lifecycle flag: a host may run its own admission (the Workstation does) and still
-        // dock across windows; the app's opt-in is loading the `WindowPosition` addon at all.
-        this.observeWindowGeometry(this.windowId)
+        // live extents as soon as it exists — during construction for an ordinary host, or from the
+        // reactive window binding for a headless one — through the same stream every admitted vessel
+        // opens on connect. A moved or resized main window therefore never claims with a stale frame.
+        // Not gated on the engine lifecycle flag: a host may run its own admission (the Workstation
+        // does) and still dock across windows; the app's opt-in is loading the addon at all.
+        this.observeBoundWindowGeometry(this.windowId)
     }
 
     /**
@@ -1172,18 +1183,40 @@ class Workspace extends Container {
      * for a titlebar grabbed from outside page content) and `observeResize` (a fixed-origin resize
      * is a geometry change the poll never sees). Without both, the manager's row for that window
      * stays the connect-time snapshot and every cross-window claim hit-tests a stale frame. The
-     * engine host arms both — for its own window at construction, for each admitted vessel before
+     * engine host arms both — for its own first real window binding, for each admitted vessel before
      * ownership publication — so an adopter that EXTENDS this host never has to know the addon
-     * exists. A host COMPOSED from the dock pieces onto a plain container never runs this
-     * constructor and must arm the same pair itself; half of it (resize only) leaves the row blind
-     * to a titlebar drag, which is the defect the composition example carried. Overridable for a
-     * realm that publishes geometry another way.
+     * exists. A host COMPOSED from the dock pieces onto a plain container never runs the binding
+     * hook and must arm the same pair itself; half of it (resize only) leaves the row blind to a
+     * titlebar drag, which is the defect the composition example carried. Overridable for a realm
+     * that publishes geometry another way.
      * @param {String} windowId The render target whose Main realm publishes
      * @returns {Promise<void>|undefined} The addon's remote settle, or `undefined` off the browser
      * @protected
      */
     observeWindowGeometry(windowId) {
         return Neo.main?.addon?.WindowPosition?.setConfigs({observeMovement: true, observeResize: true, windowId})
+    }
+
+    /**
+     * @summary Arms geometry once for each real render-target binding this Workspace enters.
+     *
+     * Construction and the reactive window-id hook deliberately share this guard: a Workspace
+     * created with a window must not issue two remote writes, while one created headless must issue
+     * none until a container supplies its first real id. The previous realm stays armed because
+     * WindowPosition's observation flags are realm-global, not Workspace-keyed leases.
+     * @param {String|null} windowId The Workspace's current render target.
+     * @returns {Promise<void>|undefined} The addon's remote settle, or `undefined` when headless,
+     *     already armed, or outside the browser.
+     * @protected
+     */
+    observeBoundWindowGeometry(windowId) {
+        if (!windowId || this.observedWindowGeometryId === windowId) {
+            return
+        }
+
+        this.observedWindowGeometryId = windowId;
+
+        return this.observeWindowGeometry(windowId)
     }
 
     /**
@@ -2043,12 +2076,18 @@ class Workspace extends Container {
     }
 
     /**
-     * The boot-time header-action sync. A consumer may mount its FIRST projection statically —
-     * items assembled in `construct()` — without ever entering {@link #refreshDockWorkspace},
-     * and on that path no header-action sync runs at all: projected action rows are
-     * projection-constant by design (per-item state must never vary the actions array), so a
-     * pane-dependent action such as reload would stay at its projected default forever. Mount is
-     * the one surface every boot path shares.
+     * @summary Projects an unseeded Workspace on first mount, or syncs a statically seeded shell.
+     *
+     * A headless Workspace owns no visible tree before binding. Once mounted, an absent shell at
+     * {@link #dockShellIndex} enters the ordinary committed-document refresh — the same projection
+     * path every later operation uses — rather than asking each consumer constructor to seed engine
+     * chrome. A consumer which already supplied a shell keeps its static boot path below.
+     *
+     * A consumer may mount its first projection statically — items assembled in `construct()` —
+     * without ever entering {@link #refreshDockWorkspace}, and on that path no header-action sync
+     * runs at all: projected action rows are projection-constant by design (per-item state must
+     * never vary the actions array), so a pane-dependent action such as reload would stay at its
+     * projected default forever. Mount is the one surface every boot path shares.
      *
      * A workspace whose boot DID run the refresh already synced on settled chrome (the
      * post-reconcile sweep), so this hook narrows to the never-refreshed case: `refreshPromise`
@@ -2083,13 +2122,19 @@ class Workspace extends Container {
     afterSetMounted(value, oldValue) {
         super.afterSetMounted(value, oldValue);
 
-        if (!value || this.refreshPromise) {
+        const me = this;
+
+        if (!value || me.refreshPromise) {
             return null
         }
 
-        return this.timeout(100).then(async () => {
-            let me = this,
-                awaited;
+        if (!me.getDockHost()?.items?.[me.dockShellIndex]) {
+            me.onDockZoneDocumentChange(me.dockModel);
+            return me.refreshPromise
+        }
+
+        return me.timeout(100).then(async () => {
+            let awaited;
 
             do {
                 awaited = me.refreshPromise;
@@ -2103,6 +2148,19 @@ class Workspace extends Container {
 
             !me.isDestroyed && me.syncDockHeaderActions()
         }).catch(() => null)
+    }
+
+    /**
+     * @summary Opens the Workspace geometry stream when it enters a real render target.
+     * @param {String|null} value
+     * @param {String|null} oldValue
+     * @returns {Promise<void>|undefined}
+     * @protected
+     */
+    afterSetWindowId(value, oldValue) {
+        super.afterSetWindowId(value, oldValue);
+
+        return this.observeBoundWindowGeometry(value)
     }
 
     /**

--- a/src/dashboard/dock/projection/Reconciler.mjs
+++ b/src/dashboard/dock/projection/Reconciler.mjs
@@ -314,16 +314,20 @@ class Reconciler extends Base {
     /**
      * @summary Stages and commits one identity-preserving dock projection.
      *
-     * The host keeps its current shell rendered while a visibility-hidden projection is inserted
-     * beside it. Four explicit ownership phases follow: mount the target tree, move pane/button
-     * descendants, move retained tab ancestors plus swap shell visibility, then destroy the empty
-     * source shell. Each phase receives its own host update so renderer cleanup cannot overtake a
-     * native reparent. Floating Overflow controls are reprojected only after final ownership settles.
+     * With a current shell, the host keeps it rendered while a visibility-hidden projection is
+     * inserted beside it. Four explicit ownership phases follow: mount the target tree, move
+     * pane/button descendants, move retained tab ancestors plus swap shell visibility, then destroy
+     * the empty source shell. With no current shell, the same projection is inserted at
+     * `shellIndex` as the explicit first projection; it resolves panes and becomes visible without
+     * inventing an outgoing shell. Each phase receives its own host update so renderer cleanup
+     * cannot overtake a native reparent. Floating Overflow controls are reprojected only after final
+     * ownership settles.
      *
      * Workspace-specific FLIP capture/play, animation timing, pane creation, and menu readiness stay
      * outside this method. `onProjectionStaged` can decorate retained chrome before the first commit.
      * @param {Object} options
-     * @param {Neo.container.Base} options.host Dock host containing the current shell.
+     * @param {Neo.container.Base} options.host Dock host containing the current shell, or the empty
+     *     destination for a first projection.
      * @param {Boolean} [options.geometryOnly=false] Explicitly admits strict in-place geometry reconciliation.
      * @param {Boolean} [options.retainTopology=false] Explicitly admits in-place item reconciliation
      *     only when every structural dock node retains its identity, ancestry, order, and orientation.
@@ -335,7 +339,8 @@ class Reconciler extends Base {
      * @param {Function|null} [options.onProjectionStaged=null]
      * @param {Number} [options.shellIndex=0]
      * @param {Function|null} [options.waitForOverflowProjection=null]
-     * @returns {Promise<{currentTabs: Map, nextShell: Neo.component.Base, overflowPlugins: Object[], plans: Map}>}
+     * @returns {Promise<{currentTabs: Map, landedInPlace: Boolean, nextShell: Neo.component.Base,
+     *     overflowPlugins: Object[], plans: Map}>}
      * @static
      */
     static async reconcileProjection({
@@ -350,13 +355,11 @@ class Reconciler extends Base {
         shellIndex=0,
         waitForOverflowProjection=null
     }) {
-        const oldShell = host?.items?.[shellIndex];
+        const
+            oldShell          = host?.items?.[shellIndex] || null,
+            initialProjection = !oldShell;
 
-        if (!oldShell) {
-            throw new Error(`Dock projection could not find a current shell at index ${shellIndex}`)
-        }
-
-        const stableProjection = geometryOnly || retainTopology
+        const stableProjection = oldShell && (geometryOnly || retainTopology)
             ? this.reconcileStableTopology(oldShell, nextConfig, placeholders, {
                 preserveItemIds,
                 reconcileItems: retainTopology,
@@ -423,23 +426,41 @@ class Reconciler extends Base {
             ? preparedConfig.setSilent({hidden: true, hideMode: 'visibility'})
             : Object.assign(preparedConfig, {hidden: true, hideMode: 'visibility'});
 
-        let nextShell = host.insert(shellIndex + 1, preparedConfig, true);
+        let nextShell;
 
-        await onProjectionStaged?.({currentTabs, nextShell, oldShell, plans});
+        try {
+            nextShell = host.insert(shellIndex + (initialProjection ? 0 : 1), preparedConfig, true);
 
-        host.updateDepth = -1;
-        host.update();
-        await host.promiseUpdate();
+            await onProjectionStaged?.({currentTabs, nextShell, oldShell, plans});
+
+            host.updateDepth = -1;
+            host.update();
+            await host.promiseUpdate()
+        } catch (error) {
+            if (!initialProjection) {
+                throw error
+            }
+
+            error.isDockProjectionFailure = true;
+            error.projectionRecovery      = await this.settleFailedInitialProjection({
+                destroyShell: true,
+                host,
+                nextShell,
+                shellIndex
+            });
+
+            throw error
+        }
 
         const commitBars = new Set();
 
-        // Phases 2-4 are the window in which the host holds TWO shells, and every one of them ends in
-        // an awaited flight that can reject: a landing ancestor update whose stored vnode still
-        // references chrome a phase destroyed silently is enough (`util.VNode.getVnode` throws on a
-        // reference whose component has left the registry). Without this guard the rejection unwinds
-        // out of the whole method and the host keeps both shells — the outgoing one visible and
-        // populated, the staged one hidden and half-built — and since every later commit reconciles
-        // against `host.items[shellIndex]` again, that state never self-heals.
+        // With an outgoing shell, phases 2-4 are the window in which the host holds TWO shells. A
+        // first projection holds one hidden shell instead, but the same awaited flights can reject
+        // after consumer-owned panes entered it. In either shape, a landing ancestor update whose
+        // stored vnode still references chrome a phase destroyed silently is enough
+        // (`util.VNode.getVnode` throws on a reference whose component has left the registry).
+        // Without this guard the rejection unwinds and leaves a partial projection at the canonical
+        // shell index, so every later commit reconciles against state which never settled.
         //
         // `VdomLifecycle#executeVdomUpdate` already promises the half this method needs: a rejected
         // flight adopts no vnode and rejects every parked promise, "so the next cycle re-diffs
@@ -492,7 +513,7 @@ class Reconciler extends Base {
             retainedRoot = oldShell === nextShell;
 
             if (!retainedRoot) {
-                oldShell.setSilent({hideMode: 'visibility', hidden: true});
+                oldShell?.setSilent({hideMode: 'visibility', hidden: true});
                 nextShell.setSilent({hidden: false})
             }
 
@@ -502,9 +523,9 @@ class Reconciler extends Base {
             // change unadopted, so recovery must treat the outgoing shell as the one still on screen.
             await host.promiseUpdate();
 
-            swapped = !retainedRoot;
+            swapped = Boolean(oldShell && !retainedRoot);
 
-            if (!retainedRoot) {
+            if (oldShell && !retainedRoot) {
                 host.remove(oldShell, true, true);
                 host.updateDepth = -1;
                 host.update();
@@ -512,9 +533,11 @@ class Reconciler extends Base {
             }
         } catch (error) {
             error.isDockProjectionFailure = true;
-            error.projectionRecovery      = await this.settleFailedProjection({
-                host, nextShell, oldShell, retainedRoot, shellIndex, swapped
-            });
+            error.projectionRecovery      = initialProjection
+                ? await this.settleFailedInitialProjection({host, nextShell, shellIndex})
+                : await this.settleFailedProjection({
+                    host, nextShell, oldShell, retainedRoot, shellIndex, swapped
+                });
 
             // Re-thrown rather than wrapped: the original message and stack ARE the diagnostic (the
             // live report that produced this guard read `Component not found for id: …` out of
@@ -537,10 +560,48 @@ class Reconciler extends Base {
             await Promise.all(overflowPlugins.map(plugin => waitForOverflowProjection(plugin)))
         }
 
-        // The staged transaction replaced the shell, so any downstream contract keyed on
-        // "no topology swap can be pending" must NOT be told otherwise, however the call was
-        // admitted. See the in-place return above.
+        // A staged transaction replaced the shell or a first projection created it, so any
+        // downstream contract keyed on "no topology swap can be pending" must NOT be told this was
+        // in-place, however the call was admitted. See the in-place return above.
         return {currentTabs, landedInPlace: false, nextShell, overflowPlugins, plans}
+    }
+
+    /**
+     * @summary Retires a rejected first projection so its one clean retry starts with no shell.
+     *
+     * A shell whose initial mount failed before item reconciliation is destroyed: it contains only
+     * engine projection placeholders. Once reconciliation may have moved consumer-owned live panes,
+     * the shell is detached without destruction instead; the retry resolves those same panes into a
+     * fresh first shell.
+     * @param {Object} data
+     * @param {Boolean} [data.destroyShell=false] Whether item reconciliation is known not to have run.
+     * @param {Neo.container.Base} data.host The dock host which attempted its first projection.
+     * @param {Neo.component.Base|null} data.nextShell The failed first shell, when insertion landed.
+     * @param {Number} [data.shellIndex=0] The slot the first shell attempted to occupy.
+     * @returns {Promise<String>} `retired-initial` | `unrecoverable`
+     * @static
+     */
+    static async settleFailedInitialProjection({destroyShell=false, host, nextShell, shellIndex=0}) {
+        const failedShell = nextShell || host.items?.[shellIndex] || null;
+
+        try {
+            if (failedShell && !failedShell.isDestroyed && host.indexOf(failedShell) > -1) {
+                host.remove(failedShell, destroyShell, true)
+            }
+
+            host.updateDepth = -1;
+            host.update();
+            await host.promiseUpdate();
+
+            return !failedShell || host.indexOf(failedShell) === -1 ? 'retired-initial' : 'unrecoverable'
+        } catch (recoveryError) {
+            console.warn(
+                'Initial dock projection recovery failed; the host may retain its failed shell',
+                host?.id,
+                recoveryError
+            );
+            return 'unrecoverable'
+        }
     }
 
     /**

--- a/test/playwright/unit/apps/workstation/Workspace.spec.mjs
+++ b/test/playwright/unit/apps/workstation/Workspace.spec.mjs
@@ -450,13 +450,10 @@ test.describe.serial('Workstation.view.Workspace', () => {
                 targetId: targetWorkspaceId
             });
 
-            // Movement observation rides the same call: the main render target's poll is owned by
-            // config, so a titlebar grabbed from outside page content still publishes.
-            expect(resizeCalls).toEqual([{
-                observeMovement: true,
-                observeResize  : true,
-                windowId       : workspace.windowId
-            }]);
+            // This unit instance has no render target. Geometry begins only when a real container
+            // supplies its window id; the focused DockWorkspace first-projection spec owns that
+            // positive bind arm.
+            expect(resizeCalls).toEqual([]);
             expect(workspace.workspaceSet.ids()).toEqual([Workspace.MAIN_WORKSPACE_ID]);
             expect(workspace.workspaceSet.getDocument(Workspace.MAIN_WORKSPACE_ID)).toBe(workspace.dockModel);
             expect(workspace.vesselConversionTargetWindowId).toBe('window-alerts');

--- a/test/playwright/unit/dashboard/DockWorkspaceFirstProjection.spec.mjs
+++ b/test/playwright/unit/dashboard/DockWorkspaceFirstProjection.spec.mjs
@@ -1,0 +1,216 @@
+import {setup} from '../../setup.mjs';
+
+const appName = 'DashboardDockWorkspaceFirstProjectionTest';
+
+setup({
+    neoConfig: {
+        allowVdomUpdatesInTests: true,
+        useDomApiRenderer      : true
+    },
+    appConfig: {
+        name: appName
+    }
+});
+
+import {test, expect}     from '@playwright/test';
+import Neo                from '../../../../src/Neo.mjs';
+import * as core          from '../../../../src/core/_export.mjs';
+import Container          from '../../../../src/container/Base.mjs';
+import DockReconciler     from '../../../../src/dashboard/dock/projection/Reconciler.mjs';
+import DockWorkspace      from '../../../../src/dashboard/dock/Workspace.mjs';
+import DomApiVnodeCreator from '../../../../src/vdom/util/DomApiVnodeCreator.mjs';
+import VdomHelper         from '../../../../src/vdom/Helper.mjs';
+import MainContainer      from '../../../../examples/dashboard/dock/MainContainer.mjs';
+import '../../../../src/manager/Instance.mjs';
+import '../../../../src/tab/Container.mjs';
+
+const createDocument = () => ({
+    schema: 'neo.dock.zone.v1',
+    root  : 'root-split',
+    items : {
+        editor  : {componentRef: 'Editor',   kind: 'panel',    title: 'Editor'},
+        preview : {componentRef: 'Preview',  kind: 'panel',    title: 'Preview'},
+        terminal: {componentRef: 'Terminal', kind: 'terminal', title: 'Terminal'}
+    },
+    nodes: {
+        'editor-tabs': {activeItemId: 'editor', items: ['editor'], type: 'tabs'},
+        'side-tabs'  : {activeItemId: 'preview', items: ['preview', 'terminal'], type: 'tabs'},
+        'root-split' : {
+            children   : ['editor-tabs', 'side-tabs'],
+            orientation: 'horizontal',
+            sizes      : [0.65, 0.35],
+            type       : 'split'
+        }
+    }
+});
+
+/**
+ * @summary Waits until the Workspace's mutable refresh pointer is the promise which just settled.
+ *
+ * A typed projection failure replaces `refreshPromise` with its one repair from inside the first
+ * refresh. Awaiting one captured promise would therefore observe the failed cycle, not the repair.
+ * @param {Neo.dashboard.dock.Workspace} workspace
+ * @returns {Promise<void>}
+ */
+const settleRefreshTail = async workspace => {
+    let tail;
+
+    do {
+        tail = workspace.refreshPromise;
+        await tail
+    } while (tail !== workspace.refreshPromise)
+};
+
+/**
+ * @summary Binds a headless Workspace through the real container adoption path, then mounts it.
+ * @param {Neo.dashboard.dock.Workspace} workspace
+ * @param {String} windowId
+ * @returns {Promise<Neo.container.Base>}
+ */
+const bindAndMount = async (workspace, windowId='first-projection-window') => {
+    const parent = Neo.create(Container, {
+        appName,
+        items: [workspace],
+        windowId
+    });
+
+    await parent.initVnode();
+    parent.mounted = true;
+
+    return parent
+};
+
+/**
+ * @summary Pins the headless-to-bound first-projection lifecycle owned by DockWorkspace.
+ */
+test.describe('Neo.dashboard.dock.Workspace first projection', () => {
+    let parent, workspace;
+
+    test.afterEach(() => {
+        parent?.destroy?.();
+        !parent && workspace?.destroy?.();
+        parent    = null;
+        workspace = null
+    });
+
+    test('a headless Workspace arms no geometry until its first real window binding', () => {
+        const
+            originalWindowPosition = Neo.main.addon.WindowPosition,
+            calls                  = [];
+
+        Neo.main.addon.WindowPosition = {
+            setConfigs(data) {
+                calls.push(data);
+                return Promise.resolve()
+            }
+        };
+
+        try {
+            workspace = Neo.create(DockWorkspace, {dockModel: createDocument()});
+
+            expect(calls, 'construction without a render target arms nothing').toEqual([]);
+
+            parent = Neo.create(Container, {
+                appName,
+                items   : [workspace],
+                windowId: 'bound-window'
+            });
+
+            expect(calls, 'the real container binding arms both geometry streams exactly once').toEqual([{
+                observeMovement: true,
+                observeResize  : true,
+                windowId       : 'bound-window'
+            }]);
+
+            workspace.windowId = 'bound-window';
+
+            expect(calls, 'setting the same binding again is idempotent').toHaveLength(1)
+        } finally {
+            originalWindowPosition
+                ? Neo.main.addon.WindowPosition = originalWindowPosition
+                : delete Neo.main.addon.WindowPosition
+        }
+    });
+
+    test('binding and mounting projects the committed document without consumer shell seeding', async () => {
+        let outcome;
+
+        workspace = Neo.create(DockWorkspace, {dockModel: createDocument()});
+        workspace.afterRefreshDockWorkspace = ({result}) => outcome = result;
+        parent    = await bindAndMount(workspace);
+
+        await settleRefreshTail(workspace);
+
+        expect(workspace.items, 'the engine owns exactly one first shell').toHaveLength(1);
+
+        const tabs = DockReconciler.collectProjectedTabs(workspace.items[0]);
+
+        expect([...tabs.keys()]).toEqual(['editor-tabs', 'side-tabs']);
+        expect(tabs.get('editor-tabs').getTabBar().sortZoneConfig.dockItemIds).toEqual(['editor']);
+        expect(tabs.get('side-tabs').getTabBar().sortZoneConfig.dockItemIds).toEqual(['preview', 'terminal']);
+        expect(outcome.landedInPlace, 'a first projection is a normal staged result, never a fast path').toBe(false)
+    });
+
+    test('the standalone dock example keeps only its toolbar static and receives its shell from the engine', async () => {
+        workspace = Neo.create(MainContainer, {});
+
+        await workspace.layoutCollectionLoadPromise;
+
+        expect(workspace.items, 'the example constructor no longer seeds engine projection chrome').toHaveLength(1);
+        expect(workspace.items[0].dockNodeType).toBe('perspective-toolbar');
+
+        parent = await bindAndMount(workspace, 'example-window');
+
+        await settleRefreshTail(workspace);
+
+        expect(workspace.items, 'mount adds exactly one engine-owned shell after the toolbar').toHaveLength(2);
+        expect(DockReconciler.collectProjectedTabs(workspace.items[1]).size).toBe(4)
+    });
+
+    test('a rejected initial mount retires its shell and spends exactly one clean retry', async () => {
+        workspace = Neo.create(DockWorkspace, {dockModel: createDocument()});
+
+        const
+            events                = [],
+            originalPromiseUpdate = workspace.promiseUpdate.bind(workspace),
+            originalRefresh       = workspace.refreshDockWorkspace.bind(workspace);
+
+        let failedShell,
+            hostFlights = 0,
+            refreshes   = 0;
+
+        workspace.promiseUpdate = () => {
+            hostFlights++;
+
+            if (hostFlights === 1) {
+                failedShell = workspace.items[0];
+                return Promise.reject(new Error('forced initial shell mount rejection'))
+            }
+
+            return originalPromiseUpdate()
+        };
+        workspace.refreshDockWorkspace = (...args) => {
+            refreshes++;
+            return originalRefresh(...args)
+        };
+        workspace.on('dockProjectionFailed', event => {
+            events.push({event, shellCount: workspace.items.length})
+        });
+
+        parent = await bindAndMount(workspace);
+
+        await settleRefreshTail(workspace);
+
+        expect(events, 'the failed initial projection is observable once').toHaveLength(1);
+        expect(events[0].event).toMatchObject({
+            isRetry : false,
+            recovery: 'retired-initial'
+        });
+        expect(events[0].event.error.message).toBe('forced initial shell mount rejection');
+        expect(events[0].shellCount, 'recovery returns the host to zero shells before retry').toBe(0);
+        expect(failedShell.isDestroyed, 'an unpopulated rejected shell leaves no detached component tree').toBe(true);
+        expect(refreshes, 'the initial attempt plus exactly one repair').toBe(2);
+        expect(workspace.items, 'the repair lands one visible shell').toHaveLength(1);
+        expect(workspace.items[0].hidden).not.toBe(true)
+    })
+});


### PR DESCRIPTION
Resolves #18276

Related: #18151

A Dock Workspace can now exist without a render target, bind into a window later, and project its committed document without consumer-seeded shell chrome. The window binding arms geometry once only for a real `windowId`; first mount enters the ordinary Workspace→Reconciler path; and a rejected initial mount retires its shell as `retired-initial` before the existing one-retry recovery runs. The standalone dock example now keeps only its perspective toolbar static and receives its first dock shell from the engine.

Evidence: L2 (single-thread VDOM projection, remote-addon spy, and forced reject/retry) → L2 required (AC-1 through AC-5 are internal projection and lifecycle contracts). Residual: none.

## AC Evidence

| AC | Evidence |
| --- | --- |
| AC-1 | Headless construction emits no geometry call; first real binding arms exactly once. `DockWorkspaceFirstProjection.spec.mjs` spies on `WindowPosition.setConfigs`: zero calls while headless, one movement+resize call after real container adoption, still one after the same id is set again. |
| AC-2 | First bind/mount projects one shell with the committed tabs, without consumer seeding. The focused spec adopts the instance through `container.Base#createItem`, mounts it, and asserts one shell plus `editor-tabs` / `side-tabs` and their item identities. |
| AC-3 | Red-first proof: before production edits at `dev@6be3197d1f`, the new three-arm seed failed 3/3—the null-window call was present, the shell count stayed zero, and no recovery event fired. |
| AC-4 | A failed initial mount retires to zero, surfaces, and retries once. The forced first host-flight rejection asserts one `dockProjectionFailed` event with `recovery: 'retired-initial'`, zero shells at event time, destruction of the unpopulated failed tree, exactly two refresh calls, and one visible repaired shell. |
| AC-5 | Example seeding is deleted and Workstation source stays unchanged. The example arm asserts toolbar-only construction and one engine shell at index 1 after mount. `apps/workstation/view/Workspace.mjs` has no diff; its prior null-window expectation is truth-synced, and the full unit tree is green. |

## Deltas from ticket

None substantive. The later optional unbind note is intentionally not implemented: `WindowPosition` observation flags are realm-global configs with no Workspace lease/refcount, so one Workspace writing `false` could silence another consumer. The focused 216-line sibling spec also avoids adding another concern to the existing 3,786-line `DockWorkspace.spec.mjs`.

Decision Record impact: aligned with ADR 0029 §§2.1 and 2.8.5; no authority change or compatibility path.

## Test Evidence

All coverage runs in CI.

## Post-Merge Validation

None owed — every close-target AC is CI-testable and achieved at its required evidence level.

Authored by Euclid (GPT-5.6 Sol Ultra, Codex) consuming Mnemosyne's ticket and live arm — session A ee061205-8271-4458-b73b-b132c1bec310, session B 01a06b6d-3323-7fa0-a10b-bbc4871c8780.
