### PR TITLE
fix(build): lower the dock Workspace baseline to the count #18324 already shipped (#18341)

### DIFF
--- a/buildScripts/util/file-size-baseline.json
+++ b/buildScripts/util/file-size-baseline.json
@@ -1,6 +1,6 @@
 {
     "apps/workstation/view/Workspace.mjs": 3390,
     "examples/dashboard/crossWindow/DemoBWorkspace.mjs": 2701,
-    "src/dashboard/dock/Workspace.mjs": 1740,
+    "src/dashboard/dock/Workspace.mjs": 1419,
     "src/main/addon/DragDrop.mjs": 1267
 }


### PR DESCRIPTION
Resolves #18341

Related: #18278 · #18305

`dev` was failing its own size guard. PR #18324 removed 321 code lines from `src/dashboard/dock/Workspace.mjs` at 22:15Z; the size guard merged at 22:22Z carrying a baseline measured before that shrink. So `dev` shipped `1740` against a tree measuring `1419`, and every open PR inherited the stale row, hit the ratchet's shrink branch, and was told to lower a baseline its diff never touched — which Dependabot cannot do, and no unrelated PR should have to. One generated row lowered to the count `#18324` already shipped; the ratchet itself is untouched and still armed.

Evidence: L2 achieved and required — the close-target ACs are a CLI verdict plus a mutation, both reachable in the sandbox and both run against this exact head. Residual: none.

Micro-review eligible: mechanical — one generated integer in a generated file, produced by the tool's own `--fix` arm.

## AC Evidence
| AC | Evidence |
|---|---|
| AC-1 | outside-CI: `npm run check-file-sizes` at `e93b8d7523` — `1297 path(s) evaluated, 4 reported, 0 violations`, exit 0, all four baselined files still listed with their bands. |
| AC-2 | outside-CI: the pre-state is the falsifier and needed no fixture — the same command on `dev@b7c9f7c953` exits 1 with exactly one violation, `HEAD baseline must equal the measured count 1419`. |
| AC-3 | outside-CI: `git diff --stat` reports `1 file changed, 1 insertion(+), 1 deletion(-)`; the single hunk is `1740` → `1419`; Workstation `3390`, DemoB `2701` and DragDrop `1267` are byte-identical. Produced by `--fix`, not hand-edited. |
| AC-4 | The File Size Guard job on this PR — the first PR to run the guard against a consistent baseline. |
| AC-5 | outside-CI mutation: raising the row to `1420` against a measured `1419` fails with `HEAD baseline must equal the measured count 1419` (exit 1); restoring it passes (exit 0). The correction did not disarm the ratchet. |

## Deltas from ticket
None substantive. The ticket's Out of Scope named my own first instinct — exempting untouched files from the ratchet — and the implementation confirms why it was wrong: with a consistent baseline an untouched file takes the equality branch and is asked for nothing, so the exemption would buy nothing and would delete the arm that catches a shrink whose PR forgot to lower the row.

## Test Evidence
Two receipts a green suite cannot produce, both at `e93b8d7523`:

- **Red-first without construction.** `npm run check-file-sizes` on `dev@b7c9f7c953` exits 1 naming `src/dashboard/dock/Workspace.mjs`. The defect was live on the base branch, so the pre-state is the control; building a fixture would have proved less.
- **Mutation, both directions.** `1419 → 1420` in the baseline turns the guard red; restoring turns it green. This is the arm that matters — a baseline correction is exactly the shape of change that can pass every other criterion while silently making the gate unfalsifiable.

Also run: `npm run check-file-sizes -- --base origin/dev`, the exact invocation `.github/workflows/file-size-guard.yml` issues — exit 0.

## Post-Merge Validation
- [ ] #18325 and #18326 (Dependabot) no longer report a File Size Guard violation. Their `components` failure is unrelated and owned by #18331; this PR does not claim to fix it.

## Commits
- `e93b8d7523` — lower the dock Workspace baseline to the count #18324 already shipped

---

One thing worth stating plainly, since the review is going to a GPT-family peer and the guard is Euclid's: **this defect is mine, not the guard's.** I approved PR #18333 at 22:17Z, two minutes after #18324 had already merged. I verified the baseline file's contents and the four counts as reported, and never re-measured them against the tree they would land on. A baseline is a witness minted at authoring time, and between authoring and merge the thing it witnesses can move. The guard behaved exactly as designed throughout — including here, where it caught its own stale input.

Authored by Grace (`@neo-opus-grace`, Claude Opus 5, Claude Code). Session `b983b2a8-18bc-4dd0-a63f-23380dc3a49d`.
