### PR TITLE
feat(dock): a projected rail carries a structural identity and reconciles in place (#18320)

### DIFF
--- a/src/dashboard/dock/Workspace.mjs
+++ b/src/dashboard/dock/Workspace.mjs
@@ -3495,46 +3495,13 @@ class Workspace extends Container {
                 return {geometryOnly: true};
 
             // The item-flag reducers write one `items[id]` field and touch `nodes` nowhere, so the
-            // shell is stable and only items reconcile. A railed item is the exception: pin and
-            // auto-hide project OUTSIDE the shell, so their placement change cannot ride an
-            // item-only refresh.
+            // shell is stable and only items reconcile — a railed item included: its rail is stable
+            // topology too, keyed by its edge-zone node and edge, and reconciles its items in place.
             case 'itemFlags':
-                return this.isDockRailedItem(descriptor?.itemId) ? {} : {retainTopology: true}
+                return {retainTopology: true}
         }
 
         return {}
-    }
-
-    /**
-     * @summary Whether an item currently renders on an edge rail rather than inside the shell.
-     *
-     * The change-class in `model/Operations` describes what an operation does to the DOCUMENT, and
-     * it is exact: the three item-flag reducers clone and assign one field, touching `nodes` nowhere.
-     * That is necessary for the item-only fast path but not sufficient, because a railed pane is
-     * projected OUTSIDE the shell. `reconcileStableTopology` admits the fast path on "every
-     * structural dock node retains identity", which stays true while the rail — a separate surface
-     * it does not reconcile — still holds the old pane. The result is a stale rail copy beside a
-     * fresh one, which is worse than the slow path this fast path replaces.
-     *
-     * So placement is the workspace's half of the answer: `Operations` cannot know it, and the
-     * document alone does not carry it. Reconciling rail surfaces inside the stable-topology path
-     * would let this guard retire; until then a railed item takes the full transaction.
-     *
-     * **This reads the PRE-COMMIT document, and that is only sound because it is reached solely for
-     * placement-NEUTRAL operations.** `getRefreshOptions` runs before `dockModel` is reassigned, so
-     * for an operation that moves a pane the answer here would describe where the item *was*, not
-     * where it is going — `setItemAutoHidden(true)` would read "not railed" on the very commit that
-     * rails it. That is why `setItemPinned` and `setItemAutoHidden` are classed `topology` rather
-     * than guarded here: a placement change cannot be rescued by asking about placement beforehand.
-     * `setItemLocked` never moves a pane, so before and after agree by construction.
-     * @param {String|null} itemId
-     * @returns {Boolean}
-     * @protected
-     */
-    isDockRailedItem(itemId) {
-        const item = itemId ? this.dockModel?.items?.[itemId] : null;
-
-        return item?.autoHidden === true && item?.pinned !== true
     }
 
     /**

--- a/src/dashboard/dock/projection/LayoutAdapter.mjs
+++ b/src/dashboard/dock/projection/LayoutAdapter.mjs
@@ -638,16 +638,19 @@ class LayoutAdapter extends Base {
      * @param {String[]} itemIds
      * @param {String} edge One of `top`, `right`, `bottom`, `left`.
      * @param {Object} context
+     * @param {String} nodeId The owning edge-zone node; with the edge it is the rail's structural
+     *     identity, so a retained rail can be recognised across projections and reconciled in place.
      * @returns {Object}
      * @protected
      * @static
      */
