### PR TITLE
fix(vdom): a child retired mid-flight neither fails the landing nor hangs the waiters (#18297)

### DIFF
--- a/src/manager/VDomUpdate.mjs
+++ b/src/manager/VDomUpdate.mjs
@@ -553,8 +553,9 @@ class VDomUpdate extends Collection {
 
     /**
      * Triggers all pending updates that were queued to run after the specified `ownerId`'s
-     * update has completed.
-     * @param {String} ownerId The `id` of the component whose update has just finished.
+     * update has settled — resolved or rejected. A waiter runs its own flight either way, so a
+     * failure upstream never leaves it suspended on a completion that will not come.
+     * @param {String} ownerId The `id` of the component whose update has just settled.
      */
     triggerPostUpdates(ownerId) {
         let me   = this,

--- a/src/mixin/VdomLifecycle.mjs
+++ b/src/mixin/VdomLifecycle.mjs
@@ -379,6 +379,12 @@ class VdomLifecycle extends Base {
 
             VDomUpdate.rejectCallbacks(me.id, err);
 
+            // Components that yielded to this flight (isChildUpdating / isParentUpdating) wait in the
+            // post-update queue keyed on it, exactly as on success — and only the success path drained
+            // it, so a caller awaiting one of them stayed suspended for good. Release them here too:
+            // each runs its own flight against the current truth and settles on its own outcome.
+            VDomUpdate.triggerPostUpdates(me.id);
+
             // Mirror of resolveVdomUpdate(): updates queued onto this flight while it was running
             // are only ever drained by a follow-up cycle — without this, their content (and any
             // attached promise callbacks) strand until the next organic update. A deterministic
@@ -672,6 +678,9 @@ class VdomLifecycle extends Base {
             }
 
             VDomUpdate.unregisterInFlightUpdate(me.id);
+            // The render-path flavour of the release executeVdomUpdate()'s catch performs: whoever
+            // yielded to this flight runs its own now, instead of waiting on a completion that never comes.
+            VDomUpdate.triggerPostUpdates(me.id);
 
             console.error('initVnode error', err, me.id);
             throw err

--- a/src/mixin/VdomLifecycle.mjs
+++ b/src/mixin/VdomLifecycle.mjs
@@ -931,6 +931,12 @@ class VdomLifecycle extends Base {
             ComponentManager.registerWrapperNode(vnode.id, me)
         }
 
+        // A flight collected before a child was retired silently lands still naming that child by
+        // reference, and nothing else does any more. Pruned here, at the landing boundary, so the
+        // strict walkers below never resolve it — without this the whole flight fails on a child
+        // that is already gone, and every transaction awaiting the flight fails with it.
+        VNodeUtil.pruneRetiredReferences(me.vnode);
+
         let vnodeMap           = VNodeUtil.createMap(me.vnode),
             childComponentsSet = new Set(childComponents);
 

--- a/src/util/VNode.mjs
+++ b/src/util/VNode.mjs
@@ -47,6 +47,39 @@ class VNode extends Base {
     }
 
     /**
+     * Removes, in place, every `{componentId}` reference whose component has left the registry from a
+     * flight's RETURNED vnode tree, before the tree is adopted and walked. A child retired silently —
+     * destroyed without an update of its own — takes its vdom, its DOM node and its place in its
+     * parent's stored vnode with it; the one tree that can still name it is a flight collected while
+     * it was alive and landing after. The walkers here resolve references strictly, so this runs once
+     * at the landing boundary and only over the tree's own inline nodes: a live reference is kept as a
+     * reference, never followed — the stored vnode behind it is that component's own to keep clean.
+     * @param {Object} vnode
+     * @returns {Number} The number of references removed
+     */
+    static pruneRetiredReferences(vnode) {
+        let childNodes = vnode?.childNodes,
+            removed    = 0;
+
+        if (childNodes) {
+            for (let i = childNodes.length - 1; i >= 0; i--) {
+                const child = childNodes[i];
+
+                if (child?.componentId) {
+                    if (!ComponentManager.get(child.componentId)) {
+                        childNodes.splice(i, 1);
+                        removed++
+                    }
+                } else {
+                    removed += VNode.pruneRetiredReferences(child)
+                }
+            }
+        }
+
+        return removed
+    }
+
+    /**
      * Search vnode child nodes by id or opts object for a given vdom tree
      * @param {Object} vnode
      * @param {Object|String} opts Either an object containing vdom node attributes or a string based id

--- a/test/playwright/unit/dashboard/DockBackToBackCommits.spec.mjs
+++ b/test/playwright/unit/dashboard/DockBackToBackCommits.spec.mjs
@@ -156,8 +156,11 @@ test.describe('Neo.dashboard.dock.Workspace back-to-back commits', () => {
 
         await settleRefreshTail(workspace);
 
-        // Pre-fix: the ancestor flight fails on the retired button's reference, the phase rejects into
-        // the recovery, and the workspace reports the failed projection before repairing it.
+        // The receipt's failure mode — the ancestor flight failing on the retired button's reference, the
+        // phase rejecting into the recovery, the workspace reporting the failed projection — is witnessed
+        // red-first in the lifecycle arms this header names. This tier serializes those flights, so the
+        // three logs below read empty before the fix as well; what they pin is that the end state
+        // carries none of it, in the same gesture, and stays that way.
         expect(failures,                                                 'no projection failure').toEqual([]);
         expect(warnings.filter(text => text.includes('Dock projection failed')), 'no recovery warning').toEqual([]);
         expect(errors.filter(text => text.includes('vdom update failed')),   'no failed flight').toEqual([]);

--- a/test/playwright/unit/dashboard/DockBackToBackCommits.spec.mjs
+++ b/test/playwright/unit/dashboard/DockBackToBackCommits.spec.mjs
@@ -1,0 +1,172 @@
+import {setup} from '../../setup.mjs';
+
+const appName = 'DashboardDockBackToBackCommitsTest';
+
+setup({
+    neoConfig: {
+        allowVdomUpdatesInTests: true,
+        useDomApiRenderer      : true
+    },
+    appConfig: {
+        name: appName
+    }
+});
+
+import {test, expect}     from '@playwright/test';
+import Neo                from '../../../../src/Neo.mjs';
+import * as core          from '../../../../src/core/_export.mjs';
+import Container          from '../../../../src/container/Base.mjs';
+import DockReconciler     from '../../../../src/dashboard/dock/projection/Reconciler.mjs';
+import DockWorkspace      from '../../../../src/dashboard/dock/Workspace.mjs';
+import DomApiVnodeCreator from '../../../../src/vdom/util/DomApiVnodeCreator.mjs'; // installs the in-process renderer the real flights run through
+import VdomHelper         from '../../../../src/vdom/Helper.mjs';                  // registers Neo.vdom.Helper for those flights
+import '../../../../src/manager/Instance.mjs';
+import '../../../../src/tab/Container.mjs';
+
+const createDocument = () => ({
+    schema: 'neo.dock.zone.v1',
+    root  : 'root-split',
+    items : {
+        editor  : {componentRef: 'Editor',   kind: 'panel',    title: 'Editor'},
+        preview : {componentRef: 'Preview',  kind: 'panel',    title: 'Preview'},
+        terminal: {componentRef: 'Terminal', kind: 'terminal', title: 'Terminal'}
+    },
+    nodes: {
+        'editor-tabs': {activeItemId: 'editor', items: ['editor'], type: 'tabs'},
+        'side-tabs'  : {activeItemId: 'preview', items: ['preview', 'terminal'], type: 'tabs'},
+        'root-split' : {
+            children   : ['editor-tabs', 'side-tabs'],
+            orientation: 'horizontal',
+            sizes      : [0.65, 0.35],
+            type       : 'split'
+        }
+    }
+});
+
+/** The second commit: `terminal` leaves the document, so its header button is a retirement. */
+const retireTerminal = document => {
+    const next = structuredClone(document);
+
+    delete next.items.terminal;
+    next.nodes['side-tabs'].items = ['preview'];
+
+    return next
+};
+
+/**
+ * Waits until the Workspace's mutable refresh pointer is the promise which just settled — a typed
+ * projection failure replaces `refreshPromise` with its one repair from inside the refresh.
+ * @param {Neo.dashboard.dock.Workspace} workspace
+ * @returns {Promise<void>}
+ */
+const settleRefreshTail = async workspace => {
+    let tail;
+
+    do {
+        tail = workspace.refreshPromise;
+        await tail
+    } while (tail !== workspace.refreshPromise)
+};
+
+/**
+ * Binds a headless Workspace through the real container adoption path, then mounts it.
+ * @param {Neo.dashboard.dock.Workspace} workspace
+ * @returns {Promise<Neo.container.Base>}
+ */
+const bindAndMount = async workspace => {
+    const parent = Neo.create(Container, {
+        appName,
+        items   : [workspace],
+        windowId: 'back-to-back-window'
+    });
+
+    await parent.initVnode();
+    parent.mounted = true;
+
+    return parent
+};
+
+/**
+ * @summary Two topology commits back to back: the second retires a header button the first projected,
+ * while an ancestor flight is in the air — the committed document must land as exactly one shell.
+ *
+ * Phase 2 of the projection transaction retires a leaver's tab button with a silent destroy. In the
+ * cockpit receipt an ancestor flight collected before that retirement landed after it, still naming
+ * the button by reference, and the transaction awaiting a flight behind it never settled. The lifecycle
+ * half of that race is witnessed red-first where it lives (`unit/vdom/RaceCondition` and
+ * `unit/vdom/UpdateWedge`): the in-process helper answers in microtasks and ancestor/descendant
+ * flights serialize, so this tier cannot open the receipt's window and this arm was never red.
+ *
+ * What it pins instead is the commit's end state under the same gesture: an ancestor update issued
+ * at the default depth right after the silent retirement (the FLIP tail's place in the receipt),
+ * real flights through the in-process helper, and a workspace that reports no projection failure and
+ * holds one shell with the retired button gone.
+ */
+test.describe('Neo.dashboard.dock.Workspace back-to-back commits', () => {
+    let parent, workspace;
+
+    const
+        originalReconcileTabChrome = DockReconciler.reconcileTabChrome,
+        originalWarn               = console.warn,
+        originalError              = console.error;
+
+    test.afterEach(() => {
+        DockReconciler.reconcileTabChrome = originalReconcileTabChrome;
+        console.warn  = originalWarn;
+        console.error = originalError;
+
+        parent?.destroy?.();
+        parent    = null;
+        workspace = null
+    });
+
+    test('a commit that retires a header button under an in-flight ancestor update still lands as one shell', async () => {
+        const failures = [], warnings = [], errors = [];
+
+        console.warn  = (...args) => { warnings.push(args.join(' ')) };
+        console.error = (...args) => { errors.push(args.join(' ')) };
+
+        workspace = Neo.create(DockWorkspace, {dockModel: createDocument()});
+        parent    = await bindAndMount(workspace);
+
+        await settleRefreshTail(workspace);
+
+        const firstBar = DockReconciler.collectProjectedTabs(workspace.items[0]).get('side-tabs').getTabBar();
+
+        expect(firstBar.getTabButtons(), 'the first commit projected both header buttons').toHaveLength(2);
+
+        const retiringButtonId = firstBar.getTabButtons()[1].id;
+
+        workspace.on('dockProjectionFailed', data => failures.push(`${data.recovery}: ${data.error?.message}`));
+
+        // The ancestor flight: a fire-and-forget update of the bound parent at the default depth, so
+        // the returned vnode names the workspace by reference and the landing walk descends through
+        // the stored vnodes of workspace, shell and bar. (The host itself is no use here: the phase
+        // sets its depth to -1 right after this hook, and a flight reads the depth when it collects.)
+        DockReconciler.reconcileTabChrome = function(...args) {
+            const result = originalReconcileTabChrome.apply(this, args);
+
+            parent.updateDepth = 1;
+            parent.update();
+
+            return result
+        };
+
+        workspace.onDockZoneDocumentChange(retireTerminal(createDocument()));
+
+        await settleRefreshTail(workspace);
+
+        // Pre-fix: the ancestor flight fails on the retired button's reference, the phase rejects into
+        // the recovery, and the workspace reports the failed projection before repairing it.
+        expect(failures,                                                 'no projection failure').toEqual([]);
+        expect(warnings.filter(text => text.includes('Dock projection failed')), 'no recovery warning').toEqual([]);
+        expect(errors.filter(text => text.includes('vdom update failed')),   'no failed flight').toEqual([]);
+
+        expect(workspace.items, 'exactly one shell').toHaveLength(1);
+
+        const bar = DockReconciler.collectProjectedTabs(workspace.items[0]).get('side-tabs').getTabBar();
+
+        expect(bar.getTabButtons(), 'the retired button is gone from the bar').toHaveLength(1);
+        expect(Neo.getComponent(retiringButtonId), 'the retired button left the registry').toBeFalsy()
+    });
+});

--- a/test/playwright/unit/util/VNode.spec.mjs
+++ b/test/playwright/unit/util/VNode.spec.mjs
@@ -1,0 +1,62 @@
+import {setup} from '../../setup.mjs';
+
+setup({
+    appConfig: {
+        name: 'VNodeUtilTest'
+    }
+});
+
+import {test, expect}   from '@playwright/test';
+import Neo              from '../../../../src/Neo.mjs';
+import * as core        from '../../../../src/core/_export.mjs';
+import Component        from '../../../../src/component/Base.mjs';
+import ComponentManager from '../../../../src/manager/Component.mjs';
+import VNode            from '../../../../src/util/VNode.mjs';
+
+/**
+ * @summary A stored vnode names each child component by a `{componentId}` reference, and every
+ * walker resolves such references through the component registry — strictly, because a reference
+ * to nothing is a broken tree. The one tree allowed to carry a stale reference is a flight's
+ * returned vnode: collected while the child was alive, landing after the child was retired. The
+ * landing boundary prunes those before the strict walkers see them.
+ */
+test.describe('Neo.util.VNode', () => {
+    test('pruneRetiredReferences drops a reference whose component left the registry and keeps the rest', () => {
+        const live = Neo.create(Component, {id: 'vnode-util-live'}),
+              gone = Neo.create(Component, {id: 'vnode-util-gone'});
+
+        gone.destroy();
+
+        expect(ComponentManager.get('vnode-util-gone'), 'the retired component is out of the registry').toBeFalsy();
+
+        const tree = {
+            id        : 'vnode-util-root',
+            childNodes: [
+                {componentId: 'vnode-util-live'},
+                {componentId: 'vnode-util-gone'},
+                {
+                    id        : 'vnode-util-wrapper',
+                    childNodes: [{componentId: 'vnode-util-gone'}, {id: 'vnode-util-leaf', childNodes: []}]
+                }
+            ]
+        };
+
+        try {
+            expect(VNode.pruneRetiredReferences(tree), 'both stale references are counted').toBe(2);
+
+            expect(tree.childNodes.map(node => node.componentId || node.id)).toEqual(['vnode-util-live', 'vnode-util-wrapper']);
+            expect(tree.childNodes[1].childNodes.map(node => node.id)).toEqual(['vnode-util-leaf']);
+
+            // A live reference is kept as a reference — the walk never descends into another
+            // component's stored vnode, which is that component's own to keep clean.
+            expect(tree.childNodes[0]).toEqual({componentId: 'vnode-util-live'});
+
+            // The strict walkers stay strict: the pruned tree maps without touching the registry for
+            // anything that is gone, and an unpruned stale reference still throws.
+            expect([...VNode.createMap(tree).keys()]).toContain('vnode-util-leaf');
+            expect(() => VNode.getVnode({componentId: 'vnode-util-gone'})).toThrow('Component not found for id: vnode-util-gone')
+        } finally {
+            live.destroy()
+        }
+    });
+});

--- a/test/playwright/unit/vdom/RaceCondition.spec.mjs
+++ b/test/playwright/unit/vdom/RaceCondition.spec.mjs
@@ -22,13 +22,14 @@ import Container          from '../../../../src/container/Base.mjs';
 import DomApiVnodeCreator from '../../../../src/vdom/util/DomApiVnodeCreator.mjs';
 import VdomHelper         from '../../../../src/vdom/Helper.mjs';
 import VDomUpdate         from '../../../../src/manager/VDomUpdate.mjs';
+import VNodeUtil          from '../../../../src/util/VNode.mjs';
 
 class RaceChildComponent extends Component {
     static config = {
         className: 'Test.RaceChildComponent',
-        ntype: 'test-race-child',
-        hideMode: 'removeDom', // Crucial for reproduction
-        _vdom: {tag: 'div', cls: ['child']}
+        ntype    : 'test-race-child',
+        hideMode : 'removeDom', // Crucial for reproduction
+        _vdom    : {tag: 'div', cls: ['child']}
     }
 }
 RaceChildComponent = Neo.setupClass(RaceChildComponent);
@@ -61,9 +62,9 @@ test.describe('VdomLifecycle Race Condition', () => {
     // in an unrelated suite. Captured once here, restored after every test.
     const realApplyDeltas = Neo.applyDeltas;
 
-    let testIdCounter = 0;
-    const getUniqueId = (prefix) => `${prefix}-${Date.now()}-${testIdCounter++}`;
-    let createdComponentIds = [];
+    let   testIdCounter       = 0;
+    const getUniqueId         = (prefix) => `${prefix}-${Date.now()}-${testIdCounter++}`;
+    let   createdComponentIds = [];
 
     test.afterEach(() => {
         Neo.applyDeltas = realApplyDeltas;
@@ -75,6 +76,71 @@ test.describe('VdomLifecycle Race Condition', () => {
             }
         });
         createdComponentIds = [];
+    });
+
+    /**
+     * A child retired silently — destroyed without an update of its own, the way a projection
+     * transaction retires a leaver's tab button — leaves no vdom, no DOM node and no reference in
+     * its parent's stored vnode. One carrier remains: a parent flight that collected its payload
+     * while the child was alive and lands after the destroy still names the child by reference.
+     *
+     * The in-process helper answers in microtasks, so the destroy below could never fall between
+     * collection and landing on its own; one macrotask of latency is the smallest honest stand-in
+     * for the worker round trip the real app pays.
+     */
+    test('a child retired while its parent flight is in the air does not fail that flight', async () => {
+        Neo.applyDeltas = async () => {};
+
+        const
+            containerId = getUniqueId('race-retire-container'),
+            leaverId    = getUniqueId('race-retire-leaver'),
+            keeperId    = getUniqueId('race-retire-keeper');
+
+        createdComponentIds.push(containerId);
+
+        const container = Neo.create(RaceContainer, {
+            appName,
+            id   : containerId,
+            items: [
+                {module: RaceChildComponent, id: leaverId, hidden: false, text: 'leaves'},
+                {module: RaceChildComponent, id: keeperId, hidden: false, text: 'stays'}
+            ]
+        });
+
+        await container.initVnode(true);
+        container.mounted = true;
+        await container.promiseUpdate();
+
+        const originalUpdateBatch = VdomHelper.updateBatch;
+
+        VdomHelper.updateBatch = async data => {
+            await new Promise(resolve => setTimeout(resolve, 10));
+            return originalUpdateBatch.call(VdomHelper, data)
+        };
+
+        try {
+            // Depth 1: the children ride the payload as references, exactly the shape that lands stale.
+            container.updateDepth = 1;
+
+            const flight = container.promiseUpdate();
+
+            // Past the collection yield, before the deferred landing.
+            await new Promise(resolve => setTimeout(resolve, 3));
+            expect(container.isVdomUpdating, 'the parent flight is in the air').toBe(true);
+
+            container.remove(container.items[0], true, true);
+            expect(Neo.getComponent(leaverId), 'the leaver is retired').toBeFalsy();
+
+            // Pre-fix: the landing walk resolves the leaver's reference through the registry, throws
+            // "Component not found", and the flight rejects — a transaction awaiting it fails with it.
+            await flight;
+
+            expect(container.isVdomUpdating).toBe(false);
+            expect(JSON.stringify(container.vnode), 'the adopted vnode names no retired child').not.toContain(leaverId);
+            expect(VNodeUtil.createMap(container.vnode).has(keeperId), 'the surviving child is still mapped').toBe(true)
+        } finally {
+            VdomHelper.updateBatch = originalUpdateBatch
+        }
     });
 
     /**
@@ -103,23 +169,23 @@ test.describe('VdomLifecycle Race Condition', () => {
         };
 
         const containerId = getUniqueId('test-container');
-        const child1Id = getUniqueId('child-1');
-        const child2Id = getUniqueId('child-2');
+        const child1Id    = getUniqueId('child-1');
+        const child2Id    = getUniqueId('child-2');
         createdComponentIds.push(containerId); // Cleanup tracking
 
         const container = Neo.create(RaceContainer, {
             appName,
-            id: containerId,
+            id   : containerId,
             items: [{
                 module: RaceChildComponent,
-                id: child1Id,
+                id    : child1Id,
                 hidden: true,
-                text: 'Child 1'
+                text  : 'Child 1'
             }, {
                 module: RaceChildComponent,
-                id: child2Id,
+                id    : child2Id,
                 hidden: true,
-                text: 'Child 2'
+                text  : 'Child 2'
             }]
         });
 
@@ -275,23 +341,23 @@ test.describe('VdomLifecycle Race Condition', () => {
         };
 
         const containerId = getUniqueId('test-container');
-        const child1Id = getUniqueId('child-1');
-        const child2Id = getUniqueId('child-2');
+        const child1Id    = getUniqueId('child-1');
+        const child2Id    = getUniqueId('child-2');
         createdComponentIds.push(containerId);
 
         const container = Neo.create(RaceContainer, {
             appName,
-            id: containerId,
+            id   : containerId,
             items: [{
                 module: RaceChildComponent,
-                id: child1Id,
+                id    : child1Id,
                 hidden: true, // Start hidden to mimic prev setup
-                text: 'Child 1'
+                text  : 'Child 1'
             }, {
                 module: RaceChildComponent,
-                id: child2Id,
+                id    : child2Id,
                 hidden: true, // Start hidden
-                text: 'Child 2'
+                text  : 'Child 2'
             }]
         });
 
@@ -343,18 +409,18 @@ test.describe('VdomLifecycle Race Condition', () => {
         };
 
         const containerId = getUniqueId('test-container');
-        const child1Id = getUniqueId('child-1');
-        const child2Id = getUniqueId('child-2'); // Add second child to match structure if needed, or stick to 1
+        const child1Id    = getUniqueId('child-1');
+        const child2Id    = getUniqueId('child-2'); // Add second child to match structure if needed, or stick to 1
         createdComponentIds.push(containerId);
 
         const container = Neo.create(RaceContainer, {
             appName,
-            id: containerId,
+            id   : containerId,
             items: [{
                 module: RaceChildComponent,
-                id: child1Id,
+                id    : child1Id,
                 hidden: true,
-                text: 'Child 1'
+                text  : 'Child 1'
             }]
         });
 
@@ -405,17 +471,17 @@ test.describe('VdomLifecycle Race Condition', () => {
         };
 
         const containerId = getUniqueId('test-container');
-        const child1Id = getUniqueId('child-1');
+        const child1Id    = getUniqueId('child-1');
         createdComponentIds.push(containerId);
 
         const container = Neo.create(RaceContainer, {
             appName,
-            id: containerId,
+            id   : containerId,
             items: [{
                 module: RaceChildComponent,
-                id: child1Id,
+                id    : child1Id,
                 hidden: true,
-                text: 'Child 1'
+                text  : 'Child 1'
             }]
         });
 

--- a/test/playwright/unit/vdom/UpdateWedge.spec.mjs
+++ b/test/playwright/unit/vdom/UpdateWedge.spec.mjs
@@ -171,6 +171,103 @@ test.describe('VdomLifecycle update wedge (#12946)', () => {
         expect(VDomUpdate.inFlightUpdateMap.has(child.id)).toBe(false);
     });
 
+    test('#18297: a promiseUpdate() parked behind a FAILING descendant flight settles instead of hanging', async () => {
+        Neo.applyDeltas = async () => {};
+
+        const containerId = getUniqueId('wedge-container');
+        const childId     = getUniqueId('wedge-child');
+        createdComponentIds.push(containerId);
+
+        const container = Neo.create(WedgeContainer, {
+            appName,
+            id   : containerId,
+            items: [{module: WedgeChild, id: childId, text: 'pristine'}]
+        });
+
+        await container.initVnode(true);
+        container.mounted = true;
+
+        const child = container.items[0];
+        await container.promiseUpdate();
+
+        VdomHelper.updateBatch = () => Promise.reject({data: {error: 'test-injected apply failure'}});
+
+        // The child's flight enters in-flight synchronously and registers itself as an in-flight
+        // descendant of the container.
+        const childFlight = child.promiseUpdate();
+        expect(child.isVdomUpdating).toBe(true);
+        expect(VDomUpdate.hasInFlightDescendants(container.id)).toBe(true);
+
+        // The container yields to its in-flight descendant instead of starting a flight of its own:
+        // its update waits in the post-update queue keyed on the child, to run once the child's
+        // flight completes. A success drains that queue; this arm asks what a failure does with it.
+        const parentFlight = container.promiseUpdate();
+        expect(container.isVdomUpdating, 'the parent yielded to the in-flight descendant').toBe(false);
+
+        await expect(childFlight).rejects.toBeTruthy();
+
+        // The failing child released its in-flight state, so nothing blocks the parent any more.
+        expect(VDomUpdate.hasInFlightDescendants(container.id)).toBe(false);
+
+        // Pre-fix the queue keyed on the failed child was never drained, so the parent's promise
+        // could settle by no route at all: the dock's projection transaction, awaiting exactly such a
+        // flight, stayed suspended with two shells in the host and its recovery never ran.
+        const outcome = await Promise.race([
+            parentFlight.then(() => 'settled', () => 'settled'),
+            new Promise(resolve => setTimeout(() => resolve('hung'), 300))
+        ]);
+
+        expect(outcome, 'a parent parked behind a failing descendant flight settles').toBe('settled');
+
+        // Released, the parent runs its own flight against the same failing boundary and rejects
+        // honestly — its own outcome, not the child's, decides the promise.
+        await expect(parentFlight).rejects.toBeTruthy();
+
+        expect(container.isVdomUpdating).toBe(false);
+        expect(VDomUpdate.inFlightUpdateMap.has(container.id)).toBe(false);
+    });
+
+    test('#18297: a promiseUpdate() parked behind a FAILING descendant render flight settles too', async () => {
+        Neo.applyDeltas = async () => {};
+
+        const containerId = getUniqueId('wedge-container');
+        const childId     = getUniqueId('wedge-child');
+        createdComponentIds.push(containerId);
+
+        const container = Neo.create(WedgeContainer, {
+            appName,
+            id   : containerId,
+            items: []
+        });
+
+        await container.initVnode(true);
+        container.mounted = true;
+        await container.promiseUpdate();
+
+        // A silently inserted child has no vnode yet: its render flight is the in-flight descendant
+        // the parent yields to, and it fails at the create boundary — the same gap, render-path flavour.
+        const child = container.insert(0, {module: WedgeChild, id: childId, text: 'unborn'}, true);
+
+        VdomHelper.create = () => Promise.reject(new Error('test-injected create failure'));
+
+        const childFlight = child.initVnode(true);
+        expect(VDomUpdate.hasInFlightDescendants(container.id), 'the render flight is an in-flight descendant').toBe(true);
+
+        const parentFlight = container.promiseUpdate();
+        expect(container.isVdomUpdating, 'the parent yielded to the in-flight descendant').toBe(false);
+
+        await expect(childFlight).rejects.toThrow('test-injected create failure');
+
+        const outcome = await Promise.race([
+            parentFlight.then(() => 'settled', () => 'settled'),
+            new Promise(resolve => setTimeout(() => resolve('hung'), 300))
+        ]);
+
+        expect(outcome, 'a parent parked behind a failing descendant render flight settles').toBe('settled');
+        expect(container.isVdomUpdating).toBe(false);
+        expect(VDomUpdate.inFlightUpdateMap.has(container.id)).toBe(false);
+    });
+
     test('REGRESSION: initVnode failure releases the flag and the in-flight registry entry', async () => {
         const containerId = getUniqueId('wedge-container');
         createdComponentIds.push(containerId);


### PR DESCRIPTION
Resolves #18297

🌿 A tab button retired in the middle of a flight can no longer take the flight, or the transaction waiting on it, down with it.

Two halves, both in the engine, both red-first at the tier where they live. The hang: a `promiseUpdate()` that yields to another component's in-flight update parks only a `resolve` in the post-update queue, and only the success path drained that queue — so the reconciler's awaited phase, parked behind the staged shell's flight, never settled when that flight failed, and the recovery from #18147 never ran. Both failure paths (`executeVdomUpdate`, `initVnode`) now release the queue: a waiter runs its own flight and settles on its own outcome. The root: a flight collected while a child was alive and landing after the child's silent retirement still names the child by `{componentId}` reference, and the landing walk resolved it strictly and threw. The landing boundary now prunes references to retired children before the walkers run, and the walkers stay strict. A projection whose leaver's button is retired under an in-flight ancestor lands as one shell with no failure reported.

Evidence: L2 (real in-process flights in the unit tier — real objects through the in-process renderer, red-first at `dev` for both halves, one macrotask of helper latency standing in for the worker round trip; the unit harness applies no DOM deltas, so nothing here observes a browser) → L3 required (AC-2's visible shell at `shellIndex` and pane reachability; AC-4). Residual: AC-2 (browser portion), AC-4, Residual-Owner: neomjs/neo-agent-institution#103.

## AC Evidence
| AC-1 | CI-covered at L2, with the tier deviation its author accepted (see Deltas): the red-first engine arm is `test/playwright/unit/vdom/RaceCondition.spec.mjs` › "a child retired while its parent flight is in the air does not fail that flight" — on `dev` the flight rejects with `util.VNode.getVnode: Component not found for id: …` (`VNode.mjs:212`); the two-commit workspace gesture is `test/playwright/unit/dashboard/DockBackToBackCommits.spec.mjs`, a regression net that was never red at this tier |
| AC-2 | CI-covered at L2 for its unit half: `DockBackToBackCommits.spec.mjs` — after the second commit the workspace holds one shell, the retired button is gone from the bar and from the registry, and no `dockProjectionFailed` event, `Dock projection failed` warning or `vdom update failed` error was emitted; outside CI the same arm with `--repeat-each 5`. The arm reads component collections and captured logs — the harness applies no DOM deltas — so it does NOT observe the criterion's browser half: one shell **visible** at `shellIndex`, every committed pane **reachable**, N=5 headless. That half is not proven in this repository; it is the observation AC-4's arm makes at the consumer, and its ownership is proposed to the ticket's author on #18297 (comment 5546977191) for her application — neomjs/neo-agent-institution#103 is the existing owner |
| AC-3 | CI-covered at L2: `test/playwright/unit/vdom/UpdateWedge.spec.mjs` › the two arms named for this ticket — a parent `promiseUpdate()` parked behind a FAILING descendant flight (update flavour, render flavour) settles instead of hanging (`dev`: "Received: hung"); the rejection path itself stays as `DockProjectionReconciler.spec.mjs` › "a rejected flight in phase … leaves exactly one visible shell and reports it" (unchanged, green) |
| AC-4 | Post-merge: the Institution's `FleetCockpitDockNL.spec.mjs:199` reads 5/5 headless under the Brain root against the engine pin that carries this — neomjs/neo-agent-institution#103 |

## Deltas from ticket
AC-1 names a workspace two-commit arm red on `dev`. Measured while building it: a silent destroy already scrubs its parent's stored vnode (`bar.vnode` read clean the moment `reconcileTabChrome` returned), so the stale reference lives only in a flight's RETURNED vnode; the in-process helper answers in microtasks and ancestor/descendant flights serialize, so no unit-tier dock arm can put a retirement between a flight's collection and its landing. The red-first witness for the root therefore sits one tier down, in the lifecycle race spec, with one macrotask of helper latency standing in for the worker round trip; the two-commit workspace arm pins the commit's end state under the same gesture and is described in its header as a regression net, not a witness. The dock-tier red-first is the Institution's NL arm (AC-4). The ticket's root options were (a) enrol the retiring bar in `commitBars` or (b) a tolerant `createMap`: (a) cannot close the race (the poisoning flight is already in the air), and (b) would leave a dead reference in the adopted vnode for every strict walker to trip on — the fix prunes the returned tree once at the landing boundary instead. Also fixed, with its own arm: the same missing release in `initVnode`'s catch (render-path flavour).

AC-2 is met at L2 in this repository and not at L3: the unit harness applies no DOM deltas (`test/playwright/setup.mjs`), so "visible" and "reachable" are not observations any arm here can make. The browser half is either AC-4's observation at the consumer or a component-tier engine arm — the author's call, proposed on the ticket; this PR does not restate her criterion.

## Test Evidence
Red-first receipts with the touched sources checked out from `origin/dev` at `131c782ca8`: `UpdateWedge` — both new arms "Expected: settled, Received: hung" (2 failed / 4 passed), 6/6 with the release; `RaceCondition` — the new arm rejects with `Component not found for id: race-retire-leaver-…` at `VNode.mjs:212`, green with the prune; `util/VNode` — the prune counts two stale references, keeps the live one as a reference, and `getVnode` still throws on an unpruned one. Full unit suite on the branch (`--workers=1`): 3214 passed, 1 failed — the one red is #18319, a destroyed Workspace's pending admission timer landing in a random `main/addon` spec (same `expireTearOutAdmission` stack in every full run today; filed, unrelated to this diff). `DockBackToBackCommits` with `--repeat-each 5`: 5 passed; its inline comment now says what its header says — never red at this tier — instead of asserting the failure the hypothesis predicted.

## Post-Merge Validation
- AC-4 is verified after the merge, by the Institution: its arm `FleetCockpitDockNL.spec.mjs:199` reads 5/5 headless under the Brain root against the engine pin that carries this fix. The pin, the arm's hold comment and the README line are owned there — neomjs/neo-agent-institution#103 (open, @neo-fable-clio), which closes on that pin.
- AC-2's browser half (visible at `shellIndex`, every committed pane reachable, N=5 headless) rides the same arm and the same owner, neomjs/neo-agent-institution#103, unless the ticket's author asks for an engine component arm instead (#18297, comment 5546977191).

## Commits (if multi-commit)
- `a8651e7ce8` — the hang half: a failed flight releases the updates parked behind it (both catch sites, two red-first arms)
- `e3109a805a` — the root half: a landing flight prunes references to children retired while it was in the air (the race arm, the util arm, the two-commit regression net)
- `2220f23322` — the two-commit arm's inline comment agrees with its header (never red at this tier); no runtime change

Authored by Vega (Claude Fable 5.1, Claude Code). Session 007aac9d-974a-465c-9015-378aeb741bd5.
