### PR TITLE
fix(monaco): restore editor initialization and lifecycle (#5822)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,9 @@ updates:
     groups:
       all-deps:
         patterns: ["*"]
+        # Monaco is exact-pinned: a version bump requires addon/wrapper compatibility checks.
+        # Keep its update in a standalone PR so it cannot hide inside the bulk dependency diff.
+        exclude-patterns: ["monaco-editor"]
 
   - package-ecosystem: github-actions
     directory: "/"

--- a/src/component/wrapper/MonacoEditor.mjs
+++ b/src/component/wrapper/MonacoEditor.mjs
@@ -130,6 +130,13 @@ class MonacoEditor extends Base {
     }
 
     /**
+     * Invalidates mounted callbacks when a holder unmounts or moves to another browser window.
+     * @member {Number} editorMountGeneration=0
+     * @protected
+     */
+    editorMountGeneration = 0
+
+    /**
      * @param {Object} config
      */
     construct(config) {
@@ -175,7 +182,9 @@ class MonacoEditor extends Base {
     }
 
     /**
-     * Triggered after the mounted config got changed
+     * @summary Starts native editor creation after DOM mount and accepts only the current mount's reply.
+     * The mounted signal already observes DOM admission; no elapsed-time guess is needed before
+     * sending the create request. Unmounting or moving windows invalidates its completion callback.
      * @param {Boolean} value
      * @param {Boolean} oldValue
      * @protected
@@ -183,13 +192,17 @@ class MonacoEditor extends Base {
     afterSetMounted(value, oldValue) {
         super.afterSetMounted(value, oldValue);
 
-        let me = this;
+        let me         = this,
+            generation = ++me.editorMountGeneration,
+            windowId   = me.windowId;
 
-        value && me.timeout(150).then(() => {
-            Neo.main.addon.MonacoEditor.createInstance(me.getInitialOptions()).then(() => {
+        value && Neo.main.addon.MonacoEditor.createInstance(me.getInitialOptions()).then(() => {
+            if (!me.isDestroyed && me.mounted && me.windowId === windowId && me.editorMountGeneration === generation) {
                 // use this custom method as needed inside your class extensions
                 me.onEditorMounted?.()
-            })
+            }
+        }).catch(error => {
+            if (error !== Neo.isDestroyed) throw error
         })
     }
 
@@ -330,13 +343,15 @@ class MonacoEditor extends Base {
     }
 
     /**
-     * Triggered after the windowId config got changed
+     * @summary Retires the old window's native editor and invalidates pending mount callbacks.
      * @param {String|null} value
      * @param {String|null} oldValue
      * @protected
      */
     afterSetWindowId(value, oldValue) {
         super.afterSetWindowId(value, oldValue);
+
+        this.editorMountGeneration++;
 
         oldValue && Neo.main.addon.MonacoEditor.destroyInstance({
             id      : this.id,

--- a/src/main/addon/MonacoEditor.mjs
+++ b/src/main/addon/MonacoEditor.mjs
@@ -60,38 +60,39 @@ class MonacoEditor extends Base {
     map = {}
 
     /**
+     * @summary Creates one native editor per mounted wrapper and routes its model changes to the worker.
      * For a complete list of options see:
      * https://microsoft.github.io/monaco-editor/typedoc/interfaces/editor.IEditorOptions.html
      * @param {Object} data
      */
     createInstance(data) {
-        let me   = this,
-            {id} = data,
-            node = DomAccess.getElement(id),
+        let me                                  = this,
+            {appName, id, windowId, ...options} = data,
+            node                                = DomAccess.getElement(id),
             editor;
-
-        delete data.appName;
-        delete data.id;
 
         if (me.map[id]) {
             return
         }
 
         if (node) {
-            editor = me.map[id] = monaco.editor.create(node, data);
+            editor = me.map[id] = monaco.editor.create(node, options);
 
-            editor.getModel().onDidChangeContent(me.onContentChange.bind(me, id))
+            editor.onDidChangeModelContent(me.onContentChange.bind(me, id))
         } else if (Neo.config.environment === 'development') {
             console.warn(`addon.MonacoEditor: node ${id} not found`)
         }
     }
 
     /**
+     * @summary Releases the editor and its owned model/listeners before forgetting the holder.
+     * Monaco owns models created from value/language options; externally supplied models remain
+     * caller-owned, so model disposal must stay with the editor's ownership rules.
      * @param {Object} data
      * @param {String} data.id
      */
     destroyInstance(data) {
-        // todo: destroy the editor instance if possible
+        this.map[data.id]?.dispose();
         delete this.map[data.id]
     }
 
@@ -114,21 +115,30 @@ class MonacoEditor extends Base {
     }
 
     /**
-     *
+     * @summary Awaits Monaco's AMD entry, including its NLS, stylesheet and worker configuration.
+     * Loading editor.main.js as a script only registers its module; addon readiness requires the
+     * AMD factory to finish. The entry owns its version-specific dependency and asset filenames.
+     * @returns {Promise<void>}
      */
     async loadFiles() {
         let me   = this,
             path = me.libraryBasePath;
 
-        window.require = {paths: {vs: path}};
+        if (typeof window.require?.config !== 'function') {
+            try {
+                await DomAccess.loadScript(path + '/loader.js')
+            } catch (error) {
+                throw new Error(`Monaco AMD loader failed: ${path}/loader.js`, {cause: error})
+            }
+        }
 
-        await DomAccess.loadScript(path + '/loader.js');
+        window.require.config({paths: {vs: path}});
 
-        await Promise.all([
-            DomAccess.loadStylesheet(path + '/editor/editor.main.css', {name: 'vs/editor/editor.main'}),
-            DomAccess.loadScript(path + '/editor/editor.main.nls.js'),
-            DomAccess.loadScript(path + '/editor/editor.main.js')
-        ])
+        await new Promise((resolve, reject) => {
+            window.require(['vs/editor/editor.main'], () => resolve(), error => {
+                reject(new Error(`Monaco editor module failed: ${path}/editor/editor.main.js`, {cause: error}))
+            })
+        })
     }
 
     /**
@@ -150,21 +160,25 @@ class MonacoEditor extends Base {
     }
 
     /**
+     * @summary Changes the current model's language through Monaco's public editor API.
      * @param {Object} data
      * @param {String} data.id
      * @param {String} data.value
      */
     setLanguage(data) {
-        this.map[data.id].getModel().setLanguage(data.value)
+        const model = this.map[data.id]?.getModel();
+
+        model && monaco.editor.setModelLanguage(model, data.value)
     }
 
     /**
+     * @summary Applies the main realm's Monaco theme through its public editor API.
      * @param {Object} data
      * @param {String} data.id
      * @param {String} data.value
      */
     setTheme(data) {
-        this.map[data.id]._themeService.setTheme(data.value)
+        this.map[data.id] && monaco.editor.setTheme(data.value)
     }
 
     /**

--- a/test/playwright/component/apps/monaco-editor/app.mjs
+++ b/test/playwright/component/apps/monaco-editor/app.mjs
@@ -1,0 +1,74 @@
+import MonacoEditor from '../../../../../src/component/wrapper/MonacoEditor.mjs';
+import Viewport     from '../../../../../src/container/Viewport.mjs';
+
+/**
+ * @summary Records real wrapper callbacks in the App Worker; Monaco and its loader are unchanged.
+ * @class Test.Playwright.MonacoEditor.Editor
+ * @extends Neo.component.wrapper.MonacoEditor
+ */
+class Editor extends MonacoEditor {
+    static config = {
+        /** @member {String} className='Test.Playwright.MonacoEditor.Editor' */
+        className: 'Test.Playwright.MonacoEditor.Editor',
+        /** @member {String} ntype='test-monaco-editor' */
+        ntype: 'test-monaco-editor',
+        /** @member {String} testGeneration='initial' */
+        testGeneration: 'initial'
+    }
+
+    /** @member {Number} changeCount=0 */
+    changeCount = 0
+    /** @member {String|null} lastChangedValue=null */
+    lastChangedValue = null
+
+    /**
+     * @summary Retains the event received through the native editor-to-worker route.
+     * @param {Object} data
+     */
+    onContentChange(data) {
+        this.changeCount++;
+        this.lastChangedValue = data.value;
+        super.onContentChange(data)
+    }
+
+    /** @summary Records which wrapper generation received a successful mount callback. */
+    onEditorMounted() {
+        Neo.getComponent('monaco-test-viewport').mountReceipts.push(this.testGeneration)
+    }
+}
+Editor = Neo.setupClass(Editor);
+
+/**
+ * @summary Owns a real editor and an observable record of completed mount generations.
+ * @class Test.Playwright.MonacoEditor.Viewport
+ * @extends Neo.container.Viewport
+ */
+class EditorViewport extends Viewport {
+    static config = {
+        /** @member {String} className='Test.Playwright.MonacoEditor.Viewport' */
+        className: 'Test.Playwright.MonacoEditor.Viewport',
+        /** @member {String} id='monaco-test-viewport' */
+        id: 'monaco-test-viewport',
+        /** @member {String} layout='fit' */
+        layout: 'fit',
+        /** @member {Object[]} items */
+        items: [{
+            module           : Editor,
+            editorTheme      : 'vs',
+            id               : 'monaco-test-editor',
+            language         : 'javascript',
+            useThemeAwareness: false,
+            value            : 'const boot = 1;'
+        }]
+    }
+
+    /** @member {String[]} mountReceipts=[] */
+    mountReceipts = []
+}
+EditorViewport = Neo.setupClass(EditorViewport);
+
+/** @summary Starts the dedicated browser fixture with ordinary Neo worker boot. */
+export const onStart = () => Neo.app({
+    mainView: EditorViewport,
+    name    : 'Test.Playwright.MonacoEditor'
+});

--- a/test/playwright/component/apps/monaco-editor/index.html
+++ b/test/playwright/component/apps/monaco-editor/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Neo.mjs Monaco Editor Component Test</title>
+</head>
+<body>
+    <script src="../../../../../src/MicroLoader.mjs" type="module"></script>
+</body>
+</html>

--- a/test/playwright/component/apps/monaco-editor/neo-config.json
+++ b/test/playwright/component/apps/monaco-editor/neo-config.json
@@ -1,0 +1,9 @@
+{
+    "appPath"         : "test/playwright/component/apps/monaco-editor/app.mjs",
+    "basePath"        : "../../../../../",
+    "environment"     : "development",
+    "mainPath"        : "./Main.mjs",
+    "mainThreadAddons": ["DragDrop", "MonacoEditor", "Navigator", "ResizeObserver", "Stylesheet"],
+    "themes"          : ["neo-theme-neo-light"],
+    "useSharedWorkers": false
+}

--- a/test/playwright/component/wrapper/MonacoEditor.spec.mjs
+++ b/test/playwright/component/wrapper/MonacoEditor.spec.mjs
@@ -1,0 +1,240 @@
+import {test, expect} from '@playwright/test';
+
+/**
+ * @summary Exercises the installed Monaco distribution through the real Neo wrapper, App Worker,
+ * AMD loader and main addon. A held network response makes loading-versus-destruction deterministic;
+ * the response is released unchanged, and no editor or loader implementation is substituted.
+ */
+const FIXTURE_URL = 'test/playwright/component/apps/monaco-editor/index.html';
+const EDITOR_ID   = 'monaco-test-editor';
+const HOST_ID     = 'monaco-test-viewport';
+
+/**
+ * @summary Reads the App Worker's native component observation surface.
+ * @param {import('@playwright/test').Page} page
+ * @param {String} id
+ * @param {String[]} keys
+ * @returns {Promise<Array>}
+ */
+const readConfigs = async (page, id, keys) => {
+    const reply = await page.evaluate(data => Neo.worker.App.getConfigs(data), {id, keys});
+
+    return reply?.data ?? reply
+};
+
+/**
+ * @summary Waits for a native editor, rather than treating the wrapper's empty div as readiness.
+ * @param {import('@playwright/test').Page} page
+ * @returns {Promise<void>}
+ */
+const expectEditor = async page => {
+    await expect.poll(() => page.evaluate(id => {
+        const addon  = globalThis.Neo?.main?.addon?.MonacoEditor,
+              editor = addon?.map[id];
+
+        return !!(addon?.isReady && editor?.getModel())
+    }, EDITOR_ID), {message: 'the real Monaco AMD module and native editor become ready', timeout: 20000}).toBe(true);
+
+    await expect(page.locator(`#${EDITOR_ID} .monaco-editor`)).toBeVisible()
+};
+
+/**
+ * @summary Creates the next wrapper generation through the ordinary worker/container API.
+ * @param {import('@playwright/test').Page} page
+ * @param {String} generation
+ * @returns {Promise<void>}
+ */
+const createEditor = async (page, generation) => {
+    const reply = await page.evaluate(config => Neo.worker.App.createNeoInstance(config), {
+        editorTheme      : 'vs',
+        id               : EDITOR_ID,
+        language         : 'javascript',
+        ntype            : 'test-monaco-editor',
+        parentId         : HOST_ID,
+        testGeneration   : generation,
+        useThemeAwareness: false,
+        value            : `const ${generation} = 2;`
+    });
+
+    expect(reply?.data ?? reply).toMatchObject({success: true, id: EDITOR_ID})
+};
+
+/**
+ * @summary Destroys the wrapper through its real parent removal and remote teardown path.
+ * @param {import('@playwright/test').Page} page
+ * @returns {Promise<void>}
+ */
+const destroyEditor = async page => {
+    const reply = await page.evaluate(id => Neo.worker.App.destroyNeoInstance(id), EDITOR_ID);
+
+    expect(reply?.data ?? reply).toMatchObject({success: true});
+    await expect(page.locator(`#${EDITOR_ID}`)).toHaveCount(0)
+};
+
+test.describe('Monaco wrapper against the installed browser distribution', () => {
+    let pageErrors = [], monacoRequests = [], monacoResponses = [];
+
+    test.beforeEach(async ({page}) => {
+        pageErrors      = [];
+        monacoRequests  = [];
+        monacoResponses = [];
+
+        page.on('pageerror', error => pageErrors.push(error.message));
+        page.on('request', request => {
+            if (request.url().includes('/node_modules/monaco-editor/')) monacoRequests.push(request.url())
+        });
+        page.on('response', response => {
+            if (response.url().includes('/node_modules/monaco-editor/')) {
+                monacoResponses.push({url: response.url(), status: response.status(), type: response.headers()['content-type']})
+            }
+        })
+    });
+
+    test.afterEach(() => {
+        expect(pageErrors, 'no browser exception escapes the real editor lifecycle').toEqual([]);
+        expect(monacoResponses.filter(response => response.status >= 400), 'all requested Monaco assets exist').toEqual([])
+    });
+
+    test('boots the AMD module, its stylesheet and the initial editor before reporting mounted', async ({page}) => {
+        await page.goto(FIXTURE_URL);
+        await expectEditor(page);
+        await expect.poll(async () => (await readConfigs(page, HOST_ID, ['mountReceipts']))[0]).toEqual(['initial']);
+
+        const native = await page.evaluate(id => {
+            const editor = Neo.main.addon.MonacoEditor.map[id];
+
+            return {value: editor.getValue(), language: editor.getModel().getLanguageId(), width: editor.getLayoutInfo().width}
+        }, EDITOR_ID);
+
+        expect(native).toMatchObject({value: 'const boot = 1;', language: 'javascript'});
+        expect(native.width).toBeGreaterThan(100);
+
+        const diagnostics = await page.evaluate(async id => {
+            const model     = Neo.main.addon.MonacoEditor.map[id].getModel(),
+                  getWorker = await monaco.typescript.getJavaScriptWorker(),
+                  worker    = await getWorker(model.uri);
+
+            return worker.getSyntacticDiagnostics(model.uri.toString())
+        }, EDITOR_ID);
+
+        expect(diagnostics, 'the installed language worker reads the live editor model').toEqual([]);
+        await expect.poll(() => monacoResponses.find(response => response.url.endsWith('/editor/editor.main.css'))?.type)
+            .toContain('text/css');
+        expect(monacoRequests.some(url => url.endsWith('/editor/editor.main.nls.js')), 'the retired NLS file is never requested').toBe(false)
+    });
+
+    test('reactive wrapper configs reach public Monaco value, language, theme and option APIs', async ({page}) => {
+        await page.goto(FIXTURE_URL);
+        await expectEditor(page);
+
+        await page.evaluate(configs => Neo.worker.App.setConfigs(configs), {
+            id      : EDITOR_ID, value: '# Updated', language: 'markdown', editorTheme: 'vs-dark', fontSize: 21,
+            readOnly: true, minimap: {enabled: true}
+        });
+
+        await expect.poll(() => page.evaluate(id => {
+            const editor  = Neo.main.addon.MonacoEditor.map[id],
+                  options = editor.getRawOptions();
+
+            return {
+                value   : editor.getValue(), language: editor.getModel().getLanguageId(), fontSize: options.fontSize,
+                readOnly: options.readOnly, minimap: options.minimap.enabled
+            }
+        }, EDITOR_ID)).toEqual({value: '# Updated', language: 'markdown', fontSize: 21, readOnly: true, minimap: true});
+        await expect(page.locator(`#${EDITOR_ID} .monaco-editor`)).toHaveClass(/\bvs-dark\b/)
+    });
+
+    test('real keyboard edits deliver the changed value back to the App Worker', async ({page}) => {
+        await page.goto(FIXTURE_URL);
+        await expectEditor(page);
+
+        const [before] = await readConfigs(page, EDITOR_ID, ['changeCount']);
+
+        await page.evaluate(id => {
+            const editor     = Neo.main.addon.MonacoEditor.map[id],
+                  model      = editor.getModel(),
+                  lineNumber = model.getLineCount();
+
+            editor.focus();
+            editor.setPosition({lineNumber, column: model.getLineMaxColumn(lineNumber)})
+        }, EDITOR_ID);
+        await page.keyboard.insertText('\nconst edited = 3;');
+
+        const nativeValue = await page.evaluate(id => Neo.main.addon.MonacoEditor.map[id].getValue(), EDITOR_ID);
+
+        await expect.poll(async () => (await readConfigs(page, EDITOR_ID, ['lastChangedValue']))[0])
+            .toBe(nativeValue);
+        expect(nativeValue.replace(/\r\n/g, '\n')).toBe('const boot = 1;\nconst edited = 3;');
+        expect((await readConfigs(page, EDITOR_ID, ['changeCount']))[0]).toBeGreaterThan(before)
+    });
+
+    test('destroy disposes the owned model and recreation gives the same holder a fresh editor', async ({page}) => {
+        await page.goto(FIXTURE_URL);
+        await expectEditor(page);
+        await page.evaluate(id => {
+            const editor = Neo.main.addon.MonacoEditor.map[id];
+
+            window.monacoLifecycleProbe = {editor, model: editor.getModel(), disposed: false};
+            editor.onDidDispose(() => { window.monacoLifecycleProbe.disposed = true })
+        }, EDITOR_ID);
+
+        await destroyEditor(page);
+        await expect.poll(() => page.evaluate(id => ({
+            disposed     : window.monacoLifecycleProbe.disposed,
+            modelDisposed: window.monacoLifecycleProbe.model.isDisposed(),
+            registered   : !!Neo.main.addon.MonacoEditor.map[id]
+        }), EDITOR_ID)).toEqual({disposed: true, modelDisposed: true, registered: false});
+
+        await createEditor(page, 'replacement');
+        await expectEditor(page);
+        expect(await page.evaluate(id => {
+            const editor = Neo.main.addon.MonacoEditor.map[id];
+
+            return {fresh: editor !== window.monacoLifecycleProbe.editor, value: editor.getValue(), models: monaco.editor.getModels().length}
+        }, EDITOR_ID)).toEqual({fresh: true, value: 'const replacement = 2;', models: 1})
+    });
+
+    test('retiring a mounted wrapper while the real module loads cannot resurrect its generation', async ({page}) => {
+        let release, entered;
+        const gate    = new Promise(resolve => { release = resolve }),
+              blocked = new Promise(resolve => { entered = resolve });
+
+        await page.route('**/node_modules/monaco-editor/min/vs/editor/editor.main.js', async route => {
+            entered();
+            await gate;
+            await route.continue()
+        });
+
+        try {
+            await page.goto(FIXTURE_URL, {waitUntil: 'domcontentloaded'});
+            await blocked;
+            await expect.poll(async () => (await readConfigs(page, EDITOR_ID, ['mounted']))[0]).toBe(true);
+            expect(await page.evaluate(() => Neo.main.addon.MonacoEditor.isReady)).toBe(false);
+
+            await destroyEditor(page);
+            await createEditor(page, 'replacement');
+        } finally {
+            release()
+        }
+
+        await expectEditor(page);
+        await expect.poll(async () => (await readConfigs(page, HOST_ID, ['mountReceipts']))[0]).toEqual(['replacement']);
+        expect(await page.evaluate(id => ({
+            value: Neo.main.addon.MonacoEditor.map[id].getValue(), models: monaco.editor.getModels().length
+        }), EDITOR_ID)).toEqual({value: 'const replacement = 2;', models: 1})
+    });
+
+    test('the actual Portal boot completes Monaco addon initialization even when home paints first', async ({page}) => {
+        await page.goto('apps/portal/index.html#home', {waitUntil: 'domcontentloaded'});
+        await expect(page.locator('.portal-main-content')).toBeVisible({timeout: 20000});
+
+        // Home can paint while the addon's deferred preload still fails. Readiness is the missing
+        // boundary: a visible Portal shell alone did not observe the obsolete NLS request.
+        await expect.poll(() => page.evaluate(() => !!globalThis.Neo?.main?.addon?.MonacoEditor?.isReady),
+            {message: 'Portal Monaco preload completes through the real AMD module', timeout: 20000}).toBe(true);
+        expect(await page.evaluate(() => typeof globalThis.monaco?.editor?.create)).toBe('function');
+        await expect.poll(() => monacoResponses.find(response => response.url.endsWith('/editor/editor.main.css'))?.type)
+            .toContain('text/css');
+        expect(monacoRequests.some(url => url.endsWith('/editor/editor.main.nls.js'))).toBe(false)
+    });
+});


### PR DESCRIPTION
Resolves #5822

Related: #18354

Monaco 0.56.0 boots through its AMD entry instead of Neo injecting the retired NLS file and raw entry script. The entry owns its stylesheet, localization and worker assets, and addon readiness waits for its completion. The addon uses public language/theme APIs and disposes native editors through Monaco's model-ownership rules. The wrapper starts creation from the mounted signal and ignores replies from retired mount/window generations.

Monaco remains exact-pinned at 0.56.0. Dependabot now proposes Monaco updates separately from the all-deps group, so an integration bump gets an explicit review.

Evidence: L3 (real installed Monaco in Chromium, including Portal preload, rendered editor and JavaScript language-worker request) → L3 required (resumed compatibility contract on #5822).

## AC Evidence

No structured ACs on #5822. The operator-directed five-point repair contract is recorded in [the resumed intake](https://github.com/neomjs/neo/issues/5822#issuecomment-5551655952).

| Resumed obligation | Evidence |
|---|---|
| Portal/AMD initialization | `component/wrapper/MonacoEditor.spec.mjs`: actual Portal preload and isolated wrapper both await the real addon; stylesheet MIME and absent retired NLS request asserted |
| Editor APIs and language worker | Same spec: live model/value/language/theme/options, real keyboard-to-worker event, and installed JavaScript worker syntax request |
| Lifecycle | Same spec: owned-model disposal/recreate plus destruction while the real AMD response is held; successor is the only accepted mount and only live model |
| CI regression detection | The spec and its app run in the existing component tier, already selected by package.json dependency changes and package-lock.json; original-loader negative control below |
| Exact pin and update isolation | package.json retains exact 0.56.0; `all-deps.exclude-patterns` isolates monaco-editor into its own Dependabot PR |

## Deltas from ticket

Removing `editor.main.nls.js` alone does not complete the migration, as the original 2024 comment warned. Proper AMD dependency resolution replaces the entire manual script/CSS sequence. The public setters existed in the older release too; no API-removal claim is needed for replacing private access.

The security issue #18354 stays open: this PR does not update Monaco's embedded DOMPurify or dismiss its alerts.

## Test Evidence

Negative control: temporarily restored the original `loadFiles()` body and ran the installed-editor boot and actual Portal checks. Both failed on unresolved addon readiness and the original browser `Event` rejection. Restoring the repaired loader returned both checks to green.

Live inspection: the retired NLS URL returned 404 `text/html`, while the actual Monaco stylesheet returned 200 `text/css`. After the standard theme preflight the Portal home could paint despite the old addon's failed preload; the new gate observes editor readiness, not merely visible page chrome.

## Post-Merge Validation

No additional compatibility prerequisite. Future Monaco updates should arrive as separate PRs and run the real-package browser gate. Bundled-sanitizer remediation remains owned by #18354.

Authored by Euclid (GPT-6 Astra, Codex Desktop). Session cb7ccc74-b375-4785-9adf-df6d1112957b.