-    static createEdgeRail(itemIds, edge, context) {
+    static createEdgeRail(itemIds, edge, context, nodeId) {
         return {
             applyDockZoneOperation  : context.applyDockZoneOperation,
             autoHideRevealOnHover   : context.autoHideRevealOnHover === true,
             defaultRevealFraction   : context.defaultRevealFraction ?? null,
             dockEdge                : edge,
+            dockNodeId              : `${nodeId}:edge-rail:${edge}`,
             dockNodeType            : 'edge-rail',
             dockZoneDocument        : context.dockZoneDocument,
             edge,
@@ -777,7 +780,7 @@ class LayoutAdapter extends Base {
         // returns null for an empty tab flow — see its constraint comment).
         let band;
 
-        if (railsByEdge.left) middleItems.push(this.createEdgeRail(railsByEdge.left, 'left', context));
+        if (railsByEdge.left) middleItems.push(this.createEdgeRail(railsByEdge.left, 'left', context, nodeId));
 
         if (zones.left && (band = this.projectEdgeBand(zones.left, 'left', childContext))) {
             middleItems.push(band);
@@ -795,10 +798,10 @@ class LayoutAdapter extends Base {
             middleItems.push(band)
         }
 
-        if (railsByEdge.right) middleItems.push(this.createEdgeRail(railsByEdge.right, 'right', context));
+        if (railsByEdge.right) middleItems.push(this.createEdgeRail(railsByEdge.right, 'right', context, nodeId));
 
         if (railsByEdge.top) {
-            rows.push(this.createEdgeRail(railsByEdge.top, 'top', context))
+            rows.push(this.createEdgeRail(railsByEdge.top, 'top', context, nodeId))
         }
 
         if (zones.top && (band = this.projectEdgeBand(zones.top, 'top', childContext))) {
@@ -824,7 +827,7 @@ class LayoutAdapter extends Base {
         }
 
         if (railsByEdge.bottom) {
-            rows.push(this.createEdgeRail(railsByEdge.bottom, 'bottom', context))
+            rows.push(this.createEdgeRail(railsByEdge.bottom, 'bottom', context, nodeId))
         }
 
         return {

--- a/src/dashboard/dock/projection/Reconciler.mjs
+++ b/src/dashboard/dock/projection/Reconciler.mjs
@@ -1,7 +1,10 @@
 import Component from '../../../component/Base.mjs';
 import Base      from '../../../core/Base.mjs';
 
-const projectionNodeTypes = new Set(['edge-zone', 'split', 'tabs']);
+// The structural identities the stable-topology walk keys retained chrome by. A rail is a leaf: its
+// identity is its owning edge-zone node plus edge (the adapter derives it), and its items reconcile
+// in place through its own reactive `railItems`, never as structural children.
+const projectionNodeTypes = new Set(['edge-rail', 'edge-zone', 'split', 'tabs']);
 
 /**
  * @summary Preserves live tab-chrome identity across dock-layout projections.
@@ -132,7 +135,7 @@ class Reconciler extends Base {
                     nodes.get(parentNodeId)?.childNodeIds.push(ownerNodeId)
                 }
 
-                if (node.dockNodeType === 'tabs') return
+                if (node.dockNodeType === 'tabs' || node.dockNodeType === 'edge-rail') return
             }
 
             node.items?.forEach(child => visit(child, ownerNodeId))
@@ -147,7 +150,8 @@ class Reconciler extends Base {
      * @summary Reconciles a geometry-only projection without moving live dock chrome.
      *
      * The fast path is deliberately strict: dock-node ancestry/order, split orientation, tab item
-     * order, and active selection must all be unchanged. Only then may projected child geometry
+     * order, active selection, and each rail's edge and membership must all be unchanged (item and
+     * rail membership deltas are admitted only under `reconcileItems`). Only then may projected child geometry
      * (`flex`, `width`, and `height`) be applied to the retained shell in place. Any structural or
      * ownership delta defers to the staged descendant → ancestor transaction in
      * {@link #reconcileProjection}.
@@ -198,6 +202,19 @@ class Reconciler extends Base {
                     return null
                 }
             }
+
+            // A rail's edge is part of its identity and never moves in place; its membership is an
+            // item delta, admitted on the same terms as a tab node's items.
+            if (current.type === 'edge-rail') {
+                const
+                    currentItemIds = (current.node.railItems || []).map(item => item.dockItemId),
+                    nextItemIds    = (next.node.railItems    || []).map(item => item.dockItemId);
+
+                if (current.node.edge !== next.node.edge
+                    || !reconcileItems && currentItemIds.join('\0') !== nextItemIds.join('\0')) {
+                    return null
+                }
+            }
         }
 
         const
@@ -223,6 +240,15 @@ class Reconciler extends Base {
             }
 
             Object.keys(dimensions).length && current.set(dimensions);
+
+            // A retained rail reads its reveal extents from the committed document, so it receives the
+            // fresh one on every in-place landing; its items reconcile through its own reactive
+            // `railItems` seam, and only when items were admitted at all.
+            if (next.type === 'edge-rail') {
+                current.set(reconcileItems
+                    ? {dockZoneDocument: next.node.dockZoneDocument, railItems: next.node.railItems}
+                    : {dockZoneDocument: next.node.dockZoneDocument})
+            }
 
             if (next.type === 'tabs') {
                 plans.set(nodeId, {

--- a/test/playwright/component/dashboard/DockLock.spec.mjs
+++ b/test/playwright/component/dashboard/DockLock.spec.mjs
@@ -40,6 +40,11 @@ const tabButton = (node, text) => node.locator('.neo-tab-header-button', {hasTex
 const actionButton = (node, glyph) =>
     node.locator(`.neo-tab-header-toolbar .neo-button:has([class*="${glyph}"])`);
 
+// The rail's own tab button, by role and exact name: a revealed overlay lives inside the rail and
+// repeats the item's title in its header, so a text match would resolve to both.
+const railButton = (page, name) =>
+    page.locator('.neo-dashboard-dock-edge-rail').getByRole('button', {name, exact: true});
+
 const readInertOwnership = (page, id) => page.evaluate(async componentId => {
     const reply  = await Neo.worker.App.getConfigs({id: componentId, keys: ['vdom']}),
           [vdom] = reply?.data ?? reply;
@@ -146,8 +151,8 @@ test.describe('dock lock — committed boundary plus reversible presentation', (
         expect(await readInertOwnership(page, 'dock-lock-pane-beta')).toEqual({owned: true, value: true})
     });
 
-    test('locked rail remains revealable while inert, then re-reveals interactive after unlock', async ({page}) => {
-        const railTab = page.locator('.neo-dashboard-dock-edge-rail').getByText('Railed'),
+    test('locked rail remains revealable while inert, and the unlock reaches the revealed pane in place', async ({page}) => {
+        const railTab = railButton(page, 'Railed'),
               overlay = page.locator(
                   '.neo-dashboard-dock-reveal-overlay:not(.neo-dashboard-dock-reveal-overlay-hidden)'
               );
@@ -156,6 +161,9 @@ test.describe('dock lock — committed boundary plus reversible presentation', (
         await expect(overlay).toHaveCount(1);
         await expect(page.locator('#dock-lock-pane-railed')).toHaveClass(/neo-dock-pane-locked/);
         expect(await page.locator('#dock-lock-pane-railed').evaluate(node => node.inert)).toBe(true);
+
+        // Marks the live pane element: an in-place landing keeps it, a rebuilt rail would mint a new one.
+        await page.locator('#dock-lock-pane-railed').evaluate(node => {node.dataset.held = 'yes'});
 
         await setWorkspace(page, {
             operationJson: JSON.stringify({
@@ -173,8 +181,11 @@ test.describe('dock lock — committed boundary plus reversible presentation', (
         }).toBe(false);
         await awaitRefresh(page);
 
-        // Reconciliation may dismiss the transient overlay through its ordinary focus/pointer state
-        // machine. Orthogonality means the rail remains usable, not that one reveal is persistent.
+        // An item-flag commit on a railed item reconciles the rail in place: the reveal survives the
+        // refresh and the unlock reaches the revealed pane where it stands — the same element, not a
+        // re-materialized one. The rail stays usable: a further click keeps the item revealed.
+        await expect(overlay).toHaveCount(1);
+        await expect(page.locator('#dock-lock-pane-railed')).toHaveAttribute('data-held', 'yes');
         await railTab.click();
         await expect(overlay).toHaveCount(1);
         await expect(page.locator('#dock-lock-pane-railed')).not.toHaveClass(/neo-dock-pane-locked/);
@@ -193,7 +204,7 @@ test.describe('dock lock — committed boundary plus reversible presentation', (
      * id collision that rejected the refresh silently.
      */
     test('a reducer-committed pin-back with an open reveal returns the pane to flow and settles', async ({page}) => {
-        const railTab = page.locator('.neo-dashboard-dock-edge-rail').getByText('Railed'),
+        const railTab = railButton(page, 'Railed'),
               overlay = page.locator(
                   '.neo-dashboard-dock-reveal-overlay:not(.neo-dashboard-dock-reveal-overlay-hidden)'
               );
@@ -298,7 +309,7 @@ test.describe('dock lock — committed boundary plus reversible presentation', (
      * the unit spec's rail-callback witness.
      */
     test('a delegating reveal pane receives the committed lock on the rail, never inert', async ({page}) => {
-        const railTab = page.locator('.neo-dashboard-dock-edge-rail').getByText('Reader'),
+        const railTab = railButton(page, 'Reader'),
               overlay = page.locator(
                   '.neo-dashboard-dock-reveal-overlay:not(.neo-dashboard-dock-reveal-overlay-hidden)'
               ),
@@ -318,11 +329,14 @@ test.describe('dock lock — committed boundary plus reversible presentation', (
         });
         await awaitRefresh(page);
 
-        await railTab.click();
+        // The rail reconciles in place, so the revealed pane persists and is asked to unlock where it
+        // stands — a re-materialized pane would never have been asked at all.
         await expect(overlay).toHaveCount(1);
         await expect(pane).not.toHaveClass(/neo-dock-pane-locked/);
         await expect(control).toBeEnabled();
-        expect(await calls(), 'the re-materialized pane was never locked, so it is never asked').toEqual([]);
+        expect(await calls(), 'the persisting pane is asked to unlock, once').toEqual([true, false]);
+        await railTab.click();
+        await expect(overlay).toHaveCount(1);
         expect(await readInertOwnership(page, 'dock-lock-pane-reader')).toEqual({owned: false, value: undefined})
     })
 });

--- a/test/playwright/unit/dashboard/DockLayoutAdapter.spec.mjs
+++ b/test/playwright/unit/dashboard/DockLayoutAdapter.spec.mjs
@@ -832,6 +832,12 @@ test.describe('Neo.dashboard.dock.projection.LayoutAdapter', () => {
         expect(rail.railItems).toEqual([
             {dockEdge: 'right', dockItemId: 'terminal', restorable: true, title: 'Terminal'}
         ]);
+        // The rail's structural identity — its owning edge-zone node and its edge — is what lets the
+        // reconciler key a retained rail across projections; the same document projects it twice alike.
+        expect(rail.dockNodeId).toBe('root:edge-rail:right');
+        expect(DockLayoutAdapter.project(model, {
+            resolveComponentRef: componentRef => ({ntype: 'dashboard-panel', reference: componentRef})
+        }).items[0].items.find(item => item.dockNodeType === 'edge-rail').dockNodeId).toBe(rail.dockNodeId);
 
         // ...and its now-empty tabs node is gone from the live split, not rendered as dead chrome.
         expect([...collectProjectedTabsById(side).keys()]).toEqual(['inspector-tabs']);

--- a/test/playwright/unit/dashboard/DockOperationChangeClass.spec.mjs
+++ b/test/playwright/unit/dashboard/DockOperationChangeClass.spec.mjs
@@ -137,13 +137,14 @@ test.describe('Neo.dashboard.dock.Workspace — getRefreshOptions derives from t
         }
     });
 
-    test('a RAILED item takes the full transaction even though its document delta is item-only', () => {
+    test('a RAILED item takes the item-only path like any other: placement no longer decides', () => {
         // The change class describes the DOCUMENT and is exact — `setItemLocked` touches `nodes`
-        // nowhere. That is necessary for the fast path but not sufficient: a railed pane is
-        // projected outside the shell, and `reconcileStableTopology` admits the fast path on "every
-        // structural dock node retains identity", which stays true while the rail still holds the
-        // old pane. Without this guard the rail keeps a stale copy beside the fresh one — worse
-        // than the slow path it replaced. Placement is the workspace's half of the answer.
+        // nowhere. A railed pane is projected outside the shell, and this used to be the one case the
+        // workspace refused the fast path for: the rail had no structural identity, so the
+        // stable-topology walk could not address it and would have left it holding a stale copy.
+        // The rail is stable topology now — keyed by its edge-zone node and edge, its items
+        // reconciled in place through its own reactive seam — so the answer comes from the change
+        // class alone, for a railed, a shell and a pinned item alike.
         const workspace = bareWorkspace({
             panel : {},
             railed: {autoHidden: true},
@@ -151,14 +152,10 @@ test.describe('Neo.dashboard.dock.Workspace — getRefreshOptions derives from t
         });
 
         try {
-            expect(workspace.getRefreshOptions({operation: 'setItemLocked', itemId: 'railed'}),
-                'a railed item cannot take the item-only path').toEqual({});
-
-            expect(workspace.getRefreshOptions({operation: 'setItemLocked', itemId: 'panel'}),
-                'a shell item still can — the guard is placement, not the operation').toEqual({retainTopology: true});
-
-            expect(workspace.getRefreshOptions({operation: 'setItemLocked', itemId: 'pinned'}),
-                'a pinned item renders in the shell, so it keeps the fast path').toEqual({retainTopology: true})
+            for (const itemId of ['railed', 'panel', 'pinned']) {
+                expect(workspace.getRefreshOptions({operation: 'setItemLocked', itemId}),
+                    `${itemId}: an item-flag commit reconciles in place wherever the item renders`).toEqual({retainTopology: true})
+            }
         } finally {
             workspace.destroy()
         }

--- a/test/playwright/unit/dashboard/DockProjectionReconciler.spec.mjs
+++ b/test/playwright/unit/dashboard/DockProjectionReconciler.spec.mjs
@@ -647,6 +647,95 @@ test.describe('Neo.dashboard.dock.projection.Reconciler', () => {
         })
     });
 
+    test.describe('a rail is stable topology: item deltas land in place, rail topology changes stage', () => {
+        // `createEdgeModel` with `left` auto-hidden projects the left band empty and surfaces the item on
+        // a left edge rail — the smallest document whose projection carries a Rail.
+        const createRailedEdgeModel = () => {
+            const model = createEdgeModel();
+
+            model.items.left.autoHidden = true;
+
+            return model
+        };
+
+        const findRails = shell => {
+            const rails = [];
+
+            const walk = node => {
+                node?.dockNodeType === 'edge-rail' && rails.push(node);
+                node?.items?.forEach?.(walk)
+            };
+
+            walk(shell);
+
+            return rails
+        };
+
+        test('a railed item-only delta lands in place and reaches the surviving rail', async () => {
+            const receipt = await reconcileModel(createRailedEdgeModel(), nextModel => {
+                nextModel.items.left.title = 'Left, renamed'
+            }, {retainTopology: true});
+
+            try {
+                expect(receipt.result.landedInPlace, 'the item-only delta lands in place').toBe(true);
+                expect(receipt.host.items, 'no staged sibling').toHaveLength(1);
+
+                const [rail, ...moreRails] = findRails(receipt.oldShell);
+
+                expect(rail, 'the retained shell carries its rail').toBeTruthy();
+                expect(moreRails).toEqual([]);
+
+                // Pre-fix the rail was invisible to the stable-topology walk: the request landed in
+                // place and the rail kept yesterday's items — a stale rail, worse than a staged shell.
+                expect(rail.railItems.map(item => item.title), 'the surviving rail received the fresh rail items').toEqual(['Left, renamed']);
+                expect(rail.items.find(item => item.dockItemId === 'left')?.text, 'and reconciled its own button in place').toBe('Left, renamed');
+                expect(rail.dockZoneDocument, 'the rail reads the committed document').toEqual(receipt.nextModel)
+            } finally {
+                receipt.host.destroy()
+            }
+        });
+
+        test('a rail that changes edge is a topology change and stages a shell', async () => {
+            const receipt = await reconcileModel(createRailedEdgeModel(), nextModel => {
+                const zones = nextModel.nodes['root-edge'].zones;
+
+                zones.right = zones.left;
+                delete zones.left
+            }, {retainTopology: true});
+
+            try {
+                // Pre-fix the walk saw the same edge-zone and center tabs on both sides and landed in
+                // place, leaving the rail on the edge the document had left.
+                expect(receipt.result.landedInPlace, 'the request was refused').not.toBe(true);
+                expect(receipt.stagedCount, 'the staged transaction ran').toBe(1);
+
+                const newShell = receipt.host.items.find(item => item !== receipt.oldShell);
+
+                expect(findRails(newShell).map(rail => rail.edge), 'the fresh shell carries the rail on its new edge').toEqual(['right'])
+            } finally {
+                receipt.host.destroy()
+            }
+        });
+
+        test('a geometry-only refresh keeps the rail and hands it the committed document', async () => {
+            const receipt = await reconcileModel(createRailedEdgeModel(), nextModel => {
+                nextModel.nodes['root-edge'].zones.left.extent = 0.3
+            }, {geometryOnly: true});
+
+            try {
+                expect(receipt.result.nextShell).toBe(receipt.oldShell);
+                expect(receipt.stagedCount).toBe(0);
+
+                const [rail] = findRails(receipt.oldShell);
+
+                expect(rail.railItems.map(item => item.dockItemId), 'the rail items are untouched').toEqual(['left']);
+                expect(rail.dockZoneDocument, 'the rail reads the committed document').toEqual(receipt.nextModel)
+            } finally {
+                receipt.host.destroy()
+            }
+        })
+    });
+
     test('reconciles an explicit same-topology item arrival without replacing the shell', async () => {
         // The stack-return adoption shape: the arriving pane exists as a live instance
         // (it survived its previous workspace), the structural shell is unchanged, and one tabs

--- a/test/playwright/unit/dashboard/DockProjectionReconciler.spec.mjs
+++ b/test/playwright/unit/dashboard/DockProjectionReconciler.spec.mjs
@@ -998,10 +998,11 @@ test.describe('Neo.dashboard.dock.projection.Reconciler', () => {
      * with every later commit reconciling against `host.items[shellIndex]` forever.
      *
      * A rejecting flight is injected by counting `host.promiseUpdate` calls, which is what the phases
-     * ARE: #1 stages the shell, #2 closes tab chrome, #3 swaps visibility, #4 retires the old shell.
-     * Rejecting #2 and #3 leaves the swap unlanded (the outgoing shell must survive); rejecting #4
-     * happens after it landed (the staged shell must survive and the swap simply finishes) — so the
-     * two recovery verdicts are both reachable and are asserted by name rather than inferred.
+     * ARE: the first stages the shell, the second closes tab chrome, the third swaps visibility, the
+     * fourth retires the old shell. Rejecting the second or third leaves the swap unlanded (the
+     * outgoing shell must survive); rejecting the fourth happens after it landed (the staged shell
+     * must survive and the swap simply finishes) — so the two recovery verdicts are both reachable
+     * and are asserted by name rather than inferred.
      */
     const reconcileWithRejectedFlight = async rejectOnCall => {
         const

--- a/test/playwright/unit/dashboard/DockWorkspace.spec.mjs
+++ b/test/playwright/unit/dashboard/DockWorkspace.spec.mjs
@@ -2894,6 +2894,50 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
         expect(playArgs.map(config => config.geometryOnly)).toEqual([true, false])
     });
 
+    test('locking a railed item admits in-place reconciliation, and the refresh pays no staged shell', async () => {
+        const document = createEdgeDocument();
+
+        document.items.inspector.autoHidden = true; // the inspector rides the right edge rail
+
+        workspace = Neo.create(PlainWorkspace, {dockModel: document});
+
+        const descriptor = {operation: 'setItemLocked', itemId: 'inspector', locked: true};
+
+        // The cost, measured on the host first so the pre-fix run prints its own receipt: the staged
+        // transaction issues one host update per phase and leaves a staged sibling until the swap; the
+        // in-place path issues none of those.
+        const
+            host     = workspace.getDockHost(),
+            original = host.promiseUpdate.bind(host);
+
+        let hostUpdates = 0,
+            outcome     = null;
+
+        host.promiseUpdate = (...args) => {
+            hostUpdates++;
+            return original(...args)
+        };
+        workspace.afterRefreshDockWorkspace = ({result}) => outcome = result;
+
+        try {
+            const committed = workspace.applyDockZoneOperation(descriptor);
+
+            expect(committed.errors ?? []).toEqual([]);
+            workspace.onDockZoneDocumentChange(committed.document, descriptor, workspace);
+            await workspace.refreshPromise
+        } finally {
+            host.promiseUpdate = original
+        }
+
+        console.log(`receipt: a railed setItemLocked refresh issued ${hostUpdates} host update(s), landedInPlace=${outcome?.landedInPlace}`);
+
+        // Pre-fix a railed item was the one item whose flag commit was refused the item-only refresh,
+        // because the reconciler could not address the rail; now it is an item-only delta like any other.
+        expect(workspace.getRefreshOptions(descriptor, null), 'a railed item admits retainTopology').toEqual({retainTopology: true});
+        expect(outcome?.landedInPlace, 'the refresh landed in place').toBe(true);
+        expect(workspace.items, 'one shell, no staged sibling').toHaveLength(1)
+    });
+
     test('the reconcile hook passes only its sanctioned seams; a hostile override cannot displace the identity keys', async () => {
         workspace = Neo.create(PlainWorkspace, {dockModel: createDocument()});
 

--- a/test/playwright/unit/dashboard/DockWorkspace.spec.mjs
+++ b/test/playwright/unit/dashboard/DockWorkspace.spec.mjs
@@ -2167,9 +2167,9 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
         expect(pinAction.hidden, 'converging on the active item\'s real policy').toBe(false);
 
         // The load-bearing half, and the reason this counts emitters rather than signals. The refresh
-        // QUEUE replays each pending refresh in order, and refresh #1 reconciles chrome to the
-        // document as it stood when it was queued — so its sweep re-hides the action before refresh
-        // #2 settles it, and the post-refresh signal COUNT is not 0. Those extra signals are a
+        // QUEUE replays each pending refresh in order, and the first refresh reconciles chrome to the
+        // document as it stood when it was queued — so its sweep re-hides the action before the
+        // second settles it, and the post-refresh signal COUNT is not 0. Those extra signals are a
         // property of the queue, not of this action: `close` lags identically, and nothing here
         // could fix it without changing refresh sequencing for every consumer. What AC-3 actually
         // claims is that no group was ever rebuilt behind them — every signal, before and after


### PR DESCRIPTION
Resolves #18320

🌿 A commit that touches a revealed rail no longer rebuilds the whole shell to change one item.

A projected rail now carries a structural identity — its owning edge-zone node plus its edge — and the reconciler's stable-topology walk keys it like a tabs node: a surviving rail with the same identity, edge and ancestry stays, receives the committed document, and (under item reconciliation) its fresh `railItems` through the Rail's own reactive seam, which already reconciles tab buttons in place; a rail that changes edge, ancestry or presence fails closed to the staged shell exactly as before. With the reconciler able to address the rail, the one exception in `Workspace#getRefreshOptions` — a railed item's flag commit declined the item-only refresh — is deleted, and its helper with it. The work is identity, not behaviour: no rail reconciler was written, and the rail's reveal, pin, auto-hide and overlay contract is untouched.

Evidence: L3 achieved (red-first unit arms at every seam — adapter, reconciler, workspace — with the workspace arm measuring the host updates a railed flag commit issues before and after) → L3 required (AC-1 to AC-6, AC-9); AC-8's witness is the two `DockLock.spec.mjs` arms, red-first on `dev`; AC-7's is the existing rail batteries, run unchanged (Test Evidence). Residual: none.

## AC Evidence
| AC-1 | CI-covered: `test/playwright/unit/dashboard/DockLayoutAdapter.spec.mjs` › "projects an autoHidden edge item into an edge rail…" — the rail carries `dockNodeId: 'root:edge-rail:right'` and a second projection of the same document yields the same id (red on `dev`: `undefined`) |
| AC-2 | CI-covered: `test/playwright/unit/dashboard/DockProjectionReconciler.spec.mjs` › "a railed item-only delta lands in place and reaches the surviving rail" — `landedInPlace: true`, one shell, the retained rail's `railItems` and its own button carry the renamed title, its `dockZoneDocument` is the committed one (red on `dev`: the rail kept the old title) |
| AC-3 | CI-covered: same spec › "a rail that changes edge is a topology change and stages a shell" — the request is refused, one staged transaction, the fresh shell carries the rail on its new edge (red on `dev`: the walk ignored rails and landed the stale rail in place) |
| AC-4 | The exception is removed last: commit `1a71e36598` lands the identity and the reconciler arms; commit `05ad1dfa33` removes the `isDockRailedItem` ternary and deletes the helper (its only two references) |
| AC-5 | CI-covered, both controls in one battery: `DockWorkspace.spec.mjs` › "locking a railed item admits in-place reconciliation…" — before: `getRefreshOptions` answered `{}` and the refresh staged; after: `{retainTopology: true}` and `landedInPlace: true` with one shell — while the reconciler arm above keeps an actual rail topology change staging |
| AC-6 | Measured on the same workspace arm, printed to the run log: a railed `setItemLocked` refresh issued **5** host updates and did not land in place before; **2** host updates and `landedInPlace: true` after |
| AC-7 | Reveal, pin, auto-hide, focus-gating and the overlay surface behave identically — the rail's own batteries run unchanged on the dock example and the Workstation (the surviving reveal is AC-8, a landing change, not a contract change). Outside CI: components tier — the whole `test/playwright/component/dashboard/` directory: 114 passed / 0 failed at head `e001d883c0` (the nine `DockRail*` / `DockReveal*` specs alone: 39 passed); e2e dashboard rail arms (`DockAutoHideRevealNL`, `DockEdgeRailPaintNL`, `DockPinCollapseNL`): 9 passed / 2 failed; Workstation reveal journeys (`WorkstationNL` rail arms): 2 passed / 2 failed. The four reds are theme-golden screenshot arms — `DockPinCollapseNL.spec.mjs:260` "the reveal pin is compact and legible" (dark 86 px, light 76 px, ratio 0.01) and `WorkstationNL.spec.mjs:2274` "the reveal header matches inline tab chrome" (expected 359×33, received 886×33, both themes) — and a control run of the same four arms on the same machine against a checkout with NO rail change (PR #18323's head `cf329eadc4`: dev plus one destroy fix) fails all four with the same expected/received image sizes and the same differing-pixel counts (86, 76, 17921, 629). The goldens are CI-captured and this machine renders them differently, so the PR's own CI run arbitrates them; every behavioural rail arm — reveal, pin, auto-hide, overlay, partition, lazy module — is green |
| AC-8 | CI-covered: `test/playwright/component/dashboard/DockLock.spec.mjs` › "locked rail remains revealable while inert, and the unlock reaches the revealed pane in place" and "a delegating reveal pane receives the committed lock on the rail, never inert" — after `setItemLocked(false)` on a revealed railed item the same overlay is still open (count 1 right after the refresh), the same pane element persists (a `data-held` mark set before the commit survives), the inert-default pane has lost `neo-dock-pane-locked` and `inert` with prior inert ownership restored, and the delegating pane's `lockCalls` reads `[true, false]`; against `dev`'s engine both arms fail at the overlay count (`Received: 0` — the staged rebuild tore it down) |
| AC-9 | `git diff origin/dev...HEAD --stat` touches `projection/LayoutAdapter.mjs`, `projection/Reconciler.mjs`, `Workspace.mjs` and three unit specs; nothing under `src/manager/**` |

## Deltas from ticket
The identity format is `<edgeZoneNodeId>:edge-rail:<edge>`, derived where the rail is created (`createEdgeRail` gains the owning node id as its fourth argument at all four call sites). Beyond the ticket's `railItems`, the retained rail also receives the committed `dockZoneDocument` on every in-place landing, geometry-only included — `Rail#resolveRevealExtent` reads its reveal extents from that document, so a rail left with the previous one would reveal at stale extents. Rail membership deltas are admitted on the same terms as a tabs node's items (only under item reconciliation); a rail whose edge changes, or that appears or disappears, fails closed. The only `itemFlags` operation is `setItemLocked` — pin and auto-hide are `topology` class by design — so the measured commit is a lock on a railed item.

**A revealed rail item survives an in-place landing** — the one place "identity, not behaviour" was not quite true. On `dev` a flag commit on a railed item rebuilt the rail, and the rebuild tore the open reveal overlay and its pane down as a side effect; the next reveal re-materialized the pane. In place, the rail is retained, the reveal stays open, and the committed flag reaches the revealed pane where it stands through the Workspace's existing `syncDockLockRails` sweep — measured on the dock-lock fixture: the inert-default pane loses `neo-dock-pane-locked` and `inert` with its prior inert ownership restored exactly, and the delegating pane's `dockLock` is called with `false` (`lockCalls` `[true, false]`, where re-materialization read `[]`). The reveal, pin, auto-hide and overlay contract is untouched; what a refresh no longer does is destroy a revealed pane to change one of its flags. Two `component/dashboard/DockLock.spec.mjs` arms encoded the teardown (a text locator that now also matches the overlay's header, and the `[]` expectation) and were moved to the persisting contract, red-first on `dev`: the overlay count right after the refresh, the same pane element, and `[true, false]`. The fork was handed to the ticket's author, @neo-opus-grace, with both options; she amended AC-7 and added AC-8 on 2026-09-04, and the rows above mirror the amended ticket.

## Test Evidence
Red-first receipts against the unfixed tree: adapter `dockNodeId` `undefined`; reconciler item delta "the surviving rail received the fresh rail items" (stale title), edge change "the request was refused" (landed in place), geometry "the rail reads the committed document" (stale document); workspace `getRefreshOptions` `{}` with the refresh receipt "issued 5 host update(s), landedInPlace=false". After the fix: the two capability specs 74 passed; the workspace spec 101 passed with the receipt "issued 2 host update(s), landedInPlace=true". Full serial unit at head `e4a4969ade` (`--workers=1`): 3215 passed / 1 failed — `unit/main/addon/ResizeObserver.spec.mjs:290`, whose failure block carries `HostOpenerWorkspace.expireTearOutAdmission`: the destroyed-workspace admission timer of #18319, fixed in PR #18323 and not on this branch's base; no dock or rail spec red. AC-7's rail batteries: its row. Four pre-existing comment lines in the two touched specs (phase numbering written `#1`–`#4`) were reworded because the shared archaeology lint flags them on any PR touching the file — mechanical, no runtime effect; the `DockWorkspace.spec.mjs` lines carry the wording PR #18323 gives them, so the two PRs merge cleanly.

## Post-Merge Validation
None — every acceptance criterion is verified before merge.

## Commits (if multi-commit)
- `1a71e36598` — a projected rail carries a structural identity and reconciles in place (adapter identity, reconciler structural set + in-place branch, the adapter and reconciler arms)
- `05ad1dfa33` — a railed item's flag commit lands in place like any other (the exception and its helper deleted, the workspace arm with the host-update receipt)
- `e4a4969ade` — the change-class arm says a railed item takes the item-only path: the arm that asserted the old refusal now witnesses railed, shell and pinned items answering `{retainTopology: true}` alike
- `6571b8d195` — the two touched dock specs name their phases in words (the archaeology-lint reword; comments only)
- `e001d883c0` — the lock arms witness a reveal that survives an in-place landing: a role-and-exact-name rail locator, the overlay still open right after the refresh, the same pane element, `[true, false]` on the delegating pane — red on `dev` at the overlay count

Authored by Vega (Claude Fable 5.1, Claude Code). Session 007aac9d-974a-465c-9015-378aeb741bd5.
