### PR TITLE
test(dashboard): a lazy-load request names the projection pass it was raised in (#18331)

### DIFF
--- a/test/playwright/component/apps/dock-lazy-rail/app.mjs
+++ b/test/playwright/component/apps/dock-lazy-rail/app.mjs
@@ -18,6 +18,38 @@ const fixtureDocument = {
 };
 
 /**
+ * @summary Renders the projection-pass context a lazy-load request was raised in.
+ *
+ * **It never names a primary pass while more than one is pending, and that restraint is the whole
+ * contract.** `refreshDockWorkspace` is async, so `activePasses` is a set of passes that have
+ * ENTERED, in entry order — not a stack of executing frames. Resuming an ordinary pass while a repair
+ * merely sits pending puts the repair last, so any last-entry heuristic names a pass that is not
+ * running and lends the request a `REPAIR` flag that is not its own. An `OVERLAP` hint beside a
+ * confident primary does not repair that; it decorates a false attribution.
+ *
+ * So the renderings are:
+ * - `no active pass` — raised outside any projection; a real answer, not a missing one
+ * - `pass N` / `pass N REPAIR` — exactly one pending context, so attribution is unambiguous
+ * - `ambiguous: pass 1, pass 2 REPAIR` — every pending context with its OWN flag and no primary
+ *
+ * A reader can still draw the cross-pass conclusion from two unambiguous entries; they cannot draw
+ * it from an ambiguous one, which is the correct amount of confidence for what this observes.
+ * @param {Object[]} active Pending pass descriptors, entry order.
+ * @returns {String}
+ */
+const describePassContext = active => {
+    const render = entry => `pass ${entry.id}${entry.isRepair ? ' REPAIR' : ''}`;
+
+    if (!active?.length) {
+        return 'no active pass'
+    }
+
+    return active.length === 1
+        ? render(active[0])
+        : `ambiguous: ${active.map(render).join(', ')}`
+};
+
+/**
  * @summary Browser fixture for a lazy rail item: an edge tabs node with one visible pane and one
  * auto-hidden item whose pane config is a lazy `module` function — the shape a tab container's
  * card layout loads on activation. The module lives in its own file (`LazyPane.mjs`) so that its
@@ -37,17 +69,22 @@ class LazyRailFixtureWorkspace extends DockWorkspace {
     /**
      * Projection passes are numbered in entry order so a load request can name the pass it was
      * raised in. `refreshDockWorkspace` is the pass owner: it builds the projection and hands it to
-     * `Reconciler.reconcileProjection`, whose `resolvedItems` memo lives and dies with that one call.
+     * `Reconciler.reconcileProjection`, which reaches `Reconciler.reconcileTabChrome` — the function
+     * that actually owns the `resolvedItems` memo — exactly once per pass, through either the
+     * stable-topology branch or the full path.
      * @member {Number} passSeq=0
      * @static
      */
     static passSeq = 0
 
     /**
-     * The passes currently executing, innermost last. A stack rather than a scalar because
-     * `refreshDockWorkspace` is async: a repair pass scheduled by `onDockProjectionFailed` can be in
-     * flight while another is still unwinding, and a scalar would silently report the wrong pass for
-     * a request raised during the overlap. Depth > 1 at request time is itself a finding.
+     * The passes that have ENTERED and not yet settled, in entry order.
+     *
+     * Deliberately not described as a stack: `refreshDockWorkspace` is async, so entry order is not
+     * execution order, and the last entry is not the frame whose continuation is running. Reading it
+     * as a stack is what made the first version of {@link describePassContext} attribute a request to
+     * the wrong pass — see that function for the falsifier. Depth > 1 at request time means the
+     * attribution is ambiguous, which is reported rather than resolved.
      * @member {Object[]} activePasses=[]
      * @static
      */
@@ -75,7 +112,20 @@ class LazyRailFixtureWorkspace extends DockWorkspace {
          * @member {String|null} applyOperationJson_=null
          * @reactive
          */
-        applyOperationJson_: null
+        applyOperationJson_: null,
+        /**
+         * Spec trigger for the attribution contract itself: a JSON array of synthetic pass
+         * descriptors, rendered through the same {@link describePassContext} the loader uses and
+         * exposed on {@link #passContextProbeResult}.
+         *
+         * Synthetic on purpose. The case that matters — an ordinary pass resuming while a repair
+         * stays suspended — is a property of the pending SET, and driving it through two real
+         * overlapping projections would make a contract test depend on scheduler timing, which is
+         * the class of arm this ticket already spent an evening distrusting.
+         * @member {String|null} passContextProbeJson_=null
+         * @reactive
+         */
+        passContextProbeJson_: null
     }
 
     /**
@@ -94,14 +144,34 @@ class LazyRailFixtureWorkspace extends DockWorkspace {
     }
 
     /**
+     * @param {String|null} value
+     * @param {String|null} oldValue
+     * @protected
+     */
+    afterSetPassContextProbeJson(value, oldValue) {
+        if (oldValue === undefined || !value) {
+            return
+        }
+
+        this.passContextProbeResult = describePassContext(JSON.parse(value))
+    }
+
+    /**
+     * Spec-readable rendering of the last {@link #passContextProbeJson_} set.
+     * @member {String|null} passContextProbeResult=null
+     */
+    passContextProbeResult = null
+
+    /**
      * Numbers each projection pass so a lazy-load request can name the one it was raised in.
      *
      * `lazyPaneConstructionTrail` already reports WHO asked; on a duplicate both stacks have been
      * observed frame-for-frame identical, which leaves the two remaining mechanisms indistinguishable
      * from the call site alone: one pass resolving the item twice, or two passes each resolving it
-     * once. `Reconciler`'s `resolvedItems` memo is created per `reconcileProjection` call and is
-     * written back on insert, so it dedupes within a pass and has no memory across one — meaning the
-     * pass id, not the caller, is the discriminator.
+     * once. The `resolvedItems` memo is created inside `Reconciler.reconcileTabChrome` — not
+     * `reconcileProjection`, which only reaches it — and is written back on insert. Since a pass
+     * reaches that function exactly once, the memo dedupes within a pass and has no memory across
+     * one, meaning the pass id, not the caller, is the discriminator.
      *
      * The stamp lives here rather than in `src/`: the engine already exposes the pass boundary as
      * this method, and the `components` job captures no app-worker console output, so a `console`
@@ -189,21 +259,8 @@ class LazyRailFixtureWorkspace extends DockWorkspace {
                 // `container.Base#insert` on the already-active insert path, `afterSetActiveIndex`
                 // on activation.
                 module: () => {
-                    const
-                        cls    = LazyRailFixtureWorkspace,
-                        active = cls.activePasses,
-                        pass   = active[active.length - 1],
-                        // No active pass means the request did not originate inside a projection at
-                        // all — a real answer, not a missing one, so it is spelled out rather than
-                        // rendered as an empty string a reader would take for "same pass".
-                        label  = pass ? `pass ${pass.id}${pass.isRepair ? ' REPAIR' : ''}` : 'no active pass',
-                        // Two passes in flight at request time is a third possible mechanism beside
-                        // cross-pass and within-pass, so it has to be visible rather than collapsed
-                        // into the innermost one.
-                        depth  = active.length > 1 ? ` OVERLAP[${active.map(entry => entry.id).join(',')}]` : '';
-
-                    cls.raiseSites.push(
-                        `[${label}${depth}]\n` +
+                    LazyRailFixtureWorkspace.raiseSites.push(
+                        `[${describePassContext(LazyRailFixtureWorkspace.activePasses)}]\n` +
                         (new Error('lazy module requested').stack || '').split('\n').slice(1, 7).join('\n')
                     );
 

--- a/test/playwright/component/apps/dock-lazy-rail/app.mjs
+++ b/test/playwright/component/apps/dock-lazy-rail/app.mjs
@@ -34,6 +34,25 @@ class LazyRailFixtureWorkspace extends DockWorkspace {
      */
     static raiseSites = []
 
+    /**
+     * Projection passes are numbered in entry order so a load request can name the pass it was
+     * raised in. `refreshDockWorkspace` is the pass owner: it builds the projection and hands it to
+     * `Reconciler.reconcileProjection`, whose `resolvedItems` memo lives and dies with that one call.
+     * @member {Number} passSeq=0
+     * @static
+     */
+    static passSeq = 0
+
+    /**
+     * The passes currently executing, innermost last. A stack rather than a scalar because
+     * `refreshDockWorkspace` is async: a repair pass scheduled by `onDockProjectionFailed` can be in
+     * flight while another is still unwinding, and a scalar would silently report the wrong pass for
+     * a request raised during the overlap. Depth > 1 at request time is itself a finding.
+     * @member {Object[]} activePasses=[]
+     * @static
+     */
+    static activePasses = []
+
     static config = {
         /**
          * @member {String} className='Test.Playwright.Component.DockLazyRail.Workspace'
@@ -72,6 +91,42 @@ class LazyRailFixtureWorkspace extends DockWorkspace {
         const result = this.applyDockZoneOperation(JSON.parse(value));
 
         result && !result.errors?.length && this.onDockZoneDocumentChange(result.document)
+    }
+
+    /**
+     * Numbers each projection pass so a lazy-load request can name the one it was raised in.
+     *
+     * `lazyPaneConstructionTrail` already reports WHO asked; on a duplicate both stacks have been
+     * observed frame-for-frame identical, which leaves the two remaining mechanisms indistinguishable
+     * from the call site alone: one pass resolving the item twice, or two passes each resolving it
+     * once. `Reconciler`'s `resolvedItems` memo is created per `reconcileProjection` call and is
+     * written back on insert, so it dedupes within a pass and has no memory across one — meaning the
+     * pass id, not the caller, is the discriminator.
+     *
+     * The stamp lives here rather than in `src/`: the engine already exposes the pass boundary as
+     * this method, and the `components` job captures no app-worker console output, so a `console`
+     * line could not carry the answer out of CI regardless. The trail travels in the assertion
+     * message instead, which is the only channel that reaches a reader on a loaded runner.
+     * @param {Object|null} [tabInsertDescriptor=null]
+     * @param {Object} [document=this.dockModel]
+     * @param {Object} [refreshOptions={}]
+     * @returns {Promise<*>}
+     */
+    async refreshDockWorkspace(tabInsertDescriptor=null, document=this.dockModel, refreshOptions={}) {
+        const
+            cls   = LazyRailFixtureWorkspace,
+            entry = {id: ++cls.passSeq, isRepair: refreshOptions.isDockProjectionRetry === true};
+
+        cls.activePasses.push(entry);
+
+        try {
+            return await super.refreshDockWorkspace(tabInsertDescriptor, document, refreshOptions)
+        } finally {
+            // `finally`, so a thrown projection failure — the very path that schedules the repair
+            // pass this instrument exists to catch — cannot leave a stale entry on the stack and
+            // mislabel every later request.
+            cls.activePasses = cls.activePasses.filter(active => active !== entry)
+        }
     }
 
     /**
@@ -134,7 +189,21 @@ class LazyRailFixtureWorkspace extends DockWorkspace {
                 // `container.Base#insert` on the already-active insert path, `afterSetActiveIndex`
                 // on activation.
                 module: () => {
-                    LazyRailFixtureWorkspace.raiseSites.push(
+                    const
+                        cls    = LazyRailFixtureWorkspace,
+                        active = cls.activePasses,
+                        pass   = active[active.length - 1],
+                        // No active pass means the request did not originate inside a projection at
+                        // all — a real answer, not a missing one, so it is spelled out rather than
+                        // rendered as an empty string a reader would take for "same pass".
+                        label  = pass ? `pass ${pass.id}${pass.isRepair ? ' REPAIR' : ''}` : 'no active pass',
+                        // Two passes in flight at request time is a third possible mechanism beside
+                        // cross-pass and within-pass, so it has to be visible rather than collapsed
+                        // into the innermost one.
+                        depth  = active.length > 1 ? ` OVERLAP[${active.map(entry => entry.id).join(',')}]` : '';
+
+                    cls.raiseSites.push(
+                        `[${label}${depth}]\n` +
                         (new Error('lazy module requested').stack || '').split('\n').slice(1, 7).join('\n')
                     );
 

--- a/test/playwright/component/dashboard/DockRailLazyModule.spec.mjs
+++ b/test/playwright/component/dashboard/DockRailLazyModule.spec.mjs
@@ -198,7 +198,15 @@ test.describe('dock rail — a lazy module item loads on its first reveal', () =
         expect(trail, 'one load request, so one call site').toHaveLength(1);
         expect(typeof trail[0], 'each entry is a string').toBe('string');
         expect(trail[0], 'the insert route is named').toContain('insert');
-        expect(trail[0], 'and is not confused with the activation route').not.toContain('afterSetActiveIndex')
+        expect(trail[0], 'and is not confused with the activation route').not.toContain('afterSetActiveIndex');
+
+        // The pass stamp has to be proven on the GREEN path, because the run it exists for produces
+        // no session to attach to. `[no active pass]` is a real, reachable rendering of the same
+        // field — a request raised outside any projection — so asserting a NUMBERED pass is what
+        // separates "the stamp worked" from "the stamp printed something". Without this, a stamp
+        // that silently never populated would reach a duplicate and report two identical labels,
+        // which reads exactly like the within-pass answer.
+        expect(trail[0], 'the request names a numbered projection pass').toMatch(/^\[pass \d+/)
     });
 
     test('the load request from the activation route names that route instead', async ({page}) => {
@@ -214,6 +222,16 @@ test.describe('dock rail — a lazy module item loads on its first reveal', () =
         expect(Array.isArray(trail), 'the trail survives the worker boundary as an array').toBe(true);
         expect(trail, 'one load request, so one call site').toHaveLength(1);
         expect(typeof trail[0], 'each entry is a string').toBe('string');
-        expect(trail[0], 'the activation route is named').toContain('afterSetActiveIndex')
+        expect(trail[0], 'the activation route is named').toContain('afterSetActiveIndex');
+
+        // Only the RENDERING is pinned here, not which of the two readings appears. The activation
+        // route usually raises its request outside any projection — a reactive-config chain,
+        // `Container.set` → `afterSetActiveIndex` → `loadModule`, with no `refreshDockWorkspace`
+        // frame under it — but measured over 10 local runs it lands inside `[pass 2]` in 2 of them,
+        // so activation and projection are not serialized against each other. Asserting
+        // `[no active pass]` here would encode an 80%-true accident as a contract and ship a flaky
+        // arm. The stamp's proof of life lives on the insert arm above, where a numbered pass is
+        // structural rather than timing-dependent.
+        expect(trail[0], 'the request names its projection-pass context').toMatch(/^\[(pass \d+|no active pass)/)
     });
 });

--- a/test/playwright/component/dashboard/DockRailLazyModule.spec.mjs
+++ b/test/playwright/component/dashboard/DockRailLazyModule.spec.mjs
@@ -232,6 +232,45 @@ test.describe('dock rail — a lazy module item loads on its first reveal', () =
         // `[no active pass]` here would encode an 80%-true accident as a contract and ship a flaky
         // arm. The stamp's proof of life lives on the insert arm above, where a numbered pass is
         // structural rather than timing-dependent.
-        expect(trail[0], 'the request names its projection-pass context').toMatch(/^\[(pass \d+|no active pass)/)
+        expect(trail[0], 'the request names its projection-pass context').toMatch(/^\[(pass \d+|ambiguous: pass \d+|no active pass)/)
+    });
+
+    /**
+     * The attribution contract itself, driven from synthetic pending sets rather than from two real
+     * overlapping projections: the property under test belongs to the SET, and racing two refreshes
+     * to produce it would make the arm depend on scheduler timing.
+     *
+     * The case that forced this contract is the third one: a last-entry heuristic emits
+     * `pass 2 REPAIR` when an ORDINARY pass resumes while a repair merely sits pending, naming a pass
+     * that is not running and a flag that is not the request's.
+     */
+    test.describe('the pass stamp reports ambiguity instead of guessing an owner', () => {
+        const probe = async (page, contexts) => {
+            await setWorkspace(page, {passContextProbeJson: JSON.stringify(contexts)});
+
+            const [result] = await readWorkspace(page, ['passContextProbeResult']);
+
+            return result
+        };
+
+        test('one pending context is attributed, and carries its own repair flag', async ({page}) => {
+            expect(await probe(page, [{id: 7, isRepair: false}])).toBe('pass 7');
+            expect(await probe(page, [{id: 8, isRepair: true}])).toBe('pass 8 REPAIR')
+        });
+
+        test('an empty set is spelled out rather than rendered blank', async ({page}) => {
+            expect(await probe(page, [])).toBe('no active pass')
+        });
+
+        test('two pending contexts name BOTH with their own flags and no primary', async ({page}) => {
+            const label = await probe(page, [{id: 1, isRepair: false}, {id: 2, isRepair: true}]);
+
+            expect(label, 'every pending context is listed').toBe('ambiguous: pass 1, pass 2 REPAIR');
+
+            // The regression this pins: the old rendering answered `pass 2 REPAIR` here, which reads
+            // as a finding — a repair pass owning the request — when the request may equally have
+            // been raised by pass 1, which is not a repair at all.
+            expect(label, 'no single pass is presented as the owner').not.toMatch(/^\[?pass \d+( REPAIR)?$/)
+        })
     });
 });


### PR DESCRIPTION
Resolves #18331
Refs #18275

`Evidence: L2 achieved (fixture-only witness; 10/10 local runs; the ambiguity contract proven red-first against the previous heuristic) → L2 required (a test instrument, no behaviour change; no src/ file is touched)`

A lazy-load request names the **projection pass context** it was raised in, in the assertion message — the only channel that reaches a reader here, because the `components` job captures no app-worker console output at all.

**Close-target restatement, per RA-2 — this must land before merge.** #18331's live body and Contract Ledger still prescribe a package bisect and a runtime repair, and this PR ships neither, so closing that record unchanged would close a ticket its own ledger contradicts. A restated scope + ledger + ACs is proposed on #18331 for its author (@neo-opus-grace) to apply or confirm. `Resolves` stays because the workflow guard requires a real closing keyword and because the ticket's *question* — which package, and same-defect-or-distinct — is genuinely answered here; what changes is the record, not the verdict. **Do not merge until that restatement is applied or confirmed.** The duplicate itself remains owned by open #18275 either way.

## Why the pass, and not the caller

Both captured stacks on the duplicate were frame-for-frame identical — `module` → `#loadModuleOnce` → `Card.loadModule` → `BodyContainer.insert` → `Reconciler.mjs:882` — so the call site cannot separate the two candidate mechanisms.

The `resolvedItems` memo is owned by `Reconciler.reconcileTabChrome` (**not** `reconcileProjection`, which only reaches it — corrected per review). A projection reaches that function exactly once, through either `reconcileStableTopology` or the full path, and the memo is written back on insert. So it dedupes within a pass and has no memory across one, which makes the pass — not the caller — the discriminator.

## What it reports, and what it refuses to report

| rendering | meaning |
|---|---|
| `no active pass` | raised outside any projection |
| `pass N` / `pass N REPAIR` | exactly one pending context — attribution is unambiguous |
| `ambiguous: pass 1, pass 2 REPAIR` | every pending context, each with its own flag, **no primary** |

The second commit is RA-1. The first rendering read `activePasses` as a stack and attributed a request to its last entry; `refreshDockWorkspace` is async, so entry order is not execution order, and resuming an ordinary pass while a repair merely sits pending made the request wear the repair's flag. The old `OVERLAP[…]` hint did not fix that — it decorated a false attribution. The cross-pass conclusion remains drawable from two unambiguous entries and is no longer drawable from an ambiguous one.

`activePasses` entries are popped in a `finally`, so the throwing path — the one that schedules the repair this exists to catch — cannot strand an entry and mislabel later requests.

## AC Evidence

| AC | evidence |
|---|---|
| **AC-1** — name the responsible package | **Not met, and narrowed per RA-2.** The observed conclusion is that **the grouped bump is not necessary to reproduce this failure**: it reproduces on a plain push build of `dev` (`b7c9f7c9`, run [33926089596](https://github.com/neomjs/neo/actions/runs/33926089596)) with no PR, no merge commit and no dependency change, and #18326 reproduces the same assertion with zero npm dependencies. That does not establish that no package can affect the failure's *timing*, which is what my earlier "no package can be responsible" overclaimed. |
| **AC-2** — spec passes on a tree carrying the bump | Met: 7/7 on the bumped head in isolation, 182/182 full suite on macOS, 236 passed on Linux arm64 at `--cpus=2`. |
| **AC-3** — relationship to #18275 | Same defect, on the evidence above. The runtime repair stays with #18275. |
| **AC-4** — red-first | N/A for the instrument; **met for the ambiguity contract** — against the previous heuristic the new arm reports `pass 2 REPAIR OVERLAP[1,2]` where it expects `ambiguous: pass 1, pass 2 REPAIR`. |
| **AC-5 / AC-6** — #18325 green, pin rationale | Not this PR's to hold; #18325 and #18326 are bystanders that caught the race. |

## Deltas from ticket

The ticket prescribes a **bisect** of the 19-package group, ordered `esbuild` first. This PR does not perform it, on evidence rather than preference: the `unit` log line ranking `esbuild` is a deliberate rejection fixture's own output (`DockRail.spec.mjs:566` hardcodes both `chunk failed to load` and the item id `terminal`; a positive control on unbumped `dev` shows 22 passed with the line present verbatim), and the failure reproduces with no package change at all. That delta is why the close-target is `Refs` and a restated scope is proposed on the ticket rather than applied unilaterally.

## Test Evidence

Local, serial, `served from` verified: **10/10** on `DockRailLazyModule.spec.mjs`.

- The insert arm asserts a **numbered** pass and held 10/10 — the stamp's proof of life, since a stamp that never populated would render `[no active pass]` and read exactly like the within-pass answer.
- Three attribution arms drive **synthetic pending sets** through a probe config rather than racing two real projections: the property belongs to the set, and an arm that raced refreshes would depend on scheduler timing.
- The activation arm pins only the rendering. Measured over 10 runs it raises its request outside any projection 8 times and inside a pass twice, so activation and projection are not serialized; asserting the 80% case would ship a flaky arm into the suite already fighting this intermittent.

## Post-Merge Validation

None required. The payoff is passive: the next `DockRailLazyModule` duplicate on any branch carries its pass context in the failure message, and reports ambiguity rather than a guess when more than one pass is pending.

Authored by @neo-opus-ada — Ada, Claude Opus 5, Claude Code. Origin Session ID: 12595f5d-68f8-48bc-93d2-4a91c7bad164

🤖 Generated with [Claude Code](https://claude.com/claude-code)
