### PR TITLE
fix(ai): set_neo_config dispatches to the runtime service (#18281)

### DIFF
--- a/src/ai/Client.mjs
+++ b/src/ai/Client.mjs
@@ -1,17 +1,17 @@
-import Base             from '../core/Base.mjs';
-import ClassSystemUtil  from '../util/ClassSystem.mjs';
-import ComponentService from './client/ComponentService.mjs';
-import DataService      from './client/DataService.mjs';
-import DockService      from './client/DockService.mjs';
-import InstanceService  from './client/InstanceService.mjs';
-import InteractionService, {registerInteractionServiceMethods}
-                            from './client/InteractionService.mjs';
-import RuntimeService       from './client/RuntimeService.mjs';
-import Socket               from '../data/connection/WebSocket.mjs';
-import WindowManager        from '../manager/Window.mjs';
-import WriteGuard           from './WriteGuard.mjs';
-import TransactionService   from './TransactionService.mjs';
-import {parseAgentEnvelope} from './parseAgentEnvelope.mjs';
+import Base                                                    from '../core/Base.mjs';
+import ClassSystemUtil                                         from '../util/ClassSystem.mjs';
+import ComponentService,   {registerComponentServiceMethods}   from './client/ComponentService.mjs';
+import DataService,        {registerDataServiceMethods}        from './client/DataService.mjs';
+import DockService,        {registerDockServiceMethods}        from './client/DockService.mjs';
+import InstanceService,    {registerInstanceServiceMethods}    from './client/InstanceService.mjs';
+import InteractionService, {registerInteractionServiceMethods} from './client/InteractionService.mjs';
+import RuntimeService,     {registerRuntimeServiceMethods}     from './client/RuntimeService.mjs';
+import {resolveServiceMethod}                                  from './client/resolveServiceMethod.mjs';
+import Socket                                                  from '../data/connection/WebSocket.mjs';
+import WindowManager                                           from '../manager/Window.mjs';
+import WriteGuard                                              from './WriteGuard.mjs';
+import TransactionService                                      from './TransactionService.mjs';
+import {parseAgentEnvelope}                                    from './parseAgentEnvelope.mjs';
 
 /**
  * The AI Client establishes a WebSocket connection to the Neural Link MCP Server.
@@ -57,7 +57,8 @@ class Client extends Base {
      */
     logs = []
     /**
-     * Map JSON-RPC method prefixes to service instances
+     * JSON-RPC method prefix → service instance, filled by each service's `register*ServiceMethods` at
+     * construction; insertion order is the prefix precedence.
      * @member {Object} serviceMap
      * @protected
      */
@@ -112,65 +113,14 @@ class Client extends Base {
 
         const {component, data, dock, instance, interaction, runtime} = me.services;
 
-        me.serviceMap = {
-            get_component      : component,
-            get_computed_styles: component,
-            get_dom_rect       : component,
-            get_vdom           : component,
-            get_vdom_vnode     : component,
-            get_vnode          : component,
-            highlight_component: component,
-            observe_motion     : component,
-            query_component    : component,
-            query_vdom         : component,
-            verify_component   : component,
+        // Registration order is prefix precedence: the first registered prefix a method starts with wins.
+        me.serviceMap = {};
 
-            capture_perspective   : dock,
-            diff_dock_topology    : dock,
-            execute_dock_operation: dock,
-            get_dock_topology     : dock,
-            list_perspectives     : dock,
-            restore_perspective   : dock,
-
-            call_method            : instance,
-            create_instance        : instance,
-            destroy_instance       : instance,
-            find_instances         : instance,
-            get_instance_properties: instance,
-            set_instance_properties: instance,
-            undo                   : instance,
-            redo                   : instance,
-            replay_transaction     : instance,
-            save_transaction       : instance,
-            abort_transaction      : instance,
-            begin_transaction      : instance,
-            commit_transaction     : instance,
-            list_transactions      : instance,
-
-            get_record            : data,
-            inspect_state_provider: data,
-            inspect_store         : data,
-            list_stores           : data,
-            modify_state_provider : data,
-
-            check_namespace      : runtime,
-            close_window         : runtime,
-            focus_window         : runtime,
-            get_dom_event        : runtime,
-            get_drag             : runtime,
-            get_method_source    : runtime,
-            get_namespace_tree   : runtime,
-            get_neo_config       : runtime,
-            get_route            : runtime,
-            get_window           : runtime,
-            inspect_class        : runtime,
-            open_component_window: runtime,
-            patch_code           : runtime,
-            position_window      : runtime,
-            reload_page          : runtime,
-            set_route            : runtime
-        };
-
+        registerComponentServiceMethods(me.serviceMap, component);
+        registerDockServiceMethods(me.serviceMap, dock);
+        registerInstanceServiceMethods(me.serviceMap, instance);
+        registerDataServiceMethods(me.serviceMap, data);
+        registerRuntimeServiceMethods(me.serviceMap, runtime);
         registerInteractionServiceMethods(me.serviceMap, interaction);
 
         Neo.currentWorker.on({
@@ -225,8 +175,8 @@ class Client extends Base {
     }
 
     /**
-     * Routes specific JSON-RPC methods to their corresponding implementation.
-     * This method acts as the central dispatcher for all AI-driven commands.
+     * Routes a JSON-RPC method to the service that registered its prefix — the central dispatcher for
+     * every AI-driven command; the rule lives in {@link Neo.ai.client.resolveServiceMethod}.
      * @param {String} method The JSON-RPC method name
      * @param {Object} params The parameters associated with the method
      * @param {Object} [context] Optional request context (e.g. `{agentId}`) threaded from the
@@ -234,36 +184,13 @@ class Client extends Base {
      * @returns {Promise<*>} The result of the operation
      */
     async handleRequest(method, params, context) {
-        let me      = this,
-            service = null,
-            prefix;
+        const target = resolveServiceMethod(this.serviceMap, method);
 
-        // Find matching service based on prefix
-        // e.g. "get_component_property" -> matches "get_component" prefix
-        for (prefix in me.serviceMap) {
-            if (method.startsWith(prefix)) {
-                service = me.serviceMap[prefix];
-                break
-            }
+        if (!target) {
+            throw new Error(`Unknown method: ${method}`)
         }
 
-        const fnName = Neo.snakeToCamel(method);
-
-        if (service) {
-            const fn = service[fnName];
-
-            if (Neo.isFunction(fn)) {
-                return fn.call(service, params, context)
-            } else if (Neo.isPromise(fn)) {
-                return await fn.call(service, params, context)
-            }
-        }
-
-        if (service && typeof service[fnName] === 'function') {
-            return service[fnName](params, context)
-        }
-
-        throw new Error(`Unknown method: ${method}`);
+        return target.fn.call(target.service, params, context)
     }
 
     /**

--- a/src/ai/client/ComponentService.mjs
+++ b/src/ai/client/ComponentService.mjs
@@ -3,6 +3,28 @@ import TreeBuilder from '../../util/vdom/TreeBuilder.mjs';
 import VdomUtil    from '../../util/VDom.mjs';
 
 /**
+ * @summary Registers the JSON-RPC method prefixes one ComponentService instance answers.
+ * @param {Object} serviceMap Mutable Client prefix map.
+ * @param {ComponentService} service Owning service instance.
+ * @returns {Object} The same map after registration.
+ */
+export function registerComponentServiceMethods(serviceMap, service) {
+    return Object.assign(serviceMap, {
+        get_component      : service,
+        get_computed_styles: service,
+        get_dom_rect       : service,
+        get_vdom           : service,
+        get_vdom_vnode     : service,
+        get_vnode          : service,
+        highlight_component: service,
+        observe_motion     : service,
+        query_component    : service,
+        query_vdom         : service,
+        verify_component   : service
+    })
+}
+
+/**
  * Handles component-related Neural Link requests.
  * @class Neo.ai.client.ComponentService
  * @extends Neo.ai.client.Service

--- a/src/ai/client/DataService.mjs
+++ b/src/ai/client/DataService.mjs
@@ -2,6 +2,22 @@ import Service      from './Service.mjs';
 import StoreManager from '../../manager/Store.mjs';
 
 /**
+ * @summary Registers the JSON-RPC method prefixes one DataService instance answers.
+ * @param {Object} serviceMap Mutable Client prefix map.
+ * @param {DataService} service Owning service instance.
+ * @returns {Object} The same map after registration.
+ */
+export function registerDataServiceMethods(serviceMap, service) {
+    return Object.assign(serviceMap, {
+        get_record            : service,
+        inspect_state_provider: service,
+        inspect_store         : service,
+        list_stores           : service,
+        modify_state_provider : service
+    })
+}
+
+/**
  * Handles data-related Neural Link requests.
  * @class Neo.ai.client.DataService
  * @extends Neo.ai.client.Service

--- a/src/ai/client/DockService.mjs
+++ b/src/ai/client/DockService.mjs
@@ -6,6 +6,23 @@ import Service                from './Service.mjs';
 import {deriveSubtreePath}    from '../deriveSubtreePath.mjs';
 
 /**
+ * @summary Registers the JSON-RPC method prefixes one DockService instance answers.
+ * @param {Object} serviceMap Mutable Client prefix map.
+ * @param {DockService} service Owning service instance.
+ * @returns {Object} The same map after registration.
+ */
+export function registerDockServiceMethods(serviceMap, service) {
+    return Object.assign(serviceMap, {
+        capture_perspective   : service,
+        diff_dock_topology    : service,
+        execute_dock_operation: service,
+        get_dock_topology     : service,
+        list_perspectives     : service,
+        restore_perspective   : service
+    })
+}
+
+/**
  * Handles dock-layout Neural Link requests: topology readout, semantic operation execution and
  * the perspective tool trio (capture / list / restore) against a live dockZone.v1 document
  * holder (contract of record: learn/agentos/DockZoneModel.md and the docking

--- a/src/ai/client/InstanceService.mjs
+++ b/src/ai/client/InstanceService.mjs
@@ -3,6 +3,31 @@ import {admitWrite}        from '../admitWrite.mjs';
 import {deriveSubtreePath} from '../deriveSubtreePath.mjs';
 
 /**
+ * @summary Registers the JSON-RPC method prefixes one InstanceService instance answers.
+ * @param {Object} serviceMap Mutable Client prefix map.
+ * @param {InstanceService} service Owning service instance.
+ * @returns {Object} The same map after registration.
+ */
+export function registerInstanceServiceMethods(serviceMap, service) {
+    return Object.assign(serviceMap, {
+        call_method            : service,
+        create_instance        : service,
+        destroy_instance       : service,
+        find_instances         : service,
+        get_instance_properties: service,
+        set_instance_properties: service,
+        undo                   : service,
+        redo                   : service,
+        replay_transaction     : service,
+        save_transaction       : service,
+        abort_transaction      : service,
+        begin_transaction      : service,
+        commit_transaction     : service,
+        list_transactions      : service
+    })
+}
+
+/**
  * Handles generic instance-related Neural Link requests.
  * @class Neo.ai.client.InstanceService
  * @extends Neo.ai.client.Service

--- a/src/ai/client/RuntimeService.mjs
+++ b/src/ai/client/RuntimeService.mjs
@@ -25,6 +25,7 @@ export function registerRuntimeServiceMethods(serviceMap, service) {
         patch_code           : service,
         position_window      : service,
         reload_page          : service,
+        set_neo_config       : service,
         set_route            : service
     })
 }

--- a/src/ai/client/RuntimeService.mjs
+++ b/src/ai/client/RuntimeService.mjs
@@ -3,6 +3,33 @@ import HashHistory     from '../../util/HashHistory.mjs';
 import Service         from './Service.mjs';
 
 /**
+ * @summary Registers the JSON-RPC method prefixes one RuntimeService instance answers.
+ * @param {Object} serviceMap Mutable Client prefix map.
+ * @param {RuntimeService} service Owning service instance.
+ * @returns {Object} The same map after registration.
+ */
+export function registerRuntimeServiceMethods(serviceMap, service) {
+    return Object.assign(serviceMap, {
+        check_namespace      : service,
+        close_window         : service,
+        focus_window         : service,
+        get_dom_event        : service,
+        get_drag             : service,
+        get_method_source    : service,
+        get_namespace_tree   : service,
+        get_neo_config       : service,
+        get_route            : service,
+        get_window           : service,
+        inspect_class        : service,
+        open_component_window: service,
+        patch_code           : service,
+        position_window      : service,
+        reload_page          : service,
+        set_route            : service
+    })
+}
+
+/**
  * Handles runtime environment related Neural Link requests.
  * @class Neo.ai.client.RuntimeService
  * @extends Neo.ai.client.Service

--- a/src/ai/client/resolveServiceMethod.mjs
+++ b/src/ai/client/resolveServiceMethod.mjs
@@ -1,0 +1,33 @@
+import Util from '../../core/Util.mjs';
+
+/**
+ * @summary Resolves a JSON-RPC method name to the service instance and handler that answer it.
+ *
+ * The pure dispatch rule behind `Neo.ai.Client#handleRequest`, kept side-effect free so the registered map
+ * can be witnessed in unit tests: importing the Client singleton opens a WebSocket in every test worker.
+ *
+ * A method matches the FIRST registered prefix it starts with, in registration order, so one key serves a
+ * family (`get_dom_event` answers `get_dom_event_listeners` and `get_dom_event_summary`). The handler is
+ * the camelCase form of the full method name on that service; a prefix hit without such a handler resolves
+ * to nothing rather than falling through to a later prefix.
+ *
+ * @param {Object} serviceMap Prefix → service instance, in registration order.
+ * @param {String} method     The snake_case JSON-RPC method name.
+ * @returns {{service: Object, fn: Function}|null} The owning service and its handler, or `null` when no
+ *     registered prefix matches or the matched service has no handler for the name.
+ */
+export function resolveServiceMethod(serviceMap, method) {
+    let prefix;
+
+    for (prefix in serviceMap) {
+        if (method.startsWith(prefix)) {
+            const
+                service = serviceMap[prefix],
+                fn      = service[Util.snakeToCamel(method)];
+
+            return typeof fn === 'function' ? {service, fn} : null
+        }
+    }
+
+    return null
+}

--- a/test/playwright/unit/ai/client/resolveServiceMethod.spec.mjs
+++ b/test/playwright/unit/ai/client/resolveServiceMethod.spec.mjs
@@ -1,0 +1,106 @@
+import {setup} from '../../../setup.mjs';
+
+setup({
+    appConfig: {
+        name: 'ClientResolveServiceMethodTest'
+    }
+});
+
+import {test, expect}                                          from '@playwright/test';
+import Neo                                                     from '../../../../../src/Neo.mjs';
+import * as core                                               from '../../../../../src/core/_export.mjs';
+import ComponentService,   {registerComponentServiceMethods}   from '../../../../../src/ai/client/ComponentService.mjs';
+import DataService,        {registerDataServiceMethods}        from '../../../../../src/ai/client/DataService.mjs';
+import DockService,        {registerDockServiceMethods}        from '../../../../../src/ai/client/DockService.mjs';
+import InstanceService,    {registerInstanceServiceMethods}    from '../../../../../src/ai/client/InstanceService.mjs';
+import InteractionService, {registerInteractionServiceMethods} from '../../../../../src/ai/client/InteractionService.mjs';
+import RuntimeService,     {registerRuntimeServiceMethods}     from '../../../../../src/ai/client/RuntimeService.mjs';
+import {resolveServiceMethod}                                  from '../../../../../src/ai/client/resolveServiceMethod.mjs';
+
+/**
+ * The wire names this client answers: one per call the Brain's Neural Link services send for an
+ * advertised tool, read from those services when the list was last synced. A name the Brain starts
+ * sending is added here and gets a handler on the service that owns its prefix.
+ */
+const WIRE_METHODS = [
+    'abort_transaction', 'begin_transaction', 'call_method', 'capture_perspective', 'check_namespace',
+    'close_window', 'commit_transaction', 'create_instance', 'diff_dock_topology', 'execute_dock_operation',
+    'find_instances', 'focus_window', 'get_component_tree', 'get_computed_styles', 'get_dock_topology',
+    'get_dom_event_listeners', 'get_dom_event_summary', 'get_dom_rect', 'get_drag_state', 'get_drag_trace',
+    'get_instance_properties', 'get_method_source', 'get_namespace_tree', 'get_neo_config', 'get_record',
+    'get_route_history', 'get_vdom_tree', 'get_vdom_vnode', 'get_vnode_tree', 'highlight_component',
+    'inspect_class', 'inspect_state_provider', 'inspect_store', 'list_perspectives', 'list_stores',
+    'list_transactions', 'modify_state_provider', 'observe_motion', 'open_component_window', 'patch_code',
+    'position_window', 'query_component', 'query_vdom', 'redo', 'reload_page', 'replay_transaction',
+    'restore_perspective', 'save_transaction', 'set_instance_properties', 'set_route',
+    'simulate_event', 'undo', 'verify_component_consistency'
+];
+
+test.describe('Neo.ai.client.resolveServiceMethod', () => {
+    let services, serviceMap;
+
+    /**
+     * @param {String} method
+     * @param {Object} service
+     * @param {Function} fn
+     */
+    function expectTarget(method, service, fn) {
+        const target = resolveServiceMethod(serviceMap, method);
+
+        expect(target?.service).toBe(service);
+        expect(target?.fn).toBe(fn)
+    }
+
+    test.beforeAll(() => {
+        services = {
+            component  : Neo.create(ComponentService),
+            data       : Neo.create(DataService),
+            dock       : Neo.create(DockService),
+            instance   : Neo.create(InstanceService),
+            interaction: Neo.create(InteractionService),
+            runtime    : Neo.create(RuntimeService)
+        };
+
+        // The Client's registration order, which is the prefix precedence.
+        serviceMap = {};
+
+        registerComponentServiceMethods(serviceMap, services.component);
+        registerDockServiceMethods(serviceMap, services.dock);
+        registerInstanceServiceMethods(serviceMap, services.instance);
+        registerDataServiceMethods(serviceMap, services.data);
+        registerRuntimeServiceMethods(serviceMap, services.runtime);
+        registerInteractionServiceMethods(serviceMap, services.interaction)
+    });
+
+    test.afterAll(() => {
+        Object.values(services).forEach(service => service.destroy())
+    });
+
+    test('every wire method resolves to a handler on a registered service', () => {
+        const unresolved = WIRE_METHODS.filter(method => !resolveServiceMethod(serviceMap, method));
+
+        expect(unresolved).toEqual([])
+    });
+
+    test('a family prefix answers each member with the full camelCase handler', () => {
+        const {runtime} = services;
+
+        expectTarget('get_dom_event_listeners', runtime, runtime.getDomEventListeners);
+        expectTarget('get_dom_event_summary',   runtime, runtime.getDomEventSummary)
+    });
+
+    test('the first registered prefix wins, in registration order', () => {
+        const
+            first  = {getABC() {}},
+            second = {getABC() {}},
+            target = resolveServiceMethod({get_a: first, get_a_b: second}, 'get_a_b_c');
+
+        expect(target.service).toBe(first);
+        expect(target.fn).toBe(first.getABC)
+    });
+
+    test('an unregistered prefix, or a prefix without that handler, resolves to nothing', () => {
+        expect(resolveServiceMethod(serviceMap, 'teleport_component')).toBeNull();
+        expect(resolveServiceMethod(serviceMap, 'get_vdom_nope')).toBeNull()
+    });
+});

--- a/test/playwright/unit/ai/client/resolveServiceMethod.spec.mjs
+++ b/test/playwright/unit/ai/client/resolveServiceMethod.spec.mjs
@@ -32,7 +32,7 @@ const WIRE_METHODS = [
     'inspect_class', 'inspect_state_provider', 'inspect_store', 'list_perspectives', 'list_stores',
     'list_transactions', 'modify_state_provider', 'observe_motion', 'open_component_window', 'patch_code',
     'position_window', 'query_component', 'query_vdom', 'redo', 'reload_page', 'replay_transaction',
-    'restore_perspective', 'save_transaction', 'set_instance_properties', 'set_route',
+    'restore_perspective', 'save_transaction', 'set_instance_properties', 'set_neo_config', 'set_route',
     'simulate_event', 'undo', 'verify_component_consistency'
 ];
 
@@ -86,7 +86,8 @@ test.describe('Neo.ai.client.resolveServiceMethod', () => {
         const {runtime} = services;
 
         expectTarget('get_dom_event_listeners', runtime, runtime.getDomEventListeners);
-        expectTarget('get_dom_event_summary',   runtime, runtime.getDomEventSummary)
+        expectTarget('get_dom_event_summary',   runtime, runtime.getDomEventSummary);
+        expectTarget('set_neo_config',          runtime, runtime.setNeoConfig)
     });
 
     test('the first registered prefix wins, in registration order', () => {

--- a/test/playwright/unit/ai/client/resolveServiceMethod.spec.mjs
+++ b/test/playwright/unit/ai/client/resolveServiceMethod.spec.mjs
@@ -24,8 +24,9 @@ import {resolveServiceMethod}                                  from '../../../..
  */
 const WIRE_METHODS = [
     'abort_transaction', 'begin_transaction', 'call_method', 'capture_perspective', 'check_namespace',
-    'close_window', 'commit_transaction', 'create_instance', 'diff_dock_topology', 'execute_dock_operation',
-    'find_instances', 'focus_window', 'get_component_tree', 'get_computed_styles', 'get_dock_topology',
+    'close_window', 'commit_transaction', 'create_instance', 'diff_dock_topology', 'drive_drag',
+    'execute_dock_operation', 'find_instances', 'focus_window', 'get_component_tree', 'get_computed_styles',
+    'get_dock_topology',
     'get_dom_event_listeners', 'get_dom_event_summary', 'get_dom_rect', 'get_drag_state', 'get_drag_trace',
     'get_instance_properties', 'get_method_source', 'get_namespace_tree', 'get_neo_config', 'get_record',
     'get_route_history', 'get_vdom_tree', 'get_vdom_vnode', 'get_vnode_tree', 'highlight_component',


### PR DESCRIPTION
Resolves #18281

The Brain forwards `manage_neo_config` `action: 'set'` as `set_neo_config`; the runtime service has implemented `setNeoConfig` all along, but no registered prefix matched the name and the client answered `Unknown method`. One key beside `get_neo_config` fixes it — and the map now has a witness: each client service registers its own wire prefixes (the shape `InteractionService` already had), the first-prefix-wins rule is a pure `resolveServiceMethod`, and a spec builds the real map from the six services and resolves every wire name the Brain sends. The dispatcher's unreachable second lookup and its promise-valued branch go with the loop.

Evidence: L3 (a live non-destructive bridge probe on the workstation session for AC-1; single-thread unit resolution over the real registered map, red-first on the unchanged map, for AC-2 and AC-3) → L3 required (AC-1 is a live dispatch effect; AC-2 and AC-3 are dispatch-contract ACs met at L2). Residual: none.

## AC Evidence

| AC | Evidence |
|---|---|
| AC-1 | Live over the bridge on this head: `manage_neo_config` `set` reaches `RuntimeService#setNeoConfig` and a following `get` returns the written key — receipt under Test Evidence. |
| AC-2 | Red-first: at 777194662f the spec's completeness arm received exactly `["set_neo_config"]` and its family arm found no handler for the name; green 4/4 at ad412dbcce — `test/playwright/unit/ai/client/resolveServiceMethod.spec.mjs`. |
| AC-3 | The same spec's completeness arm resolves every wire name the Brain's Neural Link services send (55 names across all six client services, not only the runtime family — recounted at the Brain's dev head 25d374e; the two wrapper methods without a tool route or caller stay outside the claim). |

## Deltas from ticket

The ticket's spec was to drive `Client#handleRequest`. The Client is a connect-on-init singleton (its constructor opens the WebSocket), so a unit test cannot import it; the prefix table therefore moves out of the Client into one `register*ServiceMethods` export per service and the resolution rule into `resolveServiceMethod` — the extraction the unit-testing guide prescribes for connect-on-init singletons, and the shape `InteractionService` had already chosen for the same reason. `handleRequest` delegates, and its dead second lookup is deleted. The completeness list is sourced from the names the Brain's services put on the wire (`ConnectionService.call`), not from `openapi.yaml` operationIds: an operationId is not a wire name (`manage_neo_config` alone fans out to two).

Two Brain-side findings from that census are not engine work and are handed over separately: the render-tree tool's `both` case sends `get_vdom_and_vnode` while the engine has always answered `get_vdom_vnode`, and two Brain wrapper methods (`get_component_property`, `set_component_property`) have neither a tool route nor a caller.

Decision Record impact: none.

## Test Evidence

Live wire check (AC-1) at ad412dbcce — a dev server on this branch, `apps/workstation` (`useAiClient: true`), bridge session `077342d5-621f-4c80-a49d-1321870b8617`:

1. `manage_neo_config` `get` — the baseline config carries no `enableHotPatching`;
2. `manage_neo_config` `set` `{config: {enableHotPatching: true}}` → `{"status": "ok"}` (before this head the same call answered `Unknown method: set_neo_config`);
3. `manage_neo_config` `get` → the same config ending in `"enableHotPatching": true`.

Red-first receipt at 777194662f, `resolveServiceMethod.spec.mjs` with `set_neo_config` in the wire list and the runtime registration unchanged:

```
every wire method resolves to a handler on a registered service
    - Array []
    + Array [
    +   "set_neo_config",
    + ]
a family prefix answers each member with the full camelCase handler
    Expected: {"className": "Neo.ai.client.RuntimeService", …}
    Received: undefined
  2 failed · 2 passed
```

## Post-Merge Validation

None owed — every close-target AC is verified at this head.

## Commits

- 777194662f — refactor: per-service prefix registration, pure `resolveServiceMethod`, the wire-method spec (green with `set_neo_config` absent from the list)
- ad412dbcce — fix: the `set_neo_config` key and its two spec lines
- f5a7e77701 — test: `drive_drag` joins the wire-method witness (the review's recount at the Brain's dev head)

Authored by Mnemosyne (Claude Fable 5.1, Claude Code). Session 8695dfb8-49e9-4368-a57d-67f5783808f8 — the lane turn; the recovery turn that opened the lane is session 328f5750-f251-443f-8110-05d0b6dc9a38 (the Memory Core rotated the id on a transport reconnect between the two).

