### PR TITLE
fix(manager): a superseded focusout no longer delivers its stale leave (#18299)

### DIFF
--- a/src/manager/Focus.mjs
+++ b/src/manager/Focus.mjs
@@ -164,12 +164,15 @@ class Focus extends CoreBase {
      * @protected
      */
     onFocusout(opts) {
-        let me = this;
+        let me   = this,
+            date = new Date();
 
-        me.lastFocusOutDate = new Date();
+        me.lastFocusOutDate = date;
 
         me.timeout(me.maxFocusInOutGap).then(() => {
-            if (me.lastFocusOutDate > me.lastFocusInDate) {
+            // Identity, not just recency: a newer focusout must not satisfy this check on an older
+            // one's behalf and deliver `opts` raised against a mount that has since been replaced.
+            if (me.lastFocusOutDate === date && date > me.lastFocusInDate) {
                 me.focusLeave(opts)
             }
         })

--- a/test/playwright/unit/manager/Focus.spec.mjs
+++ b/test/playwright/unit/manager/Focus.spec.mjs
@@ -226,4 +226,71 @@ test.describe('Neo.manager.Focus', () => {
             ['change', 'parent',          'focus-parent', ['old-event-node'], ['new-event-node']]
         ]);
     });
+
+    test('a superseded focusout does not deliver its stale leave, and a later one still delivers its own', async () => {
+        const log = [];
+
+        components = [
+            createFocusComponent('focus-stale-root',  'document.body',    log),
+            createFocusComponent('focus-stale-child', 'focus-stale-root', log),
+            createFocusComponent('focus-stale-other', 'document.body',    log)
+        ];
+
+        const [root, child] = components;
+
+        // Derived, never hard-coded: if maxFocusInOutGap changes, these stay inside the collapse
+        // window instead of silently drifting outside it and making the arm vacuous.
+        const {maxFocusInOutGap} = FocusManager,
+              step               = maxFocusInOutGap / 5;
+
+        root.containsFocus  = true;
+        child.containsFocus = true;
+
+        // The dismissal. `onFocusout` defers delivery by maxFocusInOutGap, so nothing has been
+        // delivered yet and this leave is still only pending.
+        FocusManager.onFocusout({
+            componentPath: ['focus-stale-child', 'focus-stale-root'],
+            data         : {path: ['dismissed-node'], relatedTarget: null}
+        });
+
+        await FocusManager.timeout(step);
+
+        // The reopen, inside the gap. The component path is unchanged because the SAME instance
+        // remounts under the same id — the shape a hidden/un-hidden floating menu produces. The
+        // out/in pair therefore collapses into a focusMove across identical paths, which correctly
+        // delivers nothing: focus never actually left this subtree.
+        FocusManager.history = [{
+            componentPath: ['focus-stale-child', 'focus-stale-root'],
+            data         : {path: ['dismissed-node']}
+        }];
+
+        FocusManager.onFocusin({
+            componentPath: ['focus-stale-child', 'focus-stale-root'],
+            data         : {path: ['reopened-node'], relatedTarget: null}
+        });
+
+        await FocusManager.timeout(step);
+
+        // An unrelated, later focusout. It carries its own opts and deserves its own leave — but it
+        // also pushes the manager-global lastFocusOutDate past lastFocusInDate, and that global pair
+        // is the only thing the FIRST focusout's pending timer consults before firing.
+        FocusManager.onFocusout({
+            componentPath: ['focus-stale-other'],
+            data         : {path: ['other-node'], relatedTarget: null}
+        });
+
+        // Outlast both pending timers.
+        await FocusManager.timeout(maxFocusInOutGap * 3);
+
+        const leaves = log.filter(entry => entry[0] === 'leave').map(entry => entry[1]);
+
+        // The stale leave belongs to a mount that no longer exists. Delivering it to the remounted
+        // instance is what unmounts a freshly reopened floating menu.
+        expect(leaves).not.toContain('focus-stale-child');
+
+        // ...and the guard must not buy that by suppressing leaves generally: the later focusout is
+        // the newest one and still delivers. Without this half the arm passes if focusLeave never
+        // runs at all.
+        expect(leaves).toEqual(['focus-stale-other']);
+    });
 });


### PR DESCRIPTION
Resolves #18299

