### PR TITLE
feat(dock): the header-action presentation policy leaves Workspace for an owned collaborator (#18306)

### DIFF
--- a/buildScripts/util/file-size-baseline.json
+++ b/buildScripts/util/file-size-baseline.json
@@ -1,6 +1,6 @@
 {
     "apps/workstation/view/Workspace.mjs": 3390,
     "examples/dashboard/crossWindow/DemoBWorkspace.mjs": 2701,
-    "src/dashboard/dock/Workspace.mjs": 1415,
+    "src/dashboard/dock/Workspace.mjs": 1281,
     "src/main/addon/DragDrop.mjs": 1267
 }

--- a/buildScripts/util/file-size-baseline.json
+++ b/buildScripts/util/file-size-baseline.json
@@ -1,6 +1,6 @@
 {
     "apps/workstation/view/Workspace.mjs": 3390,
     "examples/dashboard/crossWindow/DemoBWorkspace.mjs": 2701,
-    "src/dashboard/dock/Workspace.mjs": 1281,
+    "src/dashboard/dock/Workspace.mjs": 1284,
     "src/main/addon/DragDrop.mjs": 1267
 }

--- a/docs/output/class-hierarchy.json
+++ b/docs/output/class-hierarchy.json
@@ -240,6 +240,7 @@
  "Neo.dashboard.dock.persistence.PerspectiveLibrary": "Neo.core.Base",
  "Neo.dashboard.dock.persistence.RestorePlanner": "Neo.core.Base",
  "Neo.dashboard.dock.plugin.Maximize": "Neo.plugin.Base",
+ "Neo.dashboard.dock.projection.HeaderActionPolicy": "Neo.core.Base",
  "Neo.dashboard.dock.projection.LayoutAdapter": "Neo.core.Base",
  "Neo.dashboard.dock.projection.MotionSignal": "Neo.core.Base",
  "Neo.dashboard.dock.projection.Reconciler": "Neo.core.Base",

--- a/src/dashboard/dock/Workspace.mjs
+++ b/src/dashboard/dock/Workspace.mjs
@@ -2,6 +2,8 @@ import Component                   from '../../component/Base.mjs';
 import Container                   from '../../container/Base.mjs';
 import NeoArray                    from '../../util/Array.mjs';
 import {isDescriptor}              from '../../core/ConfigSymbols.mjs';
+import ClassSystemUtil             from '../../util/ClassSystem.mjs';
+import HeaderActionPolicy          from './projection/HeaderActionPolicy.mjs';
 import LayoutAdapter               from './projection/LayoutAdapter.mjs';
 import Maximize                    from './plugin/Maximize.mjs';
 import MotionSignal                from './projection/MotionSignal.mjs';
@@ -78,6 +80,7 @@ import TopologySeams               from './window/TopologySeams.mjs';
  *
  * @class Neo.dashboard.dock.Workspace
  * @extends Neo.container.Base
+ * @see Neo.dashboard.dock.projection.HeaderActionPolicy
  * @see Neo.dashboard.dock.projection.LayoutAdapter
  * @see Neo.dashboard.dock.projection.Reconciler
  * @see Neo.dashboard.dock.model.WorkspaceDocument
@@ -225,6 +228,15 @@ class Workspace extends Container {
          * @member {String} dockPopOutIconCls='far fa-window-restore'
          */
         dockPopOutIconCls: 'far fa-window-restore',
+        /**
+         * The header-action presentation policy: which engine action is shown, enabled or pressed
+         * for which pane, re-derived onto the retained action instances after every commit and
+         * active-item change. Resolved to one instance bound to this workspace — a module config or
+         * an instance replaces the engine policy without overriding workspace methods.
+         * @member {Neo.dashboard.dock.projection.HeaderActionPolicy|Object|null} dockHeaderActionPolicy_=null
+         * @reactive
+         */
+        dockHeaderActionPolicy_: null,
         /**
          * Tooltip texts of the engine-owned header actions and the rail's reveal pin, keyed by
          * action state: `lock` / `unlock`, `reload`, `unpin`, `popOut`, `maximize` / `restore`,
@@ -387,22 +399,6 @@ class Workspace extends Container {
      * @protected
      */
     returningTearOutPanes = {}
-
-    /**
-     * Exact pre-lock root-inert snapshots keyed by the live pane instance:
-     * `{owned:Boolean, value:*}`. A WeakMap cannot prolong a retired pane's lifetime.
-     * @member {WeakMap<Neo.component.Base,Object>} dockLockPaneState=new WeakMap()
-     * @protected
-     */
-    dockLockPaneState = new WeakMap()
-
-    /**
-     * Whether each live tab button owned the SortZone's `neo-draggable` token before lock
-     * suppressed it. Unlock restores that exact ownership instead of globally arming drag.
-     * @member {WeakMap<Neo.component.Base,Boolean>} dockLockDragState=new WeakMap()
-     * @protected
-     */
-    dockLockDragState = new WeakMap()
 
     /**
      * Item ids with a `dockReload()` invocation in flight — the single-flight guard: a second
@@ -1560,9 +1556,35 @@ class Workspace extends Container {
 
         me.dockPreviewProducer?.destroy();
         me.dockPreviewProducer = null;
-        me.refreshPromise      = null;
+        me.dockHeaderActionPolicy?.destroy();
+        me.refreshPromise = null;
 
         super.destroy(...args)
+    }
+
+    /**
+     * Resolves the policy config to one instance bound to this workspace; an instance passes
+     * through and is bound the same way.
+     * @param {Neo.dashboard.dock.projection.HeaderActionPolicy|Object|null} value
+     * @returns {Neo.dashboard.dock.projection.HeaderActionPolicy}
+     * @protected
+     */
+    beforeSetDockHeaderActionPolicy(value) {
+        let policy = ClassSystemUtil.beforeSetInstance(value, HeaderActionPolicy, {workspace: this});
+
+        policy.workspace = this;
+
+        return policy
+    }
+
+    /**
+     * A replaced policy retires, and its lock-presentation memory with it.
+     * @param {Neo.dashboard.dock.projection.HeaderActionPolicy} value
+     * @param {Neo.dashboard.dock.projection.HeaderActionPolicy|null} oldValue
+     * @protected
+     */
+    afterSetDockHeaderActionPolicy(value, oldValue) {
+        oldValue?.destroy()
     }
 
     /**
@@ -1586,7 +1608,7 @@ class Workspace extends Container {
      * **Host header actions** arrive here too: return `resolveDockHeaderActions: nodeId => [...]` to
      * project a host's own actions into that tabs node's header. The set is node-static and lives for
      * the node's retained lifetime — vary an action per active item by moving `hidden` on its stable
-     * instance, the way {@link #syncDockCloseAction} does, not by returning a different list. Names
+     * instance, the way {@link Neo.dashboard.dock.projection.HeaderActionPolicy#syncCloseAction} does, not by returning a different list. Names
      * must be unique per node, and every engine-owned name is reserved while its own opt-in is on —
      * `close` under {@link #enableDockCloseAction}, `lock` under {@link #enableDockLockAction},
      * `maximize` under {@link #enableDockMaximizeAction}, `pin` under {@link #enableDockPinAction},
@@ -1711,209 +1733,6 @@ class Workspace extends Container {
     }
 
     /**
-     * Synchronizes one retained close action against the live active item and committed policy.
-     * Hidden-state changes stay on the stable action instance so Overflow receives its existing
-     * `actionVisibilityChange` signal instead of an action-group replacement.
-     *
-     * Gated on {@link #enableDockCloseAction} for the reason given on {@link #syncDockPinAction}: the
-     * name is only this class's while its own opt-in is on.
-     * @param {Neo.tab.Container|null} tabContainer
-     * @protected
-     */
-    syncDockCloseAction(tabContainer) {
-        if (!this.enableDockCloseAction) return;
-
-        let action = tabContainer?.getActionItem?.('close'),
-            itemId = this.getActiveDockItemId(tabContainer),
-            item   = this.dockModel?.items?.[itemId],
-            hidden = !itemId || item?.closable === false || item?.locked === true;
-
-        action && (action.hidden = hidden)
-    }
-
-    /**
-     * @summary Re-evaluates the retained pop-out action against current truth after every commit.
-     *
-     * Pop-out was the one engine action with no sync. Its `hidden` is projected once as
-     * `!activeItemId || !dockPopOutActionAvailable` and then lives on a RETAINED action instance
-     * that survives re-projection, so nothing ever recomputed it: the control was correct at boot
-     * and silently gone after the first layout commit. For a consumer whose reason to be here is
-     * multi-window, the feature disappeared until reload.
-     *
-     * Mirrors the projected expression from the same reader (`dockPopOutActionActive`), so the
-     * projected and the synced answer cannot drift. Change-guarded like its siblings, so re-walking
-     * retained nodes stays idempotent.
-     * @param {Neo.tab.Container} tabContainer
-     * @protected
-     */
-    syncDockPopOutAction(tabContainer) {
-        if (!this.enableDockPopOutAction) return;
-
-        let action = tabContainer?.getActionItem?.('pop-out'),
-            itemId = this.getActiveDockItemId(tabContainer),
-            hidden = !itemId || !this.dockPopOutActionActive;
-
-        action && (action.hidden = hidden)
-    }
-
-    /**
-     * Synchronizes the retained lock action and every projected pane/button against committed
-     * item truth. The action stays one stable instance; per-item hidden/icon state moves on it.
-     *
-     * Presentation is deliberately a second layer beneath the model guards. Lock stamps
-     * `vdom.inert` plus `neo-dock-pane-locked` in one pane update and removes only the tab
-     * button's `neo-draggable` source token. Unlock restores the exact prior inert ownership/value
-     * and exact prior drag-token ownership. Locked headers remain legal drop targets. The ordinary
-     * lock gesture is focus-gated; once the protective state persists, its unlock reversal becomes
-     * persistent too, so discoverability never depends on re-entering a transient focus context.
-     * @param {Neo.tab.Container|null} tabContainer
-     * @protected
-     */
-    syncDockLockAction(tabContainer) {
-        let me = this;
-
-        if (!me.enableDockLockAction || !tabContainer) return;
-
-        let {items} = me.dockModel || {},
-            bar     = tabContainer.getTabBar(),
-            action  = tabContainer.getActionItem('lock'),
-            itemId  = me.getActiveDockItemId(tabContainer),
-            item    = items?.[itemId],
-            locked  = item?.locked === true;
-
-        // ONE write of WHAT is true. The action owns the icon / accessible name / tooltip mapping
-        // (`toolbar.ActionButton#afterSetPressed`) and the toolbar derives the focus gate from
-        // `pressed`, so nothing here states how the control should look.
-        action?.set({
-            hidden : !itemId || item?.lockable === false,
-            pressed: locked
-        });
-
-        // Buttons are addressed by identity, never by position: `tab.plugin.Overflow` removes
-        // overflowing buttons from this collection by design, so `buttons[index]` can name a
-        // different item than `dockItemIds[index]` does.
-        let buttons = tabContainer.getTabButtons(),
-            panes   = tabContainer.getCardContainer().items;
-
-        bar.sortZoneConfig?.dockItemIds?.forEach((id, index) => {
-            me.syncDockLockItemPresentation({
-                button: buttons.find(button => button.dockItemId === id) || null,
-                locked: items?.[id]?.locked === true,
-                pane  : panes[index]
-            })
-        })
-    }
-
-    /**
-     * Applies or restores one item's lock presentation without changing model state.
-     *
-     * The content half is delegable, the reload precedent: a pane implementing
-     * `dockLock(locked)` owns what locked means for its content — a form disables its fields, a
-     * grid turns cell editing off, a stream keeps scrolling — and the engine writes no `inert` for
-     * it. The probe is a pure `typeof` on the live card, never a resolver call. The hook fires
-     * once per transition, recorded in the same per-pane state as the inert snapshot, so a sweep
-     * that runs on every active-item change never re-locks a pane its author already locked.
-     * Without the hook the engine's inert default stands, byte-identical, with its exact-restore
-     * clause.
-     * @param {Object} data
-     * @param {Neo.tab.header.Button|null} data.button
-     * @param {Boolean} data.locked
-     * @param {Neo.component.Base|null} data.pane
-     * @protected
-     */
-    syncDockLockItemPresentation({button, locked, pane}={}) {
-        let me = this;
-
-        if (pane && !pane.isDestroyed) {
-            let {vdom}  = pane,
-                held    = me.dockLockPaneState.get(pane),
-                changed = false,
-                prior;
-
-            if (locked && !held) {
-                if (typeof pane.dockLock === 'function') {
-                    me.dockLockPaneState.set(pane, {delegated: true});
-                    pane.dockLock(true)
-                } else {
-                    me.dockLockPaneState.set(pane, {owned: Object.hasOwn(vdom, 'inert'), value: vdom.inert});
-                    changed    = vdom.inert !== true;
-                    vdom.inert = true
-                }
-            } else if (!locked && held) {
-                prior = held;
-                me.dockLockPaneState.delete(pane);
-
-                // Reverse along the path that locked: the record decides, never the current probe,
-                // so a pane cannot be handed an unlock it never received a lock for.
-                if (prior.delegated) {
-                    pane.dockLock(false)
-                } else {
-                    prior.owned ? (vdom.inert = prior.value) : delete vdom.inert;
-                    changed = true
-                }
-            }
-
-            if (pane.cls?.includes('neo-dock-pane-locked') !== locked) {
-                let cls = [...pane.cls || []];
-
-                NeoArray.toggle(cls, 'neo-dock-pane-locked', locked);
-                pane.setSilent({cls});
-                changed = true
-            }
-
-            changed && pane.update()
-        }
-
-        if (button && !button.isDestroyed) {
-            let was = button.wrapperCls?.includes('neo-draggable'),
-                next;
-
-            if (locked) {
-                !me.dockLockDragState.has(button) && me.dockLockDragState.set(button, was);
-                next = false
-            } else if (me.dockLockDragState.has(button)) {
-                next = me.dockLockDragState.get(button);
-                me.dockLockDragState.delete(button)
-            } else {
-                return
-            }
-
-            if (was !== next) {
-                let cls = [...button.wrapperCls];
-
-                NeoArray.toggle(cls, 'neo-draggable', next);
-                button.wrapperCls = cls
-            }
-        }
-    }
-
-    /**
-     * Synchronizes the currently materialized rail-reveal panes against committed lock truth.
-     *
-     * Rails are synthetic affordances retained across stable-topology reconciliation, so their
-     * projection config is not a state-update channel. The materialization callback covers first
-     * reveal; this sweep covers a lock transition while the same overlay remains open. Dismissed
-     * cached panes restore on their next materialization callback.
-     * @protected
-     */
-    syncDockLockRails() {
-        let me = this;
-
-        if (!me.enableDockLockAction) return;
-
-        let {items} = me.dockModel || {};
-
-        me.forEachDockRail(({revealOverlay}) => {
-            let pane = revealOverlay?.paneSlot.items[0];
-
-            pane && me.syncDockLockItemPresentation({
-                locked: items?.[revealOverlay.revealPaneItemId]?.locked === true,
-                pane
-            })
-        })
-    }
-
-    /**
      * Visits every projected edge rail below the dock shell. Rails are leaves of the walk: their
      * reveal overlays host application content, never dock nodes.
      * @param {Function} callback Receives one {@link Neo.dashboard.dock.interaction.Rail}.
@@ -1970,43 +1789,6 @@ class Workspace extends Container {
         });
 
         await Promise.all(pending)
-    }
-
-    /**
-     * Synchronizes one retained pin action against the live active item and committed policy.
-     *
-     * Hidden wherever the collapse could not complete, so the header never offers a gesture the model
-     * or the projection would refuse: no active item, `pinnable: false` (which
-     * {@link Neo.dashboard.dock.model.Operations#setItemAutoHidden} rejects), or an item no edge owns
-     * (§2.7 — center never rails). The edge answer comes from
-     * {@link Neo.dashboard.dock.model.WorkspaceDocument#findOwningEdge}, the same derivation the projection
-     * rails by, so the action cannot disagree with the rail it would collapse into.
-     *
-     * Like {@link #syncDockCloseAction}, hidden-state changes stay on the stable action instance so
-     * Overflow receives its existing `actionVisibilityChange` signal instead of an action-group
-     * replacement.
-     *
-     * **The opt-in gates policy synchronization, not only projection and dispatch.** `pin` is a
-     * reserved engine name exactly while {@link #enableDockPinAction} is on — that is the contract
-     * {@link #getDockProjectionOptions} states and the throw it enforces. While the flag is off the
-     * name belongs to whoever projected it through `resolveDockHeaderActions`, so resolving it here
-     * would let a disabled engine action move a host's `hidden` on every active-item change and
-     * reconciliation sweep. Default-off has to mean behaviorally inert, not merely unprojected.
-     * @param {Neo.tab.Container|null} tabContainer
-     * @protected
-     */
-    syncDockPinAction(tabContainer) {
-        if (!this.enableDockPinAction) return;
-
-        let action = tabContainer?.getActionItem?.('pin'),
-            itemId = this.getActiveDockItemId(tabContainer),
-            model  = this.dockModel,
-            hidden = !itemId
-                || model?.items?.[itemId]?.pinnable === false
-                || !model
-                || !WorkspaceDocument.findOwningEdge(model, itemId);
-
-        action && (action.hidden = hidden)
     }
 
     /**
@@ -2080,7 +1862,7 @@ class Workspace extends Container {
                 }
             } while (!me.isDestroyed && me.refreshPromise !== awaited);
 
-            !me.isDestroyed && me.syncDockHeaderActions()
+            !me.isDestroyed && me.dockHeaderActionPolicy.syncAll()
         }).catch(() => null)
     }
 
@@ -2095,38 +1877,6 @@ class Workspace extends Container {
         super.afterSetWindowId(value, oldValue);
 
         return this.observeBoundWindowGeometry(value)
-    }
-
-    /**
-     * Synchronizes every projected engine header action after reconciliation, including retained tabs
-     * whose action instance outlived a model-policy or active-item change.
-     *
-     * Walks the SETTLED shell, never a map handed in from the reconciler: that map is the OLD shell's
-     * tabs (`Reconciler.collectProjectedTabs(oldShell)`), so a node the projection just CREATED — a
-     * railed item pinned back into flow, a fresh boot's placeholders — is not in it, and `reload`'s
-     * availability, projected as a constant `hidden: true` by the stable-instance rule, is revealed
-     * by nothing else. Every write below is change-guarded, so re-walking retained nodes is idempotent.
-     *
-     * Each action's own sync guards on its own opt-in and is a no-op when the action was never
-     * projected — the opt-in guard is load-bearing, not redundant: a host may legally own an
-     * engine action NAME while that engine flag is off (the reserved-name guard fires only for
-     * enabled actions), and `getActionItem` finds the host's action by name. Without the guard,
-     * this sweep would rewrite consumer-owned action state.
-     * @protected
-     */
-    syncDockHeaderActions() {
-        let me    = this,
-            shell = me.getDockHost()?.items?.[me.dockShellIndex];
-
-        shell && Reconciler.collectProjectedTabs(shell).forEach(tab => {
-            me.syncDockCloseAction(tab);
-            me.syncDockLockAction(tab);
-            me.syncDockPinAction(tab);
-            me.syncDockPopOutAction(tab);
-            me.syncDockReloadAction(tab)
-        });
-
-        me.enableDockLockAction && me.syncDockLockRails()
     }
 
     /**
@@ -2148,14 +1898,12 @@ class Workspace extends Container {
             committed = me.dockModel?.nodes?.[dockNodeId]?.activeItemId,
             descriptor, result;
 
-        me.syncDockCloseAction(container);
-        me.syncDockLockAction(container);
-        me.syncDockPinAction(container);
+        me.dockHeaderActionPolicy.syncActiveItem(container);
 
         if (!me.dockModel || !itemId || committed === itemId) {
             // No commit follows (a reconciliation re-emit, or no model): this sync is the only
             // writer of the reload action's per-item state for this activation.
-            me.syncDockReloadAction(container);
+            me.dockHeaderActionPolicy.syncReloadAction(container);
             return null
         }
 
@@ -2314,8 +2062,8 @@ class Workspace extends Container {
 
         if (result && !result.errors?.length && result.document) {
             me.onDockZoneDocumentChange(result.document, descriptor, tabContainer);
-            me.syncDockCloseAction(tabContainer);
-            me.syncDockLockAction(tabContainer)
+            me.dockHeaderActionPolicy.syncCloseAction(tabContainer);
+            me.dockHeaderActionPolicy.syncLockAction(tabContainer)
         }
 
         return result
@@ -2482,7 +2230,7 @@ class Workspace extends Container {
      * pinned pane commits twice.
      *
      * **Eligibility is re-derived here, from the current document, and not inherited from the chrome
-     * that emitted the intent.** {@link #syncDockPinAction} hides the action wherever no edge owns the
+     * that emitted the intent.** {@link Neo.dashboard.dock.projection.HeaderActionPolicy#syncPinAction} hides the action wherever no edge owns the
      * item, but that visibility is a projection of the document as it stood at the last sweep, and the
      * sweep is deferred behind reconciliation. Between a commit that moves an item to the root center
      * and the refresh that re-hides its action, a retained-but-stale action is still visible and still
@@ -2544,7 +2292,7 @@ class Workspace extends Container {
      * (`{dockNodeId, itemId, errors}`), because the action wire has no result channel
      * (`Observable.fire` discards listener returns). A failing `dockReload()` keeps the pane,
      * always. One invocation per item may be in flight; the action's `disabled` state derives
-     * from the ACTIVE item's in-flight membership through {@link #syncDockReloadAction} — both
+     * from the ACTIVE item's in-flight membership through {@link Neo.dashboard.dock.projection.HeaderActionPolicy#syncReloadAction} — both
      * at the flight edges here and on every active-item change — so switching panes mid-flight
      * never inherits another item's window. Teardown mid-flight settles terminally through
      * `core.Base#trap`: destroy rejects the trapped delegation even when the pane's producer
@@ -2603,7 +2351,7 @@ class Workspace extends Container {
             recreated?.errors?.length && errors.push(...recreated.errors)
         } else {
             me.dockReloadInFlight.add(itemId);
-            me.syncDockReloadAction(tabContainer);
+            me.dockHeaderActionPolicy.syncReloadAction(tabContainer);
 
             try {
                 // trap() is the engine-native teardown race: destroy rejects every registered
@@ -2629,59 +2377,13 @@ class Workspace extends Container {
             // beside a reconcile) — a settlement is not latency-sensitive, and the post-reconcile
             // sweep re-derives the same truth anyway when a commit is what changed the item.
             (me.refreshPromise?.catch(() => {}) || Promise.resolve()).then(() => {
-                !me.isDestroyed && me.syncDockReloadAction(tabContainer)
+                !me.isDestroyed && me.dockHeaderActionPolicy.syncReloadAction(tabContainer)
             })
         }
 
         !me.isDestroyed && me.fire('dockReloadSettled', {dockNodeId, errors, itemId});
 
         return {errors}
-    }
-
-    /**
-     * Synchronizes one retained reload action against the live active pane, owning BOTH state
-     * axes: `hidden` while no active item resolves, or while neither path can serve it — no
-     * `dockReload()` contract on the active card AND the host declared no recreate through
-     * {@link #hasDockRecreateFallback}; `disabled` while the ACTIVE item — not whichever item started
-     * a flight — has a reload or recreate in flight. Deriving both here (called at the flight edges and
-     * on every active-item change) is what keeps per-item single-flight and the one node-level
-     * action instance consistent when the active item changes mid-flight. The contract probe is
-     * pure — a `typeof` on the card instance, or on its config's `module` prototype while the
-     * card container has not instantiated the slot yet (the post-reconcile sync runs before
-     * card children materialize) — never a resolver call, which may be side-effectful.
-     * @param {Neo.tab.Container|null} tabContainer
-     * @protected
-     */
-    syncDockReloadAction(tabContainer) {
-        // Opt-in guard first (the pin precedent): while the engine flag is off, a host may own
-        // the semantic name `reload` — getActionItem() would find THAT action, and writing to it
-        // here would overwrite consumer-owned state. Default-off means behaviorally inert.
-        if (!this.enableDockReloadAction) return;
-
-        let action   = tabContainer?.getActionItem?.('reload'),
-            itemId   = this.getActiveDockItemId(tabContainer),
-            disabled = false,
-            hidden   = true;
-
-        if (action && itemId) {
-            let itemIds = tabContainer.getTabBar()?.sortZoneConfig?.dockItemIds || [],
-                index   = itemIds.indexOf(itemId),
-                pane    = index > -1 ? tabContainer.getCard(index) : null,
-                carrier = pane?.isDestroyed ? null : (pane?.dockReload ?? pane?.module?.prototype?.dockReload);
-
-            disabled = this.dockReloadInFlight.has(itemId) || this.dockRecreateInFlight.has(itemId);
-
-            // An absent delegation hook no longer hides the action on its own: the recreate
-            // fallback serves exactly those panes, so hiding them would hide the only recovery
-            // they have. Hidden only when NEITHER path can serve the item.
-            hidden = typeof carrier !== 'function' && !this.hasDockRecreateFallback()
-        }
-
-        // ONE batched update for both axes (`set()`), never two sequential writes: each write
-        // opens its own vdom round trip on the tab bar, and stacked in-flight bar updates racing
-        // a following reconcile is exactly the collision that duplicated retained chrome on slow
-        // rigs.
-        action?.set({disabled, hidden})
     }
 
     /**
@@ -2934,7 +2636,7 @@ class Workspace extends Container {
         // A currently revealed rail pane is retained outside tab chrome. It already exists at the
         // commit boundary, so lock presentation follows the sole worker-truth write immediately;
         // the post-reconcile sweep repeats this for newly materialized/retained surfaces.
-        me.enableDockLockAction && me.syncDockLockRails?.();
+        me.dockHeaderActionPolicy?.syncLockRails();
 
         me.refreshPromise = tail
             .then(() => me.timeout(0))
@@ -3034,7 +2736,7 @@ class Workspace extends Container {
                 onDockZoneDocumentChange : me.onDockZoneDocumentChange.bind(me),
                 resolveComponentRef      : itemResolver || ((componentRef, item, itemId) => me.resolveProjectedPane(itemId, item)),
                 resolveRevealComponentRef: (componentRef, item, itemId) => me.decorateFlipMarker(me.resolveRevealPane(itemId, item), itemId),
-                syncDockLockPane         : (pane, itemId) => me.syncDockLockItemPresentation({
+                syncDockLockPane         : (pane, itemId) => me.dockHeaderActionPolicy.syncLockItemPresentation({
                     locked: me.dockModel?.items?.[itemId]?.locked === true,
                     pane
                 }),
@@ -3236,14 +2938,14 @@ class Workspace extends Container {
             // application: a bar write with the refresh's own update train still open is the
             // collision that duplicated retained chrome on slow rigs. Every write is
             // change-guarded, so post-settle is both the safe and the idempotent slot.
-            me.syncDockHeaderActions();
+            me.dockHeaderActionPolicy.syncAll();
 
             // Once more on SETTLED chrome: the pre-settle sync above can run while projected
             // header actions are still instantiating (a fresh boot's first refresh), and a
             // pane-dependent action state (reload's contract probe) corrected on chrome that
             // does not exist yet is a correction nobody received. Every write in the sync is
             // change-guarded, so re-running it on settled chrome is idempotent.
-            me.syncDockHeaderActions()
+            me.dockHeaderActionPolicy.syncAll()
         }
     }
 
@@ -3378,7 +3080,7 @@ class Workspace extends Container {
      * wires one: {@link #resolveFreshPane} delegates to {@link #resolvePane}, so the default answers
      * `true` and a pane without `dockReload()` keeps its reload action.
      *
-     * Never calls the factory: {@link #syncDockReloadAction} consults this on every active-item
+     * Never calls the factory: {@link Neo.dashboard.dock.projection.HeaderActionPolicy#syncReloadAction} consults this on every active-item
      * change, and minting a pane to decide whether to show a button would be a side effect.
      *
      * Override to `false` to declare this host serves no recreate; the action then hides for every

--- a/src/dashboard/dock/Workspace.mjs
+++ b/src/dashboard/dock/Workspace.mjs
@@ -232,7 +232,9 @@ class Workspace extends Container {
          * The header-action presentation policy: which engine action is shown, enabled or pressed
          * for which pane, re-derived onto the retained action instances after every commit and
          * active-item change. Resolved to one instance bound to this workspace — a module config or
-         * an instance replaces the engine policy without overriding workspace methods.
+         * an instance replaces the engine policy without overriding workspace methods, at
+         * construction or live: the replacement inherits the retiring policy's lock-restore memory
+         * before that policy is destroyed, so a lock held across the swap still unwinds exactly.
          * @member {Neo.dashboard.dock.projection.HeaderActionPolicy|Object|null} dockHeaderActionPolicy_=null
          * @reactive
          */
@@ -1578,13 +1580,18 @@ class Workspace extends Container {
     }
 
     /**
-     * A replaced policy retires, and its lock-presentation memory with it.
+     * A replaced policy hands its lock-presentation memory to the replacement and retires. The
+     * memory is keyed by panes and tab buttons that outlive the policy, so a swap while a lock is
+     * held must not lose the record of what that lock changed — the next unlock reverses along it.
      * @param {Neo.dashboard.dock.projection.HeaderActionPolicy} value
      * @param {Neo.dashboard.dock.projection.HeaderActionPolicy|null} oldValue
      * @protected
      */
     afterSetDockHeaderActionPolicy(value, oldValue) {
-        oldValue?.destroy()
+        if (oldValue && oldValue !== value) {
+            value.inheritRestoreState(oldValue);
+            oldValue.destroy()
+        }
     }
 
     /**

--- a/src/dashboard/dock/projection/HeaderActionPolicy.mjs
+++ b/src/dashboard/dock/projection/HeaderActionPolicy.mjs
@@ -25,7 +25,10 @@ import WorkspaceDocument from '../model/WorkspaceDocument.mjs';
  * `getActiveDockItemId()`, `dockPopOutActionActive`, `dockReloadInFlight`, `dockRecreateInFlight`,
  * `hasDockRecreateFallback()`, `forEachDockRail()`, `getDockHost()` and `dockShellIndex`. The
  * workspace resolves one instance through its `dockHeaderActionPolicy` config, so a consumer
- * replaces the policy with one config rather than overriding workspace methods.
+ * replaces the policy with one config rather than overriding workspace methods — at construction
+ * or live: a replacement inherits the retiring policy's restore memory
+ * ({@link #inheritRestoreState}) before the workspace destroys it, so a lock the old policy
+ * applied unwinds through the new one.
  *
  * @class Neo.dashboard.dock.projection.HeaderActionPolicy
  * @extends Neo.core.Base
@@ -61,7 +64,23 @@ class HeaderActionPolicy extends Base {
     lockDragState = new WeakMap()
 
     /**
-     * Releases the workspace reference; the WeakMaps retire with the instance.
+     * Takes over the exact-restore memory of the policy this instance replaces. The memory is
+     * keyed by the live panes and tab buttons — components that outlive the policy that locked
+     * them — so a replacement installed while a lock is held must inherit it, or the next unlock
+     * would find empty maps and leave a pane inert, a tab button disarmed, or a delegated
+     * `dockLock(true)` without its `false`. The maps transfer whole; nothing is copied.
+     * @param {Neo.dashboard.dock.projection.HeaderActionPolicy|null} previous
+     */
+    inheritRestoreState(previous) {
+        if (!previous || previous === this) return;
+
+        this.lockPaneState = previous.lockPaneState;
+        this.lockDragState = previous.lockDragState
+    }
+
+    /**
+     * Releases the workspace reference; the WeakMaps retire with the instance unless a
+     * replacement inherited them first ({@link #inheritRestoreState}).
      * @param {...*} args
      */
     destroy(...args) {

--- a/src/dashboard/dock/projection/HeaderActionPolicy.mjs
+++ b/src/dashboard/dock/projection/HeaderActionPolicy.mjs
@@ -1,0 +1,407 @@
+import Base              from '../../../core/Base.mjs';
+import NeoArray          from '../../../util/Array.mjs';
+import Reconciler        from './Reconciler.mjs';
+import WorkspaceDocument from '../model/WorkspaceDocument.mjs';
+
+/**
+ * @summary The header-action presentation policy of a dock workspace: which engine action is
+ * shown, enabled or pressed for which pane in which committed state, re-derived onto the retained
+ * action instances after every commit and every active-item change.
+ *
+ * Membership is owned elsewhere — `toolbar.Base#getActionItems` and `tab.header.Toolbar#isTabButton`
+ * decide which actions exist, and the projection emits them once as a constant row. This class owns
+ * the second layer: reading committed truth and runtime state and writing `hidden` / `disabled` /
+ * `pressed` onto the instance that survives re-projection, so the Overflow plugin receives its
+ * existing `actionVisibilityChange` signal instead of an action-group replacement. Every write is
+ * change-guarded, so re-walking retained nodes is idempotent. Command execution stays with the
+ * workspace: its `onDockHeaderAction` router and `handleDock*Action` handlers are the mutation
+ * boundary this policy reads the results of.
+ *
+ * The state this class owns is the lock presentation's exact-restore memory — which panes it made
+ * inert and what they owned before, which tab buttons it disarmed — so an unlock reverses along the
+ * path that locked and never hands a pane an unlock it never received a lock for.
+ *
+ * The workspace surface it reads, and nothing more: `dockModel`, the `enableDock*Action` opt-ins,
+ * `getActiveDockItemId()`, `dockPopOutActionActive`, `dockReloadInFlight`, `dockRecreateInFlight`,
+ * `hasDockRecreateFallback()`, `forEachDockRail()`, `getDockHost()` and `dockShellIndex`. The
+ * workspace resolves one instance through its `dockHeaderActionPolicy` config, so a consumer
+ * replaces the policy with one config rather than overriding workspace methods.
+ *
+ * @class Neo.dashboard.dock.projection.HeaderActionPolicy
+ * @extends Neo.core.Base
+ */
+class HeaderActionPolicy extends Base {
+    static config = {
+        /**
+         * @member {String} className='Neo.dashboard.dock.projection.HeaderActionPolicy'
+         * @protected
+         */
+        className: 'Neo.dashboard.dock.projection.HeaderActionPolicy',
+        /**
+         * The workspace whose header actions this policy presents.
+         * @member {Neo.dashboard.dock.Workspace|null} workspace=null
+         */
+        workspace: null
+    }
+
+    /**
+     * Exact pre-lock root-inert snapshots keyed by the live pane instance:
+     * `{owned:Boolean, value:*}`. A WeakMap cannot prolong a retired pane's lifetime.
+     * @member {WeakMap<Neo.component.Base,Object>} lockPaneState=new WeakMap()
+     * @protected
+     */
+    lockPaneState = new WeakMap()
+
+    /**
+     * Whether each live tab button owned the SortZone's `neo-draggable` token before lock
+     * suppressed it. Unlock restores that exact ownership instead of globally arming drag.
+     * @member {WeakMap<Neo.component.Base,Boolean>} lockDragState=new WeakMap()
+     * @protected
+     */
+    lockDragState = new WeakMap()
+
+    /**
+     * Releases the workspace reference; the WeakMaps retire with the instance.
+     * @param {...*} args
+     */
+    destroy(...args) {
+        this.workspace = null;
+        super.destroy(...args)
+    }
+
+    /**
+     * Synchronizes every projected engine header action after reconciliation, including retained tabs
+     * whose action instance outlived a model-policy or active-item change.
+     *
+     * Walks the SETTLED shell, never a map handed in from the reconciler: that map is the OLD shell's
+     * tabs (`Reconciler.collectProjectedTabs(oldShell)`), so a node the projection just CREATED — a
+     * railed item pinned back into flow, a fresh boot's placeholders — is not in it, and `reload`'s
+     * availability, projected as a constant `hidden: true` by the stable-instance rule, is revealed
+     * by nothing else. Every write below is change-guarded, so re-walking retained nodes is idempotent.
+     *
+     * Each action's own sync guards on its own opt-in and is a no-op when the action was never
+     * projected — the opt-in guard is load-bearing, not redundant: a host may legally own an
+     * engine action NAME while that engine flag is off (the reserved-name guard fires only for
+     * enabled actions), and `getActionItem` finds the host's action by name. Without the guard,
+     * this sweep would rewrite consumer-owned action state.
+     */
+    syncAll() {
+        let me          = this,
+            {workspace} = me,
+            shell       = workspace?.getDockHost()?.items?.[workspace.dockShellIndex];
+
+        shell && Reconciler.collectProjectedTabs(shell).forEach(tab => {
+            me.syncCloseAction(tab);
+            me.syncLockAction(tab);
+            me.syncPinAction(tab);
+            me.syncPopOutAction(tab);
+            me.syncReloadAction(tab)
+        });
+
+        workspace?.enableDockLockAction && me.syncLockRails()
+    }
+
+    /**
+     * Synchronizes the actions whose answer depends on which item is active: close, lock and pin.
+     * The reload action is synced separately by the caller, because on the commit path the
+     * post-reconcile sweep is its writer.
+     * @param {Neo.tab.Container|null} tabContainer
+     */
+    syncActiveItem(tabContainer) {
+        this.syncCloseAction(tabContainer);
+        this.syncLockAction(tabContainer);
+        this.syncPinAction(tabContainer)
+    }
+
+    /**
+     * Synchronizes one retained close action against the live active item and committed policy.
+     * Hidden-state changes stay on the stable action instance so Overflow receives its existing
+     * `actionVisibilityChange` signal instead of an action-group replacement.
+     *
+     * Gated on the workspace's `enableDockCloseAction` for the reason given on {@link #syncPinAction}:
+     * the name is only the engine's while its own opt-in is on.
+     * @param {Neo.tab.Container|null} tabContainer
+     */
+    syncCloseAction(tabContainer) {
+        let {workspace} = this;
+
+        if (!workspace?.enableDockCloseAction) return;
+
+        let action = tabContainer?.getActionItem?.('close'),
+            itemId = workspace.getActiveDockItemId(tabContainer),
+            item   = workspace.dockModel?.items?.[itemId],
+            hidden = !itemId || item?.closable === false || item?.locked === true;
+
+        action && (action.hidden = hidden)
+    }
+
+    /**
+     * @summary Re-evaluates the retained pop-out action against current truth after every commit.
+     *
+     * Pop-out was the one engine action with no sync. Its `hidden` is projected once as
+     * `!activeItemId || !dockPopOutActionAvailable` and then lives on a RETAINED action instance
+     * that survives re-projection, so nothing ever recomputed it: the control was correct at boot
+     * and silently gone after the first layout commit. For a consumer whose reason to be here is
+     * multi-window, the feature disappeared until reload.
+     *
+     * Mirrors the projected expression from the same reader (`dockPopOutActionActive`), so the
+     * projected and the synced answer cannot drift. Change-guarded like its siblings, so re-walking
+     * retained nodes stays idempotent.
+     * @param {Neo.tab.Container} tabContainer
+     */
+    syncPopOutAction(tabContainer) {
+        let {workspace} = this;
+
+        if (!workspace?.enableDockPopOutAction) return;
+
+        let action = tabContainer?.getActionItem?.('pop-out'),
+            itemId = workspace.getActiveDockItemId(tabContainer),
+            hidden = !itemId || !workspace.dockPopOutActionActive;
+
+        action && (action.hidden = hidden)
+    }
+
+    /**
+     * Synchronizes the retained lock action and every projected pane/button against committed
+     * item truth. The action stays one stable instance; per-item hidden/icon state moves on it.
+     *
+     * Presentation is deliberately a second layer beneath the model guards. Lock stamps
+     * `vdom.inert` plus `neo-dock-pane-locked` in one pane update and removes only the tab
+     * button's `neo-draggable` source token. Unlock restores the exact prior inert ownership/value
+     * and exact prior drag-token ownership. Locked headers remain legal drop targets. The ordinary
+     * lock gesture is focus-gated; once the protective state persists, its unlock reversal becomes
+     * persistent too, so discoverability never depends on re-entering a transient focus context.
+     * @param {Neo.tab.Container|null} tabContainer
+     */
+    syncLockAction(tabContainer) {
+        let me          = this,
+            {workspace} = me;
+
+        if (!workspace?.enableDockLockAction || !tabContainer) return;
+
+        let {items} = workspace.dockModel || {},
+            bar     = tabContainer.getTabBar(),
+            action  = tabContainer.getActionItem('lock'),
+            itemId  = workspace.getActiveDockItemId(tabContainer),
+            item    = items?.[itemId],
+            locked  = item?.locked === true;
+
+        // ONE write of WHAT is true. The action owns the icon / accessible name / tooltip mapping
+        // (`toolbar.ActionButton#afterSetPressed`) and the toolbar derives the focus gate from
+        // `pressed`, so nothing here states how the control should look.
+        action?.set({
+            hidden : !itemId || item?.lockable === false,
+            pressed: locked
+        });
+
+        // Buttons are addressed by identity, never by position: `tab.plugin.Overflow` removes
+        // overflowing buttons from this collection by design, so `buttons[index]` can name a
+        // different item than `dockItemIds[index]` does.
+        let buttons = tabContainer.getTabButtons(),
+            panes   = tabContainer.getCardContainer().items;
+
+        bar.sortZoneConfig?.dockItemIds?.forEach((id, index) => {
+            me.syncLockItemPresentation({
+                button: buttons.find(button => button.dockItemId === id) || null,
+                locked: items?.[id]?.locked === true,
+                pane  : panes[index]
+            })
+        })
+    }
+
+    /**
+     * Applies or restores one item's lock presentation without changing model state.
+     *
+     * The content half is delegable, the reload precedent: a pane implementing
+     * `dockLock(locked)` owns what locked means for its content — a form disables its fields, a
+     * grid turns cell editing off, a stream keeps scrolling — and the engine writes no `inert` for
+     * it. The probe is a pure `typeof` on the live card, never a resolver call. The hook fires
+     * once per transition, recorded in the same per-pane state as the inert snapshot, so a sweep
+     * that runs on every active-item change never re-locks a pane its author already locked.
+     * Without the hook the engine's inert default stands, byte-identical, with its exact-restore
+     * clause.
+     * @param {Object} data
+     * @param {Neo.tab.header.Button|null} data.button
+     * @param {Boolean} data.locked
+     * @param {Neo.component.Base|null} data.pane
+     */
+    syncLockItemPresentation({button, locked, pane}={}) {
+        let me = this;
+
+        if (pane && !pane.isDestroyed) {
+            let {vdom}  = pane,
+                held    = me.lockPaneState.get(pane),
+                changed = false,
+                prior;
+
+            if (locked && !held) {
+                if (typeof pane.dockLock === 'function') {
+                    me.lockPaneState.set(pane, {delegated: true});
+                    pane.dockLock(true)
+                } else {
+                    me.lockPaneState.set(pane, {owned: Object.hasOwn(vdom, 'inert'), value: vdom.inert});
+                    changed    = vdom.inert !== true;
+                    vdom.inert = true
+                }
+            } else if (!locked && held) {
+                prior = held;
+                me.lockPaneState.delete(pane);
+
+                // Reverse along the path that locked: the record decides, never the current probe,
+                // so a pane cannot be handed an unlock it never received a lock for.
+                if (prior.delegated) {
+                    pane.dockLock(false)
+                } else {
+                    prior.owned ? (vdom.inert = prior.value) : delete vdom.inert;
+                    changed = true
+                }
+            }
+
+            if (pane.cls?.includes('neo-dock-pane-locked') !== locked) {
+                let cls = [...pane.cls || []];
+
+                NeoArray.toggle(cls, 'neo-dock-pane-locked', locked);
+                pane.setSilent({cls});
+                changed = true
+            }
+
+            changed && pane.update()
+        }
+
+        if (button && !button.isDestroyed) {
+            let was = button.wrapperCls?.includes('neo-draggable'),
+                next;
+
+            if (locked) {
+                !me.lockDragState.has(button) && me.lockDragState.set(button, was);
+                next = false
+            } else if (me.lockDragState.has(button)) {
+                next = me.lockDragState.get(button);
+                me.lockDragState.delete(button)
+            } else {
+                return
+            }
+
+            if (was !== next) {
+                let cls = [...button.wrapperCls];
+
+                NeoArray.toggle(cls, 'neo-draggable', next);
+                button.wrapperCls = cls
+            }
+        }
+    }
+
+    /**
+     * Synchronizes the currently materialized rail-reveal panes against committed lock truth.
+     *
+     * Rails are synthetic affordances retained across stable-topology reconciliation, so their
+     * projection config is not a state-update channel. The materialization callback covers first
+     * reveal; this sweep covers a lock transition while the same overlay remains open. Dismissed
+     * cached panes restore on their next materialization callback.
+     */
+    syncLockRails() {
+        let me          = this,
+            {workspace} = me;
+
+        if (!workspace?.enableDockLockAction) return;
+
+        let {items} = workspace.dockModel || {};
+
+        workspace.forEachDockRail(({revealOverlay}) => {
+            let pane = revealOverlay?.paneSlot.items[0];
+
+            pane && me.syncLockItemPresentation({
+                locked: items?.[revealOverlay.revealPaneItemId]?.locked === true,
+                pane
+            })
+        })
+    }
+
+    /**
+     * Synchronizes one retained pin action against the live active item and committed policy.
+     *
+     * Hidden wherever the collapse could not complete, so the header never offers a gesture the model
+     * or the projection would refuse: no active item, `pinnable: false` (which
+     * {@link Neo.dashboard.dock.model.Operations#setItemAutoHidden} rejects), or an item no edge owns
+     * (§2.7 — center never rails). The edge answer comes from
+     * {@link Neo.dashboard.dock.model.WorkspaceDocument#findOwningEdge}, the same derivation the projection
+     * rails by, so the action cannot disagree with the rail it would collapse into.
+     *
+     * Like {@link #syncCloseAction}, hidden-state changes stay on the stable action instance so
+     * Overflow receives its existing `actionVisibilityChange` signal instead of an action-group
+     * replacement.
+     *
+     * **The opt-in gates policy synchronization, not only projection and dispatch.** `pin` is a
+     * reserved engine name exactly while the workspace's `enableDockPinAction` is on — that is the
+     * contract `Workspace#getDockProjectionOptions` states and the throw it enforces. While the flag
+     * is off the name belongs to whoever projected it through `resolveDockHeaderActions`, so
+     * resolving it here would let a disabled engine action move a host's `hidden` on every
+     * active-item change and reconciliation sweep. Default-off has to mean behaviorally inert, not
+     * merely unprojected.
+     * @param {Neo.tab.Container|null} tabContainer
+     */
+    syncPinAction(tabContainer) {
+        let {workspace} = this;
+
+        if (!workspace?.enableDockPinAction) return;
+
+        let action = tabContainer?.getActionItem?.('pin'),
+            itemId = workspace.getActiveDockItemId(tabContainer),
+            model  = workspace.dockModel,
+            hidden = !itemId
+                || model?.items?.[itemId]?.pinnable === false
+                || !model
+                || !WorkspaceDocument.findOwningEdge(model, itemId);
+
+        action && (action.hidden = hidden)
+    }
+
+    /**
+     * Synchronizes one retained reload action against the live active pane, owning BOTH state
+     * axes: `hidden` while no active item resolves, or while neither path can serve it — no
+     * `dockReload()` contract on the active card AND the host declared no recreate through
+     * `Workspace#hasDockRecreateFallback`; `disabled` while the ACTIVE item — not whichever item
+     * started a flight — has a reload or recreate in flight. Deriving both here (called at the
+     * flight edges and on every active-item change) is what keeps per-item single-flight and the one
+     * node-level action instance consistent when the active item changes mid-flight. The contract
+     * probe is pure — a `typeof` on the card instance, or on its config's `module` prototype while
+     * the card container has not instantiated the slot yet (the post-reconcile sync runs before
+     * card children materialize) — never a resolver call, which may be side-effectful.
+     * @param {Neo.tab.Container|null} tabContainer
+     */
+    syncReloadAction(tabContainer) {
+        let {workspace} = this;
+
+        // Opt-in guard first (the pin precedent): while the engine flag is off, a host may own
+        // the semantic name `reload` — getActionItem() would find THAT action, and writing to it
+        // here would overwrite consumer-owned state. Default-off means behaviorally inert.
+        if (!workspace?.enableDockReloadAction) return;
+
+        let action   = tabContainer?.getActionItem?.('reload'),
+            itemId   = workspace.getActiveDockItemId(tabContainer),
+            disabled = false,
+            hidden   = true;
+
+        if (action && itemId) {
+            let itemIds = tabContainer.getTabBar()?.sortZoneConfig?.dockItemIds || [],
+                index   = itemIds.indexOf(itemId),
+                pane    = index > -1 ? tabContainer.getCard(index) : null,
+                carrier = pane?.isDestroyed ? null : (pane?.dockReload ?? pane?.module?.prototype?.dockReload);
+
+            disabled = workspace.dockReloadInFlight.has(itemId) || workspace.dockRecreateInFlight.has(itemId);
+
+            // An absent delegation hook no longer hides the action on its own: the recreate
+            // fallback serves exactly those panes, so hiding them would hide the only recovery
+            // they have. Hidden only when NEITHER path can serve the item.
+            hidden = typeof carrier !== 'function' && !workspace.hasDockRecreateFallback()
+        }
+
+        // ONE batched update for both axes (`set()`), never two sequential writes: each write
+        // opens its own vdom round trip on the tab bar, and stacked in-flight bar updates racing
+        // a following reconcile is exactly the collision that duplicated retained chrome on slow
+        // rigs.
+        action?.set({disabled, hidden})
+    }
+}
+
+export default Neo.setupClass(HeaderActionPolicy);

--- a/src/dashboard/dock/projection/LayoutAdapter.mjs
+++ b/src/dashboard/dock/projection/LayoutAdapter.mjs
@@ -1077,7 +1077,7 @@ class LayoutAdapter extends Base {
         // invite a per-item action LIST, and a list that changes between projections replaces the
         // action group — destroying the stable instances `actionVisibilityChange` consumers such as
         // tab Overflow depend on. The engine's own close action varies per active item without that
-        // cost by keeping one instance and moving `hidden` (`Workspace#syncDockCloseAction`); a host
+        // cost by keeping one instance and moving `hidden` (`HeaderActionPolicy#syncCloseAction`); a host
         // needing per-item behaviour has the same mechanism, on actions it owns.
         const hostActions = context.resolveDockHeaderActions?.(nodeId) || [],
               seen        = new Set(),
@@ -1146,7 +1146,7 @@ class LayoutAdapter extends Base {
             // Reload follows lock in the frozen family order (lock · reload · pin · maximize — close
             // always last). Not a toggle, so the icon is fixed like pin's. `hidden` is a
             // CONSTANT true here — per-item availability must ride the ONE retained instance's
-            // runtime state (`Workspace#syncDockReloadAction`, the `syncDockCloseAction`
+            // runtime state (`HeaderActionPolicy#syncReloadAction`, the `syncCloseAction`
             // pattern), never this config: a row that varies between projections changes the
             // actions array, and replacing the action group mid-reconcile is exactly what the
             // stable-instance note below forbids. Fresh boots reveal through the workspace's
@@ -1169,7 +1169,7 @@ class LayoutAdapter extends Base {
                 // collapse the model or the projection would refuse: no active item, an item whose
                 // policy forbids pinning (`Operations.setItemAutoHidden` rejects `pinnable: false`),
                 // or a center-owned item (§2.7 — center never rails, main content does not auto-hide).
-                // `Workspace#syncDockPinAction` recomputes exactly this on every active-item change.
+                // `HeaderActionPolicy#syncPinAction` recomputes exactly this on every active-item change.
                 hidden    : !activeItemId
                     || context.items[activeItemId]?.pinnable === false
                     || !WorkspaceDocument.findOwningEdge({nodes: context.nodes}, activeItemId),

--- a/test/playwright/component/apps/dock-static-boot/app.mjs
+++ b/test/playwright/component/apps/dock-static-boot/app.mjs
@@ -1,6 +1,7 @@
-import Component     from '../../../../../src/component/Base.mjs';
-import DockWorkspace from '../../../../../src/dashboard/dock/Workspace.mjs';
-import Viewport      from '../../../../../src/container/Viewport.mjs';
+import Component          from '../../../../../src/component/Base.mjs';
+import DockWorkspace      from '../../../../../src/dashboard/dock/Workspace.mjs';
+import HeaderActionPolicy from '../../../../../src/dashboard/dock/projection/HeaderActionPolicy.mjs';
+import Viewport           from '../../../../../src/container/Viewport.mjs';
 import '../../../../../src/tab/Container.mjs';
 
 /**
@@ -23,6 +24,27 @@ class ContractPane extends Component {
 }
 
 ContractPane = Neo.setupClass(ContractPane);
+
+/**
+ * @summary The engine policy, counting its sweeps on the workspace: the spec asserts the absence
+ * of a write, not merely the absence of a rendered symptom — a hidden action and an un-run sweep
+ * look identical in the DOM.
+ */
+class CountingSweepPolicy extends HeaderActionPolicy {
+    static config = {
+        className: 'Test.Playwright.Component.DockStaticBoot.CountingSweepPolicy'
+    }
+
+    /**
+     * @returns {*}
+     */
+    syncAll() {
+        this.workspace.sweepCount++;
+        return super.syncAll()
+    }
+}
+
+CountingSweepPolicy = Neo.setupClass(CountingSweepPolicy);
 
 const staticDocument = {
     schema: 'neo.dock.zone.v1',
@@ -106,7 +128,13 @@ class StaticBootFixtureWorkspace extends DockWorkspace {
          * await. The spec polls this instead of sleeping.
          * @member {Boolean} tailReplaced=false
          */
-        tailReplaced_: false
+        tailReplaced_: false,
+        /**
+         * The counting policy stands in for the engine default through the one seam a consumer
+         * replaces it by.
+         * @member {Object} dockHeaderActionPolicy={module: CountingSweepPolicy}
+         */
+        dockHeaderActionPolicy: {module: CountingSweepPolicy}
     }
 
     /**
@@ -114,16 +142,6 @@ class StaticBootFixtureWorkspace extends DockWorkspace {
      * @member {Function|null} releaseTail=null
      */
     releaseTail = null
-
-    /**
-     * Counts real sweeps so the spec can assert the absence of a write, not merely the absence of
-     * a rendered symptom — a hidden action and an un-run sweep look identical in the DOM.
-     * @returns {*}
-     */
-    syncDockHeaderActions() {
-        this.sweepCount++;
-        return super.syncDockHeaderActions()
-    }
 
     /**
      * Installs the self-replacing tail AFTER the hook has sampled, so the sweep is already

--- a/test/playwright/unit/dashboard/DockLockAction.spec.mjs
+++ b/test/playwright/unit/dashboard/DockLockAction.spec.mjs
@@ -262,7 +262,7 @@ test.describe('Neo.dashboard.dock.Workspace lock action', () => {
 
         expect(Object.hasOwn(pane.vdom, 'inert')).toBe(false);
 
-        workspace.syncDockHeaderActions();
+        workspace.dockHeaderActionPolicy.syncAll();
 
         expect(pane.vdom.inert).toBe(true);
         expect(pane.cls).toContain('neo-dock-pane-locked')
@@ -285,7 +285,7 @@ test.describe('Neo.dashboard.dock.Workspace lock action', () => {
 
         pane.vdom.inert = false;
         tabButton.addWrapperCls('neo-draggable');
-        workspace.syncDockHeaderActions();
+        workspace.dockHeaderActionPolicy.syncAll();
 
         expect(tabButton.wrapperCls).toContain('neo-draggable');
 
@@ -371,8 +371,8 @@ test.describe('Neo.dashboard.dock.Workspace lock action', () => {
         expect(closeAction.hidden).toBe(true);
 
         // The sweep runs on every active-item change and every settle; the hook must not.
-        workspace.syncDockHeaderActions();
-        workspace.syncDockHeaderActions();
+        workspace.dockHeaderActionPolicy.syncAll();
+        workspace.dockHeaderActionPolicy.syncAll();
 
         expect(pane.lockCalls, 'once per transition').toEqual([true]);
         expect(Object.hasOwn(pane.vdom, 'inert')).toBe(false);
@@ -386,17 +386,17 @@ test.describe('Neo.dashboard.dock.Workspace lock action', () => {
         expect(tabButton.wrapperCls).toContain('neo-draggable');
         expect(closeAction.hidden).toBe(false);
 
-        workspace.syncDockHeaderActions();
+        workspace.dockHeaderActionPolicy.syncAll();
 
         expect(pane.lockCalls, 'unlock is a transition too, once').toEqual([true, false]);
 
         // The same sweep keeps the inert default, exact restore included, for the sibling.
-        workspace.syncDockLockItemPresentation({locked: true, pane: beta});
+        workspace.dockHeaderActionPolicy.syncLockItemPresentation({locked: true, pane: beta});
 
         expect(beta.vdom.inert).toBe(true);
         expect(beta.cls).toContain('neo-dock-pane-locked');
 
-        workspace.syncDockLockItemPresentation({locked: false, pane: beta});
+        workspace.dockHeaderActionPolicy.syncLockItemPresentation({locked: false, pane: beta});
 
         expect(Object.hasOwn(beta.vdom, 'inert')).toBe(false);
         expect(beta.cls).not.toContain('neo-dock-pane-locked')
@@ -416,7 +416,7 @@ test.describe('Neo.dashboard.dock.Workspace lock action', () => {
 
         expect(pane.lockCalls).toEqual([]);
 
-        workspace.syncDockHeaderActions();
+        workspace.dockHeaderActionPolicy.syncAll();
 
         expect(pane.lockCalls).toEqual([true]);
         expect(Object.hasOwn(pane.vdom, 'inert')).toBe(false);

--- a/test/playwright/unit/dashboard/DockLockAction.spec.mjs
+++ b/test/playwright/unit/dashboard/DockLockAction.spec.mjs
@@ -6,13 +6,14 @@ setup({
     }
 });
 
-import {test, expect} from '@playwright/test';
-import Neo            from '../../../../src/Neo.mjs';
-import * as core      from '../../../../src/core/_export.mjs';
-import Component      from '../../../../src/component/Base.mjs';
-import DockWorkspace  from '../../../../src/dashboard/dock/Workspace.mjs';
-import LayoutAdapter  from '../../../../src/dashboard/dock/projection/LayoutAdapter.mjs';
-import Reconciler     from '../../../../src/dashboard/dock/projection/Reconciler.mjs';
+import {test, expect}     from '@playwright/test';
+import Neo                from '../../../../src/Neo.mjs';
+import * as core          from '../../../../src/core/_export.mjs';
+import Component          from '../../../../src/component/Base.mjs';
+import DockWorkspace      from '../../../../src/dashboard/dock/Workspace.mjs';
+import HeaderActionPolicy from '../../../../src/dashboard/dock/projection/HeaderActionPolicy.mjs';
+import LayoutAdapter      from '../../../../src/dashboard/dock/projection/LayoutAdapter.mjs';
+import Reconciler         from '../../../../src/dashboard/dock/projection/Reconciler.mjs';
 import '../../../../src/manager/Instance.mjs';
 import '../../../../src/tab/Container.mjs';
 
@@ -400,6 +401,69 @@ test.describe('Neo.dashboard.dock.Workspace lock action', () => {
 
         expect(Object.hasOwn(beta.vdom, 'inert')).toBe(false);
         expect(beta.cls).not.toContain('neo-dock-pane-locked')
+    });
+
+    /**
+     * The restore memory is keyed by panes and tab buttons that outlive the policy that locked
+     * them. A replacement installed while a lock is held must inherit it, or the next unlock finds
+     * empty maps: the pane keeps `inert`, the tab button stays disarmed, the delegated hook never
+     * receives its `false`. Three ownership shapes, one swap, one unlock each — and the same-instance
+     * assignment as the control that must retire nothing.
+     */
+    test('a live policy replacement inherits the held lock\'s restore memory, so the next unlock reverses it exactly', () => {
+        workspace = Neo.create(DelegatingLockWorkspace, {
+            dockModel            : createDocument(),
+            enableDockCloseAction: true,
+            enableDockLockAction : true
+        });
+
+        const tabContainer = Reconciler.collectProjectedTabs(workspace.items[0]).get('main-tabs'),
+              alpha        = tabContainer.getActiveCard(),
+              beta         = tabContainer.getCardContainer().items[1],
+              tabButton    = tabContainer.getTabButtons()[0],
+              before       = workspace.dockHeaderActionPolicy;
+
+        // beta owned an explicit `inert: false` before its lock — the exact value the unlock owes.
+        beta.vdom.inert = false;
+        tabButton.addWrapperCls('neo-draggable');
+
+        const locked = workspace.handleDockLockAction({dockNodeId: 'main-tabs', tabContainer});
+
+        expect(locked.errors).toEqual([]);
+        expect(alpha.lockCalls, 'the delegated pane was locked by the first policy').toEqual([true]);
+        expect(tabButton.wrapperCls).not.toContain('neo-draggable');
+
+        before.syncLockItemPresentation({locked: true, pane: beta});
+
+        expect(beta.vdom.inert).toBe(true);
+
+        // The supported live replacement: a fresh instance through the one config.
+        workspace.set({dockHeaderActionPolicy: {module: HeaderActionPolicy}});
+
+        const after = workspace.dockHeaderActionPolicy;
+
+        expect(after).not.toBe(before);
+        expect(after.workspace).toBe(workspace);
+        expect(before.isDestroyed, 'the retired policy is gone').toBe(true);
+
+        const unlocked = workspace.handleDockLockAction({dockNodeId: 'main-tabs', tabContainer});
+
+        expect(unlocked.errors).toEqual([]);
+        expect(alpha.lockCalls, 'the delegated pane gets its false from the policy that did not lock it').toEqual([true, false]);
+        expect(Object.hasOwn(alpha.vdom, 'inert'), 'and still gains no inert').toBe(false);
+        expect(tabButton.wrapperCls, 'the drag token the first policy took is restored').toContain('neo-draggable');
+
+        after.syncLockItemPresentation({locked: false, pane: beta});
+
+        expect(Object.hasOwn(beta.vdom, 'inert'), 'ownership is restored, not deleted').toBe(true);
+        expect(beta.vdom.inert, 'to the exact prior value').toBe(false);
+        expect(beta.cls).not.toContain('neo-dock-pane-locked');
+
+        // Control: assigning the SAME instance is not a replacement — nothing retires.
+        workspace.set({dockHeaderActionPolicy: after});
+
+        expect(workspace.dockHeaderActionPolicy).toBe(after);
+        expect(after.isDestroyed).toBeFalsy()
     });
 
     test('a committed lock reaches a delegating pane from the fresh projected shell', () => {

--- a/test/playwright/unit/dashboard/DockRecreateCandidate.spec.mjs
+++ b/test/playwright/unit/dashboard/DockRecreateCandidate.spec.mjs
@@ -40,8 +40,8 @@ import '../../../../src/toolbar/Base.mjs';
  * reading its own cache answers with the currently mounted instance, which *looks* like a
  * successful candidate.
  *
- * @see ADR 0029 §2.6 — ticket-ref-ok: the record is what these arms enforce; naming it is the
- *      difference between a test and a rule with a source.
+ * @see learn/agentos/decisions/0029-docking-design.md §2.6 — the record is what these arms
+ *      enforce; naming it is the difference between a test and a rule with a source.
  */
 const buildWorkspace = (config = {}) => Neo.create(DockWorkspace, {
     appName  : 'DashboardDockRecreateCandidateTest',
@@ -618,7 +618,7 @@ test.describe('dock reload — the fallback the ticket exists to provide', () =>
 /**
  * The reconciler interaction, driven through the **production** entry point.
  *
- * This is the ticket's finding #2 turned into a witness. `core.Base#destroy` unregisters an instance
+ * This is the ticket's second finding turned into a witness. `core.Base#destroy` unregisters an instance
  * without removing it from `parent.items`, and `reconcileTabChrome` fills its live map **positionally**
  * from `body.items` and prefers that entry over the app resolver — verified by the sibling spec's
  * `resolverCalls === 0` arm. A bare destroy would therefore leave the erased object sitting in the

--- a/test/playwright/unit/dashboard/DockRecreateCandidate.spec.mjs
+++ b/test/playwright/unit/dashboard/DockRecreateCandidate.spec.mjs
@@ -599,18 +599,18 @@ test.describe('dock reload — the fallback the ticket exists to provide', () =>
         // outright, which is the remaining purpose of overriding this predicate. Stated explicitly
         // rather than relying on the base default, which is what this half used to lean on.
         workspace.hasDockRecreateFallback = () => false;
-        workspace.syncDockReloadAction(tabContainer);
+        workspace.dockHeaderActionPolicy.syncReloadAction(tabContainer);
         expect(action.hidden, 'no delegation, and recreate declared unavailable → hidden').toBe(true);
 
         // The engine's own default is enough on its own: no host factory, no declared refusal.
         delete workspace.hasDockRecreateFallback;
-        workspace.syncDockReloadAction(tabContainer);
+        workspace.dockHeaderActionPolicy.syncReloadAction(tabContainer);
         expect(action.hidden, 'the engine default alone un-hides it').toBe(false);
 
         // And a host factory on top is still honoured — the original half of this arm, now the
         // third state rather than the second.
         workspace.resolveFreshPane = () => ({module: Component});
-        workspace.syncDockReloadAction(tabContainer);
+        workspace.dockHeaderActionPolicy.syncReloadAction(tabContainer);
         expect(action.hidden, 'no delegation but a host fallback → visible').toBe(false)
     })
 });

--- a/test/playwright/unit/dashboard/DockWorkspace.spec.mjs
+++ b/test/playwright/unit/dashboard/DockWorkspace.spec.mjs
@@ -16,6 +16,7 @@ import DockLayoutAdapter        from '../../../../src/dashboard/dock/projection/
 import DockProjectionReconciler from '../../../../src/dashboard/dock/projection/Reconciler.mjs';
 import DockService              from '../../../../src/ai/client/DockService.mjs';
 import DockWorkspace            from '../../../../src/dashboard/dock/Workspace.mjs';
+import HeaderActionPolicy       from '../../../../src/dashboard/dock/projection/HeaderActionPolicy.mjs';
 import WorkspaceDocument        from '../../../../src/dashboard/dock/model/WorkspaceDocument.mjs';
 import Operations               from '../../../../src/dashboard/dock/model/Operations.mjs';
 import Persistence              from '../../../../src/dashboard/dock/model/Persistence.mjs';
@@ -396,19 +397,27 @@ Neo.setupClass(HostBothActionsWorkspace);
  * owns no `dockReload()`, so the action projects visible and only this sweep can hide it. Deleting
  * the `super` call leaves the log intact and reds the state assertions, which is the point.
  */
+class SweepWitnessPolicy extends HeaderActionPolicy {
+    static config = {className: 'Test.Unit.Dashboard.DockWorkspace.SweepWitnessPolicy'}
+
+    syncAll() {
+        this.workspace.sweepLog.push('sweep');
+        return super.syncAll()
+    }
+}
+
+Neo.setupClass(SweepWitnessPolicy);
+
 class SweepWitnessWorkspace extends PlainWorkspace {
     static config = {
         className             : 'Test.Unit.Dashboard.DockWorkspace.SweepWitnessWorkspace',
+        // The policy is the seam a consumer replaces — one config, no workspace method overridden.
+        dockHeaderActionPolicy: {module: SweepWitnessPolicy},
         enableDockCloseAction : true,
         enableDockReloadAction: true
     }
 
     sweepLog = []
-
-    syncDockHeaderActions() {
-        this.sweepLog.push('sweep');
-        return super.syncDockHeaderActions()
-    }
 }
 
 Neo.setupClass(SweepWitnessWorkspace);
@@ -2333,7 +2342,7 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
         expect([closeAction.hidden, pinAction.hidden], 'the host owns their initial visibility')
             .toEqual([false, false]);
 
-        workspace.syncDockHeaderActions();
+        workspace.dockHeaderActionPolicy.syncAll();
 
         expect([closeAction.hidden, pinAction.hidden], 'the reconciliation sweep leaves host names alone')
             .toEqual([false, false]);
@@ -2391,7 +2400,7 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
 
         // Once the deferred sweep does run, the action agrees with the document on its own.
         await workspace.refreshPromise;
-        workspace.syncDockHeaderActions();
+        workspace.dockHeaderActionPolicy.syncAll();
 
         expect(tabs.get('center-tabs')?.getActionItem('pin')?.hidden ?? true,
             'a center-owned pane offers no collapse').toBe(true)
@@ -3483,25 +3492,34 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
         });
 
         test('the post-commit sweep re-evaluates pop-out, so it survives a layout commit', () => {
-            class PopOutSweepWitness extends PlainWorkspace {
-                static config = {className: 'Test.Unit.Dashboard.DockWorkspace.PopOutSweepWitness'}
-
-                popOutSyncLog = []
+            class PopOutSweepPolicy extends HeaderActionPolicy {
+                static config = {className: 'Test.Unit.Dashboard.DockWorkspace.PopOutSweepPolicy'}
 
                 // Deliberately does NOT call super: the defect is that the SWEEP never reached this
                 // action at all, so the witness is whether it is invoked — not what it computes.
                 // Calling super would make the arm red on the base class missing the method, which
                 // is a different (and weaker) claim.
-                syncDockPopOutAction(tabContainer) {
-                    this.popOutSyncLog.push(tabContainer)
+                syncPopOutAction(tabContainer) {
+                    this.workspace.popOutSyncLog.push(tabContainer)
                 }
+            }
+
+            Neo.setupClass(PopOutSweepPolicy);
+
+            class PopOutSweepWitness extends PlainWorkspace {
+                static config = {
+                    className             : 'Test.Unit.Dashboard.DockWorkspace.PopOutSweepWitness',
+                    dockHeaderActionPolicy: {module: PopOutSweepPolicy}
+                }
+
+                popOutSyncLog = []
             }
 
             Neo.setupClass(PopOutSweepWitness);
 
             workspace = Neo.create(PopOutSweepWitness, {dockModel: createDocument()});
 
-            workspace.syncDockHeaderActions();
+            workspace.dockHeaderActionPolicy.syncAll();
 
             // close, lock, pin and reload were all swept; pop-out was the one engine action with no
             // sync. Its hidden state is projected once and then lives on a RETAINED instance, so it


### PR DESCRIPTION
Resolves #18306

Related: #18304 (epic), #18307 (the sibling that binds header state to #18303's Group and deletes the sweeps — the policy leaves it one entry to delete)

The header-action presentation policy — which engine action is shown, enabled or pressed for which pane, re-derived onto the retained action instances after every commit and active-item change — leaves `Workspace` for `src/dashboard/dock/projection/HeaderActionPolicy.mjs`. Eight methods and the two WeakMaps of lock-presentation snapshots they own move; the façade keeps the mutation boundary (`onDockHeaderAction` and the five `handleDock*Action` handlers) and dispatches into the policy at the points where it used to sync itself. The workspace resolves one instance through a `dockHeaderActionPolicy` config — a module config or an instance, bound to the workspace, destroyed with it — so a consumer replaces the policy with one config instead of overriding workspace methods, which is what every fixture that overrode the sync hooks now does.

Evidence: L3 (unit and component browser suites over the real projection; the Workstation whitebox spec with `NEO_AGENTOS_RUNTIME_ROOT` set; the dock example driven in the browser from this head) → L3 required (AC-7 names the dock example and the Workstation). No residuals.

## Ownership test (Stage 0: yes — the row owns the lock presentation's exact-restore memory)

The state that moves is not the façade state the row reads — `dockModel`, the `enableDock*Action` opt-ins, the in-flight sets, the active item — those are the policy's inputs and stay where the handlers and the projection also read them. What the row owns is `dockLockPaneState` and `dockLockDragState`: which panes it made inert and what they owned before, which tab buttons it disarmed. Only `syncDockLockItemPresentation` ever read or wrote them; they are the policy's now.

| | dev@99e66ae1d2 | this head |
|---|---|---|
| `Workspace` methods / instance fields | 77 / 17 | 71 / 15 (−8 methods, +2 config hooks; −2 WeakMaps) |
| `Workspace` code lines (the guard's count) | 1415 (the committed row said 1419; that was stale) | 1281 |
| header-action members on `Workspace` | 8 sync methods + 2 fields | 0 — no forwarding wrapper; the policy is reached through `dockHeaderActionPolicy` |
| cross-concern calls: façade → presentation | 19 `syncDock*` call sites (the sweep's own fan-out of 6 among them) | 11 dispatches into the policy: `onDockActiveIndexChange` 2 (`syncActiveItem` replaces the close/lock/pin trio), `handleDockLockAction` 2, `refreshDockWorkspace` 2, `handleDockReloadAction` 2, `projectDockModel` 1, `onDockZoneDocumentChange` 1, `afterSetMounted` 1 |

1. **Did `Workspace` lose the methods, configs and mutable state for the concern?** The eight methods and both WeakMaps are gone; the one config that arrived (`dockHeaderActionPolicy_`) is the seam, not the state.
2. **Can the owner be instantiated and destroyed independently under a bounded interface?** `Neo.create(HeaderActionPolicy, {workspace})` is the whole constructor; `destroy()` releases the workspace and the WeakMaps retire with the instance. The surface it reads is named in its class docblock and is exactly ten members.
3. **Can a consumer replace or disable it without overriding a dozen `Workspace` methods?** One config. The three fixtures that overrode `syncDockHeaderActions` / `syncDockPopOutAction` on `Workspace` subclasses now subclass the policy and install it through `dockHeaderActionPolicy: {module: …}`.
4. **Did total cross-concern calls fall, or merely become `owner.foo()` wrappers?** 19 → 11. The fan-out moved whole; what remains are the façade's own decision points dispatching once each. The policy's reads of workspace state are its inputs, not wrappers — nothing on `Workspace` forwards to it.

## Collaborator contract

The policy reads `dockModel`, the `enableDock{Close,PopOut,Lock,Pin,Reload}Action` opt-ins, `getActiveDockItemId()`, `dockPopOutActionActive`, `dockReloadInFlight`, `dockRecreateInFlight`, `hasDockRecreateFallback()`, `forEachDockRail()`, `getDockHost()` and `dockShellIndex` — and nothing more. `hasDockRecreateFallback` stays on the façade because it is a documented consumer override point; `forEachDockRail` stays because `releaseStaleRevealPanes` shares it; `getActiveDockItemId` has eleven façade callers. The router and the five handlers are untouched. `onDockZoneDocumentChange`'s lock-rail sync keeps its optional chaining: a unit spec drives that method on a hand-built `this`, exactly as the previous `syncDockLockRails?.()` tolerated.

## AC Evidence

| AC | Evidence |
|---|---|
| AC-1 — the six presentation methods and the state they read move; each method that stays is named with its row | Moved: `syncDockHeaderActions`, `syncDockCloseAction`, `syncDockPopOutAction`, `syncDockLockAction`, `syncDockPinAction`, `syncDockReloadAction`, plus `syncDockLockRails` and `syncDockLockItemPresentation` — the two the ticket's six call and the second of which owns the state. Stays — command execution: `onDockHeaderAction`, `handleDockCloseAction`, `handleDockLockAction`, `handleDockPinAction`, `handleDockPopOutAction`, `handleDockReloadAction`; effect ordering: `focusDockCloseTarget`; façade queries the policy reads: `getActiveDockItemId`, `forEachDockRail`, `hasDockRecreateFallback`, `getPaneHeaderText`. |
| AC-2 — no policy method or state retained, no forwarding wrappers; counts fall with the delta recorded | The table above: 77 → 71 methods, 17 → 15 fields, 1419 → 1281 code lines; `grep syncDock` on the façade finds only the dispatches. |
| AC-3 — Ownership test, all four questions, question 4 with the before/after count | The section above: 19 → 11. |
| AC-4 — membership owners untouched | `toolbar.Base#getActionItems` and `tab.header.Toolbar#isTabButton`: not in the diff. |
| AC-5 — the façade keeps its mutation boundary | The router and the five handlers are byte-identical apart from their dispatch lines. |
| AC-6 — projected action rows stay projection-constant | `LayoutAdapter` is touched only in three docblocks; the policy writes `hidden` / `disabled` / `pressed` onto retained instances exactly as before. |
| AC-7 — the default action rail and the focus-gated reveal behave identically on the dock example and the Workstation | Workstation whitebox spec: 6 passed / 4 failed on this head, the same four reds as on dev (the reveal-header screenshot pair, the dense-tour splitter probe, the overflow-menu theme probe) and the maximize arm green; the dock-example e2e arm 1/1. Dock example driven in the browser from this head: a real click on the Strategy tab reveals the focus-gated rail in the frozen order `lock · reload · maximize · close`, none hidden or disabled; clicking lock flips the glyph to `fa-lock-open` pressed, stamps the pane `neo-dock-pane-locked` + `inert`, hides the close action and drops the tab's `neo-draggable` token; clicking it again restores every one of those (model `locked: false` read from the App worker, pane class and `inert` gone, close back, tab draggable) — the same rail, order and enablement the example showed on dev earlier tonight. |

## Deltas from ticket

- The ticket names six methods; the cut takes eight. `syncDockLockRails` is the rail half of the lock sync and `syncDockLockItemPresentation` is the lock presentation itself and the owner of the two WeakMaps — leaving either behind would have left policy on the façade. Euclid's intake classification listed the first; the second is where the state lives.
- The vehicle is an instance collaborator, not a static sibling of `LayoutAdapter` / `Reconciler`: Stage 0 came back yes for the WeakMaps, and an instance is what makes question 3 a config instead of a subclass.
- 19 call sites, not 33: #18324 took the maximize share before this leaf started.
- The size guard's baseline row for `src/dashboard/dock/Workspace.mjs` lowers to 1281 in this PR, as the ratchet requires (dev carried 1419, then 1415 after #18344 lowered it for Vega's #18329; the branch is rebased on dev@088c8452ff).

## Test Evidence

```
npx playwright test --config test/playwright/playwright.config.unit.mjs unit/dashboard unit/tab
  892 passed (2.7s)

npx playwright test --config test/playwright/playwright.config.component.mjs component/dashboard
  116 passed (1.4m)

NEO_AGENTOS_RUNTIME_ROOT=<brain> npx playwright test --config test/playwright/playwright.config.e2e.mjs e2e/workstation/WorkstationNL.spec.mjs e2e/dashboard/DockExampleMaximizeGeometry.spec.mjs
  6 passed / 4 failed — the four reds are dev's own (identical set on dev@99e66ae1d2)

node buildScripts/util/check-file-sizes.mjs --base origin/dev
  PASS over-target  1281 code |  1632 doc (49.5%)  src/dashboard/dock/Workspace.mjs — 0 violations
```

Review round 1 (RA-1, live policy replacement): the regression in `DockLockAction.spec` locks a delegated pane, an inert-owning pane and a tab button through the first policy, swaps the policy through the config, and unlocks through the second — without the hand-off it reds on the delegated hook ("the delegated pane gets its false from the policy that did not lock it": `[true]` only); with `inheritRestoreState` the file runs 10/10.

The first unit run reddened twice and both reds were mine: `DockLockAction.spec` calls `syncDockLockItemPresentation` directly (re-pointed to the policy), and `DockTabEnterButton.spec` drives `onDockZoneDocumentChange` on a hand-built `this` (the optional chaining the previous code carried for that reason is kept).

## Post-Merge Validation

None owed — every close-target AC is verified at this head.

## Commits

- 4b225649ba — the policy, the façade's dispatches and config, the witnesses re-seamed, the docblocks, the guard row, the class hierarchy (the series is rebased on dev@ac93c04e3c; the only overlap along the way was the guard row #18344 had lowered to 1415)
- bf9886ac78 — two durable comments in `DockRecreateCandidate.spec.mjs` say the same without the tokens the published `neo-agent-skills@0.1.3` archaeology checker flags (it has no escape marker; the repo's own checker already passed both) — the baseline job's one red
- 3d32a8bbc0 — review round 1: a replaced policy hands its lock-restore memory to the replacement before it retires (`HeaderActionPolicy#inheritRestoreState`, called from `Workspace#afterSetDockHeaderActionPolicy`), the lifetime stated on the config and the class, the lock → replacement → unlock regression; the guard row moves to the measured 1284 (the hand-off is three lines of the façade)

Authored by Mnemosyne (Claude Fable 5.1, Claude Code). Session ce3d8122-fe34-44f1-91ba-dea27580b193.
