### PR TITLE
docs(readme): refresh maintainer model roster (#18334)

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,12 +100,12 @@ We are not an abstract collective. We are a structured institution of named main
 | Tobias | [@tobiu](https://github.com/tobiu) | Gardener, Substrate architect, empirical-corrector, merge-gate authority | Human |
 | Ada | [@neo-opus-ada](https://github.com/neo-opus-ada) | AI maintainer (Anthropic Claude Opus 5) | Machine Account |
 | Grace | [@neo-opus-grace](https://github.com/neo-opus-grace) | AI maintainer (Anthropic Claude Opus 5) | Machine Account |
-| Vega | [@neo-opus-vega](https://github.com/neo-opus-vega) | AI maintainer (Anthropic Claude — weekly rotation; Fable 5 active, Opus 5 planned) | Machine Account |
-| Mnemosyne | [@neo-fable](https://github.com/neo-fable) | AI maintainer (Anthropic Claude Fable 5) | Machine Account |
-| Clio | [@neo-fable-clio](https://github.com/neo-fable-clio) | AI maintainer (Anthropic Claude Fable 5) | Machine Account |
+| Vega | [@neo-opus-vega](https://github.com/neo-opus-vega) | AI maintainer (Anthropic Claude — weekly rotation; Fable 5.1 active, Opus 5 planned) | Machine Account |
+| Mnemosyne | [@neo-fable](https://github.com/neo-fable) | AI maintainer (Anthropic Claude Fable 5.1) | Machine Account |
+| Clio | [@neo-fable-clio](https://github.com/neo-fable-clio) | AI maintainer (Anthropic Claude Fable 5.1) | Machine Account |
 | - | [@neo-gemini-pro](https://github.com/neo-gemini-pro) | AI maintainer (Google Gemini 3.1 Pro) | Machine Account |
-| Euclid | [@neo-gpt](https://github.com/neo-gpt) | AI maintainer (OpenAI GPT-5.6 Sol / Codex) | Machine Account |
-| Emmy | [@neo-gpt-emmy](https://github.com/neo-gpt-emmy) | AI maintainer (OpenAI GPT-5.6 Sol / Codex) | Machine Account |
+| Euclid | [@neo-gpt](https://github.com/neo-gpt) | AI maintainer (OpenAI GPT-6 Astra / Codex) | Machine Account |
+| Emmy | [@neo-gpt-emmy](https://github.com/neo-gpt-emmy) | AI maintainer (OpenAI GPT-6 Astra / Codex) | Machine Account |
 | Phoebe | [@neo-kimi-phoebe](https://github.com/neo-kimi-phoebe) | AI maintainer (Moonshot Kimi K3) | Machine Account |
 | Iris | [@neo-kimi-iris](https://github.com/neo-kimi-iris) | AI maintainer (Moonshot Kimi K3) | Machine Account |
 | Eos | [@neo-preview](https://github.com/neo-preview) | AI maintainer (family undisclosed by design) | Machine Account |


### PR DESCRIPTION
Resolves #18334

Refresh the README maintainer table to the operator-confirmed models: GPT-6 Astra for Euclid and Emmy, Fable 5.1 for Clio and Mnemosyne, and Fable 5.1 in Vega's existing weekly rotation.

Evidence: L1 achieved and required for this documentation-only correction. No runtime residual.

Micro-review eligible: documentation-only — five model-label substitutions in the existing roster.

## AC Evidence
| AC | Evidence |
|---|---|
| AC-1 | outside-CI: inspected Euclid and Emmy's updated README rows; both retain `/ Codex`. |
| AC-2 | outside-CI: inspected Clio and Mnemosyne's updated README rows. |
| AC-3 | outside-CI: inspected Vega's row; weekly rotation and Opus 5 planned remain. |
| AC-4 | outside-CI: `git diff --numstat` reports only README.md, five additions and five deletions; `git diff --check` passes. |

## Deltas from ticket
None substantive.

## Test Evidence
Manual diff inspection supplies the four receipts above. No runtime tests are warranted for roster text. The Engine's documented `npm run agent-preflight` alias is absent after the split; the Brain-owned preflight is invoked directly against this checkout instead.

## Post-Merge Validation
None required.

Authored by Emmy (GPT-6 Astra, Codex). Session 68e52d5c-03d0-4b82-8639-3676d5b612da.
