### PR TITLE
feat(main): own reveal snapshot compositing in the engine (#18138)

### DIFF
--- a/buildScripts/util/file-size-baseline.json
+++ b/buildScripts/util/file-size-baseline.json
@@ -1,6 +1,6 @@
 {
     "apps/workstation/view/Workspace.mjs": 3390,
     "examples/dashboard/crossWindow/DemoBWorkspace.mjs": 2701,
-    "src/dashboard/dock/Workspace.mjs": 1419,
+    "src/dashboard/dock/Workspace.mjs": 1415,
     "src/main/addon/DragDrop.mjs": 1267
 }

--- a/resources/scss/src/apps/portal/Viewport.scss
+++ b/resources/scss/src/apps/portal/Viewport.scss
@@ -7,12 +7,6 @@ body {
     }
 }
 
-::view-transition-old(root),
-::view-transition-new(root) {
-    animation     : none;
-    mix-blend-mode: normal;
-}
-
 .neo-viewport {
     // sometimes when transitioning between card & cube layouts, the flex value does get lost
     // see: https://github.com/neomjs/neo/issues/5637

--- a/resources/scss/src/apps/workstation/Workspace.scss
+++ b/resources/scss/src/apps/workstation/Workspace.scss
@@ -2,25 +2,6 @@
 // app-owned Workstation token layer; all motion rides the dashboard aliases, including the
 // reduced-motion collapse owned by Neo.dashboard.Container.
 
-// The theme reveal's other half, and it is a CANCELLATION rather than decoration. The browser
-// cross-fades the two view-transition snapshots by default — old fades out over ~250ms — while
-// `DomUtils.createRevealAnimation()` grows the circle on the NEW layer for 500ms and never
-// touches the old one. Without this the old snapshot is already gone for the back half of the
-// reveal, and everything outside the circle paints as bare backdrop: black. `mix-blend-mode`
-// overrides the UA's `plus-lighter` on the image pair, which blows out where the layers overlap.
-//
-// Every consumer that calls `Neo.main.DomAccess#startViewTransition()` needs this today; the
-// engine owns the animation but not the cancellation that makes it visible.
-//
-// It MUST stay at file top level. These are DOCUMENT pseudo-elements: nesting them under
-// `.workstation-workspace` for tidiness would not scope them, it would make them never match —
-// silently, with a black reveal as the only symptom and nothing to connect it to the refactor.
-::view-transition-old(root),
-::view-transition-new(root) {
-    animation     : none;
-    mix-blend-mode: normal;
-}
-
 .workstation-workspace {
     // The grid/tab token bridge sits on `.workstation-viewport`, one level up: the `?popout=`
     // vessel is a viewport WITHOUT a workspace, so a bridge scoped here never reached the pane it

--- a/src/main/DomAccess.mjs
+++ b/src/main/DomAccess.mjs
@@ -1073,6 +1073,9 @@ class DomAccess extends Base {
      * applies its DOM change after this resolves, and `data.delay` is the window it has to do so
      * before the new state is captured. Awaiting `transition.ready` here would close that window,
      * and the transition would capture the unchanged DOM as both states.
+     *
+     * Built-in reveals own both snapshot layers' opacity and blending until the transition
+     * settles. Consumers need no cancellation CSS; raw `data.animate` payloads remain caller-owned.
      * @param {Object} data
      * @param {Object} [data.animate] Raw keyframes and options, passed to `animate()` unchanged
      * @param {Number} [data.delay=50] Milliseconds the caller has to apply its DOM change
@@ -1084,16 +1087,32 @@ class DomAccess extends Base {
             return false
         }
 
-        const animate    = data.animate || DomUtils.createRevealAnimation(data.reveal),
+        const reveal     = data.animate ? null : DomUtils.createRevealAnimation(data.reveal),
+              animate    = data.animate || reveal,
+              effects    = [],
+              cleanup    = () => effects.forEach(effect => effect.cancel()),
               transition = document.startViewTransition(async () => {
                   // `??`, not `||`: `delay: 0` is a caller asking for no window at all.
                   await this.timeout(data.delay ?? 50)
               });
 
+        if (reveal) {
+            // Finished filled effects must survive until the pseudo tree is removed, including
+            // a zero-duration reveal. Cancel only our effects so later transitions start clean.
+            transition.finished.then(cleanup, cleanup)
+        }
+
         if (animate) {
             transition.ready.then(() => {
-                document.documentElement.animate(animate.keyframes, animate.options)
+                if (reveal) {
+                    for (const layer of [reveal.oldLayer, reveal]) {
+                        effects.push(document.documentElement.animate(layer.keyframes, layer.options))
+                    }
+                } else {
+                    document.documentElement.animate(animate.keyframes, animate.options)
+                }
             }).catch(error => {
+                cleanup();
                 // Catches a rejected `ready` or a registration that throws — NOT a reveal that
                 // registers and then rasterises wrongly, which is what actually happened here and
                 // stays invisible to every runtime signal this method can read. The reveal is

--- a/src/main/DomUtils.mjs
+++ b/src/main/DomUtils.mjs
@@ -44,7 +44,12 @@ class DomUtils extends Base {
     }
 
     /**
-     * @summary Builds a circular-reveal animation in units the pseudo-element itself resolves.
+     * @summary Builds circular-reveal effects that own both snapshot layers' compositing.
+     *
+     * The old snapshot stays opaque behind the growing new snapshot. Both effects override the
+     * browser's cross-fade and additive blending, so consumers need no view-transition CSS.
+     * Filled effects must be cancelled when the owning view transition settles, not when their
+     * duration elapses: a zero-duration reveal still shares the browser's transition lifetime.
      *
      * The values are percentages on purpose. A view transition pseudo-element resolves a percentage
      * against its own box, while a pixel length depends on the coordinate space the browser resolves
@@ -71,7 +76,8 @@ class DomUtils extends Base {
      * @param {Number} [reveal.y] Viewport y coordinate to grow the new state from
      * @param {Number} [width=globalThis.innerWidth]
      * @param {Number} [height=globalThis.innerHeight]
-     * @returns {Object|null} An `Element.animate()` payload, or null when there is no usable origin
+     * @returns {Object|null} A new-layer `Element.animate()` payload with an `oldLayer` companion,
+     * or null when there is no usable origin
      */
     static createRevealAnimation(reveal, width=globalThis.innerWidth, height=globalThis.innerHeight) {
         // `x` and `y` are compared to null, not tested for truthiness: 0 is a coordinate on the
@@ -90,22 +96,31 @@ class DomUtils extends Base {
                   Math.hypot(reveal.x,         height - reveal.y),
                   Math.hypot(width - reveal.x, height - reveal.y)
               ),
+              options  = {
+                  // Nullish defaults preserve an explicit zero-duration reduced-motion reveal.
+                  duration: reveal.duration ?? 500,
+                  easing  : reveal.easing   ?? 'ease-in',
+                  fill    : 'both'
+              },
               radius   = distance / (Math.hypot(width, height) / Math.SQRT2) * 100,
               x        = reveal.x / width  * 100,
               y        = reveal.y / height * 100;
 
         return {
             keyframes: [
-                {clipPath: `circle(0% at ${x}% ${y}%)`},
-                {clipPath: `circle(${radius}% at ${x}% ${y}%)`}
+                {clipPath: `circle(0% at ${x}% ${y}%)`, opacity: 1, mixBlendMode: 'normal'},
+                {clipPath: `circle(${radius}% at ${x}% ${y}%)`, opacity: 1, mixBlendMode: 'normal'}
             ],
             options: {
-                // `??`, not `||`: a caller asking for `duration: 0` wants an instant swap — the
-                // reduced-motion answer — and a truthiness guard would silently rewrite it to 500.
-                // The same class of bug as reading `x: 0` as "no coordinate", one object over.
-                duration     : reveal.duration ?? 500,
-                easing       : reveal.easing   ?? 'ease-in',
+                ...options,
                 pseudoElement: '::view-transition-new(root)'
+            },
+            oldLayer: {
+                keyframes: [
+                    {opacity: 1, mixBlendMode: 'normal'},
+                    {opacity: 1, mixBlendMode: 'normal'}
+                ],
+                options: {...options, pseudoElement: '::view-transition-old(root)'}
             }
         }
     }

--- a/test/playwright/e2e/rendering/ViewTransitionReveal.spec.mjs
+++ b/test/playwright/e2e/rendering/ViewTransitionReveal.spec.mjs
@@ -1,0 +1,245 @@
+import {test, expect} from '@playwright/test';
+
+/**
+ * @summary Installs observation seams around the native API; the engine method and animations run unchanged.
+ * @param {import('@playwright/test').Page} page
+ * @returns {Promise<void>}
+ */
+async function prepare(page) {
+    await page.goto('/test/playwright/component/apps/empty-viewport/');
+    await page.bringToFront();
+    await page.waitForFunction(() => typeof globalThis.Neo?.main?.DomAccess?.startViewTransition === 'function');
+
+    await page.evaluate(() => {
+        const panel = document.createElement('div');
+        panel.style.cssText = 'position:fixed;inset:0;z-index:2147483647;background:rgb(200,30,40)';
+        document.body.append(panel);
+
+        const start   = document.startViewTransition.bind(document),
+              animate = document.documentElement.animate.bind(document.documentElement),
+              state   = window.revealProbe = {panel, effects: [], calls: [], warnings: []};
+
+        document.startViewTransition = callback => {
+            state.ready = false;
+            state.transition = start(async () => {
+                const pending = callback();
+                panel.style.background = state.color;
+                await pending
+            });
+            state.transition.ready.then(() => state.ready = true, () => {});
+            state.transition.finished.catch(() => {});
+            return state.transition
+        };
+
+        document.documentElement.animate = (keyframes, options) => {
+            state.calls.push({keyframes, options});
+            if (state.failAt === state.calls.length) throw Error('injected registration failure');
+            const effect = animate(keyframes, options);
+            state.effects.push(effect);
+            if (state.pauseEffects !== false) {
+                effect.pause();
+                effect.currentTime = state.sampleTime
+            }
+            return effect
+        };
+
+        console.warn = (...args) => state.warnings.push(args.map(String).join(' '))
+    })
+}
+
+/**
+ * @summary Samples a real transition at controlled animation times, without sleep-based timing.
+ * @param {import('@playwright/test').Page} page
+ * @param {Object} data Engine request
+ * @param {Number} [sampleTime=250] Script animation sample time
+ * @returns {Promise<Object>}
+ */
+async function sample(page, data, sampleTime = 250) {
+    return page.evaluate(async ({data, sampleTime}) => {
+        const state = window.revealProbe;
+        state.effects = [];
+        state.calls = [];
+        state.sampleTime = sampleTime;
+        state.color = state.panel.style.backgroundColor === 'rgb(200, 30, 40)' ? 'rgb(20,80,220)' : 'rgb(200,30,40)';
+
+        const accepted            = await Neo.main.DomAccess.startViewTransition(data),
+              returnedBeforeReady = !state.ready;
+
+        await state.transition.ready;
+        state.animations = document.getAnimations().filter(animation => animation.effect?.pseudoElement);
+        // The UA fade has ended while a 500ms reveal is still halfway through its circle.
+        for (const animation of state.animations) {
+            if (!state.effects.includes(animation)) {
+                animation.pause();
+                animation.currentTime = data.reveal ? 300 : 125
+            }
+        }
+
+        const styles = ['old', 'new'].map(layer => {
+            const style = getComputedStyle(document.documentElement, `::view-transition-${layer}(root)`);
+            return {opacity: Number(style.opacity), blend: style.mixBlendMode}
+        });
+
+        return {accepted, returnedBeforeReady, styles, calls: state.calls}
+    }, {data, sampleTime})
+}
+
+/**
+ * @summary Lets the native transition settle and observes release of the engine's exact handles.
+ * @param {import('@playwright/test').Page} page
+ * @returns {Promise<String[]>}
+ */
+async function finish(page) {
+    return page.evaluate(async () => {
+        const state = window.revealProbe;
+        state.animations.forEach(animation => animation.finish());
+        await state.transition.finished;
+        return state.effects.map(effect => effect.playState)
+    })
+}
+
+/**
+ * @summary Reads actual screenshot pixels using the browser's PNG decoder.
+ * @param {import('@playwright/test').Page} page
+ * @param {Buffer} screenshot
+ * @returns {Promise<Number[][]>}
+ */
+async function pixels(page, screenshot) {
+    return page.evaluate(async base64 => {
+        const bitmap = await createImageBitmap(await (await fetch('data:image/png;base64,' + base64)).blob()),
+              canvas = document.createElement('canvas');
+        canvas.width = bitmap.width;
+        canvas.height = bitmap.height;
+        const context = canvas.getContext('2d');
+        context.drawImage(bitmap, 0, 0);
+        return [[40, 40], [750, 550]].map(([x, y]) => Array.from(context.getImageData(x, y, 1, 1).data))
+    }, screenshot.toString('base64'))
+}
+
+test.describe('engine-owned view transition reveal', () => {
+    test.use({viewport: {width: 800, height: 600}, deviceScaleFactor: 1});
+
+    test.beforeEach(async ({page}) => prepare(page));
+
+    test('filled reveal effects complete naturally and leave the next transition untouched', async ({page}) => {
+        const states = await page.evaluate(async () => {
+            const state = window.revealProbe;
+            state.pauseEffects = false;
+            state.color = 'rgb(20,80,220)';
+            await Neo.main.DomAccess.startViewTransition({reveal: {x: 40, y: 40}});
+            await state.transition.finished;
+            return state.effects.map(effect => effect.playState)
+        });
+        expect(states).toEqual(['idle', 'idle']);
+        const plain = await sample(page, {});
+        expect(plain.calls).toHaveLength(0);
+        expect(plain.styles[0].opacity).toBeGreaterThan(0);
+        expect(plain.styles[0].opacity).toBeLessThan(1);
+        await finish(page)
+    });
+
+    test('holds the old pixels outside the circle, then restores the plain UA cross-fade', async ({page}, testInfo) => {
+        const result = await sample(page, {reveal: {x: 40, y: 40, easing: 'linear'}});
+
+        expect(result.accepted).toBe(true);
+        expect(result.returnedBeforeReady).toBe(true);
+        expect(result.calls).toHaveLength(2);
+        expect(result.styles).toEqual([{opacity: 1, blend: 'normal'}, {opacity: 1, blend: 'normal'}]);
+
+        const screenshot = await page.screenshot();
+        await testInfo.attach('reveal-halfway', {body: screenshot, contentType: 'image/png'});
+        expect(await pixels(page, screenshot)).toEqual([[20, 80, 220, 255], [200, 30, 40, 255]]);
+        expect(await finish(page)).toEqual(['idle', 'idle']);
+
+        const plain = await sample(page, {});
+        expect(plain.calls).toHaveLength(0);
+        for (const style of plain.styles) {
+            expect(style.opacity).toBeGreaterThan(0);
+            expect(style.opacity).toBeLessThan(1);
+            expect(style.blend).toBe('plus-lighter')
+        }
+        await finish(page)
+    });
+
+    for (const duration of [0, 80]) {
+        test(`a ${duration}ms reveal stays opaque until the longer UA transition settles`, async ({page}) => {
+            const result = await sample(page, {reveal: {x: 40, y: 40, duration}}, duration);
+
+            expect(result.styles).toEqual([{opacity: 1, blend: 'normal'}, {opacity: 1, blend: 'normal'}]);
+            expect(await pixels(page, await page.screenshot())).toEqual([[20, 80, 220, 255], [20, 80, 220, 255]]);
+            expect(await finish(page)).toEqual(['idle', 'idle'])
+        })
+    }
+
+    test('a skipped active reveal releases only its generated effects', async ({page}) => {
+        await page.evaluate(() => {
+            const marker = document.createElement('div');
+            document.body.append(marker);
+            window.revealProbe.unrelated = marker.animate([{opacity: 0}, {opacity: 1}], {duration: 60000})
+        });
+        await sample(page, {reveal: {x: 40, y: 40}});
+        const states = await page.evaluate(async () => {
+            const state = window.revealProbe;
+            state.transition.skipTransition();
+            await state.transition.finished;
+            const states = [...state.effects, state.unrelated].map(effect => effect.playState);
+            state.unrelated.cancel();
+            return states
+        });
+        expect(states).toEqual(['idle', 'idle', 'running'])
+    });
+
+    test('partial registration failure releases the first effect and keeps the warning', async ({page}) => {
+        await page.evaluate(() => window.revealProbe.failAt = 2);
+        const result = await sample(page, {reveal: {x: 40, y: 40}});
+        expect(result.accepted).toBe(true);
+        expect(await page.evaluate(() => ({
+            states  : window.revealProbe.effects.map(effect => effect.playState),
+            warnings: window.revealProbe.warnings
+        }))).toMatchObject({
+            states  : ['idle'],
+            warnings: [expect.stringContaining('injected registration failure')]
+        });
+        await finish(page)
+    });
+
+    test('a raw animation wins unchanged and remains caller-owned after completion', async ({page}) => {
+        const animate = {
+            keyframes: [{opacity: 0.4}, {opacity: 0.7}],
+            options  : {duration: 500, fill: 'both', pseudoElement: '::view-transition-new(root)'}
+        };
+        const result = await sample(page, {animate, reveal: {x: 40, y: 40}});
+        expect(result.calls).toEqual([animate]);
+        expect(await finish(page)).toEqual(['finished'])
+    });
+
+    test('an unusable reveal leaves the UA transition unchanged', async ({page}) => {
+        const result = await sample(page, {reveal: {}});
+        expect(result.calls).toHaveLength(0);
+        await finish(page)
+    });
+
+    test('unsupported browsers retain the false return', async ({page}) => {
+        expect(await page.evaluate(async () => {
+            document.startViewTransition = undefined;
+            return Neo.main.DomAccess.startViewTransition({reveal: {x: 40, y: 40}})
+        })).toBe(false)
+    });
+
+    test('ready rejection keeps the early return and warns without registering effects', async ({page}) => {
+        const result = await page.evaluate(async () => {
+            const start = document.startViewTransition;
+            document.startViewTransition = callback => {
+                const transition = start(callback);
+                transition.skipTransition();
+                return transition
+            };
+            const accepted = await Neo.main.DomAccess.startViewTransition({reveal: {x: 40, y: 40}});
+            await window.revealProbe.transition.finished;
+            return {accepted, calls: window.revealProbe.calls, warnings: window.revealProbe.warnings}
+        });
+        expect(result.accepted).toBe(true);
+        expect(result.calls).toEqual([]);
+        expect(result.warnings).toEqual([expect.stringContaining('the view transition reveal was not applied')])
+    })
+});

--- a/test/playwright/unit/main/DomAccessViewTransition.spec.mjs
+++ b/test/playwright/unit/main/DomAccessViewTransition.spec.mjs
@@ -130,11 +130,28 @@ test.describe('Neo.main.DomUtils - view transition reveal', () => {
         expect(DomUtils.createRevealAnimation({x: 1, y: 1}, 100, 100).options).toEqual({
             duration     : 500,
             easing       : 'ease-in',
+            fill         : 'both',
             pseudoElement: '::view-transition-new(root)'
         });
 
         expect(DomUtils.createRevealAnimation({duration: 800, easing: 'linear', x: 1, y: 1}, 100, 100).options)
             .toMatchObject({duration: 800, easing: 'linear'})
+    });
+
+    test('both snapshot layers stay opaque and normally blended for the complete transition', () => {
+        const animation = DomUtils.createRevealAnimation({x: 20, y: 30, duration: 0}, 100, 100);
+
+        expect(animation.oldLayer).toBeDefined();
+        expect(animation.oldLayer.options).toMatchObject({
+            duration     : 0,
+            fill         : 'both',
+            pseudoElement: '::view-transition-old(root)'
+        });
+
+        for (const layer of [animation, animation.oldLayer]) {
+            expect(layer.keyframes).toHaveLength(2);
+            layer.keyframes.forEach(frame => expect(frame).toMatchObject({opacity: 1, mixBlendMode: 'normal'}))
+        }
     });
 
     test('an explicit zero duration survives — it is the reduced-motion answer, not a missing value', () => {


### PR DESCRIPTION
Resolves #18138

Circular reveals now own both snapshot layers: the old state stays opaque outside the growing circle, and normal blending replaces the browser cross-fade for that reveal. The engine releases its generated effects when the transition settles. Portal and Workstation no longer need global cancellation CSS; raw animations and the immediate Boolean return keep their existing behavior.

Evidence: L3 (native Chrome compositing, pixels, lifecycle controls, and visible app theme clicks) → L3 required (AC-1–5). No residuals.

## AC Evidence

| AC | Evidence |
|---|---|
| AC-1 | Outside-CI: `ViewTransitionReveal.spec.mjs` samples the real engine method halfway through the reveal after the UA fade; screenshot pixels are new blue inside the circle and old red outside. |
| AC-2 | Outside-CI: the same browser spec observes natural completion, cancelled generated handles, and a subsequent plain transition with fractional opacity and UA `plus-lighter` blending. |
| AC-3 | Outside-CI: [intake measurement](https://github.com/neomjs/neo/issues/18138#issuecomment-5547601549) records the visible Chrome 152 precedence control; the permanent browser spec enforces both layers' opacity/blending. |
| AC-4 | Both SCSS rules and the obsolete Workstation explanation are removed. Visible theme-click probes in both apps found zero loaded old/new cancellation rules and two released engine effects. |
| AC-5 | Outside-CI: rendered frames from actual Portal and Workstation theme controls were inspected at 300ms and after completion in visible Chrome 152. Workstation retains the dark state outside the light circle; Portal retains its complete backdrop/header. Both snapshot opacities were 1 with normal blending. |

## Deltas from ticket

The JS candidate passed the browser gate. Filled effects last until the transition settles, including zero/short reveals; partial registration failure unwinds already-created effects. The browser regression also runs in current headless Chrome, beyond the previous harness limitation.

Integration hygiene: lowers the existing dock Workspace size baseline from 1419 to its measured 1415 lines after merged #18329, so this PR does not inherit a stale-baseline guard failure. No dock runtime change.

## Test Evidence

`npx playwright test -c test/playwright/playwright.config.e2e.mjs test/playwright/e2e/rendering/ViewTransitionReveal.spec.mjs`: ten native-browser cases pass in both default headless mode and with `--headed`, including unassisted completion, zero/80ms durations, skipped/failed registration, raw payload priority and unrelated-animation preservation. Before implementation, the two new helper assertions failed on the missing old-layer descriptor and fill behavior.

## Post-Merge Validation

None required; the live browser surfaces were reachable before merge.

📐 Authored by Euclid (GPT 6 Astra, Codex) consuming Ada's ticket — session A 7596538d-5324-419a-b043-95c585d833ea, session B 01a06e2f-1b39-7de0-9b90-4b8e75f683f1.
