### PR TITLE
ci(deps): dependency version updates, majors included (#18302)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,41 @@
+# Dependabot VERSION updates. Security updates are a separate, already-active surface: they need no
+# config file and have been opening PRs here for months (#18132, #16669, #16608, #16478, #16476, all
+# titled `bump the npm_and_yarn group`). Without this file nothing else ever moves a dependency, so an
+# advisory was the only event that did — which is the whole defect #18302 describes.
+#
+# MAJORS ARE INCLUDED BY NOT BEING EXCLUDED. Dependabot's default covers every semver level; you opt
+# OUT with `ignore: [{update-types: ["version-update:semver-major"]}]`. There is deliberately no such
+# key here. Operator direction 2026-09-04: move fast, take the majors, and let the next real PR's CI
+# surface a break rather than paying a review cycle per bump up front. That trade is safe because
+# `npm-publish.yml` fires on `release:` / `workflow_dispatch` only, never on a push to `dev` — a bad
+# bump reaches `dev` and stops there, behind the human release cut.
+#
+# GROUPED, because ungrouped daily updates across a 31-module dock package produce a PR per dependency
+# and train everyone to ignore the queue. One PR per ecosystem per day is reviewable; ten are noise.
+#
+# `github-actions` is here because nothing else updates the pinned action SHAs and versions
+# (`actions/checkout@v4`, `actions/setup-node@v4`). That is a live supply-chain surface, not hygiene.
+#
+# NOT A FRESHNESS MECHANISM. `#17798` settled that consuming repos take a canonical store as an npm
+# dependency and that policing duplicated bytes is "evidence of the mistake rather than mitigation of
+# it"; its Contract Ledger names this exact surface as `npm outdated / dependabot — ecosystem-native;
+# no bespoke gate`. So there is no materializer, no installer, and no drift check around this file.
+# Each repository commits its own twelve lines.
+version: 2
+
+updates:
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: daily
+    groups:
+      all-deps:
+        patterns: ["*"]
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: daily
+    groups:
+      actions:
+        patterns: ["*"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,26 +1,13 @@
-# Dependabot VERSION updates. Security updates are a separate, already-active surface: they need no
-# config file and have been opening PRs here for months (#18132, #16669, #16608, #16478, #16476, all
-# titled `bump the npm_and_yarn group`). Without this file nothing else ever moves a dependency, so an
-# advisory was the only event that did — which is the whole defect #18302 describes.
+# Version updates. Security updates are a separate surface that needs no config and already runs.
 #
-# MAJORS ARE INCLUDED BY NOT BEING EXCLUDED. Dependabot's default covers every semver level; you opt
-# OUT with `ignore: [{update-types: ["version-update:semver-major"]}]`. There is deliberately no such
-# key here. Operator direction 2026-09-04: move fast, take the majors, and let the next real PR's CI
-# surface a break rather than paying a review cycle per bump up front. That trade is safe because
-# `npm-publish.yml` fires on `release:` / `workflow_dispatch` only, never on a push to `dev` — a bad
-# bump reaches `dev` and stops there, behind the human release cut.
+# MAJORS ARE INCLUDED BY NOT BEING EXCLUDED: Dependabot's default spans every SemVer level, and you
+# opt out with `ignore: [{update-types: ["version-update:semver-major"]}]`. The absence of that key
+# is deliberate — do not add one without changing the policy it encodes.
 #
-# GROUPED, because ungrouped daily updates across a 31-module dock package produce a PR per dependency
-# and train everyone to ignore the queue. One PR per ecosystem per day is reviewable; ten are noise.
+# GROUPED, because ungrouped daily updates open a PR per dependency and the queue stops being read.
+# `github-actions` is here because nothing else updates the pinned action versions.
 #
-# `github-actions` is here because nothing else updates the pinned action SHAs and versions
-# (`actions/checkout@v4`, `actions/setup-node@v4`). That is a live supply-chain surface, not hygiene.
-#
-# NOT A FRESHNESS MECHANISM. `#17798` settled that consuming repos take a canonical store as an npm
-# dependency and that policing duplicated bytes is "evidence of the mistake rather than mitigation of
-# it"; its Contract Ledger names this exact surface as `npm outdated / dependabot — ecosystem-native;
-# no bespoke gate`. So there is no materializer, no installer, and no drift check around this file.
-# Each repository commits its own twelve lines.
+# No materializer, installer or drift check accompanies this file: each repository commits its own.
 version: 2
 
 updates:

--- a/.github/workflows/pr-baseline.yml
+++ b/.github/workflows/pr-baseline.yml
@@ -70,20 +70,6 @@ permissions:
 
 jobs:
   baseline:
-    # Dependabot authors no ticket, so `pr-body` can only ever fail on its PRs: a bump body carries no
-    # newline-isolated `Resolves #N` and no `Evidence:` line, and it would be wrong for it to — there is
-    # no leaf to close. Skipping is the honest outcome; the alternative is a permanent red that teaches
-    # readers to ignore red, which costs more than the check earns.
-    #
-    # This is NOT currently a merge block — per the header, `dev` carries no `required_status_checks`
-    # rule, so a red baseline job blocks nothing today. It becomes one the moment those contexts are
-    # bound, which #18302 sequences BEFORE enabling auto-merge. The skip is therefore signal integrity
-    # now and a genuine prerequisite later, and it is cheaper to land it before the queue exists than to
-    # explain a wall of red afterwards.
-    #
-    # Keyed on the PR AUTHOR, not `github.actor`: a human editing a bot's PR body fires `edited` with
-    # their own actor, and that must still skip — the body is Dependabot's either way.
-    if: github.event.pull_request.user.login != 'dependabot[bot]'
     uses: neomjs/neo-agent-skills/.github/workflows/reusable-pr-baseline.yml@e409dea5dcbc9f6f97d6eb86ecbef4caa7a269b8
     with:
       required_base: dev

--- a/.github/workflows/pr-baseline.yml
+++ b/.github/workflows/pr-baseline.yml
@@ -70,6 +70,20 @@ permissions:
 
 jobs:
   baseline:
+    # Dependabot authors no ticket, so `pr-body` can only ever fail on its PRs: a bump body carries no
+    # newline-isolated `Resolves #N` and no `Evidence:` line, and it would be wrong for it to — there is
+    # no leaf to close. Skipping is the honest outcome; the alternative is a permanent red that teaches
+    # readers to ignore red, which costs more than the check earns.
+    #
+    # This is NOT currently a merge block — per the header, `dev` carries no `required_status_checks`
+    # rule, so a red baseline job blocks nothing today. It becomes one the moment those contexts are
+    # bound, which #18302 sequences BEFORE enabling auto-merge. The skip is therefore signal integrity
+    # now and a genuine prerequisite later, and it is cheaper to land it before the queue exists than to
+    # explain a wall of red afterwards.
+    #
+    # Keyed on the PR AUTHOR, not `github.actor`: a human editing a bot's PR body fires `edited` with
+    # their own actor, and that must still skip — the body is Dependabot's either way.
+    if: github.event.pull_request.user.login != 'dependabot[bot]'
     uses: neomjs/neo-agent-skills/.github/workflows/reusable-pr-baseline.yml@e409dea5dcbc9f6f97d6eb86ecbef4caa7a269b8
     with:
       required_base: dev


### PR DESCRIPTION
Resolves #18302

Dependabot security updates have been running here for months — five merged PRs, all `bump the npm_and_yarn group`, which is the security-updates group and needs no config file. Version updates were never configured, so an advisory was the only event that ever moved a dependency.

One file. Majors are included **by not being excluded**: Dependabot's default spans every SemVer level and you opt out with `ignore: version-update:semver-major`. There is deliberately no such key.

Evidence: L1 (YAML contract + a source read of the pinned reusable baseline at `neo-agent-skills@e409dea5d`) → L1 required for AC-1, AC-2, AC-4, AC-5. Residual: AC-3, Post-Merge Validation by construction — Dependabot reads `.github/dependabot.yml` from the **default branch only**, so no bot PR can exist against this unmerged head. Failure becomes a new ticket.

## AC Evidence

| AC | Evidence |
| --- | --- |
| AC-1 | `.github/dependabot.yml` parses with `version: 2`, ecosystems `npm` + `github-actions`, `daily`, both grouped, and **no** `ignore` entry — asserted programmatically (`majors ignored? no`). |
| AC-2 | **No workflow is modified.** Verified at the pinned callee that both PR-body steps carry `if: startsWith(user.login, 'neo-') || contains(labels.*.name, 'ai')`, so a Dependabot PR already reports green through the existing scoping. |
| AC-3 | **Post-Merge Validation** — see below. |
| AC-4 | No materializer, installer, sync workflow or drift check. Diff is one file, +28/-0. |
| AC-5 | The one remaining operator-owned setting is recorded below as deferred, with the consequence stated. |

## Deltas from ticket

**The ticket's second prerequisite was falsified and is retracted — twice corrected, and the second correction removes it entirely.** @neo-gpt's review supplied the falsifier; I verified it at source before accepting.

`pr-baseline.yml` does fire on a Dependabot PR — that much held. But it is a *caller*, and the work happens in the pinned reusable workflow at `neo-agent-skills@e409dea5d`, which I had never opened. Both of its PR-body steps carry:

```yaml
if: startsWith(github.event.pull_request.user.login, 'neo-') || contains(github.event.pull_request.labels.*.name, 'ai')
```

A Dependabot PR is authored by `dependabot[bot]` and labelled `dependencies` / `javascript`. It matches neither clause, so **the body validator never runs on it.** There was nothing to exempt, and the first revision of this PR removed a hunk that solved a problem that did not exist.

The exemption would also have been *harmful*, not merely redundant, and the callee's own comment says why: *"The steps are gated rather than the job, so the check still REPORTS on a human PR: a skipped job cannot serve as a required status context."* A caller-level `if:` marks all five called jobs skipped — `pr-base`, `skills-materialized`, `source-comment-archaeology`, `substrate-size`, `pr-body` — and a skipped job cannot be bound as a required context. It would have broken **prerequisite (1) of this very ticket.**

**How it survived a deliberate verification pass.** I swept four workflow `on:` blocks and concluded correctly that `pr-baseline` fires; I never asked whether the job *inside* it applies to a bot. The instrument was pointed at the caller's trigger while the gate lived one level down, behind a pinned SHA. **A caller firing is not a check running.** Ticket body, Contract Ledger, AC-2 and AC-3 are all truth-synced to this.

Second delta: the config's comment preamble is cut from 23 lines to 9. The ticket history, dated operator rationale, release-routing claim and five old PR numbers live in #18302 and here, and would have staled inside an operational file.

## Test Evidence

No runtime surface. YAML validity asserted programmatically. The decisive control this time was a source read of the **pinned callee** rather than the caller: both body-validation steps' `if:` expressions read at `e409dea5d`, and the five job names enumerated to establish what a caller-level skip would have suppressed. `check-ticket-archaeology` is N/A — it scopes to `.mjs` and reports `0 files in scope` for the changed path.

## Post-Merge Validation

**AC-3 is owed here and cannot be discharged earlier** — Dependabot reads its config from the default branch, so the first real bot PR exists only after this merges to `dev`. On that PR confirm: grouped version-update PRs appear (one per ecosystem, not one per dependency), **all five baseline contexts are still emitted rather than skipped**, and `baseline / PR body` is green *because its agent-only steps skipped*. A **missing** context is the failure signal, since it would mean something removed a check. Failure creates a new ticket.

## Deferred — operator-owned, not in this PR

Prerequisite (2) no longer exists; only this remains:

**Make `unit` and `components` required status checks on `dev`, before enabling auto-merge.** Consequence of deferral: GitHub auto-merge waits only for *required* checks, and `requiredSet.contexts` is currently `[]` — so enabling auto-merge without this merges each PR as soon as it is mergeable, **before CI reports**. "Green CI is enough" would silently become "CI is irrelevant."

---

Authored by Grace (Claude Opus 5, Claude Code), session `b983b2a8-18bc-4dd0-a63f-23380dc3a49d`
