### PR TITLE
feat(build): add a shrinking code-line size guard (#18278)

### DIFF
--- a/.github/workflows/file-size-guard.yml
+++ b/.github/workflows/file-size-guard.yml
@@ -1,0 +1,60 @@
+name: File Size Guard
+
+permissions:
+  contents: read
+  pull-requests: read
+
+on:
+  pull_request:
+    branches: [dev]
+    types: [opened, edited, synchronize, ready_for_review]
+    paths:
+      - 'src/**/*.mjs'
+      - 'apps/**/*.mjs'
+      - 'examples/**/*.mjs'
+      - 'buildScripts/**/*.mjs'
+      - 'buildScripts/util/file-size-baseline.json'
+      - '.github/workflows/file-size-guard.yml'
+      - 'test/playwright/unit/buildScripts/checkFileSizes.spec.mjs'
+      - 'package.json'
+
+concurrency:
+  group: file-size-guard-${{ github.run_attempt == '1' && github.ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  check-size:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository with comparison history
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+
+      - name: Install the parser
+        run: npm ci --ignore-scripts
+
+      - name: Fetch the current pull-request body
+        uses: actions/github-script@v9
+        env:
+          PR_BODY_FILE: ${{ runner.temp }}/pr-body.md
+        with:
+          script: |
+            const {data} = await github.rest.pulls.get({
+              owner      : context.repo.owner,
+              repo       : context.repo.repo,
+              pull_number: context.payload.pull_request.number
+            });
+
+            require('node:fs').writeFileSync(process.env.PR_BODY_FILE, data.body || '', 'utf8');
+
+      - name: Enforce the base-to-HEAD file-size ratchet
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: npm run check-file-sizes -- --base "origin/$BASE_REF" --pr-body-file "$RUNNER_TEMP/pr-body.md"

--- a/buildScripts/util/check-file-sizes.mjs
+++ b/buildScripts/util/check-file-sizes.mjs
@@ -1,0 +1,605 @@
+import {parse}                                   from 'acorn';
+import {program}                                 from 'commander';
+import fg                                        from 'fast-glob';
+import {spawnSync}                               from 'node:child_process';
+import {existsSync, readFileSync, writeFileSync} from 'node:fs';
+import path                                      from 'node:path';
+import process                                   from 'node:process';
+import {fileURLToPath}                           from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url),
+      __dirname  = path.dirname(__filename),
+      repoRoot   = path.resolve(__dirname, '../..');
+
+export const BASELINE_RELATIVE_PATH = 'buildScripts/util/file-size-baseline.json';
+export const DEFAULT_SCAN_ROOTS      = ['src', 'apps', 'examples', 'buildScripts'];
+export const DEFAULT_THRESHOLDS      = Object.freeze({target: 1_000, yellow: 1_500, red: 2_000});
+
+/**
+ * @summary Reports whether a path belongs to the code-line guard population.
+ * @param {String} file Repo-relative path.
+ * @param {String[]} roots Guarded directory roots.
+ * @returns {Boolean}
+ */
+export function isInScopePath(file, roots = DEFAULT_SCAN_ROOTS) {
+    return typeof file === 'string'
+        && file.endsWith('.mjs')
+        && roots.some(root => file.startsWith(`${root}/`))
+        && !file.split('/').includes('node_modules')
+}
+
+/**
+ * @summary Adds every nonblank physical line covered by an Acorn location to a set.
+ * @param {Set<Number>} target Destination line set.
+ * @param {{start: {line: Number}, end: {line: Number}}} location Acorn location.
+ * @param {String[]} lines Source lines.
+ * @returns {void}
+ */
+function addLocationLines(target, location, lines) {
+    for (let line = location.start.line; line <= location.end.line; line++) {
+        if (lines[line - 1]?.trim()) {
+            target.add(line)
+        }
+    }
+}
+
+/**
+ * @summary Measures code and documentation lines from parser-owned token/comment ranges.
+ * @param {String} source Module source.
+ * @param {String} file Repo-relative diagnostic path.
+ * @returns {{file: String, status: String, codeLines: Number|null, docLines: Number, docPercent: Number, totalLines: Number, error?: String}}
+ */
+export function measureSource(source, file = '<memory>') {
+    source = String(source);
+
+    const lines    = source.split(/\r\n|[\n\r]/u),
+          tokens   = [],
+          comments = [];
+
+    try {
+        parse(source, {
+            allowHashBang: true,
+            ecmaVersion  : 'latest',
+            locations    : true,
+            onComment    : comments,
+            onToken      : tokens,
+            sourceType   : 'module'
+        })
+    } catch (error) {
+        return {
+            file,
+            status    : 'not-measured',
+            codeLines : null,
+            docLines  : 0,
+            docPercent: 0,
+            totalLines: lines.length,
+            error     : error.message
+        }
+    }
+
+    const codeLineSet = new Set(),
+          docLineSet  = new Set();
+
+    tokens
+        .filter(token => token.type.label !== 'eof')
+        .forEach(token => addLocationLines(codeLineSet, token.loc, lines));
+    comments.forEach(comment => addLocationLines(docLineSet, comment.loc, lines));
+
+    return {
+        file,
+        status    : 'measured',
+        codeLines : codeLineSet.size,
+        docLines  : docLineSet.size,
+        docPercent: lines.length === 0 ? 0 : Number((docLineSet.size / lines.length * 100).toFixed(1)),
+        totalLines: lines.length
+    }
+}
+
+/**
+ * @summary Reports whether a declaration path is canonical, in-scope, and repository-relative.
+ * @param {String} file Candidate path.
+ * @returns {Boolean}
+ */
+function isSafeDeclarationPath(file) {
+    return !path.posix.isAbsolute(file)
+        && !file.includes('\\')
+        && path.posix.normalize(file) === file
+        && !file.split('/').includes('..')
+        && isInScopePath(file)
+}
+
+/**
+ * @summary Parses exact per-path growth declarations without grading their prose reason.
+ * @param {String} body Pull-request body text.
+ * @returns {{declarations: Map<String, String>, malformed: String[], duplicates: String[]}}
+ */
+export function parseGrowthDeclarations(body) {
+    const declarations = new Map(),
+          malformed    = [],
+          duplicates   = [];
+
+    String(body || '').split(/\r\n|[\n\r]/u).forEach(line => {
+        if (!line.trimStart().startsWith('size-guard-growth:')) {
+            return
+        }
+
+        const match = /^[ \t]*size-guard-growth:[ \t]+(\S+)[ \t]+—[ \t]+(\S(?:.*\S)?)[ \t]*$/u.exec(line);
+
+        if (!match || !isSafeDeclarationPath(match[1])) {
+            malformed.push(line);
+            return
+        }
+
+        const [, file, reason] = match;
+
+        if (declarations.has(file) || duplicates.includes(file)) {
+            declarations.delete(file);
+            duplicates.includes(file) || duplicates.push(file);
+            malformed.push(line);
+            return
+        }
+
+        declarations.set(file, reason)
+    });
+
+    return {declarations, malformed, duplicates}
+}
+
+/**
+ * @summary Maps a measured code-line count to its report band; only target admission gates.
+ * @param {Number} codeLines Measured code lines.
+ * @param {{target: Number, yellow: Number, red: Number}} thresholds Threshold inputs.
+ * @returns {String}
+ */
+function getBand(codeLines, thresholds) {
+    if (codeLines >= thresholds.red) {
+        return 'red'
+    }
+    if (codeLines >= thresholds.yellow) {
+        return 'yellow'
+    }
+    if (codeLines > thresholds.target) {
+        return 'over-target'
+    }
+    return 'green'
+}
+
+/**
+ * @summary Validates that a baseline is a path-to-positive-integer object in guard scope.
+ * @param {Object} baseline Candidate baseline.
+ * @param {String} label Diagnostic owner.
+ * @returns {String[]} Validation failures.
+ */
+function validateBaseline(baseline, label) {
+    if (!baseline || Array.isArray(baseline) || typeof baseline !== 'object') {
+        return [`${label} must be a JSON object keyed by repo-relative .mjs path.`]
+    }
+
+    return Object.entries(baseline).flatMap(([file, value]) => {
+        const errors = [];
+
+        isInScopePath(file) || errors.push(`${label} contains out-of-scope path ${file}.`);
+        Number.isInteger(value) && value > 0 || errors.push(`${label}[${file}] must be a positive integer.`);
+
+        return errors
+    })
+}
+
+/**
+ * @summary Evaluates measurements against immutable base authority and the proposed HEAD baseline.
+ * @param {Object} options
+ * @param {Object<String, Object>} options.measurements Path-to-measurement map.
+ * @param {Object<String, Number>} options.baseBaseline Baseline at the comparison ref.
+ * @param {Object<String, Number>} options.headBaseline Baseline in the working tree.
+ * @param {{declarations: Map<String, String>, malformed: String[], duplicates: String[]}} options.declarations Parsed PR declarations.
+ * @param {Boolean} options.compareBase Whether historical monotonicity is available.
+ * @param {{target: Number, yellow: Number, red: Number}} options.thresholds Threshold inputs.
+ * @returns {{rows: Object[], violations: Object[], unusedDeclarations: String[], malformedDeclarations: String[], monotonicityEvaluated: Boolean}}
+ */
+export function evaluateMeasurements({
+    measurements,
+    baseBaseline = {},
+    headBaseline = {},
+    declarations = parseGrowthDeclarations(''),
+    compareBase  = true,
+    thresholds   = DEFAULT_THRESHOLDS
+}) {
+    const parsedDeclarations = declarations instanceof Map
+              ? {declarations, malformed: [], duplicates: []}
+              : declarations,
+          declared          = parsedDeclarations.declarations || new Map(),
+          usedDeclarations  = new Set(),
+          violations        = validateBaseline(headBaseline, 'HEAD baseline')
+              .map(reason => ({file: BASELINE_RELATIVE_PATH, reason})),
+          rows              = [],
+          files             = [...new Set([
+              ...Object.keys(measurements || {}),
+              ...Object.keys(headBaseline || {}),
+              ...(compareBase ? Object.keys(baseBaseline || {}) : [])
+          ])].sort();
+
+    if (compareBase) {
+        validateBaseline(baseBaseline, 'base baseline')
+            .forEach(reason => violations.push({file: BASELINE_RELATIVE_PATH, reason}))
+    }
+
+    const fail = (file, reason) => violations.push({file, reason});
+
+    files.forEach(file => {
+        const measurement = measurements[file],
+              baseValue   = baseBaseline[file],
+              headValue   = headBaseline[file];
+
+        if (!measurement) {
+            const row = {file, band: 'deleted', codeLines: null, docLines: 0, docPercent: 0, verdict: 'pass'};
+
+            if (headValue !== undefined) {
+                row.verdict = 'fail';
+                fail(file, `remove the HEAD baseline entry for deleted path ${file}.`)
+            }
+
+            rows.push(row);
+            return
+        }
+
+        const row = {
+            file,
+            band      : measurement.status === 'measured' ? getBand(measurement.codeLines, thresholds) : 'not-measured',
+            codeLines : measurement.codeLines,
+            docLines  : measurement.docLines,
+            docPercent: measurement.docPercent,
+            verdict   : 'pass'
+        };
+
+        rows.push(row);
+
+        if (measurement.status !== 'measured') {
+            row.verdict = 'fail';
+            fail(file, `not-measured: ${measurement.error || 'parser did not return a measurement'}.`);
+            return
+        }
+
+        const current = measurement.codeLines;
+
+        if (current <= thresholds.target) {
+            if (headValue !== undefined) {
+                row.verdict = 'fail';
+                fail(file, `remove the HEAD baseline entry: ${file} is at or below the ${thresholds.target}-line target.`)
+            }
+            return
+        }
+
+        if (!compareBase) {
+            if (headValue !== current) {
+                row.verdict = 'fail';
+                fail(file, `HEAD baseline must equal the measured count ${current} for ${file}.`)
+            }
+            return
+        }
+
+        if (baseValue === undefined) {
+            if (headValue !== current) {
+                row.verdict = 'fail';
+                fail(file, `enroll ${file} in the HEAD baseline at its measured count ${current}.`)
+            }
+            if (!declared.has(file)) {
+                row.verdict = 'fail';
+                fail(file, `${file} needs an exact size-guard-growth declaration for new enrollment.`)
+            } else {
+                usedDeclarations.add(file)
+            }
+            return
+        }
+
+        if (current < baseValue) {
+            if (headValue !== current) {
+                row.verdict = 'fail';
+                fail(file, `lower the HEAD baseline for ${file} from ${baseValue} to the measured count ${current}.`)
+            }
+            return
+        }
+
+        if (headValue !== current) {
+            row.verdict = 'fail';
+            fail(file, `HEAD baseline must equal the measured count ${current} for ${file}.`)
+        }
+
+        if (current > baseValue) {
+            if (!declared.has(file)) {
+                row.verdict = 'fail';
+                fail(file, `${file} grew from ${baseValue} to ${current}; add size-guard-growth: ${file} — <reason>.`)
+            } else {
+                usedDeclarations.add(file)
+            }
+        }
+    });
+
+    return {
+        rows,
+        violations,
+        unusedDeclarations   : [...declared.keys()].filter(file => !usedDeclarations.has(file)).sort(),
+        malformedDeclarations: parsedDeclarations.malformed || [],
+        monotonicityEvaluated: compareBase
+    }
+}
+
+/**
+ * @summary Produces the canonical sorted HEAD baseline from measured over-target files.
+ * @param {Object} options
+ * @param {Object<String, Object>} options.measurements Path-to-measurement map.
+ * @param {{target: Number}} options.thresholds Threshold inputs.
+ * @returns {Object<String, Number>}
+ */
+export function reconcileBaseline({measurements, thresholds = DEFAULT_THRESHOLDS}) {
+    return Object.fromEntries(Object.entries(measurements)
+        .filter(([, measurement]) => measurement?.status === 'measured' && measurement.codeLines > thresholds.target)
+        .map(([file, measurement]) => [file, measurement.codeLines])
+        .sort(([a], [b]) => a.localeCompare(b)))
+}
+
+/**
+ * @summary Reads and validates a JSON baseline from disk.
+ * @param {String} absolutePath Absolute file path.
+ * @param {String} label Diagnostic owner.
+ * @returns {Object<String, Number>}
+ */
+function readBaselineFile(absolutePath, label) {
+    let baseline;
+
+    try {
+        baseline = JSON.parse(readFileSync(absolutePath, 'utf8'))
+    } catch (error) {
+        throw new Error(`Could not read ${label} at ${absolutePath}: ${error.message}`)
+    }
+
+    const errors = validateBaseline(baseline, label);
+
+    if (errors.length > 0) {
+        throw new Error(errors.join('\n'))
+    }
+
+    return baseline
+}
+
+/**
+ * @summary Reads a baseline blob from a git ref without checking it out.
+ * @param {String} ref Git comparison ref.
+ * @param {String} relativePath Repo-relative baseline path.
+ * @returns {{baseline: Object<String, Number>, exists: Boolean}}
+ */
+function readBaselineAtRef(ref, relativePath) {
+    const refResult = spawnSync('git', ['rev-parse', '--verify', `${ref}^{commit}`], {
+        cwd     : repoRoot,
+        encoding: 'utf8'
+    });
+
+    if (refResult.status !== 0) {
+        throw new Error(`Could not resolve base ref ${ref}: ${refResult.stderr.trim()}`)
+    }
+
+    const result = spawnSync('git', ['show', `${ref}:${relativePath}`], {
+        cwd     : repoRoot,
+        encoding: 'utf8'
+    });
+
+    if (result.status !== 0) {
+        const treeResult = spawnSync('git', ['ls-tree', '-r', '--name-only', ref, '--', relativePath], {
+            cwd     : repoRoot,
+            encoding: 'utf8'
+        });
+
+        if (treeResult.status !== 0) {
+            throw new Error(`Could not inspect base tree ${ref}: ${treeResult.stderr.trim()}`)
+        }
+
+        if (!treeResult.stdout.trim()) {
+            return {baseline: {}, exists: false}
+        }
+
+        throw new Error(`Could not read base baseline ${relativePath} at ${ref}: ${result.stderr.trim()}`)
+    }
+
+    let baseline;
+
+    try {
+        baseline = JSON.parse(result.stdout)
+    } catch (error) {
+        throw new Error(`Base baseline at ${ref}:${relativePath} is invalid JSON: ${error.message}`)
+    }
+
+    const errors = validateBaseline(baseline, 'base baseline');
+
+    if (errors.length > 0) {
+        throw new Error(errors.join('\n'))
+    }
+
+    return {baseline, exists: true}
+}
+
+/**
+ * @summary Selects in-scope files changed against a git base.
+ * @param {String} ref Git comparison ref.
+ * @returns {String[]}
+ */
+function changedFilesAtRef(ref) {
+    const result = spawnSync('git', ['diff', '--name-only', '--diff-filter=d', `${ref}...HEAD`], {
+        cwd     : repoRoot,
+        encoding: 'utf8'
+    });
+
+    if (result.status !== 0) {
+        throw new Error(`Could not diff ${ref}...HEAD: ${result.stderr.trim()}`)
+    }
+
+    return result.stdout.split('\n').map(file => file.trim()).filter(file => isInScopePath(file))
+}
+
+/**
+ * @summary Measures selected existing files and preserves explicit missing paths for deletion checks.
+ * @param {String[]} files Repo-relative paths.
+ * @returns {Object<String, Object>}
+ */
+function measureFiles(files) {
+    return Object.fromEntries(files.flatMap(file => {
+        const absolutePath = path.resolve(repoRoot, file);
+
+        if (!existsSync(absolutePath)) {
+            return []
+        }
+
+        let source;
+
+        try {
+            source = readFileSync(absolutePath, 'utf8')
+        } catch (error) {
+            return [[file, {
+                file,
+                status    : 'not-measured',
+                codeLines : null,
+                docLines  : 0,
+                docPercent: 0,
+                totalLines: 0,
+                error     : error.message
+            }]]
+        }
+
+        return [[file, measureSource(source, file)]]
+    }))
+}
+
+/**
+ * @summary Formats one deterministic console row with code and documentation measures.
+ * @param {Object} row Evaluation row.
+ * @returns {String}
+ */
+function formatRow(row) {
+    if (row.band === 'deleted') {
+        return `${row.verdict.toUpperCase().padEnd(4)} deleted       ${row.file}`
+    }
+
+    if (row.band === 'not-measured') {
+        return `FAIL not-measured  ${row.file}`
+    }
+
+    return `${row.verdict.toUpperCase().padEnd(4)} ${row.band.padEnd(11)} ${String(row.codeLines).padStart(5)} code | ${String(row.docLines).padStart(5)} doc (${row.docPercent.toFixed(1)}%)  ${row.file}`
+}
+
+/**
+ * @summary Runs the code-line audit CLI and exits non-zero on measurement or ratchet violations.
+ * @returns {Promise<void>}
+ */
+async function main() {
+    program
+        .name('check-file-sizes')
+        .description('Measure .mjs code lines and enforce a base-to-HEAD shrinking baseline.')
+        .argument('[files...]', 'Specific repo-relative .mjs files. Omitted means changed-vs-base or the whole guarded tree.')
+        .option('-b, --base <ref>', 'Compare the HEAD baseline and changed files against this git ref.')
+        .option('--baseline <path>', 'Repo-relative HEAD baseline path.', BASELINE_RELATIVE_PATH)
+        .option('--pr-body-file <path>', 'File containing the current pull-request body. Omitted means no growth hatch.')
+        .option('--fix', 'Rewrite the HEAD baseline to measured over-target counts.', false)
+        .option('--target <lines>', 'Target code-line ceiling.', value => Number(value), DEFAULT_THRESHOLDS.target)
+        .option('--yellow <lines>', 'Yellow report threshold.', value => Number(value), DEFAULT_THRESHOLDS.yellow)
+        .option('--red <lines>', 'Red report threshold.', value => Number(value), DEFAULT_THRESHOLDS.red)
+        .showHelpAfterError();
+
+    program.parse(process.argv);
+
+    const options      = program.opts(),
+          thresholds   = {target: options.target, yellow: options.yellow, red: options.red},
+          baselinePath = path.resolve(repoRoot, options.baseline);
+
+    if (![thresholds.target, thresholds.yellow, thresholds.red].every(Number.isInteger)
+        || thresholds.target < 1 || thresholds.yellow <= thresholds.target || thresholds.red <= thresholds.yellow) {
+        console.error('check-file-sizes: thresholds must be positive integers ordered target < yellow < red.');
+        process.exit(1)
+    }
+
+    try {
+        let headBaseline = readBaselineFile(baselinePath, 'HEAD baseline'),
+            baseBaseline = {},
+            compareBase  = false,
+            selected;
+
+        if (options.base) {
+            const baseState = readBaselineAtRef(options.base, options.baseline);
+
+            baseBaseline = baseState.baseline;
+            compareBase  = baseState.exists;
+            selected     = compareBase
+                ? changedFilesAtRef(options.base)
+                : await fg(DEFAULT_SCAN_ROOTS.map(root => `${root}/**/*.mjs`), {
+                    absolute : false,
+                    cwd      : repoRoot,
+                    dot      : false,
+                    onlyFiles: true,
+                    unique   : true,
+                    ignore   : ['**/node_modules/**']
+                })
+        } else if (program.args.length > 0) {
+            selected = program.args.filter(file => isInScopePath(file))
+        } else {
+            selected = await fg(DEFAULT_SCAN_ROOTS.map(root => `${root}/**/*.mjs`), {
+                absolute : false,
+                cwd      : repoRoot,
+                dot      : false,
+                onlyFiles: true,
+                unique   : true,
+                ignore   : ['**/node_modules/**']
+            })
+        }
+
+        selected = [...new Set([
+            ...selected,
+            ...Object.keys(headBaseline),
+            ...(compareBase ? Object.keys(baseBaseline) : [])
+        ])].sort();
+
+        const measurements = measureFiles(selected),
+              body         = options.prBodyFile ? readFileSync(path.resolve(repoRoot, options.prBodyFile), 'utf8') : '',
+              declarations = parseGrowthDeclarations(body);
+
+        if (options.fix) {
+            headBaseline = reconcileBaseline({measurements, thresholds});
+            writeFileSync(baselinePath, JSON.stringify(headBaseline, null, 4) + '\n')
+        }
+
+        const result = evaluateMeasurements({
+            measurements,
+            baseBaseline,
+            headBaseline,
+            declarations,
+            compareBase,
+            thresholds
+        }),
+              explicitFiles = new Set(program.args.filter(file => isInScopePath(file))),
+              reportRows    = result.rows.filter(row => row.verdict === 'fail'
+                  || (row.codeLines ?? 0) > thresholds.target
+                  || explicitFiles.has(row.file));
+
+        reportRows.forEach(row => console.log(formatRow(row)));
+
+        declarations.malformed.forEach(line => console.warn(`IGNORED malformed growth declaration: ${line}`));
+        result.unusedDeclarations.forEach(file => console.warn(`IGNORED unused growth declaration: ${file}`));
+
+        if (!result.monotonicityEvaluated) {
+            console.log(options.base
+                ? `NOTE ${options.baseline} is absent at ${options.base}; this is the one-time baseline bootstrap and the whole guarded tree was measured.`
+                : 'NOTE historical monotonicity was not evaluated; pass --base <ref> for the base-to-HEAD ratchet.')
+        }
+
+        if (result.violations.length > 0) {
+            console.error(`\ncheck-file-sizes: ${result.violations.length} violation(s).`);
+            result.violations.forEach(({file, reason}) => console.error(`  ${file}: ${reason}`));
+            process.exit(1)
+        }
+
+        console.log(`\ncheck-file-sizes: ${result.rows.length} path(s) evaluated, ${reportRows.length} reported, 0 violations.`)
+    } catch (error) {
+        console.error(`check-file-sizes: ${error.message}`);
+        process.exit(1)
+    }
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === __filename) {
+    await main()
+}

--- a/buildScripts/util/file-size-baseline.json
+++ b/buildScripts/util/file-size-baseline.json
@@ -1,0 +1,6 @@
+{
+    "apps/workstation/view/Workspace.mjs": 3390,
+    "examples/dashboard/crossWindow/DemoBWorkspace.mjs": 2701,
+    "src/dashboard/dock/Workspace.mjs": 1740,
+    "src/main/addon/DragDrop.mjs": 1267
+}

--- a/learn/guides/advanced/BuildArchitecture.md
+++ b/learn/guides/advanced/BuildArchitecture.md
@@ -135,7 +135,7 @@ document.addEventListener('click', function(event) {
     let {target} = event;
     // Walk up to find the anchor tag
     while (target && target.tagName !== 'A') target = target.parentElement;
-    
+
     // If it's a hash link, prevent reload and set hash manually
     if (target?.getAttribute('href')?.startsWith('#')) {
         event.preventDefault();
@@ -171,3 +171,34 @@ output: {
 ```
 
 This isolation ensures that even if Webpack generates conflicting IDs across different builds, the physical files never collide. Each realm loads only its own scoped chunks.
+
+## 7. File-size ownership guard
+
+Large modules are measured by code-bearing lines, not total physical lines. The guard parses every
+in-scope `.mjs` file with Acorn, counts nonblank lines covered by tokens, and reports comment-covered
+lines separately as documentation percentage. Documentation is visible in the report but never changes
+the verdict.
+
+Run the whole-tree audit with:
+
+```bash
+npm run check-file-sizes
+```
+
+The target is at most 1,000 code lines. Counts from 1,500 are labelled yellow and counts from 2,000
+red, but those labels are reporting severity only. The admission gate remains the 1,000-line target.
+Existing offenders live in `buildScripts/util/file-size-baseline.json`.
+
+In pull requests the workflow compares that baseline with its version on the base branch. Equal counts
+preserve the entry; a shrink must lower it in the same change and remove it at the target; raising an
+entry alone cannot disguise growth. Use `--fix` to align the working-tree baseline with measured counts.
+
+Exceptional growth or enrollment requires one current PR-body line per path:
+
+```text
+size-guard-growth: src/path/Module.mjs — why the destination owner does not exist yet
+```
+
+The workflow fetches the current body at run time and passes it as a file. A missing, malformed, or
+wrong-path line provides no hatch, and the reason remains reviewer-owned prose rather than a machine
+judgment.

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
         "check-theme-surfaces"                 : "node ./buildScripts/util/check-theme-surfaces.mjs",
         "check-engine-brain-boundary"          : "node ./buildScripts/util/check-engine-brain-boundary.mjs",
         "check-examples-body-only"             : "node ./buildScripts/util/check-examples-body-only.mjs",
+        "check-file-sizes"                     : "node ./buildScripts/util/check-file-sizes.mjs",
         "check-package-contents"               : "node ./buildScripts/util/check-package-contents.mjs",
         "check-reactive-tags"                  : "node ./buildScripts/helpers/checkReactiveTags.mjs",
         "check-relative-links"                 : "node ./buildScripts/util/check-relative-links.mjs",

--- a/test/playwright/unit/buildScripts/checkFileSizes.spec.mjs
+++ b/test/playwright/unit/buildScripts/checkFileSizes.spec.mjs
@@ -1,0 +1,302 @@
+import {test, expect} from '@playwright/test';
+import {readFileSync} from 'node:fs';
+
+import {
+    DEFAULT_THRESHOLDS,
+    evaluateMeasurements,
+    isInScopePath,
+    measureSource,
+    parseGrowthDeclarations,
+    reconcileBaseline
+} from '../../../../buildScripts/util/check-file-sizes.mjs';
+
+const measured = codeLines => ({
+    codeLines,
+    docLines  : 0,
+    docPercent: 0,
+    status    : 'measured',
+    totalLines: codeLines
+});
+
+const evaluate = ({
+    current,
+    base = {},
+    head = {},
+    body = '',
+    compareBase = true
+}) => evaluateMeasurements({
+    measurements: Object.fromEntries(
+        Object.entries(current).map(([file, codeLines]) => [file, measured(codeLines)])
+    ),
+    baseBaseline: base,
+    headBaseline: head,
+    declarations: parseGrowthDeclarations(body),
+    compareBase,
+    thresholds  : DEFAULT_THRESHOLDS
+});
+
+test.describe('check-file-sizes', () => {
+    test('scope admits the four guarded roots and rejects adjacent trees', () => {
+        expect([
+            'src/a.mjs',
+            'apps/a.mjs',
+            'examples/a.mjs',
+            'buildScripts/a.mjs'
+        ].every(file => isInScopePath(file))).toBe(true);
+        expect(isInScopePath('test/a.mjs')).toBe(false);
+        expect(isInScopePath('src/a.js')).toBe(false);
+    });
+
+    test.describe('parser-owned measurement', () => {
+        test('counts token-bearing lines while excluding comments and blanks', () => {
+            const source = [
+                '/**',
+                ' * Documentation, not code.',
+                ' */',
+                '',
+                'const value = 1; // trailing documentation',
+                'const url = "https://example.test/a//b";',
+                'const marker = "/* still a string */";',
+                '',
+                'export default value;'
+            ].join('\n');
+
+            const result = measureSource(source, 'src/example.mjs');
+
+            expect(result).toMatchObject({
+                codeLines : 4,
+                docLines  : 4,
+                status    : 'measured',
+                totalLines: 9
+            });
+        });
+
+        test('counts each nonblank line spanned by a multiline token', () => {
+            const result = measureSource('const text = `one\n\ntwo`;\nexport default text;', 'src/template.mjs');
+
+            expect(result.codeLines).toBe(3);
+        });
+
+        test('returns not-measured on parse failure, never a clean zero', () => {
+            const result = measureSource('export const broken = ;', 'src/broken.mjs');
+
+            expect(result.status).toBe('not-measured');
+            expect(result.codeLines).toBeNull();
+            expect(result.error).toContain('Unexpected token');
+
+            const evaluation = evaluateMeasurements({
+                measurements: {'src/broken.mjs': result},
+                baseBaseline: {},
+                headBaseline: {},
+                declarations: parseGrowthDeclarations(''),
+                compareBase : true,
+                thresholds  : DEFAULT_THRESHOLDS
+            });
+
+            expect(evaluation.rows[0]).toMatchObject({band: 'not-measured', verdict: 'fail'});
+            expect(evaluation.violations[0].reason).toContain('not-measured');
+        });
+    });
+
+    test.describe('three thresholds, one gate', () => {
+        test('labels admitted files yellow and red without changing their verdict', () => {
+            const result = evaluate({
+                current: {
+                    'src/yellow.mjs': 1_500,
+                    'src/red.mjs'   : 2_000
+                },
+                base: {
+                    'src/yellow.mjs': 1_500,
+                    'src/red.mjs'   : 2_000
+                },
+                head: {
+                    'src/yellow.mjs': 1_500,
+                    'src/red.mjs'   : 2_000
+                }
+            });
+
+            expect(result.violations).toEqual([]);
+            expect(result.rows.map(row => [row.file, row.band, row.verdict])).toEqual([
+                ['src/red.mjs', 'red', 'pass'],
+                ['src/yellow.mjs', 'yellow', 'pass']
+            ]);
+        });
+
+        test('an unbaselined file fails at 1001 and passes at 1000', () => {
+            const result = evaluate({
+                current: {
+                    'src/at-target.mjs'  : 1_000,
+                    'src/over-target.mjs': 1_001
+                }
+            });
+
+            expect([...new Set(result.violations.map(item => item.file))]).toEqual(['src/over-target.mjs']);
+            expect(result.violations.map(item => item.reason).join('\n')).toMatch(/enroll[\s\S]*size-guard-growth/u);
+            expect(result.rows.find(row => row.file === 'src/at-target.mjs').verdict).toBe('pass');
+        });
+
+        test('doc percentage is reported but cannot change the verdict', () => {
+            const measurements = {
+                'src/doc-heavy.mjs': {
+                    ...measured(1_000),
+                    docLines  : 9_000,
+                    docPercent: 90,
+                    totalLines: 10_000
+                }
+            };
+
+            const result = evaluateMeasurements({
+                measurements,
+                baseBaseline: {},
+                headBaseline: {},
+                declarations: parseGrowthDeclarations(''),
+                compareBase : true,
+                thresholds  : DEFAULT_THRESHOLDS
+            });
+
+            expect(result.violations).toEqual([]);
+            expect(result.rows[0]).toMatchObject({docPercent: 90, verdict: 'pass'});
+        });
+    });
+
+    test.describe('base-to-HEAD ratchet', () => {
+        const file = 'src/large.mjs';
+
+        test('equality passes only with the ceiling preserved', () => {
+            expect(evaluate({current: {[file]: 1_200}, base: {[file]: 1_200}, head: {[file]: 1_200}}).violations)
+                .toEqual([]);
+
+            const raised = evaluate({current: {[file]: 1_200}, base: {[file]: 1_200}, head: {[file]: 1_300}});
+
+            expect(raised.violations[0].reason).toContain('HEAD baseline must equal the measured count');
+        });
+
+        test('a shrink fails with a stale ceiling and passes when the HEAD entry turns', () => {
+            const stale   = evaluate({current: {[file]: 1_199}, base: {[file]: 1_200}, head: {[file]: 1_200}}),
+                  lowered = evaluate({current: {[file]: 1_199}, base: {[file]: 1_200}, head: {[file]: 1_199}});
+
+            expect(stale.violations[0].reason).toContain('lower the HEAD baseline');
+            expect(lowered.violations).toEqual([]);
+        });
+
+        test('raising only the JSON cannot disguise code growth', () => {
+            const result = evaluate({current: {[file]: 1_201}, base: {[file]: 1_200}, head: {[file]: 1_201}});
+
+            expect(result.violations[0].reason).toContain('size-guard-growth');
+        });
+
+        test('declared growth passes only when the HEAD entry equals the measured count', () => {
+            const body = `size-guard-growth: ${file} — the destination owner lands in the next leaf`;
+
+            expect(evaluate({current: {[file]: 1_201}, base: {[file]: 1_200}, head: {[file]: 1_201}, body}).violations)
+                .toEqual([]);
+
+            const staleHead = evaluate({current: {[file]: 1_201}, base: {[file]: 1_200}, head: {[file]: 1_200}, body});
+
+            expect(staleHead.violations[0].reason).toContain('HEAD baseline must equal the measured count');
+        });
+
+        test('a new offender requires both exact declaration and enrollment', () => {
+            const body = `size-guard-growth: ${file} — temporarily owns the new parser seam`;
+
+            expect(evaluate({current: {[file]: 1_001}, head: {[file]: 1_001}, body}).violations).toEqual([]);
+
+            expect(evaluate({current: {[file]: 1_001}, head: {[file]: 1_001}}).violations[0].reason)
+                .toContain('size-guard-growth');
+
+            expect(evaluate({current: {[file]: 1_001}, body}).violations[0].reason)
+                .toContain('enroll');
+        });
+
+        test('at-target and deleted paths cannot retain baseline entries', () => {
+            const atTarget = evaluate({current: {[file]: 1_000}, base: {[file]: 1_200}, head: {[file]: 1_200}}),
+                  deleted  = evaluate({current: {}, base: {[file]: 1_200}, head: {[file]: 1_200}});
+
+            expect(atTarget.violations[0].reason).toContain('remove');
+            expect(deleted.violations[0].reason).toContain('remove');
+
+            expect(evaluate({current: {[file]: 1_000}, base: {[file]: 1_200}}).violations).toEqual([]);
+            expect(evaluate({current: {}, base: {[file]: 1_200}}).violations).toEqual([]);
+        });
+
+        test('on-demand mode verifies HEAD alignment and declares that history was not evaluated', () => {
+            const result = evaluate({
+                current    : {[file]: 1_200},
+                head       : {[file]: 1_200},
+                compareBase: false
+            });
+
+            expect(result.violations).toEqual([]);
+            expect(result.monotonicityEvaluated).toBe(false);
+        });
+    });
+
+    test.describe('growth declaration grammar', () => {
+        test('accepts the exact anchored grammar and records the reason', () => {
+            const parsed = parseGrowthDeclarations('size-guard-growth: src/large.mjs — the owner does not exist yet');
+
+            expect(parsed.declarations.get('src/large.mjs')).toBe('the owner does not exist yet');
+            expect(parsed.malformed).toEqual([]);
+        });
+
+        test('ignores prose that merely names the marker', () => {
+            const parsed = parseGrowthDeclarations('Use `size-guard-growth:` only when a measured path grew.');
+
+            expect([...parsed.declarations]).toEqual([]);
+            expect(parsed.malformed).toEqual([]);
+        });
+
+        test('rejects malformed, wrong-dash, unsafe, and duplicate lines', () => {
+            const parsed = parseGrowthDeclarations([
+                'size-guard-growth: src/no-reason.mjs —',
+                'size-guard-growth: src/ascii.mjs - reason',
+                'size-guard-growth: ../outside.mjs — reason',
+                'size-guard-growth: src/dup.mjs — first',
+                'size-guard-growth: src/dup.mjs — second'
+            ].join('\n'));
+
+            expect(parsed.declarations.has('src/dup.mjs')).toBe(false);
+            expect(parsed.malformed).toHaveLength(4);
+            expect(parsed.duplicates).toEqual(['src/dup.mjs']);
+        });
+
+        test('a declaration for another path does not admit growth', () => {
+            const result = evaluate({
+                current: {'src/large.mjs': 1_201},
+                base   : {'src/large.mjs': 1_200},
+                head   : {'src/large.mjs': 1_201},
+                body   : 'size-guard-growth: src/other.mjs — unrelated'
+            });
+
+            expect(result.violations[0].reason).toContain('src/large.mjs');
+            expect(result.unusedDeclarations).toEqual(['src/other.mjs']);
+        });
+    });
+
+    test('reconcileBaseline writes measured offenders only and removes target/deleted entries', () => {
+        const next = reconcileBaseline({
+            measurements: {
+                'src/b.mjs' : measured(1_200),
+                'src/a.mjs' : measured(1_100),
+                'src/ok.mjs': measured(1_000)
+            },
+            thresholds: DEFAULT_THRESHOLDS
+        });
+
+        expect(next).toEqual({
+            'src/a.mjs': 1_100,
+            'src/b.mjs': 1_200
+        });
+    });
+
+    test('the workflow fetches current PR truth and never reads the event-snapshot body', () => {
+        const workflow = readFileSync('.github/workflows/file-size-guard.yml', 'utf8');
+
+        expect(workflow).toContain('github.rest.pulls.get');
+        expect(workflow).toContain('data.body');
+        expect(workflow).not.toContain('context.payload.pull_request.body');
+        expect(workflow).toContain('fetch-depth: 0');
+        expect(workflow).toContain('--base');
+        expect(workflow).toContain('--pr-body-file');
+    });
+});


### PR DESCRIPTION
Resolves #18278

Related: #18304 · D#18150

The DockLayouts refactor now has a code-line smoke detector that cannot be gamed by comments or by raising its own baseline. Acorn token/comment ranges measure code and documentation separately; the base branch baseline is authority, HEAD must turn every shrink, and growth or enrollment needs one exact current-PR declaration per path. The first census admits exactly four current offenders and the guard measures itself at 427 code lines.

Evidence: L2 achieved for parser, ratchet, CLI, full-suite behavior, and hosted live-body fetch. Opening run `33917021681` observed the temporary declaration; edited run `33917157381` re-fetched the new body and omitted that declaration, exposing one prose-mention false-positive now covered at the new head. Residual: none.

## AC Evidence

| AC | Evidence |
|---|---|
| AC-1 | `npm run check-file-sizes -- --base origin/dev` evaluates 1,296 in-scope modules, reports exactly the four baseline offenders, labels them red/red/yellow/over-target, and returns zero violations; explicit controls report `component/Base.mjs` at 868 and `collection/Base.mjs` at 955, both green. |
| AC-2 | Parser battery proves token-owned code lines, comment-owned doc lines, multiline-token handling, and doc percentage that cannot alter a verdict. |
| AC-3 | Base-vs-HEAD battery covers equality, stale/lowered shrink, raised-JSON laundering, declared growth, declared enrollment, target removal, and deletion. |
| AC-4 | Exact grammar battery covers valid, malformed, ASCII-dash, unsafe, duplicate, wrong-path, absent, unused, and prose-mention declarations. The workflow source arm requires REST current-body fetch and forbids event-snapshot body authority. |
| AC-5 | Parse failure returns and fails as `not-measured`, never as clean zero. |

## Deltas from ticket

- Implementation-boundary intake added the missing base-vs-HEAD comparator; otherwise a PR could raise the JSON ceiling and turn forbidden growth into equality.
- Live PR-body authority is `github.rest.pulls.get()`. The event payload is explicitly rejected as a stale snapshot.
- The one-time bootstrap recognizes that `origin/dev` has no baseline, measures the whole tree, and then hands every later PR the normal monotonic comparator.
- Bootstrap counts were refreshed after merged #18332: Workstation 3,390; Demo B 2,701; dock Workspace 1,740; DragDrop 1,267 code lines.

## Test Evidence

- Red-first: the focused spec initially failed because `check-file-sizes.mjs` did not exist; after the core landed, 16/18 passed while the workflow remained deliberately absent.
- `npm run test-unit -- test/playwright/unit/buildScripts/checkFileSizes.spec.mjs` — 20/20 passed at `51947c1f`.
- `npm run test-unit` — 3,227/3,227 passed after rebasing onto merged `dev@ec5eb923da`.
- `npm run check-file-sizes -- --base origin/dev` — 1,296 evaluated, 4 reported, 0 violations.
- `NPM_CONFIG_CACHE=/private/tmp/neo-18278-npm-cache npm run check-package-contents` — passed: 5,501 files, no forbidden entries.
- Relative links, shorthand, parser, ticket archaeology, block alignment, Engine/Brain boundary, YAML/JSON parse, `git diff --check`, and the full pre-commit hook passed.

## Live-body control

Opening run `33917021681` logged the temporary unused DragDrop declaration. Edited run `33917157381` re-fetched the changed body and no longer logged it; that run exposed a prose mention as malformed, and `51947c1f` adds the discriminating ignore-prose arm. Current-head CI must contain neither warning before review request.

## Post-Merge Validation

None. The hosted opening/edit/ready event chain is complete; current body truth was fetched in every event class, and every code/CLI criterion is verified on the exact head.

## Commits

- `51947c1f` — parser metric, immutable baseline, live-body workflow, focused battery, prose-mention control, and build guide.

Authored by Euclid (`@neo-gpt`, GPT-5.6 Sol Ultra, Codex). Session `a4bbcc9e-0ed4-41bd-8b8b-73d680720770`.