### PR TITLE
fix(dock): a destroyed workspace clears its pending admission timers (#18319)

### DIFF
--- a/src/dashboard/dock/Workspace.mjs
+++ b/src/dashboard/dock/Workspace.mjs
@@ -1629,27 +1629,25 @@ class Workspace extends Container {
     }
 
     /**
-     * Tears down the producer and pending refresh chain. An enabled tear-out lifecycle first
-     * unregisters its worker routes, closes every pending/connected/committed vessel, and settles
-     * every owner-held pane exactly once; a refresh scheduled before teardown no-ops on its
-     * `isDestroyed` guard.
+     * Tears down the producer and pending refresh chain. The tear-out state this instance owns —
+     * every pending/connected/committed vessel, every admission with its expiry timer, every
+     * owner-held pane — retires exactly once whether or not the lifecycle opt-in is on, because
+     * `acquireTearOutVessel()` arms an admission and opens its vessel without it. Only the worker
+     * route subscription is the opt-in's to unregister, since only the opt-in subscribed. A refresh
+     * scheduled before teardown no-ops on its `isDestroyed` guard.
      * @param {...*} args
      */
     destroy(...args) {
         let me = this;
 
-        // Armed by acquireTearOutVessel() with or without the lifecycle opt-in below, so cleared with or without it.
-        me.tearOutAdmissions?.forEach((admission, itemId) => me.clearTearOutAdmission(itemId, admission));
+        me.enableDockTearOutLifecycle && Neo.currentWorker.un({
+            connect   : me.onWindowConnect,
+            disconnect: me.onWindowDisconnect,
+            scope     : me
+        });
 
-        if (me.enableDockTearOutLifecycle) {
-            Neo.currentWorker.un({
-                connect   : me.onWindowConnect,
-                disconnect: me.onWindowDisconnect,
-                scope     : me
-            });
-            me.retireTearOutState();
-            me.tearOutHandlers = null
-        }
+        me.retireTearOutState();
+        me.tearOutHandlers = null;
 
         if (me.dockMaximizeResizeObserved) {
             me.dockMaximizeResizeObserved = false;

--- a/src/dashboard/dock/Workspace.mjs
+++ b/src/dashboard/dock/Workspace.mjs
@@ -714,7 +714,8 @@ class Workspace extends Container {
     async expireTearOutAdmission(itemId, admission) {
         let me = this;
 
-        if (admission?.connected) return;
+        // An expiry already queued when the instance went away has nothing left to expire.
+        if (me.isDestroyed || admission?.connected) return;
         if (!admission || me.tearOutAdmissions.get(itemId) !== admission) return;
 
         const entry  = me.tearOutPanes[itemId],
@@ -1636,6 +1637,9 @@ class Workspace extends Container {
      */
     destroy(...args) {
         let me = this;
+
+        // Armed by acquireTearOutVessel() with or without the lifecycle opt-in below, so cleared with or without it.
+        me.tearOutAdmissions?.forEach((admission, itemId) => me.clearTearOutAdmission(itemId, admission));
 
         if (me.enableDockTearOutLifecycle) {
             Neo.currentWorker.un({

--- a/test/playwright/unit/dashboard/DockWorkspace.spec.mjs
+++ b/test/playwright/unit/dashboard/DockWorkspace.spec.mjs
@@ -2167,9 +2167,9 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
         expect(pinAction.hidden, 'converging on the active item\'s real policy').toBe(false);
 
         // The load-bearing half, and the reason this counts emitters rather than signals. The refresh
-        // QUEUE replays each pending refresh in order, and refresh #1 reconciles chrome to the
-        // document as it stood when it was queued — so its sweep re-hides the action before refresh
-        // #2 settles it, and the post-refresh signal COUNT is not 0. Those extra signals are a
+        // QUEUE replays each pending refresh in order, and the first refresh reconciles chrome to the
+        // document as it stood when it was queued — so its sweep re-hides the action before the
+        // second settles it, and the post-refresh signal COUNT is not 0. Those extra signals are a
         // property of the queue, not of this action: `close` lags identically, and nothing here
         // could fix it without changing refresh sequencing for every consumer. What AC-3 actually
         // claims is that no group was ever rebuilt behind them — every signal, before and after
@@ -3756,6 +3756,55 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
                 // the only thing the engine default does that a host cannot undo, so an empty
                 // collector is the honest statement that no second vessel exists.
                 expect(opens, 'the engine opened nothing of its own').toEqual([])
+            } finally {
+                Neo.Main = originalMain;
+                Neo.config.useSharedWorkers = useSharedWorkers
+            }
+        });
+
+        test('a destroyed workspace fires no pending admission expiry, lifecycle opt-in or not', async () => {
+            class ShortWindowOpenerWorkspace extends PlainWorkspace {
+                static config = {
+                    className             : 'Test.Unit.Dashboard.DockWorkspace.ShortWindowOpenerWorkspace',
+                    tearOutConnectWindowMs: 20
+                }
+
+                openTearOutVessel(request) {
+                    return {admissionToken: request.admissionToken, windowName: `short-${request.itemId}`}
+                }
+            }
+
+            Neo.setupClass(ShortWindowOpenerWorkspace);
+
+            // The lifecycle opt-in is OFF here (the default), so `destroy()` does not run the retire that
+            // sweeps admissions — while `acquireTearOutVessel` arms the expiry timer regardless.
+            workspace = Neo.create(ShortWindowOpenerWorkspace, {dockModel: createDocument()});
+
+            const
+                {useSharedWorkers} = Neo.config,
+                originalMain       = Neo.Main;
+
+            Neo.Main = {
+                getByPath    : () => Promise.resolve('https://example.test/app/index.html'),
+                getWindowData: () => Promise.resolve({innerHeight: 800, outerHeight: 860, screenLeft: 0, screenTop: 0}),
+                windowOpen   : () => Promise.resolve(true)
+            };
+            Neo.config.useSharedWorkers = true;
+
+            try {
+                expect(workspace.enableDockTearOutLifecycle, 'the lifecycle opt-in is off').toBe(false);
+
+                await workspace.acquireTearOutVessel({admissionToken: 7, itemId: 'editor'});
+
+                expect(workspace.tearOutAdmissions.get('editor')?.timerId, 'the admission armed its expiry').toBeTruthy();
+
+                workspace.destroy();
+                workspace = null;
+
+                // Pre-fix the 20 ms expiry fires on the destroyed instance and dereferences a field core
+                // destroy removed — an uncaught TypeError charged to whichever test is running by then.
+                // Waiting past the window inside THIS arm makes that test this one.
+                await new Promise(resolve => setTimeout(resolve, 60))
             } finally {
                 Neo.Main = originalMain;
                 Neo.config.useSharedWorkers = useSharedWorkers

--- a/test/playwright/unit/dashboard/DockWorkspace.spec.mjs
+++ b/test/playwright/unit/dashboard/DockWorkspace.spec.mjs
@@ -3762,7 +3762,9 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
             }
         });
 
-        test('a destroyed workspace fires no pending admission expiry, lifecycle opt-in or not', async () => {
+        test('a destroyed workspace fires no pending admission expiry and closes the vessel it opened, lifecycle opt-in or not', async () => {
+            const closes = [];
+
             class ShortWindowOpenerWorkspace extends PlainWorkspace {
                 static config = {
                     className             : 'Test.Unit.Dashboard.DockWorkspace.ShortWindowOpenerWorkspace',
@@ -3771,6 +3773,11 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
 
                 openTearOutVessel(request) {
                     return {admissionToken: request.admissionToken, windowName: `short-${request.itemId}`}
+                }
+
+                closeTearOutVessel(vessel) {
+                    closes.push(vessel);
+                    return true
                 }
             }
 
@@ -3796,7 +3803,10 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
 
                 await workspace.acquireTearOutVessel({admissionToken: 7, itemId: 'editor'});
 
-                expect(workspace.tearOutAdmissions.get('editor')?.timerId, 'the admission armed its expiry').toBeTruthy();
+                const admission = workspace.tearOutAdmissions.get('editor');
+
+                expect(admission?.timerId, 'the admission armed its expiry').toBeTruthy();
+                expect(admission?.windowName, 'and holds the vessel the host opened').toBe('short-editor');
 
                 workspace.destroy();
                 workspace = null;
@@ -3804,7 +3814,11 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
                 // Pre-fix the 20 ms expiry fires on the destroyed instance and dereferences a field core
                 // destroy removed — an uncaught TypeError charged to whichever test is running by then.
                 // Waiting past the window inside THIS arm makes that test this one.
-                await new Promise(resolve => setTimeout(resolve, 60))
+                await new Promise(resolve => setTimeout(resolve, 60));
+
+                // The admission is one ownership unit: its timer, its record, and the native vessel it
+                // opened retire together, and the vessel exactly once.
+                expect(closes.map(vessel => vessel.windowName), 'the opened vessel was closed exactly once').toEqual(['short-editor'])
             } finally {
                 Neo.Main = originalMain;
                 Neo.config.useSharedWorkers = useSharedWorkers


### PR DESCRIPTION
Resolves #18319

🌿 A workspace that is gone no longer keeps an appointment its expiry timer made while it was alive, nor a window it opened.

`acquireTearOutVessel` arms an admission's expiry timer and records the vessel the host opener returns whether or not `enableDockTearOutLifecycle` is on, while `destroy()` retired admissions — timer, record and vessel — only through `retireTearOutState()` inside that opt-in; with the opt-in off (the default) a pending admission's timer outlived the instance, `core.Base#destroy` stripped the fields, the expiry threw `TypeError … reading 'get'` on the destroyed instance twenty seconds later — charged, in a serial unit run, to whatever spec was executing by then — and the opened vessel stayed open with nothing owning it. `destroy()` now runs the owner-state retirement unconditionally, so the admission's timer, record and native vessel retire together and the vessel is closed exactly once; only the worker `connect`/`disconnect` unregistration stays under the opt-in, because only the opt-in subscribed. `expireTearOutAdmission` returns on a destroyed instance the way `onWindowDisconnect` already does. No signature, config or event changes.

Evidence: L3 achieved (a red-first unit arm on a lifecycle-off workspace with a 20 ms connect window and a host close seam, plus consecutive full serial unit runs) → L3 required (AC-1, AC-2, AC-3). Residual: none.

Micro-review eligible: restoration — one method's teardown boundary in one file and one arm; the mechanism is stated in the ticket with line anchors.

## AC Evidence
| AC-1 | CI-covered: `test/playwright/unit/dashboard/DockWorkspace.spec.mjs` › "a destroyed workspace fires no pending admission expiry and closes the vessel it opened, lifecycle opt-in or not" — a `PlainWorkspace` subclass with `tearOutConnectWindowMs: 20` acquires a vessel through a host opener (the admission holds `windowName: 'short-editor'`), is destroyed with the admission pending, and waits 60 ms; on `dev` the wait ends in `TypeError: Cannot read properties of undefined (reading 'get')` at `expireTearOutAdmission` (`Workspace.mjs:718`) and the host's `closeTearOutVessel` is never called; with the fix nothing fires and the close seam receives `['short-editor']` — exactly once |
| AC-2 | Outside CI: `npm run test-unit -- --workers=1` twice on the branch — run 1: 3213 passed / 0 failed; run 2: 3212 passed / 1 failed — the pre-existing wedge-watchdog timing arm (`unit/vdom/UpdateWedge.spec.mjs:194`, a 40 ms threshold against a 120 ms wait) while three Playwright processes shared the machine, 3/3 alone afterwards; zero `expireTearOutAdmission` stacks in either log; zero `expireTearOutAdmission` stacks in either log (four runs earlier today each carried exactly one, in a different `main/addon` victim) |
| AC-3 | CI-covered: the whole `DockWorkspace.spec.mjs` with the lifecycle ON arms (`#17681 engine tear-out lifecycle matrix` and siblings) — 101 passed on the fixed source; the retire runs once because the opt-in block no longer calls it |

## Deltas from ticket
The first head cleared only the timer and record; @neo-gpt's review (RA-1) widened the ledger to the whole admission: the vessel the host opener had already named was never closed on the lifecycle-off path, because `retireTearOutState()` — the one place that closes admitted vessels — ran only under the opt-in. The fix moved from a separate admissions sweep to running the retire unconditionally and leaving only the listener unregistration to the opt-in; #18319's Problem, Ledger and AC-1 were truth-synced to that shape, and its #17990 sentence corrected: that ticket guards destruction WHILE the open is awaited (`:633–656`), not after it returned.

## Test Evidence
Red-first receipt: the arm alone against the unfixed `Workspace.mjs` fails inside its own 60 ms wait with the production stack (`ShortWindowOpenerWorkspace.expireTearOutAdmission` at `:718`, `Timeout._onTimeout` at `:682`), and — before the widening — its close seam stayed empty; the same arm passes on the fixed source with `closes` reading `['short-editor']`. Full serial unit runs: run 1: 3213 passed / 0 failed; run 2: 3212 passed / 1 failed — the pre-existing wedge-watchdog timing arm (`unit/vdom/UpdateWedge.spec.mjs:194`, a 40 ms threshold against a 120 ms wait) while three Playwright processes shared the machine, 3/3 alone afterwards; zero `expireTearOutAdmission` stacks in either log. Two pre-existing comment lines in the same spec ("refresh #1"/"#2") were reworded because the shared archaeology lint flags them on any PR touching the file — mechanical, no runtime effect.

## Post-Merge Validation
None — every acceptance criterion is verified before merge.

## Commits (if multi-commit)
- `9cc7cf1d32` — the timer: unconditional admission sweep in `destroy()`, the `isDestroyed` expiry guard, the red-first arm
- `cf329eadc4` — the whole admission: `retireTearOutState()` runs regardless of the opt-in (vessel closed exactly once), the sweep folds into it, the arm gains the close-seam witness, the `destroy()` docblock says which teardown is unconditional

Authored by Vega (Claude Fable 5.1, Claude Code). Session 007aac9d-974a-465c-9015-378aeb741bd5.