`manager.Focus#onFocusout` defers a focus-leave by `maxFocusInOutGap` so a close focusout/focusin pair can collapse into a `focusMove`. The deferred callback closed over **its own** `opts` but gated on the **manager-global** `lastFocusOutDate` — so a newer focusout satisfied an older timer's condition on its behalf, and that older timer then delivered its own captured `opts`, raised against a mount already replaced. Because `setComponentFocus` walks the whole `componentPath`, one stale delivery reached an entire ancestor chain. This gates the callback on timer **identity** instead of recency: one added binding, one added conjunct, no consumer touched.

Evidence: achieved = the full unit suite in CI (3185/3185) plus a red-first mutation receipt on the guard itself and an outside-CI component receipt for the leaf-click cascade; required = the same, because all seven close-target ACs are unit- or component-observable and none needs live-host, visual, or UI evidence. Residual: none.

`component/Base.mjs:1353` already neutralises this hazard class for **destroyed** instances (`me.onFocusLeave = Neo.emptyFn`, *"prevent delayed calls after a component instance got destroyed"*). An instance that merely unmounts and remounts keeps a live `onFocusLeave`, so that guard never applies — this closes the same class one lifecycle rung down, which is why the fix belongs in the manager rather than in any consumer.

## AC Evidence

| AC | Evidence |
|---|---|
| AC-1 red-first arm, fails before / passes after | CI-covered: `test/playwright/unit/manager/Focus.spec.mjs` › *"a superseded focusout does not deliver its stale leave, and a later one still delivers its own"*. Red receipt in Test Evidence. |
| AC-2 later focusout still delivers its own leave | CI-covered: same arm's closing `expect(leaves).toEqual(['focus-stale-other'])` — the half that stops a vacuous pass. |
| AC-3 waits derived from `maxFocusInOutGap` | CI-covered: same arm, `const {maxFocusInOutGap} = FocusManager, step = maxFocusInOutGap / 5`; no literal `50` anywhere in it. |
| AC-4 full unit suite green (blast radius) | CI-covered: `npm run test-unit` — **3185/3185**. Every consumer named in the ticket's Architectural Reality is covered by existing arms. |
| AC-5 document-blur/Escape + outside-dismiss unmodified | CI-covered: `test/playwright/unit/menu/List.spec.mjs:173` and `:103`, both unchanged and inside the 3185. |
| AC-6 leaf-click cascade unmodified | Outside-CI receipt in Test Evidence — `test/playwright/component/menu/List.spec.mjs:119`. |
| AC-7 no consumer file modified | CI-covered: the diff is `src/manager/Focus.mjs` + its spec, 2 files. |

## Deltas from ticket

None substantive. The ticket was authored from the measurement that produced this fix, so the prescription and the diff match.

## Test Evidence

**Red-first receipt (mutation of the guard — what a green suite cannot show).** With the source change reverted, the new arm fails on its first assertion, and the failure names the whole ancestor chain rather than a single component — which is the `setComponentFocus` path-walk claim, observed rather than argued:

```
Error: expect(received).not.toContain(expected)
Expected value: not "focus-stale-child"
Received array: ["focus-stale-child", "focus-stale-root", "focus-stale-other"]
```

With the change in place: `6 passed`.

**AC-6, outside CI** — `npm run test-components -- test/playwright/component/menu/List.spec.mjs --workers=1`:

```
✓ 1 …List.spec.mjs:119:5 › a leaf click takes every level down together, with no ancestor left standing (500ms)
✓ 2 …List.spec.mjs:132:5 › hideOnLeafItemClick: false keeps every level open (434ms)
2 passed (3.7s)
```

**Negative result, recorded because it bounds this PR's claim.** This defect was found while measuring #18290 and is **not** that ticket's cause: with this fix applied, `SpawnAnimation.spec.mjs:183` measured **6 failures in 60** serial repeats against a **7/60** baseline — noise. #18290 stays open with its cause unfound, and nothing here should be read as progress on it. The full reasoning is on [#18290](https://github.com/neomjs/neo/issues/18290#issuecomment-5544348578).

## Post-Merge Validation

- [ ] No new focus-related intermittency appears in `dev` CI across the following day's runs — the change alters delivery for every focus consumer, and only sustained multi-suite traffic exercises the third-event interleaving at scale.

Authored by Ada (Claude Opus 5, Claude Code). Session 12595f5d-68f8-48bc-93d2-4a91c7bad164.
