### PR TITLE
fix(dock): a host-less workspace maximizes onto its projected shell, so the chrome it frames the shell with stays in sight (#18328)

### DIFF
--- a/buildScripts/util/file-size-baseline.json
+++ b/buildScripts/util/file-size-baseline.json
@@ -1,6 +1,6 @@
 {
     "apps/workstation/view/Workspace.mjs": 3390,
     "examples/dashboard/crossWindow/DemoBWorkspace.mjs": 2701,
-    "src/dashboard/dock/Workspace.mjs": 1740,
+    "src/dashboard/dock/Workspace.mjs": 1419,
     "src/main/addon/DragDrop.mjs": 1267
 }

--- a/src/dashboard/dock/plugin/Maximize.mjs
+++ b/src/dashboard/dock/plugin/Maximize.mjs
@@ -331,22 +331,26 @@ class Maximize extends Plugin {
     }
 
     /**
-     * Measures the dock host's live viewport rect — the geometry authority for the maximize
+     * Measures the dock area's live viewport rect — the geometry authority for the maximize
      * presentation. A maximized pane fills the DOCK AREA, not the app view: a workspace that
-     * frames its host with a tour bar or a status bar keeps them in sight. The host is measured
-     * explicitly (the workspace root stands in while no host is mounted): `inset: 0` would answer
-     * to the viewport or an incidental fixed containing block instead. `null` is the fail-safe
-     * trigger (unmounted mid-gesture, zero-area rect).
+     * frames it with a tour bar or a status bar keeps them in sight. The area is measured
+     * explicitly: a named dock host is the consumer's stated dock area; a workspace that is its own
+     * host measures the projected shell at `dockShellIndex` — the chrome it frames the shell with
+     * (a perspective toolbar at index 0) sits outside that rect; the workspace root stands in only
+     * while nothing is mounted. `inset: 0` would answer to the viewport or an incidental fixed
+     * containing block instead. `null` is the fail-safe trigger (unmounted mid-gesture, zero-area
+     * rect).
      * @returns {Promise<Object|null>}
      * @protected
      */
     async measureRect() {
         let {owner} = this,
-            id      = owner.getDockHost()?.id || owner.id,
+            host    = owner.getDockHost(),
+            area    = host === owner ? (owner.items?.[owner.dockShellIndex] || owner) : (host || owner),
             rect    = null;
 
         try {
-            rect = await Neo.main.DomAccess.getBoundingClientRect({id, windowId: owner.windowId})
+            rect = await Neo.main.DomAccess.getBoundingClientRect({id: area.id, windowId: owner.windowId})
         } catch (error) {
             rect = null
         }

--- a/test/playwright/component/apps/dock-maximize/app.mjs
+++ b/test/playwright/component/apps/dock-maximize/app.mjs
@@ -344,6 +344,26 @@ class MaximizeFixtureWorkspace extends DockWorkspace {
          */
         enableDockReloadAction: true,
         /**
+         * The workspace is its own dock host (no `dockHostReference`) and frames the projected
+         * shell with chrome of its own: the shell mounts at index 1, under the bar at index 0.
+         * The workspace root and the shell therefore have DIFFERENT rects — a maximize measured
+         * off the root covers the bar, one measured off the shell keeps it in sight.
+         * @member {Number} dockShellIndex=1
+         */
+        dockShellIndex: 1,
+        /**
+         * The chrome the workspace frames its shell with — the consumer-owned bar that sits
+         * outside the dock area, the `examples/dashboard/dock` perspective toolbar's shape.
+         * @member {Object[]} items
+         */
+        items: [{
+            ntype : 'component',
+            id    : 'dock-maximize-chrome',
+            height: 42,
+            style : {alignItems: 'center', display: 'flex', flexShrink: 0, paddingInline: '8px'},
+            text  : 'chrome outside the dock area'
+        }],
+        /**
          * The instrumented maximize plugin stands in for the engine default.
          * @member {Object[]} plugins=[{module:MaximizeFixturePlugin}]
          */

--- a/test/playwright/component/dashboard/DockMaximize.spec.mjs
+++ b/test/playwright/component/dashboard/DockMaximize.spec.mjs
@@ -84,16 +84,18 @@ const expectMaximizedCount = async (page, count) => {
 };
 
 /**
- * The maximized node fills the DOCK HOST inset by the gap token on every side — not the workspace
- * root, not the viewport. The expected rect is derived from the rendered host and the token's
- * computed value, so a host framed by other chrome, or a consumer that tunes the gap, both
- * measure against the same contract.
+ * The maximized node fills the DOCK AREA inset by the gap token on every side — not the workspace
+ * root, not the viewport. The fixture workspace is its own host and frames the projected shell
+ * with a 42px chrome bar at index 0 (`dockShellIndex: 1`), so the root and the shell have different
+ * rects: the expected rect is derived from the rendered shell and the token's computed value, and
+ * the bar must stay uncovered. A consumer that tunes the gap measures against the same contract.
  */
 const maximizedRectMatchesHost = page => page.waitForFunction(() => {
-    const el   = document.querySelector('.neo-dock-maximized'),
-          host = document.querySelector('#dock-maximize-workspace .neo-dashboard');
+    const el     = document.querySelector('.neo-dock-maximized'),
+          host   = document.querySelector('#dock-maximize-workspace .neo-dashboard'),
+          chrome = document.getElementById('dock-maximize-chrome');
 
-    if (!el || !host) return false;
+    if (!el || !host || !chrome) return false;
 
     const a   = el.getBoundingClientRect(),
           b   = host.getBoundingClientRect(),
@@ -101,6 +103,7 @@ const maximizedRectMatchesHost = page => page.waitForFunction(() => {
 
     return Math.abs(a.top - (b.top + gap)) < 1.5 && Math.abs(a.left - (b.left + gap)) < 1.5
         && Math.abs(a.width - (b.width - 2 * gap)) < 1.5 && Math.abs(a.height - (b.height - 2 * gap)) < 1.5
+        && a.top >= chrome.getBoundingClientRect().bottom - 0.5
 });
 
 /** The rendered maximize chrome: the shadow token applied, no residual band cap. */
@@ -193,6 +196,46 @@ test.describe('dock maximize — presentation, never topology', () => {
             document.activeElement?.classList?.contains('neo-tab-header-button')
             && document.activeElement.textContent.includes('Frame')
         )
+    });
+
+    test('a host-less workspace that frames the shell with chrome maximizes onto the SHELL — the chrome stays in sight', async ({page}) => {
+        const side = tabsNodeWith(page, 'Frame');
+
+        await tabButton(side, 'Frame').click();
+        await actionButton(side, 'fa-window-maximize').click();
+        await expect(page.locator('.neo-dock-maximized')).toHaveCount(1);
+
+        // Read the geometry once the presentation settled; the numbers name the failure when
+        // the measurement authority is wrong (root ⇒ the pane starts at the root's gap inset,
+        // above the chrome's bottom edge).
+        await page.waitForFunction(() => !document.querySelector('.neo-dock-maximized')?.style.transform);
+
+        const geometry = await page.evaluate(() => {
+            const rect = id => document.querySelector(id).getBoundingClientRect(),
+                  el   = rect('.neo-dock-maximized'),
+                  root = rect('#dock-maximize-workspace'),
+                  bar  = rect('#dock-maximize-chrome'),
+                  host = document.querySelector('#dock-maximize-workspace .neo-dashboard'),
+                  gap  = parseFloat(getComputedStyle(host).getPropertyValue('--dock-maximize-gap')) || 0;
+
+            return {
+                barBottom: bar.bottom,
+                barTop   : bar.top,
+                gap,
+                paneTop  : el.top,
+                rootTop  : root.top,
+                shellTop : host.getBoundingClientRect().top
+            }
+        });
+
+        expect(geometry.barTop, 'the chrome bar sits at the workspace root').toBeCloseTo(geometry.rootTop, 0);
+        expect(geometry.shellTop, 'the projected shell mounts under the bar').toBeCloseTo(geometry.barBottom, 0);
+        expect(geometry.paneTop, 'the maximized pane starts at the SHELL inset by the gap, not at the root')
+            .toBeCloseTo(geometry.shellTop + geometry.gap, 0);
+        expect(geometry.paneTop, 'the chrome stays uncovered').toBeGreaterThanOrEqual(geometry.barBottom - 0.5);
+
+        await page.keyboard.press('Escape');
+        await expect(page.locator('.neo-dock-maximized')).toHaveCount(0)
     });
 
     test('an edge-band node maximizes to the same host rect as a center node — the band caps lift for the duration', async ({page}) => {

--- a/test/playwright/e2e/dashboard/DockExampleMaximizeGeometry.spec.mjs
+++ b/test/playwright/e2e/dashboard/DockExampleMaximizeGeometry.spec.mjs
@@ -1,0 +1,73 @@
+import {test, expect} from '../../fixtures.mjs';
+
+/**
+ * Whitebox-e2e: maximize on a host-less consumer measures the DOCK AREA, not the app view.
+ *
+ * `examples/dashboard/dock` lets the workspace host the projected shell directly (no
+ * `dockHostReference`) and frames it with a perspective toolbar at index 0 (`dockShellIndex: 1`).
+ * The maximize contract says the chrome outside the dock area stays in sight; a measurement taken
+ * off the workspace root paints the maximized pane over that toolbar. The component fixture
+ * witnesses the rule on a synthetic bar; this arm reads it on the shipped consumer that showed
+ * the defect, through the real header action behind its focus gate.
+ *
+ * Run: npm run test-e2e -- e2e/dashboard/DockExampleMaximizeGeometry --workers=1
+ */
+const readGeometry = () => {
+    const rect  = sel => document.querySelector(sel)?.getBoundingClientRect() || null,
+          pane  = rect('.neo-dock-maximized'),
+          bar   = rect('.neo-dashboard-dock-perspective-toolbar'),
+          shell = document.querySelector('.neo-dashboard-dock-edge-zone.neo-dashboard'),
+          root  = rect('.neo-dock-workspace'),
+          gap   = shell ? parseFloat(getComputedStyle(shell).getPropertyValue('--dock-maximize-gap')) || 0 : null;
+
+    return pane && bar && shell && root ? {
+        barBottom : bar.bottom,
+        gap,
+        paneBottom: pane.bottom,
+        paneLeft  : pane.left,
+        paneTop   : pane.top,
+        rootTop   : root.top,
+        shellLeft : shell.getBoundingClientRect().left,
+        shellTop  : shell.getBoundingClientRect().top
+    } : null
+};
+
+test.describe('examples/dashboard/dock — maximize keeps the perspective toolbar in sight', () => {
+    test.setTimeout(120000);
+    test.use({viewport: {width: 1280, height: 720}});
+
+    test('the maximized pane fills the projected shell inset by the gap, under the toolbar', async ({page}) => {
+        await page.goto('/examples/dashboard/dock/index.html');
+
+        const strategy = page.locator('.neo-dashboard-dock-tabs', {
+            has: page.locator('.neo-tab-header-button:has-text("Strategy")')
+        });
+
+        await expect(strategy, 'the example must project its main tabs node').toBeVisible({timeout: 60000});
+
+        // The header actions are focus-gated: a real click on the tab reveals the rail.
+        await strategy.locator('.neo-tab-header-button', {hasText: 'Strategy'}).click();
+
+        const maximize = strategy.locator('.neo-tab-header-toolbar .neo-button:has([class*="fa-window-maximize"])');
+
+        await expect(maximize, 'the maximize action appears on the focused node').toBeVisible({timeout: 15000});
+        await maximize.click();
+
+        await expect(page.locator('.neo-dock-maximized')).toHaveCount(1);
+        await page.waitForFunction(() => !document.querySelector('.neo-dock-maximized')?.style.transform);
+
+        const geometry = await page.evaluate(readGeometry);
+
+        expect(geometry, 'the example must render the toolbar, the shell and the maximized pane').toBeTruthy();
+        expect(geometry.barBottom, 'the perspective toolbar sits above the shell').toBeCloseTo(geometry.shellTop, 0);
+        expect(geometry.paneTop, 'the pane starts at the SHELL inset by the gap, not at the workspace root')
+            .toBeCloseTo(geometry.shellTop + geometry.gap, 0);
+        expect(geometry.paneLeft).toBeCloseTo(geometry.shellLeft + geometry.gap, 0);
+        expect(geometry.paneTop, 'the toolbar stays uncovered').toBeGreaterThanOrEqual(geometry.barBottom - 0.5);
+        expect(geometry.paneTop - geometry.rootTop, 'a root measurement would put the pane one gap below the root')
+            .toBeGreaterThan(geometry.gap + 1);
+
+        await page.keyboard.press('Escape');
+        await expect(page.locator('.neo-dock-maximized')).toHaveCount(0)
+    });
+});


### PR DESCRIPTION
Resolves #18328

Related: #18305 (the plugin this changes), #18122 (the host decision this refines), #18304 (epic; a defect on the moved concern, not a decomposition leaf)

`Maximize#measureRect` measured `getDockHost()`, which is the workspace itself when no `dockHostReference` is named, so a consumer that frames the projected shell with chrome of its own — `examples/dashboard/dock`, perspective toolbar at index 0, `dockShellIndex: 1` — had the bar painted over. The measurement now takes the named host when one exists (the consumer's stated dock area), else the projected shell at `dockShellIndex`, and the root only while nothing is mounted. One method, its docblock, no new surface.

The witnesses change shape with it. The component fixture workspace now frames its shell with a 42px bar at index 0, so its root and shell no longer share a rect: the host-inset helper measures the shell and requires the bar uncovered, which turns four previously blind arms into real witnesses (they were green on dev only because root and shell coincided); a dedicated arm names the geometry. A plain-page e2e arm reads the same rule on the shipped example through the real focus-gated header action.

Evidence: L3 (the real header action on the served example, driven by Playwright and by hand in a browser; the component suite over the real projection) → L3 required (AC-3 names a live receipt). No residuals.

## AC Evidence

| AC | Evidence |
|---|---|
| AC-1 — a host-less workspace framing the shell with chrome maximizes onto the shell rect inset by the gap, chrome visible; component arm, red-first | `DockMaximize.spec` "a host-less workspace that frames the shell with chrome maximizes onto the SHELL": red on the root measurement — `Expected: 50, Received: 8` (shell top 42 + gap 8 vs root 0 + gap 8) — green with the fix. The fixture change also reds the four existing host-inset arms on the old code (5 failed / 11 passed), 16/16 after. |
| AC-2 — the Workstation e2e arm (named host) and the existing host-inset arms stay green | `WorkstationNL.spec` "maximize uses measured workspace geometry…" 1/1 with `NEO_AGENTOS_RUNTIME_ROOT` set; the four host-inset arms are in the 16/16; full component `dashboard` 116/116; unit `dashboard` 821/821. |
| AC-3 — `examples/dashboard/dock` keeps the perspective toolbar in sight; live receipt | Served from this head at 1280×720, Strategy header's maximize action clicked by hand: pane `{x: 8, y: 50, w: 1264, h: 662}` = the shell `{x: 0, y: 42, w: 1280, h: 678}` inset by the 8px gap; toolbar `{0, 0, 1280, 42}` uncovered; Escape → 0 maximized, 0 restoring. On dev the same click paints `{x: 8, y: 8, w: 1264, h: 704}` over the toolbar (#18328's measurement). The tracked e2e arm `DockExampleMaximizeGeometry.spec` reads the same numbers: red without the fix, 1/1 with it. |

## Deltas from ticket

The ticket asked for a component arm; this lands the component arm AND makes the fixture host-less-with-chrome so the existing host-inset helper witnesses the rule in every maximize arm, plus a tracked e2e arm on the example (the ticket's AC-3 receipt, made durable). `measureRect` keeps the root as the last fallback exactly as the ticket states.

Outside the ticket, carried because the gate demands it in the same PR: `buildScripts/util/file-size-baseline.json` lowers `src/dashboard/dock/Workspace.mjs` from 1740 to the measured 1419 code lines. The shrink landed with #18324 (dev@0cc5cad95e) minutes before the guard landed with #18333 (dev@33d12ba837), whose baseline had been measured before the shrink — so dev itself is stale-high, and the ratchet fails every PR in guard scope until an entry lowers it. This is the first such PR; the guard's own message names the exact edit.

## Test Evidence

```
# component, fixture + arms without the fix (red)
npx playwright test --config test/playwright/playwright.config.component.mjs component/dashboard/DockMaximize.spec.mjs
  5 failed  (the new arm + the four host-inset arms)   11 passed
# with the fix
  16 passed (16.2s)

# full component dashboard suite, with the fix
  116 passed (1.6m)

# unit dashboard tier
npx playwright test --config test/playwright/playwright.config.unit.mjs unit/dashboard
  821 passed (2.8s)

# Workstation named-host arm (Brain checkout at NEO_AGENTOS_RUNTIME_ROOT)
npx playwright test --config test/playwright/playwright.config.e2e.mjs e2e/workstation/WorkstationNL.spec.mjs --grep "maximize uses measured workspace geometry"
  1 passed (6.0s)

# example e2e arm
npx playwright test --config test/playwright/playwright.config.e2e.mjs e2e/dashboard/DockExampleMaximizeGeometry.spec.mjs
  without the fix: 1 failed — "the pane starts at the SHELL inset by the gap, not at the workspace root": Expected 50, Received 8
  with the fix:    1 passed (4.2s)
```

## Post-Merge Validation

None owed — every close-target AC is verified at this head.

## Commits

- a7057f4bc1 — the measurement rule, the fixture's chrome bar, the component arm, the example e2e arm (rebased on dev@33d12ba837, which carries the new code-line guard)
- 610ddfa0a3 — the guard's baseline entry for `src/dashboard/dock/Workspace.mjs` lowered to the measured 1419 (the ratchet's own demand; see Deltas)

Authored by Mnemosyne (Claude Fable 5.1, Claude Code). Session ce3d8122-fe34-44f1-91ba-dea27580b193.
