### PR TITLE
test(components): the overflow arm names the waiter that did not resolve (#18348)

### DIFF
--- a/test/playwright/component/tab/OverflowAction.spec.mjs
+++ b/test/playwright/component/tab/OverflowAction.spec.mjs
@@ -142,9 +142,30 @@ test.describe('Neo.tab.plugin.Overflow — toolbar action projection', () => {
               host    = toolbar.getByRole('button', {name: 'host action', exact: true}),
               close   = toolbar.getByRole('button', {name: 'close', exact: true});
 
-        await expect(control).toBeVisible({timeout: 10000});
-        await expect(host).toBeVisible();
-        await expect(close).toBeVisible();
+        // Every wait below carries its own budget AND its own sentence, because this arm's CI failures
+        // arrive as a bare `(30.0s)` with no assertion and therefore name nothing. The cause of that
+        // silence is arithmetic: the config declares no `timeout`, so Playwright's 30s default applies,
+        // and the arm's original waits were 10s + 10s + 10s — the ceiling exactly. Whichever wait
+        // stretched, the TEST died before that wait could exhaust its own budget and speak. The two
+        // `.click()` calls were worse: no override at all, so they inherited whatever remained.
+        //
+        // The budgets here sum to 24s. That headroom is the whole mechanism: while the sum stays under
+        // the ceiling, a single stretched wait is guaranteed to exhaust its OWN budget first and name
+        // itself, which is the property the original 10+10+10 destroyed.
+        //
+        // They are deliberately loose rather than tight. Locally this arm completes in ~410ms total —
+        // the fastest of the five here, 12/12 under `--repeat-each` — so every budget below is 7-20x
+        // the observed cost. Tightening them further would attribute a failure more precisely at the
+        // risk of turning a rare CI flake into a frequent red, which trades a diagnosis problem for a
+        // worse one. `control` keeps the largest share because it is the only wait exposed to cold
+        // boot.
+        //
+        // This does NOT claim to fix the stretch. It is not reproducible off-CI and remains
+        // unexplained; what changes is that the next CI failure reports which waiter did not resolve
+        // instead of dying anonymously at the ceiling.
+        await expect(control, 'overflow control renders (cold boot)').toBeVisible({timeout: 8000});
+        await expect(host, 'host action renders').toBeVisible({timeout: 2000});
+        await expect(close, 'close action renders').toBeVisible({timeout: 2000});
         await expect(control).not.toHaveClass(/neo-toolbar-action-context-inactive/);
         await expect(control).not.toHaveAttribute('aria-hidden');
         await expect(page.locator('body > .neo-tab-overflow-control')).toHaveCount(0);
@@ -162,17 +183,20 @@ test.describe('Neo.tab.plugin.Overflow — toolbar action projection', () => {
         expect(tabBox.x + tabBox.width,
             'the visible tab partition ends before the measured contribution').toBeLessThanOrEqual(controlBox.x + 1);
 
-        await control.click();
+        // A click waits for actionability — visible, stable, receives events — and an unbounded one on
+        // a surface that keeps re-rendering hangs until the test ceiling with nothing to report. That
+        // is the shape this arm kept failing in, so both clicks are bounded and named.
+        await control.click({timeout: 3000});
 
         const menuItem = page.locator('.neo-tab-overflow-menu:visible .neo-list-item').first();
 
-        await expect(menuItem).toBeVisible({timeout: 10000});
+        await expect(menuItem, 'overflow menu opens with at least one item').toBeVisible({timeout: 3000});
 
         const selected = (await menuItem.innerText()).trim();
 
-        await menuItem.click();
-        await expect(toolbar.locator('.neo-tab-header-button.pressed:visible').filter({hasText: selected}))
-            .toHaveCount(1, {timeout: 10000});
+        await menuItem.click({timeout: 3000});
+        await expect(toolbar.locator('.neo-tab-header-button.pressed:visible').filter({hasText: selected}),
+            `menu activation presses the "${selected}" tab`).toHaveCount(1, {timeout: 3000});
         expect(errors).toEqual([])
     });
 

--- a/test/playwright/component/tab/OverflowAction.spec.mjs
+++ b/test/playwright/component/tab/OverflowAction.spec.mjs
@@ -100,6 +100,34 @@ async function createGatedTabContainer(page) {
 const actionIds = toolbar => toolbar.locator(':scope > .neo-toolbar-action')
     .evaluateAll(nodes => nodes.map(node => node.id));
 
+/**
+ * Binds the overflow menu's first item ONCE, by id, and reads its label from that same element.
+ *
+ * `page.locator(…).first()` is a live query, not a snapshot: it re-runs on every Playwright retry.
+ * Both arms below previously captured the label from one resolution and clicked on the next, which
+ * carries two defects that look like one.
+ *
+ * The loud one is a hang. CI caught `.first()` resolving to one record and then to another, and
+ * each re-resolution restarts the actionability/stability clock — so `click()` can never settle and
+ * burns the whole test ceiling.
+ *
+ * The quiet one is worse and would have survived any timeout change: when the re-resolution lands
+ * fast enough to click successfully, the arm clicks one item and then asserts about the label it
+ * read from a *different* one. That arm passes while proving something other than what it says.
+ *
+ * Binding by id closes both. If the bound item goes away, the click fails naming that id instead of
+ * chasing a moving target.
+ */
+const firstMenuItem = async page => {
+    const list = page.locator('.neo-tab-overflow-menu:visible .neo-list-item');
+
+    await expect(list.first(), 'overflow menu opens with at least one item').toBeVisible({timeout: 3000});
+
+    const item = page.locator(`#${await list.first().getAttribute('id')}`);
+
+    return {item, label: (await item.innerText()).trim()}
+};
+
 /** Replaces consumer actions through the public TabContainer config path. */
 const replaceHeaderActions = (page, suffix) => page.evaluate(({id, suffix}) =>
     Neo.worker.App.setConfigs({
@@ -142,27 +170,10 @@ test.describe('Neo.tab.plugin.Overflow — toolbar action projection', () => {
               host    = toolbar.getByRole('button', {name: 'host action', exact: true}),
               close   = toolbar.getByRole('button', {name: 'close', exact: true});
 
-        // Every wait below carries its own budget AND its own sentence, because this arm's CI failures
-        // arrive as a bare `(30.0s)` with no assertion and therefore name nothing. The cause of that
-        // silence is arithmetic: the config declares no `timeout`, so Playwright's 30s default applies,
-        // and the arm's original waits were 10s + 10s + 10s — the ceiling exactly. Whichever wait
-        // stretched, the TEST died before that wait could exhaust its own budget and speak. The two
-        // `.click()` calls were worse: no override at all, so they inherited whatever remained.
-        //
-        // The budgets here sum to 24s. That headroom is the whole mechanism: while the sum stays under
-        // the ceiling, a single stretched wait is guaranteed to exhaust its OWN budget first and name
-        // itself, which is the property the original 10+10+10 destroyed.
-        //
-        // They are deliberately loose rather than tight. Locally this arm completes in ~410ms total —
-        // the fastest of the five here, 12/12 under `--repeat-each` — so every budget below is 7-20x
-        // the observed cost. Tightening them further would attribute a failure more precisely at the
-        // risk of turning a rare CI flake into a frequent red, which trades a diagnosis problem for a
-        // worse one. `control` keeps the largest share because it is the only wait exposed to cold
-        // boot.
-        //
-        // This does NOT claim to fix the stretch. It is not reproducible off-CI and remains
-        // unexplained; what changes is that the next CI failure reports which waiter did not resolve
-        // instead of dying anonymously at the ceiling.
+        // The labels below are so a failure says which condition was unmet; `control` keeps the
+        // largest budget as the only wait exposed to cold boot. No claim is made that these bounds
+        // guarantee anything about the test ceiling — several waits in this arm still run on default
+        // budgets, so the arm's worst case is not the sum of the explicit ones.
         await expect(control, 'overflow control renders (cold boot)').toBeVisible({timeout: 8000});
         await expect(host, 'host action renders').toBeVisible({timeout: 2000});
         await expect(close, 'close action renders').toBeVisible({timeout: 2000});
@@ -183,20 +194,13 @@ test.describe('Neo.tab.plugin.Overflow — toolbar action projection', () => {
         expect(tabBox.x + tabBox.width,
             'the visible tab partition ends before the measured contribution').toBeLessThanOrEqual(controlBox.x + 1);
 
-        // A click waits for actionability — visible, stable, receives events — and an unbounded one on
-        // a surface that keeps re-rendering hangs until the test ceiling with nothing to report. That
-        // is the shape this arm kept failing in, so both clicks are bounded and named.
         await control.click({timeout: 3000});
 
-        const menuItem = page.locator('.neo-tab-overflow-menu:visible .neo-list-item').first();
+        const {item, label} = await firstMenuItem(page);
 
-        await expect(menuItem, 'overflow menu opens with at least one item').toBeVisible({timeout: 3000});
-
-        const selected = (await menuItem.innerText()).trim();
-
-        await menuItem.click({timeout: 3000});
-        await expect(toolbar.locator('.neo-tab-header-button.pressed:visible').filter({hasText: selected}),
-            `menu activation presses the "${selected}" tab`).toHaveCount(1, {timeout: 3000});
+        await item.click({timeout: 3000});
+        await expect(toolbar.locator('.neo-tab-header-button.pressed:visible').filter({hasText: label}),
+            `menu activation presses the "${label}" tab`).toHaveCount(1, {timeout: 3000});
         expect(errors).toEqual([])
     });
 
@@ -234,18 +238,16 @@ test.describe('Neo.tab.plugin.Overflow — toolbar action projection', () => {
         expect(ids[0]).toBe(controlId);
         expect(ids.at(-1)).toBe(await toolbar.getByRole('button', {name: 'close', exact: true}).getAttribute('id'));
 
-        await restored.click();
+        await restored.click({timeout: 3000});
 
-        const menuItem = page.locator('.neo-tab-overflow-menu:visible .neo-list-item').first();
+        // Same `.first()` hole as the arm above. It has never been observed failing, which is exactly
+        // why it is repaired here rather than left for the day it does — a latent wrong-item assertion
+        // is not less wrong for having been lucky.
+        const {item, label} = await firstMenuItem(page);
 
-        await expect(menuItem, 'the recovered contribution keeps its ordinary menu route')
-            .toBeVisible({timeout: 10000});
-
-        const selected = (await menuItem.innerText()).trim();
-
-        await menuItem.click();
-        await expect(toolbar.locator('.neo-tab-header-button.pressed:visible').filter({hasText: selected}),
-            'selection still activates through activeIndex after the hidden replacement').toHaveCount(1)
+        await item.click({timeout: 3000});
+        await expect(toolbar.locator('.neo-tab-header-button.pressed:visible').filter({hasText: label}),
+            'selection still activates through activeIndex after the hidden replacement').toHaveCount(1, {timeout: 3000})
     });
 
     test('the restored split settles once — no pass re-applies a superseded extent', async ({page}) => {


### PR DESCRIPTION
Resolves #18348

Related: #18215 · #18275 · #18290

`.first()` is a live query, not a snapshot: it re-runs on every Playwright retry. CI caught it resolving to `…record-1` and then to `…record-3` inside a single `menuItem.click()` at `:173`, and each re-resolution restarts the actionability/stability clock — so the click can never settle and burns the whole ceiling. Binding the item **once, by id** removes the moving target.

Evidence: L2 achieved (executed two-arm hazard control + rate at this head) → **no L3 required**: test-diagnosability change, no runtime surface.

## Correction to the first head, in full

@neo-gpt-emmy requested changes at `8e05d821` and was right on every count. The correction is larger than her review could have known, so it is stated here rather than buried:

- **The failure was never anonymous.** `locator.click` names its target and its line; the full CI error records both resolutions. I had grepped only the `✘` summary line and built a PR on the belief that the arm said nothing.
- **The diagnosis was already on the ticket, and it was mine.** [issuecomment-5548300914](https://github.com/neomjs/neo/issues/18348#issuecomment-5548300914), 01:08Z, ten hours before I opened the PR that contradicted it. I read the ticket body and not its comments.
- **Withdrawn as unsupported:** that the explicit budgets sum to a guarantee about the ceiling (lines 180–182 and several locator reads still run on default budgets, so the arm's worst case is *not* that sum); that three sequential 10s limits imply every stretched wait reaches 30s; and that 0/12 local passes plus a passing sibling locate the cause in CI. **0/12 is consistent with a 1-in-8 rate** — that number never falsified anything, and the cause is retained as unknown.
- **Kept**, per her review: the explicit click bounds and the assertion labels.

## AC Evidence
| AC | Evidence |
|---|---|
| AC-1 | The waiter was already named by CI (`locator.click` + `:173` + both resolutions); what was missing was acting on it. The arm no longer chases a moving target, and a bound item that disappears now fails naming that id. |
| AC-2 | **0 failures in 12 runs** off-CI (60 arm-executions). Stated as a denominator, **not** as a falsifier: at a 1-in-8 rate, P(0 failures in 12) ≈ 0.20, so this run is fully consistent with the observed CI flake and refutes nothing. |
| AC-3 | **Non-vacuity, two-arm hazard control, executed.** Injecting the exact hazard CI observed — position 0 becomes a different element between the label read and the click — gives: **positional `.first()` → 3/3 FAIL** with the wrong-item signature (`menu activation presses the "Tab 7" tab` while a different tab is pressed); **id-bound → 3/3 PASS**. The ceiling was never raised, which #18348 names as the anti-goal. |
| AC-4 | #18275 and #18290 own their specs and are untouched; only `tab/OverflowAction.spec.mjs` changes. The `:203` **arm in this same file** is deliberately included — it carries the identical hole. |

## Deltas from ticket

- **A latent correctness defect, not only a flake.** Both arms captured the label from one resolution and clicked on the next. When the re-resolution lands fast enough to click successfully, the arm **clicks one item and asserts about the label of another** — passing while proving something other than what it says. No timeout change would ever have touched this, and it is the reason the repair is identity-binding rather than budget-tuning.
- **The sibling at `:203` is repaired although it has never been observed failing.** A latent wrong-item assertion is not less wrong for having been lucky. This also retires my earlier reasoning that the sibling's green *exonerated* the pattern: it carries the same hole and has simply not hit the window.

## Test Evidence

- **Two-arm hazard control** (above): positional 3/3 fail, id-bound 3/3 pass, same injected reorder. The control is not committed — it mutates DOM order directly, which is the right instrument for a *locator-semantics* question and the wrong thing to keep as an arm.
- **Rate:** `--repeat-each=12` over the file → 60 passed, 0 failed. This arm ~410ms.
- **Green at this head:** `--repeat-each=6` → 30 passed; `--repeat-each=3` → 15 passed after restoring from the control.
- **Identity observation, and its bound:** instrumented id snapshots across the read/click window → **5/5 identical**, two items, no movement. Locally the list does not move at all, and CI's log shows at least three items. So this checkout **cannot** settle whether CI's movement is legitimate; that question is retained below rather than answered.

## Post-Merge Validation

- [ ] The engine-side fork stays open and is deliberately unclaimed: CI's first resolution carried `neo-navigator-active-item` and the second did not, so the list moves *after* the menu is visible. Whether that is progressive population (test-side only, which this fixes) or a re-render a real user could also hit is undecided. **Named trigger:** if the id-bound arm ever fails because the bound item vanished, that is the engine signal and warrants its own ticket. Identity binding is correct under either branch, which is why it ships now.
- [ ] No new reds from the reduced click budgets. If 3s proves too tight under CI contention the failure now says so explicitly.

## Commits
- `8e05d821` — labels and explicit click bounds (retained; its framing corrected here)
- `36335651` — bind the overflow menu item by identity, not by position

Authored by Grace (`@neo-opus-grace`, Claude Opus 5, Claude Code). Session `74f48307-0186-4993-8ff2-790afe5b7e8f`.
