### PR TITLE
fix(build): scope baseline row demands to the files a change actually touched (#18345)

### DIFF
--- a/buildScripts/util/check-file-sizes.mjs
+++ b/buildScripts/util/check-file-sizes.mjs
@@ -193,12 +193,23 @@ function validateBaseline(baseline, label) {
  * @param {Object<String, Number>} options.headBaseline Baseline in the working tree.
  * @param {{declarations: Map<String, String>, malformed: String[], duplicates: String[]}} options.declarations Parsed PR declarations.
  * @param {Boolean} options.compareBase Whether historical monotonicity is available.
+ * @param {Set<String>|null} [options.changedFiles=null] The paths this change actually touched. Row
+ * demands are scoped to it, because a baseline row that goes stale on the base branch otherwise
+ * fails every unrelated pull request until someone repairs a number nobody involved changed. `null`
+ * means no diff scope — the whole-tree audit, where every path is in scope because there is no diff
+ * to be outside of.
+ *
+ * **The deleted-path branch is deliberately NOT scoped**, and the asymmetry is load-bearing:
+ * `changedFilesAtRef` runs `--diff-filter=d`, so a deletion never appears in the changed set. Scoping
+ * that branch would let a pull request delete a baselined file and silently orphan its row — trading
+ * a real guard for a rare transitional block.
  * @param {{target: Number, yellow: Number, red: Number}} options.thresholds Threshold inputs.
  * @returns {{rows: Object[], violations: Object[], unusedDeclarations: String[], malformedDeclarations: String[], monotonicityEvaluated: Boolean}}
  */
 export function evaluateMeasurements({
     measurements,
     baseBaseline = {},
+    changedFiles = null,
     headBaseline = {},
     declarations = parseGrowthDeclarations(''),
     compareBase  = true,
@@ -252,6 +263,21 @@ export function evaluateMeasurements({
         };
 
         rows.push(row);
+
+        // A pull request is accountable for the files it changed. Outside its diff the row is
+        // REPORTED and never gated, because every demand below asks for an edit only the PR that
+        // moved the file can justify — and a stale row therefore failed every unrelated PR,
+        // a bot's included, until a human repaired a number nobody involved cared about.
+        //
+        // Nothing is lost: a file this PR did not touch cannot have been grown by it, so the growth
+        // gate — the reason the ratchet exists — is unaffected. A shrink whose PR forgot to lower
+        // its row is still caught, on the PR that shrank it, which is the only one able to fix it.
+        //
+        // `changedFiles === null` means no diff scope was supplied (the whole-tree audit), and then
+        // every path is in scope because there is no diff to be outside of.
+        if (changedFiles && !changedFiles.has(file)) {
+            return
+        }
 
         if (measurement.status !== 'measured') {
             row.verdict = 'fail';
@@ -517,6 +543,7 @@ async function main() {
     try {
         let headBaseline = readBaselineFile(baselinePath, 'HEAD baseline'),
             baseBaseline = {},
+            changedFiles = null,
             compareBase  = false,
             selected;
 
@@ -525,6 +552,9 @@ async function main() {
 
             baseBaseline = baseState.baseline;
             compareBase  = baseState.exists;
+            // Captured before the union below folds the baselines in: after that, `selected` is the
+            // measurement population and no longer says which paths this change actually touched.
+            changedFiles = compareBase ? new Set(changedFilesAtRef(options.base)) : null;
             selected     = compareBase
                 ? changedFilesAtRef(options.base)
                 : await fg(DEFAULT_SCAN_ROOTS.map(root => `${root}/**/*.mjs`), {
@@ -566,6 +596,7 @@ async function main() {
         const result = evaluateMeasurements({
             measurements,
             baseBaseline,
+            changedFiles,
             headBaseline,
             declarations,
             compareBase,

--- a/buildScripts/util/check-file-sizes.mjs
+++ b/buildScripts/util/check-file-sizes.mjs
@@ -193,11 +193,13 @@ function validateBaseline(baseline, label) {
  * @param {Object<String, Number>} options.headBaseline Baseline in the working tree.
  * @param {{declarations: Map<String, String>, malformed: String[], duplicates: String[]}} options.declarations Parsed PR declarations.
  * @param {Boolean} options.compareBase Whether historical monotonicity is available.
- * @param {Set<String>|null} [options.changedFiles=null] The paths this change actually touched. Row
- * demands are scoped to it, because a baseline row that goes stale on the base branch otherwise
- * fails every unrelated pull request until someone repairs a number nobody involved changed. `null`
- * means no diff scope — the whole-tree audit, where every path is in scope because there is no diff
- * to be outside of.
+ * @param {Set<String>|null} [options.changedFiles=null] The in-scope source paths this change
+ * actually touched. Row demands are waived only where the source is untouched **and** its baseline
+ * row is inherited unchanged, because a row that goes stale on the base branch otherwise fails every
+ * unrelated pull request until someone repairs a number nobody involved changed. Source membership
+ * alone is not sufficient: the changed set holds `.mjs` paths only, so a baseline-only change
+ * presents an empty set and could otherwise raise any row unchecked. `null` means no diff scope —
+ * the whole-tree audit, where every path is in scope because there is no diff to be outside of.
  *
  * **The deleted-path branch is deliberately NOT scoped**, and the asymmetry is load-bearing:
  * `changedFilesAtRef` runs `--diff-filter=d`, so a deletion never appears in the changed set. Scoping
@@ -264,24 +266,31 @@ export function evaluateMeasurements({
 
         rows.push(row);
 
-        // A pull request is accountable for the files it changed. Outside its diff the row is
-        // REPORTED and never gated, because every demand below asks for an edit only the PR that
-        // moved the file can justify — and a stale row therefore failed every unrelated PR,
-        // a bot's included, until a human repaired a number nobody involved cared about.
-        //
-        // Nothing is lost: a file this PR did not touch cannot have been grown by it, so the growth
-        // gate — the reason the ratchet exists — is unaffected. A shrink whose PR forgot to lower
-        // its row is still caught, on the PR that shrank it, which is the only one able to fix it.
-        //
-        // `changedFiles === null` means no diff scope was supplied (the whole-tree audit), and then
-        // every path is in scope because there is no diff to be outside of.
-        if (changedFiles && !changedFiles.has(file)) {
-            return
-        }
-
         if (measurement.status !== 'measured') {
             row.verdict = 'fail';
             fail(file, `not-measured: ${measurement.error || 'parser did not return a measurement'}.`);
+            return
+        }
+
+        // A change is accountable for what it actually altered. Where BOTH the source and its
+        // baseline row are inherited untouched, the row is REPORTED and never gated — otherwise a
+        // row that went stale on the base branch fails every unrelated pull request, a dependency
+        // bot's included, until a human repairs a number nobody involved changed.
+        //
+        // **Both halves are required, and the second is the one that is easy to miss.** The changed
+        // set is built from in-scope `.mjs` paths, so the baseline JSON can never appear in it: a
+        // baseline-only change presents an EMPTY source set. Waiving on source membership alone
+        // therefore let a change raise any row unchecked, and a later change could then grow that
+        // source under the inflated ceiling and read as a shrink — no declaration required. Two
+        // steps, no source edit in the first, and the growth gate defeated. Requiring the row to be
+        // inherited (`headValue === baseValue`) is what makes "untouched" mean untouched.
+        //
+        // A measurement failure is never waived: it is decided above, so an unparsable inherited
+        // file still fails rather than reporting `not-measured` and exiting 0.
+        //
+        // `changedFiles === null` means no diff scope was supplied (the whole-tree audit), and then
+        // every path is in scope because there is no diff to be outside of.
+        if (changedFiles && !changedFiles.has(file) && headValue === baseValue) {
             return
         }
 

--- a/buildScripts/util/file-size-baseline.json
+++ b/buildScripts/util/file-size-baseline.json
@@ -1,6 +1,6 @@
 {
     "apps/workstation/view/Workspace.mjs": 3390,
     "examples/dashboard/crossWindow/DemoBWorkspace.mjs": 2701,
-    "src/dashboard/dock/Workspace.mjs": 1419,
+    "src/dashboard/dock/Workspace.mjs": 1415,
     "src/main/addon/DragDrop.mjs": 1267
 }

--- a/test/playwright/unit/buildScripts/checkFileSizes.spec.mjs
+++ b/test/playwright/unit/buildScripts/checkFileSizes.spec.mjs
@@ -215,6 +215,65 @@ test.describe('check-file-sizes', () => {
             expect(result.violations.map(violation => violation.reason).join(' ')).toContain('enroll');
         });
 
+        test('RA-1: a baseline-only change cannot raise an untouched row unchecked', () => {
+            // The two-step ratchet bypass @neo-gpt executed against the first revision of this fix.
+            // `changedFilesAtRef` collects in-scope `.mjs` paths only, so a change touching just the
+            // baseline JSON presents an EMPTY source set. Waiving on source membership alone let it
+            // inflate any ceiling; a later change could then grow that source under the raised limit
+            // and read as a *shrink*, requiring no growth declaration at all.
+            const raised = evaluate({
+                changed: [],
+                current: {[theirs]: 1_200},
+                base   : {[theirs]: 1_200},
+                head   : {[theirs]: 9_000}
+            });
+
+            expect(raised.violations[0].reason).toContain('HEAD baseline must equal the measured count');
+        });
+
+        test('RA-1: step two of the bypass — growth under an inflated ceiling still needs a declaration', () => {
+            // Proves the first arm closes the bypass rather than merely reporting its first step:
+            // with the ceiling raised, growth to 1500 must not pass as a shrink.
+            const grown = evaluate({
+                changed: [theirs],
+                current: {[theirs]: 1_500},
+                base   : {[theirs]: 1_200},
+                head   : {[theirs]: 1_500}
+            });
+
+            expect(grown.violations[0].reason).toContain('size-guard-growth');
+        });
+
+        test('RA-1: a legitimate baseline-only correction still passes', () => {
+            // The positive that keeps the arm above from being a blanket refusal: lowering a row to
+            // a measurement that already shrank on the base branch is exactly the repair we want.
+            const corrected = evaluate({
+                changed: [],
+                current: {[theirs]: 1_199},
+                base   : {[theirs]: 1_200},
+                head   : {[theirs]: 1_199}
+            });
+
+            expect(corrected.violations).toEqual([]);
+        });
+
+        test('RA-1: an untouched unparsable file still fails, never a green with FAIL printed', () => {
+            // The exemption is decided AFTER the measurement branch. Before that, an untouched
+            // `not-measured` row printed `FAIL` while the process exited 0 — a green that means
+            // nothing, which is the defect class this guard exists to prevent.
+            const result = evaluateMeasurements({
+                measurements: {[theirs]: {status: 'not-measured', codeLines: null, docLines: 0, docPercent: 0}},
+                baseBaseline: {[theirs]: 1_200},
+                changedFiles: new Set(),
+                headBaseline: {[theirs]: 1_200},
+                declarations: parseGrowthDeclarations(''),
+                compareBase : true,
+                thresholds  : DEFAULT_THRESHOLDS
+            });
+
+            expect(result.violations[0].reason).toContain('not-measured');
+        });
+
         test('whole-tree mode has no diff to be outside of, so every path stays in scope', () => {
             // `changed: null` is the on-demand audit. Exempting everything there would make the
             // whole-tree run structurally incapable of reporting the very drift it exists to find.

--- a/test/playwright/unit/buildScripts/checkFileSizes.spec.mjs
+++ b/test/playwright/unit/buildScripts/checkFileSizes.spec.mjs
@@ -231,9 +231,15 @@ test.describe('check-file-sizes', () => {
             expect(raised.violations[0].reason).toContain('HEAD baseline must equal the measured count');
         });
 
-        test('RA-1: step two of the bypass — growth under an inflated ceiling still needs a declaration', () => {
-            // Proves the first arm closes the bypass rather than merely reporting its first step:
-            // with the ceiling raised, growth to 1500 must not pass as a shrink.
+        test('RA-1: ordinary growth on a touched file still needs a declaration', () => {
+            // The bypass is stopped at step ONE — the arm above prevents an inflated base from being
+            // created — so this is not "step two". Named for what it actually is: the control that
+            // the waiver did not weaken ordinary growth against a normal base.
+            //
+            // Stated because the arm's name previously overclaimed it (@neo-gpt, R2): an ALREADY
+            // inflated base is NOT retroactively rejected. `base 9000 / current 1500 / head 1500`
+            // returns zero violations, because against that base 1500 is a shrink. Nothing here
+            // reaches back to undo a ceiling; the guarantee is that this waiver cannot mint one.
             const grown = evaluate({
                 changed: [theirs],
                 current: {[theirs]: 1_500},

--- a/test/playwright/unit/buildScripts/checkFileSizes.spec.mjs
+++ b/test/playwright/unit/buildScripts/checkFileSizes.spec.mjs
@@ -23,12 +23,14 @@ const evaluate = ({
     base = {},
     head = {},
     body = '',
+    changed = null,
     compareBase = true
 }) => evaluateMeasurements({
     measurements: Object.fromEntries(
         Object.entries(current).map(([file, codeLines]) => [file, measured(codeLines)])
     ),
     baseBaseline: base,
+    changedFiles: changed && new Set(changed),
     headBaseline: head,
     declarations: parseGrowthDeclarations(body),
     compareBase,
@@ -157,6 +159,73 @@ test.describe('check-file-sizes', () => {
             expect(result.violations).toEqual([]);
             expect(result.rows[0]).toMatchObject({docPercent: 90, verdict: 'pass'});
         });
+    });
+
+    test.describe('row demands are scoped to the changed set (#18345)', () => {
+        const
+            mine   = 'src/large.mjs',
+            theirs = 'src/other.mjs';
+
+        test('a stale row on a path this change did not touch is reported, not gated', () => {
+            // The defect, twice in ninety minutes: a baseline row goes stale on the base branch and
+            // every unrelated pull request — a dependency bot's included — is told to lower a number
+            // its diff never touched, and cannot justify.
+            const result = evaluate({
+                changed: [mine],
+                current: {[mine]: 1_100, [theirs]: 1_415},
+                base   : {[mine]: 1_100, [theirs]: 1_419},
+                head   : {[mine]: 1_100, [theirs]: 1_419}
+            });
+
+            expect(result.violations).toEqual([]);
+            expect(result.rows.find(row => row.file === theirs).verdict).toBe('pass');
+            // Reported, not silenced — the row still carries its measurement.
+            expect(result.rows.find(row => row.file === theirs).codeLines).toBe(1_415);
+        });
+
+        test('NON-VACUITY: the same stale row on a path this change DID touch still fails', () => {
+            // Without this, the arm above passes on a guard that stopped checking anything at all.
+            const result = evaluate({
+                changed: [mine, theirs],
+                current: {[mine]: 1_100, [theirs]: 1_415},
+                base   : {[mine]: 1_100, [theirs]: 1_419},
+                head   : {[mine]: 1_100, [theirs]: 1_419}
+            });
+
+            expect(result.violations[0].reason).toContain('lower the HEAD baseline');
+        });
+
+        test('the GROWTH gate is untouched by the scoping', () => {
+            // The one that must never be scoped away. Growth is why the ratchet exists, and a future
+            // refactor that applies the changed-set filter to the declaration branch would disarm it
+            // while leaving every other arm green.
+            const result = evaluate({
+                changed: [mine],
+                current: {[mine]: 1_201},
+                base   : {[mine]: 1_200},
+                head   : {[mine]: 1_201}
+            });
+
+            expect(result.violations[0].reason).toContain('size-guard-growth');
+        });
+
+        test('enrollment of a newly added offender still needs declaration and row', () => {
+            const result = evaluate({changed: [mine], current: {[mine]: 1_201}, base: {}, head: {}});
+
+            expect(result.violations.map(violation => violation.reason).join(' ')).toContain('enroll');
+        });
+
+        test('whole-tree mode has no diff to be outside of, so every path stays in scope', () => {
+            // `changed: null` is the on-demand audit. Exempting everything there would make the
+            // whole-tree run structurally incapable of reporting the very drift it exists to find.
+            const result = evaluate({
+                current: {[theirs]: 1_415},
+                base   : {[theirs]: 1_419},
+                head   : {[theirs]: 1_419}
+            });
+
+            expect(result.violations[0].reason).toContain('lower the HEAD baseline');
+        })
     });
 
     test.describe('base-to-HEAD ratchet', () => {


### PR DESCRIPTION
Resolves #18345

Related: #18278 · #18320 · #18341

A baseline row that goes stale on `dev` failed **every unrelated pull request** — a dependency bot's included — until a human repaired a number nobody involved had changed. It happened twice in ninety minutes. A row is now waived only where the source is untouched **and** its baseline row is inherited unchanged; everything inside a change's diff behaves exactly as before.

Evidence: L2 achieved and required — the close-target ACs are pure-function seams plus a CLI verdict, both reachable in the sandbox and both run at this head. Residual: none.

## AC Evidence
| AC | Evidence |
|---|---|
| AC-1 | `a stale row on a path this change did not touch is reported, not gated` — passes, and the row still carries its measurement (`codeLines: 1415`) rather than being silenced. Red-first: `dev@99e66ae1` fails the same shape today, `npm run check-file-sizes` exit 1. |
| AC-2 | `the GROWTH gate is untouched by the scoping` — a touched file growing 1200 → 1201 without a declaration still fails with `size-guard-growth`. |
| AC-3 | `NON-VACUITY: the same stale row on a path this change DID touch still fails` — the shrink obligation stays with the only PR that can discharge it. |
| AC-4 | `enrollment of a newly added offender still needs declaration and row`. |
| AC-5 | `whole-tree mode has no diff to be outside of, so every path stays in scope` — `changedFiles: null` keeps the on-demand audit able to report the drift it exists to find. |
| AC-6 | `npm run check-file-sizes` on this branch exits **0**; `--base origin/dev` (the exact CI invocation) exits **0**. |
| AC-7 | Mutation: disabling the waiver turns **exactly one** arm red — the one naming the property — 1 failed / 24 passed at the time it was run. The growth and non-vacuity arms stay green in both states, which is what makes them controls rather than restatements. |
| AC-8 | `RA-1: a baseline-only change cannot raise an untouched row unchecked` — the changed set holds `.mjs` paths only, so a baseline-only change presents an empty source set; raising 1200 → 9000 from it now fails. |
| AC-9 | `RA-1: ordinary growth on a touched file still needs a declaration` — the waiver did not weaken the growth gate against a normal base. **Corrected (@neo-gpt, R2):** the bypass is blocked at step ONE, so this arm never reaches an inflated base; an already-inflated base is not retroactively rejected (`9000 / 1500 / 1500` → 0 violations, a shrink). The waiver cannot mint a ceiling; it cannot undo one either. |
| AC-10 | `RA-1: a legitimate baseline-only correction still passes` — the positive that keeps AC-8 from being a blanket refusal. |
| AC-11 | `RA-1: an untouched unparsable file still fails` — the waiver is decided after the measurement branch, so `not-measured` can never print `FAIL` on an exit-0 run. |

## Deltas from ticket

- **RA-1 changed the shape of the fix, and the ticket now records why.** Revision one waived on source membership alone. @neo-gpt executed the exported evaluator against it and demonstrated a two-step ratchet bypass: `changedFilesAtRef` collects in-scope `.mjs` paths only, so a **baseline-only change presents an empty source set** and could raise any row unchecked; a later change growing that source beneath the inflated ceiling then read as a *shrink*, requiring no declaration. The waiver now additionally requires `headValue === baseValue`. #18345's prescription, contract ledger and ACs are corrected to match.
- **The deleted-path branch is deliberately NOT waived.** `changedFilesAtRef` runs `--diff-filter=d`, so a deletion never enters the changed set; waiving there would let a PR delete a baselined file and silently orphan its row. Strictness costs a rare transitional block and buys a real guard. Stated in the JSDoc where the next reader hits it.
- **This supersedes my own reasoning on #18341, not its fix.** I closed that ticket asserting recurrence was impossible. It recurred in ninety minutes: the transitional window (a PR whose CI predates the guard — closing) and **concurrent shrinks** (two PRs lowering the row from the same base value — permanent). Epic #18304 has four extractions queued against this exact file.

## Test Evidence

Outside-CI receipts at `1b0ec11665`:

- **@neo-gpt's table, re-run against the fix.** **One row flips** — the bypass's entry point — and every other row is unchanged, which is the correct shape: the waiver can no longer mint an inflated ceiling, and nothing else moved.

  | Change | Measured | Base → head row | before | after |
  |---|---:|---:|---:|---:|
  | **baseline only — the bypass entry point** | 1200 | 1200 → 9000 | 0 | **1** |
  | ordinary touched growth | 1201 | 1200 → 1201 | 1 | 1 |
  | touched shrink with stale row | 1199 | 1200 → 1200 | 1 | 1 |
  | untouched inherited shrink | 1199 | 1200 → 1200 | 0 | 0 |
  | legitimate baseline-only correction | 1199 | 1200 → 1199 | 0 | 0 |
  | *growth against an already-inflated base* | 1500 | 9000 → 1500 | 0 | **0 — unchanged, and stated** |

  The last row is the residual, kept visible rather than dropped: against a base of 9000 a current of 1500 **is** a shrink and passes. Step one is where this is stopped; nothing reaches back to undo a ceiling that already exists. My first R2 table reported that row as a `0 → 1` flip, which was false — corrected in [this comment](https://github.com/neomjs/neo/pull/18346#issuecomment-5548014680).

- **Red-first needed no fixture.** `npm run check-file-sizes` on `dev@99e66ae1` exits 1 for the original defect. The pre-state was live on the base branch, so it is the control.
- **Mutation at revision one** reddened exactly one arm — which is also the honest limit of that receipt: the arm was the only thing testing the property I had thought of, and it could not have caught the bypass. Recorded because a precise mutation over an incomplete control set is not the assurance it looks like.
- **Local guard run before pushing.** `check-ticket-archaeology` on the explicit paths: `2 file(s) read, 0 violations`. Its `--base origin/dev` form reported `0 .mjs files in scope` pre-commit and passed vacuously — the supplied-paths form is the honest one pre-push.
- Full engine unit tier for this spec: **29/29**, up from 20 (five scoping arms, four RA-1 arms).

## Post-Merge Validation

- [ ] The two Dependabot PRs (#18325, #18326) stop reporting a File Size Guard violation. Their `components` failures are unrelated and owned by #18275 / #18290; this PR does not claim to fix those.

## Commits
- `9af22ec947` — scope row demands to the changed set, lower the row 1419 → 1415
- `312a9823bb` — RA-1: waive only when the source **and** its row are inherited; measurement failures never waived
- `1b0ec11665` — name the growth arm for what it controls; record the not-retroactive residual

---

**What I got wrong, since it is the more useful half.** I wrote *"a change cannot grow a file it did not touch, so the growth gate is unaffected"* — in the JSDoc, the ticket, the PR body and a fleet broadcast. True and irrelevant: it cannot grow the **file**, but it can raise the file's **permitted size** by editing the baseline alone. I verified the waiver preserved the growth gate for the *source* and never asked whether it preserved the gate's *authority*.

Every control I wrote passed a `changed` list of `.mjs` paths, so **none of them could ever exercise the empty-set case** — the controls were shaped by the same assumption as the defect. #18278's ratchet was never the problem; revision one of this fix briefly was.

Authored by Grace (`@neo-opus-grace`, Claude Opus 5, Claude Code). Session `b983b2a8-18bc-4dd0-a63f-23380dc3a49d`.
