### PR TITLE
test(e2e): drop the playwright-core version assertion and name the gap it was standing in for (#18327)

### DIFF
--- a/test/playwright/unit/e2e/browserLifecycleReporter.spec.mjs
+++ b/test/playwright/unit/e2e/browserLifecycleReporter.spec.mjs
@@ -31,17 +31,29 @@ const launchExit = ({
  * @summary Coverage for the bounded E2E browser-launch lifecycle receipt.
  *
  * The reporter owns classification and retention only. Playwright still owns the browser and the
- * failing launch already owns the test result. These units therefore use the exact public error-log
- * version-pinned runner grammar with fakes instead of creating another browser lifecycle merely
- * to test diagnostics.
+ * failing launch already owns the test result. These units therefore drive the classifier with
+ * fakes instead of creating another browser lifecycle merely to test diagnostics.
+ *
+ * WHAT THESE ARMS DO NOT PROVE, stated because the gap is invisible otherwise. `launchExit()` is a
+ * RECONSTRUCTION of Playwright's internal browser-log grammar, not a capture of it. Every arm below
+ * feeds the classifier a string this file wrote, so all of them keep passing if that grammar drifts —
+ * they cover the classifier's branches, never its fidelity to the real format. Treating them as
+ * upgrade protection is the mistake to avoid.
+ *
+ * There is deliberately no live witness, and the reason is measured rather than assumed: the parsed
+ * grammar only appears once a browser has LAUNCHED and then exited abnormally. A forced pre-launch
+ * failure does not produce it — `chromium.launch({executablePath: '/nonexistent/browser'})` returns
+ * `browserType.launch: Failed to launch chromium because executable doesn't exist`, carrying none of
+ * `Browser logs:`, `<launched> pid=` or `<process did exit:`. Reproducing a launched-then-crashed
+ * browser deterministically is not a unit-scope operation, which is why fakes are the right shape here.
+ *
+ * RESIDUAL RISK, owned rather than guarded: a Playwright upgrade can change the grammar and every arm
+ * here stays green. The previous mitigation asserted `playwright-core`'s version string, which fired
+ * on every bump regardless of whether the format moved and could never detect the format moving — a
+ * 100%-false-alarm, 0%-detection proxy that blocked dependency updates while proving nothing. If this
+ * needs a real guard, it belongs at the E2E layer where a browser actually launches, not here.
  */
 test.describe('e2e/custom-reporter browser lifecycle', () => {
-    test('#16161 binds the internal launch-exit grammar to Playwright Core 1.61.1', async () => {
-        const manifest = await fs.readJson(path.resolve('node_modules/playwright-core/package.json'));
-
-        expect(manifest.version).toBe('1.61.1')
-    });
-
     test('#16161 classifies SIGABRT without inventing transport state', () => {
         expect(classifyBrowserLaunchExit(launchExit(), {
             browserName: 'chromium',


### PR DESCRIPTION
Resolves #18327

The first Dependabot version-update PR (#18325) is red on `unit` because `browserLifecycleReporter.spec.mjs` asserted `playwright-core` is exactly `1.61.1`. Operator challenge: *"i would severely challenge unit tests that bind to specific versions. these have a negative ROI. utterly pointless."* Measured, and correct — on a sharper basis than a general objection to version binding.

Evidence: L2 (the modified suite run locally, plus a measured probe of real Playwright launch-failure output) → L2 required. Residual: none.

## AC Evidence

| AC | Evidence |
| --- | --- |
| AC-1 | The `toBe('1.61.1')` assertion and its test are deleted; no version string remains in a test name. |
| AC-2 | Fallback path taken, and the docblock now states the reconstruction and names the residual — see *Deltas* for why the probe path was rejected on measurement rather than convenience. |
| AC-3 | N/A — no probe landed, so there is no probe to mutation-test. Stated rather than silently skipped. |
| AC-4 | `npm run test-unit -- test/playwright/unit/e2e/browserLifecycleReporter.spec.mjs` → **11 passed**, exit 0. Was 12; the 11 surviving classifier arms pass **unchanged**, which is the evidence that this removed a proxy and not parser coverage. |
| AC-5 | `unit` green on this branch; #18325's `unit` goes green once this merges (its red is this assertion — re-verified on a re-run of the failed jobs). |
| AC-6 | This section states the path taken and why. |

## Deltas from ticket

**The ticket's preferred path was a probe against real launch-exit output. I attempted it and rejected it on measurement, not on effort.**

The classifier parses Playwright's internal grammar — `Browser logs:`, `<launched> pid=…`, `[pid=…] <process did exit: exitCode=…, signal=…>`. That text only exists once a browser has **launched and then exited abnormally**. A forced pre-launch failure does not produce it:

```
chromium.launch({executablePath: '/nonexistent/browser'})
→ browserType.launch: Failed to launch chromium because executable doesn't exist at /nonexistent/browser
  Browser logs:       false
  <launched> pid=     false
  <process did exit:  false
```

None of the three markers. Reproducing a launched-then-crashed browser deterministically is not a unit-scope operation — which means **the original author's hand-written fixtures were the right shape**, and the mistake was bolting a version-string proxy on top and calling it a guard. I ran that probe specifically because I would otherwise have written an AC whose witness I had never executed; @neo-fable caught exactly that failure in my #18305 earlier today.

Second delta, and the reason this is not just a deletion: the ticket says removing a bad guard without replacing or naming the residual turns a real risk into an invisible one. So the docblock now records three things it did not say before — that every arm feeds the classifier a string the file itself wrote and therefore covers branches rather than fidelity; that no live witness exists and *why*, with the measurement above; and that a real guard belongs at the E2E layer where a browser actually launches.

## Test Evidence

`npm run test-unit -- test/playwright/unit/e2e/browserLifecycleReporter.spec.mjs` → 11 passed, exit 0 (project config, not bare `playwright`). Imports checked after the deletion: `fs`, `os` and `path` are all still used by later arms, so none became dead.

## Post-Merge Validation

None owed for this change itself. Downstream: #18325 (or its daily successor) should reach green on `unit` once this lands, unblocking the nineteen grouped updates that one assertion was holding.

Its `components` red is a **second, separate failure — and my first attribution of it was wrong.**

I initially called it pre-existing and unrelated, because `DockRailLazyModule` "one construction — 2 recorded" is verbatim the symptom of open ticket #18275 (assigned @neo-opus-ada), other open PRs passed `components` concurrently, and `dev` had failed it at earlier heads today. I did not assert that on N=1 — I re-ran the failed jobs as the falsifier, and **the falsifier refuted me**: the same test failed again at 5m37s, same assertion. It is **deterministic on #18325**, and `dev` is green on `components` at `55920c5a79`, the exact head #18325 branches from.

So the bump causes it. What I can state: it reproduces deterministically on the bumped tree and not on its base. What I cannot yet state is whether the bump triggers the same underlying defect #18275 describes — turning intermittent into deterministic — or is a distinct regression presenting identically; that needs a bisect, not a guess. `esbuild 0.28.1 → 0.28.2` and `monaco-editor 0.50.0 → 0.56.0` are the suspects, and the `unit` log's *"lazy pane module … chunk failed to load"* points at the bundler first.

That is a separate ticket from this one, and it is the operator's stated model working: a real break, caught pre-merge on the bot PR, gets its own ticket. **This PR fixes only the `unit` red.** It does not make #18325 green on its own, and claiming otherwise would be the overclaim this correction exists to remove.

---

Authored by Grace (Claude Opus 5, Claude Code), session `b983b2a8-18bc-4dd0-a63f-23380dc3a49d`
