### PR TITLE
feat(manager): logical topology Groups bind windows across generations; the dock, the Workstation and DemoB reserve their vessels in them (#18309)

### DIFF
--- a/apps/workstation/view/Workspace.mjs
+++ b/apps/workstation/view/Workspace.mjs
@@ -1,23 +1,24 @@
-import Component                   from '../../../src/component/Base.mjs';
-import Container                   from '../../../src/container/Base.mjs';
-import DockWorkspace               from '../../../src/dashboard/dock/Workspace.mjs';
-import Feed                        from '../store/Feed.mjs';
-import FeedPane                    from './FeedPane.mjs';
-import Scale                       from '../store/Scale.mjs';
-import ScalePane                   from './ScalePane.mjs';
-import DockDragAffordances         from '../../../src/dashboard/dock/interaction/DragAffordances.mjs';
-import DockDropIndicators          from '../../../src/dashboard/dock/interaction/DropIndicators.mjs';
-import DockLayoutAdapter           from '../../../src/dashboard/dock/projection/LayoutAdapter.mjs';
-import PerspectiveLibrary          from '../../../src/dashboard/dock/persistence/PerspectiveLibrary.mjs';
-import DockPreview                 from '../../../src/dashboard/dock/interaction/Preview.mjs';
-import DockProjectionReconciler    from '../../../src/dashboard/dock/projection/Reconciler.mjs';
-import DockService                 from '../../../src/ai/client/DockService.mjs';
-import WorkspaceDocument           from '../../../src/dashboard/dock/model/WorkspaceDocument.mjs';
-import Operations                  from '../../../src/dashboard/dock/model/Operations.mjs';
-import Persistence                 from '../../../src/dashboard/dock/model/Persistence.mjs';
-import InteractionService          from '../../../src/ai/client/InteractionService.mjs';
-import StateProvider               from '../../../src/state/Provider.mjs';
-import TourRunner                  from '../../../src/ai/client/TourRunner.mjs';
+import Component                from '../../../src/component/Base.mjs';
+import Container                from '../../../src/container/Base.mjs';
+import DockWorkspace            from '../../../src/dashboard/dock/Workspace.mjs';
+import Feed                     from '../store/Feed.mjs';
+import FeedPane                 from './FeedPane.mjs';
+import Scale                    from '../store/Scale.mjs';
+import ScalePane                from './ScalePane.mjs';
+import DockDragAffordances      from '../../../src/dashboard/dock/interaction/DragAffordances.mjs';
+import DockDropIndicators       from '../../../src/dashboard/dock/interaction/DropIndicators.mjs';
+import DockLayoutAdapter        from '../../../src/dashboard/dock/projection/LayoutAdapter.mjs';
+import PerspectiveLibrary       from '../../../src/dashboard/dock/persistence/PerspectiveLibrary.mjs';
+import DockPreview              from '../../../src/dashboard/dock/interaction/Preview.mjs';
+import DockProjectionReconciler from '../../../src/dashboard/dock/projection/Reconciler.mjs';
+import DockService              from '../../../src/ai/client/DockService.mjs';
+import WorkspaceDocument        from '../../../src/dashboard/dock/model/WorkspaceDocument.mjs';
+import Operations               from '../../../src/dashboard/dock/model/Operations.mjs';
+import Persistence              from '../../../src/dashboard/dock/model/Persistence.mjs';
+import InteractionService       from '../../../src/ai/client/InteractionService.mjs';
+import StateProvider            from '../../../src/state/Provider.mjs';
+import TourRunner               from '../../../src/ai/client/TourRunner.mjs';
+import TransactionManager       from '../../../src/manager/Transaction.mjs';
 import {
     createDockVesselEmbodiment,
     createDockVesselProxyEmbodiment
@@ -491,16 +492,14 @@ class Workspace extends DockWorkspace {
             }
         });
 
-        // The cross-window composition (docking design record §2.1/§2.3): one worker-owned
-        // workspace set resolves documents by STABLE workspace identity — windowId, screen
-        // geometry, and projection state never enter it; a window is a render target, not a
-        // state owner. Vessel workspaces register lazily on first dock-INTO (Edit 2).
-        me.workspaceSet = createDockWorkspaceSet();
-
-        me.workspaceSet.register(Workspace.MAIN_WORKSPACE_ID, {
-            getDocument: () => me.dockModel,
-            setDocument: document => me.dockModel = document
-        });
+        // The cross-window composition (docking design record §2.1/§2.3): the workspace set resolves
+        // documents by STABLE workspace identity — windowId, screen geometry, and projection state
+        // never enter it; a window is a render target, not a state owner. Its membership lives in
+        // this workspace's Group on `Neo.manager.Transaction`: the app imports the manager, so its
+        // window is admitted at registration and the Group exists before this constructor runs.
+        // Vessel workspaces register lazily on first dock-INTO (Edit 2).
+        me.workspaceSet = createDockWorkspaceSet({manager: TransactionManager, getGroupId: () => me.topologyGroupId});
+        me.registerMainWorkspace();
 
         me.crossWindowParticipationPromise = me.refreshCrossWindowParticipation(Workspace.MAIN_WORKSPACE_ID)
             .catch(error => {
@@ -899,6 +898,40 @@ class Workspace extends DockWorkspace {
      */
     admitDockPopOut(data) {
         return this.onDockTearOutExit(data)
+    }
+
+    /**
+     * @summary Publishes this workspace's own document as the `main` participant of its Group.
+     *
+     * Membership is the Group's, and a workspace has a Group only once its window is bound — which its
+     * app did at registration, before any view of that window constructed. An instance created
+     * headless has no window yet and joins nothing; {@link #afterSetWindowId} registers it the moment
+     * a container supplies its first real window id.
+     * @returns {Boolean} Whether the participant is registered.
+     * @protected
+     */
+    registerMainWorkspace() {
+        let me = this;
+
+        return me.workspaceSet.register(Workspace.MAIN_WORKSPACE_ID, {
+            getDocument: () => me.dockModel,
+            setDocument: document => me.dockModel = document
+        })
+    }
+
+    /**
+     * A headless instance joins its Group when a real render target arrives (see
+     * {@link #registerMainWorkspace}); the engine's geometry binding runs on the same signal.
+     * @param {String|null} value
+     * @param {String|null} oldValue
+     * @protected
+     */
+    afterSetWindowId(value, oldValue) {
+        super.afterSetWindowId(value, oldValue);
+
+        let me = this;
+
+        value && me.workspaceSet && !me.workspaceSet.has(Workspace.MAIN_WORKSPACE_ID) && me.registerMainWorkspace()
     }
 
     /**

--- a/apps/workstation/view/Workspace.mjs
+++ b/apps/workstation/view/Workspace.mjs
@@ -18,7 +18,6 @@ import Persistence                 from '../../../src/dashboard/dock/model/Persi
 import InteractionService          from '../../../src/ai/client/InteractionService.mjs';
 import StateProvider               from '../../../src/state/Provider.mjs';
 import TourRunner                  from '../../../src/ai/client/TourRunner.mjs';
-import {createDockTearOutHandlers} from '../../../src/dashboard/dock/window/TearOut.mjs';
 import {
     createDockVesselEmbodiment,
     createDockVesselProxyEmbodiment
@@ -121,6 +120,12 @@ class Workspace extends DockWorkspace {
          * @protected
          */
         className: 'Workstation.view.Workspace',
+        /**
+         * The engine's tear-out lifecycle: the workspace reserves each vessel's slot in its Group and
+         * admits the window that binds it. This host supplies the platform seams and its own receipts.
+         * @member {Boolean} enableDockTearOutLifecycle=true
+         */
+        enableDockTearOutLifecycle: true,
         /**
          * @member {String[]} additionalThemeFiles
          */
@@ -232,29 +237,6 @@ class Workspace extends DockWorkspace {
      */
     vesselProxyEmbodiment = null
     /**
-     * The tear-out gesture choreography (admission chain + commit-at-terminal routing).
-     * @member {Object|null} tearOutHandlers=null
-     */
-    tearOutHandlers = null
-    /**
-     * Connect-time admission tokens for tear-out vessels whose render stage is still settling.
-     * @member {Map} tearOutConnectAdmissions=new Map()
-     * @protected
-     */
-    tearOutConnectAdmissions = new Map()
-    /**
-     * Pre-terminal connected tear-out vessels by item id.
-     * @member {Object} tearOutConnects={}
-     * @protected
-     */
-    tearOutConnects = {}
-    /**
-     * Post-commit vessel-owned panes by item id (the detached terminal committed).
-     * @member {Object} tearOutPanes={}
-     * @protected
-     */
-    tearOutPanes = {}
-    /**
      * Exact pre-conversion and target-cover outer geometry for parked tear-out vessels.
      * Runtime-only physical recovery authority; never persisted workspace state.
      * @member {Object} tearOutParkGeometries={}
@@ -268,18 +250,6 @@ class Workspace extends DockWorkspace {
      * @protected
      */
     tearOutParkAttempts = {}
-    /**
-     * Exact `{tabsNodeId, index}` placement captured at each detach commit — the return truth.
-     * @member {Object} tearOutPlacements={}
-     * @protected
-     */
-    tearOutPlacements = {}
-    /**
-     * Retirement fences: items whose vessel close is in flight (connects stay cleanup-only).
-     * @member {Set} tearOutRetirements=new Set()
-     * @protected
-     */
-    tearOutRetirements = new Set()
     /**
      * The runtime window id of the vessel an in-flight conversion is hovering over — stashed by
      * the conversion-in seam so the park's cover geometry resolves the exact target. Never
@@ -357,18 +327,6 @@ class Workspace extends DockWorkspace {
      * @member {Object|null} lastTearOutClose=null
      */
     lastTearOutClose = null
-    /**
-     * Product-semantic vessel owner grants by `flow:itemId`.
-     * @member {Map} vesselOwnerGrants=new Map()
-     * @protected
-     */
-    vesselOwnerGrants = new Map()
-    /**
-     * Monotonic grant generation counter.
-     * @member {Number} vesselOwnerGrantGeneration=0
-     * @protected
-     */
-    vesselOwnerGrantGeneration = 0
     /**
      * Number of coalesced producer batches appended over this workspace lifetime.
      * @member {Number} feedBatchCount=0
@@ -476,18 +434,6 @@ class Workspace extends DockWorkspace {
 
         me.appendFeedBatch(25);
 
-        // The gesture tear-out choreography. A vessel never writes shared detach bookkeeping
-        // mid-gesture — model truth stays untouched until the detached terminal. Create the ONE
-        // effective bundle before first projection: pop-out membership is stable, while its initial
-        // hidden state samples bundle availability. Constructing it after `projectDockModel()`
-        // strands the retained action hidden until an unrelated refresh.
-        me.tearOutHandlers = createDockTearOutHandlers({
-            applyOperation  : descriptor => me.applyTearOutOperation(descriptor),
-            closeVessel     : vessel => me.closeTearOutVessel(vessel),
-            onDocumentChange: (document, operation, vessel) => me.onTearOutDocumentChange(document, operation, vessel),
-            openVessel      : request => me.openTearOutVessel(request)
-        });
-
         me.add([me.createTourBar(), me.createStatusBar(), {
             module: Container,
             cls   : ['workstation-dock-host', 'neo-dashboard', 'neo-dashboard-dock-query-host'],
@@ -575,14 +521,6 @@ class Workspace extends DockWorkspace {
             disposeVessel: ({itemId}) => me.retireReturnedVessel(Workspace.vesselWorkspaceId(itemId)),
             parkVessel   : vessel => me.parkTearOutVessel({...vessel, nativeTitlebar: true}),
             reshowVessel : vessel => me.reshowTearOutVessel(vessel)
-        });
-
-        // vessel lifecycle: a granted `?popout=` window adopts the live pane on connect,
-        // and a vessel death brings its item home on disconnect
-        Neo.currentWorker.on({
-            connect   : me.onWindowConnect,
-            disconnect: me.onWindowDisconnect,
-            scope     : me
         });
 
         // The reactive afterSet fires before the dock host exists during construction —
@@ -975,6 +913,9 @@ class Workspace extends DockWorkspace {
         let me = this;
 
         return {
+            // The engine's tear-out opt-in and its gesture handler bundle come first; this host wraps
+            // one of them (the exit, with its park retirement) and adds the flagship's own surfaces.
+            ...super.getDockProjectionOptions(),
             // Dense Workstation panes need more than the engine's compact 25% reveal floor. The
             // committed edge extent still wins whenever it is larger.
             defaultRevealFraction      : 0.35,
@@ -982,11 +923,10 @@ class Workspace extends DockWorkspace {
             // coordinator-visible drag source under one sort group; the workspace id rides the
             // payload for the receiving window's `transferItem` resolution.
             crossWindowSortGroup        : Workspace.CROSS_WINDOW_SORT_GROUP,
-            // Tear-out opt-in (§2.8): every tab zone shares the Workstation root as its physical
+            // Tear-out boundary (§2.8): every tab zone shares the Workstation root as its physical
             // window boundary. Exiting a source toolbar remains ordinary cross-zone motion; only
             // leaving this app/window root enters the vessel outcome machine.
             dockTearOutBoundaryContainerId: me.id,
-            enableDockTearOut             : true,
             // Vessel conversion (the multi-window amendment): popup-over-vessel converts to a
             // proxy over the target while the park keeps the real vessel alive — the projection
             // threads the opt-in; this host owns every platform effect.
@@ -994,10 +934,7 @@ class Workspace extends DockWorkspace {
             onDockCrossZoneDragCancel: data => me.dragAffordances.onDragCancel(data),
             onDockCrossZoneDragMove  : data => me.dragAffordances.onDragMove(data),
             onDockCrossZoneDrop      : data => me.dragAffordances.onDrop(data),
-            onDockTearOutCancel      : data => me.tearOutHandlers.onDockTearOutCancel(data),
-            onDockTearOutEntry       : data => me.tearOutHandlers.onDockTearOutEntry(data),
             onDockTearOutExit        : data => me.onDockTearOutExit(data),
-            onDockTearOutTerminal    : data => me.tearOutHandlers.onDockTearOutTerminal(data),
             onDockVesselConversionIn : data => {
                 let targetWorkspaceId = data.targetId,
                     targetState       = me.vesselWorkspaces.get(targetWorkspaceId);
@@ -1959,7 +1896,9 @@ class Workspace extends DockWorkspace {
             receipt.phases.push('close-dispatched')
         }
 
-        const closed = await me.closeTearOutVessel(vessel);
+        // Through the engine's retirement, not the platform seam directly: the fence it holds keeps a
+        // late bind for the same item cleanup-only while the close is in flight.
+        const closed = await me.retireTearOutVessel(vessel);
 
         if (closed) {
             state.closeRequested = true;
@@ -2790,102 +2729,33 @@ class Workspace extends DockWorkspace {
     }
 
     /**
-     * @summary Mints one product-semantic vessel grant and supersedes the prior generation for
-     * the same flow/item. The token is a bearer hint only; {@link #consumeVesselOwnerGrant}
-     * additionally requires the opener-minted native route for the exact connected child.
-     * @param {String} flow Vessel flow discriminator (`tear-out`).
-     * @param {String} itemId
-     * @returns {{generation: Number, token: String}}
-     * @protected
-     */
-    createVesselOwnerGrant(flow, itemId) {
-        let grant = {
-            generation: ++this.vesselOwnerGrantGeneration,
-            token     : crypto.randomUUID()
-        };
-
-        this.vesselOwnerGrants.set(`${flow}:${itemId}`, grant);
-
-        return grant
-    }
-
-    /**
-     * @summary Consumes one exact product grant after validating the generic native route.
-     * Consumption precedes every reparent, making replay and same-name reuse inert.
-     * @param {Object} data
-     * @param {Object} data.windowData
-     * @param {String} flow
-     * @param {Number} generation
-     * @param {String} grant
-     * @param {String} itemId
-     * @param {String} windowId
-     * @returns {Boolean}
-     * @protected
-     */
-    consumeVesselOwnerGrant({data, flow, generation, grant, itemId, windowId}) {
-        let me     = this,
-            key    = `${flow}:${itemId}`,
-            stored = me.vesselOwnerGrants.get(key),
-            route  = data.windowData?.nativeRoute;
-
-        if (
-            !stored || !grant || stored.token !== grant || stored.generation !== generation ||
-            !route?.nativeHandleKey || route.ownerWindowId !== me.windowId || route.targetWindowId !== windowId
-        ) {
-            return false
-        }
-
-        me.vesselOwnerGrants.delete(key);
-
-        return true
-    }
-
-    /**
-     * @summary Revokes the current semantic grant for one flow/item admission.
-     * @param {String} flow
-     * @param {String} itemId
-     * @protected
-     */
-    revokeVesselOwnerGrant(flow, itemId) {
-        this.vesselOwnerGrants.delete(`${flow}:${itemId}`)
-    }
-
-    /**
      * @summary Opens one theme-correct vessel window for a mid-gesture boundary exit.
      *
-     * Reuses the workstation viewport's `?popout=` pure-pane-host mode. The granted child
+     * Reuses the workstation viewport's `?popout=` pure-pane-host mode. The vessel carries the slot the
+     * engine reserved in this workspace's Group through `Main.windowOpen`; which pane it shows is
+     * content and stays in the URL, whom it belongs to is identity and never does. The bound child
      * immediately carries the same live pane through {@link Neo.dashboard.dock.window.VesselEmbodiment};
      * it owns no workspace document. Fail-closed per the admission contract: `windowOpen` returns
      * a BOOLEAN (a blocked popup never throws), and any falsy/throwing acquisition returns `null`
      * so the gesture degrades to its in-window fallback. The theme bootstrap is part of that
      * acquisition rather than optional presentation: an unavailable authority reaches the outer
-     * diagnostic boundary, revokes the owner grant, and prevents an unthemed child from opening.
+     * diagnostic boundary and prevents an unthemed child from opening.
      * @param {Object} request
-     * @param {Number} request.admissionToken
      * @param {String} request.itemId
      * @param {Object} request.proxyRect
-     * @returns {Promise<{admissionToken: Number, generation: Number, popupHeight: Number, popupWidth: Number, windowName: String}|null>}
+     * @param {Object} request.topologyIdentity The reserved slot, written into the vessel's carrier.
+     * @returns {Promise<{popupHeight: Number, popupWidth: Number, windowName: String}|null>}
      * @protected
      */
-    async openTearOutVessel({admissionToken, itemId, proxyRect}) {
+    async openTearOutVessel({itemId, proxyRect, topologyIdentity}) {
         let me         = this,
             {windowId} = me,
-            windowName = `tearout-${itemId}`,
-            ownerGrant = me.createVesselOwnerGrant('tear-out', itemId);
-
-        admissionToken = Number.isFinite(admissionToken) ? admissionToken : ownerGrant.generation;
-        ownerGrant.admissionToken = admissionToken;
+            windowName = `tearout-${itemId}`;
 
         // Diagnostic trail for the birth gate: absence has three distinct layers (admission
-        // refused / platform refused the window / window granted but never connected), and the
+        // refused / platform refused the window / window granted but never bound), and the
         // failure diag must name which one this gesture died in.
         me.lastVesselOpen = {itemId, stage: 'invoked'};
-
-        if (me.tearOutRetirements.has(itemId)) {
-            me.lastVesselOpen.stage = 'blocked-by-retirement';
-            me.revokeVesselOwnerGrant('tear-out', itemId);
-            return null
-        }
 
         try {
             let [winData, bootstrap] = await Promise.all([
@@ -2904,12 +2774,9 @@ class Workspace extends DockWorkspace {
             let opened = await Neo.Main.windowOpen({
                 nativeCapabilities: {close: true, position: true, resize: true},
                 stagedColorScheme : schemes[selectedTheme],
-                url               : `./index.html?popout=${itemId}&hostId=${me.id}`
-                    + `&vesselFlow=tear-out&vesselGrant=${ownerGrant.token}`
-                    + `&vesselGeneration=${ownerGrant.generation}`
-                    + `&vesselAdmission=${admissionToken}`
-                    + `&theme=${encodeURIComponent(selectedTheme)}`,
-                windowFeatures: `height=${height},left=${left},top=${top},width=${width}`,
+                topologyIdentity,
+                url               : `./index.html?popout=${itemId}&theme=${encodeURIComponent(selectedTheme)}`,
+                windowFeatures    : `height=${height},left=${left},top=${top},width=${width}`,
                 windowId,
                 windowName
             });
@@ -2917,61 +2784,49 @@ class Workspace extends DockWorkspace {
             me.lastVesselOpen.stage = opened === false ? 'windowOpen-false' : 'granted';
 
             if (opened === false) {
-                me.revokeVesselOwnerGrant('tear-out', itemId);
                 return null
             }
 
             me.tearOutVesselDims = {height, width};
 
-            return {
-                admissionToken,
-                generation : ownerGrant.generation,
-                popupHeight: height,
-                popupWidth : width,
-                windowName
-            }
+            return {popupHeight: height, popupWidth: width, windowName}
         } catch (error) {
             me.lastVesselOpen.stage = 'threw';
             me.lastVesselOpen.error = String(error?.message || error);
-            me.revokeVesselOwnerGrant('tear-out', itemId);
             return null
         }
     }
 
     /**
-     * The tear-out retirement seam: closes a vessel the gesture no longer needs (re-entry,
-     * cancel, or a refused model commit). The live connection and owner grant remain recoverable
-     * until the platform strictly admits the close; an explicit refusal can therefore be retried
-     * instead of orphaning a parked native generation.
+     * The tear-out retirement seam: closes a vessel the gesture no longer needs (re-entry, cancel,
+     * or a refused model commit). Identity is the slot's lineage token — a successor admission for
+     * the same item shares the window name, never the token — so a retirement presenting a superseded
+     * token is refused and the live vessel survives it. The engine's `retireTearOutVessel` holds the
+     * retirement fence and clears the ownership records around this call; the platform close and its
+     * receipt are this host's, and an explicit refusal retains exact retry authority.
      * @param {Object} vessel
-     * @param {Number} [vessel.admissionToken]
-     * @param {Number} [vessel.generation]
+     * @param {String} [vessel.generationToken] The reservation's lineage token.
      * @param {String} vessel.itemId
      * @param {Object} [vessel.nativeRoute] Exact opener-minted physical route when available.
-     * @param {Boolean} [vessel.nativeTitlebar=false] Use the exact Main native route rather than
-     *     pointer-follow DragDrop state after a terminal popup was dropped.
      * @param {String} vessel.windowName
      * @returns {Promise<Boolean>}
      * @protected
      */
-    async closeTearOutVessel({admissionToken, generation, itemId, nativeRoute, windowName}) {
+    async closeTearOutVessel({generationToken, itemId, nativeRoute, windowName}) {
         let me               = this,
             entry            = me.resolveTearOutVessel(itemId),
-            admission        = me.tearOutConnectAdmissions.get(itemId),
-            ownerGrant       = me.vesselOwnerGrants.get(`tear-out:${itemId}`),
+            admission        = me.tearOutAdmissions.get(itemId),
             expected         = `tearout-${itemId}`,
-            exactGeneration  = entry?.generation ?? admission?.generation ?? ownerGrant?.generation,
-            exactToken       = entry?.admissionToken ?? admission?.admissionToken ?? ownerGrant?.admissionToken,
+            exactToken       = entry?.generationToken ?? admission?.generationToken ?? null,
             embodiedWindowId = entry?.windowId ?? admission?.windowId ?? me.tearOutEmbodiment.getWindowId(itemId),
             closed           = false;
 
         const closeReceipt = me.lastTearOutClose = {
             identity: {
-                admissionMatches : !Number.isFinite(admissionToken) || admissionToken === exactToken,
                 entryNameMatches : !entry || entry.windowName === windowName,
-                generationMatches: !Number.isFinite(generation) || generation === exactGeneration,
                 hasEntry         : Boolean(entry),
                 hasItemId        : Boolean(itemId),
+                lineageMatches   : !generationToken || !exactToken || generationToken === exactToken,
                 windowNameMatches: windowName === expected
             },
             itemId: itemId ?? null,
@@ -2980,14 +2835,13 @@ class Workspace extends DockWorkspace {
 
         if (
             !itemId || windowName !== expected || (entry && entry.windowName !== windowName) ||
-            (Number.isFinite(generation) && generation !== exactGeneration) ||
-            (Number.isFinite(admissionToken) && admissionToken !== exactToken)
+            (generationToken && exactToken && generationToken !== exactToken)
         ) {
             closeReceipt.stage = 'identity-refused';
             return false
         }
 
-        nativeRoute ??= entry?.nativeRoute ?? admission?.nativeRoute ?? (
+        nativeRoute ??= entry?.nativeRoute ?? (
             admission?.windowId && Neo.manager?.Window?.get(admission.windowId)?.nativeRoute
         );
 
@@ -3014,12 +2868,8 @@ class Workspace extends DockWorkspace {
             return false
         }
 
-        // Establish retirement before restoring any source embodiment or awaiting the platform.
-        // A refused close retains the exact route + tear-out machine slot for retry, but the
-        // content stays safely home.
-        me.tearOutRetirements.add(itemId);
-        admission && (admission.invalidated = true);
-
+        // The engine established retirement before this call; a refused close retains the exact
+        // route + tear-out machine slot for retry, but the content goes safely home first.
         if (embodiedWindowId && me.tearOutEmbodiment.isStaged(itemId)) {
             const sourceOwns = Boolean(WorkspaceDocument.findContainingTabsId(me.dockModel, itemId)),
                   settled    = me.tearOutEmbodiment[sourceOwns ? 'restore' : 'promote']({
@@ -3063,11 +2913,7 @@ class Workspace extends DockWorkspace {
             return false
         }
 
-        delete me.tearOutConnects[itemId];
         delete me.tearOutParkGeometries[itemId];
-        me.tearOutConnectAdmissions.delete(itemId);
-        me.revokeVesselOwnerGrant('tear-out', itemId);
-        me.tearOutRetirements.delete(itemId);
         closeReceipt.stage = 'acknowledged';
 
         return true
@@ -3084,19 +2930,12 @@ class Workspace extends DockWorkspace {
 
         if (!entry?.windowId) return null;
 
-        const resolved = {
+        return {
             ...entry,
             itemId,
             nativeRoute: entry.nativeRoute ?? Neo.manager?.Window?.get(entry.windowId)?.nativeRoute ?? null,
             windowName : entry.windowName ?? `tearout-${itemId}`
-        };
-
-        Object.defineProperties(resolved, {
-            admissionToken: {value: entry.admissionToken},
-            generation    : {value: entry.generation}
-        });
-
-        return resolved
+        }
     }
 
     /**
@@ -3542,7 +3381,7 @@ class Workspace extends DockWorkspace {
      * the source reconciler must preserve the pane until the granted child arrives.
      * @param {Object} document
      * @param {Object} operation
-     * @param {Object} vessel Exact admitted vessel identity, including its private generation.
+     * @param {Object} vessel The admitted vessel identity: the reservation's slot and lineage token.
      * @protected
      */
     onTearOutDocumentChange(document, operation, vessel) {
@@ -3559,70 +3398,35 @@ class Workspace extends DockWorkspace {
             operation      : operation.operation,
             preserveItemIds: me.tearOutEmbodiment.isStaged(itemId) ? [] : [itemId]
         });
-        me.adoptTearOutPane(itemId, vessel?.generation, vessel?.admissionToken)
+        me.adoptTearOutPane(itemId, vessel)
     }
 
     /**
-     * The post-commit adoption: the detached terminal committed `detachItem` (the item left the
-     * tree, catalog preserved), so the vessel now OWNS the pane. Writes the {@link #tearOutPanes}
-     * entry and — if the vessel already connected ({@link #tearOutConnects}, the long-drag order)
-     * — reparents the live pane into it immediately; otherwise {@link #onWindowConnect} adopts on
-     * arrival (the fast-terminal order).
-     * @param {String} itemId
-     * @param {Number} [generation] Exact owner-grant generation for terminal-first adoption.
-     * @param {Number} [admissionToken] Exact gesture admission for terminal-first adoption.
+     * The vessel owns the pane now. If it had already bound (the long-drag order) it also becomes a
+     * dock target — a vessel workspace registers lazily on its first dock-INTO, this only opens the
+     * door. A vessel that binds later registers from {@link #afterTearOutWindowConnect}.
+     * @param {Object} data
+     * @param {Object|null} data.connection The connection the engine adopted, when the vessel had already bound.
+     * @param {String} data.itemId
      * @protected
      */
-    adoptTearOutPane(itemId, generation, admissionToken) {
-        let me        = this,
-            connected = me.tearOutConnects[itemId];
+    afterTearOutPaneAdopt({connection, itemId}) {
+        let me = this;
 
-        me.tearOutPanes[itemId] = connected
-            ? {...connected}
-            : {windowName: `tearout-${itemId}`, windowId: null};
-
-        Object.defineProperties(me.tearOutPanes[itemId], {
-            admissionToken: {
-                configurable: true,
-                value       : connected?.admissionToken ?? admissionToken ?? null,
-                writable    : true
-            },
-            generation: {
-                configurable: true,
-                value       : connected?.generation ?? generation ?? null,
-                writable    : true
-            },
-            nativeRoute: {
-                configurable: true,
-                value       : connected?.nativeRoute ?? null,
-                writable    : true
-            }
-        });
-
-        if (connected) {
-            // Promotion is synchronous and single-owner: committed disconnects may only match
-            // tearOutPanes from this point onward, never the pre-terminal connect branch first.
-            delete me.tearOutConnects[itemId];
-
-            if (me.tearOutEmbodiment.isStaged(itemId)) {
-                me.tearOutEmbodiment.promote({itemId, windowId: connected.windowId})
-            } else {
-                me.reparentTearOutPane(itemId, connected)
-            }
-
-            me.registerVesselWorkspaceTarget({
-                app     : Neo.apps[connected.windowId],
-                itemId,
-                windowId: connected.windowId
-            }).catch(error => {
-                me.lastCrossWindowTransfer = {applied: false, errors: [error.message]}
-            })
-        }
+        connection && me.registerVesselWorkspaceTarget({
+            app     : Neo.apps[connection.windowId],
+            itemId,
+            windowId: connection.windowId
+        }).catch(error => {
+            me.lastCrossWindowTransfer = {applied: false, errors: [error.message]}
+        })
     }
 
     /**
-     * Moves the LIVE cached pane into a connected tear-out vessel — pure render-target work;
-     * the model already committed at the terminal.
+     * Moves the LIVE cached pane into a bound tear-out vessel — pure render-target work; the model
+     * already committed at the terminal. A pane the connect-first order already staged into the
+     * vessel stays where it is: the exact-slot placeholder retires with the promotion instead of the
+     * pane moving twice.
      * @param {String} itemId
      * @param {Object} target `{windowId}`
      * @returns {Boolean}
@@ -3634,9 +3438,13 @@ class Workspace extends DockWorkspace {
             app        = Neo.apps[windowId],
             pane       = me.paneCache[itemId];
 
-        if (!app || !pane || pane.isDestroyed) return false;
-
         me.tearOutPanes[itemId] && Object.assign(me.tearOutPanes[itemId], target);
+
+        if (me.tearOutEmbodiment.isStaged(itemId)) {
+            return me.tearOutEmbodiment.promote({itemId, windowId}) !== false
+        }
+
+        if (!app || !pane || pane.isDestroyed) return false;
 
         if (pane.parent !== app.mainView) {
             pane.parent?.remove(pane, false);
@@ -3683,241 +3491,148 @@ class Workspace extends DockWorkspace {
     }
 
     /**
-     * A popup window joined the shared heap: if it is one of OURS (the pop-out URL carries
-     * `popout=<itemId>&hostId=<this.id>` plus an exact vessel grant), reparent the LIVE cached
-     * pane into its main view. The instance moves trees; nothing is recreated.
-     * @param {Object} data `{appName, windowId, windowData}`
+     * Retirement authority is established before any awaited close: a vessel that binds while its
+     * retirement is in flight is cleanup-only, and no content is ever staged into a closing realm.
+     * The engine's `retireTearOutVessel` holds the fence; this host only reads it.
+     * @param {Object} context
+     * @param {String} context.itemId
+     * @returns {Boolean}
+     * @protected
      */
-    async onWindowConnect(data) {
-        let me         = this,
-            {windowId} = data,
-            app        = Neo.apps[windowId];
-
-        if (!app || me.isDestroyed) return;
-
-        let url            = await Neo.Main.getByPath({path: 'document.URL', windowId}),
-            params         = new URL(url).searchParams,
-            itemId         = params.get('popout'),
-            flow           = params.get('vesselFlow'),
-            grant          = params.get('vesselGrant'),
-            admissionValue = params.get('vesselAdmission'),
-            admissionToken = admissionValue === null ? NaN : Number(admissionValue),
-            generation     = Number(params.get('vesselGeneration'));
-
-        if (params.get('hostId') !== me.id) return;
-        if (!itemId || flow !== 'tear-out' || !Number.isFinite(admissionToken)) return;
-
-        // Geometry-ready is part of child admission: the vessel's Main realm publishes movement and
-        // resize (the engine host's stream) before the connection reaches any ownership branch.
-        await me.observeWindowGeometry(windowId);
-
-        // Retirement authority is established before any awaited close. A connect continuation
-        // that resumes after that boundary is cleanup-only. Consume its exact grant and retain
-        // the route for a refused-close retry, but never stage content into the closing realm.
-        if (me.tearOutRetirements.has(itemId)) {
-            if (me.consumeVesselOwnerGrant({data, flow, generation, grant, itemId, windowId})) {
-                const admission = {admissionToken, generation, invalidated: true, windowId};
-
-                Object.defineProperty(admission, 'nativeRoute', {value: data.windowData.nativeRoute});
-                me.tearOutConnectAdmissions.set(itemId, admission)
-            }
-            return
+    admitTearOutConnection({itemId}) {
+        for (const vessel of this.tearOutRetirements.values()) {
+            if (vessel.itemId === itemId) return false
         }
 
-        if (!me.consumeVesselOwnerGrant({data, flow, generation, grant, itemId, windowId})) return;
+        return true
+    }
 
-        // A granted tear-out embodies immediately: the same live pane moves into the vessel while
-        // a hidden exact-slot placeholder keeps source tab/card indices coherent. Model truth
-        // remains untouched until the terminal.
-        const
-            admission  = {admissionToken, generation, invalidated: false, windowId},
-            connection = {windowId};
+    /**
+     * A vessel bound its reserved slot: the engine recorded the connection (pre-terminal) or moved the
+     * committed pane into it (terminal-first). Pre-terminal, the SAME live pane embodies into the
+     * vessel right away while a hidden exact-slot placeholder keeps the source tab/card indices
+     * coherent — model truth stays untouched until the terminal. Terminal-first, the vessel becomes a
+     * dock target. The instance moves trees; nothing is recreated.
+     * @param {Object} context
+     * @param {Neo.controller.Application} context.app
+     * @param {Object} context.connection
+     * @param {String} context.itemId
+     * @param {String} context.windowId
+     * @protected
+     */
+    async afterTearOutWindowConnect({app, connection, itemId, windowId}) {
+        let me = this;
 
-        Object.defineProperties(connection, {
-            admissionToken: {value: admissionToken},
-            generation    : {value: generation},
-            nativeRoute   : {value: data.windowData.nativeRoute}
-        });
-        Object.defineProperty(admission, 'nativeRoute', {value: data.windowData.nativeRoute});
-        me.tearOutConnectAdmissions.set(itemId, admission);
+        if (me.tearOutPanes[itemId]?.windowId === windowId) {
+            await me.registerVesselWorkspaceTarget({app, itemId, windowId});
+            return
+        }
 
         const staged = await me.tearOutEmbodiment.stage({itemId, windowId});
 
-        // A re-entry/cancel may retire the semantic vessel while the cross-window render
-        // transaction is still painting. The exact admission token is durable across a close
-        // acknowledgement clearing the transient retirement fence, so a dead generation can
-        // never resume here and publish itself after its disconnect already fired.
+        // A re-entry, cancel or physical death may retire the vessel while the cross-window render
+        // transaction is still painting; the connection this stage began for is then gone, and a dead
+        // generation must never publish itself. A terminal landing meanwhile promoted the stage.
         if (
-            me.tearOutConnectAdmissions.get(itemId) !== admission || admission.invalidated ||
-            me.tearOutRetirements.has(itemId)
+            staged && (me.isDestroyed || (
+                me.tearOutConnects[itemId] !== connection && me.tearOutPanes[itemId]?.windowId !== windowId
+            ))
         ) {
-            staged && me.tearOutEmbodiment.restore({itemId, windowId});
-            return
-        }
-
-        me.tearOutConnectAdmissions.delete(itemId);
-
-        if (me.tearOutPanes[itemId]) {
-            Object.assign(me.tearOutPanes[itemId], connection);
-            Object.defineProperties(me.tearOutPanes[itemId], {
-                admissionToken: {configurable: true, value: admissionToken, writable: true},
-                generation    : {configurable: true, value: generation, writable: true},
-                nativeRoute   : {configurable: true, value: data.windowData.nativeRoute, writable: true}
-            });
-
-            if (staged) {
-                me.tearOutEmbodiment.promote({itemId, windowId})
-            } else {
-                me.reparentTearOutPane(itemId, connection)
-            }
-        } else {
-            me.tearOutConnects[itemId] = connection
-        }
-
-        if (me.tearOutPanes[itemId]) {
-            await me.registerVesselWorkspaceTarget({app, itemId, windowId})
+            me.tearOutEmbodiment.restore({itemId, windowId})
         }
     }
 
     /**
-     * A vessel window left the shared heap. Physical death is authoritative: clear every state
-     * owner so a successor gesture cannot inherit or be blocked by the retired generation, and
-     * bring a committed item HOME (model commit precedes every render effect; the reintegration
-     * is exact-once and idempotent).
-     * @param {Object} data `{appName, windowId}`
+     * A vessel window left the shared heap. Physical death is authoritative: before the engine clears
+     * the ownership records and brings a committed item home, this host retires what only it knows —
+     * the native drop candidate, the target-proxy embodiment, a pane still staged in the dying realm,
+     * and a committed vessel WORKSPACE, whose whole stack comes home atomically or, when recovery is
+     * refused, survives headless as the only A+B truth.
+     * @param {Object} data
+     * @param {String} data.groupId
+     * @param {String} data.windowId
+     * @protected
      */
-    onWindowDisconnect(data) {
-        let me = this;
+    async onTopologyRelease(data) {
+        let me         = this,
+            {windowId} = data;
 
-        if (me.isDestroyed) return;
+        if (me.isDestroyed || data.groupId !== me.topologyGroupId) return;
 
         // Physical source death is the one cancellation that must NOT attempt a restore. Retire
-        // the coordinator's exact candidate/retry generation before the app-owned vessel machines
-        // clear their matching slots below.
-        Neo.manager.DragCoordinator?.clearNativeWindowDropCandidate(data.windowId, {
-            restoreSource: false
-        });
-        Neo.manager.DragCoordinator?.endNativeGesture(data.windowId);
+        // the coordinator's exact candidate/retry generation before the vessel machines clear
+        // their matching slots.
+        Neo.manager.DragCoordinator?.clearNativeWindowDropCandidate(windowId, {restoreSource: false});
+        Neo.manager.DragCoordinator?.endNativeGesture(windowId);
 
         // A disconnect can invalidate either side of the nested popup→target-proxy transaction.
-        // Restore it before the outer main→popup embodiment below decides restore vs promote.
-        me.vesselProxyEmbodiment.restoreByWindow(data.windowId);
+        // Restore it before the outer main→popup embodiment decides restore vs promote.
+        me.vesselProxyEmbodiment.restoreByWindow(windowId);
 
-        // A child can disconnect while its live-pane stage is still awaiting renderer settlement.
-        // The connect is not in tearOutConnects yet, so this private generation token is the only
-        // exact owner. Retire it now; the stage continuation observes the deleted token and cannot
-        // republish the dead window.
-        for (const [itemId, admission] of me.tearOutConnectAdmissions) {
-            if (admission.windowId === data.windowId) {
-                const
-                    committed  = Boolean(me.tearOutPanes[itemId]),
-                    windowName = `tearout-${itemId}`;
+        const
+            committedItemId = Object.entries(me.tearOutPanes).find(([, entry]) => entry.windowId === windowId)?.[0],
+            itemId          = committedItemId ?? Object.entries(me.tearOutConnects).find(([, entry]) => entry.windowId === windowId)?.[0];
 
-                me.tearOutConnectAdmissions.delete(itemId);
-                delete me.tearOutParkGeometries[itemId];
-                me.tearOutRetirements.add(itemId);
+        if (itemId && me.tearOutEmbodiment.isStaged(itemId)) {
+            const sourceOwns = Boolean(WorkspaceDocument.findContainingTabsId(me.dockModel, itemId));
 
-                if (me.tearOutEmbodiment.isStaged(itemId)) {
-                    me.tearOutEmbodiment.restore({itemId, windowId: data.windowId})
-                }
+            me.tearOutEmbodiment[sourceOwns ? 'restore' : 'promote']({itemId, windowId})
+        }
 
-                me.tearOutHandlers.onVesselRetired({
-                    admissionToken: admission.admissionToken,
-                    generation    : admission.generation,
-                    itemId,
-                    windowName
-                });
-                me.vesselParkHandlers.onVesselRetired({itemId, retirement: true});
-                me.nativeVesselParkHandlers.onVesselRetired({itemId, retirement: true});
-                me.revokeVesselOwnerGrant('tear-out', itemId);
-                me.retireVesselWorkspaceTarget(itemId);
-                me.tearOutRetirements.delete(itemId);
-                delete me.tearOutPanes[itemId];
-                committed && me.reintegrateTearOutItem(itemId);
+        if (committedItemId) {
+            const
+                workspaceId = Workspace.vesselWorkspaceId(committedItemId),
+                state       = me.vesselWorkspaces.get(workspaceId);
+
+            if (
+                state?.committed && Object.keys(state.document?.items || {}).length &&
+                !me.recoverDisconnectedVesselWorkspace(committedItemId)
+            ) {
+                // Recovery refused: the headless document is the only surviving A+B truth, so the item
+                // does not come home and only the dead render-target seams go.
+                const entry = me.tearOutPanes[committedItemId];
+
+                delete me.tearOutPanes[committedItemId];
+                delete me.tearOutConnects[committedItemId];
+                me.clearTearOutAdmission(committedItemId);
+                me.tearOutHandlers?.onVesselRetired({...entry, itemId: committedItemId});
+                me.afterTearOutWindowDisconnect({committed: true, data, entry, itemId: committedItemId, pane: null, recovered: false});
+                me.demoteDisconnectedVesselWorkspace(state);
                 return
             }
-        }
 
-        // A pre-terminal tear-out may disconnect after an exact close returned false (the native
-        // event can outrun its Boolean acknowledgement) or after the user closes the retained
-        // window manually. Clear BOTH state owners.
-        for (const [itemId, entry] of Object.entries(me.tearOutConnects)) {
-            if (entry.windowId === data.windowId) {
-                const windowName = `tearout-${itemId}`;
-
-                me.tearOutRetirements.add(itemId);
-
-                if (me.tearOutEmbodiment.isStaged(itemId)) {
-                    const sourceOwns = Boolean(WorkspaceDocument.findContainingTabsId(me.dockModel, itemId));
-
-                    me.tearOutEmbodiment[sourceOwns ? 'restore' : 'promote']({itemId, windowId: entry.windowId})
-                }
-
-                delete me.tearOutConnects[itemId];
-                delete me.tearOutParkGeometries[itemId];
-                me.tearOutHandlers.onVesselRetired({
-                    admissionToken: entry.admissionToken,
-                    generation    : entry.generation,
-                    itemId,
-                    windowName
-                });
-                me.vesselParkHandlers.onVesselRetired({itemId, retirement: true});
-                me.nativeVesselParkHandlers.onVesselRetired({itemId, retirement: true});
-                me.revokeVesselOwnerGrant('tear-out', itemId);
-                me.retireVesselWorkspaceTarget(itemId);
-                me.tearOutRetirements.delete(itemId);
-                return
+            if (
+                state?.committed &&
+                me.lastCrossWindowTransfer?.sourceWorkspaceId === workspaceId &&
+                me.lastCrossWindowTransfer.targetWorkspaceId === Workspace.MAIN_WORKSPACE_ID
+            ) {
+                me.lastCrossWindowTransfer.topologyExited = true;
+                me.lastCrossWindowTransfer.phases ??= [];
+                me.lastCrossWindowTransfer.phases.push('topology-exited')
             }
+
+            me.retireVesselWorkspaceTarget(committedItemId)
         }
 
-        // Tear-out vessel death after the commit: the item comes HOME. A pre-terminal disconnect
-        // has no entry in either map and needs nothing.
-        for (const [itemId, entry] of Object.entries(me.tearOutPanes)) {
-            if (entry.windowId === data.windowId) {
-                const
-                    windowName     = entry.windowName ?? `tearout-${itemId}`,
-                    workspaceId    = Workspace.vesselWorkspaceId(itemId),
-                    workspaceState = me.vesselWorkspaces.get(workspaceId);
-                let workspaceSettled = true;
+        await super.onTopologyRelease(data)
+    }
 
-                if (workspaceState?.committed) {
-                    workspaceSettled = Object.keys(workspaceState.document?.items || {}).length === 0
-                        || me.recoverDisconnectedVesselWorkspace(itemId)
-                }
+    /**
+     * The engine cleared a vessel's ownership records — on its release, its lease running out, or a
+     * refused recovery — and brought a committed item home. The park and native-park machines, the
+     * park geometry and, unless the workspace survives headless, the vessel target retire with it.
+     * @param {Object} data
+     * @param {String} data.itemId
+     * @param {Boolean} [data.recovered=true] `false` when the vessel's workspace stays registered headless.
+     * @protected
+     */
+    afterTearOutWindowDisconnect({itemId, recovered=true}) {
+        let me = this;
 
-                delete me.tearOutPanes[itemId];
-                delete me.tearOutConnects[itemId];
-                delete me.tearOutParkGeometries[itemId];
-                me.tearOutRetirements.delete(itemId);
-                me.tearOutHandlers.onVesselRetired({
-                    admissionToken: entry.admissionToken,
-                    generation    : entry.generation,
-                    itemId,
-                    windowName
-                });
-                me.vesselParkHandlers.onVesselRetired({itemId, retirement: true});
-                me.nativeVesselParkHandlers.onVesselRetired({itemId, retirement: true});
-
-                if (workspaceSettled) {
-                    if (
-                        workspaceState?.committed &&
-                        me.lastCrossWindowTransfer?.sourceWorkspaceId === workspaceId &&
-                        me.lastCrossWindowTransfer.targetWorkspaceId === Workspace.MAIN_WORKSPACE_ID
-                    ) {
-                        me.lastCrossWindowTransfer.topologyExited = true;
-                        me.lastCrossWindowTransfer.phases ??= [];
-                        me.lastCrossWindowTransfer.phases.push('topology-exited')
-                    }
-
-                    me.retireVesselWorkspaceTarget(itemId);
-                    me.reintegrateTearOutItem(itemId)
-                } else {
-                    me.demoteDisconnectedVesselWorkspace(workspaceState)
-                }
-
-                break
-            }
-        }
+        delete me.tearOutParkGeometries[itemId];
+        me.vesselParkHandlers.onVesselRetired({itemId, retirement: true});
+        me.nativeVesselParkHandlers.onVesselRetired({itemId, retirement: true});
+        recovered && me.retireVesselWorkspaceTarget(itemId)
     }
 
     /**
@@ -5011,7 +4726,8 @@ class Workspace extends DockWorkspace {
      *
      * Arms a tab drag, flings the proxy past the window boundary so
      * {@link Neo.dashboard.dock.interaction.TabSortZone} fires `dockTearOutExit`, the host opens a `?popout=`
-     * vessel, then — gated on that vessel's ACTUAL birth ({@link #onWindowConnect}) — survives
+     * vessel, then — gated on that vessel's ACTUAL birth (its slot binding through
+     * {@link Neo.dashboard.dock.Workspace#onTopologyBind}) — survives
      * deliberate post-birth moves and settles one of three terminals: release while detached
      * (`dockTearOutTerminal` → the `detachItem` commit + adoption), Escape-cancel (zero-mutation
      * vessel close), or RE-ENTRY (`reenter` — the drag walks back inside past the reattach
@@ -5174,7 +4890,7 @@ class Workspace extends DockWorkspace {
                 await moveTo(p.x, p.y)
             }
 
-            // Gate on the vessel's ACTUAL birth: a `?popout=` window connecting through onWindowConnect.
+            // Gate on the vessel's ACTUAL birth: a `?popout=` window binding its reserved slot.
             let born = await me.waitForTearOutVessel(itemId, {attempts: birthAttempts});
 
             sortZone.un('dragBoundaryEntry', preBirthBoundaryProbe);
@@ -5349,8 +5065,9 @@ class Workspace extends DockWorkspace {
     }
 
     /**
-     * Gates on the tear-out vessel's ACTUAL birth: the `?popout=<itemId>` window connecting
-     * through {@link #onWindowConnect}. Polls that observable rather than any internal drag flag.
+     * Gates on the tear-out vessel's ACTUAL birth: the `?popout=<itemId>` window binding its
+     * reserved slot ({@link Neo.dashboard.dock.Workspace#onTopologyBind}). Polls that observable
+     * rather than any internal drag flag.
      * @param {String} itemId
      * @param {Object} [options={}]
      * @param {Number} [options.attempts=180]
@@ -5383,7 +5100,7 @@ class Workspace extends DockWorkspace {
     async waitForTearOutVesselRetired(itemId, {attempts=180, delay=16}={}) {
         let me      = this,
             retired = () => Boolean(
-                !me.tearOutConnects[itemId] && !me.tearOutConnectAdmissions.has(itemId) &&
+                !me.tearOutConnects[itemId] && !me.tearOutAdmissions.has(itemId) &&
                 !me.tearOutEmbodiment.isStaged(itemId) && !me.tearOutHandlers.activeVessel
             );
 
@@ -5485,11 +5202,10 @@ class Workspace extends DockWorkspace {
             me.#feedIntervalId = null
         }
 
-        Neo.currentWorker.un({
-            connect   : me.onWindowConnect,
-            disconnect: me.onWindowDisconnect,
-            scope     : me
-        });
+        // Vessels close through this host's seam, which settles a staged pane through the embodiment
+        // first — so the sweep runs while the embodiments are alive, and the engine's own sweep in
+        // `super.destroy` finds nothing left.
+        me.retireTearOutState();
 
         me.crossWindowParticipations.forEach(participation => participation?.destroy());
         me.crossWindowParticipations.clear();

--- a/apps/workstation/view/Workspace.mjs
+++ b/apps/workstation/view/Workspace.mjs
@@ -496,7 +496,10 @@ class Workspace extends DockWorkspace {
         // documents by STABLE workspace identity — windowId, screen geometry, and projection state
         // never enter it; a window is a render target, not a state owner. Its membership lives in
         // this workspace's Group on `Neo.manager.Transaction`: the app imports the manager, so its
-        // window is admitted at registration and the Group exists before this constructor runs.
+        // window is admitted at registration, and a Group the carrier already held is known before
+        // this constructor runs. A first boot's minted identity arrives once the carrier accepted it,
+        // through `afterSetTopologyGroupId`, which registers the main participant then. The Group is
+        // kept for the instance's lifetime: releasing the window's slot never loses the documents.
         // Vessel workspaces register lazily on first dock-INTO (Edit 2).
         me.workspaceSet = createDockWorkspaceSet({manager: TransactionManager, getGroupId: () => me.topologyGroupId});
         me.registerMainWorkspace();
@@ -903,10 +906,11 @@ class Workspace extends DockWorkspace {
     /**
      * @summary Publishes this workspace's own document as the `main` participant of its Group.
      *
-     * Membership is the Group's, and a workspace has a Group only once its window is bound — which its
-     * app did at registration, before any view of that window constructed. An instance created
-     * headless has no window yet and joins nothing; {@link #afterSetWindowId} registers it the moment
-     * a container supplies its first real window id.
+     * Membership is the Group's, and a workspace has a Group only once its window's binding is
+     * accepted — which its app did at registration, before any view of that window constructed, unless
+     * a first boot is still awaiting its carrier; {@link #afterSetTopologyGroupId} registers it then.
+     * An instance created headless has no window yet and joins nothing; {@link #afterSetWindowId}
+     * registers it the moment a container supplies its first real window id.
      * @returns {Boolean} Whether the participant is registered.
      * @protected
      */
@@ -928,6 +932,21 @@ class Workspace extends DockWorkspace {
      */
     afterSetWindowId(value, oldValue) {
         super.afterSetWindowId(value, oldValue);
+
+        let me = this;
+
+        value && me.workspaceSet && !me.workspaceSet.has(Workspace.MAIN_WORKSPACE_ID) && me.registerMainWorkspace()
+    }
+
+    /**
+     * The Group arrived after construction — a first boot's minted identity, accepted by its carrier —
+     * so the main participant registers now (see {@link #registerMainWorkspace}).
+     * @param {String|null} value
+     * @param {String|null} oldValue
+     * @protected
+     */
+    afterSetTopologyGroupId(value, oldValue) {
+        super.afterSetTopologyGroupId(value, oldValue);
 
         let me = this;
 

--- a/buildScripts/util/file-size-baseline.json
+++ b/buildScripts/util/file-size-baseline.json
@@ -1,6 +1,6 @@
 {
-    "apps/workstation/view/Workspace.mjs": 3390,
-    "examples/dashboard/crossWindow/DemoBWorkspace.mjs": 2701,
-    "src/dashboard/dock/Workspace.mjs": 1284,
+    "apps/workstation/view/Workspace.mjs": 3187,
+    "examples/dashboard/crossWindow/DemoBWorkspace.mjs": 2631,
+    "src/dashboard/dock/Workspace.mjs": 1278,
     "src/main/addon/DragDrop.mjs": 1267
 }

--- a/buildScripts/util/file-size-baseline.json
+++ b/buildScripts/util/file-size-baseline.json
@@ -1,5 +1,5 @@
 {
-    "apps/workstation/view/Workspace.mjs": 3187,
+    "apps/workstation/view/Workspace.mjs": 3197,
     "examples/dashboard/crossWindow/DemoBWorkspace.mjs": 2631,
     "src/dashboard/dock/Workspace.mjs": 1278,
     "src/main/addon/DragDrop.mjs": 1267

--- a/buildScripts/util/file-size-baseline.json
+++ b/buildScripts/util/file-size-baseline.json
@@ -1,6 +1,6 @@
 {
-    "apps/workstation/view/Workspace.mjs": 3197,
-    "examples/dashboard/crossWindow/DemoBWorkspace.mjs": 2631,
-    "src/dashboard/dock/Workspace.mjs": 1278,
+    "apps/workstation/view/Workspace.mjs": 3202,
+    "examples/dashboard/crossWindow/DemoBWorkspace.mjs": 2645,
+    "src/dashboard/dock/Workspace.mjs": 1292,
     "src/main/addon/DragDrop.mjs": 1267
 }

--- a/docs/output/class-hierarchy.json
+++ b/docs/output/class-hierarchy.json
@@ -433,6 +433,7 @@
  "Neo.manager.Store": "Neo.manager.Base",
  "Neo.manager.Task": "Neo.manager.Base",
  "Neo.manager.Toast": "Neo.manager.Base",
+ "Neo.manager.Transaction": "Neo.manager.Base",
  "Neo.manager.VDomUpdate": "Neo.collection.Base",
  "Neo.manager.Window": "Neo.manager.Base",
  "Neo.manager.rpc.Api": "Neo.manager.Base",

--- a/examples/dashboard/crossWindow/DemoBCrossWindowStage.mjs
+++ b/examples/dashboard/crossWindow/DemoBCrossWindowStage.mjs
@@ -38,7 +38,6 @@ import {previewToOperation} from '../../../src/dashboard/dock/model/PreviewContr
  * @param {Object} seams.workspaceIds `{main, popup, popup2}` semantic workspace ids (`popup2`
  *     optional — the stage parameterizes over every popup id the host registers).
  * @param {String} seams.sortGroup The shared cross-window coordinator sort group.
- * @param {String} seams.hostComponentId The workspace component id, stamped into stage URLs as `hostId`.
  * @param {Function} seams.applyWorkspaceOperation `(workspaceId, descriptor) => {document, errors}|null`
  * @param {Function} seams.adoptCommittedTransferPair `(pair) => Boolean` — the HOST's wrappable
  *     adoption facade; `commitWholeStackReturn` routes through it (never its own internal twin)
@@ -51,7 +50,6 @@ import {previewToOperation} from '../../../src/dashboard/dock/model/PreviewContr
  * @param {Function} seams.clearWorkspaceAffordances `(workspaceId)`
  * @param {Function} seams.commitCrossWindowTransfer `(data)` — the host's gesture transfer commit (Phase 2 surface).
  * @param {Function} seams.createPopupDocument `() => Object` — a valid empty popup workspace document.
- * @param {Function} seams.createVesselOwnerGrant `(flow, itemId) => {generation, token}`
  * @param {Function} seams.ensurePopupRegistered `(workspaceId) => Boolean` — re-registers the popup workspace's live accessors.
  * @param {Function} seams.getPopupDocument `(workspaceId) => Object|null`
  * @param {Function} seams.getStagePromise `(workspaceId) => Promise|null`
@@ -71,8 +69,10 @@ import {previewToOperation} from '../../../src/dashboard/dock/model/PreviewContr
  * @param {Function} seams.projectDockModel `(resolveComponentRef|null, workspaceId) => Object`
  * @param {Function} seams.refreshWorkspace `(workspaceId, document) => Promise`
  * @param {Function} seams.renderWorkspacePreview `(workspaceId, data) => Object|null`
+ * @param {Function} seams.reserveVessel `(workspaceKey, flow, windowName) => identity|null` — reserves the
+ *     target's slot in the host's Group; the identity rides `windowOpen` into the popup's carrier.
  * @param {Function} seams.resolveGesture `(receipt)` — consumes the host's gesture settlement resolver.
- * @param {Function} seams.revokeVesselOwnerGrant `(flow, itemId)`
+ * @param {Function} seams.revokeVessel `(workspaceKey)` — gives an unbound reservation back.
  * @param {Function} seams.setPopupDocument `(workspaceId, document)`
  * @param {Function} seams.setStagePromise `(workspaceId, promise|null)`
  * @param {Function} seams.setStageReject `(workspaceId, fn|null)`
@@ -95,7 +95,6 @@ export function createCrossWindowStage(seams) {
         clearWorkspaceAffordances,
         commitCrossWindowTransfer,
         createPopupDocument,
-        createVesselOwnerGrant,
         ensurePopupRegistered,
         getPopupDocument,
         getStagePromise,
@@ -115,8 +114,9 @@ export function createCrossWindowStage(seams) {
         projectDockModel,
         refreshWorkspace,
         renderWorkspacePreview,
+        reserveVessel,
         resolveGesture,
-        revokeVesselOwnerGrant,
+        revokeVessel,
         setPopupDocument,
         setStagePromise,
         setStageReject,
@@ -329,28 +329,33 @@ export function createCrossWindowStage(seams) {
         setStageResolve(workspaceId, stageResolve);
         setStageReject(workspaceId, stageReject);
 
-        let ownerGrant = createVesselOwnerGrant('workspace-target', workspaceId);
+        // The target's slot in the host's Group: the popup presents this identity when it binds, and
+        // the host mounts the workspace into it from that binding — the URL names the workspace only.
+        const reservation = reserveVessel(workspaceId, 'workspace-target', getStageWindowName(workspaceId));
 
         try {
+            if (!reservation) {
+                throw new Error('cross-window stage could not reserve its Group slot')
+            }
+
             let winData = await Neo.Main.getWindowData({windowId: getWindowId()}),
                 left    = winData.screenLeft > 660
                     ? winData.screenLeft - 640
                     : winData.screenLeft + (winData.innerWidth || 1280) + 40,
                 top     = winData.screenTop,
                 opened  = await Neo.Main.windowOpen({
-                    url           : `./index.html?workspaceId=${workspaceId}&hostId=${seams.hostComponentId}`
-                        + `&vesselFlow=workspace-target&vesselGrant=${ownerGrant.token}`
-                        + `&vesselGeneration=${ownerGrant.generation}`,
-                    windowFeatures: `height=520,width=600,left=${left},top=${top}`,
-                    windowId      : getWindowId(),
-                    windowName    : getStageWindowName(workspaceId)
+                    topologyIdentity: reservation,
+                    url             : `./index.html?workspaceId=${workspaceId}`,
+                    windowFeatures  : `height=520,width=600,left=${left},top=${top}`,
+                    windowId        : getWindowId(),
+                    windowName      : getStageWindowName(workspaceId)
                 });
 
             if (opened === false) {
                 throw new Error('cross-window popup blocked')
             }
         } catch (error) {
-            revokeVesselOwnerGrant('workspace-target', workspaceId);
+            revokeVessel(workspaceId);
             getStageReject(workspaceId)?.(error);
             setStagePromise(workspaceId, null);
             setStageResolve(workspaceId, null);
@@ -365,7 +370,7 @@ export function createCrossWindowStage(seams) {
         try {
             return await Promise.race([stagePromise, timeout])
         } catch (error) {
-            revokeVesselOwnerGrant('workspace-target', workspaceId);
+            revokeVessel(workspaceId);
             setStagePromise(workspaceId, null);
             throw error
         }

--- a/examples/dashboard/crossWindow/DemoBWorkspace.mjs
+++ b/examples/dashboard/crossWindow/DemoBWorkspace.mjs
@@ -512,9 +512,11 @@ class DemoBWorkspace extends Container {
         // pieces, as this one is, arms it itself.
         Neo.main.addon.WindowPosition?.setConfigs({observeMovement: true, observeResize: true, windowId: me.windowId});
 
-        // Both workspaces register under their STABLE semantic ids — the seams read/write the
-        // live owner fields, so registry resolution always answers with committed truth.
-        me.workspaceSet = createDockWorkspaceSet();
+        // Every workspace registers under its STABLE semantic id — the seams read/write the live
+        // owner fields, so resolution always answers with committed truth. Membership lives in this
+        // host's Group on `Neo.manager.Transaction`: the app imports the manager, so its window is
+        // admitted at registration and the Group exists before this constructor runs.
+        me.workspaceSet = createDockWorkspaceSet({manager: TransactionManager, getGroupId: () => me.topologyGroupId});
 
         me.workspaceSet.register(DemoBWorkspace.MAIN_WORKSPACE_ID, {
             getDocument: () => me.dockModel,

--- a/examples/dashboard/crossWindow/DemoBWorkspace.mjs
+++ b/examples/dashboard/crossWindow/DemoBWorkspace.mjs
@@ -515,23 +515,11 @@ class DemoBWorkspace extends Container {
         // Every workspace registers under its STABLE semantic id — the seams read/write the live
         // owner fields, so resolution always answers with committed truth. Membership lives in this
         // host's Group on `Neo.manager.Transaction`: the app imports the manager, so its window is
-        // admitted at registration and the Group exists before this constructor runs.
+        // admitted at registration, and a Group the carrier already held is known before this
+        // constructor runs; a first boot's minted identity arrives with its accepted binding, and
+        // `onTopologyBind` registers the participants then.
         me.workspaceSet = createDockWorkspaceSet({manager: TransactionManager, getGroupId: () => me.topologyGroupId});
-
-        me.workspaceSet.register(DemoBWorkspace.MAIN_WORKSPACE_ID, {
-            getDocument: () => me.dockModel,
-            setDocument: document => me.dockModel = document
-        });
-
-        me.workspaceSet.register(DemoBWorkspace.POPUP_WORKSPACE_ID, {
-            getDocument: () => me.popupDocument,
-            setDocument: document => me.popupDocument = document
-        });
-
-        me.workspaceSet.register(DemoBWorkspace.POPUP2_WORKSPACE_ID, {
-            getDocument: () => me.popup2Document,
-            setDocument: document => me.popup2Document = document
-        });
+        me.adoptTopologyGroup(TransactionManager.findByWindow(me.windowId)?.groupId ?? null);
 
         me.dockPreviewProducer = Neo.create(DockPreviewProducer);
         me.dockService      = Neo.create(DockService, {});
@@ -703,9 +691,10 @@ class DemoBWorkspace extends Container {
         // this workspace answers only for the slots it reserved in its own Group — the pop-out pane
         // reparents when its vessel binds, comes home when the binding is released.
         TransactionManager.on({
-            bind   : me.onTopologyBind,
-            release: me.onTopologyRelease,
-            scope  : me
+            bind        : me.onTopologyBind,
+            leaseExpired: me.onTopologyLeaseExpired,
+            release     : me.onTopologyRelease,
+            scope       : me
         });
 
         me.add([me.createTourBar(), me.createSwitcherBar(), {
@@ -1142,13 +1131,17 @@ class DemoBWorkspace extends Container {
     }
 
     /**
-     * Resolves worker-owned document truth by semantic workspace id — through the workspace-set
-     * registry, so an unknown id fails closed instead of guessing.
+     * Resolves worker-owned document truth by semantic workspace id. The main document is the host's
+     * own for the host's lifetime and resolves from its owner field — the same truth its participant
+     * seam reads, available before the window's binding is accepted, when there is no membership yet
+     * and the first projection cannot wait for one. Every vessel workspace resolves through the
+     * workspace set, whose registration IS that workspace's lifetime: a retired popup resolves to
+     * `null`, and an unknown id fails closed instead of guessing.
      * @param {String} workspaceId
      * @returns {Object|null}
      */
     getWorkspaceDocument(workspaceId) {
-        return this.workspaceSet.getDocument(workspaceId)
+        return workspaceId === DemoBWorkspace.MAIN_WORKSPACE_ID ? this.dockModel : this.workspaceSet.getDocument(workspaceId)
     }
 
     /**
@@ -2999,11 +2992,59 @@ class DemoBWorkspace extends Container {
     }
 
     /**
-     * The Group this workspace's window is bound into, or `null` before its window has bound.
-     * @member {String|null} topologyGroupId
+     * The Group this workspace belongs to — learned from its window's accepted binding and kept for
+     * the instance's lifetime, so the documents it registered stay reachable after the window's slot
+     * is released or its lease runs out. `null` until the binding is accepted: a first boot mints its
+     * identity and awaits the carrier, so {@link #onTopologyBind} adopts the Group after construction.
+     * @member {String|null} topologyGroupId=null
      */
-    get topologyGroupId() {
-        return TransactionManager.findByWindow(this.windowId)?.groupId ?? null
+    topologyGroupId = null
+
+    /**
+     * @summary Learns the Group and registers the three workspace participants into it — at
+     * construction when the window bound before this instance existed, else when its binding arrives.
+     * @param {String|null} groupId
+     * @protected
+     */
+    adoptTopologyGroup(groupId) {
+        let me = this;
+
+        if (!groupId || me.topologyGroupId) return;
+
+        me.topologyGroupId = groupId;
+
+        me.workspaceSet.register(DemoBWorkspace.MAIN_WORKSPACE_ID, {
+            getDocument: () => me.dockModel,
+            setDocument: document => me.dockModel = document
+        });
+
+        me.workspaceSet.register(DemoBWorkspace.POPUP_WORKSPACE_ID, {
+            getDocument: () => me.popupDocument,
+            setDocument: document => me.popupDocument = document
+        });
+
+        me.workspaceSet.register(DemoBWorkspace.POPUP2_WORKSPACE_ID, {
+            getDocument: () => me.popup2Document,
+            setDocument: document => me.popup2Document = document
+        })
+    }
+
+    /**
+     * A slot this workspace reserved ran out its lease without a window binding: the manager freed
+     * it, and a window presenting that reservation later forks into its own Group. The pending record
+     * leaves with the slot, so no handler here still expects that child.
+     * @param {Object} data
+     * @param {String} data.groupId
+     * @param {String} data.workspaceKey
+     * @protected
+     */
+    onTopologyLeaseExpired({groupId, workspaceKey}) {
+        let me          = this,
+            reservation = me.vesselReservations.get(workspaceKey);
+
+        if (me.isDestroyed || groupId !== me.topologyGroupId || !reservation || reservation.windowId) return;
+
+        me.vesselReservations.delete(workspaceKey)
     }
 
     /**
@@ -3071,7 +3112,13 @@ class DemoBWorkspace extends Container {
             app         = Neo.apps[windowId],
             reservation = me.vesselReservations.get(workspaceKey);
 
-        if (!app || me.isDestroyed || groupId !== me.topologyGroupId || !reservation || reservation.windowId) return;
+        if (me.isDestroyed) return;
+
+        // The host's own window binding, accepted after construction: the Group is learned and the
+        // participants register before any reserved slot is answered.
+        windowId === me.windowId && me.adoptTopologyGroup(groupId);
+
+        if (!app || groupId !== me.topologyGroupId || !reservation || reservation.windowId) return;
 
         reservation.windowId = windowId;
 
@@ -4495,9 +4542,10 @@ class DemoBWorkspace extends Container {
         me.crossWindowGeometry.clear();
         me.workspaceProjectionRequests.clear();
         TransactionManager.un({
-            bind   : me.onTopologyBind,
-            release: me.onTopologyRelease,
-            scope  : me
+            bind        : me.onTopologyBind,
+            leaseExpired: me.onTopologyLeaseExpired,
+            release     : me.onTopologyRelease,
+            scope       : me
         });
         me.vesselReservations.clear();
         me.tearOutEmbodiment?.destroy();

--- a/examples/dashboard/crossWindow/DemoBWorkspace.mjs
+++ b/examples/dashboard/crossWindow/DemoBWorkspace.mjs
@@ -21,6 +21,7 @@ import {createDockVesselEmbodiment}         from '../../../src/dashboard/dock/wi
 import {createDockWorkspaceSet}             from '../../../src/dashboard/dock/window/WorkspaceSet.mjs';
 import {createVesselParkHandlers}           from '../../../src/dashboard/dock/window/VesselPark.mjs';
 import TourRunner                           from '../../../src/ai/client/TourRunner.mjs';
+import TransactionManager                   from '../../../src/manager/Transaction.mjs';
 import {PREVIEW_SCHEMA, previewToOperation} from '../../../src/dashboard/dock/model/PreviewContract.mjs';
 import {demoBTourScript, initialDocument}   from './demoBPerspectives.mjs';
 import '../../../src/button/Base.mjs';   // registers the `button` ntype the bars compose
@@ -390,13 +391,16 @@ class DemoBWorkspace extends Container {
      */
     tearOutConnects = {}
     /**
-     * Exact connect continuations admitted by one consumed owner grant but not yet published after
-     * cross-window pane staging. Closing a vessel deletes this token before awaiting the platform,
-     * so the resumed stage can never publish a retired generation after the fence is later cleared.
-     * @member {Map<String,Object>} tearOutConnectAdmissions
+     * The slots this workspace reserved in its Group, keyed by workspace key — `popup:<itemId>` for
+     * a tear-out or click pop-out vessel, the popup workspace id for a cross-window stage target.
+     * Each remembers the flow that reserved it, the reservation's lineage token and, once bound, the
+     * window. `Neo.manager.Transaction` owns identity, token and clock; this map only holds what the
+     * host needs to answer a binding, and a stage continuation that finds its reservation gone knows
+     * the window died under it.
+     * @member {Map<String,Object>} vesselReservations
      * @protected
      */
-    tearOutConnectAdmissions = new Map()
+    vesselReservations = new Map()
     /**
      * Transient render-only pane embodiment. An admitted pre-terminal vessel carries the real pane
      * while an exact-slot placeholder preserves the source card/header pairing. WorkspaceDocument truth is
@@ -420,22 +424,6 @@ class DemoBWorkspace extends Container {
      * @protected
      */
     tearOutAcquisitionAttempts = 0
-    /**
-     * Product-semantic owner grants for popup vessels. The merged native-window identity spine
-     * proves the exact physical child; this map binds that child to one product flow + item +
-     * generation without trusting URL shape, item id, arrival order, or an existing pane entry.
-     * Keys are `${flow}:${itemId}` and values are `{generation, token}`.
-     * @member {Map} vesselOwnerGrants
-     * @protected
-     */
-    vesselOwnerGrants = new Map()
-    /**
-     * Monotonic product-vessel generation. A new admission for the same flow/item replaces the
-     * prior grant, so reload, replay, and same-name reuse cannot recover semantic ownership.
-     * @member {Number} vesselOwnerGrantGeneration=0
-     * @protected
-     */
-    vesselOwnerGrantGeneration = 0
     /**
      * Exact-position return truth: `tearOutPlacements[itemId] = {tabsNodeId, index}`, captured
      * at the detach terminal BEFORE the commit removes the item from the tree (`addTab` appends
@@ -570,7 +558,6 @@ class DemoBWorkspace extends Container {
             clearWorkspaceAffordances: workspaceId => me.clearWorkspaceAffordances(workspaceId),
             commitCrossWindowTransfer: data => me.commitCrossWindowTransfer(data),
             createPopupDocument      : () => DemoBWorkspace.createPopupDocument(),
-            createVesselOwnerGrant   : (flow, itemId) => me.createVesselOwnerGrant(flow, itemId),
             ensurePopupRegistered    : workspaceId => me.ensurePopupWorkspaceRegistered(workspaceId),
             getPopupDocument         : workspaceId => workspaceId === DemoBWorkspace.POPUP2_WORKSPACE_ID
                 ? me.popup2Document
@@ -594,7 +581,6 @@ class DemoBWorkspace extends Container {
             getWindowId             : () => me.windowId,
             getWorkspaceDocument    : workspaceId => me.getWorkspaceDocument(workspaceId),
             hitTestWorkspace        : (workspaceId, localX, localY) => me.hitTestWorkspace(workspaceId, localX, localY),
-            hostComponentId         : me.id,
             hostTimeout             : ms => me.timeout(ms),
             incrementTransferCommits: () => me.crossWindowStats.transferCommits++,
             isHostDestroyed         : () => me.isDestroyed,
@@ -616,8 +602,9 @@ class DemoBWorkspace extends Container {
                 me.crossWindowGestureResolve?.(receipt);
                 me.crossWindowGestureResolve = null
             },
-            revokeVesselOwnerGrant: (flow, itemId) => me.revokeVesselOwnerGrant(flow, itemId),
-            setPopupDocument      : (workspaceId, document) => workspaceId === DemoBWorkspace.POPUP2_WORKSPACE_ID
+            reserveVessel   : (workspaceKey, flow, windowName) => me.reserveVessel(workspaceKey, flow, windowName),
+            revokeVessel    : workspaceKey => me.revokeVessel(workspaceKey),
+            setPopupDocument: (workspaceId, document) => workspaceId === DemoBWorkspace.POPUP2_WORKSPACE_ID
                 ? me.popup2Document = document
                 : me.popupDocument = document,
             setStagePromise          : (workspaceId, promise) => workspaceId === DemoBWorkspace.POPUP2_WORKSPACE_ID
@@ -710,11 +697,13 @@ class DemoBWorkspace extends Container {
             scope           : me
         });
 
-        // popup lifecycle: the pop-out pane reparents on connect, comes home on disconnect
-        Neo.currentWorker.on({
-            connect   : me.onWindowConnect,
-            disconnect: me.onWindowDisconnect,
-            scope     : me
+        // Popup lifecycle: `Neo.manager.Transaction` announces every binding and release in the worker;
+        // this workspace answers only for the slots it reserved in its own Group — the pop-out pane
+        // reparents when its vessel binds, comes home when the binding is released.
+        TransactionManager.on({
+            bind   : me.onTopologyBind,
+            release: me.onTopologyRelease,
+            scope  : me
         });
 
         me.add([me.createTourBar(), me.createSwitcherBar(), {
@@ -3008,210 +2997,196 @@ class DemoBWorkspace extends Container {
     }
 
     /**
-     * A popup window joined the shared heap: if it is one of OURS (the pop-out URL carries
-     * `popout=<itemId>&hostId=<this.id>`), reparent the LIVE cached pane into its main view.
-     * The instance moves trees; nothing is recreated — the counter proves it.
-     * @param {Object} data `{appName, windowId}`
+     * The Group this workspace's window is bound into, or `null` before its window has bound.
+     * @member {String|null} topologyGroupId
      */
-    async onWindowConnect(data) {
-        let me         = this,
-            {windowId} = data,
-            app        = Neo.apps[windowId];
+    get topologyGroupId() {
+        return TransactionManager.findByWindow(this.windowId)?.groupId ?? null
+    }
 
-        if (!app || me.isDestroyed) return;
+    /**
+     * @summary Reserves one slot of this workspace's Group for a window about to open, and remembers
+     * the flow that asked. The reservation IS the admission: the manager holds the slot, the lineage
+     * token the window must present and the clock; the returned identity rides `Main.windowOpen`
+     * into the child's carrier, so nothing about the owner is in the popup's URL. A slot with a live
+     * binder, or a workspace whose own window has not bound, refuses.
+     * @param {String} workspaceKey `popup:<itemId>` for a vessel, the popup workspace id for a stage target.
+     * @param {String} flow `workspace-target`, `click-popout`, or `tear-out`.
+     * @param {String} [windowName=null] The native window name the opener will use.
+     * @returns {{groupId: String, workspaceKey: String, generationToken: String}|null}
+     * @protected
+     */
+    reserveVessel(workspaceKey, flow, windowName=null) {
+        let me          = this,
+            groupId     = me.topologyGroupId,
+            reservation = groupId && TransactionManager.reserve({groupId, workspaceKey});
 
-        let url            = await Neo.Main.getByPath({path: 'document.URL', windowId}),
-            params         = new URL(url).searchParams,
-            workspaceId    = params.get('workspaceId'),
-            itemId         = params.get('popout'),
-            flow           = params.get('vesselFlow'),
-            grant          = params.get('vesselGrant'),
-            admissionValue = params.get('vesselAdmission'),
-            admissionToken = admissionValue === null ? NaN : Number(admissionValue),
-            generation     = Number(params.get('vesselGeneration'));
+        if (!reservation) return null;
 
-        if (params.get('hostId') !== me.id) return;
+        me.vesselReservations.set(workspaceKey, {
+            ...reservation,
+            flow,
+            itemId  : flow === 'workspace-target' ? workspaceKey : workspaceKey.slice('popup:'.length),
+            windowId: null,
+            windowName
+        });
 
-        // Geometry-ready is part of child admission: do not publish the connected vessel to any
+        return reservation
+    }
+
+    /**
+     * @summary Gives a reserved slot back before its window came — the popup was blocked, the stage
+     * timed out, a transfer was reversed. A slot whose window already bound is the manager's to
+     * release on that window's disconnect; only this host's record of it goes.
+     * @param {String} workspaceKey
+     * @protected
+     */
+    revokeVessel(workspaceKey) {
+        let me          = this,
+            reservation = me.vesselReservations.get(workspaceKey);
+
+        if (!reservation) return;
+
+        me.vesselReservations.delete(workspaceKey);
+        reservation.windowId || TransactionManager.revoke(reservation)
+    }
+
+    /**
+     * A window bound one of this workspace's reserved slots: a cross-window stage target mounts its
+     * popup workspace, a click pop-out receives its parked pane, and a tear-out vessel embodies the
+     * SAME live pane right away while a hidden exact-slot placeholder keeps the source tab/card
+     * indices coherent — model truth stays untouched until the terminal. The instance moves trees;
+     * nothing is recreated — the counter proves it. A window presenting a copied or stale identity
+     * was forked into its own Group by the manager and never reaches this handler's Group check.
+     * @param {Object} data
+     * @param {String} data.groupId
+     * @param {String} data.windowId
+     * @param {String} data.workspaceKey
+     * @protected
+     */
+    async onTopologyBind({groupId, windowId, workspaceKey}) {
+        let me          = this,
+            app         = Neo.apps[windowId],
+            reservation = me.vesselReservations.get(workspaceKey);
+
+        if (!app || me.isDestroyed || groupId !== me.topologyGroupId || !reservation || reservation.windowId) return;
+
+        reservation.windowId = windowId;
+
+        // Geometry-ready is part of child admission: do not publish the bound vessel to any
         // ownership branch until its Main realm has installed movement and resize observation — the
         // same pair the host window armed at construction, for the same reason.
         await Neo.main.addon.WindowPosition?.setConfigs({observeMovement: true, observeResize: true, windowId});
 
-        if (workspaceId === DemoBWorkspace.POPUP_WORKSPACE_ID || workspaceId === DemoBWorkspace.POPUP2_WORKSPACE_ID) {
-            if (flow !== 'workspace-target') return;
+        if (me.isDestroyed || me.vesselReservations.get(workspaceKey) !== reservation) return;
 
-            if (!me.consumeVesselOwnerGrant({
-                data,
-                flow,
-                generation,
-                grant,
-                itemId: workspaceId,
-                windowId
-            })) return;
+        const {flow, itemId} = reservation;
 
-            await me.mountCrossWindowTarget(app, windowId, workspaceId);
+        if (flow === 'workspace-target') {
+            await me.mountCrossWindowTarget(app, windowId, itemId);
             return
         }
 
-        if (!itemId) return;
-        if (flow !== 'click-popout' && flow !== 'tear-out') return;
+        if (flow === 'click-popout') {
+            let entry = me.detachedPanes[itemId],
+                pane  = me.paneCache[itemId];
 
-        if (flow === 'tear-out' && !Number.isFinite(admissionToken)) return;
-
-        // Retirement authority is established before any awaited close. A connect continuation
-        // that resumes after that boundary is cleanup-only. Consume its exact grant and retain the
-        // route for a refused-close retry, but never stage or publish content into the closing realm.
-        if (flow === 'tear-out' && me.tearOutRetirements.has(itemId)) {
-            if (me.consumeVesselOwnerGrant({data, flow, generation, grant, itemId, windowId})) {
-                const admission = {
-                    admissionToken, generation, invalidated: true, windowId
-                };
-
-                Object.defineProperty(admission, 'nativeRoute', {value: data.windowData.nativeRoute});
-                me.tearOutConnectAdmissions.set(itemId, admission)
+            if (entry && pane && me.popupDocument?.items?.[itemId]) {
+                entry.windowId = windowId;
+                app.mainView.add(pane)
             }
+
             return
         }
 
-        if (!me.consumeVesselOwnerGrant({data, flow, generation, grant, itemId, windowId})) return;
+        // Retirement authority is established before any awaited close: a vessel that binds while its
+        // retirement is in flight is cleanup-only — never stage or publish content into a closing realm.
+        if (me.tearOutRetirements.has(itemId)) return;
 
-        // Click-popout creates its entry before windowOpen; tear-out deliberately does not.
-        // Keeping those births separate is load-bearing: an ungranted connect stays inert rather
-        // than becoming stray tearOutConnects state or stealing an existing detachedPanes entry.
-        // A granted tear-out DOES embody immediately: the same live pane moves into the vessel while
-        // a hidden exact-slot placeholder keeps source tab/card indices coherent. Model truth remains
-        // untouched until the terminal.
-        if (flow === 'tear-out') {
-            const
-                admission  = {admissionToken, generation, invalidated: false, windowId},
-                connection = {windowId};
+        const
+            connection = {generationToken: reservation.generationToken, windowId, windowName: reservation.windowName, workspaceKey},
+            staged     = await me.tearOutEmbodiment.stage({itemId, windowId});
 
-            Object.defineProperties(connection, {
-                admissionToken: {value: admissionToken},
-                generation    : {value: generation},
-                nativeRoute   : {value: data.windowData.nativeRoute}
-            });
-            Object.defineProperty(admission, 'nativeRoute', {value: data.windowData.nativeRoute});
-            me.tearOutConnectAdmissions.set(itemId, admission);
-
-            const staged = await me.tearOutEmbodiment.stage({itemId, windowId});
-
-            // A re-entry/cancel may retire the semantic vessel while the cross-window render
-            // transaction is still painting. The exact admission token is durable across a close
-            // acknowledgement clearing the transient retirement fence, so a dead generation can
-            // never resume here and publish itself after its disconnect already fired.
-            if (
-                me.tearOutConnectAdmissions.get(itemId) !== admission || admission.invalidated ||
-                me.tearOutRetirements.has(itemId)
-            ) {
-                staged && me.tearOutEmbodiment.restore({itemId, windowId});
-                return
-            }
-
-            me.tearOutConnectAdmissions.delete(itemId);
-
-            if (me.tearOutPanes[itemId]) {
-                Object.assign(me.tearOutPanes[itemId], connection);
-                Object.defineProperties(me.tearOutPanes[itemId], {
-                    admissionToken: {configurable: true, value: admissionToken, writable: true},
-                    generation    : {configurable: true, value: generation, writable: true},
-                    nativeRoute   : {configurable: true, value: data.windowData.nativeRoute, writable: true}
-                });
-
-                if (staged) {
-                    me.tearOutEmbodiment.promote({itemId, windowId})
-                } else {
-                    me.reparentTearOutPane(itemId, connection)
-                }
-            } else {
-                me.tearOutConnects[itemId] = connection;
-            }
-            return
-        }
-
-        let entry = me.detachedPanes[itemId],
-            pane  = me.paneCache[itemId];
-
-        if (flow === 'click-popout' && entry && pane && me.popupDocument?.items?.[itemId]) {
-            entry.windowId = windowId;
-            app.mainView.add(pane)
-        }
-    }
-
-    /**
-     * @summary Mints one product-semantic vessel grant and supersedes the prior generation for
-     * the same flow/item. The token is a bearer hint only; {@link #consumeVesselOwnerGrant}
-     * additionally requires the opener-minted native route for the exact connected child.
-     * @param {String} flow `workspace-target`, `click-popout`, or `tear-out`.
-     * @param {String} itemId
-     * @returns {{generation: Number, token: String}}
-     * @protected
-     */
-    createVesselOwnerGrant(flow, itemId) {
-        let grant = {
-            generation: ++this.vesselOwnerGrantGeneration,
-            token     : crypto.randomUUID()
-        };
-
-        this.vesselOwnerGrants.set(`${flow}:${itemId}`, grant);
-
-        return grant
-    }
-
-    /**
-     * @summary Consumes one exact product grant after validating the generic native route.
-     * Consumption precedes every reparent, making replay and same-name reuse inert.
-     * @param {Object} data
-     * @param {Object} data.windowData
-     * @param {String} flow
-     * @param {Number} generation
-     * @param {String} grant
-     * @param {String} itemId
-     * @param {String} windowId
-     * @returns {Boolean}
-     * @protected
-     */
-    consumeVesselOwnerGrant({data, flow, generation, grant, itemId, windowId}) {
-        let me     = this,
-            key    = `${flow}:${itemId}`,
-            stored = me.vesselOwnerGrants.get(key),
-            route  = data.windowData?.nativeRoute;
-
+        // A re-entry, cancel or physical death may retire the vessel while the cross-window render
+        // transaction is still painting; the reservation this stage began for is then gone, and a
+        // dead generation must never publish itself.
         if (
-            !stored || !grant || stored.token !== grant || stored.generation !== generation ||
-            !route?.nativeHandleKey || route.ownerWindowId !== me.windowId || route.targetWindowId !== windowId
+            me.isDestroyed || me.vesselReservations.get(workspaceKey) !== reservation ||
+            me.tearOutRetirements.has(itemId)
         ) {
-            return false
+            staged && me.tearOutEmbodiment.restore({itemId, windowId});
+            return
         }
 
-        me.vesselOwnerGrants.delete(key);
+        if (me.tearOutPanes[itemId]) {
+            Object.assign(me.tearOutPanes[itemId], connection);
 
-        return true
+            if (staged) {
+                me.tearOutEmbodiment.promote({itemId, windowId})
+            } else {
+                me.reparentTearOutPane(itemId, connection)
+            }
+        } else {
+            me.tearOutConnects[itemId] = connection
+        }
     }
 
     /**
-     * @summary Revokes the current semantic grant for one flow/item admission.
-     * @param {String} flow
-     * @param {String} itemId
+     * A window that held one of this workspace's slots left the shared heap: whatever pane it hosted
+     * comes HOME — the reattach commit brings the item back into the document; the re-projection
+     * re-adopts the parked instance. Physical death is authoritative: every state owner clears, so
+     * a successor gesture can neither inherit nor be blocked by the retired generation.
+     * @param {Object} data
+     * @param {String} data.groupId
+     * @param {String} data.windowId
+     * @param {String} data.workspaceKey
      * @protected
      */
-    revokeVesselOwnerGrant(flow, itemId) {
-        this.vesselOwnerGrants.delete(`${flow}:${itemId}`)
-    }
+    onTopologyRelease(data) {
+        let me                                = this,
+            {groupId, windowId, workspaceKey} = data,
+            reservation                       = me.vesselReservations.get(workspaceKey);
 
-    /**
-     * A popup closed: whatever pane it hosted comes HOME — the reattach commit brings the
-     * item back into the document; the re-projection re-adopts the parked instance.
-     * @param {Object} data `{appName, windowId}`
-     */
-    onWindowDisconnect(data) {
-        let me = this;
+        if (me.isDestroyed || groupId !== me.topologyGroupId) return;
 
-        if (me.isDestroyed) return;
+        if (reservation?.windowId === windowId) {
+            me.vesselReservations.delete(workspaceKey);
 
-        let disconnectedWorkspaceId = data.windowId === me.crossWindowTargetWindowId
+            // A tear-out vessel can die while its live-pane stage is still awaiting renderer
+            // settlement — nothing published it yet, so the maps below do not know this window. The
+            // stage continuation finds its reservation gone and restores; the ownership it would have
+            // published retires here, and a committed item comes home.
+            if (reservation.flow === 'tear-out') {
+                const
+                    {itemId}  = reservation,
+                    published = me.tearOutConnects[itemId]?.windowId === windowId || me.tearOutPanes[itemId]?.windowId === windowId;
+
+                if (!published) {
+                    const committed = Boolean(me.tearOutPanes[itemId]);
+
+                    me.tearOutRetirements.add(itemId);
+
+                    if (me.tearOutEmbodiment.isStaged(itemId)) {
+                        me.tearOutEmbodiment.restore({itemId, windowId})
+                    }
+
+                    me.tearOutHandlers.onVesselRetired({
+                        generationToken: reservation.generationToken,
+                        itemId,
+                        windowName     : reservation.windowName
+                    });
+                    me.vesselParkHandlers.onVesselRetired({itemId, retirement: true});
+                    me.tearOutRetirements.delete(itemId);
+                    delete me.tearOutPanes[itemId];
+                    committed && me.reintegrateTearOutItem(itemId);
+                    return
+                }
+            }
+        }
+
+        let disconnectedWorkspaceId = windowId === me.crossWindowTargetWindowId
                 ? DemoBWorkspace.POPUP_WORKSPACE_ID
-                : data.windowId === me.crossWindowTarget2WindowId
+                : windowId === me.crossWindowTarget2WindowId
                     ? DemoBWorkspace.POPUP2_WORKSPACE_ID
                     : null;
 
@@ -3219,7 +3194,7 @@ class DemoBWorkspace extends Container {
             let isPopup2       = disconnectedWorkspaceId === DemoBWorkspace.POPUP2_WORKSPACE_ID,
                 workspaceId    = disconnectedWorkspaceId,
                 detachedItemId = Object.entries(me.detachedPanes)
-                    .find(([, entry]) => entry.windowId === data.windowId)?.[0];
+                    .find(([, entry]) => entry.windowId === windowId)?.[0];
 
             me.crossWindowStageGeneration++;
             me.crossWindowGestureContext?.sourceZone?.dragCoordinator?.onDragCancel({
@@ -3275,40 +3250,8 @@ class DemoBWorkspace extends Container {
             return
         }
 
-        // A child can disconnect while its live-pane stage is still awaiting renderer settlement.
-        // The connect is not in tearOutConnects yet, so this private generation token is the only
-        // exact owner. Retire it now; the stage continuation observes the deleted token and cannot
-        // republish the dead window.
-        for (const [itemId, admission] of me.tearOutConnectAdmissions) {
-            if (admission.windowId === data.windowId) {
-                const
-                    committed  = Boolean(me.tearOutPanes[itemId]),
-                    windowName = `tearout-${itemId}`;
-
-                me.tearOutConnectAdmissions.delete(itemId);
-                me.tearOutRetirements.add(itemId);
-
-                if (me.tearOutEmbodiment.isStaged(itemId)) {
-                    me.tearOutEmbodiment.restore({itemId, windowId: data.windowId})
-                }
-
-                me.tearOutHandlers.onVesselRetired({
-                    admissionToken: admission.admissionToken,
-                    generation    : admission.generation,
-                    itemId,
-                    windowName
-                });
-                me.vesselParkHandlers.onVesselRetired({itemId, retirement: true});
-                me.revokeVesselOwnerGrant('tear-out', itemId);
-                me.tearOutRetirements.delete(itemId);
-                delete me.tearOutPanes[itemId];
-                committed && me.reintegrateTearOutItem(itemId);
-                return
-            }
-        }
-
         for (const [itemId, entry] of Object.entries(me.detachedPanes)) {
-            if (entry.windowId === data.windowId) {
+            if (entry.windowId === windowId) {
                 me.reattachPane(itemId, {windowAlreadyClosed: true});
                 break
             }
@@ -3319,9 +3262,7 @@ class DemoBWorkspace extends Container {
         // recovery window manually. Physical death is now authoritative: clear BOTH state owners
         // so a successor gesture cannot inherit or be blocked by the retired generation.
         for (const [itemId, entry] of Object.entries(me.tearOutConnects)) {
-            if (entry.windowId === data.windowId) {
-                const windowName = `tearout-${itemId}`;
-
+            if (entry.windowId === windowId) {
                 me.tearOutRetirements.add(itemId);
 
                 if (me.tearOutEmbodiment.isStaged(itemId)) {
@@ -3331,14 +3272,8 @@ class DemoBWorkspace extends Container {
                 }
 
                 delete me.tearOutConnects[itemId];
-                me.tearOutHandlers.onVesselRetired({
-                    admissionToken: entry.admissionToken,
-                    generation    : entry.generation,
-                    itemId,
-                    windowName
-                });
+                me.tearOutHandlers.onVesselRetired({...entry, itemId, windowName: entry.windowName ?? `tearout-${itemId}`});
                 me.vesselParkHandlers.onVesselRetired({itemId, retirement: true});
-                me.revokeVesselOwnerGrant('tear-out', itemId);
                 me.tearOutRetirements.delete(itemId);
                 return
             }
@@ -3349,18 +3284,11 @@ class DemoBWorkspace extends Container {
         // item, and the bookkeeping retires with the vessel. A pre-terminal disconnect has no
         // entry in either map and needs nothing.
         for (const [itemId, entry] of Object.entries(me.tearOutPanes)) {
-            if (entry.windowId === data.windowId) {
-                const windowName = entry.windowName ?? `tearout-${itemId}`;
-
+            if (entry.windowId === windowId) {
                 delete me.tearOutPanes[itemId];
                 delete me.tearOutConnects[itemId];
                 me.tearOutRetirements.delete(itemId);
-                me.tearOutHandlers.onVesselRetired({
-                    admissionToken: entry.admissionToken,
-                    generation    : entry.generation,
-                    itemId,
-                    windowName
-                });
+                me.tearOutHandlers.onVesselRetired({...entry, itemId, windowName: entry.windowName ?? `tearout-${itemId}`});
                 me.vesselParkHandlers.onVesselRetired({itemId, retirement: true});
                 me.reintegrateTearOutItem(itemId);
                 break
@@ -3376,7 +3304,7 @@ class DemoBWorkspace extends Container {
      * captured before publishing the committed document; the deferred projection can never race it.
      * @param {Object} document
      * @param {Object} operation
-     * @param {Object} vessel Exact admitted vessel identity, including its private generation.
+     * @param {Object} vessel The admitted vessel identity: the reservation's slot and lineage token.
      * @protected
      */
     onTearOutDocumentChange(document, operation, vessel) {
@@ -3392,7 +3320,7 @@ class DemoBWorkspace extends Container {
         me.onWorkspaceDocumentChange(DemoBWorkspace.MAIN_WORKSPACE_ID, document, {
             preserveItemIds: me.tearOutEmbodiment.isStaged(itemId) ? [] : [itemId]
         });
-        me.adoptTearOutPane(itemId, vessel?.generation, vessel?.admissionToken)
+        me.adoptTearOutPane(itemId, vessel)
     }
 
     /**
@@ -3494,7 +3422,14 @@ class DemoBWorkspace extends Container {
             return {detached: false, errors: result.errors}
         }
 
-        let ownerGrant = me.createVesselOwnerGrant('click-popout', itemId);
+        const
+            workspaceKey = `popup:${itemId}`,
+            windowName   = `demo-b-${itemId}`,
+            reservation  = me.reserveVessel(workspaceKey, 'click-popout', windowName);
+
+        if (!reservation) {
+            return {detached: false, errors: ['no Group slot could be reserved for the pop-out vessel']}
+        }
 
         me.detachedPanes[itemId] = {tabsNodeId: home, windowId: null};
 
@@ -3508,12 +3443,11 @@ class DemoBWorkspace extends Container {
             let winData = await Neo.Main.getWindowData({windowId: me.windowId});
 
             let opened = await Neo.Main.windowOpen({
-                url           : `./index.html?popout=${itemId}&hostId=${me.id}`
-                    + `&vesselFlow=click-popout&vesselGrant=${ownerGrant.token}`
-                    + `&vesselGeneration=${ownerGrant.generation}`,
-                windowFeatures: `height=420,width=560,left=${winData.screenLeft + 120},top=${winData.screenTop + 120}`,
-                windowId      : me.windowId,
-                windowName    : `demo-b-${itemId}`
+                topologyIdentity: reservation,
+                url             : `./index.html?popout=${itemId}`,
+                windowFeatures  : `height=420,width=560,left=${winData.screenLeft + 120},top=${winData.screenTop + 120}`,
+                windowId        : me.windowId,
+                windowName
             });
 
             if (opened === false) {
@@ -3524,7 +3458,7 @@ class DemoBWorkspace extends Container {
             // inputs: the source's old home may have normalized away after losing its sole item,
             // so replaying another placement is weaker than the transfer's commit-or-neither truth.
             delete me.detachedPanes[itemId];
-            me.revokeVesselOwnerGrant('click-popout', itemId);
+            me.revokeVessel(workspaceKey);
             me.popupDocument = popupBefore;
             me.onDockZoneDocumentChange(sourceBefore);
 
@@ -3830,18 +3764,11 @@ class DemoBWorkspace extends Container {
 
         if (!entry?.windowId) return null;
 
-        const resolved = {
+        return {
             ...entry,
             nativeRoute: entry.nativeRoute ?? Neo.manager?.Window?.get(entry.windowId)?.nativeRoute ?? null,
             windowName : entry.windowName ?? `tearout-${itemId}`
-        };
-
-        Object.defineProperties(resolved, {
-            admissionToken: {value: entry.admissionToken},
-            generation    : {value: entry.generation}
-        });
-
-        return resolved
+        }
     }
 
     /**
@@ -4044,23 +3971,27 @@ class DemoBWorkspace extends Container {
      * machinery remains structurally absent. Fail-closed per the admission contract: `windowOpen`
      * returns a BOOLEAN (a blocked popup never throws), and any falsy/throwing acquisition returns
      * `null` so the gesture degrades to its in-window fallback.
+     * The slot the workspace reserves in its Group rides `Main.windowOpen` into the vessel's carrier;
+     * nothing about the owner is in the URL.
      * @param {Object} request
      * @param {String} request.itemId
      * @param {Object} request.proxyRect
-     * @returns {Promise<{popupHeight: Number, popupWidth: Number, windowName: String}|null>}
+     * @returns {Promise<{generationToken: String, popupHeight: Number, popupWidth: Number, windowName: String, workspaceKey: String}|null>}
      * @protected
      */
-    async openTearOutVessel({admissionToken, itemId, proxyRect}) {
-        let me         = this,
-            {windowId} = me,
-            windowName = `tearout-${itemId}`,
-            ownerGrant = me.createVesselOwnerGrant('tear-out', itemId);
-
-        admissionToken = Number.isFinite(admissionToken) ? admissionToken : ownerGrant.generation;
-        ownerGrant.admissionToken = admissionToken;
+    async openTearOutVessel({itemId, proxyRect}) {
+        let me           = this,
+            {windowId}   = me,
+            windowName   = `tearout-${itemId}`,
+            workspaceKey = `popup:${itemId}`;
 
         if (me.tearOutRetirements.has(itemId)) {
-            me.revokeVesselOwnerGrant('tear-out', itemId);
+            return null
+        }
+
+        const reservation = me.reserveVessel(workspaceKey, 'tear-out', windowName);
+
+        if (!reservation) {
             return null
         }
 
@@ -4075,71 +4006,68 @@ class DemoBWorkspace extends Container {
 
             let opened = await Neo.Main.windowOpen({
                     nativeCapabilities: {close: true, position: true},
-                    url               : `./index.html?popout=${itemId}&hostId=${me.id}`
-                        + `&vesselFlow=tear-out&vesselGrant=${ownerGrant.token}`
-                        + `&vesselGeneration=${ownerGrant.generation}`
-                        + `&vesselAdmission=${admissionToken}`,
-                    windowFeatures: `height=${height},left=${left},top=${top},width=${width}`,
+                    topologyIdentity  : reservation,
+                    url               : `./index.html?popout=${itemId}`,
+                    windowFeatures    : `height=${height},left=${left},top=${top},width=${width}`,
                     windowId,
                     windowName
                 });
 
             if (opened === false) {
-                me.revokeVesselOwnerGrant('tear-out', itemId);
+                me.revokeVessel(workspaceKey);
                 return null
             }
 
             return {
-                admissionToken,
-                generation : ownerGrant.generation,
-                popupHeight: height,
-                popupWidth : width,
-                windowName
+                generationToken: reservation.generationToken,
+                popupHeight    : height,
+                popupWidth     : width,
+                windowName,
+                workspaceKey
             }
         } catch (error) {
-            me.revokeVesselOwnerGrant('tear-out', itemId);
+            me.revokeVessel(workspaceKey);
             return null
         }
     }
 
     /**
-     * The tear-out retirement seam: closes a vessel the gesture no longer needs (re-entry,
-     * cancel, or a refused model commit). The live connection and owner grant remain recoverable
-     * until the platform strictly admits the close; an explicit refusal can therefore be retried
-     * instead of orphaning a parked native generation. {@link #onWindowDisconnect} ignores
-     * tear-out windows by construction (no {@link #detachedPanes} entry), so no reattach machinery
-     * fires after success.
+     * The tear-out retirement seam: closes a vessel the gesture no longer needs (re-entry, cancel,
+     * or a refused model commit). Identity is the slot's lineage token — a successor admission for
+     * the same item shares the window name, never the token — so a retirement presenting a superseded
+     * token is refused and the live vessel survives it. The live connection remains recoverable until
+     * the platform strictly admits the close; an explicit refusal can therefore be retried instead of
+     * orphaning a parked native generation. {@link #onTopologyRelease} ignores tear-out windows by
+     * construction (no {@link #detachedPanes} entry), so no reattach machinery fires after success.
      * @param {Object} vessel
+     * @param {String} [vessel.generationToken] The reservation's lineage token.
      * @param {String} vessel.itemId
      * @param {String} vessel.windowName
      * @param {Object} [vessel.nativeRoute] Exact opener-minted physical route when available
      * @returns {Promise<Boolean>}
      * @protected
      */
-    async closeTearOutVessel({admissionToken, generation, itemId, nativeRoute, windowName}) {
+    async closeTearOutVessel({generationToken, itemId, nativeRoute, windowName}) {
         let me               = this,
             entry            = me.resolveTearOutVessel(itemId),
-            admission        = me.tearOutConnectAdmissions.get(itemId),
-            ownerGrant       = me.vesselOwnerGrants.get(`tear-out:${itemId}`),
+            reservation      = me.vesselReservations.get(`popup:${itemId}`),
             expected         = `tearout-${itemId}`,
-            exactGeneration  = entry?.generation ?? admission?.generation ?? ownerGrant?.generation,
-            exactToken       = entry?.admissionToken ?? admission?.admissionToken ?? ownerGrant?.admissionToken,
-            embodiedWindowId = entry?.windowId ?? admission?.windowId ?? me.tearOutEmbodiment.getWindowId(itemId),
+            exactToken       = entry?.generationToken ?? reservation?.generationToken ?? null,
+            embodiedWindowId = entry?.windowId ?? reservation?.windowId ?? me.tearOutEmbodiment.getWindowId(itemId),
             closed           = false;
 
         if (
             !itemId || windowName !== expected || (entry && entry.windowName !== windowName) ||
-            (Number.isFinite(generation) && generation !== exactGeneration) ||
-            (Number.isFinite(admissionToken) && admissionToken !== exactToken)
+            (generationToken && exactToken && generationToken !== exactToken)
         ) {
             return false
         }
 
-        nativeRoute ??= entry?.nativeRoute ?? admission?.nativeRoute ?? (
-            admission?.windowId && Neo.manager?.Window?.get(admission.windowId)?.nativeRoute
+        nativeRoute ??= entry?.nativeRoute ?? (
+            reservation?.windowId && Neo.manager?.Window?.get(reservation.windowId)?.nativeRoute
         );
 
-        const exactWindowId = entry?.windowId ?? admission?.windowId;
+        const exactWindowId = entry?.windowId ?? reservation?.windowId;
 
         if (nativeRoute && (
             !nativeRoute.nativeHandleKey || nativeRoute.ownerWindowId !== me.windowId ||
@@ -4152,7 +4080,6 @@ class DemoBWorkspace extends Container {
         // stays safely home; a committed transfer promotes the staged pane instead, letting the
         // target-first reconciler take it without a false source restoration.
         me.tearOutRetirements.add(itemId);
-        admission && (admission.invalidated = true);
 
         if (embodiedWindowId && me.tearOutEmbodiment.isStaged(itemId)) {
             const sourceOwns = Boolean(WorkspaceDocument.findContainingTabsId(me.dockModel, itemId)),
@@ -4184,9 +4111,8 @@ class DemoBWorkspace extends Container {
         if (!closed) return false;
 
         delete me.tearOutConnects[itemId];
-        me.tearOutConnectAdmissions.delete(itemId);
-        me.revokeVesselOwnerGrant('tear-out', itemId);
         me.tearOutRetirements.delete(itemId);
+        me.revokeVessel(`popup:${itemId}`);
 
         return true
     }
@@ -4194,40 +4120,26 @@ class DemoBWorkspace extends Container {
     /**
      * The post-commit adoption: the detached terminal committed `detachItem` (the item left the
      * tree, catalog preserved), so the vessel now OWNS the pane. Writes the {@link #tearOutPanes}
-     * entry and — if the vessel already connected ({@link #tearOutConnects}, the long-drag order)
-     * — reparents the live pane into it immediately; otherwise {@link #onWindowConnect} adopts on
+     * entry and — if the vessel already bound ({@link #tearOutConnects}, the long-drag order) —
+     * reparents the live pane into it immediately; otherwise {@link #onTopologyBind} adopts on
      * arrival (the fast-terminal order). Close-after-adoption reintegration is the vessel-lifecycle
      * leaf's scope, deliberately not handled here.
      * @param {String} itemId
-     * @param {Number} [generation] Exact owner-grant generation for terminal-first adoption.
-     * @param {Number} [admissionToken] Exact gesture admission for terminal-first adoption.
+     * @param {Object} [vessel={}] The admitted identity for terminal-first adoption: its lineage token and slot.
      * @protected
      */
-    adoptTearOutPane(itemId, generation, admissionToken) {
+    adoptTearOutPane(itemId, vessel={}) {
         let me        = this,
             connected = me.tearOutConnects[itemId];
 
         me.tearOutPanes[itemId] = connected
             ? {...connected}
-            : {windowName: `tearout-${itemId}`, windowId: null};
-
-        Object.defineProperties(me.tearOutPanes[itemId], {
-            admissionToken: {
-                configurable: true,
-                value       : connected?.admissionToken ?? admissionToken ?? null,
-                writable    : true
-            },
-            generation: {
-                configurable: true,
-                value       : connected?.generation ?? generation ?? null,
-                writable    : true
-            },
-            nativeRoute: {
-                configurable: true,
-                value       : connected?.nativeRoute ?? null,
-                writable    : true
-            }
-        });
+            : {
+                generationToken: vessel.generationToken ?? null,
+                windowId       : null,
+                windowName     : `tearout-${itemId}`,
+                workspaceKey   : vessel.workspaceKey ?? `popup:${itemId}`
+            };
 
         if (connected) {
             // Promotion is synchronous and single-owner: committed disconnects may only match
@@ -4302,7 +4214,7 @@ class DemoBWorkspace extends Container {
             return {errors: result.errors, reattached: false}
         }
 
-        me.revokeVesselOwnerGrant('click-popout', itemId);
+        me.revokeVessel(`popup:${itemId}`);
         delete me.detachedPanes[itemId];
 
         // Commit model ownership before awaiting the vessel. The deleted bookkeeping entry is
@@ -4580,8 +4492,12 @@ class DemoBWorkspace extends Container {
         me.crossWindowHosts.clear();
         me.crossWindowGeometry.clear();
         me.workspaceProjectionRequests.clear();
-        me.vesselOwnerGrants.clear();
-        me.tearOutConnectAdmissions.clear();
+        TransactionManager.un({
+            bind   : me.onTopologyBind,
+            release: me.onTopologyRelease,
+            scope  : me
+        });
+        me.vesselReservations.clear();
         me.tearOutEmbodiment?.destroy();
         me.tearOutEmbodiment = null;
         me.tearOutRetirements.clear();

--- a/learn/benefits/ArchitectureOverview.md
+++ b/learn/benefits/ArchitectureOverview.md
@@ -439,6 +439,7 @@ complete organism where the codebase and the agent co-evolve.
 | `src/data/` | Data layer | `Store`, `Model`, `RecordFactory` | — |
 | `src/state/` | State management | `Provider` | — |
 | `src/worker/` | Thread management | `App`, `VDom`, `Data`, `Manager` | — |
+| `src/manager/` | Worker-side registries and authorities: instances, components, window geometry, drag coordination, and the logical topology Groups a window binds into across reloads | `Instance`, `Component`, `Window`, `DragCoordinator`, `Transaction` | [ADR 0029](https://github.com/neomjs/neo/blob/dev/learn/agentos/decisions/0029-docking-design.md) |
 | `src/vdom/` | Virtual DOM engine | `Helper` | — |
 | `src/main/` | Main thread addons | `DomEvents`, `DomAccess` | — |
 | `src/ai/` | Neural Link client | `Client` | — |

--- a/src/Main.mjs
+++ b/src/Main.mjs
@@ -103,15 +103,6 @@ class Main extends core.Base {
          */
         nativeRouteTtl: 5000,
         /**
-         * The `sessionStorage` key carrying this window's topology identity — `{groupId, workspaceKey,
-         * generationToken}` — across page loads. A same-origin popup inherits a copy at creation, which
-         * {@link #windowOpen} replaces with the slot its opener reserved, or clears so the popup boots as
-         * a root of its own. The App Worker's `Neo.manager.Transaction` decides what the identity means;
-         * this thread only carries it.
-         * @member {String} topologyIdentityStorageKey='neo-topology-identity'
-         */
-        topologyIdentityStorageKey: 'neo-topology-identity',
-        /**
          * @member {Object} nativeWindowCapabilities
          * @protected
          */
@@ -344,33 +335,15 @@ class Main extends core.Base {
                 width      : screen.width
             },
             screenLeft: win.screenLeft,
-            screenTop : win.screenTop,
-            topologyIdentity: this.readTopologyIdentity(win)
+            screenTop : win.screenTop
         }
     }
 
     /**
-     * Reads this window's carried topology identity. An empty object means "no identity yet": the App
-     * Worker mints one and writes it back through {@link #setTopologyIdentity}. Unavailable storage and a
-     * malformed or incomplete record read the same way, so the window boots as a fresh root instead of
-     * failing.
-     * @param {Window} [win=window]
-     * @returns {{groupId: String, workspaceKey: String, generationToken: String}|{}}
-     */
-    readTopologyIdentity(win=window) {
-        try {
-            const {generationToken, groupId, workspaceKey} = JSON.parse(win.sessionStorage?.getItem(this.topologyIdentityStorageKey) || 'null') || {};
-
-            return groupId && workspaceKey && generationToken ? {generationToken, groupId, workspaceKey} : {}
-        } catch {
-            return {}
-        }
-    }
-
-    /**
-     * Writes the identity the App Worker bound this window to, so the next page load presents it again.
-     * `Neo.manager.Transaction` calls this after it minted, cold-created or forked a Group for the window;
-     * a plain bind or rebind writes nothing, because the carrier already holds what it presented.
+     * Writes the identity the App Worker bound this window to, so the next page load presents it again
+     * (the worker manager reads it into every worker registration). `Neo.manager.Transaction` asks for
+     * this after it minted, cold-created or forked a Group for the window; a plain bind or rebind writes
+     * nothing, because the carrier already holds what it presented.
      * @param {Object} data
      * @param {String} data.groupId
      * @param {String} data.workspaceKey
@@ -379,7 +352,7 @@ class Main extends core.Base {
      */
     setTopologyIdentity({generationToken, groupId, workspaceKey}) {
         try {
-            window.sessionStorage.setItem(this.topologyIdentityStorageKey, JSON.stringify({generationToken, groupId, workspaceKey}));
+            window.sessionStorage.setItem(WorkerManager.topologyIdentityStorageKey, JSON.stringify({generationToken, groupId, workspaceKey}));
             return true
         } catch {
             return false
@@ -1219,9 +1192,9 @@ class Main extends core.Base {
             // its own instead of forking the opener's Group on connect.
             try {
                 if (topologyIdentity) {
-                    openedWindow.sessionStorage.setItem(this.topologyIdentityStorageKey, JSON.stringify(topologyIdentity))
+                    openedWindow.sessionStorage.setItem(WorkerManager.topologyIdentityStorageKey, JSON.stringify(topologyIdentity))
                 } else {
-                    openedWindow.sessionStorage.removeItem(this.topologyIdentityStorageKey)
+                    openedWindow.sessionStorage.removeItem(WorkerManager.topologyIdentityStorageKey)
                 }
             } catch {/* Cross-origin or unavailable storage: the child boots as a fresh root. */}
 

--- a/src/Main.mjs
+++ b/src/Main.mjs
@@ -103,6 +103,15 @@ class Main extends core.Base {
          */
         nativeRouteTtl: 5000,
         /**
+         * The `sessionStorage` key carrying this window's topology identity — `{groupId, workspaceKey,
+         * generationToken}` — across page loads. A same-origin popup inherits a copy at creation, which
+         * {@link #windowOpen} replaces with the slot its opener reserved, or clears so the popup boots as
+         * a root of its own. The App Worker's `Neo.manager.Transaction` decides what the identity means;
+         * this thread only carries it.
+         * @member {String} topologyIdentityStorageKey='neo-topology-identity'
+         */
+        topologyIdentityStorageKey: 'neo-topology-identity',
+        /**
          * @member {Object} nativeWindowCapabilities
          * @protected
          */
@@ -141,6 +150,7 @@ class Main extends core.Base {
                 'reloadWindow',
                 'setNeoConfig',
                 'setRoute',
+                'setTopologyIdentity',
                 'windowClose',
                 'windowCloseAll',
                 'windowFocus',
@@ -334,7 +344,45 @@ class Main extends core.Base {
                 width      : screen.width
             },
             screenLeft: win.screenLeft,
-            screenTop : win.screenTop
+            screenTop : win.screenTop,
+            topologyIdentity: this.readTopologyIdentity(win)
+        }
+    }
+
+    /**
+     * Reads this window's carried topology identity. An empty object means "no identity yet": the App
+     * Worker mints one and writes it back through {@link #setTopologyIdentity}. Unavailable storage and a
+     * malformed or incomplete record read the same way, so the window boots as a fresh root instead of
+     * failing.
+     * @param {Window} [win=window]
+     * @returns {{groupId: String, workspaceKey: String, generationToken: String}|{}}
+     */
+    readTopologyIdentity(win=window) {
+        try {
+            const {generationToken, groupId, workspaceKey} = JSON.parse(win.sessionStorage?.getItem(this.topologyIdentityStorageKey) || 'null') || {};
+
+            return groupId && workspaceKey && generationToken ? {generationToken, groupId, workspaceKey} : {}
+        } catch {
+            return {}
+        }
+    }
+
+    /**
+     * Writes the identity the App Worker bound this window to, so the next page load presents it again.
+     * `Neo.manager.Transaction` calls this after it minted, cold-created or forked a Group for the window;
+     * a plain bind or rebind writes nothing, because the carrier already holds what it presented.
+     * @param {Object} data
+     * @param {String} data.groupId
+     * @param {String} data.workspaceKey
+     * @param {String} data.generationToken
+     * @returns {Boolean} Whether the carrier accepted the write.
+     */
+    setTopologyIdentity({generationToken, groupId, workspaceKey}) {
+        try {
+            window.sessionStorage.setItem(this.topologyIdentityStorageKey, JSON.stringify({generationToken, groupId, workspaceKey}));
+            return true
+        } catch {
+            return false
         }
     }
 
@@ -1098,7 +1146,7 @@ class Main extends core.Base {
      * @param {String}  data.windowName
      * @return {Boolean}
      */
-    windowOpen({nativeCapabilities, stagedColorScheme, url, useTotalHeight=true, windowFeatures, windowName}) {
+    windowOpen({nativeCapabilities, stagedColorScheme, topologyIdentity=null, url, useTotalHeight=true, windowFeatures, windowName}) {
         let existingWin = this.openWindows[windowName],
             stagedUrl   = null,
             targetName;
@@ -1166,6 +1214,16 @@ class Main extends core.Base {
             } catch {
                 this.#pendingWindowRoutes.delete(token)
             }
+            // A same-origin child inherits a copy of this window's identity at creation. The opener's
+            // reservation replaces it; without one the copy is cleared, so the popup boots as a root of
+            // its own instead of forking the opener's Group on connect.
+            try {
+                if (topologyIdentity) {
+                    openedWindow.sessionStorage.setItem(this.topologyIdentityStorageKey, JSON.stringify(topologyIdentity))
+                } else {
+                    openedWindow.sessionStorage.removeItem(this.topologyIdentityStorageKey)
+                }
+            } catch {/* Cross-origin or unavailable storage: the child boots as a fresh root. */}
 
             if (useTotalHeight) {
                 openedWindow.resizeTo(openedWindow.outerWidth, openedWindow.innerHeight)

--- a/src/dashboard/dock/Workspace.mjs
+++ b/src/dashboard/dock/Workspace.mjs
@@ -623,11 +623,13 @@ class Workspace extends Container {
 
     /**
      * The Group this workspace's window is bound into, or `null` before its window has bound — which
-     * includes the moment before the manager has loaded.
+     * includes the moment before the manager has loaded. Read off the loaded singleton when a
+     * participant loaded it before this instance's own load settled: an app that imports the manager
+     * is admitted at registration, so its host workspace is bound before it constructs.
      * @member {String|null} topologyGroupId
      */
     get topologyGroupId() {
-        return this.transactionManager?.findByWindow(this.windowId)?.groupId ?? null
+        return (this.transactionManager ?? Neo.manager?.Transaction)?.findByWindow(this.windowId)?.groupId ?? null
     }
 
     /**

--- a/src/dashboard/dock/Workspace.mjs
+++ b/src/dashboard/dock/Workspace.mjs
@@ -4,7 +4,6 @@ import NeoArray                    from '../../util/Array.mjs';
 import {isDescriptor}              from '../../core/ConfigSymbols.mjs';
 import ClassSystemUtil             from '../../util/ClassSystem.mjs';
 import HeaderActionPolicy          from './projection/HeaderActionPolicy.mjs';
-import TransactionManager          from '../../manager/Transaction.mjs';
 import LayoutAdapter               from './projection/LayoutAdapter.mjs';
 import Maximize                    from './plugin/Maximize.mjs';
 import MotionSignal                from './projection/MotionSignal.mjs';
@@ -334,6 +333,23 @@ class Workspace extends Container {
     tearOutAdmissions = new Map()
 
     /**
+     * `Neo.manager.Transaction`, once the tear-out lifecycle loaded it — `null` until then, and for a
+     * workspace that never opted in. The module is not part of a single-window app's closure: the
+     * opt-in is the load, so a host with the lifecycle off pays no Group machinery.
+     * @member {Neo.manager.Transaction|null} transactionManager=null
+     * @protected
+     */
+    transactionManager = null
+
+    /**
+     * Resolves to {@link #transactionManager} once it is loaded and this workspace observes its Group;
+     * `null` for a workspace that never asked (see {@link #loadTransactionManager}).
+     * @member {Promise<Neo.manager.Transaction>|null} transactionManagerReady=null
+     * @protected
+     */
+    transactionManagerReady = null
+
+    /**
      * Tear-out windows that connected before the detach terminal committed.
      * @member {Object} tearOutConnects={}
      * @protected
@@ -441,12 +457,7 @@ class Workspace extends Container {
 
             // One worker lifecycle subscriber exists — `Neo.manager.Transaction`. This workspace only
             // observes its own Group: slots it reserved bind, release, or run out their lease.
-            TransactionManager.on({
-                bind        : this.onTopologyBind,
-                leaseExpired: this.onTopologyLeaseExpired,
-                release     : this.onTopologyRelease,
-                scope       : this
-            })
+            this.loadTransactionManager()
         }
 
         // Cross-window hit testing reads manager.Window as its one geometry authority, and the
@@ -482,10 +493,16 @@ class Workspace extends Container {
     async acquireTearOutVessel(request={}) {
         let me       = this,
             {itemId} = request,
-            groupId  = me.topologyGroupId,
-            admission, reservation, vessel;
+            admission, groupId, manager, reservation, vessel;
 
         if (typeof itemId !== 'string' || !itemId) {
+            return null
+        }
+
+        manager = await me.loadTransactionManager();
+        groupId = me.topologyGroupId;
+
+        if (me.isDestroyed) {
             return null
         }
 
@@ -499,7 +516,7 @@ class Workspace extends Container {
         // The reservation IS the admission: `Neo.manager.Transaction` holds the slot, the lineage
         // token the vessel must present and the clock. This map keeps only what the host needs to
         // answer the binding — the gesture's sort zone and, once the platform names it, the window.
-        reservation = TransactionManager.reserve({groupId, workspaceKey: me.tearOutWorkspaceKey(itemId)});
+        reservation = manager.reserve({groupId, workspaceKey: me.tearOutWorkspaceKey(itemId)});
 
         if (!reservation) {
             return null
@@ -530,7 +547,7 @@ class Workspace extends Container {
 
         if (!vessel) {
             me.tearOutAdmissions.get(itemId) === admission && me.clearTearOutAdmission(itemId, admission);
-            TransactionManager.revoke(reservation);
+            manager.revoke(reservation);
             return null
         }
 
@@ -580,11 +597,37 @@ class Workspace extends Container {
     }
 
     /**
-     * The Group this workspace's window is bound into, or `null` before its window has bound.
+     * Loads `Neo.manager.Transaction` and observes this workspace's Group on it — once. The load is the
+     * opt-in: the tear-out lifecycle asks at construction, a host running its own admission asks the
+     * moment it reserves a slot, and a workspace that does neither never loads the module — which is
+     * how a single-window app's closure stays without Group machinery.
+     * @returns {Promise<Neo.manager.Transaction>}
+     * @protected
+     */
+    loadTransactionManager() {
+        return this.transactionManagerReady ??= import('../../manager/Transaction.mjs').then(({default: manager}) => {
+            if (!this.isDestroyed) {
+                this.transactionManager = manager;
+
+                manager.on({
+                    bind        : this.onTopologyBind,
+                    leaseExpired: this.onTopologyLeaseExpired,
+                    release     : this.onTopologyRelease,
+                    scope       : this
+                })
+            }
+
+            return manager
+        })
+    }
+
+    /**
+     * The Group this workspace's window is bound into, or `null` before its window has bound — which
+     * includes the moment before the manager has loaded.
      * @member {String|null} topologyGroupId
      */
     get topologyGroupId() {
-        return TransactionManager.findByWindow(this.windowId)?.groupId ?? null
+        return this.transactionManager?.findByWindow(this.windowId)?.groupId ?? null
     }
 
     /**
@@ -1531,7 +1574,7 @@ class Workspace extends Container {
     destroy(...args) {
         let me = this;
 
-        me.enableDockTearOutLifecycle && TransactionManager.un({
+        me.transactionManager?.un({
             bind        : me.onTopologyBind,
             leaseExpired: me.onTopologyLeaseExpired,
             release     : me.onTopologyRelease,

--- a/src/dashboard/dock/Workspace.mjs
+++ b/src/dashboard/dock/Workspace.mjs
@@ -4,6 +4,7 @@ import NeoArray                    from '../../util/Array.mjs';
 import {isDescriptor}              from '../../core/ConfigSymbols.mjs';
 import ClassSystemUtil             from '../../util/ClassSystem.mjs';
 import HeaderActionPolicy          from './projection/HeaderActionPolicy.mjs';
+import TransactionManager          from '../../manager/Transaction.mjs';
 import LayoutAdapter               from './projection/LayoutAdapter.mjs';
 import Maximize                    from './plugin/Maximize.mjs';
 import MotionSignal                from './projection/MotionSignal.mjs';
@@ -280,11 +281,6 @@ class Workspace extends Container {
          */
         enableDockTearOutLifecycle: false,
         /**
-         * Maximum time between an opened gesture vessel and its admitted worker connection.
-         * @member {Number} tearOutConnectWindowMs=20000
-         */
-        tearOutConnectWindowMs: 20000,
-        /**
          * Index of the projected shell inside the dock host — `1` when one toolbar precedes it.
          * @member {Number} dockShellIndex=0
          */
@@ -295,14 +291,7 @@ class Workspace extends Container {
          * config, so consumers never carry the marker by hand.
          * @member {String} flipMarkerPrefix='dock-flip-item-'
          */
-        flipMarkerPrefix: 'dock-flip-item-',
-        /**
-         * URL-search parameter whose value identifies this workspace as a tear-out vessel's
-         * owner. The engine default is product-neutral; legacy consumers may select their
-         * existing parameter name without teaching the engine that name.
-         * @member {String} tearOutHostParam='hostId'
-         */
-        tearOutHostParam: 'hostId'
+        flipMarkerPrefix: 'dock-flip-item-'
     }
 
     /**
@@ -336,19 +325,13 @@ class Workspace extends Container {
     refreshPromise = null
 
     /**
-     * Gesture admission tokens keyed by item while the platform vessel is opening or waiting to
-     * connect. The token is engine-owned gesture identity, distinct from optional product grants.
+     * Host-side context of a reserved tear-out slot, keyed by item, while the platform vessel is
+     * opening or waiting to bind: the sort zone that started the gesture and the vessel's window name.
+     * Identity, lineage token and clock live with the reservation in `Neo.manager.Transaction`.
      * @member {Map<String,Object>} tearOutAdmissions=new Map()
      * @protected
      */
     tearOutAdmissions = new Map()
-
-    /**
-     * Monotonic engine generation for opened-vessel admission records.
-     * @member {Number} tearOutAdmissionGeneration=0
-     * @protected
-     */
-    tearOutAdmissionGeneration = 0
 
     /**
      * Tear-out windows that connected before the detach terminal committed.
@@ -456,10 +439,13 @@ class Workspace extends Container {
                 openVessel      : request => this.acquireTearOutVessel(request)
             });
 
-            Neo.currentWorker.on({
-                connect   : this.onWindowConnect,
-                disconnect: this.onWindowDisconnect,
-                scope     : this
+            // One worker lifecycle subscriber exists — `Neo.manager.Transaction`. This workspace only
+            // observes its own Group: slots it reserved bind, release, or run out their lease.
+            TransactionManager.on({
+                bind        : this.onTopologyBind,
+                leaseExpired: this.onTopologyLeaseExpired,
+                release     : this.onTopologyRelease,
+                scope       : this
             })
         }
 
@@ -486,39 +472,49 @@ class Workspace extends Container {
     }
 
     /**
-     * @summary Opens one platform vessel under the gesture admission token the engine owns.
+     * @summary Opens one platform vessel under a slot reserved in this workspace's Group.
      * @param {Object} request
-     * @param {Number} request.admissionToken
+     * @param {Number} [request.gestureToken] The gesture pair's own correlation id, echoed on every vessel record.
      * @param {String} request.itemId
      * @returns {Promise<Object|null>}
      * @protected
      */
     async acquireTearOutVessel(request={}) {
-        let me                       = this,
-            {admissionToken, itemId} = request,
-            admission, vessel;
+        let me       = this,
+            {itemId} = request,
+            groupId  = me.topologyGroupId,
+            admission, reservation, vessel;
 
         if (typeof itemId !== 'string' || !itemId) {
             return null
         }
 
+        if (!groupId) {
+            console.warn(`Dock tear-out: workspace ${me.id} has no topology Group — its window has not bound`, itemId);
+            return null
+        }
+
         if (!await me.retryTearOutRetirements(itemId)) return null;
 
-        if (!Number.isFinite(admissionToken)) {
-            admissionToken = me.tearOutAdmissionGeneration + 1;
-            request = {...request, admissionToken}
+        // The reservation IS the admission: `Neo.manager.Transaction` holds the slot, the lineage
+        // token the vessel must present and the clock. This map keeps only what the host needs to
+        // answer the binding — the gesture's sort zone and, once the platform names it, the window.
+        reservation = TransactionManager.reserve({groupId, workspaceKey: me.tearOutWorkspaceKey(itemId)});
+
+        if (!reservation) {
+            return null
         }
 
         admission = {
             connected         : false,
             connectingWindowId: null,
-            generation        : ++me.tearOutAdmissionGeneration,
+            generationToken   : reservation.generationToken,
+            gestureToken      : request.gestureToken ?? null,
             itemId,
             sortZone          : request.sortZone || null,
-            timerId           : null,
-            token             : admissionToken,
             windowId          : null,
-            windowName        : null
+            windowName        : null,
+            workspaceKey      : reservation.workspaceKey
         };
         me.tearOutAdmissions.set(itemId, admission);
 
@@ -527,13 +523,14 @@ class Workspace extends Container {
         const closeVessel = me.closeTearOutVessel.bind(me);
 
         try {
-            vessel = await me.openTearOutVessel(request)
+            vessel = await me.openTearOutVessel({...request, topologyIdentity: reservation})
         } catch (error) {
             vessel = null
         }
 
         if (!vessel) {
             me.tearOutAdmissions.get(itemId) === admission && me.clearTearOutAdmission(itemId, admission);
+            TransactionManager.revoke(reservation);
             return null
         }
 
@@ -555,26 +552,21 @@ class Workspace extends Container {
         // Exactly once: this branch runs at most once per admission and then refuses, so no later
         // path can retire the same vessel again. Wrapped because a hook that throws here would
         // surface as an unhandled rejection — the caller discards this promise.
+        // Every record of this vessel carries the same exact identity: the reservation's slot and
+        // lineage token, and the gesture pair's own correlation id, echoed unread.
+        const identity = {...reservation, gestureToken: admission.gestureToken, itemId};
+
         if (me.isDestroyed) {
             try {
-                await closeVessel({...vessel, admissionToken, generation: admission.generation, itemId})
+                await closeVessel({...vessel, ...identity})
             } catch (error) {}
 
             return null
         }
 
-        // The engine token is exact. A product hook may not replace the gesture identity it was
-        // asked to carry, and a stale async open may never orphan the OS window it already created.
-        if (
-            me.tearOutAdmissions.get(itemId) !== admission ||
-            (Number.isFinite(vessel.admissionToken) && vessel.admissionToken !== admissionToken)
-        ) {
-            await me.retireTearOutVessel({
-                ...vessel,
-                admissionToken,
-                generation: admission.generation,
-                itemId
-            });
+        // A stale async open may never orphan the OS window it already created.
+        if (me.tearOutAdmissions.get(itemId) !== admission) {
+            await me.retireTearOutVessel({...vessel, ...identity});
             return null
         }
 
@@ -584,21 +576,37 @@ class Workspace extends Container {
 
         connection && !connection.windowName && (connection.windowName = admission.windowName);
 
-        if (!admission.connected) {
-            admission.timerId = setTimeout(() => {
-                me.expireTearOutAdmission(itemId, admission)
-            }, me.tearOutConnectWindowMs)
-        }
-
-        return {
-            ...vessel,
-            admissionToken,
-            generation: admission.generation
-        }
+        return {...vessel, ...identity}
     }
 
     /**
-     * @summary Clears one exact admission record and its connect bound.
+     * The Group this workspace's window is bound into, or `null` before its window has bound.
+     * @member {String|null} topologyGroupId
+     */
+    get topologyGroupId() {
+        return TransactionManager.findByWindow(this.windowId)?.groupId ?? null
+    }
+
+    /**
+     * The workspace key a torn-out item's vessel binds under: one slot per item, prefixed so the
+     * host can tell its own vessels from the other slots of its Group.
+     * @param {String} itemId
+     * @returns {String}
+     */
+    tearOutWorkspaceKey(itemId) {
+        return `popup:${itemId}`
+    }
+
+    /**
+     * @param {String} workspaceKey
+     * @returns {String|null} The item id a vessel key names, or `null` for any other slot.
+     */
+    tearOutItemIdFor(workspaceKey) {
+        return typeof workspaceKey === 'string' && workspaceKey.startsWith('popup:') ? workspaceKey.slice(6) : null
+    }
+
+    /**
+     * @summary Clears one exact admission record.
      * @param {String} itemId
      * @param {Object|null} [admission=this.tearOutAdmissions.get(itemId)]
      * @protected
@@ -606,14 +614,32 @@ class Workspace extends Container {
     clearTearOutAdmission(itemId, admission=this.tearOutAdmissions.get(itemId)) {
         if (!admission || this.tearOutAdmissions.get(itemId) !== admission) return false;
 
-        admission.timerId && clearTimeout(admission.timerId);
         this.tearOutAdmissions.delete(itemId);
 
         return true
     }
 
     /**
-     * @summary Expires an opened vessel that never established an admitted worker connection.
+     * A reserved slot in this workspace's Group ran out its lease without a window binding: the
+     * vessel the host opened for it is retired.
+     * @param {Object} data
+     * @param {String} data.groupId
+     * @param {String} data.workspaceKey
+     * @protected
+     */
+    onTopologyLeaseExpired({groupId, workspaceKey}) {
+        let me     = this,
+            itemId = me.tearOutItemIdFor(workspaceKey);
+
+        if (me.isDestroyed || groupId !== me.topologyGroupId || !itemId) return;
+
+        const admission = me.tearOutAdmissions.get(itemId);
+
+        admission && !admission.connected && me.expireTearOutAdmission(itemId, admission)
+    }
+
+    /**
+     * @summary Retires an opened vessel whose slot ran out its lease without ever binding.
      * @param {String} itemId
      * @param {Object} admission
      * @protected
@@ -621,16 +647,17 @@ class Workspace extends Container {
     async expireTearOutAdmission(itemId, admission) {
         let me = this;
 
-        // An expiry already queued when the instance went away has nothing left to expire.
+        // A lease that ran out after the instance went away has nothing left to expire.
         if (me.isDestroyed || admission?.connected) return;
         if (!admission || me.tearOutAdmissions.get(itemId) !== admission) return;
 
         const entry  = me.tearOutPanes[itemId],
               vessel = {
-                  admissionToken: admission.token,
-                  generation    : admission.generation,
+                  generationToken: admission.generationToken,
+                  gestureToken   : admission.gestureToken,
                   itemId,
-                  windowName    : admission.windowName || entry?.windowName
+                  windowName     : admission.windowName || entry?.windowName,
+                  workspaceKey   : admission.workspaceKey
               };
 
         if (!await me.retireTearOutVessel(vessel)) return;
@@ -700,11 +727,12 @@ class Workspace extends Container {
         if (closed !== false) {
             key && me.tearOutRetirements.get(key) === vessel && me.tearOutRetirements.delete(key);
 
+            // Exact identity: the reservation's lineage token when the vessel carries one, else the
+            // window name — a successor admission for the same item shares the name, never the token.
             const matches = entry => Boolean(entry &&
-                (Number.isFinite(vessel.admissionToken)
-                    ? (entry.token ?? entry.admissionToken) === vessel.admissionToken
-                    : entry.windowName === vessel.windowName) &&
-                (!Number.isFinite(vessel.generation) || entry.generation === vessel.generation)
+                (vessel.generationToken
+                    ? entry.generationToken === vessel.generationToken
+                    : entry.windowName === vessel.windowName)
             );
 
             const admission = me.tearOutAdmissions.get(vessel.itemId);
@@ -717,26 +745,23 @@ class Workspace extends Container {
     }
 
     /**
-     * @summary Opens the tear-out vessel, defaulting to the engine's own connect vocabulary.
+     * @summary Opens the tear-out vessel, defaulting to the host's own document.
      *
      * This hook used to return `null`, so pop-out and drag tear-out were both inert for any host
      * that wrote no window code: the action rendered, the click opened nothing, and no signal said
-     * why. The engine was asking each consumer to re-implement a SENDER for a protocol only the
-     * engine defines — `onWindowConnect` parses `tearout`, the host param, `vesselFlow` and
-     * `vesselAdmission` off the vessel's own URL — from a specification that existed nowhere but
-     * one app's source.
-     *
-     * Nothing in those four parameters is app-specific, so the default constructs them and reopens
-     * the host's own document. A consumer that wants a dedicated vessel shell, its own routing or
-     * staged theming still overrides, and the override remains authoritative.
+     * why. The default reopens the host's document with the item as its one content parameter and
+     * hands the reserved slot to `Main.windowOpen`, which carries it to the vessel; the owner is never
+     * in the URL. A consumer that wants a dedicated vessel shell, its own routing or staged theming
+     * still overrides, and the override remains authoritative.
      * @param {Object} request
-     * @param {Number} request.admissionToken The engine's gesture token; echoed back in the URL.
      * @param {String} request.itemId
      * @param {Object} [request.proxyRect] Where the user released the drag proxy.
-     * @returns {Promise<Object|null>} `{admissionToken, windowName}`, or `null` when no vessel opened.
+     * @param {Object} request.topologyIdentity The slot the host reserved; `Main.windowOpen` writes it
+     *   into the vessel's carrier, and the vessel presents it when it connects.
+     * @returns {Promise<Object|null>} `{windowName}`, or `null` when no vessel opened.
      * @protected
      */
-    async openTearOutVessel({admissionToken, itemId, proxyRect}={}) {
+    async openTearOutVessel({itemId, proxyRect, topologyIdentity}={}) {
         let me         = this,
             {windowId} = me;
 
@@ -755,17 +780,12 @@ class Workspace extends Container {
                 ]),
                 url = new URL(hostUrl);
 
-            // The vessel boots the SAME document with the engine's own connect vocabulary — the
-            // exact four parameters `onWindowConnect` parses. Nothing about them is app-specific,
-            // which is why the engine can construct this and every consumer was re-deriving it.
-            // Stripping first matters: a vessel re-torn from a vessel would otherwise inherit the
-            // parent's item and admission and connect as the wrong pane.
-            ['tearout', 'vesselFlow', 'vesselAdmission', me.tearOutHostParam].forEach(param => url.searchParams.delete(param));
-
-            url.searchParams.set('tearout',         itemId);
-            url.searchParams.set(me.tearOutHostParam, me.id);
-            url.searchParams.set('vesselFlow',      'tear-out');
-            url.searchParams.set('vesselAdmission', String(admissionToken));
+            // The vessel boots the SAME document. Which pane it shows is content, so `tearout` stays a
+            // URL parameter; whom it belongs to is identity, which rides the topology carrier — nothing
+            // about the owner is in the URL. Stripping first matters: a vessel re-torn from a vessel
+            // would otherwise inherit the parent's item and connect as the wrong pane.
+            url.searchParams.delete('tearout');
+            url.searchParams.set('tearout', itemId);
 
             // The proxy rect is the pane the user dragged, so the vessel opens where they let go.
             // Floors keep a degenerate rect (a collapsed rail tab) from opening an unusable window.
@@ -777,6 +797,7 @@ class Workspace extends Container {
 
             const opened = await Neo.Main.windowOpen({
                 nativeCapabilities: {close: true, position: true, resize: true},
+                topologyIdentity,
                 url               : url.href,
                 windowFeatures    : `height=${height},left=${left},top=${top},width=${width}`,
                 windowId,
@@ -790,7 +811,7 @@ class Workspace extends Container {
                 return null
             }
 
-            return {admissionToken, windowName}
+            return {windowName}
         } catch (error) {
             console.warn(`Dock tear-out: opening a vessel for "${itemId}" threw`, me.id, error);
             return null
@@ -868,10 +889,12 @@ class Workspace extends Container {
         let me         = this,
             connection = me.tearOutConnects[itemId],
             entry      = {
-                admissionToken: vessel.admissionToken ?? connection?.admissionToken ?? null,
-                generation    : vessel.generation ?? connection?.generation ?? null,
-                windowId      : connection?.windowId ?? null,
-                windowName    : vessel.windowName || connection?.windowName || `tearout-${itemId}`
+                generation     : vessel.generation ?? connection?.generation ?? null,
+                generationToken: vessel.generationToken ?? connection?.generationToken ?? null,
+                gestureToken   : vessel.gestureToken ?? connection?.gestureToken ?? null,
+                windowId       : connection?.windowId ?? null,
+                windowName     : vessel.windowName || connection?.windowName || `tearout-${itemId}`,
+                workspaceKey   : vessel.workspaceKey ?? connection?.workspaceKey ?? null
             };
 
         me.tearOutPanes[itemId] = entry;
@@ -1006,7 +1029,7 @@ class Workspace extends Container {
         });
         // Reported HERE because this is the one place both failing paths already meet: the
         // document-change adoption and the window-connect adoption each call it before throwing.
-        // Their throws do not reach anyone — `onWindowConnect` is registered as a worker event
+        // Their throws do not reach anyone — `onTopologyBind` is registered as a manager event
         // listener, so an async throw becomes a rejected promise the emitter drops, which is why a
         // vessel could die with nothing but an unattributed unhandled rejection in the console.
         //
@@ -1146,71 +1169,35 @@ class Workspace extends Container {
     afterTearOutWindowConnect(context) {}
 
     /**
-     * Hook: handles an owner-matching worker connection that is not a gesture tear-out.
+     * @summary Admits the window that bound one of this workspace's reserved tear-out slots.
+     * @description `Neo.manager.Transaction` announces every binding in the worker; this workspace
+     * answers only for its own Group and only for slots it reserved — a `popup:<itemId>` key with a
+     * pending admission. Nothing about the owner travels in the vessel's URL.
      * @param {Object} data
-     * @param {Object} context
-     * @returns {Promise<void>|void}
+     * @param {Number} data.generation
+     * @param {String} data.groupId
+     * @param {String} data.windowId
+     * @param {String} data.workspaceKey
      * @protected
      */
-    onUnhandledWindowConnect(data, context) {}
+    async onTopologyBind(data) {
+        let me                                            = this,
+            {generation, groupId, windowId, workspaceKey} = data,
+            itemId                                        = me.tearOutItemIdFor(workspaceKey),
+            app                                           = Neo.apps[windowId];
 
-    /**
-     * Hook: captures app-owned generation state synchronously before the worker URL round trip.
-     * @param {Object} data
-     * @returns {*}
-     * @protected
-     */
-    captureWindowConnectContext(data) {
-        return null
-    }
-
-    /**
-     * @summary Admits one worker window into pre-terminal or committed tear-out ownership.
-     * @param {Object} data
-     * @protected
-     */
-    async onWindowConnect(data) {
-        let me              = this,
-            {windowId}      = data,
-            app             = Neo.apps[windowId],
-            consumerContext = me.captureWindowConnectContext(data);
-
-        if (!app || me.isDestroyed) return;
-
-        let url, params;
-
-        try {
-            url    = await Neo.Main.getByPath({path: 'document.URL', windowId});
-            params = new URL(url).searchParams
-        } catch (error) {
-            return
-        }
-
-        if (me.isDestroyed || params.get(me.tearOutHostParam) !== me.id) return;
-
-        let itemId         = params.get('tearout'),
-            flow           = params.get('vesselFlow'),
-            admissionToken = Number(params.get('vesselAdmission'));
-
-        if (!itemId) {
-            await me.onUnhandledWindowConnect(data, {app, consumerContext, params});
-            return
-        }
-        if (flow === null) return;
-        if (flow !== 'tear-out') return;
+        if (me.isDestroyed || !itemId || !app || groupId !== me.topologyGroupId) return;
 
         const admission = me.tearOutAdmissions.get(itemId);
 
-        if (!Number.isFinite(admissionToken) || !admission || admission.token !== admissionToken) {
-            return
-        }
+        if (!admission || admission.connected) return;
 
         if (admission.connectingWindowId && admission.connectingWindowId !== windowId) return;
 
         admission.connectingWindowId = windowId;
 
         const activeVessel = me.tearOutHandlers?.activeVessel,
-              context      = {activeVessel, admission, admissionToken, app, consumerContext, data, itemId, params, windowId};
+              context      = {activeVessel, admission, app, data, generation, itemId, windowId, workspaceKey};
 
         try {
             if (await me.admitTearOutConnection(context) === false) {
@@ -1228,7 +1215,7 @@ class Workspace extends Container {
         // page content and never emits the `mouseout` that would otherwise arm the poll.
         await me.observeWindowGeometry(windowId);
 
-        // The grant hook and the geometry arming are async boundaries. Retirement, timeout or a
+        // The grant hook and the geometry arming are async boundaries. Retirement, the lease or a
         // successor admission may have replaced this exact record while they were pending.
         if (
             me.isDestroyed || me.tearOutAdmissions.get(itemId) !== admission ||
@@ -1238,16 +1225,16 @@ class Workspace extends Container {
         }
 
         const connection = {
-            admissionToken,
-            generation: me.tearOutPanes[itemId]?.generation ?? activeVessel?.generation ?? admission.generation,
+            generation,
+            generationToken: admission.generationToken,
+            gestureToken   : admission.gestureToken,
             windowId,
-            windowName: activeVessel?.windowName || me.tearOutPanes[itemId]?.windowName || admission.windowName
+            windowName     : activeVessel?.windowName || me.tearOutPanes[itemId]?.windowName || admission.windowName,
+            workspaceKey
         };
 
         admission.connected = true;
         admission.windowId  = windowId;
-        admission.timerId && clearTimeout(admission.timerId);
-        admission.timerId = null;
 
         if (me.tearOutPanes[itemId]) {
             if (!me.reparentTearOutPane(itemId, connection)) {
@@ -1363,21 +1350,20 @@ class Workspace extends Container {
     }
 
     /**
-     * Hook: handles a disconnect unrelated to an engine-owned gesture tear-out.
+     * @summary Reconciles a released vessel binding against pre-terminal or committed ownership.
+     * @description Fired by `Neo.manager.Transaction` when the window holding a binding disconnects.
+     * Releasing a binding never destroys anything on its own — the Group keeps the slot for its
+     * lineage — so this is where the host decides what the pane does now that its vessel is gone.
      * @param {Object} data
+     * @param {String} data.groupId
+     * @param {String} data.windowId
+     * @param {String} data.workspaceKey
      * @protected
      */
-    onUnhandledWindowDisconnect(data) {}
-
-    /**
-     * @summary Reconciles physical vessel death against pre-terminal or committed ownership.
-     * @param {Object} data
-     * @protected
-     */
-    async onWindowDisconnect(data) {
+    async onTopologyRelease(data) {
         let me = this;
 
-        if (me.isDestroyed) return;
+        if (me.isDestroyed || data.groupId !== me.topologyGroupId) return;
 
         for (const [itemId, entry] of Object.entries(me.tearOutPanes)) {
             if (entry.windowId === data.windowId) {
@@ -1405,8 +1391,6 @@ class Workspace extends Container {
                 return
             }
         }
-
-        me.onUnhandledWindowDisconnect(data)
     }
 
     /**
@@ -1540,17 +1524,18 @@ class Workspace extends Container {
      * every pending/connected/committed vessel, every admission with its expiry timer, every
      * owner-held pane — retires exactly once whether or not the lifecycle opt-in is on, because
      * `acquireTearOutVessel()` arms an admission and opens its vessel without it. Only the worker
-     * route subscription is the opt-in's to unregister, since only the opt-in subscribed. A refresh
+     * Group subscription is the opt-in's to unregister, since only the opt-in subscribed. A refresh
      * scheduled before teardown no-ops on its `isDestroyed` guard.
      * @param {...*} args
      */
     destroy(...args) {
         let me = this;
 
-        me.enableDockTearOutLifecycle && Neo.currentWorker.un({
-            connect   : me.onWindowConnect,
-            disconnect: me.onWindowDisconnect,
-            scope     : me
+        me.enableDockTearOutLifecycle && TransactionManager.un({
+            bind        : me.onTopologyBind,
+            leaseExpired: me.onTopologyLeaseExpired,
+            release     : me.onTopologyRelease,
+            scope       : me
         });
 
         me.retireTearOutState();

--- a/src/dashboard/dock/Workspace.mjs
+++ b/src/dashboard/dock/Workspace.mjs
@@ -290,7 +290,19 @@ class Workspace extends Container {
          * config, so consumers never carry the marker by hand.
          * @member {String} flipMarkerPrefix='dock-flip-item-'
          */
-        flipMarkerPrefix: 'dock-flip-item-'
+        flipMarkerPrefix: 'dock-flip-item-',
+        /**
+         * The Group this workspace belongs to — learned from its window's accepted binding and kept for
+         * the workspace's lifetime. A reload releases the window's slot and rebinds the next generation,
+         * a vessel closes, a lease runs out: the documents this workspace's host registered stay this
+         * Group's, reached through this value and never through the live binding. `null` until the
+         * binding is accepted — a first boot mints its identity and awaits the carrier, so the value
+         * arrives through {@link #onTopologyBind} after construction; a never-bound host has no
+         * membership to reach. Hosts register their participants from {@link #afterSetTopologyGroupId}.
+         * @member {String|null} topologyGroupId_=null
+         * @reactive
+         */
+        topologyGroupId_: null
     }
 
     /**
@@ -460,6 +472,10 @@ class Workspace extends Container {
             this.loadTransactionManager()
         }
 
+        // A host that imported the manager was admitted at app registration, before this instance
+        // constructed: its Group is readable now. One still awaiting its carrier learns it on bind.
+        this.resolveTopologyGroup();
+
         // Cross-window hit testing reads manager.Window as its one geometry authority, and the
         // manager only learns what the Main realm publishes. The host's own render target publishes
         // live extents as soon as it exists — during construction for an ordinary host, or from the
@@ -500,7 +516,7 @@ class Workspace extends Container {
         }
 
         manager = await me.loadTransactionManager();
-        groupId = me.topologyGroupId;
+        groupId = me.resolveTopologyGroup(manager);
 
         if (me.isDestroyed) {
             return null
@@ -614,7 +630,10 @@ class Workspace extends Container {
                     leaseExpired: this.onTopologyLeaseExpired,
                     release     : this.onTopologyRelease,
                     scope       : this
-                })
+                });
+
+                // A window bound before this subscription existed announces nothing further.
+                this.resolveTopologyGroup(manager)
             }
 
             return manager
@@ -622,14 +641,34 @@ class Workspace extends Container {
     }
 
     /**
-     * The Group this workspace's window is bound into, or `null` before its window has bound — which
-     * includes the moment before the manager has loaded. Read off the loaded singleton when a
-     * participant loaded it before this instance's own load settled: an app that imports the manager
-     * is admitted at registration, so its host workspace is bound before it constructs.
-     * @member {String|null} topologyGroupId
+     * Hook: this workspace learned its Group. A host whose participants could not register at
+     * construction — its window's binding was still awaiting the carrier — registers them here.
+     * @param {String|null} value
+     * @param {String|null} oldValue
+     * @protected
      */
-    get topologyGroupId() {
-        return (this.transactionManager ?? Neo.manager?.Transaction)?.findByWindow(this.windowId)?.groupId ?? null
+    afterSetTopologyGroupId(value, oldValue) {}
+
+    /**
+     * Learns this workspace's Group from an accepted binding of its window, if there is one: at
+     * construction, when the app imported the manager and its window bound before this instance
+     * existed; when the manager this instance loads on demand has resolved; and when a headless
+     * instance receives its window. A window whose binding is still awaiting the carrier learns it
+     * later, through {@link #onTopologyBind}. Once learned the Group is kept — see {@link #topologyGroupId}.
+     * @param {Neo.manager.Transaction} [manager=this.transactionManager ?? Neo.manager?.Transaction]
+     * @returns {String|null}
+     * @protected
+     */
+    resolveTopologyGroup(manager=this.transactionManager ?? Neo.manager?.Transaction) {
+        let me = this;
+
+        if (!me.topologyGroupId && me.windowId) {
+            const groupId = manager?.findByWindow(me.windowId)?.groupId;
+
+            groupId && (me.topologyGroupId = groupId)
+        }
+
+        return me.topologyGroupId
     }
 
     /**
@@ -1231,7 +1270,15 @@ class Workspace extends Container {
             itemId                                        = me.tearOutItemIdFor(workspaceKey),
             app                                           = Neo.apps[windowId];
 
-        if (me.isDestroyed || !itemId || !app || groupId !== me.topologyGroupId) return;
+        if (me.isDestroyed) return;
+
+        // The host's own window: a first boot's minted identity binds once its carrier accepted it,
+        // after this instance constructed. The Group is learned here, before any vessel logic runs.
+        if (windowId === me.windowId && !me.topologyGroupId) {
+            me.topologyGroupId = groupId
+        }
+
+        if (!itemId || !app || groupId !== me.topologyGroupId) return;
 
         const admission = me.tearOutAdmissions.get(itemId);
 
@@ -1912,6 +1959,9 @@ class Workspace extends Container {
      */
     afterSetWindowId(value, oldValue) {
         super.afterSetWindowId(value, oldValue);
+
+        // A headless instance receiving its first window may find that window already bound.
+        this.resolveTopologyGroup();
 
         return this.observeBoundWindowGeometry(value)
     }

--- a/src/dashboard/dock/window/TearOut.mjs
+++ b/src/dashboard/dock/window/TearOut.mjs
@@ -63,19 +63,20 @@ export function createDockTearOutHandlers({applyOperation, closeVessel, onDocume
      * @summary Creates the exact vessel identity without widening its enumerable public payload.
      * @param {String} itemId
      * @param {Object} vessel
-     * @param {Number} fallbackGeneration
+     * @param {Number} fallbackToken The gesture's own correlation id, when the host did not echo it.
      * @returns {Object}
      */
-    const createVesselIdentity = (itemId, vessel, fallbackGeneration) => {
-        const identity = {itemId, windowName: vessel.windowName};
+    const createVesselIdentity = (itemId, vessel, fallbackToken) => {
+        const identity = {itemId, windowName: vessel.windowName},
+              token    = Number.isFinite(vessel.gestureToken) ? vessel.gestureToken : fallbackToken;
 
+        vessel.workspaceKey !== undefined && (identity.workspaceKey = vessel.workspaceKey);
+
+        // `admissionToken` is the same value under the name the Workstation and DemoB closers still
+        // read; it leaves with their migration to the Group.
         Object.defineProperties(identity, {
-            admissionToken: {
-                value: Number.isFinite(vessel.admissionToken) ? vessel.admissionToken : fallbackGeneration
-            },
-            generation: {
-                value: Number.isFinite(vessel.generation) ? vessel.generation : fallbackGeneration
-            }
+            admissionToken: {value: token},
+            gestureToken  : {value: token}
         });
 
         return identity
@@ -180,10 +181,10 @@ export function createDockTearOutHandlers({applyOperation, closeVessel, onDocume
          * @param {String} identity.windowName
          * @returns {Boolean}
          */
-        onVesselRetired({admissionToken, generation, itemId, windowName} = {}) {
+        onVesselRetired({admissionToken, gestureToken=admissionToken, itemId, windowName} = {}) {
             if (
                 pendingAdmission?.itemId === itemId &&
-                pendingAdmission.token === admissionToken
+                pendingAdmission.token === gestureToken
             ) {
                 pendingAdmission.externallyRetired = true;
                 return invalidateAdmission(itemId)
@@ -191,8 +192,7 @@ export function createDockTearOutHandlers({applyOperation, closeVessel, onDocume
 
             const matches = vessel => Boolean(
                 vessel && vessel.itemId === itemId && vessel.windowName === windowName &&
-                (!Number.isFinite(generation) || vessel.generation === generation) &&
-                (!Number.isFinite(admissionToken) || vessel.admissionToken === admissionToken)
+                (!Number.isFinite(gestureToken) || vessel.gestureToken === gestureToken)
             );
 
             let vessel = matches(activeVessel) ? activeVessel : lateVessel;
@@ -273,7 +273,8 @@ export function createDockTearOutHandlers({applyOperation, closeVessel, onDocume
 
             try {
                 vessel = await openVessel({
-                    admissionToken: state.token,
+                    admissionToken: state.token, // the name the unmigrated consumers' openers read
+                    gestureToken  : state.token,
                     itemId        : data.itemId,
                     proxyRect     : data.proxyRect,
                     sortZone      : data.sortZone

--- a/src/dashboard/dock/window/TearOut.mjs
+++ b/src/dashboard/dock/window/TearOut.mjs
@@ -41,8 +41,8 @@
  *     receives the committed post-detach document plus the exact admitted vessel generation (the
  *     same document/operation seam shape the adapter's `moveTo` listener feeds).
  * @param {Function} seams.openVessel Host vessel acquisition:
- *     `({admissionToken, itemId, proxyRect, sortZone}) => Promise<{admissionToken, generation,
- *     popupHeight, popupWidth, windowName}|null>` —
+ *     `({gestureToken, itemId, proxyRect, sortZone}) => Promise<{generationToken, popupHeight,
+ *     popupWidth, windowName, workspaceKey}|null>` —
  *     the host performs the platform work (URL, geometry, `windowOpen`) and resolves FALSY on any
  *     failed admission (`windowOpen` returns a Boolean — a blocked popup never throws, so the host
  *     must check the Boolean, not catch).
@@ -70,14 +70,13 @@ export function createDockTearOutHandlers({applyOperation, closeVessel, onDocume
         const identity = {itemId, windowName: vessel.windowName},
               token    = Number.isFinite(vessel.gestureToken) ? vessel.gestureToken : fallbackToken;
 
-        vessel.workspaceKey !== undefined && (identity.workspaceKey = vessel.workspaceKey);
+        // The slot and its lineage token, when the host's admission carries them: a retirement that
+        // presents a superseded token then names a vessel this machine no longer holds.
+        vessel.generationToken !== undefined && (identity.generationToken = vessel.generationToken);
+        vessel.workspaceKey    !== undefined && (identity.workspaceKey    = vessel.workspaceKey);
 
-        // `admissionToken` is the same value under the name the Workstation and DemoB closers still
-        // read; it leaves with their migration to the Group.
-        Object.defineProperties(identity, {
-            admissionToken: {value: token},
-            gestureToken  : {value: token}
-        });
+        // The gesture pair's own correlation id, echoed unread by the host — never part of the public payload.
+        Object.defineProperty(identity, 'gestureToken', {value: token});
 
         return identity
     };
@@ -177,11 +176,13 @@ export function createDockTearOutHandlers({applyOperation, closeVessel, onDocume
         /**
          * @summary Clears one exact vessel after its external owner observed physical retirement.
          * @param {Object} identity
+         * @param {String} [identity.generationToken] The slot's lineage token; a superseded one clears nothing.
+         * @param {Number} [identity.gestureToken] The gesture pair's correlation id, when the owner echoes it.
          * @param {String} identity.itemId
          * @param {String} identity.windowName
          * @returns {Boolean}
          */
-        onVesselRetired({admissionToken, gestureToken=admissionToken, itemId, windowName} = {}) {
+        onVesselRetired({generationToken, gestureToken, itemId, windowName} = {}) {
             if (
                 pendingAdmission?.itemId === itemId &&
                 pendingAdmission.token === gestureToken
@@ -190,9 +191,12 @@ export function createDockTearOutHandlers({applyOperation, closeVessel, onDocume
                 return invalidateAdmission(itemId)
             }
 
+            // A superseded lineage token names a vessel this machine no longer holds — a successor
+            // admission for the same item shares the name, never the token — so it clears nothing.
             const matches = vessel => Boolean(
                 vessel && vessel.itemId === itemId && vessel.windowName === windowName &&
-                (!Number.isFinite(gestureToken) || vessel.gestureToken === gestureToken)
+                (!Number.isFinite(gestureToken) || vessel.gestureToken === gestureToken) &&
+                (!generationToken || !vessel.generationToken || vessel.generationToken === generationToken)
             );
 
             let vessel = matches(activeVessel) ? activeVessel : lateVessel;
@@ -273,11 +277,10 @@ export function createDockTearOutHandlers({applyOperation, closeVessel, onDocume
 
             try {
                 vessel = await openVessel({
-                    admissionToken: state.token, // the name the unmigrated consumers' openers read
-                    gestureToken  : state.token,
-                    itemId        : data.itemId,
-                    proxyRect     : data.proxyRect,
-                    sortZone      : data.sortZone
+                    gestureToken: state.token,
+                    itemId      : data.itemId,
+                    proxyRect   : data.proxyRect,
+                    sortZone    : data.sortZone
                 })
             } catch {
                 vessel = null

--- a/src/dashboard/dock/window/WorkspaceSet.mjs
+++ b/src/dashboard/dock/window/WorkspaceSet.mjs
@@ -1,54 +1,74 @@
 /**
- * @summary Pure worker-owned workspace-set registry — the `{workspaceId → document}` composition
- * of the docking design record (§2.1 workspace topology; §2.8.3 vessel lifecycle;
- * `learn/agentos/decisions/0029-docking-design.md`).
+ * @summary The dock adapter over a Group's participant membership — the `{workspaceId → document}`
+ * composition of the docking design record (§2.1 workspace topology; §2.8.3 vessel lifecycle;
+ * `learn/agentos/decisions/0029-docking-design.md`), resolved through `Neo.manager.Transaction`.
  *
- * A workspace is one dock-zone document owned by one workspace container; multi-window
- * composition registers each vessel's document under a STABLE workspace id. This registry is that
- * composition's single source of resolution: cross-window participations resolve foreign
- * documents through it, and an atomic transfer's committed pair is adopted through it —
- * both-or-neither, mirroring the executor's commit-or-neither contract at the ownership tier.
+ * A workspace is one dock-zone document owned by one workspace container; multi-window composition
+ * registers each vessel's document under a STABLE workspace id. That membership lives in the host's
+ * topology Group: the manager holds the participants, this adapter phrases them as the dock's
+ * registry and adds the dock's own adoption semantics — cross-window participations resolve foreign
+ * documents through it, and an atomic transfer's committed pair is adopted through it, both-or-neither,
+ * mirroring the executor's commit-or-neither contract at the ownership tier.
  *
  * Boundary discipline (the §2.1 state-class table, binding):
- * - **Worker-owned shared truth only.** Entries carry document accessors keyed by semantic
- *   workspace identity. `windowId`, screen geometry, and projection state NEVER enter this
- *   registry — a window is a render target, not a state owner, and runtime window identity is
+ * - **No registry of its own.** The adapter keeps no entry map: every registration, lookup and count
+ *   is the Group's. Before the host's window has bound there is no Group and so no membership —
+ *   registration is refused and every lookup fails closed. A host that imports the manager is
+ *   admitted at app registration, before its workspace constructs, so this is the exception path.
+ * - **Worker-owned shared truth only.** Participants carry document accessors keyed by semantic
+ *   workspace identity. `windowId`, screen geometry, and projection state NEVER enter the Group as
+ *   membership — a window is a render target, not a state owner, and runtime window identity is
  *   never persisted workspace identity.
- * - **Retirement is an explicit owner decision.** Closing a vessel unbinds a render target; it
- *   does not delete worker documents — so this registry never auto-retires an entry. Whether an
- *   emptied workspace-set entry is retained or retired is decided and named separately by the
- *   reintegration tier (§2.8.3).
- * - **Projection choreography stays with the owner.** The registry answers "whose document, and
- *   what is it now" — reconcile ordering, generation guards, and render-target sync remain the
- *   workspace container's own contract.
+ * - **Membership is separate from binding.** Closing a vessel unbinds a render target; it does not
+ *   delete worker documents — a participant lives while its Group does, and a Group holding
+ *   participants is never empty. Whether an emptied entry is retained or retired is decided and
+ *   named by the reintegration tier (§2.8.3), through {@link #unregister}.
+ * - **Projection choreography stays with the owner.** The adapter answers "whose document, and what
+ *   is it now" — reconcile ordering, generation guards, and render-target sync remain the workspace
+ *   container's own contract.
  *
- * Dependency-free by design — closure state, injected accessor seams — so witnesses drive the
- * full registry contract without a browser or a model import.
+ * Dependency-free beyond its two seams — the manager and the Group resolver are injected — so
+ * witnesses drive the full contract without a browser or a model import.
  */
 
 /**
- * Creates one worker-owned workspace-set registry.
+ * Creates the dock's view of one Group's participant membership.
+ * @param {Object} seams
+ * @param {Neo.manager.Transaction} seams.manager The worker-wide topology manager.
+ * @param {Function} seams.getGroupId `() => String|null` — the host's Group, `null` while its window has not bound.
  * @returns {Object} workspaceSet
+ * @returns {Function} workspaceSet.adoptAll       `(workspaces)` all-or-nothing adoption of one document per registered key; Boolean.
  * @returns {Function} workspaceSet.adoptTransfer  `({sourceWorkspaceId, sourceDocument, targetWorkspaceId, targetDocument})` both-or-neither pair adoption; Boolean.
- * @returns {Function} workspaceSet.getDocument    `(workspaceId)` → the entry's current document, or `null` (fail closed).
+ * @returns {Function} workspaceSet.getDocument    `(workspaceId)` → the participant's current document, or `null` (fail closed).
  * @returns {Function} workspaceSet.has            `(workspaceId)` → Boolean.
  * @returns {Function} workspaceSet.ids            `()` → registered workspace ids.
- * @returns {Function} workspaceSet.register       `(workspaceId, {getDocument, setDocument})` registers-or-replaces an entry; Boolean.
- * @returns {Number}   workspaceSet.size           Registered entry count.
+ * @returns {Function} workspaceSet.register       `(workspaceId, {getDocument, setDocument})` registers-or-replaces a participant; Boolean.
+ * @returns {Number}   workspaceSet.size           Registered participant count.
  * @returns {Function} workspaceSet.unregister     `(workspaceId)` explicit retirement; Boolean.
  */
-export function createDockWorkspaceSet() {
-    const entries = new Map();
+export function createDockWorkspaceSet({manager, getGroupId}) {
+    const
+        groupId     = () => getGroupId?.() ?? null,
+        participant = workspaceId => {
+            const id = groupId();
+
+            return id ? manager.getParticipant(id, workspaceId) : null
+        },
+        keys        = () => {
+            const id = groupId();
+
+            return id ? manager.participantKeys(id) : []
+        };
 
     return {
         get size() {
-            return entries.size
+            return keys().length
         },
 
         /**
-         * Adopts an atomically-committed document pair into both owning entries — or neither.
+         * Adopts an atomically-committed document pair into both owning participants — or neither.
          * Fail-closed preconditions, all checked BEFORE the first write: distinct source and
-         * target ids, both entries registered, both writable.
+         * target ids, both participants registered, both writable.
          *
          * Both-or-neither against THROWING writers holds by two-sided compensation: BOTH previous
          * documents are captured before the first write, and either write failing compensates
@@ -71,8 +91,8 @@ export function createDockWorkspaceSet() {
          */
         adoptTransfer({sourceDocument, sourceWorkspaceId, targetDocument, targetWorkspaceId}) {
             const
-                source = entries.get(sourceWorkspaceId),
-                target = entries.get(targetWorkspaceId);
+                source = participant(sourceWorkspaceId),
+                target = participant(targetWorkspaceId);
 
             if (
                 sourceWorkspaceId === targetWorkspaceId ||
@@ -117,8 +137,8 @@ export function createDockWorkspaceSet() {
          * Adopts one committed document per registered workspace key.
          *
          * All-or-nothing, like {@link #adoptTransfer} one arity up: the payload must name exactly
-         * the registered semantic keys. Object insertion order and registry order never pair a
-         * document with its owner. A missing/excess key, missing document, or read-only entry
+         * the registered semantic keys. Object insertion order and registration order never pair a
+         * document with its owner. A missing/excess key, missing document, or read-only participant
          * refuses before the first write; a throw mid-write compensates every earlier writer.
          * @param {Object<String,Object>} workspaces Documents keyed by stable workspace identity.
          * @returns {Boolean} true when every workspace adopted its keyed document
@@ -127,13 +147,14 @@ export function createDockWorkspaceSet() {
             const
                 isRecord = workspaces !== null && typeof workspaces === 'object' && !Array.isArray(workspaces) &&
                     (Object.getPrototypeOf(workspaces) === Object.prototype || Object.getPrototypeOf(workspaces) === null),
-                ids      = [...entries.keys()],
-                keys     = isRecord ? Object.keys(workspaces) : [];
+                ids      = keys(),
+                entries  = ids.map(workspaceId => participant(workspaceId)),
+                names    = isRecord ? Object.keys(workspaces) : [];
 
             if (
-                !isRecord || keys.length !== ids.length ||
-                keys.some(workspaceId => !entries.has(workspaceId) || !workspaces[workspaceId]) ||
-                ids.some(workspaceId => !Object.hasOwn(workspaces, workspaceId) || !entries.get(workspaceId).setDocument)
+                !isRecord || names.length !== ids.length ||
+                names.some(workspaceId => !ids.includes(workspaceId) || !workspaces[workspaceId]) ||
+                entries.some((entry, index) => !Object.hasOwn(workspaces, ids[index]) || !entry?.setDocument)
             ) {
                 return false
             }
@@ -141,7 +162,7 @@ export function createDockWorkspaceSet() {
             const written = [];
 
             for (let index = 0; index < ids.length; index++) {
-                const entry = entries.get(ids[index]);
+                const entry = entries[index];
 
                 written.push([entry, entry.getDocument()]);
 
@@ -167,10 +188,10 @@ export function createDockWorkspaceSet() {
 
         /**
          * @param {String} workspaceId
-         * @returns {Object|null} the entry's current document, or null (fail closed)
+         * @returns {Object|null} the participant's current document, or null (fail closed)
          */
         getDocument(workspaceId) {
-            return entries.get(workspaceId)?.getDocument() ?? null
+            return participant(workspaceId)?.getDocument() ?? null
         },
 
         /**
@@ -178,47 +199,55 @@ export function createDockWorkspaceSet() {
          * @returns {Boolean}
          */
         has(workspaceId) {
-            return entries.has(workspaceId)
+            return participant(workspaceId) !== null
         },
 
         /**
          * @returns {String[]}
          */
         ids() {
-            return [...entries.keys()]
+            return keys()
         },
 
         /**
-         * Registers-or-replaces one workspace entry. Replacement is deliberate: a re-embodied
-         * vessel re-registers the SAME stable workspace id with fresh accessor seams, and the
-         * stale seams must not survive it.
+         * Registers-or-replaces one workspace participant in the host's Group. Replacement is
+         * deliberate: a re-embodied vessel re-registers the SAME stable workspace id with fresh
+         * accessor seams, and the stale seams must not survive it. Refused while the host has no
+         * Group — there is no membership to join yet.
          * @param {String} workspaceId Stable semantic identity — never a `windowId`.
          * @param {Object} seams
          * @param {Function} seams.getDocument `()` → the workspace's current committed document.
-         * @param {Function} [seams.setDocument] `(document)` adopts a committed document; an
-         *     entry without one is read-only to `adoptTransfer` (fail closed).
+         * @param {Function} [seams.setDocument] `(document)` adopts a committed document; a
+         *     participant without one is read-only to `adoptTransfer` (fail closed).
          * @returns {Boolean} true when registered
          */
         register(workspaceId, {getDocument, setDocument} = {}) {
-            if (!workspaceId || typeof workspaceId !== 'string' || typeof getDocument !== 'function') {
+            const id = groupId();
+
+            if (!id || !workspaceId || typeof workspaceId !== 'string' || typeof getDocument !== 'function') {
                 return false
             }
 
-            entries.set(workspaceId, {
-                getDocument,
-                setDocument: typeof setDocument === 'function' ? setDocument : null
-            });
-            return true
+            return manager.registerParticipant({
+                groupId    : id,
+                participant: {
+                    getDocument,
+                    setDocument: typeof setDocument === 'function' ? setDocument : null
+                },
+                workspaceKey: workspaceId
+            })
         },
 
         /**
-         * Explicit entry retirement — never invoked by the registry itself (see the class
-         * summary's vessel-lifecycle boundary).
+         * Explicit participant retirement — never a side effect of a window's binding leaving (see
+         * the summary's vessel-lifecycle boundary).
          * @param {String} workspaceId
-         * @returns {Boolean} true when an entry was removed
+         * @returns {Boolean} true when a participant was removed
          */
         unregister(workspaceId) {
-            return entries.delete(workspaceId)
+            const id = groupId();
+
+            return id ? manager.unregisterParticipant({groupId: id, workspaceKey: workspaceId}) : false
         }
     }
 }

--- a/src/manager/Transaction.mjs
+++ b/src/manager/Transaction.mjs
@@ -53,6 +53,14 @@ class Transaction extends Manager {
     leaseTimers = new Map()
 
     /**
+     * Carrier writes the main realm could not take yet, keyed by window: a window is admitted when its
+     * config registers, which can precede the main realm registering its remote surface.
+     * @member {Map} pendingCarrierWrites=new Map()
+     * @protected
+     */
+    pendingCarrierWrites = new Map()
+
+    /**
      * @param {Object} config
      */
     construct(config) {
@@ -61,10 +69,38 @@ class Transaction extends Manager {
         let me = this;
 
         Neo.currentWorker?.on?.({
-            connect   : me.onWindowConnect,
             disconnect: me.onWindowDisconnect,
             scope     : me
         })
+    }
+
+    /**
+     * Admits a window the worker just learned of: binds it under the identity its carrier presented and
+     * tells the carrier what to hold from now on when that differs — a minted, cold or forked identity.
+     * A plain bind or rebind changes nothing the window did not already carry.
+     * @param {Object} data
+     * @param {Object} data.topologyIdentity `{}` for a first boot; else `{groupId, workspaceKey, generationToken}`
+     * @param {String} data.windowId
+     * @returns {Object} The binding description, see {@link #bind}.
+     */
+    admit({topologyIdentity, windowId}) {
+        let me       = this,
+            identity = topologyIdentity || {},
+            result   = me.bind({...identity, windowId});
+
+        if (
+            result.groupId         !== identity.groupId      ||
+            result.workspaceKey    !== identity.workspaceKey ||
+            result.generationToken !== identity.generationToken
+        ) {
+            me.writeCarrier(windowId, {
+                generationToken: result.generationToken,
+                groupId        : result.groupId,
+                workspaceKey   : result.workspaceKey
+            })
+        }
+
+        return result
     }
 
     /**
@@ -217,37 +253,20 @@ class Transaction extends Manager {
     }
 
     /**
-     * Worker `connect`: a window presenting a carried identity binds; one without is a new root.
-     * The identity travels inside `windowData`, beside the native route the main thread already resolves
-     * for it.
-     * @param {Object} data
-     * @param {Object} [data.windowData]
-     * @param {String} data.windowId
-     * @protected
+     * Sends a parked carrier write for a window once the main realm can take it.
+     * @param {String} windowId
+     * @returns {Boolean} Whether a write was sent.
      */
-    onWindowConnect({windowData, windowId}) {
-        const identity = windowData?.topologyIdentity;
+    flushCarrierWrite(windowId) {
+        let me       = this,
+            identity = me.pendingCarrierWrites.get(windowId);
 
-        // Windows that carry no identity slot at all (a worker booted without the main-thread carrier)
-        // are left alone; consumers opting in present `topologyIdentity: {}` for a fresh root.
-        if (identity === undefined) return;
+        if (!identity || !Neo.Main?.setTopologyIdentity) return false;
 
-        const result = this.bind({...identity, windowId});
+        me.pendingCarrierWrites.delete(windowId);
+        Neo.Main.setTopologyIdentity({...identity, windowId});
 
-        // The carrier learns what the worker decided: a minted, cold or forked identity differs from the
-        // one presented; a plain bind or rebind changes nothing the window did not already carry.
-        if (
-            result.groupId         !== identity.groupId      ||
-            result.workspaceKey    !== identity.workspaceKey ||
-            result.generationToken !== identity.generationToken
-        ) {
-            Neo.Main?.setTopologyIdentity?.({
-                generationToken: result.generationToken,
-                groupId        : result.groupId,
-                windowId,
-                workspaceKey   : result.workspaceKey
-            })
-        }
+        return true
     }
 
     /**
@@ -274,7 +293,7 @@ class Transaction extends Manager {
                 if (binding.windowId === windowId) {
                     binding.windowId = null;
                     me.startLease(group, binding);
-                    me.fire('release', {generation: binding.generation, groupId: group.id, workspaceKey: binding.workspaceKey});
+                    me.fire('release', {generation: binding.generation, groupId: group.id, windowId, workspaceKey: binding.workspaceKey});
                     return true
                 }
             }
@@ -319,6 +338,27 @@ class Transaction extends Manager {
     }
 
     /**
+     * Gives a reserved or released slot back before its lease ends — the opener's vessel never came,
+     * or the host retired it. A slot with a live binder is not the caller's to revoke.
+     * @param {Object} data
+     * @param {String} data.groupId
+     * @param {String} data.workspaceKey
+     * @returns {Boolean}
+     */
+    revoke({groupId, workspaceKey}) {
+        let me      = this,
+            group   = me.get(groupId),
+            binding = group?.bindings.get(workspaceKey);
+
+        if (!binding || binding.windowId !== null) return false;
+
+        me.clearLease(binding);
+        group.bindings.delete(workspaceKey);
+
+        return true
+    }
+
+    /**
      * Retires a Group and every lease it holds. Whether a Group MAY retire — durably persisted, no
      * retained reference — is the caller's contract; this manager only forgets what it is told to.
      * @param {String} groupId
@@ -334,6 +374,21 @@ class Transaction extends Manager {
         me.unregister(group);
 
         return true
+    }
+
+    /**
+     * Tells a window's carrier what to hold from now on, or parks the write until the main realm has
+     * registered its remote surface (see {@link #flushCarrierWrite}).
+     * @param {String} windowId
+     * @param {{groupId: String, workspaceKey: String, generationToken: String}} identity
+     * @protected
+     */
+    writeCarrier(windowId, identity) {
+        if (Neo.Main?.setTopologyIdentity) {
+            Neo.Main.setTopologyIdentity({...identity, windowId})
+        } else {
+            this.pendingCarrierWrites.set(windowId, identity)
+        }
     }
 
     /**

--- a/src/manager/Transaction.mjs
+++ b/src/manager/Transaction.mjs
@@ -17,9 +17,13 @@ import Manager from './Base.mjs';
  * - A released slot is held for its lineage for {@link #reconnectLeaseMs}; afterwards the slot is free.
  * - An opener reserves a slot for a window it is about to create; the reservation is the token the
  *   child must present, bounded by the same lease.
+ * - A Group also holds keyed participants — the owners its slots resolve to, registered by the hosts
+ *   that live in it. Membership is separate from binding: a participant lives while its Group does,
+ *   whatever its window's generation is doing, and a Group holding participants is never empty.
  *
  * The main thread carries the identity across page loads in `sessionStorage` and rewrites it on request;
- * it never decides. This manager knows windows, keys and tokens — no dock, no document, no app class.
+ * it never decides. This manager knows windows, keys, tokens and opaque participants — no dock, no
+ * document, no app class.
  * @class Neo.manager.Transaction
  * @extends Neo.manager.Base
  * @singleton
@@ -189,9 +193,10 @@ class Transaction extends Manager {
      */
     createGroup(groupId=crypto.randomUUID()) {
         const group = {
-            bindings : new Map(),
-            createdAt: Date.now(),
-            id       : groupId
+            bindings    : new Map(),
+            createdAt   : Date.now(),
+            id          : groupId,
+            participants: new Map()
         };
 
         this.register(group);
@@ -249,6 +254,59 @@ class Transaction extends Manager {
         const binding = this.get(groupId)?.bindings.get(workspaceKey);
 
         return binding ? {generation: binding.generation, windowId: binding.windowId, workspaceKey} : null
+    }
+
+    /**
+     * The participant a Group resolves one key to, or `null`.
+     * @param {String} groupId
+     * @param {String} workspaceKey
+     * @returns {Object|null}
+     */
+    getParticipant(groupId, workspaceKey) {
+        return this.get(groupId)?.participants.get(workspaceKey) ?? null
+    }
+
+    /**
+     * The keys a Group holds participants under, in registration order.
+     * @param {String} groupId
+     * @returns {String[]}
+     */
+    participantKeys(groupId) {
+        return [...(this.get(groupId)?.participants.keys() ?? [])]
+    }
+
+    /**
+     * Registers — or replaces — the participant a Group resolves one key to. What a participant IS is the
+     * host's business: this manager holds it opaque, so a dock host registers document accessors and
+     * another domain registers whatever its slots resolve to. An unknown Group refuses.
+     * @param {Object} data
+     * @param {String} data.groupId
+     * @param {String} data.workspaceKey
+     * @param {Object} data.participant
+     * @returns {Boolean}
+     */
+    registerParticipant({groupId, workspaceKey, participant}) {
+        const group = this.get(groupId);
+
+        if (!group || typeof workspaceKey !== 'string' || !workspaceKey || !participant || typeof participant !== 'object') {
+            return false
+        }
+
+        group.participants.set(workspaceKey, participant);
+
+        return true
+    }
+
+    /**
+     * Retires one participant of a Group — an explicit owner decision, never a side effect of a window's
+     * binding leaving: closing a vessel unbinds a render target, it does not delete worker documents.
+     * @param {Object} data
+     * @param {String} data.groupId
+     * @param {String} data.workspaceKey
+     * @returns {Boolean}
+     */
+    unregisterParticipant({groupId, workspaceKey}) {
+        return this.get(groupId)?.participants.delete(workspaceKey) ?? false
     }
 
     /**
@@ -341,8 +399,9 @@ class Transaction extends Manager {
     }
 
     /**
-     * Retires a Group and every lease it holds. Whether a Group MAY retire — durably persisted, no
-     * retained reference — is the caller's contract; this manager only forgets what it is told to.
+     * Retires a Group with every lease and participant it holds. Whether a Group MAY retire — durably
+     * persisted, no retained reference — is the caller's contract; this manager only forgets what it is
+     * told to.
      * @param {String} groupId
      * @returns {Boolean}
      */
@@ -353,6 +412,7 @@ class Transaction extends Manager {
         if (!group) return false;
 
         group.bindings.forEach(binding => me.clearLease(binding));
+        group.participants.clear();
         me.unregister(group);
 
         return true
@@ -389,11 +449,12 @@ class Transaction extends Manager {
                 group.bindings.delete(binding.workspaceKey);
                 me.fire('leaseExpired', {groupId: group.id, workspaceKey: binding.workspaceKey});
 
-                // A Group with no binding left holds nothing this manager keeps for it — no history, no
-                // snapshot — so letting it go loses nothing. Conditional, lossless retirement of a
-                // Group that DOES hold state is a later contract; this only stops closed windows from
-                // leaving empty Groups behind in a long-lived worker.
-                if (group.bindings.size === 0 && me.get(group.id) === group) {
+                // A Group with no binding AND no participant left holds nothing this manager keeps for
+                // it — no history, no snapshot — so letting it go loses nothing. A Group whose
+                // participants outlive its last window is not empty: its documents are still owned.
+                // Conditional, lossless retirement of a Group that DOES hold state is a later contract;
+                // this only stops closed windows from leaving empty Groups behind in a long-lived worker.
+                if (group.bindings.size === 0 && group.participants.size === 0 && me.get(group.id) === group) {
                     me.unregister(group);
                     me.fire('groupRetired', {groupId: group.id})
                 }

--- a/src/manager/Transaction.mjs
+++ b/src/manager/Transaction.mjs
@@ -1,0 +1,347 @@
+import Manager from './Base.mjs';
+
+/**
+ * @summary The worker-side authority for logical topology Groups and their window bindings.
+ * @description A Group is the persistent identity of one multi-window topology instance. `appName` is
+ * routing metadata and never identifies a Group: two independent roots of the same app under one
+ * SharedWorker are two Groups. A window binds into a Group under a `workspaceKey` — one key per full
+ * Workspace slot — and the binding records the replaceable runtime generation, the `windowId`.
+ *
+ * The rules a binding follows:
+ * - A warm reload releases its binding on `disconnect` and rebinds on `connect` with the same lineage
+ *   token; only that binding's generation moves, no other slot and no other Group is touched.
+ * - A late `disconnect` for a superseded generation finds no binding carrying its `windowId` and does
+ *   nothing — it cannot unbind its successor.
+ * - An identity presented while its binder is live, or against a released slot with a foreign token,
+ *   forks: the newcomer receives a fresh Group and the caller rewrites the boot carrier.
+ * - A released slot is held for its lineage for {@link #reconnectLeaseMs}; afterwards the slot is free.
+ * - An opener reserves a slot for a window it is about to create; the reservation is the token the
+ *   child must present, bounded by the same lease.
+ *
+ * The main thread carries the identity across page loads in `sessionStorage` and rewrites it on request;
+ * it never decides. This manager knows windows, keys and tokens — no dock, no document, no app class.
+ * @class Neo.manager.Transaction
+ * @extends Neo.manager.Base
+ * @singleton
+ */
+class Transaction extends Manager {
+    static config = {
+        /**
+         * @member {String} className='Neo.manager.Transaction'
+         * @protected
+         */
+        className: 'Neo.manager.Transaction',
+        /**
+         * @member {Boolean} singleton=true
+         * @protected
+         */
+        singleton: true,
+        /**
+         * How long a released or reserved binding holds its slot for a token-matched successor before the
+         * slot is free. The dock tear-out connect window is the precedent for the bound.
+         * @member {Number} reconnectLeaseMs=20000
+         */
+        reconnectLeaseMs: 20000
+    }
+
+    /**
+     * Lease timers keyed by binding, so a binding that is superseded, rebound or retired before its
+     * lease ends never expires a slot it no longer describes.
+     * @member {Map} leaseTimers=new Map()
+     * @protected
+     */
+    leaseTimers = new Map()
+
+    /**
+     * @param {Object} config
+     */
+    construct(config) {
+        super.construct(config);
+
+        let me = this;
+
+        Neo.currentWorker?.on?.({
+            connect   : me.onWindowConnect,
+            disconnect: me.onWindowDisconnect,
+            scope     : me
+        })
+    }
+
+    /**
+     * Binds a window into a Group under a workspace key. Without an identity the window is a new root and
+     * receives a freshly minted Group. Every outcome names the identity the caller must carry from now on:
+     * after `forked` it differs from the one presented.
+     * @param {Object} data
+     * @param {String} [data.groupId] The presented Group, absent for a first boot.
+     * @param {String} [data.workspaceKey='main'] One key per full Workspace slot.
+     * @param {String} [data.generationToken] The lineage token the carrier holds.
+     * @param {String} data.windowId The runtime generation binding now.
+     * @returns {{outcome: String, groupId: String, workspaceKey: String, generationToken: String, windowId: String, generation: Number}}
+     *   `outcome` is one of `minted` (no identity presented), `cold` (a Group this worker never saw),
+     *   `bound` (a free or reserved slot), `rebound` (a released slot, token matched) or `forked`.
+     */
+    bind({groupId, workspaceKey='main', generationToken, windowId}) {
+        let me = this,
+            group, binding, outcome;
+
+        if (!groupId) {
+            group   = me.createGroup();
+            outcome = 'minted'
+        } else {
+            group = me.get(groupId);
+
+            if (!group) {
+                group   = me.createGroup(groupId);
+                outcome = 'cold'
+            }
+        }
+
+        binding = group.bindings.get(workspaceKey);
+
+        if (binding) {
+            const live = binding.windowId !== null;
+
+            if (live && binding.windowId === windowId) {
+                return me.describe(group, binding, 'bound')
+            }
+
+            if (live || binding.generationToken !== generationToken) {
+                // A copied identity while the binder lives, or a stranger on a held slot: the newcomer
+                // gets its own Group. The current binder is never superseded from the outside.
+                group   = me.createGroup();
+                binding = null;
+                outcome = 'forked'
+            } else {
+                me.clearLease(binding);
+                binding.windowId = windowId;
+                binding.generation++;
+                return me.describe(group, binding, 'rebound')
+            }
+        }
+
+        binding = {
+            generation     : 1,
+            generationToken: (outcome === 'forked' || !generationToken) ? crypto.randomUUID() : generationToken,
+            windowId,
+            workspaceKey
+        };
+
+        group.bindings.set(workspaceKey, binding);
+
+        return me.describe(group, binding, outcome || 'bound')
+    }
+
+    /**
+     * Ends a lease timer for a binding, if one is running.
+     * @param {Object} binding
+     * @protected
+     */
+    clearLease(binding) {
+        let me      = this,
+            timerId = me.leaseTimers.get(binding);
+
+        if (timerId !== undefined) {
+            clearTimeout(timerId);
+            me.leaseTimers.delete(binding)
+        }
+    }
+
+    /**
+     * Registers a new Group. The id is minted here unless a carrier presents one this worker never saw.
+     * @param {String} [groupId]
+     * @returns {Object} The Group record: `{id, bindings, createdAt}`
+     * @protected
+     */
+    createGroup(groupId=crypto.randomUUID()) {
+        const group = {
+            bindings : new Map(),
+            createdAt: Date.now(),
+            id       : groupId
+        };
+
+        this.register(group);
+
+        return group
+    }
+
+    /**
+     * @param {Object} group
+     * @param {Object} binding
+     * @param {String} outcome
+     * @returns {Object}
+     * @protected
+     */
+    describe(group, binding, outcome) {
+        const result = {
+            generation     : binding.generation,
+            generationToken: binding.generationToken,
+            groupId        : group.id,
+            outcome,
+            windowId       : binding.windowId,
+            workspaceKey   : binding.workspaceKey
+        };
+
+        // The emitter annotates the object it is handed; callers get the plain description.
+        this.fire('bind', {...result});
+
+        return result
+    }
+
+    /**
+     * Finds the Group and binding a live window belongs to.
+     * @param {String} windowId
+     * @returns {{groupId: String, workspaceKey: String, generation: Number}|null}
+     */
+    findByWindow(windowId) {
+        for (const group of this.items) {
+            for (const binding of group.bindings.values()) {
+                if (binding.windowId === windowId) {
+                    return {generation: binding.generation, groupId: group.id, workspaceKey: binding.workspaceKey}
+                }
+            }
+        }
+
+        return null
+    }
+
+    /**
+     * @param {String} groupId
+     * @param {String} workspaceKey
+     * @returns {{windowId: String|null, generation: Number, workspaceKey: String}|null} A copy of the binding
+     *   without its token; `windowId` is `null` while the slot is released or reserved.
+     */
+    getBinding(groupId, workspaceKey) {
+        const binding = this.get(groupId)?.bindings.get(workspaceKey);
+
+        return binding ? {generation: binding.generation, windowId: binding.windowId, workspaceKey} : null
+    }
+
+    /**
+     * Worker `connect`: a window presenting a carried identity binds; one without is a new root.
+     * The identity travels inside `windowData`, beside the native route the main thread already resolves
+     * for it.
+     * @param {Object} data
+     * @param {Object} [data.windowData]
+     * @param {String} data.windowId
+     * @protected
+     */
+    onWindowConnect({windowData, windowId}) {
+        const identity = windowData?.topologyIdentity;
+
+        // Windows that carry no identity slot at all (a worker booted without the main-thread carrier)
+        // are left alone; consumers opting in present `topologyIdentity: {}` for a fresh root.
+        if (identity === undefined) return;
+
+        this.bind({...identity, windowId})
+    }
+
+    /**
+     * Worker `disconnect`: the binding carrying this `windowId` is released and its slot held for the
+     * lease. A `windowId` no binding carries — a superseded generation reporting late — changes nothing.
+     * @param {Object} data
+     * @param {String} data.windowId
+     * @protected
+     */
+    onWindowDisconnect({windowId}) {
+        this.release(windowId)
+    }
+
+    /**
+     * Releases the binding a window holds and starts its lease.
+     * @param {String} windowId
+     * @returns {Boolean} Whether a binding was released.
+     */
+    release(windowId) {
+        let me = this;
+
+        for (const group of me.items) {
+            for (const binding of group.bindings.values()) {
+                if (binding.windowId === windowId) {
+                    binding.windowId = null;
+                    me.startLease(group, binding);
+                    me.fire('release', {generation: binding.generation, groupId: group.id, workspaceKey: binding.workspaceKey});
+                    return true
+                }
+            }
+        }
+
+        return false
+    }
+
+    /**
+     * Reserves a slot for a window the caller is about to open. The returned identity is what the opener
+     * writes into the child's carrier; the child's `connect` then binds with the reserved token. A slot
+     * with a live binder cannot be reserved.
+     * @param {Object} data
+     * @param {String} data.groupId
+     * @param {String} data.workspaceKey
+     * @returns {{groupId: String, workspaceKey: String, generationToken: String}|null}
+     */
+    reserve({groupId, workspaceKey}) {
+        let me    = this,
+            group = me.get(groupId),
+            binding;
+
+        if (!group || !workspaceKey) return null;
+
+        binding = group.bindings.get(workspaceKey);
+
+        if (binding?.windowId) return null;
+
+        binding && me.clearLease(binding);
+
+        binding = {
+            generation     : binding ? binding.generation : 0,
+            generationToken: crypto.randomUUID(),
+            windowId       : null,
+            workspaceKey
+        };
+
+        group.bindings.set(workspaceKey, binding);
+        me.startLease(group, binding);
+
+        return {generationToken: binding.generationToken, groupId, workspaceKey}
+    }
+
+    /**
+     * Retires a Group and every lease it holds. Whether a Group MAY retire — durably persisted, no
+     * retained reference — is the caller's contract; this manager only forgets what it is told to.
+     * @param {String} groupId
+     * @returns {Boolean}
+     */
+    retireGroup(groupId) {
+        let me    = this,
+            group = me.get(groupId);
+
+        if (!group) return false;
+
+        group.bindings.forEach(binding => me.clearLease(binding));
+        me.unregister(group);
+
+        return true
+    }
+
+    /**
+     * Holds a released or reserved slot for its lineage; on expiry the slot is free.
+     * @param {Object} group
+     * @param {Object} binding
+     * @protected
+     */
+    startLease(group, binding) {
+        let me = this;
+
+        me.clearLease(binding);
+
+        me.leaseTimers.set(binding, setTimeout(() => {
+            me.leaseTimers.delete(binding);
+
+            // Only the binding this lease was started for; a rebind replaced it with a live one.
+            if (group.bindings.get(binding.workspaceKey) === binding && binding.windowId === null) {
+                group.bindings.delete(binding.workspaceKey);
+                me.fire('leaseExpired', {groupId: group.id, workspaceKey: binding.workspaceKey})
+            }
+        }, me.reconnectLeaseMs))
+    }
+}
+
+export default Neo.setupClass(Transaction);

--- a/src/manager/Transaction.mjs
+++ b/src/manager/Transaction.mjs
@@ -232,7 +232,22 @@ class Transaction extends Manager {
         // are left alone; consumers opting in present `topologyIdentity: {}` for a fresh root.
         if (identity === undefined) return;
 
-        this.bind({...identity, windowId})
+        const result = this.bind({...identity, windowId});
+
+        // The carrier learns what the worker decided: a minted, cold or forked identity differs from the
+        // one presented; a plain bind or rebind changes nothing the window did not already carry.
+        if (
+            result.groupId         !== identity.groupId      ||
+            result.workspaceKey    !== identity.workspaceKey ||
+            result.generationToken !== identity.generationToken
+        ) {
+            Neo.Main?.setTopologyIdentity?.({
+                generationToken: result.generationToken,
+                groupId        : result.groupId,
+                windowId,
+                workspaceKey   : result.workspaceKey
+            })
+        }
     }
 
     /**

--- a/src/manager/Transaction.mjs
+++ b/src/manager/Transaction.mjs
@@ -53,14 +53,9 @@ class Transaction extends Manager {
     leaseTimers = new Map()
 
     /**
-     * Carrier writes the main realm could not take yet, keyed by window: a window is admitted when its
-     * config registers, which can precede the main realm registering its remote surface.
-     * @member {Map} pendingCarrierWrites=new Map()
-     * @protected
-     */
-    pendingCarrierWrites = new Map()
-
-    /**
+     * This module loads on demand — the first multi-window participant imports it — so windows whose apps
+     * registered before that moment are admitted here, with the identity their config registered with.
+     * Every later window is admitted as its app registers (`worker/App#registerApp`).
      * @param {Object} config
      */
     construct(config) {
@@ -71,6 +66,10 @@ class Transaction extends Manager {
         Neo.currentWorker?.on?.({
             disconnect: me.onWindowDisconnect,
             scope     : me
+        });
+
+        Object.keys(Neo.apps || {}).forEach(windowId => {
+            me.admit({topologyIdentity: Neo.windowConfigs?.[windowId]?.topologyIdentity, windowId})
         })
     }
 
@@ -253,23 +252,6 @@ class Transaction extends Manager {
     }
 
     /**
-     * Sends a parked carrier write for a window once the main realm can take it.
-     * @param {String} windowId
-     * @returns {Boolean} Whether a write was sent.
-     */
-    flushCarrierWrite(windowId) {
-        let me       = this,
-            identity = me.pendingCarrierWrites.get(windowId);
-
-        if (!identity || !Neo.Main?.setTopologyIdentity) return false;
-
-        me.pendingCarrierWrites.delete(windowId);
-        Neo.Main.setTopologyIdentity({...identity, windowId});
-
-        return true
-    }
-
-    /**
      * Worker `disconnect`: the binding carrying this `windowId` is released and its slot held for the
      * lease. A `windowId` no binding carries — a superseded generation reporting late — changes nothing.
      * @param {Object} data
@@ -377,18 +359,15 @@ class Transaction extends Manager {
     }
 
     /**
-     * Tells a window's carrier what to hold from now on, or parks the write until the main realm has
-     * registered its remote surface (see {@link #flushCarrierWrite}).
+     * Tells a window's carrier what to hold from now on. A window is admitted once its app registered,
+     * which is after the main realm registered its remote surface; the optional call only spares a unit
+     * harness that mocks no `Neo.Main`.
      * @param {String} windowId
      * @param {{groupId: String, workspaceKey: String, generationToken: String}} identity
      * @protected
      */
     writeCarrier(windowId, identity) {
-        if (Neo.Main?.setTopologyIdentity) {
-            Neo.Main.setTopologyIdentity({...identity, windowId})
-        } else {
-            this.pendingCarrierWrites.set(windowId, identity)
-        }
+        Neo.Main?.setTopologyIdentity?.({...identity, windowId})
     }
 
     /**

--- a/src/manager/Transaction.mjs
+++ b/src/manager/Transaction.mjs
@@ -408,7 +408,16 @@ class Transaction extends Manager {
             // Only the binding this lease was started for; a rebind replaced it with a live one.
             if (group.bindings.get(binding.workspaceKey) === binding && binding.windowId === null) {
                 group.bindings.delete(binding.workspaceKey);
-                me.fire('leaseExpired', {groupId: group.id, workspaceKey: binding.workspaceKey})
+                me.fire('leaseExpired', {groupId: group.id, workspaceKey: binding.workspaceKey});
+
+                // A Group with no binding left holds nothing this manager keeps for it — no history, no
+                // snapshot — so letting it go loses nothing. Conditional, lossless retirement of a
+                // Group that DOES hold state is a later contract; this only stops closed windows from
+                // leaving empty Groups behind in a long-lived worker.
+                if (group.bindings.size === 0 && me.get(group.id) === group) {
+                    me.unregister(group);
+                    me.fire('groupRetired', {groupId: group.id})
+                }
             }
         }, me.reconnectLeaseMs))
     }

--- a/src/manager/Transaction.mjs
+++ b/src/manager/Transaction.mjs
@@ -14,16 +14,22 @@ import Manager from './Base.mjs';
  *   nothing — it cannot unbind its successor.
  * - An identity presented while its binder is live, or against a released slot with a foreign token,
  *   forks: the newcomer receives a fresh Group and the caller rewrites the boot carrier.
- * - A released slot is held for its lineage for {@link #reconnectLeaseMs}; afterwards the slot is free.
+ * - A released or reserved slot is held for its lineage for {@link #reconnectLeaseMs}; afterwards the
+ *   lineage is dead — a window presenting it finds no slot in its Group and forks, a revocation naming
+ *   it is refused. Only a Group this worker never saw admits a carried identity into an absent slot: a
+ *   cold root returning after the worker restarted.
  * - An opener reserves a slot for a window it is about to create; the reservation is the token the
- *   child must present, bounded by the same lease.
+ *   child must present, bounded by the same lease, and the only token that may give the slot back.
+ * - A minted or forked identity exists once its window's carrier holds it: admission awaits the main
+ *   thread's acknowledgement, and a pending, refused or rejected write binds nothing and publishes
+ *   nothing. An identity the carrier already holds — a rebind, a cold root — binds at once.
  * - A Group also holds keyed participants — the owners its slots resolve to, registered by the hosts
  *   that live in it. Membership is separate from binding: a participant lives while its Group does,
  *   whatever its window's generation is doing, and a Group holding participants is never empty.
  *
  * The main thread carries the identity across page loads in `sessionStorage` and rewrites it on request;
- * it never decides. This manager knows windows, keys, tokens and opaque participants — no dock, no
- * document, no app class.
+ * it never decides — it only says whether it could. This manager knows windows, keys, tokens and opaque
+ * participants — no dock, no document, no app class.
  * @class Neo.manager.Transaction
  * @extends Neo.manager.Base
  * @singleton
@@ -57,6 +63,14 @@ class Transaction extends Manager {
     leaseTimers = new Map()
 
     /**
+     * Admissions whose carrier write is still in flight, keyed by `windowId`. A window that leaves
+     * while its write is pending is refused when the answer arrives — never bound to a gone window.
+     * @member {Map} pendingAdmissions=new Map()
+     * @protected
+     */
+    pendingAdmissions = new Map()
+
+    /**
      * This module loads on demand — the first multi-window participant imports it — so windows whose apps
      * registered before that moment are admitted here, with the identity their config registered with.
      * Every later window is admitted as its app registers (`worker/App#registerApp`).
@@ -78,38 +92,84 @@ class Transaction extends Manager {
     }
 
     /**
-     * Admits a window the worker just learned of: binds it under the identity its carrier presented and
-     * tells the carrier what to hold from now on when that differs — a minted, cold or forked identity.
-     * A plain bind or rebind changes nothing the window did not already carry.
+     * Admits a window the worker just learned of: binds it under the identity its carrier presented.
+     * An identity the carrier already holds — a rebind, a reserved slot, a cold root — binds and is
+     * published at once. A minted or forked outcome names an identity the carrier does not hold yet, so
+     * the write is awaited and only an accepted write binds and publishes: while it is pending nothing
+     * is registered or announced; a refused or rejected write, or a window that left meanwhile, admits
+     * nothing and fires `admissionRefused`.
      * @param {Object} data
      * @param {Object} data.topologyIdentity `{}` for a first boot; else `{groupId, workspaceKey, generationToken}`
      * @param {String} data.windowId
-     * @returns {Object} The binding description, see {@link #bind}.
+     * @returns {Promise<Object>} The binding description, see {@link #bind}, or `{outcome: 'refused',
+     *   groupId: null, generationToken: null, generation: 0, windowId, workspaceKey}` when nothing was admitted.
      */
-    admit({topologyIdentity, windowId}) {
+    async admit({topologyIdentity, windowId}) {
         let me       = this,
             identity = topologyIdentity || {},
-            result   = me.bind({...identity, windowId});
+            plan     = me.plan({...identity, windowId});
 
         if (
-            result.groupId         !== identity.groupId      ||
-            result.workspaceKey    !== identity.workspaceKey ||
-            result.generationToken !== identity.generationToken
+            plan.groupId         === identity.groupId      &&
+            plan.workspaceKey    === identity.workspaceKey &&
+            plan.generationToken === identity.generationToken
         ) {
-            me.writeCarrier(windowId, {
-                generationToken: result.generationToken,
-                groupId        : result.groupId,
-                workspaceKey   : result.workspaceKey
-            })
+            return me.settle(plan)
         }
 
-        return result
+        const pending = {cancelled: false};
+
+        me.pendingAdmissions.set(windowId, pending);
+
+        const accepted = await me.writeCarrier(windowId, {
+            generationToken: plan.generationToken,
+            groupId        : plan.groupId,
+            workspaceKey   : plan.workspaceKey
+        });
+
+        me.pendingAdmissions.get(windowId) === pending && me.pendingAdmissions.delete(windowId);
+
+        if (!accepted || pending.cancelled) {
+            const description = {
+                generation     : 0,
+                generationToken: null,
+                groupId        : null,
+                outcome        : 'refused',
+                windowId,
+                workspaceKey   : plan.workspaceKey
+            };
+
+            me.fire('admissionRefused', {...description, presented: identity, reason: pending.cancelled ? 'window-gone' : 'carrier-refused'});
+
+            return description
+        }
+
+        // Only a minted or forked identity waits, and both name a Group that does not exist yet, so the
+        // registry cannot have moved under the plan — except by admitting this same window elsewhere,
+        // in which case that binding stands and nothing new is published.
+        const settled = me.findByWindow(windowId);
+
+        if (settled) {
+            const binding = me.get(settled.groupId).bindings.get(settled.workspaceKey);
+
+            return {
+                generation     : binding.generation,
+                generationToken: binding.generationToken,
+                groupId        : settled.groupId,
+                outcome        : 'bound',
+                windowId,
+                workspaceKey   : settled.workspaceKey
+            }
+        }
+
+        return me.settle(plan)
     }
 
     /**
-     * Binds a window into a Group under a workspace key. Without an identity the window is a new root and
-     * receives a freshly minted Group. Every outcome names the identity the caller must carry from now on:
-     * after `forked` it differs from the one presented.
+     * Binds a window into a Group under a workspace key, synchronously and published at once — the
+     * registry operation {@link #admit} runs after the carrier accepted. Without an identity the window is
+     * a new root and receives a freshly minted Group. Every outcome names the identity the caller must
+     * carry from now on: after `forked` it differs from the one presented.
      * @param {Object} data
      * @param {String} [data.groupId] The presented Group, absent for a first boot.
      * @param {String} [data.workspaceKey='main'] One key per full Workspace slot.
@@ -117,57 +177,91 @@ class Transaction extends Manager {
      * @param {String} data.windowId The runtime generation binding now.
      * @returns {{outcome: String, groupId: String, workspaceKey: String, generationToken: String, windowId: String, generation: Number}}
      *   `outcome` is one of `minted` (no identity presented), `cold` (a Group this worker never saw),
-     *   `bound` (a free or reserved slot), `rebound` (a released slot, token matched) or `forked`.
+     *   `bound` (a reserved slot, or this window's own live binding), `rebound` (a released slot, token
+     *   matched) or `forked` (a live binder's copy, a stranger's token, or a slot the Group no longer holds).
      */
-    bind({groupId, workspaceKey='main', generationToken, windowId}) {
-        let me = this,
-            group, binding, outcome;
+    bind(data) {
+        return this.settle(this.plan(data))
+    }
+
+    /**
+     * Decides what binding a presented identity gets, without touching the registry. The plan carries
+     * everything {@link #settle} needs, so a decision can wait for the carrier and land unchanged.
+     * @param {Object} data See {@link #bind}.
+     * @returns {{outcome: String, groupId: String, workspaceKey: String, generationToken: String, windowId: String, group: Object|null, binding: Object|null}}
+     *   `group` is the existing Group the binding lands in, `null` when {@link #settle} creates it;
+     *   `binding` is the existing slot the window takes over, `null` when a new one is added.
+     * @protected
+     */
+    plan({groupId, workspaceKey='main', generationToken, windowId}) {
+        let me      = this,
+            group   = groupId ? me.get(groupId) : null,
+            binding = group?.bindings.get(workspaceKey) ?? null,
+            outcome;
 
         if (!groupId) {
-            group   = me.createGroup();
             outcome = 'minted'
+        } else if (!group) {
+            outcome = 'cold'
+        } else if (!binding) {
+            // The presented lineage names a slot this Group does not hold: never reserved here, revoked,
+            // or its lease ran out. A dead lineage is not a door into a live Group.
+            outcome = 'forked'
+        } else if (binding.windowId !== null) {
+            // A copied identity while the binder lives forks; the binder is never superseded from outside.
+            outcome = binding.windowId === windowId ? 'bound' : 'forked'
+        } else if (binding.generationToken !== generationToken) {
+            outcome = 'forked'
         } else {
-            group = me.get(groupId);
-
-            if (!group) {
-                group   = me.createGroup(groupId);
-                outcome = 'cold'
-            }
+            outcome = binding.generation === 0 ? 'bound' : 'rebound'
         }
 
-        binding = group.bindings.get(workspaceKey);
+        const fresh = outcome === 'minted' || outcome === 'forked';
 
-        if (binding) {
-            const live = binding.windowId !== null;
-
-            if (live && binding.windowId === windowId) {
-                return me.describe(group, binding, 'bound')
-            }
-
-            if (live || binding.generationToken !== generationToken) {
-                // A copied identity while the binder lives, or a stranger on a held slot: the newcomer
-                // gets its own Group. The current binder is never superseded from the outside.
-                group   = me.createGroup();
-                binding = null;
-                outcome = 'forked'
-            } else {
-                me.clearLease(binding);
-                binding.windowId = windowId;
-                binding.generation++;
-                return me.describe(group, binding, 'rebound')
-            }
-        }
-
-        binding = {
-            generation     : 1,
-            generationToken: (outcome === 'forked' || !generationToken) ? crypto.randomUUID() : generationToken,
+        return {
+            binding        : fresh ? null : binding,
+            generationToken: fresh || !generationToken ? crypto.randomUUID() : generationToken,
+            group          : fresh ? null : group,
+            groupId        : fresh ? crypto.randomUUID() : groupId,
+            outcome,
             windowId,
             workspaceKey
-        };
+        }
+    }
 
-        group.bindings.set(workspaceKey, binding);
+    /**
+     * Lands a {@link #plan}: creates the Group a fresh or cold identity names, takes over or adds the
+     * slot, and publishes the binding.
+     * @param {Object} plan
+     * @returns {Object} The binding description, see {@link #bind}.
+     * @protected
+     */
+    settle(plan) {
+        let me                                = this,
+            {outcome, windowId, workspaceKey} = plan,
+            group                             = plan.group ?? me.createGroup(plan.groupId),
+            binding                           = plan.binding;
 
-        return me.describe(group, binding, outcome || 'bound')
+        if (binding) {
+            if (binding.windowId === windowId) {
+                return me.describe(group, binding, outcome)
+            }
+
+            me.clearLease(binding);
+            binding.windowId = windowId;
+            binding.generation++
+        } else {
+            binding = {
+                generation     : 1,
+                generationToken: plan.generationToken,
+                windowId,
+                workspaceKey
+            };
+
+            group.bindings.set(workspaceKey, binding)
+        }
+
+        return me.describe(group, binding, outcome)
     }
 
     /**
@@ -321,12 +415,16 @@ class Transaction extends Manager {
     }
 
     /**
-     * Releases the binding a window holds and starts its lease.
+     * Releases the binding a window holds and starts its lease. A window still waiting for its carrier's
+     * answer holds no binding yet; its admission is cancelled instead, so the answer binds nothing.
      * @param {String} windowId
      * @returns {Boolean} Whether a binding was released.
      */
     release(windowId) {
-        let me = this;
+        let me      = this,
+            pending = me.pendingAdmissions.get(windowId);
+
+        pending && (pending.cancelled = true);
 
         for (const group of me.items) {
             for (const binding of group.bindings.values()) {
@@ -379,18 +477,21 @@ class Transaction extends Manager {
 
     /**
      * Gives a reserved or released slot back before its lease ends — the opener's vessel never came,
-     * or the host retired it. A slot with a live binder is not the caller's to revoke.
+     * or the host retired it. Only the lineage holding the slot may give it back: an older reservation's
+     * failure or cleanup, arriving after the slot was reserved again, names a token the slot no longer
+     * carries and is refused. A slot with a live binder is not the caller's to revoke.
      * @param {Object} data
      * @param {String} data.groupId
      * @param {String} data.workspaceKey
+     * @param {String} data.generationToken The reservation's own token.
      * @returns {Boolean}
      */
-    revoke({groupId, workspaceKey}) {
+    revoke({groupId, workspaceKey, generationToken}) {
         let me      = this,
             group   = me.get(groupId),
             binding = group?.bindings.get(workspaceKey);
 
-        if (!binding || binding.windowId !== null) return false;
+        if (!binding || binding.windowId !== null || !generationToken || binding.generationToken !== generationToken) return false;
 
         me.clearLease(binding);
         group.bindings.delete(workspaceKey);
@@ -419,15 +520,24 @@ class Transaction extends Manager {
     }
 
     /**
-     * Tells a window's carrier what to hold from now on. A window is admitted once its app registered,
-     * which is after the main realm registered its remote surface; the optional call only spares a unit
-     * harness that mocks no `Neo.Main`.
+     * Tells a window's carrier what to hold from now on and reports whether it took. A window is admitted
+     * once its app registered, which is after the main realm registered its remote surface; a realm
+     * without the setter — a unit harness that mocks no `Neo.Main` — has no carrier to disagree, so its
+     * absence accepts. A present setter must answer exactly `true`: a pending answer is awaited, and
+     * `false`, a rejection or anything else refuses.
      * @param {String} windowId
      * @param {{groupId: String, workspaceKey: String, generationToken: String}} identity
+     * @returns {Promise<Boolean>}
      * @protected
      */
-    writeCarrier(windowId, identity) {
-        Neo.Main?.setTopologyIdentity?.({...identity, windowId})
+    async writeCarrier(windowId, identity) {
+        if (typeof Neo.Main?.setTopologyIdentity !== 'function') return true;
+
+        try {
+            return await Neo.Main.setTopologyIdentity({...identity, windowId}) === true
+        } catch (error) {
+            return false
+        }
     }
 
     /**

--- a/src/manager/_export.mjs
+++ b/src/manager/_export.mjs
@@ -1,7 +1,8 @@
-import Base      from './Base.mjs';
-import Component from './Component.mjs';
-import DomEvent  from './DomEvent.mjs';
-import Focus     from './Focus.mjs';
-import Instance  from './Instance.mjs';
+import Base        from './Base.mjs';
+import Component   from './Component.mjs';
+import DomEvent    from './DomEvent.mjs';
+import Focus       from './Focus.mjs';
+import Instance    from './Instance.mjs';
+import Transaction from './Transaction.mjs';
 
-export {Base, Component, DomEvent, Instance, Focus};
+export {Base, Component, DomEvent, Instance, Focus, Transaction};

--- a/src/worker/App.mjs
+++ b/src/worker/App.mjs
@@ -686,10 +686,6 @@ class App extends Base {
             appPath = appPath.startsWith('/') ? appPath.substring(1) : appPath
         }
 
-        // The main realm's remote surface is registered by now; a carrier write the admission parked
-        // because `Neo.Main` had no `setTopologyIdentity` yet lands here.
-        Neo.manager.Transaction?.flushCarrierWrite(windowId);
-
         me.importApp(appPath).then(module => {
             Neo.bootingWindowId = windowId;
             module.onStart();
@@ -744,15 +740,6 @@ class App extends Base {
         Neo.windowConfigs = Neo.windowConfigs || {};
 
         Neo.windowConfigs[data.windowId] = Neo.clone(data, true);
-
-        // Every window arrives carrying its topology identity; `Neo.manager.Transaction` binds it into
-        // its Group and answers what the carrier must hold next. Loaded here rather than statically:
-        // the manager subscribes to this worker at construction, which needs the worker to exist first.
-        if (data.topologyIdentity) {
-            import('../manager/Transaction.mjs').then(({default: TransactionManager}) => {
-                TransactionManager.admit({topologyIdentity: data.topologyIdentity, windowId: data.windowId})
-            })
-        }
 
         if (!me.themeMapFetchStarted) {
             me.themeMapFetchStarted = true;
@@ -850,13 +837,18 @@ class App extends Base {
     }
 
     /**
-     * Only needed for SharedWorkers
+     * An Application instance announces itself for its window. The port bookkeeping matters only for
+     * SharedWorkers; the topology admission runs for both worker types — this is the first moment the
+     * window has a live app, and the window's config carries the identity its carrier presented. The
+     * manager is loaded by the first multi-window participant, never here: an app that loaded none is
+     * admitted by the manager's own sweep the moment one does.
      * @param {String} appName
      * @param {String} windowId
      */
     registerApp(appName, windowId) {
         // register the name as fast as possible
         this.onRegisterApp({appName}, this.getPort({windowId}));
+        Neo.manager.Transaction?.admit({topologyIdentity: Neo.windowConfigs?.[windowId]?.topologyIdentity, windowId});
         this.sendMessage(windowId, {action: 'registerAppName', appName})
     }
 

--- a/src/worker/App.mjs
+++ b/src/worker/App.mjs
@@ -686,6 +686,10 @@ class App extends Base {
             appPath = appPath.startsWith('/') ? appPath.substring(1) : appPath
         }
 
+        // The main realm's remote surface is registered by now; a carrier write the admission parked
+        // because `Neo.Main` had no `setTopologyIdentity` yet lands here.
+        Neo.manager.Transaction?.flushCarrierWrite(windowId);
+
         me.importApp(appPath).then(module => {
             Neo.bootingWindowId = windowId;
             module.onStart();
@@ -740,6 +744,15 @@ class App extends Base {
         Neo.windowConfigs = Neo.windowConfigs || {};
 
         Neo.windowConfigs[data.windowId] = Neo.clone(data, true);
+
+        // Every window arrives carrying its topology identity; `Neo.manager.Transaction` binds it into
+        // its Group and answers what the carrier must hold next. Loaded here rather than statically:
+        // the manager subscribes to this worker at construction, which needs the worker to exist first.
+        if (data.topologyIdentity) {
+            import('../manager/Transaction.mjs').then(({default: TransactionManager}) => {
+                TransactionManager.admit({topologyIdentity: data.topologyIdentity, windowId: data.windowId})
+            })
+        }
 
         if (!me.themeMapFetchStarted) {
             me.themeMapFetchStarted = true;

--- a/src/worker/Manager.mjs
+++ b/src/worker/Manager.mjs
@@ -107,6 +107,15 @@ class Manager extends Base {
          */
         windowId: window.__NEO_SSR__?.windowId || crypto.randomUUID(),
         /**
+         * The `sessionStorage` key carrying this window's topology identity — `{groupId, workspaceKey,
+         * generationToken}` — across page loads. Read once per worker registration and sent with the
+         * config, so every window arrives in the App Worker already carrying what it is; `Neo.Main`
+         * writes it on the worker's word and hands a staged popup its reserved slot under the same key.
+         * @member {String} topologyIdentityStorageKey='neo-topology-identity'
+         * @protected
+         */
+        topologyIdentityStorageKey: 'neo-topology-identity',
+        /**
          * Contains the fileNames for the App, Data & Vdom workers
          * @member {Object} workers
          * @protected
@@ -295,7 +304,7 @@ class Manager extends Base {
                 break
             }
 
-            let workerConfig = {...config, windowId};
+            let workerConfig = {...config, topologyIdentity: me.readTopologyIdentity(), windowId};
 
             if (ssrData && key === 'app') {
                 Object.assign(workerConfig, {
@@ -599,6 +608,23 @@ class Manager extends Base {
 
             me.promises[msgId] = {reject, resolve}
         })
+    }
+
+    /**
+     * Reads this window's carried topology identity for a worker registration. An empty object means
+     * "no identity yet": the App Worker mints one and asks `Neo.Main#setTopologyIdentity` to write it
+     * back. Unavailable storage and a malformed or incomplete record read the same way, so the window
+     * boots as a fresh root instead of failing.
+     * @returns {{groupId: String, workspaceKey: String, generationToken: String}|{}}
+     */
+    readTopologyIdentity() {
+        try {
+            const {generationToken, groupId, workspaceKey} = JSON.parse(window.sessionStorage?.getItem(this.topologyIdentityStorageKey) || 'null') || {};
+
+            return groupId && workspaceKey && generationToken ? {generationToken, groupId, workspaceKey} : {}
+        } catch {
+            return {}
+        }
     }
 
     /**

--- a/test/playwright/component/apps/dock-popout/app.mjs
+++ b/test/playwright/component/apps/dock-popout/app.mjs
@@ -1,6 +1,7 @@
-import DockWorkspace from '../../../../../src/dashboard/dock/Workspace.mjs';
-import Viewport      from '../../../../../src/container/Viewport.mjs';
-import WindowManager from '../../../../../src/manager/Window.mjs';
+import DockWorkspace      from '../../../../../src/dashboard/dock/Workspace.mjs';
+import Viewport           from '../../../../../src/container/Viewport.mjs';
+import WindowManager      from '../../../../../src/manager/Window.mjs';
+import TransactionManager from '../../../../../src/manager/Transaction.mjs';
 import '../../../../../src/tab/Container.mjs';
 
 const fixtureDocument = {
@@ -116,6 +117,14 @@ class PopOutFixtureWorkspace extends DockWorkspace {
          */
         readWindowGeometry_: 0,
         /**
+         * Spec trigger: any new tick mirrors this window's Group binding from
+         * `Neo.manager.Transaction` into {@link #topologyJson} — the witness that a host binds on
+         * connect, which is the identity every pop-out reserves its vessel slot under.
+         * @member {Number} readTopologyIdentity_=0
+         * @reactive
+         */
+        readTopologyIdentity_: 0,
+        /**
          * Spec trigger: an item id drives the engine's own dead-vessel compensation — release the
          * pane, retire the vessel, reintegrate. The reintegration arm asserts the item comes home
          * through THIS path, which is the drag path's path; a click-specific return branch would
@@ -123,15 +132,7 @@ class PopOutFixtureWorkspace extends DockWorkspace {
          * @member {String|null} retireItemId_=null
          * @reactive
          */
-        retireItemId_: null,
-        /**
-         * The default 20s connect window would expire the admission of a vessel that — by this
-         * fixture's design — never connects a worker, and the engine would then retire and
-         * reintegrate the item mid-spec. Pushing the bound past any run keeps that real behaviour
-         * from racing arms that are about the click, not about connect timeouts.
-         * @member {Number} tearOutConnectWindowMs=600000
-         */
-        tearOutConnectWindowMs: 600000
+        retireItemId_: null
     }
 
     /**
@@ -164,6 +165,12 @@ class PopOutFixtureWorkspace extends DockWorkspace {
     windowGeometryJson = null
 
     /**
+     * Mirror of this window's Group binding, refreshed by {@link #readTopologyIdentity_}.
+     * @member {String|null} topologyJson=null
+     */
+    topologyJson = null
+
+    /**
      * @param {Number} value
      * @param {Number} oldValue
      * @protected
@@ -176,6 +183,23 @@ class PopOutFixtureWorkspace extends DockWorkspace {
         const row = WindowManager.get(this.windowId);
 
         this.windowGeometryJson = JSON.stringify(row ? {innerRect: row.innerRect, outerRect: row.outerRect} : null)
+    }
+
+    /**
+     * @param {Number} value
+     * @param {Number} oldValue
+     * @protected
+     */
+    afterSetReadTopologyIdentity(value, oldValue) {
+        if (oldValue === undefined || !value) {
+            return
+        }
+
+        this.topologyJson = JSON.stringify({
+            binding : TransactionManager.findByWindow(this.windowId),
+            groups  : TransactionManager.items.length,
+            windowId: this.windowId
+        })
     }
 
     /**
@@ -252,6 +276,12 @@ class PopOutFixtureWorkspace extends DockWorkspace {
      */
     construct(config) {
         super.construct(config);
+
+        // The default 20 s lease would expire the reservation of a vessel that — by this fixture's
+        // design — never connects a worker, and the engine would then retire and reintegrate the item
+        // mid-spec. Pushing the bound past any run keeps that real behaviour from racing arms that are
+        // about the click, not about a lease running out.
+        TransactionManager.reconnectLeaseMs = 600000;
 
         // The proven deferred-boot dance: seed the empty shell, then commit the real document.
         this.add(this.projectDockModel());

--- a/test/playwright/component/dashboard/DockPopOut.spec.mjs
+++ b/test/playwright/component/dashboard/DockPopOut.spec.mjs
@@ -87,7 +87,13 @@ test('the host window is bound into a Group on connect — the identity every po
     }).toBe('main');
 
     expect(topology.binding).toEqual({generation: 1, groupId: expect.any(String), workspaceKey: 'main'});
-    expect(topology.groups, 'one root, one Group').toBe(1)
+    expect(topology.groups, 'one root, one Group').toBe(1);
+
+    // The carrier: the worker's word reached the page, so the next load of this window presents the
+    // same Group. Read from the page itself — the only realm that can read its own sessionStorage.
+    const carried = await page.evaluate(() => JSON.parse(sessionStorage.getItem('neo-topology-identity') ?? 'null'));
+
+    expect(carried).toEqual({generationToken: expect.any(String), groupId: topology.binding.groupId, workspaceKey: 'main'})
 });
 
 test.describe('dock pop-out — the click is the drag terminal', () => {

--- a/test/playwright/component/dashboard/DockPopOut.spec.mjs
+++ b/test/playwright/component/dashboard/DockPopOut.spec.mjs
@@ -73,6 +73,23 @@ test.beforeEach(async ({page}) => {
     await page.waitForSelector('.neo-tab-header-button', {state: 'visible'})
 });
 
+test('the host window is bound into a Group on connect — the identity every pop-out reserves its vessel under', async ({page}) => {
+    // A real worker, a real connect: `Neo.manager.Transaction` must have heard it and bound the
+    // window as `main` before the first pop-out asks for a reservation. Read through the fixture's
+    // mirror, because the manager lives in the App Worker.
+    await setWorkspace(page, {readTopologyIdentity: 1});
+
+    let topology;
+
+    await expect.poll(async () => {
+        topology = JSON.parse((await readWorkspace(page, ['topologyJson']))[0] ?? 'null');
+        return topology?.binding?.workspaceKey ?? null
+    }).toBe('main');
+
+    expect(topology.binding).toEqual({generation: 1, groupId: expect.any(String), workspaceKey: 'main'});
+    expect(topology.groups, 'one root, one Group').toBe(1)
+});
+
 test.describe('dock pop-out — the click is the drag terminal', () => {
     test('pop-out holds the frozen family slot, focus-gated beside an always-visible close', async ({page}) => {
         const main = tabsNodeWith(page, 'Alpha');

--- a/test/playwright/e2e/dashboard/TearOutMatrixRows4To7NL.spec.mjs
+++ b/test/playwright/e2e/dashboard/TearOutMatrixRows4To7NL.spec.mjs
@@ -46,6 +46,21 @@ test.describe('tear-out portability matrix — Demo B dock lifecycle, headed', (
     }
 
     /**
+     * Re-announces a vessel window's release to the host the way `Neo.manager.Transaction` does for a
+     * physical death — a repeat of a terminal the host already processed must change nothing.
+     * @param {Object} app Neural Link app wrapper.
+     * @param {String} wsId Demo B workspace component id.
+     * @param {String} windowId The vessel's runtime window id.
+     * @param {String} [itemId='workbench'] The torn-out item; its slot key is `popup:<itemId>`.
+     * @returns {Promise<void>}
+     */
+    async function releaseVesselWindow(app, wsId, windowId, itemId='workbench') {
+        const {topologyGroupId} = await app.getComponent(wsId, ['topologyGroupId']);
+
+        await app.callMethod(wsId, 'onTopologyRelease', [{generation: 1, groupId: topologyGroupId, windowId, workspaceKey: `popup:${itemId}`}])
+    }
+
+    /**
      * @param {Object} app Neural Link app wrapper.
      * @param {String} wsId Demo B workspace component id.
      * @returns {Promise<Object>}
@@ -396,7 +411,7 @@ test.describe('tear-out portability matrix — Demo B dock lifecycle, headed', (
             .toEqual({storedDetached, storedReturned});
 
         // Repeat the same terminal signal: all model, identity, and cleanup state must stay still.
-        await app.callMethod(wsId, 'onWindowDisconnect', [{windowId: vesselWindowId}]);
+        await releaseVesselWindow(app, wsId, vesselWindowId);
 
         expect(await getLifecycleState(app, wsId)).toEqual(returned);
         expect((await getCounter(app)).id).toBe(paneBefore.id);
@@ -512,7 +527,7 @@ test.describe('tear-out portability matrix — Demo B dock lifecycle, headed', (
             windowId  : before.pane.windowId
         });
 
-        await app.callMethod(wsId, 'onWindowDisconnect', [{windowId: vesselWindowId}]);
+        await releaseVesselWindow(app, wsId, vesselWindowId);
 
         expect(await getTerminalSnapshot(page, app, wsId)).toEqual(returned);
         expectNoRuntimeErrors(ledger);

--- a/test/playwright/e2e/dashboard/TearOutMatrixRows4To7NL.spec.mjs
+++ b/test/playwright/e2e/dashboard/TearOutMatrixRows4To7NL.spec.mjs
@@ -55,13 +55,12 @@ test.describe('tear-out portability matrix — Demo B dock lifecycle, headed', (
             'dockModel',
             'perspectiveStore.collection',
             'tearOutAcquisitionAttempts',
-            'tearOutConnectAdmissions.size',
             'tearOutConnects',
             'tearOutHandlers.activeVessel',
             'tearOutPanes',
             'tearOutPlacements',
             'tearOutRetirements.size',
-            'vesselOwnerGrants.size'
+            'vesselReservations.size'
         ])
     }
 
@@ -153,13 +152,12 @@ test.describe('tear-out portability matrix — Demo B dock lifecycle, headed', (
      */
     function expectNoTearOutResidue(snapshot) {
         expect(snapshot.lifecycle).toMatchObject({
-            'tearOutConnectAdmissions.size': 0,
-            'tearOutHandlers.activeVessel' : null,
-            'tearOutRetirements.size'      : 0,
-            'vesselOwnerGrants.size'       : 0,
-            tearOutConnects                : {},
-            tearOutPanes                   : {},
-            tearOutPlacements              : {}
+            'tearOutHandlers.activeVessel': null,
+            'tearOutRetirements.size'     : 0,
+            'vesselReservations.size'     : 0,
+            tearOutConnects               : {},
+            tearOutPanes                  : {},
+            tearOutPlacements             : {}
         });
         expect(snapshot.homeCount).toBe(1);
         expect(snapshot.mainRenderCount).toBe(1);
@@ -453,12 +451,12 @@ test.describe('tear-out portability matrix — Demo B dock lifecycle, headed', (
         expect(result.proof.documentBefore).toEqual(before.lifecycle.dockModel);
         expect(committed.lifecycle.dockModel).toEqual(result.proof.documentAfter);
         expect(committed.lifecycle).toMatchObject({
-            'tearOutConnectAdmissions.size': 0,
-            'tearOutHandlers.activeVessel' : null,
-            'tearOutRetirements.size'      : 0,
-            'vesselOwnerGrants.size'       : 0,
-            tearOutAcquisitionAttempts     : 1,
-            tearOutConnects                : {}
+            // the bound vessel's slot lives as long as the vessel: one reservation, no other residue
+            'tearOutHandlers.activeVessel': null,
+            'tearOutRetirements.size'     : 0,
+            'vesselReservations.size'     : 1,
+            tearOutAcquisitionAttempts    : 1,
+            tearOutConnects               : {}
         });
         expect(Object.keys(committed.lifecycle.tearOutPanes)).toEqual(['workbench']);
         expect(Object.keys(committed.lifecycle.tearOutPlacements)).toEqual(['workbench']);

--- a/test/playwright/e2e/workstation/WorkstationDragAffordancesNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationDragAffordancesNL.spec.mjs
@@ -418,7 +418,9 @@ test.describe('Workstation drag affordances — the flagship journey (Neural Lin
             const popup = await popupPromise;
 
             await popup.waitForLoadState('domcontentloaded');
-            const firstVesselGeneration = new URL(popup.url()).searchParams.get('vesselGeneration');
+            // The vessel's lineage rides its carrier, not its URL: the opener wrote the reserved slot
+            // into the staged child's sessionStorage before navigating it.
+            const firstVesselGeneration = await popup.evaluate(() => JSON.parse(sessionStorage.getItem('neo-topology-identity') || 'null')?.generationToken ?? null);
 
             await page.mouse.move(outside.x, outside.y + 24, {steps: 3});
             await page.mouse.move(reentry.x, reentry.y, {steps: 40});
@@ -560,7 +562,7 @@ test.describe('Workstation drag affordances — the flagship journey (Neural Lin
             );
 
             const
-                secondVesselGeneration = new URL(reexitPopup.url()).searchParams.get('vesselGeneration'),
+                secondVesselGeneration = await reexitPopup.evaluate(() => JSON.parse(sessionStorage.getItem('neo-topology-identity') || 'null')?.generationToken ?? null),
                 firstWindowPosition    = await reexitPopup.evaluate(() => ({x: screenX, y: screenY})),
                 pointerDelta           = {
                     x: reexitDrive.x - reexitStart.x,

--- a/test/playwright/e2e/workstation/WorkstationTopologyGroupsNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationTopologyGroupsNL.spec.mjs
@@ -1,0 +1,189 @@
+import {test, expect} from '../../fixtures.mjs';
+
+/**
+ * @summary Whitebox E2E witness: two Workstation roots under one SharedWorker are two logical topology
+ * Groups; a root and the vessel it pops out share one; reloading a root moves its own generation and
+ * touches nothing else.
+ *
+ * Both roots boot the same app under the same name in the same App Worker — the case in which the app
+ * name cannot identify a topology, and the case the manager exists for. Root A is the full Workstation.
+ * Root B boots the same document in its pane-host mode (`?popout=<item>`) with no opener and no carrier:
+ * the same app, the same SharedWorker, its own window, admitted as a root of its own — nothing reserved
+ * a slot for it, so it is not a vessel of A. It carries no dock, and that is deliberate: two FULL roots
+ * in one headless harness process crash the shared worker on `dev` as on this branch (measured on both
+ * trees; real Chrome runs them side by side), so the falsifier's second root is the lightest boot that is
+ * still a second Workstation window.
+ *
+ * Every window's identity is read where the engine keeps it: the `sessionStorage` carrier the worker
+ * writes back on admission, and the manager's bindings, read through root A's live Workspace over the
+ * Neural Link. The vessel is a REAL popup the pop-out action opens; its carrier was written by the opener
+ * before the child navigated, so nothing about the owner is in its URL.
+ *
+ * The reload is the falsifier: the reloaded root presents the carrier it kept, rebinds its own slot at
+ * the next generation, and root B, the popup's binding and the number of Groups are unchanged; the
+ * superseded generation holds nothing.
+ *
+ * Run: NEO_AGENTOS_RUNTIME_ROOT=<abs path to neo-agent-brain> \
+ *      npx playwright test workstation/WorkstationTopologyGroupsNL -c test/playwright/playwright.config.e2e.mjs --workers=1
+ *
+ * The runtime root is not optional: `playwright.config.e2e.mjs` ignores every neuralLink-fixture spec
+ * without it, so the command selects ZERO tests and reports success.
+ */
+const
+    ACTION     = '.neo-toolbar-action',
+    CARRIER    = 'neo-topology-identity',
+    FEED_TITLE = 'Live Event Stream', // the Feed pane's tab title in the Workstation's boot document
+    HEADER     = '.neo-tab-header-toolbar',
+    PANE_HOST  = '.workstation-popout-host',
+    POP_OUT    = 'window-restore',
+    TAB        = '.neo-tab-header-button',
+    WORKSPACE  = 'Workstation.view.Workspace';
+
+/** The identity a window carries across its own reloads, as the worker wrote it. */
+const readCarrier = page => page.evaluate(key => JSON.parse(sessionStorage.getItem(key) || 'null'), CARRIER);
+
+/** A window's runtime generation, read where `Main.mjs` reads it. */
+const readWindowId = page => page.evaluate(() => Neo.worker.Manager.windowId);
+
+/** Boots the full Workstation in a page and waits for its dock to project. */
+const bootRoot = async page => {
+    await page.goto('/apps/workstation/index.html');
+    await page.waitForSelector('.workstation-dock-host',               {timeout: 60000});
+    await page.waitForSelector('.neo-tab-header-button.neo-draggable', {timeout: 60000})
+};
+
+/** Boots the Workstation's pane-host mode with no opener: a second root of the same app, carrying no dock. */
+const bootPaneHost = async page => {
+    await page.goto('/apps/workstation/index.html?popout=alerts');
+    await page.waitForSelector(PANE_HOST, {timeout: 60000});
+    await page.waitForFunction(() => Boolean(window.Neo?.worker?.Manager?.windowId), null, {timeout: 60000})
+};
+
+/**
+ * The live Workspace projected for one window, or `null`. A reloaded root is a new instance; the one
+ * its superseded generation created stays in the worker, so the lookup is by window, never "the first".
+ */
+const workspaceFor = async (app, windowId) => {
+    const records = await app.findInstances({className: WORKSPACE}, ['id', 'windowId']);
+
+    return (Array.isArray(records) ? records : [records]).filter(Boolean)
+        .map(record => ({...(record.properties ?? record), id: record.id ?? record.properties?.id}))
+        .find(workspace => workspace.windowId === windowId)?.id ?? null
+};
+
+/** The manager's own record, read through a live Workspace's reference to the worker-wide singleton. */
+const managerOf = (app, workspaceId) => ({
+    binding   : windowId => app.callMethod(workspaceId, 'transactionManager.findByWindow', [windowId]),
+    groupCount: async () => (await app.getComponent(workspaceId, ['transactionManager.items.length']))['transactionManager.items.length']
+});
+
+/**
+ * Clicks a pane's tab by its title, which is how a user gives that pane focus, and returns the tab
+ * header toolbar that carries it — the surface the focus-gated action set renders into.
+ */
+const focusPane = async (page, title) => {
+    const header = page.locator(HEADER).filter({has: page.locator(TAB, {hasText: title})}).first();
+
+    await expect(header, `${title} must have a projected tab header`).toBeVisible({timeout: 30000});
+    await header.locator(TAB, {hasText: title}).first().click();
+
+    return header
+};
+
+test.describe('Workstation topology Groups — two roots under one SharedWorker (Neural Link)', () => {
+    test.setTimeout(180000);
+    test.use({viewport: {width: 1600, height: 900}});
+
+    test('A and its pop-out share one Group, B shares only the app name, and reloading A moves one generation and touches nothing else', async ({page, context, neuralLink}) => {
+        const pageA = page,
+              pageB = await context.newPage();
+
+        await bootRoot(pageA);
+        await bootPaneHost(pageB);
+
+        const app = await neuralLink.connectToApp('Workstation'),
+              aId = await readWindowId(pageA),
+              bId = await readWindowId(pageB);
+
+        expect(aId, 'root A knows its own window id').toBeTruthy();
+        expect(bId, 'root B is its own window').not.toBe(aId);
+
+        // Admission writes the minted identity back into each root's carrier.
+        await expect.poll(async () => (await readCarrier(pageA))?.groupId, {message: 'root A carries a Group', timeout: 15000}).toBeTruthy();
+        await expect.poll(async () => (await readCarrier(pageB))?.groupId, {message: 'root B carries a Group', timeout: 15000}).toBeTruthy();
+
+        const carrierA = await readCarrier(pageA),
+              carrierB = await readCarrier(pageB);
+
+        expect(carrierA).toEqual({generationToken: expect.any(String), groupId: expect.any(String), workspaceKey: 'main'});
+        expect(carrierB).toEqual({generationToken: expect.any(String), groupId: expect.any(String), workspaceKey: 'main'});
+        expect(carrierA.groupId, 'two roots of one app are two Groups').not.toBe(carrierB.groupId);
+
+        const workspaceA = await workspaceFor(app, aId);
+
+        expect(workspaceA, 'root A projects a Workspace').toBeTruthy();
+
+        let manager = managerOf(app, workspaceA);
+
+        await expect(manager.binding(aId)).resolves.toEqual({generation: 1, groupId: carrierA.groupId, workspaceKey: 'main'});
+        await expect(manager.binding(bId)).resolves.toEqual({generation: 1, groupId: carrierB.groupId, workspaceKey: 'main'});
+        await expect(manager.groupCount(), 'exactly the two roots').resolves.toBe(2);
+
+        // A pops a pane out: the reserved slot rides the opener's `windowOpen` into the child's carrier.
+        const header = await focusPane(pageA, FEED_TITLE),
+              popOut = header.locator(`${ACTION}:has(span[class*="${POP_OUT}"])`).first();
+
+        await expect(popOut, 'the Feed pane offers the pop-out action').toBeVisible({timeout: 10000});
+
+        // Subscribed before the click: the vessel can open faster than the next await.
+        const vesselPromise = context.waitForEvent('page', {timeout: 45000});
+
+        await popOut.click();
+
+        const vessel = await vesselPromise;
+
+        await vessel.waitForLoadState('domcontentloaded');
+        await vessel.waitForFunction(() => Boolean(window.Neo?.worker?.Manager?.windowId), null, {timeout: 45000});
+
+        const vesselId      = await readWindowId(vessel),
+              vesselCarrier = await readCarrier(vessel);
+
+        expect(vesselId, 'the vessel is its own window').not.toBe(aId);
+        expect(vesselCarrier, 'the vessel carries a slot of A\'s Group, never the URL').toEqual({
+            generationToken: expect.any(String),
+            groupId        : carrierA.groupId,
+            workspaceKey   : expect.stringMatching(/^popup:/)
+        });
+        expect([...new URL(vessel.url()).searchParams.keys()].sort(), 'the vessel URL names content and theme, never an owner').toEqual(['popout', 'theme']);
+
+        await expect.poll(() => manager.binding(vesselId), {message: 'the vessel binds the slot A reserved', timeout: 15000})
+            .toEqual({generation: 1, groupId: carrierA.groupId, workspaceKey: vesselCarrier.workspaceKey});
+        await expect(manager.groupCount(), 'the vessel joined A\'s Group; nothing was minted').resolves.toBe(2);
+
+        // The falsifier: reload A. The kept carrier rebinds A's own slot one generation on.
+        await pageA.reload();
+        await pageA.waitForSelector('.workstation-dock-host',               {timeout: 60000});
+        await pageA.waitForSelector('.neo-tab-header-button.neo-draggable', {timeout: 60000});
+
+        const aId2 = await readWindowId(pageA);
+
+        expect(aId2, 'a reload is a new runtime generation').not.toBe(aId);
+        expect(await readCarrier(pageA), 'the identity survived the reload unchanged').toEqual(carrierA);
+
+        // The reloaded root is a new Workspace instance; the manager behind it is the same singleton.
+        await expect.poll(() => workspaceFor(app, aId2), {message: 'the reloaded root projects a Workspace', timeout: 15000}).toBeTruthy();
+        manager = managerOf(app, await workspaceFor(app, aId2));
+
+        await expect.poll(() => manager.binding(aId2), {message: 'A rebinds its own slot at the next generation', timeout: 15000})
+            .toEqual({generation: 2, groupId: carrierA.groupId, workspaceKey: 'main'});
+        await expect(manager.binding(aId), 'the superseded generation holds nothing').resolves.toBeNull();
+        await expect(manager.binding(bId), 'B was not touched').resolves.toEqual({generation: 1, groupId: carrierB.groupId, workspaceKey: 'main'});
+        expect(await readCarrier(pageB), 'B\'s carrier was not touched').toEqual(carrierB);
+        await expect(manager.binding(vesselId), 'A\'s vessel keeps its binding').resolves.toEqual({generation: 1, groupId: carrierA.groupId, workspaceKey: vesselCarrier.workspaceKey});
+        expect(vessel.isClosed(), 'A\'s vessel is still open').toBe(false);
+        await expect(manager.groupCount(), 'reloading A minted no Group').resolves.toBe(2);
+
+        await vessel.close({runBeforeUnload: true});
+        await pageB.close()
+    })
+});

--- a/test/playwright/unit/apps/workstation/Workspace.spec.mjs
+++ b/test/playwright/unit/apps/workstation/Workspace.spec.mjs
@@ -121,6 +121,33 @@ const stageCommittedVessel = (workspace, ownerItemId='alerts', incomingItemId='s
 };
 
 /**
+ * @summary Binds the fixture's host window into a Group the way the app boot does — once the
+ * workspace has loaded `Neo.manager.Transaction` — and returns the Group id.
+ * @param {Workstation.view.Workspace} workspace
+ * @returns {Promise<String>}
+ */
+const bindHost = async workspace => {
+    const manager = await workspace.transactionManagerReady;
+
+    manager.bind({windowId: workspace.windowId, workspaceKey: 'main'});
+
+    return workspace.topologyGroupId
+};
+
+/**
+ * @summary Releases one vessel's binding the way the manager announces a physical window death.
+ * @param {Workstation.view.Workspace} workspace
+ * @param {String} windowId
+ * @param {String} [itemId='alerts']
+ * @returns {Promise<void>}
+ */
+const releaseVessel = async (workspace, windowId, itemId='alerts') => {
+    const groupId = workspace.topologyGroupId ?? await bindHost(workspace);
+
+    await workspace.onTopologyRelease({generation: 1, groupId, windowId, workspaceKey: `popup:${itemId}`})
+};
+
+/**
  * @summary Pins the composition choices Workstation itself owns: one provider with two stores,
  * an exact 100k Turbo scale set, a growing capped feed, and stable pane/store identities
  * across a reducer-driven coarse projection. Primitive grid/Canvas stress remains in its
@@ -1856,7 +1883,7 @@ test.describe.serial('Workstation.view.Workspace', () => {
         }
     });
 
-    test('unexpected vessel death atomically recovers the whole A+B stack', () => {
+    test('unexpected vessel death atomically recovers the whole A+B stack', async () => {
         const
             workspace              = Neo.create(Workspace, {}),
             {state, workspaceId}   = stageCommittedVessel(workspace),
@@ -1868,10 +1895,9 @@ test.describe.serial('Workstation.view.Workspace', () => {
         try {
             workspace.tearOutPlacements.alerts = {index: 0, tabsNodeId: 'heavy-tabs'};
             workspace.tearOutPanes.alerts = {
-                admissionToken: 7,
-                generation    : 3,
-                windowId      : 'window-alerts',
-                windowName    : 'tearout-alerts'
+                generationToken: 'lineage-3',
+                windowId       : 'window-alerts',
+                windowName     : 'tearout-alerts'
             };
             workspace.tearOutHandlers = {onVesselRetired() {}};
             workspace.vesselParkHandlers = {onVesselRetired() {}};
@@ -1879,7 +1905,7 @@ test.describe.serial('Workstation.view.Workspace', () => {
                 projections.push({document, options})
             };
 
-            workspace.onWindowDisconnect({windowId: 'window-alerts'});
+            await releaseVessel(workspace, 'window-alerts');
 
             expect(workspace.dockModel.items.alerts).toEqual(initialDocument.items.alerts);
             expect(workspace.dockModel.items.security).toEqual(initialDocument.items.security);
@@ -1905,7 +1931,7 @@ test.describe.serial('Workstation.view.Workspace', () => {
         }
     });
 
-    test('a refused disconnect recovery retains the only A+B truth as a headless workspace', () => {
+    test('a refused disconnect recovery retains the only A+B truth as a headless workspace', async () => {
         const
             workspace            = Neo.create(Workspace, {}),
             {state, workspaceId} = stageCommittedVessel(workspace),
@@ -1916,16 +1942,15 @@ test.describe.serial('Workstation.view.Workspace', () => {
         try {
             workspace.tearOutPlacements.alerts = {index: 0, tabsNodeId: 'heavy-tabs'};
             workspace.tearOutPanes.alerts = {
-                admissionToken: 7,
-                generation    : 3,
-                windowId      : 'window-alerts',
-                windowName    : 'tearout-alerts'
+                generationToken: 'lineage-3',
+                windowId       : 'window-alerts',
+                windowName     : 'tearout-alerts'
             };
             workspace.tearOutHandlers = {onVesselRetired() {}};
             workspace.vesselParkHandlers = {onVesselRetired() {}};
             workspace.workspaceSet.adoptTransfer = () => false;
 
-            workspace.onWindowDisconnect({windowId: 'window-alerts'});
+            await releaseVessel(workspace, 'window-alerts');
 
             expect(workspace.dockModel.items.alerts).toBeUndefined();
             expect(workspace.dockModel.items.security).toBeUndefined();
@@ -1989,10 +2014,9 @@ test.describe.serial('Workstation.view.Workspace', () => {
             workspace.crossWindowParticipations.set(workspaceId, state.participation);
             workspace.tearOutPlacements.alerts = {index: 0, tabsNodeId: 'heavy-tabs'};
             workspace.tearOutPanes.alerts = {
-                admissionToken: 7,
-                generation    : 3,
-                windowId      : 'window-alerts',
-                windowName    : 'tearout-alerts'
+                generationToken: 'lineage-3',
+                windowId       : 'window-alerts',
+                windowName     : 'tearout-alerts'
             };
             workspace.lastCrossWindowTransfer = {
                 applied          : true,
@@ -2024,7 +2048,7 @@ test.describe.serial('Workstation.view.Workspace', () => {
 
             workspace.tearOutHandlers = {onVesselRetired() {}};
             workspace.vesselParkHandlers = {onVesselRetired() {}};
-            workspace.onWindowDisconnect({windowId: 'window-alerts'});
+            await releaseVessel(workspace, 'window-alerts');
 
             expect(workspace.vesselWorkspaces.has(workspaceId)).toBe(false);
             expect(workspace.workspaceSet.has(workspaceId)).toBe(false);
@@ -2139,7 +2163,7 @@ test.describe.serial('Workstation.view.Workspace', () => {
         }
     });
 
-    test('physical vessel death clears both tear-out and park lifecycle owners', () => {
+    test('physical vessel death clears both tear-out and park lifecycle owners', async () => {
         const
             workspace       = Neo.create(Workspace, {}),
             originalTearOut = workspace.tearOutHandlers,
@@ -2149,9 +2173,9 @@ test.describe.serial('Workstation.view.Workspace', () => {
 
         try {
             workspace.tearOutConnects.alerts = {
-                admissionToken: 7,
-                generation    : 3,
-                windowId      : 'tear-child'
+                generationToken: 'lineage-3',
+                windowId       : 'tear-child',
+                windowName     : 'tearout-alerts'
             };
             workspace.tearOutParkGeometries.alerts = {
                 park   : {height: 260, width: 360, x: 800, y: 120},
@@ -2170,17 +2194,17 @@ test.describe.serial('Workstation.view.Workspace', () => {
                 }
             };
 
-            workspace.onWindowDisconnect({windowId: 'tear-child'});
+            await releaseVessel(workspace, 'tear-child');
 
             expect(workspace.tearOutConnects.alerts).toBeUndefined();
             expect(workspace.tearOutParkGeometries.alerts).toBeUndefined();
             expect(calls).toEqual([
                 ['proxy', 'tear-child'],
                 ['tear-out', {
-                    admissionToken: 7,
-                    generation    : 3,
-                    itemId        : 'alerts',
-                    windowName    : 'tearout-alerts'
+                    generationToken: 'lineage-3',
+                    itemId         : 'alerts',
+                    windowId       : 'tear-child',
+                    windowName     : 'tearout-alerts'
                 }],
                 ['park', {itemId: 'alerts', retirement: true}]
             ])
@@ -2224,31 +2248,40 @@ test.describe.serial('Workstation.view.Workspace', () => {
             return true
         };
 
+        // The slot the engine reserved rides `windowOpen` into the vessel's carrier; the URL names the
+        // pane and the theme, never the owner.
+        const identity = itemId => ({generationToken: `lineage-${itemId}`, groupId: 'group-a', workspaceKey: `popup:${itemId}`});
+
         try {
             await workspace.openTearOutVessel({
-                itemId   : 'alerts',
-                proxyRect: {height: 320, width: 480, x: 40, y: 60}
+                itemId          : 'alerts',
+                proxyRect       : {height: 320, width: 480, x: 40, y: 60},
+                topologyIdentity: identity('alerts')
             });
 
             workspace.theme = 'neo-theme-neo-dark';
 
             await workspace.openTearOutVessel({
-                itemId   : 'security',
-                proxyRect: {height: 320, width: 480, x: 80, y: 100}
+                itemId          : 'security',
+                proxyRect       : {height: 320, width: 480, x: 80, y: 100},
+                topologyIdentity: identity('security')
             });
 
             workspace.theme = 'neo-theme-candidate';
 
             await workspace.openTearOutVessel({
-                itemId   : 'memory',
-                proxyRect: {height: 320, width: 480, x: 120, y: 140}
+                itemId          : 'memory',
+                proxyRect       : {height: 320, width: 480, x: 120, y: 140},
+                topologyIdentity: identity('memory')
             });
 
             expect(calls).toHaveLength(3);
             expect(calls.map(call => new URL(call.url, 'https://example.test').searchParams.get('theme')))
                 .toEqual(['neo-theme-neo-light', 'neo-theme-neo-dark', 'neo-theme-neo-dark']);
-            expect(calls.map(call => new URL(call.url, 'https://example.test').searchParams.get('vesselFlow')))
-                .toEqual(['tear-out', 'tear-out', 'tear-out']);
+            expect(calls.map(call => [...new URL(call.url, 'https://example.test').searchParams.keys()]), 'content and theme only — no owner in the URL')
+                .toEqual([['popout', 'theme'], ['popout', 'theme'], ['popout', 'theme']]);
+            expect(calls.map(call => call.topologyIdentity))
+                .toEqual([identity('alerts'), identity('security'), identity('memory')]);
             expect(calls.map(call => call.stagedColorScheme))
                 .toEqual(['light', 'dark', 'dark']);
             expect(bootstrapCalls).toEqual([
@@ -2298,12 +2331,44 @@ test.describe.serial('Workstation.view.Workspace', () => {
                 error : 'WorkstationBootstrap unavailable',
                 itemId: 'alerts',
                 stage : 'threw'
-            });
-            expect(workspace.vesselOwnerGrants.has('tear-out:alerts')).toBe(false)
+            })
         } finally {
             Neo.Main.getByPath    = originalGetByPath;
             Neo.Main.getWindowData = originalWindowData;
             Neo.Main.windowOpen     = originalWindowOpen;
+            workspace.destroy()
+        }
+    });
+
+    test('a retirement presenting a superseded lineage token is refused, and the live vessel survives it', async () => {
+        // The control the ticket's author ran against dev: a stale retirement matching item and window
+        // name but carrying a superseded generation was refused there and must stay refused here — the
+        // reservation's lineage token is the generation now.
+        const
+            workspace     = Neo.create(Workspace, {}),
+            originalClose = Neo.Main.windowClose,
+            closes        = [];
+
+        Neo.Main.windowClose = async data => {
+            closes.push(data);
+            return true
+        };
+
+        try {
+            workspace.tearOutConnects.alerts = {generationToken: 'lineage-2', windowId: 'tear-live', windowName: 'tearout-alerts'};
+
+            await expect(workspace.closeTearOutVessel({generationToken: 'lineage-1', itemId: 'alerts', windowName: 'tearout-alerts'}))
+                .resolves.toBe(false);
+            expect(workspace.lastTearOutClose).toMatchObject({identity: {lineageMatches: false}, stage: 'identity-refused'});
+            expect(workspace.tearOutConnects.alerts, 'the live vessel survives the stale retirement').toMatchObject({windowId: 'tear-live'});
+            expect(closes, 'nothing reached the platform').toEqual([]);
+
+            await expect(workspace.closeTearOutVessel({generationToken: 'lineage-2', itemId: 'alerts', windowName: 'tearout-alerts'}))
+                .resolves.toBe(true);
+            expect(workspace.lastTearOutClose.stage).toBe('acknowledged');
+            expect(closes).toEqual([{names: ['tearout-alerts'], windowId: workspace.windowId}])
+        } finally {
+            Neo.Main.windowClose = originalClose;
             workspace.destroy()
         }
     });

--- a/test/playwright/unit/apps/workstation/Workspace.spec.mjs
+++ b/test/playwright/unit/apps/workstation/Workspace.spec.mjs
@@ -2395,6 +2395,43 @@ test.describe.serial('Workstation.view.Workspace', () => {
         }
     });
 
+    test('the production resolver keeps the main participant through the root\'s release and lease expiry; a never-bound first boot joins when its binding is accepted', async () => {
+        // The window is NOT pre-bound: a first boot, whose minted identity the carrier accepts after
+        // this instance constructed. Until then there is no Group to join — registration refuses.
+        const workspace = Neo.create(Workspace, {windowId: 'workstation-first-boot'}),
+              manager   = await workspace.transactionManagerReady;
+
+        try {
+            expect(workspace.topologyGroupId).toBeNull();
+            expect(workspace.workspaceSet.has(Workspace.MAIN_WORKSPACE_ID), 'never bound: nothing to join').toBe(false);
+            expect(workspace.workspaceSet.getDocument(Workspace.MAIN_WORKSPACE_ID)).toBeNull();
+
+            const minted = await manager.admit({topologyIdentity: {}, windowId: 'workstation-first-boot'});
+
+            expect(minted.outcome).toBe('minted');
+            expect(workspace.topologyGroupId, 'learned from the accepted binding').toBe(minted.groupId);
+            expect(workspace.workspaceSet.has(Workspace.MAIN_WORKSPACE_ID), 'registered when the Group arrived').toBe(true);
+            expect(workspace.workspaceSet.getDocument(Workspace.MAIN_WORKSPACE_ID)).toBe(workspace.dockModel);
+
+            // The root window dies and its lease runs out: the live binding is gone, the resolver the
+            // WorkspaceSet was built with — `() => me.topologyGroupId` — still reaches the documents.
+            manager.reconnectLeaseMs = 20;
+            manager.release('workstation-first-boot');
+
+            await expect.poll(() => manager.getBinding(minted.groupId, 'main')).toBeNull();
+
+            expect(manager.findByWindow('workstation-first-boot')).toBeNull();
+            expect(workspace.topologyGroupId).toBe(minted.groupId);
+            expect(workspace.workspaceSet.ids()).toEqual([Workspace.MAIN_WORKSPACE_ID]);
+            expect(workspace.workspaceSet.getDocument(Workspace.MAIN_WORKSPACE_ID), 'the headless document is still the Group\'s').toBe(workspace.dockModel);
+            expect(manager.get(minted.groupId), 'the Group outlives its last binding').toBeTruthy()
+        } finally {
+            manager.reconnectLeaseMs = 20000;
+            workspace.destroy();
+            workspace.topologyGroupId && manager.retireGroup(workspace.topologyGroupId)
+        }
+    });
+
     test('a successor tear-out retries retained retirement before opening a fresh vessel', async () => {
         const
             workspace       = Neo.create(Workspace, {windowId: Neo.config.windowId}),

--- a/test/playwright/unit/apps/workstation/Workspace.spec.mjs
+++ b/test/playwright/unit/apps/workstation/Workspace.spec.mjs
@@ -14,9 +14,10 @@ import WorkspaceDocument        from '../../../../../src/dashboard/dock/model/Wo
 import Operations               from '../../../../../src/dashboard/dock/model/Operations.mjs';
 import {previewToOperation}     from '../../../../../src/dashboard/dock/model/PreviewContract.mjs';
 import '../../../../../src/manager/Instance.mjs';
-import FeedPane  from '../../../../../apps/workstation/view/FeedPane.mjs';
-import ScalePane from '../../../../../apps/workstation/view/ScalePane.mjs';
-import Workspace from '../../../../../apps/workstation/view/Workspace.mjs';
+import TransactionManager from '../../../../../src/manager/Transaction.mjs';
+import FeedPane           from '../../../../../apps/workstation/view/FeedPane.mjs';
+import ScalePane          from '../../../../../apps/workstation/view/ScalePane.mjs';
+import Workspace          from '../../../../../apps/workstation/view/Workspace.mjs';
 
 import {initialDocument} from '../../../../../apps/workstation/tour/denseWorkstation.mjs';
 
@@ -154,6 +155,21 @@ const releaseVessel = async (workspace, windowId, itemId='alerts') => {
  * existing suites; the browser journey owns rendered continuity.
  */
 test.describe.serial('Workstation.view.Workspace', () => {
+    // The app imports the manager and is admitted at registration, so a Workspace constructs with its
+    // window already bound into a Group and registers its participants there. The fixture binds the
+    // unit window the same way before every arm, and retires the Group after it.
+    test.beforeEach(() => {
+        TransactionManager.bind({windowId: Neo.config.windowId, workspaceKey: 'main'})
+    });
+
+    test.afterEach(() => {
+        let bound;
+
+        while ((bound = TransactionManager.findByWindow(Neo.config.windowId))) {
+            TransactionManager.retireGroup(bound.groupId)
+        }
+    });
+
     test('renderer-rich scale columns carry unique pooling keys', () => {
         const
             dataFields     = ScalePane.config.columns.map(column => column.dataField),
@@ -183,7 +199,7 @@ test.describe.serial('Workstation.view.Workspace', () => {
     test('film cursor retirement awaits physical body-node removal before settling', async () => {
         const
             realApplyDeltas = Neo.applyDeltas,
-            workspace       = Neo.create(Workspace, {}),
+            workspace       = Neo.create(Workspace, {windowId: Neo.config.windowId}),
             calls           = [],
             cursorDot       = {
                 isDestroyed: false,
@@ -236,7 +252,7 @@ test.describe.serial('Workstation.view.Workspace', () => {
     test('non-film mode keeps all six cursor retirement boundaries side-effect free', async () => {
         const
             realApplyDeltas = Neo.applyDeltas,
-            workspace       = Neo.create(Workspace, {}),
+            workspace       = Neo.create(Workspace, {windowId: Neo.config.windowId}),
             deltaCalls      = [];
 
         try {
@@ -306,7 +322,7 @@ test.describe.serial('Workstation.view.Workspace', () => {
     });
 
     test('provider-owned stores and cached data panes survive split + return', async () => {
-        const workspace = Neo.create(Workspace, {});
+        const workspace = Neo.create(Workspace, {windowId: Neo.config.windowId});
 
         try {
             const
@@ -479,8 +495,14 @@ test.describe.serial('Workstation.view.Workspace', () => {
 
             // This unit instance has no render target. Geometry begins only when a real container
             // supplies its window id; the focused DockWorkspace first-projection spec owns that
-            // positive bind arm.
+            // positive bind arm. Membership follows the same signal: without a window there is no
+            // Group to join, and the main participant registers the moment the window id arrives.
             expect(resizeCalls).toEqual([]);
+            expect(workspace.workspaceSet.ids(), 'no window, no Group, no membership yet').toEqual([]);
+
+            workspace.windowId = Neo.config.windowId;
+
+            expect(resizeCalls).toEqual([{observeMovement: true, observeResize: true, windowId: Neo.config.windowId}]);
             expect(workspace.workspaceSet.ids()).toEqual([Workspace.MAIN_WORKSPACE_ID]);
             expect(workspace.workspaceSet.getDocument(Workspace.MAIN_WORKSPACE_ID)).toBe(workspace.dockModel);
             expect(workspace.vesselConversionTargetWindowId).toBe('window-alerts');
@@ -506,7 +528,7 @@ test.describe.serial('Workstation.view.Workspace', () => {
 
     test('target-proxy staging uses the physical parked popup instead of the source sort-zone window', async () => {
         const
-            workspace       = Neo.create(Workspace, {}),
+            workspace       = Neo.create(Workspace, {windowId: Neo.config.windowId}),
             originalProxy   = workspace.vesselProxyEmbodiment,
             settledPayloads = [],
             stagedPayloads  = [];
@@ -567,7 +589,7 @@ test.describe.serial('Workstation.view.Workspace', () => {
 
     test('large-over-small park uses both live extents and restores the same exact popup', async () => {
         const
-            workspace          = Neo.create(Workspace, {}),
+            workspace          = Neo.create(Workspace, {windowId: Neo.config.windowId}),
             originalDragDrop   = Neo.main.addon.DragDrop,
             originalFocus      = Neo.Main.windowNativeFocus,
             originalManagerGet = Neo.manager.Window.get,
@@ -709,7 +731,7 @@ test.describe.serial('Workstation.view.Workspace', () => {
             parkResizeAdmitted = true;
 
         const
-            workspace        = Neo.create(Workspace, {}),
+            workspace        = Neo.create(Workspace, {windowId: Neo.config.windowId}),
             originalDragDrop = Neo.main.addon.DragDrop,
             originalMove     = Neo.Main.windowNativeMoveTo,
             originalResize   = Neo.Main.windowNativeResizeTo,
@@ -826,7 +848,7 @@ test.describe.serial('Workstation.view.Workspace', () => {
 
     test('target refocus refusal never admits conversion, regardless of source-restore outcome', async () => {
         const
-            workspace          = Neo.create(Workspace, {}),
+            workspace          = Neo.create(Workspace, {windowId: Neo.config.windowId}),
             originalDragDrop   = Neo.main.addon.DragDrop,
             originalFocus      = Neo.Main.windowNativeFocus,
             originalManagerGet = Neo.manager.Window.get,
@@ -914,7 +936,7 @@ test.describe.serial('Workstation.view.Workspace', () => {
     });
 
     test('convert-out restores the target proxy before the exact parked popup is re-shown', () => {
-        const workspace = Neo.create(Workspace, {});
+        const workspace = Neo.create(Workspace, {windowId: Neo.config.windowId});
         const
             chrome        = readTabChrome(workspace),
             originalPark  = workspace.vesselParkHandlers,
@@ -970,7 +992,7 @@ test.describe.serial('Workstation.view.Workspace', () => {
 
     test('a connected vessel stays unregistered until an accepted drop seeds document ownership', async () => {
         const
-            workspace   = Neo.create(Workspace, {}),
+            workspace   = Neo.create(Workspace, {windowId: Neo.config.windowId}),
             workspaceId = Workspace.vesselWorkspaceId('alerts'),
             classes     = [],
             destroyed   = [],
@@ -1107,7 +1129,7 @@ test.describe.serial('Workstation.view.Workspace', () => {
 
     test('remote main previews resolve through the affordance geometry: the full grammar on the pointed zone, the stored-home tab-into off-zone', async () => {
         const
-            workspace         = Neo.create(Workspace, {}),
+            workspace         = Neo.create(Workspace, {windowId: Neo.config.windowId}),
             sourceWorkspaceId = Workspace.vesselWorkspaceId('queues'),
             hostRect          = {x: 100, y: 80, width: 900, height: 600},
             leftRect          = {x: 160, y: 140, width: 260, height: 260},
@@ -1244,7 +1266,7 @@ test.describe.serial('Workstation.view.Workspace', () => {
 
     test('the remote affordance feed never clears the semantic stored-home renderer after it settles (#16309)', async () => {
         const
-            workspace         = Neo.create(Workspace, {}),
+            workspace         = Neo.create(Workspace, {windowId: Neo.config.windowId}),
             sourceWorkspaceId = Workspace.vesselWorkspaceId('queues'),
             hostRect          = {x: 100, y: 80, width: 900, height: 600},
             targetRect        = {x: 120, y: 120, width: 260, height: 260};
@@ -1315,7 +1337,7 @@ test.describe.serial('Workstation.view.Workspace', () => {
     });
 
     test('pane identity remains readable after the catalog moves into a vessel workspace', () => {
-        const workspace = Neo.create(Workspace, {});
+        const workspace = Neo.create(Workspace, {windowId: Neo.config.windowId});
 
         try {
             const
@@ -1335,7 +1357,7 @@ test.describe.serial('Workstation.view.Workspace', () => {
 
     test('native-titlebar source discovery resolves the exact live bare-vessel pane and rejects stale topology', () => {
         const
-            workspace   = Neo.create(Workspace, {}),
+            workspace   = Neo.create(Workspace, {windowId: Neo.config.windowId}),
             itemId      = 'alerts',
             pane        = workspace.paneCache[itemId],
             workspaceId = Workspace.vesselWorkspaceId(itemId),
@@ -1399,7 +1421,7 @@ test.describe.serial('Workstation.view.Workspace', () => {
         // focus and no move, so the coordinator proceeds to embodiment and the commit — and the receipt
         // says the park was not physical.
         const
-            workspace           = Neo.create(Workspace, {}),
+            workspace           = Neo.create(Workspace, {windowId: Neo.config.windowId}),
             originalManagerGet  = Neo.manager.Window.get,
             originalNativeFocus = Neo.Main.windowNativeFocus,
             originalNativeMove  = Neo.Main.windowNativeMoveTo,
@@ -1448,7 +1470,7 @@ test.describe.serial('Workstation.view.Workspace', () => {
         // moves behind it, the refocus decides the outcome. (A main-window target no longer parks
         // physically — the arm above — so this arm targets a popup, where the choreography still runs.)
         const
-            workspace           = Neo.create(Workspace, {}),
+            workspace           = Neo.create(Workspace, {windowId: Neo.config.windowId}),
             originalDragDrop    = Neo.main.addon.DragDrop,
             originalManagerGet  = Neo.manager.Window.get,
             originalNativeFocus = Neo.Main.windowNativeFocus,
@@ -1567,7 +1589,7 @@ test.describe.serial('Workstation.view.Workspace', () => {
      */
     test('a refused park counts its attempts per vessel, and the count resets after a park', async () => {
         const
-            workspace           = Neo.create(Workspace, {}),
+            workspace           = Neo.create(Workspace, {windowId: Neo.config.windowId}),
             originalDragDrop    = Neo.main.addon.DragDrop,
             originalManagerGet  = Neo.manager.Window.get,
             originalNativeFocus = Neo.Main.windowNativeFocus,
@@ -1646,7 +1668,7 @@ test.describe.serial('Workstation.view.Workspace', () => {
 
     test('control: a POPUP target still refuses the park when its owner-routed focus is refused', async () => {
         const
-            workspace           = Neo.create(Workspace, {}),
+            workspace           = Neo.create(Workspace, {windowId: Neo.config.windowId}),
             originalDragDrop    = Neo.main.addon.DragDrop,
             originalManagerGet  = Neo.manager.Window.get,
             originalNativeFocus = Neo.Main.windowNativeFocus,
@@ -1704,7 +1726,7 @@ test.describe.serial('Workstation.view.Workspace', () => {
 
     test('first dock adopts A+B once; whole-stack return projects main before a refused close', async () => {
         const
-            workspace     = Neo.create(Workspace, {}),
+            workspace     = Neo.create(Workspace, {windowId: Neo.config.windowId}),
             workspaceId   = Workspace.vesselWorkspaceId('alerts'),
             tabsNodeId    = Workspace.vesselTabsNodeId('alerts'),
             originalAdopt = workspace.workspaceSet.adoptTransfer,
@@ -1885,7 +1907,7 @@ test.describe.serial('Workstation.view.Workspace', () => {
 
     test('unexpected vessel death atomically recovers the whole A+B stack', async () => {
         const
-            workspace              = Neo.create(Workspace, {}),
+            workspace              = Neo.create(Workspace, {windowId: Neo.config.windowId}),
             {state, workspaceId}   = stageCommittedVessel(workspace),
             originalTearOut        = workspace.tearOutHandlers,
             originalPark           = workspace.vesselParkHandlers,
@@ -1933,7 +1955,7 @@ test.describe.serial('Workstation.view.Workspace', () => {
 
     test('a refused disconnect recovery retains the only A+B truth as a headless workspace', async () => {
         const
-            workspace            = Neo.create(Workspace, {}),
+            workspace            = Neo.create(Workspace, {windowId: Neo.config.windowId}),
             {state, workspaceId} = stageCommittedVessel(workspace),
             originalAdopt        = workspace.workspaceSet.adoptTransfer,
             originalTearOut      = workspace.tearOutHandlers,
@@ -1980,7 +2002,7 @@ test.describe.serial('Workstation.view.Workspace', () => {
 
     test('close acknowledgement retains workspace truth until exact topology exit', async () => {
         const
-            workspace              = Neo.create(Workspace, {}),
+            workspace              = Neo.create(Workspace, {windowId: Neo.config.windowId}),
             {state, workspaceId}   = stageCommittedVessel(workspace),
             originalClose          = workspace.closeTearOutVessel,
             originalTearOut        = workspace.tearOutHandlers,
@@ -2064,7 +2086,7 @@ test.describe.serial('Workstation.view.Workspace', () => {
 
     test('vessel projection retires its one-shot incoming target after paint', async () => {
         const
-            workspace   = Neo.create(Workspace, {}),
+            workspace   = Neo.create(Workspace, {windowId: Neo.config.windowId}),
             workspaceId = Workspace.vesselWorkspaceId('alerts'),
             provisional = workspace.createVesselWorkspaceDocument('alerts'),
             moved       = Operations.transferItem(workspace.dockModel, provisional, {
@@ -2123,7 +2145,7 @@ test.describe.serial('Workstation.view.Workspace', () => {
 
     test('cross-window hit-testing follows live manager.Window dimensions', async () => {
         const
-            workspace   = Neo.create(Workspace, {}),
+            workspace   = Neo.create(Workspace, {windowId: Neo.config.windowId}),
             workspaceId = Workspace.vesselWorkspaceId('alerts');
 
         try {
@@ -2165,7 +2187,7 @@ test.describe.serial('Workstation.view.Workspace', () => {
 
     test('physical vessel death clears both tear-out and park lifecycle owners', async () => {
         const
-            workspace       = Neo.create(Workspace, {}),
+            workspace       = Neo.create(Workspace, {windowId: Neo.config.windowId}),
             originalTearOut = workspace.tearOutHandlers,
             originalPark    = workspace.vesselParkHandlers,
             originalProxy   = workspace.vesselProxyEmbodiment,
@@ -2218,7 +2240,7 @@ test.describe.serial('Workstation.view.Workspace', () => {
 
     test('tear-out navigation carries the workspace active theme into each admitted child', async () => {
         const
-            workspace          = Neo.create(Workspace, {theme: 'neo-theme-neo-light'}),
+            workspace          = Neo.create(Workspace, {theme: 'neo-theme-neo-light', windowId: Neo.config.windowId}),
             originalGetByPath  = Neo.Main.getByPath,
             originalWindowData = Neo.Main.getWindowData,
             originalWindowOpen = Neo.Main.windowOpen,
@@ -2299,7 +2321,7 @@ test.describe.serial('Workstation.view.Workspace', () => {
 
     test('a missing theme bootstrap fails loud before an unthemed tear-out can open', async () => {
         const
-            workspace          = Neo.create(Workspace, {theme: 'neo-theme-neo-light'}),
+            workspace          = Neo.create(Workspace, {theme: 'neo-theme-neo-light', windowId: Neo.config.windowId}),
             originalGetByPath  = Neo.Main.getByPath,
             originalWindowData = Neo.Main.getWindowData,
             originalWindowOpen = Neo.Main.windowOpen,
@@ -2345,7 +2367,7 @@ test.describe.serial('Workstation.view.Workspace', () => {
         // name but carrying a superseded generation was refused there and must stay refused here — the
         // reservation's lineage token is the generation now.
         const
-            workspace     = Neo.create(Workspace, {}),
+            workspace     = Neo.create(Workspace, {windowId: Neo.config.windowId}),
             originalClose = Neo.Main.windowClose,
             closes        = [];
 
@@ -2375,7 +2397,7 @@ test.describe.serial('Workstation.view.Workspace', () => {
 
     test('a successor tear-out retries retained retirement before opening a fresh vessel', async () => {
         const
-            workspace       = Neo.create(Workspace, {}),
+            workspace       = Neo.create(Workspace, {windowId: Neo.config.windowId}),
             originalTearOut = workspace.tearOutHandlers,
             originalPark    = workspace.vesselParkHandlers,
             active          = {itemId: 'alerts', windowName: 'tearout-alerts'},
@@ -2423,7 +2445,7 @@ test.describe.serial('Workstation.view.Workspace', () => {
     });
 
     test('previewLanguage maps to the dock-host modifier: initial, live swap, null reset, open values', () => {
-        const workspace = Neo.create(Workspace, {previewLanguage: 'signal'});
+        const workspace = Neo.create(Workspace, {previewLanguage: 'signal', windowId: Neo.config.windowId});
 
         try {
             const host = workspace.getReference('dock-host');
@@ -2823,7 +2845,7 @@ test.describe('refreshDockWorkspace — DockFlip is told the OUTCOME, not the re
         const
             originalReconcile = DockProjectionReconciler.reconcileProjection,
             originalAddon     = Neo.main?.addon,
-            workspace         = Neo.create(Workspace, {appName: 'WorkstationWorkspaceTest'});
+            workspace         = Neo.create(Workspace, {appName: 'WorkstationWorkspaceTest', windowId: Neo.config.windowId});
 
         let flipOptions = null;
 
@@ -2898,7 +2920,7 @@ test.describe('Workspace — the theme toggle reveals from the pointer (#18125)'
         };
 
         try {
-            workspace = Neo.create(Workspace, {theme: startingTheme});
+            workspace = Neo.create(Workspace, {theme: startingTheme, windowId: Neo.config.windowId});
 
             try {
                 themeAfter = await workspace.toggleWorkspaceTheme(data)
@@ -2993,7 +3015,7 @@ test.describe('getRefreshOptions — the geometry admission is the ENGINE\'s, no
         const
             enginePrototype = Object.getPrototypeOf(Workspace.prototype),
             original        = enginePrototype.getRefreshOptions,
-            workspace       = Neo.create(Workspace, {appName: 'WorkstationWorkspaceTest'});
+            workspace       = Neo.create(Workspace, {appName: 'WorkstationWorkspaceTest', windowId: Neo.config.windowId});
 
         neuterEngine && (enginePrototype.getRefreshOptions = () => ({}));
 

--- a/test/playwright/unit/dashboard/DockTearOut.spec.mjs
+++ b/test/playwright/unit/dashboard/DockTearOut.spec.mjs
@@ -78,8 +78,10 @@ test.describe('Neo.dashboard.dock.window.TearOut — createDockTearOutHandlers',
 
         await handlers.onDockTearOutExit(data);
 
+        // `gestureToken` is the pair's correlation id; `admissionToken` is the same value under the
+        // name the unmigrated consumers' openers still read, until they adopt the Group.
         expect(calls.opened[0]).toEqual({
-            admissionToken: 1, itemId: 'graph', proxyRect: data.proxyRect, sortZone
+            admissionToken: 1, gestureToken: 1, itemId: 'graph', proxyRect: data.proxyRect, sortZone
         });
         expect(calls.ended).toBe(0);
         expect(calls.started).toEqual([{

--- a/test/playwright/unit/dashboard/DockTearOut.spec.mjs
+++ b/test/playwright/unit/dashboard/DockTearOut.spec.mjs
@@ -78,10 +78,9 @@ test.describe('Neo.dashboard.dock.window.TearOut — createDockTearOutHandlers',
 
         await handlers.onDockTearOutExit(data);
 
-        // `gestureToken` is the pair's correlation id; `admissionToken` is the same value under the
-        // name the unmigrated consumers' openers still read, until they adopt the Group.
+        // `gestureToken` is the pair's own correlation id, echoed unread by the host
         expect(calls.opened[0]).toEqual({
-            admissionToken: 1, gestureToken: 1, itemId: 'graph', proxyRect: data.proxyRect, sortZone
+            gestureToken: 1, itemId: 'graph', proxyRect: data.proxyRect, sortZone
         });
         expect(calls.ended).toBe(0);
         expect(calls.started).toEqual([{
@@ -215,24 +214,22 @@ test.describe('Neo.dashboard.dock.window.TearOut — createDockTearOutHandlers',
             openResult: request => ++attempt === 1
                 ? new Promise(resolve => resolveOpen = resolve)
                 : {
-                    admissionToken: request.admissionToken,
-                    generation    : 22,
-                    popupHeight   : 480,
-                    popupWidth    : 640,
-                    windowName    : 'vessel-graph'
+                    gestureToken: request.gestureToken,
+                    popupHeight : 480,
+                    popupWidth  : 640,
+                    windowName  : 'vessel-graph'
                 }
         });
 
         const first = handlers.onDockTearOutExit(exitData(sortZone));
 
         expect(handlers.onVesselRetired({
-            admissionToken: 1,
-            generation    : 17,
-            itemId        : 'graph',
-            windowName    : 'vessel-graph'
+            gestureToken: 1,
+            itemId      : 'graph',
+            windowName  : 'vessel-graph'
         })).toBe(true);
 
-        resolveOpen({admissionToken: 1, generation: 17, windowName: 'vessel-graph'});
+        resolveOpen({gestureToken: 1, windowName: 'vessel-graph'});
 
         await expect(first).resolves.toBe(false);
         expect(calls.closed, 'the already-dead physical generation is not closed by semantic name').toHaveLength(0);
@@ -241,6 +238,29 @@ test.describe('Neo.dashboard.dock.window.TearOut — createDockTearOutHandlers',
         await expect(handlers.onDockTearOutExit(exitData(sortZone))).resolves.toBe(true);
         expect(calls.started).toHaveLength(1);
         expect(handlers.activeVessel).toEqual({itemId: 'graph', windowName: 'vessel-graph'})
+    });
+
+    test('a retirement presenting a superseded lineage token clears nothing; the live vessel survives it', async () => {
+        // The host's admission carries the slot's lineage token; a successor admission for the same
+        // item shares the window name, never the token. A stale retirement — the old generation's
+        // disconnect arriving after its successor bound — must not clear the successor's vessel.
+        const {handlers, sortZone} = harness({
+            openResult: () => ({generationToken: 'lineage-2', popupHeight: 480, popupWidth: 640, windowName: 'vessel-graph', workspaceKey: 'popup:graph'})
+        });
+
+        await handlers.onDockTearOutExit(exitData(sortZone));
+
+        expect(handlers.activeVessel).toEqual({
+            generationToken: 'lineage-2', itemId: 'graph', windowName: 'vessel-graph', workspaceKey: 'popup:graph'
+        });
+
+        expect(handlers.onVesselRetired({generationToken: 'lineage-1', itemId: 'graph', windowName: 'vessel-graph'}),
+            'the superseded lineage names no vessel this machine holds').toBe(false);
+        expect(handlers.activeVessel, 'the live vessel survives the stale retirement').toMatchObject({generationToken: 'lineage-2'});
+
+        expect(handlers.onVesselRetired({generationToken: 'lineage-2', itemId: 'graph', windowName: 'vessel-graph'}),
+            'the exact lineage retires it').toBe(true);
+        expect(handlers.activeVessel).toBeNull()
     });
 
     test('an explicit close refusal retains the active vessel and coalesces one in-flight retirement', async () => {

--- a/test/playwright/unit/dashboard/DockTopologySeams.spec.mjs
+++ b/test/playwright/unit/dashboard/DockTopologySeams.spec.mjs
@@ -15,6 +15,7 @@ import DockWorkspace            from '../../../../src/dashboard/dock/Workspace.m
 import Persistence              from '../../../../src/dashboard/dock/model/Persistence.mjs';
 import TopologyReconciler       from '../../../../src/dashboard/dock/model/TopologyReconciler.mjs';
 import {createDockWorkspaceSet} from '../../../../src/dashboard/dock/window/WorkspaceSet.mjs';
+import TransactionManager       from '../../../../src/manager/Transaction.mjs';
 
 /**
  * @summary The holder seam pair a multi-window perspective restore reaches an app through.
@@ -88,20 +89,27 @@ Neo.setupClass(TopologyWorkspace);
 test.describe('Neo.dashboard.dock.window.TopologySeams — the multi-window restore seams', () => {
     let workspace;
 
+    const groups = [];
+
     test.afterEach(() => {
         workspace?.isDestroyed === false && workspace.destroy();
-        workspace = null
+        workspace = null;
+        groups.splice(0).forEach(groupId => TransactionManager.retireGroup(groupId))
     });
 
     /**
      * Registers the primary first, exactly as a host does — `ids()` order IS slot order, and the
-     * capture/restore pair index by it.
+     * capture/restore pair index by it. Membership lives in a Group of its own, bound the way a host
+     * window is at app registration.
      * @returns {Object} `{set, vessel}` — the live set plus a mutable second-slot handle
      */
     function createSet(host) {
         const
-            vessel = {document: vesselDoc()},
-            set    = createDockWorkspaceSet();
+            groupId = TransactionManager.bind({windowId: `seams-host-${groups.length + 1}`, workspaceKey: 'main'}).groupId,
+            vessel  = {document: vesselDoc()},
+            set     = createDockWorkspaceSet({manager: TransactionManager, getGroupId: () => groupId});
+
+        groups.push(groupId);
 
         set.register('main', {
             getDocument: () => host.dockModel,

--- a/test/playwright/unit/dashboard/DockWorkspace.spec.mjs
+++ b/test/playwright/unit/dashboard/DockWorkspace.spec.mjs
@@ -17,6 +17,7 @@ import DockProjectionReconciler from '../../../../src/dashboard/dock/projection/
 import DockService              from '../../../../src/ai/client/DockService.mjs';
 import DockWorkspace            from '../../../../src/dashboard/dock/Workspace.mjs';
 import HeaderActionPolicy       from '../../../../src/dashboard/dock/projection/HeaderActionPolicy.mjs';
+import TransactionManager       from '../../../../src/manager/Transaction.mjs';
 import WorkspaceDocument        from '../../../../src/dashboard/dock/model/WorkspaceDocument.mjs';
 import Operations               from '../../../../src/dashboard/dock/model/Operations.mjs';
 import Persistence              from '../../../../src/dashboard/dock/model/Persistence.mjs';
@@ -142,6 +143,8 @@ class PlainWorkspace extends DockWorkspace {
 
     construct(config) {
         super.construct(config);
+        // The app boot the fixture stands in for: the host window bound into its Group at connect.
+        TransactionManager.bind({windowId: this.windowId, workspaceKey: 'main'});
         this.add(this.projectDockModel())
     }
 }
@@ -315,21 +318,38 @@ class TearOutWorkspace extends DockWorkspace {
     static config = {
         className                 : 'Test.Unit.Dashboard.DockWorkspace.TearOutWorkspace',
         enableDockTearOutLifecycle: true,
-        layout                    : {ntype: 'vbox', align: 'stretch'},
-        tearOutConnectWindowMs    : 20
+        layout                    : {ntype: 'vbox', align: 'stretch'}
     }
 
-    closeRequests     = []
-    closeResult       = true
-    grant             = null
-    lifecycleEvents   = []
-    openDeferred      = null
-    openRequests      = []
-    unhandledConnects = []
+    binds           = []
+    closeRequests   = []
+    closeResult     = true
+    grant           = null
+    lifecycleEvents = []
+    openDeferred    = null
+    openRequests    = []
+    releases        = []
 
     construct(config) {
         super.construct(config);
+        // The app boot the fixture stands in for: the host window bound into its Group at connect.
+        TransactionManager.bind({windowId: this.windowId, workspaceKey: 'main'});
         this.add(this.projectDockModel())
+    }
+
+    // The manager fires and forgets; the arms need the handler's promise to await or to see reject.
+    onTopologyBind(data) {
+        const pending = super.onTopologyBind(data);
+
+        this.binds.push(pending);
+        return pending
+    }
+
+    onTopologyRelease(data) {
+        const pending = super.onTopologyRelease(data);
+
+        this.releases.push(pending);
+        return pending
     }
 
     admitTearOutConnection(context) {
@@ -352,18 +372,13 @@ class TearOutWorkspace extends DockWorkspace {
         return this.closeResult
     }
 
-    onUnhandledWindowConnect(data) {
-        this.unhandledConnects.push(data)
-    }
-
     openTearOutVessel(request) {
         this.openRequests.push(request);
 
         return this.openDeferred || {
-            admissionToken: request.admissionToken,
-            popupHeight   : 360,
-            popupWidth    : 480,
-            windowName    : `tearout-${request.itemId}-${this.id}`
+            popupHeight: 360,
+            popupWidth : 480,
+            windowName : `tearout-${request.itemId}-${this.id}`
         }
     }
 
@@ -515,7 +530,10 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
 
     test.afterEach(() => {
         workspace?.destroy?.();
-        workspace = null
+        workspace = null;
+        // Every fixture bound its host into a Group; retire them so no arm inherits another's slots.
+        [...TransactionManager.items].forEach(group => TransactionManager.retireGroup(group.id));
+        TransactionManager.reconnectLeaseMs = 20000
     });
 
     test.describe('#17947 pop-out dispatches the drag terminal, never a second lifecycle', () => {
@@ -940,8 +958,8 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
         for (const method of [
             'adoptTearOutPane',
             'applyTearOutOperation',
-            'onWindowConnect',
-            'onWindowDisconnect',
+            'onTopologyBind',
+            'onTopologyRelease',
             'reintegrateTearOutItem',
             'reparentTearOutPane'
         ]) {
@@ -1094,7 +1112,7 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
     });
 
     test.describe('#17681 engine tear-out lifecycle matrix', () => {
-        let previousApps, previousGetByPath, urls;
+        let previousApps;
 
         const createSortZone = () => {
             const calls = {ended: 0, started: []};
@@ -1106,28 +1124,25 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
             }
         };
 
-        const vesselUrl = (request, itemId, {
-            flow  = 'tear-out',
-            hostId = workspace.id,
-            token = request.admissionToken
-        } = {}) => {
-            const url = new URL('https://unit.test/widget/index.html');
-
-            url.searchParams.set('tearout', itemId);
-            url.searchParams.set('hostId', hostId);
-            flow !== null && url.searchParams.set('vesselFlow', flow);
-            token !== null && url.searchParams.set('vesselAdmission', String(token));
-
-            return url.href
-        };
-
-        const addWindow = (windowId, url) => {
+        const addWindow = windowId => {
             const mainView = Neo.create(Container, {});
 
             Neo.apps[windowId] = {mainView};
-            urls[windowId] = url;
 
             return mainView
+        };
+
+        // The vessel's arrival, as the worker admits it: the carried identity its config registered
+        // with. The manager binds synchronously and fires; the host's handler is async, so the arms
+        // await the promises the fixture captured.
+        const connectVessel = async (windowId, topologyIdentity) => {
+            TransactionManager.admit({topologyIdentity, windowId});
+            await Promise.all(workspace.binds)
+        };
+
+        const disconnectVessel = async windowId => {
+            TransactionManager.onWindowDisconnect({windowId});
+            await Promise.all(workspace.releases)
         };
 
         const beginExit = async itemId => {
@@ -1143,18 +1158,14 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
         };
 
         test.beforeEach(() => {
-            previousApps      = Neo.apps;
-            previousGetByPath = Neo.Main.getByPath;
-            urls              = {};
-            Neo.apps          = {};
-            Neo.Main.getByPath = async ({windowId}) => urls[windowId]
+            previousApps = Neo.apps;
+            Neo.apps     = {}
         });
 
         test.afterEach(() => {
             workspace?.destroy?.();
             workspace = null;
-            Neo.apps = previousApps;
-            Neo.Main.getByPath = previousGetByPath
+            Neo.apps  = previousApps
         });
 
         test('#17947 pop-out commits detachItem through the REAL lifecycle, not a stubbed pair', async () => {
@@ -1294,7 +1305,7 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
             ws.openTearOutVessel = request => {
                 opens.push(request);
 
-                return {admissionToken: request.admissionToken, windowName: 'tearout-unreachable'}
+                return {windowName: 'tearout-unreachable'}
             };
 
             // Teardown lands inside the FIRST await. Nothing has been admitted yet, so the only
@@ -1373,10 +1384,9 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
             ws.destroy();
 
             admitLate({
-                admissionToken: opens[0]?.admissionToken,
-                popupHeight   : 360,
-                popupWidth    : 480,
-                windowName    : 'tearout-late-preview'
+                popupHeight: 360,
+                popupWidth : 480,
+                windowName : 'tearout-late-preview'
             });
 
             const result = await pending;
@@ -1423,15 +1433,15 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
             expect(workspace.tearOutPaneHandles.preview).toBe(pane);
             await workspace.refreshPromise;
 
-            const mainView = addWindow('terminal-first', vesselUrl(request, 'preview'));
+            const mainView = addWindow('terminal-first');
 
-            await workspace.onWindowConnect({windowId: 'terminal-first'});
+            await connectVessel('terminal-first', request.topologyIdentity);
 
             expect(mainView.items).toContain(pane);
             expect(workspace.tearOutPanes.preview.windowId).toBe('terminal-first');
             expect(workspace.tearOutAdmissions.has('preview')).toBe(false);
 
-            await workspace.onWindowDisconnect({windowId: 'terminal-first'});
+            await disconnectVessel('terminal-first');
 
             expect(mainView.items).not.toContain(pane);
             expect(workspace.getReference('tearout-pane-preview')).toBe(pane);
@@ -1506,11 +1516,11 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
                 expect(workspace.tearOutHandlers.onDockTearOutTerminal({itemId: 'preview', sortZone: zone})).toBe(true);
                 await workspace.refreshPromise;
 
-                const mainView = addWindow('vessel-window', vesselUrl(request, 'preview'));
+                const mainView = addWindow('vessel-window');
 
                 workspace.afterTearOutWindowConnect = () => calls.push('afterTearOutWindowConnect');
 
-                await workspace.onWindowConnect({windowId: 'vessel-window'});
+                await connectVessel('vessel-window', request.topologyIdentity);
 
                 expect(calls, 'host at construction, vessel on admission, observers last').toEqual([
                     {observeMovement: true, observeResize: true, windowId: 'host-window'},
@@ -1527,12 +1537,12 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
             const
                 pane            = workspace.getReference('tearout-pane-preview'),
                 {request, zone} = await beginExit('preview'),
-                mainView        = addWindow('connect-first', vesselUrl(request, 'preview'));
+                mainView        = addWindow('connect-first');
 
-            await workspace.onWindowConnect({windowId: 'connect-first'});
+            await connectVessel('connect-first', request.topologyIdentity);
 
-            expect(workspace.tearOutConnects.preview).toMatchObject({windowId: 'connect-first'});
-            expect(workspace.tearOutAdmissions.get('preview')).toMatchObject({connected: true, timerId: null});
+            expect(workspace.tearOutConnects.preview).toMatchObject({windowId: 'connect-first', workspaceKey: 'popup:preview'});
+            expect(workspace.tearOutAdmissions.get('preview')).toMatchObject({connected: true, workspaceKey: 'popup:preview'});
             expect(mainView.items).not.toContain(pane);
 
             expect(workspace.tearOutHandlers.onDockTearOutTerminal({itemId: 'preview', sortZone: zone})).toBe(true);
@@ -1558,16 +1568,15 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
 
             const
                 request  = workspace.openRequests[0],
-                mainView = addWindow('early-connect', vesselUrl(request, 'preview'));
+                mainView = addWindow('early-connect');
 
-            await workspace.onWindowConnect({windowId: 'early-connect'});
+            await connectVessel('early-connect', request.topologyIdentity);
             expect(workspace.tearOutAdmissions.get('preview')).toMatchObject({connected: true});
 
             resolveOpen({
-                admissionToken: request.admissionToken,
-                popupHeight   : 360,
-                popupWidth    : 480,
-                windowName    : `tearout-preview-${workspace.id}`
+                popupHeight: 360,
+                popupWidth : 480,
+                windowName : `tearout-preview-${workspace.id}`
             });
             await exit;
 
@@ -1576,25 +1585,30 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
             expect(mainView.items).toContain(workspace.tearOutPaneHandles.preview)
         });
 
-        test('wrong host, missing/wrong flow and wrong token never reach product continuation or ownership', async () => {
+        test('a foreign Group, a stranger token and an unreserved slot never reach product continuation or ownership', async () => {
             workspace = Neo.create(TearOutWorkspace, {dockModel: createDocument()});
 
             const {request} = await beginExit('preview'),
+                  identity  = request.topologyIdentity,
                   cases     = [
-                      ['wrong-host', vesselUrl(request, 'preview', {hostId: 'other'})],
-                      ['missing-flow', vesselUrl(request, 'preview', {flow: null})],
-                      ['wrong-flow', vesselUrl(request, 'preview', {flow: 'transfer'})],
-                      ['wrong-token', vesselUrl(request, 'preview', {token: request.admissionToken + 1})]
+                      // Another Group's identity: the manager creates that Group cold and binds the
+                      // window there — never into this host's slot.
+                      ['foreign-group',   {...identity, groupId: 'some-other-group'}],
+                      // A copied pair with the wrong lineage token: the manager forks it away.
+                      ['stranger-token',  {...identity, generationToken: 'not-the-reservation'}],
+                      // A slot this host never reserved binds in the Group; the host has no admission for it.
+                      ['unreserved-slot', {...identity, workspaceKey: 'popup:terminal'}]
                   ];
 
-            for (const [windowId, url] of cases) {
-                addWindow(windowId, url);
-                await workspace.onWindowConnect({windowId})
+            for (const [windowId, topologyIdentity] of cases) {
+                addWindow(windowId);
+                await connectVessel(windowId, topologyIdentity)
             }
 
-            expect(workspace.unhandledConnects).toEqual([]);
             expect(workspace.tearOutConnects.preview).toBeUndefined();
-            expect(workspace.tearOutAdmissions.get('preview').token).toBe(request.admissionToken);
+            expect(workspace.tearOutAdmissions.get('preview')).toMatchObject({connected: false, windowId: null});
+            expect(TransactionManager.getBinding(identity.groupId, 'popup:preview').windowId,
+                'the reservation still waits for its own vessel').toBeNull();
 
             await workspace.tearOutHandlers.onDockTearOutCancel({itemId: 'preview'})
         });
@@ -1607,8 +1621,11 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
             workspace.grant = () => new Promise(resolve => {releaseGrant = resolve});
 
             const {request} = await beginExit('preview'),
-                  mainView  = addWindow('grant-race', vesselUrl(request, 'preview')),
-                  connect   = workspace.onWindowConnect({windowId: 'grant-race'});
+                  mainView  = addWindow('grant-race');
+
+            TransactionManager.admit({topologyIdentity: request.topologyIdentity, windowId: 'grant-race'});
+
+            const connect = workspace.binds.at(-1);
 
             await expect.poll(() => typeof releaseGrant).toBe('function');
 
@@ -1635,7 +1652,7 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
 
             expect(JSON.stringify(workspace.dockModel)).toBe(before);
             expect(workspace.closeRequests).toHaveLength(1);
-            expect(workspace.closeRequests[0].admissionToken).toBe(request.admissionToken);
+            expect(workspace.closeRequests[0]).toMatchObject({itemId: 'preview', workspaceKey: 'popup:preview'});
             expect(workspace.tearOutPlacements.preview).toBeUndefined();
             expect(workspace.tearOutPaneHandles.preview).toBeUndefined()
         });
@@ -1647,9 +1664,9 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
                 before          = JSON.stringify(workspace.dockModel),
                 {request, zone} = await beginExit('preview');
 
-            addWindow('preterminal-disconnect', vesselUrl(request, 'preview'));
-            await workspace.onWindowConnect({windowId: 'preterminal-disconnect'});
-            await workspace.onWindowDisconnect({windowId: 'preterminal-disconnect'});
+            addWindow('preterminal-disconnect');
+            await connectVessel('preterminal-disconnect', request.topologyIdentity);
+            await disconnectVessel('preterminal-disconnect');
 
             expect(JSON.stringify(workspace.dockModel)).toBe(before);
             expect(workspace.tearOutConnects.preview).toBeUndefined();
@@ -1659,10 +1676,10 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
             expect(workspace.lifecycleEvents).toEqual(['disconnect'])
         });
 
-        test('connect timeout closes and ends the in-window embodiment, while explicit close refusal retains authority', async () => {
-            workspace = Neo.create(TearOutWorkspace, {
-                dockModel: createDocument(), tearOutConnectWindowMs: 1
-            });
+        test('a lease that runs out closes and ends the in-window embodiment, while explicit close refusal retains authority', async () => {
+            // The clock is the manager's: the reservation's lease, not a per-workspace timer.
+            TransactionManager.reconnectLeaseMs = 1;
+            workspace = Neo.create(TearOutWorkspace, {dockModel: createDocument()});
 
             let observeClose;
 
@@ -1679,9 +1696,7 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
             expect(workspace.tearOutHandlers.activeVessel).toBeNull();
 
             workspace.destroy();
-            workspace = Neo.create(TearOutWorkspace, {
-                dockModel: createDocument(), tearOutConnectWindowMs: 1
-            });
+            workspace = Neo.create(TearOutWorkspace, {dockModel: createDocument()});
             workspace.closeResult = false;
 
             const refused = new Promise(resolve => {workspace.onClose = resolve});
@@ -1700,14 +1715,18 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
         test('stale-open close refusal remains tracked and blocks a successor until exact retry succeeds', async () => {
             workspace = Neo.create(TearOutWorkspace, {dockModel: createDocument()});
             workspace.closeResult = false;
-            workspace.openTearOutVessel = request => ({
-                admissionToken: request.admissionToken + 1,
-                popupHeight   : 360,
-                popupWidth    : 480,
-                windowName    : `stale-preview-${workspace.id}`
-            });
 
-            const vessel = await workspace.acquireTearOutVessel({admissionToken: 7, itemId: 'preview'});
+            // Stale: the admission was replaced while the host was still opening, so the record the
+            // open returns into is no longer the one the acquisition made.
+            workspace.openTearOutVessel = request => {
+                const admission = workspace.tearOutAdmissions.get(request.itemId);
+
+                workspace.tearOutAdmissions.set(request.itemId, {...admission});
+
+                return {popupHeight: 360, popupWidth: 480, windowName: `stale-preview-${workspace.id}`}
+            };
+
+            const vessel = await workspace.acquireTearOutVessel({itemId: 'preview'});
 
             expect(vessel).toBeNull();
             expect(workspace.tearOutRetirements.size).toBe(1);
@@ -1715,7 +1734,7 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
 
             const closeCount = workspace.closeRequests.length;
 
-            expect(await workspace.acquireTearOutVessel({admissionToken: 8, itemId: 'preview'})).toBeNull();
+            expect(await workspace.acquireTearOutVessel({itemId: 'preview'})).toBeNull();
             expect(workspace.closeRequests.length).toBe(closeCount + 1);
 
             workspace.closeResult = true;
@@ -1734,12 +1753,13 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
             workspace.tearOutHandlers.onDockTearOutTerminal({itemId: 'preview', sortZone: zone});
             await workspace.refreshPromise;
 
-            const mainView = addWindow('reparent-failure', vesselUrl(request, 'preview'));
+            const mainView = addWindow('reparent-failure');
 
             mainView.add = () => {throw new Error('reparent refused')};
             workspace.closeResult = false;
 
-            await expect(workspace.onWindowConnect({windowId: 'reparent-failure'})).rejects.toThrow(/could not enter/);
+            TransactionManager.admit({topologyIdentity: request.topologyIdentity, windowId: 'reparent-failure'});
+            await expect(workspace.binds.at(-1)).rejects.toThrow(/could not enter/);
             await expect.poll(() => workspace.dockModel.nodes['side-tabs'].items.includes('preview')).toBe(true);
             await workspace.refreshPromise;
             await expect.poll(() => workspace.tearOutRetirements.size).toBe(1);
@@ -3608,7 +3628,7 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
             class OpenerOnlyWorkspace extends PlainWorkspace {
                 static config = {className: 'Test.Unit.Dashboard.DockWorkspace.OpenerOnlyWorkspace'}
 
-                openTearOutVessel({admissionToken, itemId}) {return {admissionToken, windowName: `own-${itemId}`}}
+                openTearOutVessel({itemId}) {return {windowName: `own-${itemId}`}}
             }
 
             Neo.setupClass(OpenerOnlyWorkspace);
@@ -3641,7 +3661,7 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
                 // to claim the capability must not be silently opted in.
                 get canOpenTearOutVessel() {return true}
 
-                openTearOutVessel({admissionToken, itemId}) {return {admissionToken, windowName: `native-${itemId}`}}
+                openTearOutVessel({itemId}) {return {windowName: `native-${itemId}`}}
             }
 
             Neo.setupClass(TransportWorkspace);
@@ -3705,7 +3725,7 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
                 'while a real pane is untouched by the widening').toBe(true)
         });
 
-        test('the engine opens its own vessel, carrying the four params onWindowConnect parses', async () => {
+        test('the engine opens its own vessel: the item as content in the URL, the reserved slot as the carrier', async () => {
             workspace = Neo.create(PlainWorkspace, {dockModel: createDocument()});
 
             const opens              = [],
@@ -3721,56 +3741,57 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
             Neo.config.useSharedWorkers = true;
 
             try {
-                const vessel = await workspace.openTearOutVessel({admissionToken: 7, itemId: 'editor', proxyRect: {height: 500, width: 640, x: 100, y: 60}});
+                const identity = {generationToken: 'lineage-7', groupId: 'group-a', workspaceKey: 'popup:editor'},
+                      vessel   = await workspace.openTearOutVessel({itemId: 'editor', proxyRect: {height: 500, width: 640, x: 100, y: 60}, topologyIdentity: identity});
 
                 expect(opens.length, 'the engine opened a window without any consumer hook').toBe(1);
 
                 const url = new URL(opens[0].url);
 
-                // The exact vocabulary onWindowConnect parses. A consumer re-deriving these from
-                // one app's source is the defect; the engine defines them, so it can write them.
+                // Content in the URL, identity in the carrier: the item is the one parameter the vessel
+                // needs to render; whom it belongs to travels through `Main.windowOpen`.
                 expect(url.searchParams.get('tearout')).toBe('editor');
-                expect(url.searchParams.get(workspace.tearOutHostParam)).toBe(workspace.id);
-                expect(url.searchParams.get('vesselFlow')).toBe('tear-out');
-                expect(url.searchParams.get('vesselAdmission')).toBe('7');
+                expect([...url.searchParams.keys()].sort(), 'no owner, flow or admission in the URL').toEqual(['existing', 'tearout']);
                 expect(url.searchParams.get('existing'), 'the host document\'s own params survive').toBe('keep');
+                expect(opens[0].topologyIdentity, 'the reserved slot rides the staged-open carrier').toEqual(identity);
 
                 // The proxy rect is where the user let go, offset into screen space.
                 expect(opens[0].windowFeatures).toContain('width=640');
                 expect(opens[0].windowFeatures).toContain('height=500');
 
-                expect(vessel).toMatchObject({admissionToken: 7, windowName: 'neo-dock-tearout-editor'})
+                expect(vessel).toMatchObject({windowName: 'neo-dock-tearout-editor'})
             } finally {
                 Neo.Main = originalMain;
                 Neo.config.useSharedWorkers = useSharedWorkers
             }
         });
 
-        test('a vessel re-torn from a vessel does not inherit the parent\'s item or admission', async () => {
+        test('a vessel re-torn from a vessel does not inherit the parent\'s item', async () => {
             workspace = Neo.create(PlainWorkspace, {dockModel: createDocument()});
 
             const opens              = [],
                   {useSharedWorkers} = Neo.config,
                   originalMain       = Neo.Main;
 
-            // The host document ALREADY carries vessel params — the case a re-tear produces.
+            // The host document ALREADY names an item — the case a re-tear produces.
             Neo.Main = {
-                getByPath    : () => Promise.resolve(`https://example.test/i.html?tearout=preview&vesselFlow=tear-out&vesselAdmission=3&${workspace.tearOutHostParam}=stale-host`),
+                getByPath    : () => Promise.resolve('https://example.test/i.html?tearout=preview'),
                 getWindowData: () => Promise.resolve({innerHeight: 800, outerHeight: 860, screenLeft: 0, screenTop: 0}),
                 windowOpen   : data => { opens.push(data); return Promise.resolve(true) }
             };
             Neo.config.useSharedWorkers = true;
 
             try {
-                await workspace.openTearOutVessel({admissionToken: 9, itemId: 'terminal'});
+                const identity = {generationToken: 'lineage-9', groupId: 'group-a', workspaceKey: 'popup:terminal'};
+
+                await workspace.openTearOutVessel({itemId: 'terminal', topologyIdentity: identity});
 
                 const url = new URL(opens[0].url);
 
-                // Without the strip, the vessel would connect as the PARENT's pane against a stale
-                // host id — a wrong pane in a real window, which reads as a success.
+                // Without the strip, the vessel would render the PARENT's pane — a wrong pane in a real
+                // window, which reads as a success. Its owner was never in the URL to inherit.
                 expect(url.searchParams.getAll('tearout')).toEqual(['terminal']);
-                expect(url.searchParams.getAll('vesselAdmission')).toEqual(['9']);
-                expect(url.searchParams.get(workspace.tearOutHostParam)).toBe(workspace.id)
+                expect(opens[0].topologyIdentity).toEqual(identity)
             } finally {
                 Neo.Main = originalMain;
                 Neo.config.useSharedWorkers = useSharedWorkers
@@ -3785,7 +3806,7 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
 
                 openTearOutVessel(request) {
                     this.hostOpens.push(request);
-                    return {admissionToken: request.admissionToken, windowName: `host-${request.itemId}`}
+                    return {windowName: `host-${request.itemId}`}
                 }
             }
 
@@ -3809,7 +3830,7 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
             Neo.config.useSharedWorkers = true;
 
             try {
-                const vessel = await workspace.acquireTearOutVessel({admissionToken: 5, itemId: 'editor'});
+                const vessel = await workspace.acquireTearOutVessel({itemId: 'editor'});
 
                 expect(workspace.hostOpens, 'the host opener ran exactly once').toHaveLength(1);
                 expect(vessel).toMatchObject({windowName: 'host-editor'});
@@ -3828,13 +3849,10 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
             const closes = [];
 
             class ShortWindowOpenerWorkspace extends PlainWorkspace {
-                static config = {
-                    className             : 'Test.Unit.Dashboard.DockWorkspace.ShortWindowOpenerWorkspace',
-                    tearOutConnectWindowMs: 20
-                }
+                static config = {className: 'Test.Unit.Dashboard.DockWorkspace.ShortWindowOpenerWorkspace'}
 
                 openTearOutVessel(request) {
-                    return {admissionToken: request.admissionToken, windowName: `short-${request.itemId}`}
+                    return {windowName: `short-${request.itemId}`}
                 }
 
                 closeTearOutVessel(vessel) {
@@ -3845,8 +3863,9 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
 
             Neo.setupClass(ShortWindowOpenerWorkspace);
 
-            // The lifecycle opt-in is OFF here (the default), so `destroy()` does not run the retire that
-            // sweeps admissions — while `acquireTearOutVessel` arms the expiry timer regardless.
+            // The lifecycle opt-in is OFF here (the default) — while `acquireTearOutVessel` reserves a
+            // slot whose lease runs in the manager regardless.
+            TransactionManager.reconnectLeaseMs = 20;
             workspace = Neo.create(ShortWindowOpenerWorkspace, {dockModel: createDocument()});
 
             const
@@ -3863,25 +3882,27 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
             try {
                 expect(workspace.enableDockTearOutLifecycle, 'the lifecycle opt-in is off').toBe(false);
 
-                await workspace.acquireTearOutVessel({admissionToken: 7, itemId: 'editor'});
+                await workspace.acquireTearOutVessel({itemId: 'editor'});
 
                 const admission = workspace.tearOutAdmissions.get('editor');
 
-                expect(admission?.timerId, 'the admission armed its expiry').toBeTruthy();
-                expect(admission?.windowName, 'and holds the vessel the host opened').toBe('short-editor');
+                expect(TransactionManager.getBinding(workspace.topologyGroupId, 'popup:editor'),
+                    'the slot is reserved in the manager, its lease running').toMatchObject({windowId: null});
+                expect(admission?.windowName, 'and the admission holds the vessel the host opened').toBe('short-editor');
 
                 workspace.destroy();
                 workspace = null;
 
-                // Pre-fix the 20 ms expiry fires on the destroyed instance and dereferences a field core
-                // destroy removed — an uncaught TypeError charged to whichever test is running by then.
-                // Waiting past the window inside THIS arm makes that test this one.
+                // The lease runs out after the instance is gone. The manager's event finds no listener
+                // on this workspace — nothing fires into a destroyed instance — and waiting past the
+                // lease inside THIS arm makes it the test that would be charged if it did.
                 await new Promise(resolve => setTimeout(resolve, 60));
 
-                // The admission is one ownership unit: its timer, its record, and the native vessel it
-                // opened retire together, and the vessel exactly once.
+                // The admission is one ownership unit: its record and the native vessel it opened
+                // retire together, and the vessel exactly once.
                 expect(closes.map(vessel => vessel.windowName), 'the opened vessel was closed exactly once').toEqual(['short-editor'])
             } finally {
+                TransactionManager.reconnectLeaseMs = 20000;
                 Neo.Main = originalMain;
                 Neo.config.useSharedWorkers = useSharedWorkers
             }
@@ -3900,7 +3921,7 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
             try {
                 // A live pane cannot be served to a second window without a shared worker, so
                 // opening one would produce an empty vessel — worse than not opening it.
-                expect(await workspace.openTearOutVessel({admissionToken: 1, itemId: 'editor'})).toBeNull();
+                expect(await workspace.openTearOutVessel({itemId: 'editor'})).toBeNull();
                 expect(opens, 'no window is opened').toEqual([])
             } finally {
                 Neo.Main = originalMain;

--- a/test/playwright/unit/dashboard/DockWorkspace.spec.mjs
+++ b/test/playwright/unit/dashboard/DockWorkspace.spec.mjs
@@ -1134,8 +1134,10 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
 
         // The vessel's arrival, as the worker admits it: the carried identity its config registered
         // with. The manager binds synchronously and fires; the host's handler is async, so the arms
-        // await the promises the fixture captured.
+        // await the promises the fixture captured. The host observes its Group once the manager it
+        // loads on demand has resolved — a real vessel binds long after that, a unit arm may not.
         const connectVessel = async (windowId, topologyIdentity) => {
+            await workspace.transactionManagerReady;
             TransactionManager.admit({topologyIdentity, windowId});
             await Promise.all(workspace.binds)
         };

--- a/test/playwright/unit/dashboard/DockWorkspace.spec.mjs
+++ b/test/playwright/unit/dashboard/DockWorkspace.spec.mjs
@@ -321,21 +321,32 @@ class TearOutWorkspace extends DockWorkspace {
         layout                    : {ntype: 'vbox', align: 'stretch'}
     }
 
-    binds           = []
-    closeRequests   = []
-    closeResult     = true
-    grant           = null
-    lifecycleEvents = []
-    openDeferred    = null
-    openRequests    = []
-    releases        = []
+    /**
+     * `false` leaves the host window unbound, for the arms that admit it after construction.
+     * @member {Boolean} bindHostAtConstruct=true
+     */
+    bindHostAtConstruct = true
+    binds               = []
+    closeRequests       = []
+    closeResult         = true
+    grant               = null
+    lifecycleEvents     = []
+    openDeferred        = null
+    openRequests        = []
+    releases            = []
 
     construct(config) {
+        // Every instance renders in its own host window: a real window id, unique per arm, so the
+        // Group the fixture binds below is the one this instance resolves — never a sibling arm's.
+        config.windowId ??= `tearout-host-${++TearOutWorkspace.hostSeq}`;
+
         super.construct(config);
         // The app boot the fixture stands in for: the host window bound into its Group at connect.
-        TransactionManager.bind({windowId: this.windowId, workspaceKey: 'main'});
+        this.bindHostAtConstruct && TransactionManager.bind({windowId: this.windowId, workspaceKey: 'main'});
         this.add(this.projectDockModel())
     }
+
+    static hostSeq = 0
 
     // The manager fires and forgets; the arms need the handler's promise to await or to see reject.
     onTopologyBind(data) {
@@ -1133,12 +1144,13 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
         };
 
         // The vessel's arrival, as the worker admits it: the carried identity its config registered
-        // with. The manager binds synchronously and fires; the host's handler is async, so the arms
-        // await the promises the fixture captured. The host observes its Group once the manager it
-        // loads on demand has resolved — a real vessel binds long after that, a unit arm may not.
+        // with. An identity the carrier holds binds synchronously inside the admission and fires; a
+        // forked one binds after the carrier answered — so the admission is awaited before the host's
+        // async handler promises are. The host observes its Group once the manager it loads on demand
+        // has resolved — a real vessel binds long after that, a unit arm may not.
         const connectVessel = async (windowId, topologyIdentity) => {
             await workspace.transactionManagerReady;
-            TransactionManager.admit({topologyIdentity, windowId});
+            await TransactionManager.admit({topologyIdentity, windowId});
             await Promise.all(workspace.binds)
         };
 
@@ -1598,7 +1610,7 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
                       ['foreign-group',   {...identity, groupId: 'some-other-group'}],
                       // A copied pair with the wrong lineage token: the manager forks it away.
                       ['stranger-token',  {...identity, generationToken: 'not-the-reservation'}],
-                      // A slot this host never reserved binds in the Group; the host has no admission for it.
+                      // A slot this host never reserved is no door into its Group: the presenter forks.
                       ['unreserved-slot', {...identity, workspaceKey: 'popup:terminal'}]
                   ];
 
@@ -1611,8 +1623,145 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
             expect(workspace.tearOutAdmissions.get('preview')).toMatchObject({connected: false, windowId: null});
             expect(TransactionManager.getBinding(identity.groupId, 'popup:preview').windowId,
                 'the reservation still waits for its own vessel').toBeNull();
+            expect(TransactionManager.getBinding(identity.groupId, 'popup:terminal'), 'the unreserved slot stays absent').toBeNull();
+            expect(TransactionManager.findByWindow('unreserved-slot').groupId).not.toBe(identity.groupId);
 
             await workspace.tearOutHandlers.onDockTearOutCancel({itemId: 'preview'})
+        });
+
+        test('two overlapping opens for one item: the older open\'s late failure cannot revoke the replacement reservation, whose vessel is admitted', async () => {
+            workspace = Neo.create(TearOutWorkspace, {dockModel: createDocument()});
+
+            const opens = [],
+                  zone  = createSortZone();
+
+            workspace.openTearOutVessel = request => new Promise(resolve => opens.push({request, resolve}));
+
+            // The acquisition method itself, twice for one item while the first platform open is still
+            // pending: the second reservation supersedes the first in the manager and in the host. (The
+            // gesture handler serializes exits; this is the seam an asynchronous host reaches directly.)
+            const first = workspace.acquireTearOutVessel({itemId: 'preview', sortZone: zone});
+
+            await expect.poll(() => opens.length).toBe(1);
+
+            const second = workspace.acquireTearOutVessel({itemId: 'preview', sortZone: zone});
+
+            await expect.poll(() => opens.length).toBe(2);
+
+            const [s1, s2] = opens.map(open => open.request.topologyIdentity);
+
+            expect(s2.groupId).toBe(s1.groupId);
+            expect(s2.generationToken, 'the slot was reserved again under a fresh lineage').not.toBe(s1.generationToken);
+            expect(workspace.tearOutAdmissions.get('preview')).toMatchObject({generationToken: s2.generationToken});
+
+            // The older platform open fails late and cleans up after itself.
+            opens[0].resolve(null);
+
+            expect(await first, 'the older acquisition reports its failure').toBeNull();
+            expect(TransactionManager.getBinding(s2.groupId, 'popup:preview'), 'the replacement reservation survives the older failure')
+                .toEqual({generation: 0, windowId: null, workspaceKey: 'popup:preview'});
+            expect(workspace.tearOutAdmissions.get('preview'), 'the replacement admission survives it too').toMatchObject({generationToken: s2.generationToken});
+
+            // The replacement's open succeeds and its child binds the reserved slot.
+            opens[1].resolve({popupHeight: 360, popupWidth: 480, windowName: 'tearout-preview-second'});
+
+            expect(await second).toMatchObject({generationToken: s2.generationToken, windowName: 'tearout-preview-second', workspaceKey: 'popup:preview'});
+
+            addWindow('second-child');
+            await connectVessel('second-child', s2);
+
+            expect(workspace.tearOutAdmissions.get('preview')).toMatchObject({connected: true, generationToken: s2.generationToken, windowId: 'second-child'});
+            expect(workspace.tearOutConnects.preview).toMatchObject({windowId: 'second-child'})
+        });
+
+        test('a late child presenting an expired reservation forks and never connects; a fresh reservation still admits its child', async () => {
+            workspace = Neo.create(TearOutWorkspace, {dockModel: createDocument()});
+
+            TransactionManager.reconnectLeaseMs = 20;
+
+            try {
+                const {request} = await beginExit('preview'),
+                      identity  = request.topologyIdentity;
+
+                // The reservation runs out its lease with no window binding: the manager frees the slot,
+                // and the host retires the vessel it had opened for it.
+                await expect.poll(() => TransactionManager.getBinding(identity.groupId, 'popup:preview')).toBeNull();
+                await expect.poll(() => workspace.tearOutAdmissions.has('preview')).toBe(false);
+                expect(workspace.closeRequests.map(vessel => vessel.itemId)).toEqual(['preview']);
+
+                const lateView = addWindow('late-child');
+
+                await connectVessel('late-child', identity);
+
+                expect(TransactionManager.findByWindow('late-child').groupId, 'the dead lineage forked away').not.toBe(identity.groupId);
+                expect(TransactionManager.getBinding(identity.groupId, 'popup:preview'), 'nothing entered the Group').toBeNull();
+                expect(workspace.tearOutConnects.preview).toBeUndefined();
+                expect(workspace.tearOutAdmissions.has('preview')).toBe(false);
+                expect(lateView.items).toEqual([]);
+
+                // Positive control: a fresh exit reserves again, and its own child is admitted.
+                TransactionManager.reconnectLeaseMs = 20000;
+
+                const {request: fresh} = await beginExit('preview');
+
+                addWindow('fresh-child');
+                await connectVessel('fresh-child', fresh.topologyIdentity);
+
+                expect(workspace.tearOutAdmissions.get('preview')).toMatchObject({connected: true, windowId: 'fresh-child'});
+
+                await workspace.tearOutHandlers.onDockTearOutCancel({itemId: 'preview'})
+            } finally {
+                TransactionManager.reconnectLeaseMs = 20000
+            }
+        });
+
+        test('the host keeps the Group it learned: its own window\'s release and lease expiry change nothing it resolves, and a first boot learns the Group from its accepted binding', async () => {
+            workspace = Neo.create(TearOutWorkspace, {dockModel: createDocument()});
+
+            const manager = await workspace.transactionManagerReady,
+                  groupId = workspace.topologyGroupId;
+
+            expect(groupId, 'learned when the manager resolved: the window bound before this instance subscribed').toBeTruthy();
+
+            // A host registers its documents into the Group; that is what keeps the Group alive.
+            manager.registerParticipant({groupId, workspaceKey: 'main', participant: {getDocument: () => workspace.dockModel}});
+            manager.reconnectLeaseMs = 20;
+
+            try {
+                manager.release(workspace.windowId);
+
+                await expect.poll(() => manager.getBinding(groupId, 'main')).toBeNull();
+
+                expect(manager.findByWindow(workspace.windowId), 'the live binding is gone').toBeNull();
+                expect(workspace.topologyGroupId, 'the Group is remembered, not re-derived').toBe(groupId);
+                expect(manager.get(groupId), 'a Group holding a participant survives its last binding').toBeTruthy();
+                expect(manager.participantKeys(groupId)).toEqual(['main']);
+
+                // The host still acts for its Group: a vessel it reserves lands in it.
+                const {request} = await beginExit('preview');
+
+                expect(request.topologyIdentity.groupId).toBe(groupId);
+                await workspace.tearOutHandlers.onDockTearOutCancel({itemId: 'preview'})
+            } finally {
+                manager.reconnectLeaseMs = 20000
+            }
+
+            // A first boot: the window's minted identity is accepted by its carrier after construction.
+            const firstBoot = Neo.create(TearOutWorkspace, {bindHostAtConstruct: false, dockModel: createDocument(), windowId: 'first-boot'});
+
+            try {
+                await firstBoot.transactionManagerReady;
+
+                expect(firstBoot.topologyGroupId, 'nothing to learn yet').toBeNull();
+
+                const minted = await manager.admit({topologyIdentity: {}, windowId: 'first-boot'});
+
+                expect(minted.outcome).toBe('minted');
+                expect(firstBoot.topologyGroupId, 'learned from the accepted binding').toBe(minted.groupId)
+            } finally {
+                firstBoot.destroy();
+                manager.retireGroup(manager.findByWindow('first-boot')?.groupId)
+            }
         });
 
         test('an async grant cannot publish a connection after its exact admission was retired', async () => {
@@ -3814,7 +3963,10 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
 
             Neo.setupClass(HostOpenerWorkspace);
 
-            workspace = Neo.create(HostOpenerWorkspace, {dockModel: createDocument()});
+            // A host that runs no lifecycle still reserves its vessel's slot in its window's Group,
+            // so the window is bound the way its app registration binds it.
+            workspace = Neo.create(HostOpenerWorkspace, {dockModel: createDocument(), windowId: 'host-opener-window'});
+            TransactionManager.bind({windowId: 'host-opener-window', workspaceKey: 'main'});
 
             const opens              = [],
                   {useSharedWorkers} = Neo.config,
@@ -3868,7 +4020,8 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
             // The lifecycle opt-in is OFF here (the default) — while `acquireTearOutVessel` reserves a
             // slot whose lease runs in the manager regardless.
             TransactionManager.reconnectLeaseMs = 20;
-            workspace = Neo.create(ShortWindowOpenerWorkspace, {dockModel: createDocument()});
+            workspace = Neo.create(ShortWindowOpenerWorkspace, {dockModel: createDocument(), windowId: 'short-opener-window'});
+            TransactionManager.bind({windowId: 'short-opener-window', workspaceKey: 'main'});
 
             const
                 {useSharedWorkers} = Neo.config,

--- a/test/playwright/unit/dashboard/DockWorkspaceSet.spec.mjs
+++ b/test/playwright/unit/dashboard/DockWorkspaceSet.spec.mjs
@@ -85,6 +85,17 @@ test.describe('Neo.dashboard.dock.window.WorkspaceSet — the dock adapter over 
         expect(set.ids(), 'the participant survived its window').toEqual(['main']);
         expect(set.getDocument('main')).toEqual({rootId: 'root-main'});
 
+        // The fixture's resolver is the hosts' shape: a Group remembered once, never re-derived. A
+        // resolver reading the LIVE binding instead loses the membership with the window — which is
+        // why the engine Workspace, the Workstation and DemoB remember their Group.
+        const liveResolver = createDockWorkspaceSet({
+            getGroupId: () => TransactionManager.findByWindow('workspace-set-host')?.groupId ?? null,
+            manager   : TransactionManager
+        });
+
+        expect(liveResolver.ids(), 'a live-binding resolver reaches nothing after release').toEqual([]);
+        expect(liveResolver.getDocument('main')).toBeNull();
+
         // Retirement stays the owner's explicit decision.
         expect(set.unregister('main')).toBe(true);
         expect(set.ids()).toEqual([])

--- a/test/playwright/unit/dashboard/DockWorkspaceSet.spec.mjs
+++ b/test/playwright/unit/dashboard/DockWorkspaceSet.spec.mjs
@@ -9,19 +9,32 @@ setup({
 });
 
 import {test, expect}           from '@playwright/test';
+import Neo                      from '../../../../src/Neo.mjs';
+import * as core                from '../../../../src/core/_export.mjs';
+import TransactionManager       from '../../../../src/manager/Transaction.mjs';
 import {createDockWorkspaceSet} from '../../../../src/dashboard/dock/window/WorkspaceSet.mjs';
 
 /**
- * @summary The worker-owned `{workspaceId → document}` registry contract (docking design
- * record §2.1 / §2.8.3): stable semantic identity in, document truth out, fail-closed everywhere
- * a resolution cannot be proven, and both-or-neither adoption for an atomic transfer's committed
- * pair. Retirement never happens implicitly — the registry outlives any render target.
+ * @summary The dock's `{workspaceId → document}` view of a Group's participant membership (docking
+ * design record §2.1 / §2.8.3): stable semantic identity in, document truth out, fail-closed everywhere
+ * a resolution cannot be proven, and both-or-neither adoption for an atomic transfer's committed pair.
+ * Membership is the Group's, never the adapter's; retirement never happens implicitly — a participant
+ * outlives any render target, and its Group outlives its last binding.
  */
-test.describe('Neo.dashboard.dock.window.WorkspaceSet — the workspace-set registry', () => {
-    let set;
+test.describe('Neo.dashboard.dock.window.WorkspaceSet — the dock adapter over Group membership', () => {
+    let groupId,
+        set;
 
     test.beforeEach(() => {
-        set = createDockWorkspaceSet()
+        // The host window binds into a Group the way its app registration does; the adapter reads
+        // that Group back through the same seam the hosts hand it.
+        groupId = TransactionManager.bind({windowId: 'workspace-set-host', workspaceKey: 'main'}).groupId;
+        set     = createDockWorkspaceSet({manager: TransactionManager, getGroupId: () => groupId})
+    });
+
+    test.afterEach(() => {
+        TransactionManager.retireGroup(groupId);
+        TransactionManager.reconnectLeaseMs = 20000
     });
 
     /**
@@ -39,6 +52,43 @@ test.describe('Neo.dashboard.dock.window.WorkspaceSet — the workspace-set regi
 
         return holder
     }
+
+    test('before the host binds there is no membership: registration is refused and every lookup fails closed', () => {
+        const unbound = createDockWorkspaceSet({manager: TransactionManager, getGroupId: () => null}),
+              holder  = createHolder({rootId: 'root-early'});
+
+        expect(unbound.register('main', holder.seams), 'no Group to join').toBe(false);
+        expect(unbound.has('main')).toBe(false);
+        expect(unbound.getDocument('main')).toBeNull();
+        expect(unbound.ids()).toEqual([]);
+        expect(unbound.size).toBe(0);
+        expect(unbound.unregister('main')).toBe(false);
+        expect(unbound.adoptAll({main: {rootId: 'x'}}), 'nothing to adopt into').toBe(false);
+        expect(TransactionManager.participantKeys(groupId), 'the refusal wrote nowhere').toEqual([])
+    });
+
+    test('membership is the Group\'s, and it outlives the binding: a released and expired slot keeps the participants and the Group', async () => {
+        const holder = createHolder({rootId: 'root-main'});
+
+        expect(set.register('main', holder.seams)).toBe(true);
+        expect(TransactionManager.getParticipant(groupId, 'main'), 'the adapter kept no entry of its own — the Group holds it')
+            .toEqual({getDocument: holder.seams.getDocument, setDocument: holder.seams.setDocument});
+
+        // The host window dies; its binding is released and its lease runs out.
+        TransactionManager.reconnectLeaseMs = 20;
+        TransactionManager.release('workspace-set-host');
+
+        await new Promise(resolve => setTimeout(resolve, 60));
+
+        expect(TransactionManager.getBinding(groupId, 'main'), 'the slot is free').toBeNull();
+        expect(TransactionManager.get(groupId), 'a Group holding participants is not empty and is not retired').toBeTruthy();
+        expect(set.ids(), 'the participant survived its window').toEqual(['main']);
+        expect(set.getDocument('main')).toEqual({rootId: 'root-main'});
+
+        // Retirement stays the owner's explicit decision.
+        expect(set.unregister('main')).toBe(true);
+        expect(set.ids()).toEqual([])
+    });
 
     test('register → resolve: document truth flows through the owner seam, live', () => {
         const holder = createHolder({rootId: 'root-main'});

--- a/test/playwright/unit/examples/dashboard/crossWindow/DemoBWorkspace.spec.mjs
+++ b/test/playwright/unit/examples/dashboard/crossWindow/DemoBWorkspace.spec.mjs
@@ -18,6 +18,7 @@ import DockProjectionReconciler                            from '../../../../../
 import WorkspaceDocument                                   from '../../../../../../src/dashboard/dock/model/WorkspaceDocument.mjs';
 import Operations                                          from '../../../../../../src/dashboard/dock/model/Operations.mjs';
 import Persistence                                         from '../../../../../../src/dashboard/dock/model/Persistence.mjs';
+import TransactionManager                                  from '../../../../../../src/manager/Transaction.mjs';
 
 import {demoBTourScript, initialDocument} from '../../../../../../examples/dashboard/crossWindow/demoBPerspectives.mjs';
 
@@ -121,23 +122,36 @@ function installWindowVessel({
 }
 
 /**
- * @summary Installs exact child-window connection seams for vessel-owner tests.
- * Each registered child carries the production-shaped native route minted by its opener;
- * URL parameters alone therefore never stand in for physical-window authority.
+ * @summary Installs exact child-window binding seams for vessel-owner tests.
+ * A child binds through the REAL `Neo.manager.Transaction`, presenting the identity its opener handed
+ * `Main.windowOpen` — the URL never stands in for ownership. Each bound child carries the
+ * production-shaped native route minted by its opener. The manager fires `bind` synchronously and
+ * discards the handler's promise, so the harness re-seats the workspace's listener through a wrapper
+ * that keeps it: a connect is awaited to the handler's settlement.
  * @param {Neo.component.Base} workspace
- * @returns {{addedTo: Function, connect: Function, register: Function, restore: Function}}
+ * @returns {{addedTo: Function, connect: Function, disconnect: Function, register: Function, restore: Function}}
  */
 function installWindowConnectHarness(workspace) {
     let previous = {
-            getByPath    : Neo.Main.getByPath,
             getWindowData: Neo.Main.getWindowData,
             managerGet   : Neo.manager.Window.get,
             windowOpen   : Neo.Main.windowOpen
         },
+        bindings       = new Map(),
         managerRecords = new Map(),
         windows        = new Map();
 
-    Neo.Main.getByPath = async ({windowId}) => windows.get(windowId)?.url;
+    const onBind = data => {
+        const settled = workspace.onTopologyBind(data);
+
+        bindings.set(data.windowId, settled);
+
+        return settled
+    };
+
+    TransactionManager.un({bind: workspace.onTopologyBind, scope: workspace});
+    TransactionManager.on({bind: onBind, scope: workspace});
+
     Neo.Main.getWindowData = async () => ({
         innerHeight: 700,
         outerHeight: 740,
@@ -151,7 +165,15 @@ function installWindowConnectHarness(workspace) {
             return windows.get(windowId)?.added ?? []
         },
 
-        async connect(windowId, url) {
+        /**
+         * A child window boots with the identity its opener wrote into its carrier and is admitted the
+         * way `worker/App#registerApp` admits it. Settles with the workspace's bind handler — or at once
+         * when the manager routed the window elsewhere (a fork, a slot the host never reserved).
+         * @param {String} windowId
+         * @param {Object} topologyIdentity
+         * @returns {Promise<void>}
+         */
+        async connect(windowId, topologyIdentity) {
             let added       = [],
                 nativeRoute = {
                     capabilities   : {close: true, focus: true, position: true},
@@ -160,7 +182,7 @@ function installWindowConnectHarness(workspace) {
                     targetWindowId : windowId
                 };
 
-            windows.set(windowId, {added, url: new URL(url, 'https://example.test').href});
+            windows.set(windowId, {added});
             managerRecords.set(windowId, {
                 innerRect: {height: 320, width: 480, x: 40, y: 60},
                 outerRect: {height: 360, width: 480, x: 40, y: 60},
@@ -172,12 +194,17 @@ function installWindowConnectHarness(workspace) {
                 }
             };
 
-            await workspace.onWindowConnect({
-                windowData: {
-                    nativeRoute
-                },
-                windowId
-            })
+            TransactionManager.admit({topologyIdentity, windowId});
+
+            await bindings.get(windowId)
+        },
+
+        /**
+         * The window left the shared heap: the manager releases its binding and announces it.
+         * @param {String} windowId
+         */
+        disconnect(windowId) {
+            TransactionManager.release(windowId)
         },
 
         register(windowId, {
@@ -197,13 +224,20 @@ function installWindowConnectHarness(workspace) {
         },
 
         restore() {
+            TransactionManager.un({bind: onBind, scope: workspace});
+            TransactionManager.on({bind: workspace.onTopologyBind, scope: workspace});
             Object.assign(Neo.Main, {
-                getByPath    : previous.getByPath,
                 getWindowData: previous.getWindowData,
                 windowOpen   : previous.windowOpen
             });
             Neo.manager.Window.get = previous.managerGet;
-            windows.forEach((value, windowId) => delete Neo.apps[windowId])
+            windows.forEach((value, windowId) => {
+                const bound = TransactionManager.findByWindow(windowId);
+
+                // a forked newcomer's own Group leaves with the arm; the host's Group is the fixture's
+                bound && bound.groupId !== workspace.topologyGroupId && TransactionManager.retireGroup(bound.groupId);
+                delete Neo.apps[windowId]
+            })
         }
     }
 }
@@ -219,12 +253,34 @@ test.describe.serial('Neo.examples.dashboard.crossWindow.DemoBWorkspace', () => 
     let workspace;
 
     test.beforeEach(() => {
-        workspace = Neo.create(DemoBWorkspace, {})
+        workspace = Neo.create(DemoBWorkspace, {});
+
+        // The host window binds into a Group the way its app registration does; every slot the
+        // workspace reserves lives in it, and `topologyGroupId` reads it back.
+        TransactionManager.bind({windowId: workspace.windowId, workspaceKey: 'main'})
     });
 
     test.afterEach(() => {
+        const windowId = workspace?.windowId;
+        let bound;
+
         workspace?.destroy?.();
-        workspace = null
+        workspace = null;
+
+        // The host's Group leaves with the arm: nothing of this window survives into the next one.
+        while ((bound = TransactionManager.findByWindow(windowId))) {
+            TransactionManager.retireGroup(bound.groupId)
+        }
+    });
+
+    /**
+     * @summary Announces a window's release the way the manager does for a physical death — the host
+     * answers only for its own Group.
+     * @param {String} windowId
+     * @param {String} [workspaceKey='main']
+     */
+    const releaseWindow = (windowId, workspaceKey='main') => workspace.onTopologyRelease({
+        generation: 1, groupId: workspace.topologyGroupId, windowId, workspaceKey
     });
 
     test('the holder contract: an own cloned stage, readable before any operation', () => {
@@ -342,10 +398,11 @@ test.describe.serial('Neo.examples.dashboard.crossWindow.DemoBWorkspace', () => 
         };
 
         try {
-            await harness.connect(
-                'competing-g1',
-                `https://example.test/?popout=workbench&hostId=${workspace.id}`
-            );
+            // a newcomer naming the host's Group under a slot the host never reserved binds a free slot
+            // in the manager — and the host, which answers only for its reservations, ignores it
+            await harness.connect('competing-g1', {
+                generationToken: 'forged', groupId: workspace.topologyGroupId, workspaceKey: 'popup:workbench'
+            });
 
             expect(harness.addedTo('competing-g1')).toEqual([]);
             expect(workspace.detachedPanes.workbench.windowId).toBe('workspace-target');
@@ -355,10 +412,10 @@ test.describe.serial('Neo.examples.dashboard.crossWindow.DemoBWorkspace', () => 
         }
     });
 
-    test('the workspace stage consumes one exact target grant instead of trusting its URL shape', async () => {
+    test('the workspace stage mounts the one child that binds its reserved slot — never a forged or replayed identity', async () => {
         const harness = installWindowConnectHarness(workspace),
               mounts  = [];
-        let stageUrl;
+        let stageOpen;
 
         workspace.timeout = () => new Promise(() => {});
         workspace.mountCrossWindowTarget = async (app, windowId) => {
@@ -368,58 +425,63 @@ test.describe.serial('Neo.examples.dashboard.crossWindow.DemoBWorkspace', () => 
             })
         };
         Neo.Main.windowOpen = async data => {
-            stageUrl = data.url;
+            stageOpen = data;
 
-            const wrongFlowUrl = new URL(stageUrl, 'https://example.test');
+            // a stranger presenting the reserved slot under a foreign token forks into its own Group
+            await harness.connect('forged-child', {...data.topologyIdentity, generationToken: 'forged'});
 
-            wrongFlowUrl.searchParams.set('vesselFlow', 'click-popout');
-            await harness.connect('wrong-flow-child', wrongFlowUrl);
-
-            await harness.connect('workspace-child', stageUrl);
+            await harness.connect('workspace-child', data.topologyIdentity);
             return true
         };
 
         try {
             expect(await workspace.openCrossWindowStage()).toMatchObject({windowId: 'workspace-child'});
 
-            const params = new URL(stageUrl, 'https://example.test').searchParams;
+            const params = new URL(stageOpen.url, 'https://example.test').searchParams;
 
-            expect(params.get('vesselFlow')).toBe('workspace-target');
-            expect(params.get('vesselGrant')).toBeTruthy();
-            expect(params.get('vesselGeneration')).toBeTruthy();
-            expect(harness.addedTo('wrong-flow-child')).toEqual([]);
+            expect([...params.keys()], 'the URL names the workspace; the owner rides the carrier').toEqual(['workspaceId']);
+            expect(stageOpen.topologyIdentity).toEqual({
+                generationToken: expect.any(String),
+                groupId        : workspace.topologyGroupId,
+                workspaceKey   : DemoBWorkspace.POPUP_WORKSPACE_ID
+            });
+            expect(harness.addedTo('forged-child')).toEqual([]);
             expect(mounts).toEqual(['workspace-child']);
 
-            await harness.connect('workspace-replay', stageUrl);
+            // the same identity presented again while its binder lives forks — the stage mounts once
+            await harness.connect('workspace-replay', stageOpen.topologyIdentity);
             expect(mounts).toEqual(['workspace-child'])
         } finally {
             harness.restore()
         }
     });
 
-    test('click pop-out consumes its exact owner grant once even when connect beats open settlement', async () => {
+    test('click pop-out admits the one child that binds its reserved slot, even when the bind beats open settlement', async () => {
         const harness = installWindowConnectHarness(workspace),
               pane    = workspace.resolvePane('workbench', initialDocument.items.workbench);
-        let clickUrl;
+        let clickOpen;
 
         Neo.Main.windowOpen = async data => {
-            clickUrl = data.url;
-            await harness.connect('click-child', clickUrl);
+            clickOpen = data;
+            await harness.connect('click-child', data.topologyIdentity);
             return true
         };
 
         try {
             expect(await workspace.popOutPane('workbench')).toEqual({detached: true, errors: []});
 
-            const params = new URL(clickUrl, 'https://example.test').searchParams;
+            const params = new URL(clickOpen.url, 'https://example.test').searchParams;
 
-            expect(params.get('vesselFlow')).toBe('click-popout');
-            expect(params.get('vesselGrant')).toBeTruthy();
-            expect(params.get('vesselGeneration')).toBeTruthy();
+            expect([...params.keys()], 'the URL names the pane; the owner rides the carrier').toEqual(['popout']);
+            expect(clickOpen.topologyIdentity).toEqual({
+                generationToken: expect.any(String),
+                groupId        : workspace.topologyGroupId,
+                workspaceKey   : 'popup:workbench'
+            });
             expect(harness.addedTo('click-child')).toEqual([pane]);
             expect(workspace.detachedPanes.workbench.windowId).toBe('click-child');
 
-            await harness.connect('click-replay', clickUrl);
+            await harness.connect('click-replay', clickOpen.topologyIdentity);
 
             expect(harness.addedTo('click-replay')).toEqual([]);
             expect(workspace.detachedPanes.workbench.windowId).toBe('click-child')
@@ -445,11 +507,9 @@ test.describe.serial('Neo.examples.dashboard.crossWindow.DemoBWorkspace', () => 
         workspace = Neo.create(DemoBWorkspace, {});
 
         const harness = installWindowConnectHarness(workspace);
-        let clickUrl;
 
         Neo.Main.windowOpen = async data => {
-            clickUrl = data.url;
-            await harness.connect('geometry-child', clickUrl);
+            await harness.connect('geometry-child', data.topologyIdentity);
             return true
         };
 
@@ -468,7 +528,7 @@ test.describe.serial('Neo.examples.dashboard.crossWindow.DemoBWorkspace', () => 
         }
     });
 
-    test('tear-out connect-before-terminal consumes its grant and a replay stays inert', async () => {
+    test('tear-out bind-before-terminal embodies the one child holding its slot, and a replay stays inert', async () => {
         const harness      = installWindowConnectHarness(workspace),
               pane         = workspace.resolvePane('timeline', initialDocument.items.timeline),
               sourceParent = pane.parent,
@@ -486,16 +546,23 @@ test.describe.serial('Neo.examples.dashboard.crossWindow.DemoBWorkspace', () => 
                 itemId: 'timeline', proxyRect: {height: 320, width: 480, x: 40, y: 60}
             })).toMatchObject({windowName: 'tearout-timeline'});
 
-            const tearOutUrl = tearOutOpen.url;
-            const params     = new URL(tearOutUrl, 'https://example.test').searchParams;
+            const params = new URL(tearOutOpen.url, 'https://example.test').searchParams;
 
             expect(tearOutOpen.nativeCapabilities).toEqual({close: true, position: true});
-            expect(params.get('vesselFlow')).toBe('tear-out');
-            expect(params.get('vesselGrant')).toBeTruthy();
-            expect(params.get('vesselGeneration')).toBeTruthy();
+            expect([...params.keys()], 'the URL names the pane; the owner rides the carrier').toEqual(['popout']);
+            expect(tearOutOpen.topologyIdentity).toEqual({
+                generationToken: expect.any(String),
+                groupId        : workspace.topologyGroupId,
+                workspaceKey   : 'popup:timeline'
+            });
 
-            await harness.connect('tear-child', tearOutUrl);
-            expect(workspace.tearOutConnects.timeline).toEqual({windowId: 'tear-child'});
+            await harness.connect('tear-child', tearOutOpen.topologyIdentity);
+            expect(workspace.tearOutConnects.timeline).toEqual({
+                generationToken: tearOutOpen.topologyIdentity.generationToken,
+                windowId       : 'tear-child',
+                windowName     : 'tearout-timeline',
+                workspaceKey   : 'popup:timeline'
+            });
             expect(harness.addedTo('tear-child'), 'the admitted moving vessel renders the live pane pre-terminal')
                 .toEqual([pane]);
             expect(JSON.stringify(workspace.getDockZoneDocument()), 'render embodiment mutates no document truth')
@@ -509,7 +576,7 @@ test.describe.serial('Neo.examples.dashboard.crossWindow.DemoBWorkspace', () => 
             expect(workspace.tearOutPanes.timeline.windowId).toBe('tear-child');
             expect(workspace.tearOutConnects.timeline, 'committed ownership has only one lifecycle map').toBeUndefined();
 
-            await harness.connect('tear-replay', tearOutUrl);
+            await harness.connect('tear-replay', tearOutOpen.topologyIdentity);
             expect(harness.addedTo('tear-replay')).toEqual([]);
             expect(workspace.tearOutPanes.timeline.windowId).toBe('tear-child')
         } finally {
@@ -547,25 +614,28 @@ test.describe.serial('Neo.examples.dashboard.crossWindow.DemoBWorkspace', () => 
                 itemId: 'timeline', proxyRect: {height: 320, width: 480, x: 40, y: 60}, sortZone
             });
 
-            const open           = vessel.openCalls.at(-1),
-                  params         = new URL(open.url, 'https://example.test').searchParams,
-                  admissionToken = Number(params.get('vesselAdmission')),
-                  generation     = Number(params.get('vesselGeneration')),
-                  connecting     = harness.connect('tear-stage-race', open.url);
+            const open        = vessel.openCalls.at(-1),
+                  reservation = {
+                      ...open.topologyIdentity,
+                      flow      : 'tear-out',
+                      itemId    : 'timeline',
+                      windowId  : 'tear-stage-race',
+                      windowName: 'tearout-timeline'
+                  },
+                  connecting  = harness.connect('tear-stage-race', open.topologyIdentity);
 
             await expect(stageEntered).resolves.toEqual({itemId: 'timeline', windowId: 'tear-stage-race'});
-            expect(workspace.tearOutConnectAdmissions.get('timeline')).toEqual({
-                admissionToken, generation, invalidated: false, windowId: 'tear-stage-race'
-            });
+            expect(workspace.vesselReservations.get('popup:timeline'), 'the bound slot remembers its window').toEqual(reservation);
 
             await expect(workspace.tearOutHandlers.onDockTearOutCancel({itemId: 'timeline', sortZone})).resolves.toBe(false);
 
-            expect(workspace.tearOutConnectAdmissions.get('timeline')).toEqual({
-                admissionToken, generation, invalidated: true, windowId: 'tear-stage-race'
-            });
+            expect(workspace.vesselReservations.get('popup:timeline'), 'a refused close keeps the slot for its retry').toEqual(reservation);
             expect(workspace.tearOutRetirements.has('timeline')).toBe(true);
-            expect(workspace.tearOutHandlers.activeVessel).toEqual({
-                itemId: 'timeline', windowName: 'tearout-timeline'
+            expect(workspace.tearOutHandlers.activeVessel, 'the machine holds the vessel under its slot and lineage token').toEqual({
+                generationToken: open.topologyIdentity.generationToken,
+                itemId         : 'timeline',
+                windowName     : 'tearout-timeline',
+                workspaceKey   : 'popup:timeline'
             });
 
             resolveStage(true);
@@ -578,7 +648,7 @@ test.describe.serial('Neo.examples.dashboard.crossWindow.DemoBWorkspace', () => 
             admitClose = true;
 
             await expect(workspace.tearOutHandlers.onDockTearOutCancel({itemId: 'timeline', sortZone})).resolves.toBe(true);
-            expect(workspace.tearOutConnectAdmissions.has('timeline')).toBe(false);
+            expect(workspace.vesselReservations.has('popup:timeline'), 'the acknowledged close gives the slot record back').toBe(false);
             expect(workspace.tearOutRetirements.has('timeline')).toBe(false);
             expect(workspace.tearOutHandlers.activeVessel).toBeNull();
             expect(vessel.nativeCloseCalls).toEqual([
@@ -626,19 +696,19 @@ test.describe.serial('Neo.examples.dashboard.crossWindow.DemoBWorkspace', () => 
                 itemId: 'timeline', proxyRect: {height: 320, width: 480, x: 40, y: 60}, sortZone
             });
 
-            const connecting = harness.connect('tear-stage-committed', vessel.openCalls.at(-1).url);
+            const connecting = harness.connect('tear-stage-committed', vessel.openCalls.at(-1).topologyIdentity);
 
             await expect(stageEntered).resolves.toEqual({itemId: 'timeline', windowId: 'tear-stage-committed'});
             expect(workspace.tearOutHandlers.onDockTearOutTerminal({itemId: 'timeline', sortZone})).toBe(true);
             expect(WorkspaceDocument.findContainingTabsId(workspace.getDockZoneDocument(), 'timeline')).toBeNull();
             expect(workspace.tearOutPanes.timeline.windowId).toBeNull();
 
-            workspace.onWindowDisconnect({windowId: 'tear-stage-committed'});
+            harness.disconnect('tear-stage-committed');
 
             expect(WorkspaceDocument.findContainingTabsId(workspace.getDockZoneDocument(), 'timeline'))
                 .toBe('side-tabs');
             expect(workspace.tearOutPanes.timeline).toBeUndefined();
-            expect(workspace.tearOutConnectAdmissions.has('timeline')).toBe(false);
+            expect(workspace.vesselReservations.has('popup:timeline'), 'the dead window\'s slot record is gone').toBe(false);
             expect(restored).toEqual([{itemId: 'timeline', windowId: 'tear-stage-committed'}]);
 
             resolveStage(false);
@@ -668,7 +738,7 @@ test.describe.serial('Neo.examples.dashboard.crossWindow.DemoBWorkspace', () => 
             await workspace.openTearOutVessel({
                 itemId: 'timeline', proxyRect: {height: 320, width: 480, x: 40, y: 60}
             });
-            await harness.connect('tear-child', vessel.openCalls.at(-1).url);
+            await harness.connect('tear-child', vessel.openCalls.at(-1).topologyIdentity);
             harness.register('target-child');
             workspace.crossWindowTargetWindowId = 'target-child';
 
@@ -736,7 +806,7 @@ test.describe.serial('Neo.examples.dashboard.crossWindow.DemoBWorkspace', () => 
                 itemId: 'timeline', windowName: 'tearout-timeline'
             })).resolves.toBe(false);
             expect(workspace.tearOutConnects.timeline, 'strict close refusal retains recovery routing')
-                .toEqual({windowId: 'tear-child'});
+                .toMatchObject({windowId: 'tear-child'});
             expect(sourceParent.items[sourceIndex], 'refused close leaves content home, not in a doomed vessel')
                 .toBe(pane);
             expect(workspace.tearOutEmbodiment.isStaged('timeline')).toBe(false);
@@ -774,11 +844,11 @@ test.describe.serial('Neo.examples.dashboard.crossWindow.DemoBWorkspace', () => 
         };
 
         try {
-            workspace.onWindowDisconnect({windowId: 'tear-pending'});
+            releaseWindow('tear-pending', 'popup:timeline');
 
             expect(workspace.tearOutConnects.timeline).toBeUndefined();
             expect(calls).toEqual([
-                ['tear-out', {itemId: 'timeline', windowName: 'tearout-timeline'}],
+                ['tear-out', {itemId: 'timeline', windowId: 'tear-pending', windowName: 'tearout-timeline'}],
                 ['park', {itemId: 'timeline', retirement: true}]
             ])
         } finally {
@@ -837,7 +907,7 @@ test.describe.serial('Neo.examples.dashboard.crossWindow.DemoBWorkspace', () => 
             await workspace.openTearOutVessel({
                 itemId: 'timeline', proxyRect: {height: 320, width: 480, x: 40, y: 60}
             });
-            await harness.connect('tear-child', vessel.openCalls.at(-1).url);
+            await harness.connect('tear-child', vessel.openCalls.at(-1).topologyIdentity);
             harness.register('target-child');
             workspace.crossWindowTargetWindowId = 'target-child';
 
@@ -862,7 +932,7 @@ test.describe.serial('Neo.examples.dashboard.crossWindow.DemoBWorkspace', () => 
             await workspace.openTearOutVessel({
                 itemId: 'timeline', proxyRect: {height: 320, width: 480, x: 40, y: 60}
             });
-            await harness.connect('tear-child', vessel.openCalls.at(-1).url);
+            await harness.connect('tear-child', vessel.openCalls.at(-1).topologyIdentity);
             harness.register('target-child');
             workspace.crossWindowTargetWindowId = 'target-child';
 
@@ -893,10 +963,10 @@ test.describe.serial('Neo.examples.dashboard.crossWindow.DemoBWorkspace', () => 
     test('tear-out terminal-before-connect adopts only the granted child', async () => {
         const harness = installWindowConnectHarness(workspace),
               pane    = workspace.resolvePane('timeline', initialDocument.items.timeline);
-        let tearOutUrl;
+        let tearOutOpen;
 
         Neo.Main.windowOpen = async data => {
-            tearOutUrl = data.url;
+            tearOutOpen = data;
             return true
         };
 
@@ -915,7 +985,7 @@ test.describe.serial('Neo.examples.dashboard.crossWindow.DemoBWorkspace', () => 
             expect(pane.isDestroyed, 'terminal-first projection preserves the live pane for its late child')
                 .toBeFalsy();
 
-            await harness.connect('tear-after-terminal', tearOutUrl);
+            await harness.connect('tear-after-terminal', tearOutOpen.topologyIdentity);
 
             expect(harness.addedTo('tear-after-terminal')).toEqual([pane]);
             expect(workspace.tearOutPanes.timeline.windowId).toBe('tear-after-terminal')
@@ -1006,7 +1076,7 @@ test.describe.serial('Neo.examples.dashboard.crossWindow.DemoBWorkspace', () => 
             windowName: 'demo-b-cross-window'
         };
 
-        workspace.onWindowDisconnect({windowId: 'window-popup'});
+        releaseWindow('window-popup', DemoBWorkspace.POPUP_WORKSPACE_ID);
 
         expect(workspace.dockModel.items.workbench).toEqual(initialDocument.items.workbench);
         expect(workspace.popupDocument.items.workbench).toBeUndefined();
@@ -1066,7 +1136,7 @@ test.describe.serial('Neo.examples.dashboard.crossWindow.DemoBWorkspace', () => 
 
         expect(workspace.detachedPanes.workbench.windowId).toBe('window-popup');
 
-        workspace.onWindowDisconnect({windowId: 'window-popup'});
+        releaseWindow('window-popup', DemoBWorkspace.POPUP_WORKSPACE_ID);
 
         expect(workspace.dockModel.items.workbench).toEqual(initialDocument.items.workbench);
         expect(workspace.popupDocument.items.workbench).toBeUndefined();
@@ -1627,7 +1697,7 @@ test.describe.serial('Neo.examples.dashboard.crossWindow.DemoBWorkspace', () => 
 
         // the vessel dies: the disconnect correlates by windowId and the item returns home
         workspace.tearOutPanes.timeline = {windowName: 'demo-b-tearout-timeline', windowId: 'tear-win-9'};
-        workspace.onWindowDisconnect({windowId: 'tear-win-9'});
+        releaseWindow('tear-win-9', 'popup:timeline');
 
         expect(workspace.getDockZoneDocument().nodes['side-tabs'].items, 'identical order, not append order').toEqual(['inspector', 'timeline', 'console']);
         expect(workspace.tearOutPanes.timeline).toBeUndefined();
@@ -1636,7 +1706,7 @@ test.describe.serial('Neo.examples.dashboard.crossWindow.DemoBWorkspace', () => 
         // idempotent: a duplicate disconnect for the same window finds nothing and mutates nothing
         const stable = JSON.stringify(workspace.getDockZoneDocument());
 
-        workspace.onWindowDisconnect({windowId: 'tear-win-9'});
+        releaseWindow('tear-win-9', 'popup:timeline');
         expect(JSON.stringify(workspace.getDockZoneDocument())).toBe(stable)
     });
 
@@ -1658,7 +1728,7 @@ test.describe.serial('Neo.examples.dashboard.crossWindow.DemoBWorkspace', () => 
         expect(workspace.getDockZoneDocument().nodes['side-tabs']).toBeUndefined();
 
         workspace.tearOutPanes.timeline = {windowName: 'demo-b-tearout-timeline', windowId: 'tear-win-10'};
-        workspace.onWindowDisconnect({windowId: 'tear-win-10'});
+        releaseWindow('tear-win-10', 'popup:timeline');
 
         // semantic recovery: the first surviving tabs node, append — never a resurrected node,
         // never geometry
@@ -1686,7 +1756,7 @@ test.describe.serial('Neo.examples.dashboard.crossWindow.DemoBWorkspace', () => 
         workspace.onWorkspaceDocumentChange('demo-b-main', readd.document);
 
         workspace.tearOutPanes.timeline = {windowName: 'demo-b-tearout-timeline', windowId: 'tear-win-11'};
-        workspace.onWindowDisconnect({windowId: 'tear-win-11'});
+        releaseWindow('tear-win-11', 'popup:timeline');
 
         // the reintegration finds the item already placed and leaves it EXACTLY there — one
         // occurrence, in the node the other flow chose, placement record still consumed
@@ -1950,7 +2020,7 @@ test.describe.serial('Neo.examples.dashboard.crossWindow.DemoBWorkspace', () => 
 
     test('the second popup stages through the same seams with its own continuation and window name', async () => {
         const harness = installWindowConnectHarness(workspace);
-        let stageUrl, stageWindowName;
+        let stageOpen, stageWindowName;
 
         workspace.timeout = () => new Promise(() => {});
         workspace.mountCrossWindowTarget = async (app, windowId, workspaceId) => {
@@ -1961,9 +2031,9 @@ test.describe.serial('Neo.examples.dashboard.crossWindow.DemoBWorkspace', () => 
             resolve?.({hostId: 'workspace-host', windowId, workspaceId})
         };
         Neo.Main.windowOpen = async data => {
-            stageUrl        = data.url;
+            stageOpen       = data;
             stageWindowName = data.windowName;
-            await harness.connect('workspace-2-child', stageUrl);
+            await harness.connect('workspace-2-child', data.topologyIdentity);
             return true
         };
 
@@ -1973,11 +2043,13 @@ test.describe.serial('Neo.examples.dashboard.crossWindow.DemoBWorkspace', () => 
             expect(receipt).toMatchObject({windowId: 'workspace-2-child', workspaceId: DemoBWorkspace.POPUP2_WORKSPACE_ID});
             expect(stageWindowName).toBe('demo-b-cross-window-2');
 
-            const params = new URL(stageUrl, 'https://example.test').searchParams;
+            const params = new URL(stageOpen.url, 'https://example.test').searchParams;
 
             expect(params.get('workspaceId')).toBe('demo-b-popup-2');
-            expect(params.get('vesselFlow')).toBe('workspace-target');
-            expect(params.get('vesselGrant')).toBeTruthy();
+            expect([...params.keys()], 'the URL names the workspace; the owner rides the carrier').toEqual(['workspaceId']);
+            expect(stageOpen.topologyIdentity).toMatchObject({
+                groupId: workspace.topologyGroupId, workspaceKey: DemoBWorkspace.POPUP2_WORKSPACE_ID
+            });
 
             // popup-1's stage continuation is untouched by the popup-2 stage
             expect(workspace.crossWindowStagePromise).toBe(null);
@@ -2006,7 +2078,7 @@ test.describe.serial('Neo.examples.dashboard.crossWindow.DemoBWorkspace', () => 
         workspace.kbdLivePopup2 = Neo.create(Component, {});
 
         // popup-2 leaves: its own stage retires; the staged sibling pair (main + popup-1) survives
-        workspace.onWindowDisconnect({windowId: 'win-popup-2'});
+        releaseWindow('win-popup-2', DemoBWorkspace.POPUP2_WORKSPACE_ID);
 
         expect(popup2.destroyed).toBe(true);
         expect(popup.destroyed).toBe(false);
@@ -2018,7 +2090,7 @@ test.describe.serial('Neo.examples.dashboard.crossWindow.DemoBWorkspace', () => 
         expect(workspace.kbdLivePopup2).toBe(null);
 
         // popup-1 leaves: no popup target remains, so the main participation retires with it
-        workspace.onWindowDisconnect({windowId: 'win-popup-1'});
+        releaseWindow('win-popup-1', DemoBWorkspace.POPUP_WORKSPACE_ID);
 
         expect(popup.destroyed).toBe(true);
         expect(main.destroyed).toBe(true);

--- a/test/playwright/unit/examples/dashboard/crossWindow/DemoBWorkspace.spec.mjs
+++ b/test/playwright/unit/examples/dashboard/crossWindow/DemoBWorkspace.spec.mjs
@@ -194,7 +194,9 @@ function installWindowConnectHarness(workspace) {
                 }
             };
 
-            TransactionManager.admit({topologyIdentity, windowId});
+            // An identity the carrier holds binds synchronously inside the admission; a forked one
+            // after the carrier answered — awaited, so the handler's promise exists when read.
+            await TransactionManager.admit({topologyIdentity, windowId});
 
             await bindings.get(windowId)
         },
@@ -493,6 +495,90 @@ test.describe.serial('Neo.examples.dashboard.crossWindow.DemoBWorkspace', () => 
         } finally {
             harness.restore()
         }
+    });
+
+    test('a child presenting an expired or revoked reservation forks and reparents nothing — the pending record left with the slot', async () => {
+        const harness = installWindowConnectHarness(workspace);
+        let clickOpen;
+
+        // The popup opens but its window never connects.
+        Neo.Main.windowOpen = async data => {
+            clickOpen = data;
+            return true
+        };
+        TransactionManager.reconnectLeaseMs = 20;
+
+        try {
+            expect(await workspace.popOutPane('workbench')).toEqual({detached: true, errors: []});
+            expect(workspace.vesselReservations.get('popup:workbench')).toMatchObject({flow: 'click-popout', windowId: null});
+
+            // The lease runs out: the manager frees the slot, the workspace forgets the pending child.
+            await expect.poll(() => TransactionManager.getBinding(workspace.topologyGroupId, 'popup:workbench')).toBeNull();
+
+            expect(workspace.vesselReservations.has('popup:workbench'), 'the pending record left with the slot').toBe(false);
+
+            await harness.connect('late-child', clickOpen.topologyIdentity);
+
+            expect(TransactionManager.findByWindow('late-child').groupId, 'a dead lineage forks away').not.toBe(workspace.topologyGroupId);
+            expect(harness.addedTo('late-child'), 'nothing was reparented into the late window').toEqual([]);
+            expect(workspace.detachedPanes.workbench.windowId).toBeNull();
+
+            // A revoked reservation is dead the same way.
+            TransactionManager.reconnectLeaseMs = 20000;
+
+            const revoked = workspace.reserveVessel('popup:revoked', 'click-popout', 'demo-b-revoked');
+
+            workspace.revokeVessel('popup:revoked');
+
+            expect(workspace.vesselReservations.has('popup:revoked')).toBe(false);
+
+            await harness.connect('revoked-child', revoked);
+
+            expect(TransactionManager.findByWindow('revoked-child').groupId).not.toBe(workspace.topologyGroupId);
+            expect(harness.addedTo('revoked-child')).toEqual([])
+        } finally {
+            TransactionManager.reconnectLeaseMs = 20000;
+            harness.restore()
+        }
+    });
+
+    test('the production resolver keeps the three participants through the host window\'s release and lease expiry; a first boot registers them when its binding is accepted', async () => {
+        const groupId = workspace.topologyGroupId,
+              keys    = [DemoBWorkspace.MAIN_WORKSPACE_ID, DemoBWorkspace.POPUP_WORKSPACE_ID, DemoBWorkspace.POPUP2_WORKSPACE_ID];
+
+        expect(groupId).toBe(hostGroupId);
+        expect(workspace.workspaceSet.ids()).toEqual(keys);
+
+        TransactionManager.reconnectLeaseMs = 20;
+
+        try {
+            TransactionManager.release(Neo.config.windowId);
+
+            await expect.poll(() => TransactionManager.getBinding(groupId, 'main')).toBeNull();
+
+            expect(TransactionManager.findByWindow(Neo.config.windowId), 'the live binding is gone').toBeNull();
+            expect(workspace.topologyGroupId, 'the Group is remembered, not re-derived').toBe(groupId);
+            expect(workspace.workspaceSet.ids(), 'the documents are still the Group\'s').toEqual(keys);
+            expect(workspace.workspaceSet.getDocument(DemoBWorkspace.MAIN_WORKSPACE_ID)).toBe(workspace.dockModel)
+        } finally {
+            TransactionManager.reconnectLeaseMs = 20000
+        }
+
+        // A first boot: the window is not bound when the workspace constructs; its participants
+        // register when the minted identity is accepted and announced. The fixture instance goes
+        // first — this class hosts one live instance at a time — and the afterEach retires the
+        // first boot's Group through its window id.
+        workspace.destroy();
+        workspace = Neo.create(DemoBWorkspace, {windowId: 'demo-b-first-boot'});
+
+        expect(workspace.topologyGroupId).toBeNull();
+        expect(workspace.workspaceSet.ids(), 'nothing to join yet').toEqual([]);
+
+        const minted = await TransactionManager.admit({topologyIdentity: {}, windowId: 'demo-b-first-boot'});
+
+        expect(minted.outcome).toBe('minted');
+        expect(workspace.topologyGroupId, 'learned from the accepted binding').toBe(minted.groupId);
+        expect(workspace.workspaceSet.ids(), 'registered when the Group arrived').toEqual(keys)
     });
 
     test('the composition host arms BOTH geometry streams: its own window at construction, each admitted vessel before publication', async () => {

--- a/test/playwright/unit/examples/dashboard/crossWindow/DemoBWorkspace.spec.mjs
+++ b/test/playwright/unit/examples/dashboard/crossWindow/DemoBWorkspace.spec.mjs
@@ -250,14 +250,15 @@ function installWindowConnectHarness(workspace) {
  * owns it post-merge — these specs pin every seam the workspace itself decides.
  */
 test.describe.serial('Neo.examples.dashboard.crossWindow.DemoBWorkspace', () => {
-    let workspace;
+    let hostGroupId,
+        workspace;
 
     test.beforeEach(() => {
         workspace = Neo.create(DemoBWorkspace, {});
 
         // The host window binds into a Group the way its app registration does; every slot the
         // workspace reserves lives in it, and `topologyGroupId` reads it back.
-        TransactionManager.bind({windowId: workspace.windowId, workspaceKey: 'main'})
+        hostGroupId = TransactionManager.bind({windowId: workspace.windowId, workspaceKey: 'main'}).groupId
     });
 
     test.afterEach(() => {
@@ -267,7 +268,11 @@ test.describe.serial('Neo.examples.dashboard.crossWindow.DemoBWorkspace', () => 
         workspace?.destroy?.();
         workspace = null;
 
-        // The host's Group leaves with the arm: nothing of this window survives into the next one.
+        // The host's Group leaves with the arm — released slots and their leases included, which a
+        // live-window lookup could not find — so nothing of this window survives into the next one,
+        // or into the next spec file this worker runs.
+        TransactionManager.retireGroup(hostGroupId);
+
         while ((bound = TransactionManager.findByWindow(windowId))) {
             TransactionManager.retireGroup(bound.groupId)
         }

--- a/test/playwright/unit/examples/dashboard/crossWindow/DemoBWorkspace.spec.mjs
+++ b/test/playwright/unit/examples/dashboard/crossWindow/DemoBWorkspace.spec.mjs
@@ -254,11 +254,11 @@ test.describe.serial('Neo.examples.dashboard.crossWindow.DemoBWorkspace', () => 
         workspace;
 
     test.beforeEach(() => {
-        workspace = Neo.create(DemoBWorkspace, {});
-
-        // The host window binds into a Group the way its app registration does; every slot the
-        // workspace reserves lives in it, and `topologyGroupId` reads it back.
-        hostGroupId = TransactionManager.bind({windowId: workspace.windowId, workspaceKey: 'main'}).groupId
+        // The host window binds into a Group the way its app registration does — before the workspace
+        // constructs, as in production, so its participants register into that Group; every slot the
+        // workspace reserves lives in it too, and `topologyGroupId` reads it back.
+        hostGroupId = TransactionManager.bind({windowId: Neo.config.windowId, workspaceKey: 'main'}).groupId;
+        workspace   = Neo.create(DemoBWorkspace, {windowId: Neo.config.windowId})
     });
 
     test.afterEach(() => {
@@ -509,7 +509,7 @@ test.describe.serial('Neo.examples.dashboard.crossWindow.DemoBWorkspace', () => 
 
         // The stub has to be in place before construction, which is where the host arms its own window.
         workspace.destroy();
-        workspace = Neo.create(DemoBWorkspace, {});
+        workspace = Neo.create(DemoBWorkspace, {windowId: Neo.config.windowId});
 
         const harness = installWindowConnectHarness(workspace);
 

--- a/test/playwright/unit/main/MainNativeWindowRoute.spec.mjs
+++ b/test/playwright/unit/main/MainNativeWindowRoute.spec.mjs
@@ -341,6 +341,8 @@ async function runNativeWindowRouteProbe(scenario) {
                 secondHandle: second?.nativeHandleKey ?? null
             }))
         } else if (scenario === 'topology-identity') {
+            // The boot-time reader lives on the worker manager; Main only writes and hands off.
+            const {default: WorkerManager} = await import('./src/worker/Manager.mjs');
             const
                 storage      = new Map(),
                 childStorage = new Map(),
@@ -350,13 +352,13 @@ async function runNativeWindowRouteProbe(scenario) {
                 removeItem: key => storage.delete(key),
                 setItem   : (key, value) => storage.set(key, value)
             };
-            const empty    = Main.getWindowData().topologyIdentity;
+            const empty    = WorkerManager.readTopologyIdentity();
             const accepted = Main.setTopologyIdentity({generationToken: 't1', groupId: 'g1', workspaceKey: 'main'});
-            const carried  = Main.getWindowData().topologyIdentity;
+            const carried  = WorkerManager.readTopologyIdentity();
             storage.set('neo-topology-identity', '{not json');
-            const malformed = Main.getWindowData().topologyIdentity;
+            const malformed = WorkerManager.readTopologyIdentity();
             storage.set('neo-topology-identity', JSON.stringify({groupId: 'g1'}));
-            const partial = Main.getWindowData().topologyIdentity;
+            const partial = WorkerManager.readTopologyIdentity();
             const popup = {
                 closed        : false,
                 innerHeight   : 500,

--- a/test/playwright/unit/main/MainNativeWindowRoute.spec.mjs
+++ b/test/playwright/unit/main/MainNativeWindowRoute.spec.mjs
@@ -340,6 +340,46 @@ async function runNativeWindowRouteProbe(scenario) {
                 released,
                 secondHandle: second?.nativeHandleKey ?? null
             }))
+        } else if (scenario === 'topology-identity') {
+            const
+                storage      = new Map(),
+                childStorage = new Map(),
+                inherited    = () => childStorage.set('neo-topology-identity', JSON.stringify({generationToken: 't1', groupId: 'g1', workspaceKey: 'main'}));
+            globalThis.sessionStorage = {
+                getItem   : key => storage.get(key) ?? null,
+                removeItem: key => storage.delete(key),
+                setItem   : (key, value) => storage.set(key, value)
+            };
+            const empty    = Main.getWindowData().topologyIdentity;
+            const accepted = Main.setTopologyIdentity({generationToken: 't1', groupId: 'g1', workspaceKey: 'main'});
+            const carried  = Main.getWindowData().topologyIdentity;
+            storage.set('neo-topology-identity', '{not json');
+            const malformed = Main.getWindowData().topologyIdentity;
+            storage.set('neo-topology-identity', JSON.stringify({groupId: 'g1'}));
+            const partial = Main.getWindowData().topologyIdentity;
+            const popup = {
+                closed        : false,
+                innerHeight   : 500,
+                outerWidth    : 600,
+                document      : {createElement: () => ({}), head: {append() {}}},
+                location      : {replace() {}},
+                resizeTo() {},
+                sessionStorage: {
+                    getItem   : key => childStorage.get(key) ?? null,
+                    removeItem: key => childStorage.delete(key),
+                    setItem   : (key, value) => childStorage.set(key, value)
+                }
+            };
+            globalThis.open       = () => popup;
+            globalThis.setTimeout = () => 1;
+            Main.openWindows      = {};
+            inherited();
+            Main.windowOpen({topologyIdentity: {generationToken: 't2', groupId: 'g1', workspaceKey: 'popup:documents'}, url: './popup.html', windowName: 'reserved'});
+            const reserved = JSON.parse(childStorage.get('neo-topology-identity'));
+            inherited();
+            Main.windowOpen({url: './popup.html', windowName: 'plain'});
+            const cleared = !childStorage.has('neo-topology-identity');
+            console.log(JSON.stringify({accepted, carried, cleared, empty, malformed, partial, reserved}))
         } else {
             const
                 events   = [],
@@ -807,5 +847,17 @@ test.describe('Neo.Main native window routes (#15396)', () => {
         expect(result.consumed.map(item => item.token)).toEqual(['token-a']);
         expect(result.released).toEqual(['handle-token-a']);
         expect(result.remainingToken).toBe('token-b')
+    });
+
+    test('the topology identity rides the native route carrier: read on boot, written back, reserved for a staged child, cleared when nothing was reserved', async () => {
+        const result = await runNativeWindowRouteProbe('topology-identity');
+
+        expect(result.empty, 'no carrier yet: the worker mints').toEqual({});
+        expect(result.accepted).toBe(true);
+        expect(result.carried, 'the next page load presents what the worker wrote back').toEqual({generationToken: 't1', groupId: 'g1', workspaceKey: 'main'});
+        expect(result.malformed, 'a broken record boots a fresh root').toEqual({});
+        expect(result.partial, 'an incomplete record boots a fresh root').toEqual({});
+        expect(result.reserved, 'the staged child carries the slot its opener reserved').toEqual({generationToken: 't2', groupId: 'g1', workspaceKey: 'popup:documents'});
+        expect(result.cleared, 'a child opened without a reservation boots as its own root').toBe(true)
     })
 });

--- a/test/playwright/unit/manager/Transaction.spec.mjs
+++ b/test/playwright/unit/manager/Transaction.spec.mjs
@@ -22,11 +22,8 @@ import * as core      from '../../../../src/core/_export.mjs';
 test.describe.serial('Neo.manager.Transaction — Groups and token-matched window bindings', () => {
     let Transaction;
 
-    const connect = (windowId, topologyIdentity) => Transaction.onWindowConnect({
-        appName   : 'Workstation',
-        windowData: topologyIdentity === undefined ? {} : {topologyIdentity},
-        windowId
-    });
+    // The worker admits a window when its config registers, carrying the identity the main thread read.
+    const connect = (windowId, topologyIdentity) => Transaction.admit({topologyIdentity, windowId});
 
     test.beforeAll(async () => {
         Transaction = (await import('../../../../src/manager/Transaction.mjs')).default
@@ -140,7 +137,7 @@ test.describe.serial('Neo.manager.Transaction — Groups and token-matched windo
         expect(Transaction.getBinding('group-from-a-previous-worker', 'main').windowId).toBe('w1')
     });
 
-    test('a reserved slot cannot be reserved again while live, and a connect without any identity slot is left alone', () => {
+    test('a reserved slot cannot be reserved again while live, and an empty carrier admits a fresh root', () => {
         const a = Transaction.bind({windowId: 'a1', workspaceKey: 'main'});
 
         expect(Transaction.reserve({groupId: a.groupId, workspaceKey: 'main'}), 'a live slot').toBeNull();
@@ -148,9 +145,29 @@ test.describe.serial('Neo.manager.Transaction — Groups and token-matched windo
 
         const before = Transaction.items.length;
 
-        connect('legacy-window');
+        expect(connect('fresh-root', {}).outcome, 'no carrier yet: a Group is minted').toBe('minted');
+        expect(Transaction.items).toHaveLength(before + 1)
+    });
 
-        expect(Transaction.items, 'no identity slot in windowData: nothing bound').toHaveLength(before)
+    test('a carrier write the main realm cannot take yet is parked, and flushed once it can', () => {
+        const writes = [];
+
+        Neo.ns('Neo.Main', true);
+        delete Neo.Main.setTopologyIdentity;
+
+        connect('early-root', {});
+
+        expect(Transaction.pendingCarrierWrites.has('early-root'), 'parked: no remote surface yet').toBe(true);
+
+        Neo.Main.setTopologyIdentity = data => writes.push(data);
+
+        try {
+            expect(Transaction.flushCarrierWrite('early-root')).toBe(true);
+            expect(writes).toEqual([{generationToken: expect.any(String), groupId: expect.any(String), windowId: 'early-root', workspaceKey: 'main'}]);
+            expect(Transaction.flushCarrierWrite('early-root'), 'nothing left to flush').toBe(false)
+        } finally {
+            delete Neo.Main.setTopologyIdentity
+        }
     });
 
     test('the carrier learns what the worker decided: minted and forked identities are written back, a rebind is not', () => {

--- a/test/playwright/unit/manager/Transaction.spec.mjs
+++ b/test/playwright/unit/manager/Transaction.spec.mjs
@@ -1,0 +1,155 @@
+import {setup} from '../../setup.mjs';
+
+setup({
+    appConfig: {
+        name: 'ManagerTransactionTest'
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../src/Neo.mjs';
+import * as core      from '../../../../src/core/_export.mjs';
+
+/**
+ * A Group is the identity of one multi-window topology instance; `appName` only routes. These arms drive
+ * the manager the way the worker does — `onWindowConnect` with the carrier's identity inside `windowData`,
+ * `onWindowDisconnect` with the generation that left — and read the outcomes back.
+ *
+ * The falsifier is two Workstation roots under one worker: A and its popup share a Group, B shares only
+ * the app name, reloading A's root moves one generation and touches neither B nor a second Group, and a
+ * late disconnect for the superseded generation cannot unbind its successor.
+ */
+test.describe.serial('Neo.manager.Transaction — Groups and token-matched window bindings', () => {
+    let Transaction;
+
+    const connect = (windowId, topologyIdentity) => Transaction.onWindowConnect({
+        appName   : 'Workstation',
+        windowData: topologyIdentity === undefined ? {} : {topologyIdentity},
+        windowId
+    });
+
+    test.beforeAll(async () => {
+        Transaction = (await import('../../../../src/manager/Transaction.mjs')).default
+    });
+
+    test.afterEach(() => {
+        [...Transaction.items].forEach(group => Transaction.retireGroup(group.id));
+        Transaction.reconnectLeaseMs = 20000
+    });
+
+    test('a root without identity mints a Group; a second root of the same app mints another', () => {
+        const a = Transaction.bind({windowId: 'a1', workspaceKey: 'main'}),
+              b = Transaction.bind({windowId: 'b1', workspaceKey: 'main'});
+
+        expect(a.outcome).toBe('minted');
+        expect(b.outcome).toBe('minted');
+        expect(a.groupId).not.toBe(b.groupId);
+        expect(Transaction.items).toHaveLength(2);
+        expect(Transaction.getBinding(a.groupId, 'main')).toEqual({generation: 1, windowId: 'a1', workspaceKey: 'main'});
+        expect(Transaction.findByWindow('b1')).toEqual({generation: 1, groupId: b.groupId, workspaceKey: 'main'})
+    });
+
+    test('the two-Workstation falsifier: a reload moves one generation, and a late disconnect cannot unbind the successor', () => {
+        const a = Transaction.bind({windowId: 'a1', workspaceKey: 'main'}),
+              b = Transaction.bind({windowId: 'b1', workspaceKey: 'main'});
+
+        // The opener reserves the popup slot and writes the reservation into the child's carrier.
+        const reservation = Transaction.reserve({groupId: a.groupId, workspaceKey: 'popup:documents'});
+
+        expect(reservation).toEqual({generationToken: expect.any(String), groupId: a.groupId, workspaceKey: 'popup:documents'});
+
+        connect('a2', reservation);
+
+        expect(Transaction.findByWindow('a2')).toEqual({generation: 1, groupId: a.groupId, workspaceKey: 'popup:documents'});
+
+        // Reload A's root: the old generation leaves, the new one presents the carried identity.
+        Transaction.onWindowDisconnect({windowId: 'a1'});
+
+        expect(Transaction.getBinding(a.groupId, 'main').windowId, 'the slot is held, not freed').toBeNull();
+
+        const reloaded = Transaction.bind({groupId: a.groupId, workspaceKey: 'main', generationToken: a.generationToken, windowId: 'a3'});
+
+        expect(reloaded.outcome).toBe('rebound');
+        expect(reloaded.groupId, 'no Group was created').toBe(a.groupId);
+        expect(reloaded.generation).toBe(2);
+        expect(Transaction.items, 'A and B, nothing else').toHaveLength(2);
+
+        // B and A's popup are untouched.
+        expect(Transaction.getBinding(b.groupId, 'main')).toEqual({generation: 1, windowId: 'b1', workspaceKey: 'main'});
+        expect(Transaction.findByWindow('a2').groupId).toBe(a.groupId);
+
+        // The superseded generation reports its disconnect late.
+        expect(Transaction.release('a1'), 'no binding carries a1 any more').toBe(false);
+        expect(Transaction.getBinding(a.groupId, 'main')).toEqual({generation: 2, windowId: 'a3', workspaceKey: 'main'})
+    });
+
+    test('a copied identity presented while its binder is live forks a new Group', () => {
+        const a         = Transaction.bind({windowId: 'a1', workspaceKey: 'main'}),
+              duplicate = Transaction.bind({groupId: a.groupId, workspaceKey: 'main', generationToken: a.generationToken, windowId: 'a1-copy'});
+
+        expect(duplicate.outcome).toBe('forked');
+        expect(duplicate.groupId).not.toBe(a.groupId);
+        expect(duplicate.generationToken, 'the fork carries its own lineage').not.toBe(a.generationToken);
+        expect(Transaction.getBinding(a.groupId, 'main').windowId, 'the live binder was not superseded').toBe('a1');
+        expect(Transaction.findByWindow('a1-copy').groupId).toBe(duplicate.groupId)
+    });
+
+    test('a released slot rebinds only for its lineage token; a stranger forks', () => {
+        const a = Transaction.bind({windowId: 'a1', workspaceKey: 'main'});
+
+        Transaction.release('a1');
+
+        const stranger = Transaction.bind({groupId: a.groupId, workspaceKey: 'main', generationToken: 'not-the-lineage', windowId: 's1'});
+
+        expect(stranger.outcome).toBe('forked');
+        expect(stranger.groupId).not.toBe(a.groupId);
+        expect(Transaction.getBinding(a.groupId, 'main').windowId, 'the held slot stays held for its lineage').toBeNull();
+
+        const heir = Transaction.bind({groupId: a.groupId, workspaceKey: 'main', generationToken: a.generationToken, windowId: 'a2'});
+
+        expect(heir.outcome).toBe('rebound');
+        expect(heir.generation).toBe(2)
+    });
+
+    test('the reconnect lease is bounded: past it the slot is free and a fresh binder is bound, not rebound', async () => {
+        Transaction.reconnectLeaseMs = 20;
+
+        const a       = Transaction.bind({windowId: 'a1', workspaceKey: 'main'}),
+              expired = [];
+
+        Transaction.on('leaseExpired', data => expired.push(data));
+        Transaction.release('a1');
+
+        await new Promise(resolve => setTimeout(resolve, 60));
+
+        expect(expired).toEqual([expect.objectContaining({groupId: a.groupId, workspaceKey: 'main'})]);
+        expect(Transaction.getBinding(a.groupId, 'main'), 'the slot is free').toBeNull();
+
+        const late = Transaction.bind({groupId: a.groupId, workspaceKey: 'main', generationToken: a.generationToken, windowId: 'a2'});
+
+        expect(late.outcome).toBe('bound');
+        expect(late.groupId, 'the Group itself is kept — retirement is a separate, conditional contract').toBe(a.groupId)
+    });
+
+    test('a Group this worker never saw is created cold under the carried id, so persisted state can find it later', () => {
+        const cold = Transaction.bind({groupId: 'group-from-a-previous-worker', workspaceKey: 'main', generationToken: 'lineage', windowId: 'w1'});
+
+        expect(cold.outcome).toBe('cold');
+        expect(cold.groupId).toBe('group-from-a-previous-worker');
+        expect(cold.generationToken, 'the carried lineage is kept').toBe('lineage');
+        expect(Transaction.getBinding('group-from-a-previous-worker', 'main').windowId).toBe('w1')
+    });
+
+    test('a reserved slot cannot be reserved again while live, and a connect without any identity slot is left alone', () => {
+        const a = Transaction.bind({windowId: 'a1', workspaceKey: 'main'});
+
+        expect(Transaction.reserve({groupId: a.groupId, workspaceKey: 'main'}), 'a live slot').toBeNull();
+        expect(Transaction.reserve({groupId: 'unknown', workspaceKey: 'popup:x'}), 'an unknown Group').toBeNull();
+
+        const before = Transaction.items.length;
+
+        connect('legacy-window');
+
+        expect(Transaction.items, 'no identity slot in windowData: nothing bound').toHaveLength(before)
+    })
+});

--- a/test/playwright/unit/manager/Transaction.spec.mjs
+++ b/test/playwright/unit/manager/Transaction.spec.mjs
@@ -166,23 +166,33 @@ test.describe.serial('Neo.manager.Transaction — Groups and token-matched windo
         expect(Transaction.items).toHaveLength(before + 1)
     });
 
-    test('a carrier write the main realm cannot take yet is parked, and flushed once it can', () => {
-        const writes = [];
+    test('a manager loading after apps registered admits every live window with the identity its config carried', () => {
+        // The module loads on demand — with the first multi-window participant — so the windows whose
+        // apps registered before that moment must not stay unbound. A second instance of the class
+        // stands in for that later load; the singleton the worker uses is untouched.
+        const
+            writes          = [],
+            previousApps    = Neo.apps,
+            previousConfigs = Neo.windowConfigs,
+            carried         = {generationToken: 'lineage-7', groupId: 'group-carried', workspaceKey: 'popup:notes'};
 
-        Neo.ns('Neo.Main', true);
-        delete Neo.Main.setTopologyIdentity;
+        let late;
 
-        connect('early-root', {});
-
-        expect(Transaction.pendingCarrierWrites.has('early-root'), 'parked: no remote surface yet').toBe(true);
-
-        Neo.Main.setTopologyIdentity = data => writes.push(data);
+        Neo.ns('Neo.Main', true).setTopologyIdentity = data => writes.push(data);
+        Neo.apps          = {'late-popup': {}, 'late-root': {}};
+        Neo.windowConfigs = {'late-popup': {topologyIdentity: carried}};
 
         try {
-            expect(Transaction.flushCarrierWrite('early-root')).toBe(true);
-            expect(writes).toEqual([{generationToken: expect.any(String), groupId: expect.any(String), windowId: 'early-root', workspaceKey: 'main'}]);
-            expect(Transaction.flushCarrierWrite('early-root'), 'nothing left to flush').toBe(false)
+            late = Neo.create(Transaction.constructor, {});
+
+            expect(late.findByWindow('late-root')).toEqual({generation: 1, groupId: expect.any(String), workspaceKey: 'main'});
+            expect(late.findByWindow('late-popup'), 'a carried identity binds cold under its own Group').toEqual({generation: 1, groupId: 'group-carried', workspaceKey: 'popup:notes'});
+            expect(late.items).toHaveLength(2);
+            expect(writes.map(write => write.windowId), 'only the minted root learns something new').toEqual(['late-root'])
         } finally {
+            late?.destroy();
+            Neo.apps          = previousApps;
+            Neo.windowConfigs = previousConfigs;
             delete Neo.Main.setTopologyIdentity
         }
     });

--- a/test/playwright/unit/manager/Transaction.spec.mjs
+++ b/test/playwright/unit/manager/Transaction.spec.mjs
@@ -122,10 +122,27 @@ test.describe.serial('Neo.manager.Transaction — Groups and token-matched windo
         expect(expired).toEqual([expect.objectContaining({groupId: a.groupId, workspaceKey: 'main'})]);
         expect(Transaction.getBinding(a.groupId, 'main'), 'the slot is free').toBeNull();
 
+        // Its last slot gone, the Group held nothing else: it is retired rather than left behind.
+        expect(Transaction.get(a.groupId), 'an empty Group does not linger').toBeNull();
+
         const late = Transaction.bind({groupId: a.groupId, workspaceKey: 'main', generationToken: a.generationToken, windowId: 'a2'});
 
-        expect(late.outcome).toBe('bound');
-        expect(late.groupId, 'the Group itself is kept — retirement is a separate, conditional contract').toBe(a.groupId)
+        expect(late.outcome, 'the carried id comes back cold, not into a lingering record').toBe('cold');
+        expect(late.groupId).toBe(a.groupId)
+    });
+
+    test('a lease running out on one slot keeps a Group that still binds another', async () => {
+        Transaction.reconnectLeaseMs = 20;
+
+        const a = Transaction.bind({windowId: 'a1', workspaceKey: 'main'});
+
+        connect('a2', Transaction.reserve({groupId: a.groupId, workspaceKey: 'popup:documents'}));
+        Transaction.release('a2');
+
+        await new Promise(resolve => setTimeout(resolve, 60));
+
+        expect(Transaction.getBinding(a.groupId, 'popup:documents'), 'the popup slot is free').toBeNull();
+        expect(Transaction.getBinding(a.groupId, 'main'), 'the root still binds').toEqual({generation: 1, windowId: 'a1', workspaceKey: 'main'})
     });
 
     test('a Group this worker never saw is created cold under the carried id, so persisted state can find it later', () => {

--- a/test/playwright/unit/manager/Transaction.spec.mjs
+++ b/test/playwright/unit/manager/Transaction.spec.mjs
@@ -25,14 +25,19 @@ test.describe.serial('Neo.manager.Transaction — Groups and token-matched windo
     // The worker admits a window when its config registers, carrying the identity the main thread read.
     const connect = (windowId, topologyIdentity) => Transaction.admit({topologyIdentity, windowId});
 
+    // The manager is a worker-wide singleton, and a Playwright worker runs many spec files: a Group a
+    // sibling spec released and left to its lease would count here. Every arm starts from nothing.
+    const reset = () => {
+        [...Transaction.items].forEach(group => Transaction.retireGroup(group.id));
+        Transaction.reconnectLeaseMs = 20000
+    };
+
     test.beforeAll(async () => {
         Transaction = (await import('../../../../src/manager/Transaction.mjs')).default
     });
 
-    test.afterEach(() => {
-        [...Transaction.items].forEach(group => Transaction.retireGroup(group.id));
-        Transaction.reconnectLeaseMs = 20000
-    });
+    test.beforeEach(reset);
+    test.afterEach(reset);
 
     test('a root without identity mints a Group; a second root of the same app mints another', () => {
         const a = Transaction.bind({windowId: 'a1', workspaceKey: 'main'}),

--- a/test/playwright/unit/manager/Transaction.spec.mjs
+++ b/test/playwright/unit/manager/Transaction.spec.mjs
@@ -151,5 +151,36 @@ test.describe.serial('Neo.manager.Transaction — Groups and token-matched windo
         connect('legacy-window');
 
         expect(Transaction.items, 'no identity slot in windowData: nothing bound').toHaveLength(before)
+    });
+
+    test('the carrier learns what the worker decided: minted and forked identities are written back, a rebind is not', () => {
+        const writes = [];
+
+        Neo.ns('Neo.Main', true).setTopologyIdentity = data => writes.push(data);
+
+        try {
+            connect('r1', {});
+
+            expect(writes).toHaveLength(1);
+
+            const identity = writes[0];
+
+            expect(identity).toEqual({generationToken: expect.any(String), groupId: expect.any(String), windowId: 'r1', workspaceKey: 'main'});
+
+            // A warm reload presents the carried identity and rebinds — the carrier already holds it.
+            Transaction.onWindowDisconnect({windowId: 'r1'});
+            connect('r2', {generationToken: identity.generationToken, groupId: identity.groupId, workspaceKey: 'main'});
+
+            expect(writes, 'a rebind carries nothing new').toHaveLength(1);
+
+            // A copied identity while r2 is live forks, and the fork's window learns its new Group.
+            connect('r3', {generationToken: identity.generationToken, groupId: identity.groupId, workspaceKey: 'main'});
+
+            expect(writes).toHaveLength(2);
+            expect(writes[1].windowId).toBe('r3');
+            expect(writes[1].groupId).not.toBe(identity.groupId)
+        } finally {
+            delete Neo.Main.setTopologyIdentity
+        }
     })
 });

--- a/test/playwright/unit/manager/Transaction.spec.mjs
+++ b/test/playwright/unit/manager/Transaction.spec.mjs
@@ -12,7 +12,7 @@ import * as core      from '../../../../src/core/_export.mjs';
 
 /**
  * A Group is the identity of one multi-window topology instance; `appName` only routes. These arms drive
- * the manager the way the worker does — `onWindowConnect` with the carrier's identity inside `windowData`,
+ * the manager the way the worker does — `admit` with the identity the carrier presented at registration,
  * `onWindowDisconnect` with the generation that left — and read the outcomes back.
  *
  * The falsifier is two Workstation roots under one worker: A and its popup share a Group, B shares only
@@ -23,6 +23,8 @@ test.describe.serial('Neo.manager.Transaction — Groups and token-matched windo
     let Transaction;
 
     // The worker admits a window when its config registers, carrying the identity the main thread read.
+    // Admission is a promise: an identity the carrier already holds settles synchronously inside it, a
+    // minted or forked one only after the carrier answered — so every arm awaits it.
     const connect = (windowId, topologyIdentity) => Transaction.admit({topologyIdentity, windowId});
 
     // The manager is a worker-wide singleton, and a Playwright worker runs many spec files: a Group a
@@ -51,7 +53,7 @@ test.describe.serial('Neo.manager.Transaction — Groups and token-matched windo
         expect(Transaction.findByWindow('b1')).toEqual({generation: 1, groupId: b.groupId, workspaceKey: 'main'})
     });
 
-    test('the two-Workstation falsifier: a reload moves one generation, and a late disconnect cannot unbind the successor', () => {
+    test('the two-Workstation falsifier: a reload moves one generation, and a late disconnect cannot unbind the successor', async () => {
         const a = Transaction.bind({windowId: 'a1', workspaceKey: 'main'}),
               b = Transaction.bind({windowId: 'b1', workspaceKey: 'main'});
 
@@ -60,7 +62,7 @@ test.describe.serial('Neo.manager.Transaction — Groups and token-matched windo
 
         expect(reservation).toEqual({generationToken: expect.any(String), groupId: a.groupId, workspaceKey: 'popup:documents'});
 
-        connect('a2', reservation);
+        expect((await connect('a2', reservation)).outcome, 'a reserved slot binds').toBe('bound');
 
         expect(Transaction.findByWindow('a2')).toEqual({generation: 1, groupId: a.groupId, workspaceKey: 'popup:documents'});
 
@@ -141,7 +143,7 @@ test.describe.serial('Neo.manager.Transaction — Groups and token-matched windo
 
         const a = Transaction.bind({windowId: 'a1', workspaceKey: 'main'});
 
-        connect('a2', Transaction.reserve({groupId: a.groupId, workspaceKey: 'popup:documents'}));
+        await connect('a2', Transaction.reserve({groupId: a.groupId, workspaceKey: 'popup:documents'}));
         Transaction.release('a2');
 
         await new Promise(resolve => setTimeout(resolve, 60));
@@ -194,7 +196,7 @@ test.describe.serial('Neo.manager.Transaction — Groups and token-matched windo
         expect(Transaction.getBinding('group-from-a-previous-worker', 'main').windowId).toBe('w1')
     });
 
-    test('a reserved slot cannot be reserved again while live, and an empty carrier admits a fresh root', () => {
+    test('a reserved slot cannot be reserved again while live, and an empty carrier admits a fresh root', async () => {
         const a = Transaction.bind({windowId: 'a1', workspaceKey: 'main'});
 
         expect(Transaction.reserve({groupId: a.groupId, workspaceKey: 'main'}), 'a live slot').toBeNull();
@@ -202,11 +204,154 @@ test.describe.serial('Neo.manager.Transaction — Groups and token-matched windo
 
         const before = Transaction.items.length;
 
-        expect(connect('fresh-root', {}).outcome, 'no carrier yet: a Group is minted').toBe('minted');
+        expect((await connect('fresh-root', {})).outcome, 'no carrier yet: a Group is minted').toBe('minted');
         expect(Transaction.items).toHaveLength(before + 1)
     });
 
-    test('a manager loading after apps registered admits every live window with the identity its config carried', () => {
+    test('a revocation is fenced by lineage: an older reservation\'s failure cannot give back its replacement\'s slot, the holder can', () => {
+        const a  = Transaction.bind({windowId: 'a1', workspaceKey: 'main'}),
+              s1 = Transaction.reserve({groupId: a.groupId, workspaceKey: 'popup:x'}),
+              // A second open for the same item while the first is still pending: the slot is
+              // reserved again under a fresh token, and the first token is superseded.
+              s2 = Transaction.reserve({groupId: a.groupId, workspaceKey: 'popup:x'});
+
+        expect(s2.generationToken).not.toBe(s1.generationToken);
+
+        // The older open fails late and cleans up after itself — naming a token the slot no longer carries.
+        expect(Transaction.revoke(s1), 'a superseded reservation revokes nothing').toBe(false);
+        expect(Transaction.getBinding(a.groupId, 'popup:x'), 'the replacement is untouched').toEqual({generation: 0, windowId: null, workspaceKey: 'popup:x'});
+        expect(Transaction.revoke({groupId: a.groupId, workspaceKey: 'popup:x'}), 'no token, no revocation').toBe(false);
+
+        expect(Transaction.revoke(s2), 'the holder gives its slot back').toBe(true);
+        expect(Transaction.getBinding(a.groupId, 'popup:x')).toBeNull();
+        expect(Transaction.revoke(s2), 'exact-once').toBe(false)
+    });
+
+    test('a dead lineage is not a door: an expired or revoked reservation presented late forks, an active one binds, a cold root still returns', async () => {
+        Transaction.reconnectLeaseMs = 20;
+
+        const a       = Transaction.bind({windowId: 'a1', workspaceKey: 'main'}),
+              expired = Transaction.reserve({groupId: a.groupId, workspaceKey: 'popup:documents'});
+
+        await new Promise(resolve => setTimeout(resolve, 60));
+
+        expect(Transaction.getBinding(a.groupId, 'popup:documents'), 'the lease ran out; the root keeps the Group alive').toBeNull();
+
+        const late = await connect('late-child', expired);
+
+        expect(late.outcome, 'the presented lineage names a slot the Group no longer holds').toBe('forked');
+        expect(late.groupId).not.toBe(a.groupId);
+        expect(Transaction.getBinding(a.groupId, 'popup:documents'), 'nothing entered the Group').toBeNull();
+
+        const revoked = Transaction.reserve({groupId: a.groupId, workspaceKey: 'popup:documents'});
+
+        expect(Transaction.revoke(revoked)).toBe(true);
+        expect((await connect('revoked-child', revoked)).outcome).toBe('forked');
+
+        // The root's own token presented for a slot it never reserved is a dead lineage for that slot too.
+        expect((await connect('unreserved', {...a, workspaceKey: 'popup:terminal'})).outcome).toBe('forked');
+        expect(Transaction.getBinding(a.groupId, 'popup:terminal')).toBeNull();
+
+        // Positive control: the reservation that is live admits its child into the Group.
+        const active = Transaction.reserve({groupId: a.groupId, workspaceKey: 'popup:documents'}),
+              child  = await connect('child', active);
+
+        expect(child).toMatchObject({generation: 1, groupId: a.groupId, outcome: 'bound', workspaceKey: 'popup:documents'});
+
+        // Cold control: a Group this worker never saw still admits the identity its carrier holds.
+        expect(Transaction.bind({groupId: 'from-a-dead-worker', workspaceKey: 'popup:notes', generationToken: 'lineage', windowId: 'c1'}).outcome).toBe('cold')
+    });
+
+    test('a minted or forked identity is published once its carrier accepted it: pending exposes nothing, false or a rejection admits nothing, a gone window is refused, and the accepted root rebinds on reload', async () => {
+        const
+            before  = Transaction.items.length,
+            binds   = [],
+            refused = [],
+            writes  = [],
+            // `fire` drops a listener whose scope carries no `id` — the sign of a destroyed instance.
+            scope    = {id: 'transaction-spec-publication-witness'},
+            listener = {admissionRefused: data => refused.push(data), bind: data => binds.push(data), scope};
+
+        let answer;
+
+        const deferredSetter = data => {
+            writes.push(data);
+
+            return new Promise(resolve => {answer = resolve})
+        };
+
+        Transaction.on(listener);
+        Neo.ns('Neo.Main', true).setTopologyIdentity = deferredSetter;
+
+        try {
+            const pending = connect('p1', {});
+
+            expect(writes).toHaveLength(1);
+            expect(Transaction.findByWindow('p1'), 'pending: nothing is bound').toBeNull();
+            expect(Transaction.items, 'pending: no Group exists yet').toHaveLength(before);
+            expect(binds, 'pending: nothing is published').toEqual([]);
+
+            answer(true);
+
+            const root = await pending;
+
+            expect(root).toMatchObject({generation: 1, outcome: 'minted', windowId: 'p1', workspaceKey: 'main'});
+            expect(Transaction.findByWindow('p1').groupId).toBe(root.groupId);
+            expect(binds.map(data => data.windowId), 'published exactly once, after acceptance').toEqual(['p1']);
+
+            // The carrier refuses: a write that returns false, one that rejects, and one that answers
+            // anything but `true` all admit nothing.
+            for (const setter of [() => false, () => Promise.reject(new Error('storage unavailable')), data => writes.push(data)]) {
+                Neo.Main.setTopologyIdentity = setter;
+
+                const outcome = await connect(`refused-${refused.length}`, {});
+
+                expect(outcome).toMatchObject({generation: 0, generationToken: null, groupId: null, outcome: 'refused'});
+                expect(Transaction.findByWindow(outcome.windowId)).toBeNull()
+            }
+
+            expect(refused.map(data => data.reason)).toEqual(['carrier-refused', 'carrier-refused', 'carrier-refused']);
+            expect(Transaction.items, 'a refused admission leaves no Group behind').toHaveLength(before + 1);
+
+            // The window leaves while its write is pending: the late answer binds nothing.
+            Neo.Main.setTopologyIdentity = deferredSetter;
+
+            const gone = connect('p3', {});
+
+            Transaction.release('p3');
+            answer(true);
+
+            expect((await gone).outcome).toBe('refused');
+            expect(refused.at(-1)).toMatchObject({reason: 'window-gone', windowId: 'p3'});
+            expect(Transaction.findByWindow('p3')).toBeNull();
+
+            // A fork waits the same way: the copy is invisible until its carrier accepted it.
+            const copy = connect('p1-copy', {generationToken: root.generationToken, groupId: root.groupId, workspaceKey: 'main'});
+
+            expect(Transaction.findByWindow('p1-copy')).toBeNull();
+            expect(Transaction.getBinding(root.groupId, 'main').windowId, 'the live binder is untouched').toBe('p1');
+
+            answer(true);
+
+            expect((await copy).outcome).toBe('forked');
+            expect(Transaction.findByWindow('p1-copy').groupId).not.toBe(root.groupId);
+
+            // The accepted root reloads: its carrier holds the identity, so the rebind neither writes nor waits.
+            Transaction.release('p1');
+
+            const writesBefore = writes.length,
+                  reloaded     = await connect('p1-reload', {generationToken: root.generationToken, groupId: root.groupId, workspaceKey: 'main'});
+
+            expect(reloaded).toMatchObject({generation: 2, groupId: root.groupId, outcome: 'rebound'});
+            expect(writes, 'a rebind carries nothing new').toHaveLength(writesBefore);
+            expect(binds.at(-1).windowId).toBe('p1-reload')
+        } finally {
+            Transaction.un(listener);
+            delete Neo.Main.setTopologyIdentity
+        }
+    });
+
+    test('a manager loading after apps registered admits every live window with the identity its config carried', async () => {
         // The module loads on demand — with the first multi-window participant — so the windows whose
         // apps registered before that moment must not stay unbound. A second instance of the class
         // stands in for that later load; the singleton the worker uses is untouched.
@@ -218,15 +363,19 @@ test.describe.serial('Neo.manager.Transaction — Groups and token-matched windo
 
         let late;
 
-        Neo.ns('Neo.Main', true).setTopologyIdentity = data => writes.push(data);
+        Neo.ns('Neo.Main', true).setTopologyIdentity = data => {
+            writes.push(data);
+            return true
+        };
         Neo.apps          = {'late-popup': {}, 'late-root': {}};
         Neo.windowConfigs = {'late-popup': {topologyIdentity: carried}};
 
         try {
             late = Neo.create(Transaction.constructor, {});
 
-            expect(late.findByWindow('late-root')).toEqual({generation: 1, groupId: expect.any(String), workspaceKey: 'main'});
+            // The carried identity binds at once; the minted root binds when its carrier has answered.
             expect(late.findByWindow('late-popup'), 'a carried identity binds cold under its own Group').toEqual({generation: 1, groupId: 'group-carried', workspaceKey: 'popup:notes'});
+            await expect.poll(() => late.findByWindow('late-root')).toEqual({generation: 1, groupId: expect.any(String), workspaceKey: 'main'});
             expect(late.items).toHaveLength(2);
             expect(writes.map(write => write.windowId), 'only the minted root learns something new').toEqual(['late-root'])
         } finally {
@@ -237,13 +386,16 @@ test.describe.serial('Neo.manager.Transaction — Groups and token-matched windo
         }
     });
 
-    test('the carrier learns what the worker decided: minted and forked identities are written back, a rebind is not', () => {
+    test('the carrier learns what the worker decided: minted and forked identities are written back, a rebind is not', async () => {
         const writes = [];
 
-        Neo.ns('Neo.Main', true).setTopologyIdentity = data => writes.push(data);
+        Neo.ns('Neo.Main', true).setTopologyIdentity = data => {
+            writes.push(data);
+            return true
+        };
 
         try {
-            connect('r1', {});
+            await connect('r1', {});
 
             expect(writes).toHaveLength(1);
 
@@ -253,12 +405,12 @@ test.describe.serial('Neo.manager.Transaction — Groups and token-matched windo
 
             // A warm reload presents the carried identity and rebinds — the carrier already holds it.
             Transaction.onWindowDisconnect({windowId: 'r1'});
-            connect('r2', {generationToken: identity.generationToken, groupId: identity.groupId, workspaceKey: 'main'});
+            await connect('r2', {generationToken: identity.generationToken, groupId: identity.groupId, workspaceKey: 'main'});
 
             expect(writes, 'a rebind carries nothing new').toHaveLength(1);
 
             // A copied identity while r2 is live forks, and the fork's window learns its new Group.
-            connect('r3', {generationToken: identity.generationToken, groupId: identity.groupId, workspaceKey: 'main'});
+            await connect('r3', {generationToken: identity.generationToken, groupId: identity.groupId, workspaceKey: 'main'});
 
             expect(writes).toHaveLength(2);
             expect(writes[1].windowId).toBe('r3');

--- a/test/playwright/unit/manager/Transaction.spec.mjs
+++ b/test/playwright/unit/manager/Transaction.spec.mjs
@@ -150,6 +150,41 @@ test.describe.serial('Neo.manager.Transaction — Groups and token-matched windo
         expect(Transaction.getBinding(a.groupId, 'main'), 'the root still binds').toEqual({generation: 1, windowId: 'a1', workspaceKey: 'main'})
     });
 
+    test('participants are the Group\'s and outlive its bindings: opaque, replaced by key, kept through release and lease expiry, gone only with the Group', async () => {
+        Transaction.reconnectLeaseMs = 20;
+
+        const a     = Transaction.bind({windowId: 'a1', workspaceKey: 'main'}),
+              owner = {getDocument: () => 'doc'};
+
+        expect(Transaction.registerParticipant({groupId: 'unknown', workspaceKey: 'main', participant: owner}), 'an unknown Group refuses').toBe(false);
+        expect(Transaction.registerParticipant({groupId: a.groupId, workspaceKey: '', participant: owner}), 'a key is required').toBe(false);
+        expect(Transaction.registerParticipant({groupId: a.groupId, workspaceKey: 'main', participant: null}), 'a participant is required').toBe(false);
+        expect(Transaction.registerParticipant({groupId: a.groupId, workspaceKey: 'main', participant: owner})).toBe(true);
+        expect(Transaction.registerParticipant({groupId: a.groupId, workspaceKey: 'vessel', participant: {}})).toBe(true);
+        expect(Transaction.participantKeys(a.groupId)).toEqual(['main', 'vessel']);
+        expect(Transaction.getParticipant(a.groupId, 'main'), 'held opaque, returned as registered').toBe(owner);
+
+        const replacement = {getDocument: () => 'doc2'};
+
+        expect(Transaction.registerParticipant({groupId: a.groupId, workspaceKey: 'main', participant: replacement}), 'the same key replaces').toBe(true);
+        expect(Transaction.getParticipant(a.groupId, 'main')).toBe(replacement);
+        expect(Transaction.participantKeys(a.groupId), 'a replacement keeps its key\'s place').toEqual(['main', 'vessel']);
+
+        // The window dies and its lease runs out: the slot is free; the Group and its participants stay.
+        Transaction.release('a1');
+
+        await new Promise(resolve => setTimeout(resolve, 60));
+
+        expect(Transaction.getBinding(a.groupId, 'main'), 'the slot is free').toBeNull();
+        expect(Transaction.get(a.groupId), 'a Group holding participants is not empty and is not retired').toBeTruthy();
+        expect(Transaction.participantKeys(a.groupId)).toEqual(['main', 'vessel']);
+
+        expect(Transaction.unregisterParticipant({groupId: a.groupId, workspaceKey: 'vessel'})).toBe(true);
+        expect(Transaction.unregisterParticipant({groupId: a.groupId, workspaceKey: 'vessel'}), 'retirement is exact-once').toBe(false);
+        expect(Transaction.retireGroup(a.groupId)).toBe(true);
+        expect(Transaction.getParticipant(a.groupId, 'main'), 'gone with the Group').toBeNull()
+    });
+
     test('a Group this worker never saw is created cold under the carried id, so persisted state can find it later', () => {
         const cold = Transaction.bind({groupId: 'group-from-a-previous-worker', workspaceKey: 'main', generationToken: 'lineage', windowId: 'w1'});
 


### PR DESCRIPTION
Resolves #18309
Related: #18303 #18304 #18317

🌿 A window no longer proves who it is by reading its own URL; it carries what its Group told it, and the Group cannot be taken from it.

`Neo.manager.Transaction` is the worker-side authority for logical topology Groups: `appName` routes and never identifies, a window binds into a Group under one `workspaceKey`, and every binding records the replaceable runtime generation. A warm reload releases and rebinds its own slot on a lineage token; a late disconnect for a superseded generation finds no binding carrying its `windowId` and changes nothing; a copied identity presented while its binder lives forks a new Group; a released or reserved slot is held for its lineage for a bounded lease; an opener reserves a slot for a window it is about to create. Two boundaries the review executed and this head closes: a minted or forked identity is bound and published only once the window's carrier accepted it — the main thread's acknowledgement is awaited, and a pending, refused or rejected write, or a window that left meanwhile, admits nothing; and a lineage is dead once its lease ran out or its holder revoked it — a late child presenting it forks into its own Group instead of entering the live one, and only the holder's own token gives a slot back, so an older open's late failure cannot revoke its replacement. The boot carrier is a separately named persistent `sessionStorage` record, read by `worker/Manager` into every config registration and written by `Neo.Main#setTopologyIdentity` on the worker's word; `Main.windowOpen({topologyIdentity})` hands a staged same-origin child its reserved slot, or clears the inherited copy so a plain popup boots as a root of its own. The manager loads with the first multi-window participant — a single-window app's closure carries no Group machinery — and admits every window as its app registers.

The three consumers of the old vessel protocol change with the shared contract, per the author's disposition on the ticket: the dock `Workspace` reserves `popup:<itemId>` in its own Group for every tear-out vessel and observes its Group's bind, release and lease expiry on the manager; the Workstation adopts that lifecycle through the engine's hooks and keeps only what it alone knows (platform seams, theme bootstrap, embodiment staging, vessel workspaces, its journeys' receipts); the composition-style DemoB host reserves its stage targets, click pop-outs and tear-out vessels on the manager directly. Their owner grants, generation counters, connect-admission maps, `hostId`/`vesselFlow`/`vesselGrant`/`vesselGeneration`/`vesselAdmission` URLs, URL parses and per-instance worker `connect`/`disconnect` subscriptions are deleted; no compatibility branch remains and the `admissionToken` alias left with its last reader. A vessel's identity is its slot's lineage token, so a retirement presenting a superseded one is refused and the live vessel survives it. Every host remembers the Group its window bound into for its lifetime — the engine Workspace as `topologyGroupId`, DemoB in its own field — so releasing the window's slot, a reload's new generation or a lease running out never loses the documents it registered; a first boot's minted identity arrives with its accepted binding, and the host registers its participants then.

Evidence: L3 achieved (red-first unit arms on the manager, the carrier, the engine Workspace, the Workstation and DemoB; the real-browser pop-out component spec; under the Brain root, the two-root browser arm for AC-6 and the flagship journey reading the lineage off the vessel's carrier) → L3 required (AC-1 to AC-8). Residual: none.

## AC Evidence
| AC-1 | CI-covered: `test/playwright/unit/manager/Transaction.spec.mjs` › "a root without identity mints a Group; a second root of the same app mints another" — two Groups, distinct ids; exported through `src/manager/_export.mjs` |
| AC-2 | CI-covered: `Transaction.spec.mjs` › "the two-Workstation falsifier…" (the root reload rebinds its own slot at generation 2, same Group, the popup's slot untouched) and "a Group this worker never saw is created cold under the carried id"; `unit/main/MainNativeWindowRoute.spec.mjs` › "the topology identity rides the native route carrier…" (empty carrier reads `{}`, the write-back is what the next load presents, a staged child receives its reservation, a child opened without one has its inherited copy cleared); real browser: `component/dashboard/DockPopOut.spec.mjs` › "the host window is bound into a Group…" — a dedicated worker's host admitted at registration, the minted identity written into the page's `sessionStorage`. Acknowledged admission: `Transaction.spec.mjs` › "a minted or forked identity is published once its carrier accepted it…" — while the write is pending there is no binding, no Group and no event; `false`, a rejection and a non-`true` answer refuse with `admissionRefused`; a window released while its write is pending is refused (`window-gone`); the accepted root is published once and rebinds on reload without a write |
| AC-3 | The slot key is `popup:<itemId>` for every vessel (`Workspace#tearOutWorkspaceKey`, DemoB's openers) and the popup workspace id for DemoB's stage targets; the manager's binding is the one identity — the engine's `tearOutAdmissions` and DemoB's `vesselReservations` hold host context (sort zone, flow, window name) and no token or generation of their own, and the Workstation's `vesselOwnerGrants` + `tearOutConnectAdmissions` and DemoB's copies are deleted. Keyed participant membership is the Group's (`Neo.manager.Transaction#registerParticipant` / `getParticipant` / `participantKeys` / `unregisterParticipant`): `createDockWorkspaceSet` keeps no entry map — registration, lookup and count are the host's Group's, refused and fail-closed before the host's window has bound — and only the dock's both-or-neither adoption stays the adapter's until #18312 (the author's split, ticket comment 5548622668). The hosts remember their Group: the engine Workspace's `topologyGroupId` and DemoB's field are learned from the window's accepted binding — at construct when the carrier already held the identity, else from the `bind` event — and kept for the instance's lifetime, so the production resolver (`getGroupId: () => me.topologyGroupId`) reaches the participants after the root's release and lease expiry; a first boot registers them when its binding arrives (`afterSetTopologyGroupId`, DemoB's `adoptTopologyGroup`), a never-bound host refuses, a headless Workstation joins when a container supplies its window id. CI-covered: `unit/dashboard/DockWorkspaceSet.spec.mjs` › "before the host binds there is no membership…" and "membership is the Group's, and it outlives the binding…" (with the live-binding resolver as the control that loses it); `unit/manager/Transaction.spec.mjs` › "participants are the Group's and outlive its bindings…"; `unit/apps/workstation/Workspace.spec.mjs` › "the production resolver keeps the main participant through the root's release and lease expiry; a never-bound first boot joins when its binding is accepted"; `unit/examples/dashboard/crossWindow/DemoBWorkspace.spec.mjs` › "the production resolver keeps the three participants…"; `unit/dashboard/DockWorkspace.spec.mjs` › "the host keeps the Group it learned…"; the Workstation spec's headless arm registers `main` on the window id's arrival |
| AC-4 | CI-covered: `Transaction.spec.mjs` › the falsifier's tail — `release('a1')` after `a3` rebound returns `false`, `a3` stays bound at generation 2; at the consumers: `unit/dashboard/DockTearOut.spec.mjs` › "a retirement presenting a superseded lineage token clears nothing…" and `unit/apps/workstation/Workspace.spec.mjs` › "a retirement presenting a superseded lineage token is refused, and the live vessel survives it" — the control the author ran against `dev`. Revocation is fenced the same way: `Transaction.spec.mjs` › "a revocation is fenced by lineage…" and `unit/dashboard/DockWorkspace.spec.mjs` › "two overlapping opens for one item…" — `acquireTearOutVessel` twice with the first platform open pending: the older open's late failure revokes nothing, the replacement's child is admitted |
| AC-5 | CI-covered: `Transaction.spec.mjs` › "a copied identity presented while its binder is live forks a new Group" and "a released slot rebinds only for its lineage token; a stranger forks"; `unit/examples/dashboard/crossWindow/DemoBWorkspace.spec.mjs` › "the workspace stage mounts the one child that binds its reserved slot — never a forged or replayed identity"; a bookmarked popup URL names content only and carries no owner at all, so it boots as a fresh root (`MainNativeWindowRoute.spec` — a fresh window's carrier is empty). A dead lineage forks: `Transaction.spec.mjs` › "a dead lineage is not a door…" (expired, revoked and unreserved presentations fork, the live reservation binds, a cold root still returns); `unit/dashboard/DockWorkspace.spec.mjs` › "a late child presenting an expired reservation forks and never connects…"; `DemoBWorkspace.spec.mjs` › "a child presenting an expired or revoked reservation forks and reparents nothing — the pending record left with the slot" (DemoB subscribes `leaseExpired`; the engine's admission expiry already retired its vessel) |
| AC-6 | CI-covered, unit form: `Transaction.spec.mjs` › "the two-Workstation falsifier: a reload moves one generation, and a late disconnect cannot unbind the successor" — A + its popup one Group, B shares only the app name, reloading A creates no Group and touches neither B nor A's popup. Browser form, outside CI under the Brain root: `test/playwright/e2e/workstation/WorkstationTopologyGroupsNL.spec.mjs` — root A (the full Workstation) and root B (the Workstation's pane-host boot with no opener and no carrier: the same app in the same SharedWorker, its own window, admitted as a root of its own) carry two Groups; A's real pop-out binds a `popup:` slot of A's Group and its URL names content and theme only; reloading A rebinds A's slot at generation 2 under the same Group, the superseded generation holds nothing, B's binding and carrier and the vessel's binding are unchanged, and the Group count stays two (1/1 at head). B is the pane-host boot because two full roots crash the headless harness process on `dev` as on this branch — real Chrome runs both side by side; defect-noted to the swarm, not this PR's scope |
| AC-7 | Implementation code by the repository's Acorn counter (`check-file-sizes.mjs`'s `measureSource`), against `dev@ea54d5ff89` at this head: `src/` +307 (`manager/Transaction.mjs` is +261 of it), `apps/` −188, `examples/` −54 → `src/ + apps/ + examples/` **+65**. Raw diff lines beside it: `src/` +1008/−256, `apps/` +273/−505, `examples/` +339/−368 → +1620/−1129. At `5170aa0b1e` the same measure read **−20**: the four boundaries the first review executed — acknowledged admission, dead-lineage refusal, lineage-fenced revocation, the remembered Group — cost 85 implementation lines, 52 of them in the manager. **Met under the author's amended criterion** (ticket comment 5551938509: at most +65 net implementation lines for this first ownership cut — a bounded accounting amendment on the complete implementation, not a general growth exemption; any further growth needs a fresh disposition): +65 at this head is exactly the bound, the original named deletions are in, no compatibility owner remains, and no deletion was manufactured for the number. The replaced paths are gone in all three consumers — owner grants and generation counters, the URL admission and its parses, connect-admission maps, per-instance worker subscriptions (#18317's included), the `admissionToken` alias, and the WorkspaceSet's own entry map — with no compatibility branch |
| AC-8 | `learn/benefits/ArchitectureOverview.md` gains the `src/manager/` inventory row linking ADR 0029 |

size-guard-growth: src/dashboard/dock/Workspace.mjs — the host remembers the Group its window bound into (review round 1, RA-1): the resolver, its hook and the own-window adoption in onTopologyBind; 1284 → 1292 code lines, against the standing stop-adding directive as the review-demanded exception

## Deltas from ticket
**Admission rides app registration, not `connect`.** `connect` is a SharedWorker port event; `worker/Base.onRegisterApp` finds no port for a dedicated worker and never calls `onConnect`, so a manager subscribed to `connect` never hears a single-window app's host (measured on the pop-out component fixture: zero Groups). The identity therefore rides the config registration every window sends, and the manager admits a window as its app registers — the first moment a live app exists for the bind to reach. The manager subscribes to `disconnect` alone.

**The manager loads on demand.** The engine Workspace imports it only when the tear-out lifecycle is enabled or a slot is reserved, so a single-window app's closure stays without Group machinery (70 modules at `dev` and at head; a static import had made it 71) — the single-window load boundary the author named.

**AC-7's accounting and AC-3's boundary (the author's disposition, ticket comment 5548622668).** The criterion counts implementation code across `src/ + apps/ + examples/` with the repository's Acorn counter, raw totals beside it — DemoB is a named consumer of the same criterion. The Group owns keyed participant membership here; `WorkspaceSet` adapts it with no entry map of its own; prepare / adopt / compensate stay #18312. Participants are separate from bindings: a released or expired slot keeps them, and a Group holding participants is never classified empty. Membership needs a Group, and a Group needs a bound window: the hosts import the manager and are admitted at app registration, before their views construct, so their participants join at construct — and a Workstation constructed headless joins on its first window id, the same signal that arms its geometry.

**#18317 absorbed.** The per-Workspace worker subscription and its `hostId` filter are deleted here, not left coexisting with the Group subscriber; #18317 is closed by its author.

**Admission is acknowledged, a dead lineage forks, and hosts remember their Group (review round 1).** The first review executed four boundaries at `5170aa0b1e` and found each open: a host resolving its Group through the live binding lost its participants after release; `revoke` ignored the token; an expired reservation presented late was admitted into the live Group; a mint or fork was published before the carrier had accepted it. This head closes them where each lives — `plan` / `settle` split the decision from the registry write so `admit` can await `Main.setTopologyIdentity`'s `true` before binding or publishing; `plan` treats an existing Group's absent slot as a dead lineage and forks; `revoke` demands the holder's token; `topologyGroupId` is a remembered reactive config on the engine Workspace (learned at construct, at manager load, on the window's arrival or from the own-window `bind` event) and a field on DemoB, and both hosts register their participants when the Group arrives. One consequence for hosts: a first boot's participants register a round trip after construction, not during it — the Workstation's `afterSetTopologyGroupId` and DemoB's `adoptTopologyGroup` carry that, and DemoB's first projection reads its own document off the owner field rather than through membership that does not exist yet. The boundaries cost 85 implementation lines; the author re-ran the counter and amended AC-7 to a bounded +65 for this cut (ticket comment 5551938509), which this head meets exactly.

## Test Evidence
Unit: 3282 passed / 0 failed at this head (`playwright.config.unit.mjs`, one worker; 3273 at the reviewed head plus the nine review-round arms).
Components: `component/dashboard` 120 passed / 0 failed at this head (`playwright.config.component.mjs`, one worker), the pop-out spec's host-binding arm included — the host now binds one acknowledgement round trip after registration, and the arm's poll covers it.
E2E (outside CI, Brain root, one worker, at this head): `e2e/workstation/WorkstationTopologyGroupsNL` 1/1 — AC-6's browser form; `e2e/dashboard/TearOutMatrixRows4To7NL` 4/4 — reads the reservation map, and its repeated-terminal arms drive the manager-shaped release; `e2e/workstation/WorkstationDragAffordancesNL` 5 passed / 1 skipped (the skip is the spec's own, unchanged) — reads the lineage off the vessel's carrier instead of its URL.
Red-first: the manager spec fails by absence on `dev`; the carrier arm fails on `dev` (`Main.setTopologyIdentity` is not a function); the host-binding component arm read `{binding: null, groups: 0}` against a connect-subscribed manager. The two stale-lineage arms (TearOut, Workstation) are the author's dev control re-run at head: refused there, refused here. The DemoB unit harness binds children through the real manager rather than a URL: a forged token forks, a replayed identity forks, a slot the host never reserved forks. The four review-round arms are the reviewer's executed controls turned into specs, each red at `5170aa0b1e`: the production resolver after root release, the overlapping opens through `acquireTearOutVessel`, the expired reservation presented late, and the pending carrier write.

## Post-Merge Validation
- [ ] The Workstation's tear-out journeys on `dev` under the Brain root (`WorkstationDragAffordancesNL`, `WorkstationNativeTitlebarDragNL`) read the lineage off the carrier and stay green.

## Commits (if multi-commit)
- `a210b22092` — `Neo.manager.Transaction`: Groups, token-matched bindings, reserve / release / revoke, the bounded lease, 7 arms
- `b548d29a21` — the carrier: `Main.setTopologyIdentity`, `windowOpen({topologyIdentity})`, write-back after minted / cold / forked
- `9cb9a6412f` — the engine Workspace on the Group: reservations instead of URL admission; its worker subscription, admissions map and expiry timer deleted; admission at registration for both worker types
- `4c3d9ae69e` — ArchitectureOverview `src/manager/` row (AC-8)
- `41688acf4e` — a Group whose last lease runs out is retired
- `5509a7907e` — the manager loads with the first multi-window participant and admits windows as their apps register
- `56e3e60889` — the Workstation adopts the engine's tear-out lifecycle and reserves its vessels in its Group
- `bd491789c8` — the tear-out identity carries its slot's lineage token; DemoB reserves its vessels in its Group; the alias leaves
- `0c66a8d5b8` — the code-line baseline follows the three files this branch shrinks
- `689e9e0f0f` — the manager spec starts every arm from an empty singleton; DemoB retires the Group it bound
- `00269ae13c` — the tear-out matrix re-announces a vessel's release the way the manager does
- `39e3e26914` — the two-root browser arm: two Workstation roots under one SharedWorker are two Groups, and reloading one touches nothing else
- `4dbac19cd7` — the tracked class hierarchy gains `Neo.manager.Transaction` (the freshness job's demand)
- `5170aa0b1e` — a Group holds keyed participants; the dock WorkspaceSet is an adapter over that membership with no entry map of its own; the hosts join their Group at construct, a headless Workstation on its first window id
- `7c64f2bc98` — admission awaits the carrier's acknowledgement before binding or publishing a minted or forked identity; a dead lineage forks; only the holder's token revokes a slot (review round 1, RA-2 / RA-3 / RA-4)
- `8547ad0bb7` — the hosts remember the Group their window bound into and register their participants when the binding is accepted; DemoB drops a pending reservation with its expired lease (review round 1, RA-1 / RA-3)
- `f8bd4569a1` — the code-line baseline follows the files this round changed

Authored by Vega (Claude Fable 5.1, Claude Code). Sessions 87064b54-7440-441c-8bbf-f29fcd6899d5 (review round 1), 213ad267-6268-4cb2-9dc6-eaf4a349bb6d, 007aac9d-974a-465c-9015-378aeb741bd5.

