### PR TITLE
feat(dock): a header repartition enters the dock motion signal on its own toolbar (#18356)

### DIFF
--- a/resources/scss/src/dashboard/Container.scss
+++ b/resources/scss/src/dashboard/Container.scss
@@ -3,7 +3,8 @@
     // transitions — splitter ease, tab insert/remove morphing, auto-hide rail slide, and the
     // FLIP commit layer all read THESE (a call-site duration/easing literal is a contract
     // violation). Motion lifecycle is observable via the `neo-dashboard-dock-animating` class
-    // (present during motion, removed on settle — see Neo.dashboard.dock.projection.MotionSignal).
+    // (present during motion AND during a tab header's overflow repartition, removed on settle —
+    // see Neo.dashboard.dock.projection.MotionSignal).
     //
     // Layering: these are the DOCK-DOMAIN aliases of the product motion vocabulary (the
     // motion-standards tier owns the semantic set — panel-move duration, settle easing). Dock

--- a/src/dashboard/dock/projection/LayoutAdapter.mjs
+++ b/src/dashboard/dock/projection/LayoutAdapter.mjs
@@ -4,6 +4,7 @@ import DockSplitter      from '../interaction/DockSplitter.mjs';
 import TabEnterButton    from '../interaction/TabEnterButton.mjs';
 import TabSortZone       from '../interaction/TabSortZone.mjs';
 import WorkspaceDocument from '../model/WorkspaceDocument.mjs';
+import MotionSignal      from './MotionSignal.mjs';
 import TabOverflowPlugin from '../../../tab/plugin/Overflow.mjs';
 
 // Private runtime restoration slot for live component instances projected through the popup
@@ -1245,6 +1246,19 @@ class LayoutAdapter extends Base {
             // (below), cross-zone drops report their release point to `onDockCrossZoneDrop` so the owner can
             // hit-test the target zone and commit a `moveItem`. Still one drag system — no parallel pipeline.
             headerToolbar : {
+                // The overflow plugin publishes its repartition as a start/idle pair on this toolbar; a
+                // repartition removes and restores header nodes, so it enters the dock motion signal like
+                // any motion does — counted, instance-keyed, fail-safe — and a consumer waiting for
+                // `neo-dashboard-dock-animating` to be absent from the dock host waits for both. The
+                // carrier is the toolbar ITSELF, the producer's own component (the tab-enter button's
+                // precedent): a class toggled on the workspace root from inside a header pass forces a
+                // whole-tree vnode sync while that header's buttons are being replaced, and at boot that
+                // sync fails on a retired button id and strands the projection. The generic plugin stays
+                // dock-blind: the routing lives here, in the config that installs it.
+                listeners: {
+                    overflowProjectionIdle : ({owner}) => MotionSignal.leave(owner),
+                    overflowProjectionStart: ({owner}) => MotionSignal.enter(owner)
+                },
                 // Tab-overflow affordance: when the projected headers exceed the toolbar width, the
                 // overflowing tabs collapse behind the first stable header action whose menu reaches them
                 // (Neo.tab.plugin.Overflow — a generic tab-subsystem plugin the dock only consumes). The

--- a/src/dashboard/dock/projection/MotionSignal.mjs
+++ b/src/dashboard/dock/projection/MotionSignal.mjs
@@ -9,7 +9,11 @@ import Base from '../../../core/Base.mjs';
  * class leaves. Assertion surfaces (`observe_motion` e2e specs, tour-runner step gating) key off
  * exactly this signal, and every motion producer — the choreography transitions AND the FLIP
  * commit layer — routes through it rather than toggling classes ad hoc, so there is ONE lifecycle
- * to observe no matter how many mechanisms animate.
+ * to observe no matter how many mechanisms animate. A header's overflow repartition is the one
+ * non-animated producer: it removes and restores header nodes, so the dock's projection adapter
+ * routes the tab-overflow plugin's `overflowProjectionStart` / `overflowProjectionIdle` pair through
+ * here too, carried by the header toolbar itself — "do not act on this DOM yet" is one question
+ * whether the cause moves or replaces, and a consumer asks it of the dock host's subtree.
  *
  * Semantics (binding):
  *

--- a/src/tab/plugin/Overflow.mjs
+++ b/src/tab/plugin/Overflow.mjs
@@ -32,7 +32,8 @@ import Plugin from '../../plugin/Base.mjs';
  * brackets for {@link #whenProjectionIdle} as two events on its owner toolbar — `overflowProjectionStart`
  * when a measuring pass arms, `overflowProjectionIdle` when the pass and its coalesced rerun have settled —
  * so a host can expose "in flight" where its consumers look (the dock routes it into its motion signal).
- * A projection parked behind an open menu or a drag is not in flight: the header is stable until it drains.
+ * A projection parked behind an open menu or a drag is not in flight: the header is stable until it drains,
+ * so a pass that parks closes its pair and the pass that resumes after the drain opens a new one.
  *
  * @class Neo.tab.plugin.Overflow
  * @extends Neo.plugin.Base
@@ -515,8 +516,11 @@ class Overflow extends Plugin {
     /**
      * Publishes the projection lifecycle on the owner toolbar at its edges only: `overflowProjectionStart`
      * when a measuring pass arms while nothing was in flight, `overflowProjectionIdle` when neither a pass
-     * nor a coalesced rerun remains. Called after every latch transition, so intermediate states publish
-     * nothing and one transaction is exactly one pair. A destroyed owner has no listeners left to reach.
+     * nor a coalesced rerun remains. Called when a pass arms and after every pass releases, so intermediate
+     * states publish nothing and one transaction is exactly one pair. A pass parked behind an open menu
+     * has stopped moving header nodes: it closes its pair here while the drag-start waiters keep waiting,
+     * and the pass that resumes after the drain opens a new one. A destroyed owner has no listeners left
+     * to reach.
      * @protected
      */
     publishProjectionState() {
@@ -534,15 +538,15 @@ class Overflow extends Plugin {
     }
 
     /**
-     * Resolves drag-start callers after the projection and any coalesced rerun are idle, and publishes the
-     * idle edge to the owner.
+     * Resolves drag-start callers after the projection and any coalesced rerun are idle. The published
+     * lifecycle has its own, narrower edge in {@link #publishProjectionState}: an open menu holds these
+     * waiters, not the signal.
      * @protected
      */
     resolveProjectionIdle() {
         let waiters = this.projectionIdleWaiters || [];
 
         this.projectionIdleWaiters = null;
-        this.publishProjectionState();
         waiters.forEach(resolve => resolve())
     }
 
@@ -827,6 +831,12 @@ class Overflow extends Plugin {
         } else if (!me.menuProjectionQueued) {
             me.resolveProjectionIdle()
         }
+
+        // The signal's edge, apart from the waiter's: it closes whenever nothing is measuring or queued —
+        // including a pass parked behind an open menu, which the waiter above keeps waiting on, and a
+        // coalesced rerun that returned early because it found the menu open. A pass that resumes after
+        // the drain therefore opens a fresh pair.
+        me.publishProjectionState()
     }
 
     /**

--- a/src/tab/plugin/Overflow.mjs
+++ b/src/tab/plugin/Overflow.mjs
@@ -27,6 +27,13 @@ import Plugin from '../../plugin/Base.mjs';
  * changes) and caches them; a plain resize only re-reads the always-visible strip extent and recomputes
  * against that cache.
  *
+ * Lifecycle publication: a repartition removes and restores header nodes, so a pointer that aimed at a
+ * button before the pass can land on nothing after it. The plugin publishes the transaction it already
+ * brackets for {@link #whenProjectionIdle} as two events on its owner toolbar — `overflowProjectionStart`
+ * when a measuring pass arms, `overflowProjectionIdle` when the pass and its coalesced rerun have settled —
+ * so a host can expose "in flight" where its consumers look (the dock routes it into its motion signal).
+ * A projection parked behind an open menu or a drag is not in flight: the header is stable until it drains.
+ *
  * @class Neo.tab.plugin.Overflow
  * @extends Neo.plugin.Base
  */
@@ -233,6 +240,14 @@ class Overflow extends Plugin {
      * @member {Boolean} sortDragDrainScheduled=false
      */
     sortDragDrainScheduled = false
+    /**
+     * Whether the published projection lifecycle is currently open: `true` between the
+     * `overflowProjectionStart` a measuring pass fired and the `overflowProjectionIdle` its settle fires.
+     * A coalesced rerun keeps it open, so one transaction publishes one pair.
+     * @member {Boolean} projectionBusy=false
+     * @protected
+     */
+    projectionBusy = false
     /**
      * Drag-start callers waiting for the complete projection transaction to settle.
      * @member {Function[]|null} projectionIdleWaiters=null
@@ -498,13 +513,36 @@ class Overflow extends Plugin {
     }
 
     /**
-     * Resolves drag-start callers after the projection and any coalesced rerun are idle.
+     * Publishes the projection lifecycle on the owner toolbar at its edges only: `overflowProjectionStart`
+     * when a measuring pass arms while nothing was in flight, `overflowProjectionIdle` when neither a pass
+     * nor a coalesced rerun remains. Called after every latch transition, so intermediate states publish
+     * nothing and one transaction is exactly one pair. A destroyed owner has no listeners left to reach.
+     * @protected
+     */
+    publishProjectionState() {
+        let me      = this,
+            {owner} = me,
+            busy    = me.measuring || me.projectQueued;
+
+        if (busy === me.projectionBusy) return;
+
+        me.projectionBusy = busy;
+
+        if (owner && !owner.isDestroyed) {
+            owner.fire?.(busy ? 'overflowProjectionStart' : 'overflowProjectionIdle', {owner, plugin: me})
+        }
+    }
+
+    /**
+     * Resolves drag-start callers after the projection and any coalesced rerun are idle, and publishes the
+     * idle edge to the owner.
      * @protected
      */
     resolveProjectionIdle() {
         let waiters = this.projectionIdleWaiters || [];
 
         this.projectionIdleWaiters = null;
+        this.publishProjectionState();
         waiters.forEach(resolve => resolve())
     }
 
@@ -631,6 +669,7 @@ class Overflow extends Plugin {
         }
 
         me.measuring = true;
+        me.publishProjectionState();
 
         try {
             let controlIconCls = geometry.dimension === 'height'

--- a/src/tab/plugin/Overflow.mjs
+++ b/src/tab/plugin/Overflow.mjs
@@ -1192,7 +1192,7 @@ class Overflow extends Plugin {
 
         me.hiddenSignature = signature;
 
-        // RA-13: re-align against the CURRENT owner rect. A floating component aligns once at mount and does
+        // Re-align against the CURRENT owner rect: a floating component aligns once at mount and does
         // NOT re-align when its target moves. Re-aligning on each sync re-pins it to the current action or
         // owner edge — cheap + idempotent. The e2e owner-exact geometry assertion falsifies its absence.
         if (me.control) {

--- a/test/playwright/component/dashboard/DockOverflowSettleSignal.spec.mjs
+++ b/test/playwright/component/dashboard/DockOverflowSettleSignal.spec.mjs
@@ -1,0 +1,97 @@
+import {test, expect} from '@playwright/test';
+
+/**
+ * A tab header's overflow repartition is a projection pass that removes and restores header nodes.
+ * Without a published signal a pointer consumer could only guess when a header was safe to click; a
+ * node that was visible, enabled and rect-stable could be detached before the click dispatched. The
+ * dock routes the plugin's `overflowProjectionStart` / `overflowProjectionIdle`
+ * pair into its motion signal, so while the pass is in flight the header toolbar carries
+ * `neo-dashboard-dock-animating` inside the dock host, exactly as motion producers do, and drops it
+ * when the pass settles. A consumer asks the dock host's subtree, not one carrier.
+ *
+ * The bracket is captured with a subtree observer installed BEFORE the trigger: a pass can be shorter
+ * than a poll interval, so sampling would miss it and read as the defect. Red-first: on `dev` no
+ * producer enters the signal during a tab activation, so `seen` stays `false` and the first assertion
+ * reds. The click that follows is the consumer's real act — gated on the class being absent, it lands
+ * on an attached header action and the lock state flips, which a click into a detached node cannot
+ * produce.
+ */
+
+const WORKSPACE = '#dock-maximize-workspace';
+
+const tabsNodeWith = (page, tabText) => page.locator('.neo-dashboard-dock-tabs', {
+    has: page.locator(`.neo-tab-header-button:has-text("${tabText}")`)
+});
+
+const tabButton    = (node, text)  => node.locator('.neo-tab-header-button', {hasText: text});
+const actionButton = (node, glyph) => node.locator(`.neo-tab-header-toolbar .neo-button:has([class*="${glyph}"])`);
+
+/**
+ * Records whether any element inside the workspace carries the signal class, at install time and at
+ * every class mutation in the subtree, so a bracket shorter than one poll is still seen.
+ * @param {import('@playwright/test').Page} page
+ * @returns {Promise<void>}
+ */
+const watchSignal = page => page.evaluate(selector => {
+    const
+        root     = document.querySelector(selector),
+        log      = [],
+        record   = () => log.push(!!root.querySelector('.neo-dashboard-dock-animating') || root.classList.contains('neo-dashboard-dock-animating')),
+        observer = new MutationObserver(record);
+
+    observer.observe(root, {attributes: true, attributeFilter: ['class'], subtree: true});
+    record();
+
+    globalThis.__dockSignalWatch = {log, stop: () => observer.disconnect()}
+}, WORKSPACE);
+
+const signalCarriers = page => page.locator(`${WORKSPACE} .neo-dashboard-dock-animating, ${WORKSPACE}.neo-dashboard-dock-animating`);
+
+/**
+ * @param {import('@playwright/test').Page} page
+ * @returns {Promise<Boolean[]>} The recorded presence values, first entry the state at install.
+ */
+const readSignal = page => page.evaluate(() => {
+    const watch = globalThis.__dockSignalWatch;
+
+    watch.stop();
+
+    return watch.log
+});
+
+test.beforeEach(async ({page}) => {
+    await page.goto('test/playwright/component/apps/dock-maximize/index.html');
+    await page.waitForSelector(WORKSPACE, {state: 'attached'});
+    await page.waitForSelector('.neo-tab-header-button', {state: 'visible'});
+    await expect(signalCarriers(page), 'at rest nothing is in flight').toHaveCount(0)
+});
+
+test('a tab activation\'s header repartition brackets the header with the dock motion signal, and a click gated on its absence lands', async ({page}) => {
+    const main = tabsNodeWith(page, 'Alpha');
+
+    await expect(main).toHaveCount(1);
+    await expect(tabButton(main, 'Alpha')).toHaveAttribute('aria-selected', 'true');
+
+    await watchSignal(page);
+
+    // Activation is a repartition trigger: the overflow plugin re-measures the header and re-applies
+    // its split for the new active tab, which is the pass that removes and restores header nodes.
+    await tabButton(main, 'Beta').click();
+
+    await expect(tabButton(main, 'Beta')).toHaveAttribute('aria-selected', 'true');
+    await expect(signalCarriers(page)).toHaveCount(0);
+
+    const log = await readSignal(page);
+
+    expect(log[0], 'installed at rest').toBe(false);
+    expect(log, 'the signal was present inside the dock host during the pass').toContain(true);
+    expect(log.at(-1), 'and absent once the pass settled').toBe(false);
+
+    // The consumer's act: a header action clicked once the signal is absent lands on an attached node,
+    // and the lock policy flips the action to its unlock presentation.
+    await expect(signalCarriers(page)).toHaveCount(0);
+    await actionButton(main, 'fa-lock').click();
+
+    await expect(actionButton(main, 'fa-lock-open')).toBeVisible();
+    await expect(signalCarriers(page)).toHaveCount(0)
+});

--- a/test/playwright/unit/dashboard/DockLayoutAdapter.spec.mjs
+++ b/test/playwright/unit/dashboard/DockLayoutAdapter.spec.mjs
@@ -1113,6 +1113,105 @@ test.describe('Neo.dashboard.dock.projection.LayoutAdapter', () => {
         expect(plugins[0].projectAsAction, 'dock headers project Overflow into their action rail').toBe(true);
     });
 
+    test('a projected header routes the overflow plugin\'s start/idle pair into the dock motion signal, carried by the header toolbar itself — one entry per header, a nested pass counted, an idle without a start a no-op', async () => {
+        const
+            MotionSignal = (await import('../../../../src/dashboard/dock/projection/MotionSignal.mjs')).default,
+            result       = DockLayoutAdapter.project(createModel(), {
+                resolveComponentRef: componentRef => ({ntype: 'dashboard-panel', reference: componentRef})
+            }),
+            listeners    = result.items[0].headerToolbar.listeners,
+            makeToolbar  = id => ({id, isDestroyed: false, isDestroying: false, cls: [], addCls(cls) { this.cls.push(cls) }, removeCls(cls) { this.cls = this.cls.filter(c => c !== cls) }}),
+            headerA      = makeToolbar('header-a'),
+            headerB      = makeToolbar('header-b');
+
+        MotionSignal.activeMotions.clear();
+
+        try {
+            expect(typeof listeners.overflowProjectionStart).toBe('function');
+            expect(typeof listeners.overflowProjectionIdle).toBe('function');
+
+            // Each header toolbar carries its own signal: the class lands where the nodes move.
+            listeners.overflowProjectionStart({owner: headerA});
+            listeners.overflowProjectionStart({owner: headerB});
+
+            expect(headerA.cls).toEqual(['neo-dashboard-dock-animating']);
+            expect(headerB.cls).toEqual(['neo-dashboard-dock-animating']);
+            expect(MotionSignal.isAnimating('header-a')).toBe(true);
+
+            listeners.overflowProjectionIdle({owner: headerA});
+
+            expect(headerA.cls, 'A settled').toEqual([]);
+            expect(headerB.cls, 'B is still in flight').toEqual(['neo-dashboard-dock-animating']);
+
+            listeners.overflowProjectionIdle({owner: headerB});
+
+            expect(headerB.cls).toEqual([]);
+            expect(MotionSignal.isAnimating('header-b')).toBe(false);
+
+            // Counted: a second producer on the same toolbar (a FLIP or reveal nesting a repartition)
+            // keeps the class until the last one leaves; an idle without a start changes nothing.
+            listeners.overflowProjectionStart({owner: headerA});
+            MotionSignal.enter(headerA);
+            listeners.overflowProjectionIdle({owner: headerA});
+
+            expect(headerA.cls, 'the other producer still holds it').toEqual(['neo-dashboard-dock-animating']);
+
+            MotionSignal.leave(headerA);
+            listeners.overflowProjectionIdle({owner: headerA});
+
+            expect(headerA.cls).toEqual([]);
+            expect(MotionSignal.activeMotions.size, 'an unbalanced idle registers nothing').toBe(0)
+        } finally {
+            MotionSignal.activeMotions.clear()
+        }
+    });
+
+    test('a header re-projected mid-pass cannot wedge the signal: the destroyed toolbar\'s entry clears through the fail-safe, its late idle is a no-op, and the new header\'s pass is a clean pair', async () => {
+        const
+            MotionSignal = (await import('../../../../src/dashboard/dock/projection/MotionSignal.mjs')).default,
+            result       = DockLayoutAdapter.project(createModel(), {
+                resolveComponentRef: componentRef => ({ntype: 'dashboard-panel', reference: componentRef})
+            }),
+            listeners    = result.items[0].headerToolbar.listeners,
+            makeToolbar  = id => ({id, isDestroyed: false, isDestroying: false, cls: [], addCls(cls) { this.cls.push(cls) }, removeCls(cls) { this.cls = this.cls.filter(c => c !== cls) }}),
+            oldHeader    = makeToolbar('header-old'),
+            newHeader    = makeToolbar('header-new'),
+            failSafeMs   = MotionSignal.FAIL_SAFE_MS;
+
+        MotionSignal.activeMotions.clear();
+        MotionSignal.FAIL_SAFE_MS = 30;
+
+        try {
+            // The old header arms a pass, then the dock re-projects and destroys it mid-flight: its idle
+            // never publishes (a destroyed owner has no listeners), so its entry outlives it — until the
+            // fail-safe clears it. Nothing else carries a stale class.
+            listeners.overflowProjectionStart({owner: oldHeader});
+            expect(MotionSignal.isAnimating('header-old')).toBe(true);
+
+            oldHeader.isDestroyed = true;
+
+            await new Promise(resolve => setTimeout(resolve, 80));
+
+            expect(MotionSignal.isAnimating('header-old'), 'the fail-safe cleared the destroyed header\'s entry').toBe(false);
+            expect(MotionSignal.activeMotions.size).toBe(0);
+
+            // A late idle from the destroyed header — the pass's finally reaching a listener after all —
+            // registers nothing and touches no other component.
+            listeners.overflowProjectionIdle({owner: oldHeader});
+            expect(MotionSignal.activeMotions.size).toBe(0);
+
+            // The re-projected header's own pass is a clean pair.
+            listeners.overflowProjectionStart({owner: newHeader});
+            expect(newHeader.cls).toEqual(['neo-dashboard-dock-animating']);
+            listeners.overflowProjectionIdle({owner: newHeader});
+            expect(newHeader.cls).toEqual([]);
+            expect(MotionSignal.isAnimating('header-new')).toBe(false)
+        } finally {
+            MotionSignal.FAIL_SAFE_MS = failSafeMs;
+            MotionSignal.activeMotions.clear()
+        }
+    });
+
     test.describe('tab sort boundary + tear-out projection threading', () => {
         test('a workspace boundary enables ordinary cross-zone motion without arming tear-out', () => {
             const result = DockLayoutAdapter.project(createModel(), {

--- a/test/playwright/unit/dashboard/DockLayoutAdapter.spec.mjs
+++ b/test/playwright/unit/dashboard/DockLayoutAdapter.spec.mjs
@@ -20,6 +20,14 @@ import '../../../../src/dashboard/Panel.mjs'; // registers the `dashboard-panel`
 import TabContainer      from '../../../../src/tab/Container.mjs';
 import TabOverflowPlugin from '../../../../src/tab/plugin/Overflow.mjs';
 
+class MountableMenuList extends Neo.core.Base {
+    static config = {
+        className: 'Test.Unit.Dashboard.DockLayoutAdapter.MountableMenuList',
+        mounted_ : false
+    }
+}
+MountableMenuList = Neo.setupClass(MountableMenuList);
+
 const createModel = () => ({
     schema: 'neo.dock.zone.v1',
     root  : 'root',
@@ -1209,6 +1217,112 @@ test.describe('Neo.dashboard.dock.projection.LayoutAdapter', () => {
         } finally {
             MotionSignal.FAIL_SAFE_MS = failSafeMs;
             MotionSignal.activeMotions.clear()
+        }
+    });
+
+    test('the composed pointer contract with the real plugin: a menu that parks an active pass releases the header toolbar\'s signal at once, and the pass that resumes after the menu drains runs its split with the signal present — not by way of the fail-safe', async () => {
+        let release,
+            callCount = 0,
+            plugin;
+
+        const
+            MotionSignal = (await import('../../../../src/dashboard/dock/projection/MotionSignal.mjs')).default,
+            result       = DockLayoutAdapter.project(createModel(), {
+                resolveComponentRef: componentRef => ({ntype: 'dashboard-panel', reference: componentRef})
+            }),
+            listeners    = result.items[0].headerToolbar.listeners,
+            failSafeMs   = MotionSignal.FAIL_SAFE_MS,
+            gate         = new Promise(resolve => {release = resolve}),
+            splits       = [],
+            // A lean header toolbar: what the plugin measures and mutates, what the signal marks, and the
+            // projected header config's own listeners as the owner's event surface.
+            owner        = {
+                id          : 'header-live',
+                appName     : 'DashboardDockLayoutAdapterTest',
+                dock        : 'top',
+                mounted     : true,
+                isDestroyed : false,
+                isDestroying: false,
+                cls         : [],
+                parent      : {activeIndex: 0, on() {}, un() {}},
+                theme       : 'neo-theme-neo-dark',
+                windowId    : 1,
+                items       : [{id: 'b1'}, {id: 'b2'}],
+                addCls(cls) { this.cls.push(cls) },
+                removeCls(cls) { this.cls = this.cls.filter(c => c !== cls) },
+                getActionItems: () => [],
+                getTabButtons() { return this.items },
+                getTheme() { return this.theme },
+                async getDomRect(ids) {
+                    callCount++;
+                    if (callCount === 1) { await gate }
+                    return ids[0] === 'header-live' ? [{width: 1000}] : [{width: 10}, {width: 10}]
+                },
+                add            : () => ({}),
+                addDomListeners: () => {},
+                fire           : (name, data) => listeners[name]?.(data),
+                on             : () => {},
+                un             : () => {},
+                remove         : () => {},
+                up             : () => ({activeIndex: 0})
+            };
+
+        MotionSignal.activeMotions.clear();
+        MotionSignal.FAIL_SAFE_MS = 30;
+
+        try {
+            plugin         = Neo.create(TabOverflowPlugin, {owner});
+            plugin.control = null;
+
+            const applySplit = plugin.applySplit;
+
+            plugin.applySplit = function (...args) {
+                splits.push(MotionSignal.isAnimating('header-live'));
+                return applySplit.apply(this, args)
+            };
+
+            await new Promise(resolve => setTimeout(resolve, 0));
+
+            // An active measure carries the signal on the toolbar itself.
+            expect(plugin.measuring).toBe(true);
+            expect(MotionSignal.isAnimating('header-live'), 'a measuring header carries the signal').toBe(true);
+
+            // The menu opens during the awaited measure: the mutation boundary parks the pass. Parked means
+            // stable, so the signal leaves at once — no fail-safe involved.
+            const menuList = Neo.create(MountableMenuList, {mounted: true});
+
+            plugin.control = {alignTo() {}, destroy() {}, iconCls: 'fa fa-ellipsis', menuList, mounted: true};
+
+            release();
+            await new Promise(resolve => setTimeout(resolve, 0));
+            await new Promise(resolve => setTimeout(resolve, 0));
+
+            expect(plugin.menuProjectionQueued, 'the pass is parked behind the menu').toBe(true);
+            expect(splits, 'a parked pass mutates nothing').toEqual([]);
+            expect(MotionSignal.isAnimating('header-live'), 'a parked pass releases the signal at once').toBe(false);
+
+            // The menu is held past the fail-safe window: nothing is left for the fail-safe to clear, and
+            // nothing may be left that the resume below depends on.
+            await new Promise(resolve => setTimeout(resolve, 80));
+
+            expect(MotionSignal.activeMotions.size).toBe(0);
+
+            // The menu closes and the drain resumes the pass as a fresh transaction: its split executes with
+            // the signal present, and the signal leaves once it settles.
+            menuList.mounted = false;
+
+            await plugin.whenProjectionIdle();
+            await new Promise(resolve => setTimeout(resolve, 0));
+
+            expect(splits, 'the resumed split ran with the signal present').toEqual([true]);
+            expect(MotionSignal.isAnimating('header-live'), 'settled: the signal left').toBe(false);
+            expect(MotionSignal.activeMotions.size).toBe(0);
+
+            menuList.destroy()
+        } finally {
+            MotionSignal.FAIL_SAFE_MS = failSafeMs;
+            MotionSignal.activeMotions.clear();
+            plugin?.destroy()
         }
     });
 

--- a/test/playwright/unit/tab/plugin/Overflow.spec.mjs
+++ b/test/playwright/unit/tab/plugin/Overflow.spec.mjs
@@ -309,6 +309,63 @@ test.describe('Neo.tab.plugin.Overflow (re-entrancy contract)', () => {
         expect(seen.length, 'no pass, no edge').toBe(before)
     });
 
+    test('a menu opening during an active measure parks the pass and closes its pair while the drag-start waiter keeps waiting; the pass that resumes after the drain opens a fresh pair', async () => {
+        let release,
+            callCount = 0,
+            settled   = false;
+
+        const
+            gate   = new Promise(resolve => {release = resolve}),
+            events = [];
+
+        const plugin = createPlugin(async ids => {
+            callCount++;
+            if (callCount === 1) { await gate }
+            return ids[0] === 'tab-overflow-test-owner' ? [{width: 1000}] : [{width: 10}, {width: 10}]
+        }, name => events.push(name));
+
+        await new Promise(resolve => setTimeout(resolve, 0));
+
+        expect(events, 'the construct-time pass armed').toEqual(['overflowProjectionStart']);
+
+        // A rerun requested mid-flight is queued behind the active pass, and a drag-start waiter registers
+        // against the same transaction; both must survive the parking below.
+        plugin.project(true);
+        plugin.whenProjectionIdle().then(() => {settled = true});
+
+        // The menu opens while the measure is awaited: the mutation boundary parks the active pass, and the
+        // drained rerun finds the menu open and returns before arming.
+        const menuList = Neo.create(MountableMenuList, {items: [], mounted: true});
+
+        plugin.control = {alignTo() {}, destroy() {}, iconCls: 'fa fa-ellipsis', menuList, mounted: true};
+
+        release();
+        await new Promise(resolve => setTimeout(resolve, 0));
+        await new Promise(resolve => setTimeout(resolve, 0));
+
+        expect(plugin.measuring).toBe(false);
+        expect(plugin.projectQueued).toBe(false);
+        expect(plugin.menuProjectionQueued, 'the projection is parked behind the menu').toBe(true);
+        expect(events, 'parking closes the pair: nothing is moving header nodes').toEqual(['overflowProjectionStart', 'overflowProjectionIdle']);
+        expect(plugin.projectionBusy).toBe(false);
+        expect(settled, 'the drag-start waiter still waits for the menu to drain').toBe(false);
+
+        // The menu closes: the drain resumes the pass as a fresh transaction — a new start, the split runs,
+        // and the waiter resolves with its idle.
+        menuList.mounted = false;
+
+        await plugin.whenProjectionIdle();
+        await new Promise(resolve => setTimeout(resolve, 0));
+
+        expect(settled).toBe(true);
+        expect(plugin.menuProjectionQueued).toBe(false);
+        expect(events, 'the resumed pass is its own pair').toEqual(['overflowProjectionStart', 'overflowProjectionIdle', 'overflowProjectionStart', 'overflowProjectionIdle']);
+        expect(plugin.projectionBusy).toBe(false);
+
+        menuList.destroy();
+        plugin.destroy()
+    });
+
     test('action mode excludes its own geometry and visibility feedback, but not other actions', () => {
         const plugin = createPlugin(async () => []),
               own    = {hidden: false, id: 'overflow-action'},

--- a/test/playwright/unit/tab/plugin/Overflow.spec.mjs
+++ b/test/playwright/unit/tab/plugin/Overflow.spec.mjs
@@ -551,7 +551,7 @@ test.describe('Neo.tab.plugin.Overflow (re-entrancy contract)', () => {
         });
         await new Promise(resolve => setTimeout(resolve, 0)); // auto-project settles (no throw)
 
-        // Pass 1 surfaces the defect via console.error (RA-8) against the live owner — silence it; the point
+        // Pass 1 surfaces the defect via console.error against the live owner — silence it; the point
         // of THIS test is that the failure does not freeze future passes.
         const orig = console.error;
         console.error = () => {};

--- a/test/playwright/unit/tab/plugin/Overflow.spec.mjs
+++ b/test/playwright/unit/tab/plugin/Overflow.spec.mjs
@@ -117,8 +117,12 @@ test.describe('Neo.tab.plugin.Overflow (re-entrancy contract)', () => {
         Overflow = (await import('../../../../../src/tab/plugin/Overflow.mjs')).default
     });
 
-    /** A lean toolbar-owner stub: two header buttons, a controllable getDomRect. */
-    const createPlugin = getDomRect => {
+    /**
+     * A lean toolbar-owner stub: two header buttons, a controllable getDomRect, and an optional event
+     * collector standing in for the owner's `fire` — attached before construction, because the plugin
+     * runs its first projection pass while constructing against a mounted owner.
+     */
+    const createPlugin = (getDomRect, fire) => {
         const items = [{id: 'b1'}, {id: 'b2'}];
 
         const plugin = Neo.create(Overflow, {
@@ -137,6 +141,7 @@ test.describe('Neo.tab.plugin.Overflow (re-entrancy contract)', () => {
                 getDomRect,
                 add            : () => ({}),
                 addDomListeners: () => {},
+                fire,
                 on             : () => {},
                 un             : () => {},
                 remove         : () => {},
@@ -222,6 +227,86 @@ test.describe('Neo.tab.plugin.Overflow (re-entrancy contract)', () => {
 
         expect(plugin.projectQueued, 'the queued flag is consumed by the drain').toBe(false);
         expect(plugin.measuring, 'no pass is left latched').toBe(false)
+    });
+
+    test('the repartition lifecycle is published on the owner as one start/idle pair per transaction — a coalesced rerun keeps it open, a thrown measure still closes it', async () => {
+        let release,
+            callCount = 0;
+
+        const
+            gate   = new Promise(resolve => {release = resolve}),
+            events = [];
+
+        const plugin = createPlugin(async ids => {
+            callCount++;
+            if (callCount === 1) { await gate }
+            return ids[0] === 'tab-overflow-test-owner' ? [{width: 1000}] : [{width: 10}, {width: 10}]
+        }, (name, data) => events.push([name, data.owner === data.plugin.owner]));
+
+        // Construction against a mounted owner runs the first pass; its measure blocks on the gate, so
+        // the start edge is observable in flight, with the owner and plugin in its payload.
+        await new Promise(resolve => setTimeout(resolve, 0));
+
+        expect(plugin.measuring, 'the construct-time pass holds the latch').toBe(true);
+        expect(plugin.projectionBusy).toBe(true);
+        expect(events, 'the start edge fired when the latch armed').toEqual([['overflowProjectionStart', true]]);
+
+        // A pass requested mid-flight is the same transaction: no second start, no premature idle.
+        plugin.project(true);
+
+        expect(plugin.projectQueued).toBe(true);
+        expect(events).toHaveLength(1);
+
+        release();
+        await plugin.whenProjectionIdle();
+        await new Promise(resolve => setTimeout(resolve, 0));
+
+        expect(plugin.measuring).toBe(false);
+        expect(plugin.projectQueued).toBe(false);
+        expect(events.map(([name]) => name), 'one pair for the pass and its coalesced rerun').toEqual(['overflowProjectionStart', 'overflowProjectionIdle']);
+        expect(plugin.projectionBusy).toBe(false);
+
+        // A later pass is a second transaction: a second pair, never an unbalanced edge.
+        await plugin.project(false);
+        await new Promise(resolve => setTimeout(resolve, 0));
+
+        expect(events.map(([name]) => name)).toEqual(['overflowProjectionStart', 'overflowProjectionIdle', 'overflowProjectionStart', 'overflowProjectionIdle']);
+
+        // A measure that throws against a live owner is caught, the latch releases, and the idle edge
+        // still publishes — the pair never stays open on an error.
+        const thrown = [],
+              error  = console.error;
+
+        let throwing;
+
+        console.error = () => {};
+
+        try {
+            // the construct-time pass is the throwing one: caught, latch released, pair closed
+            throwing = createPlugin(async () => { throw new Error('measure failed') }, name => thrown.push(name));
+            await throwing.whenProjectionIdle();
+            await new Promise(resolve => setTimeout(resolve, 0))
+        } finally {
+            console.error = error
+        }
+
+        expect(thrown).toEqual(['overflowProjectionStart', 'overflowProjectionIdle']);
+        expect(throwing.measuring).toBe(false);
+        expect(throwing.projectionBusy).toBe(false);
+
+        // Idle paths that never armed a pass publish nothing: a destroying plugin resolves its waiters
+        // silently, with no edge.
+        const seen  = [],
+              quiet = createPlugin(async () => [], name => seen.push(name));
+
+        await new Promise(resolve => setTimeout(resolve, 0));
+
+        const before = seen.length;
+
+        quiet.isDestroying = true;
+        await quiet.project(false);
+
+        expect(seen.length, 'no pass, no edge').toBe(before)
     });
 
     test('action mode excludes its own geometry and visibility feedback, but not other actions', () => {


### PR DESCRIPTION
Resolves #18356
Related: #18151 #14973 #18134

🌿 A header about to move its buttons now says so where the dock already says everything about motion, and a click that waited for silence no longer lands on nothing.

`Neo.tab.plugin.Overflow` publishes the transaction it already brackets for `whenProjectionIdle()` as two events on its owner toolbar — `overflowProjectionStart` when a measuring pass arms while nothing was in flight, `overflowProjectionIdle` when neither a pass nor its coalesced rerun remains — so one repartition is exactly one pair, a thrown measure still closes it, and a pass that parks behind an open menu closes it too, because a parked pass moves nothing until the menu drains; the pass that resumes after the drain opens a fresh pair. The plugin stays generic: no class, no dock import, `whenProjectionIdle()` and its `SortZone` consumer unchanged.

The dock routes the pair where it installs the plugin — the tab header toolbar config in `projection/LayoutAdapter` — into `MotionSignal.enter` / `leave` on the toolbar itself, so `neo-dashboard-dock-animating` covers a header repartition the way it covers a splitter ease or a FLIP commit: counted (a repartition nested in a motion holds until the last producer leaves), instance-keyed (a header destroyed mid-pass cannot strand or strip another's entry), fail-safe (a lost idle clears within `FAIL_SAFE_MS`). The carrier is the toolbar, not the workspace root, for a measured reason: toggling the class on the root from inside a header pass forces a whole-tree vnode sync while that header's buttons are being replaced, and at boot that sync failed on a retired button id (`util.VNode.getVnode: Component not found for id: neo-tab-header-button-1`) and stranded the projection — the fixture rendered no header at all. The producer's own component is where the nodes move, the tab-enter button's precedent, and a consumer asks the dock host's subtree for the class rather than one carrier.

Evidence: L3 achieved (the component arm on the `dock-maximize` fixture observes the bracket inside the dock host during a real tab activation and lands a lock click gated on its absence) → L3 required (AC-5); L2 achieved → L2 required (AC-1 to AC-4, AC-6). Residual: none.

## AC Evidence
| AC-1 | Amended in the ticket body to the carrier the measurement chose: the projected header toolbar carries `neo-dashboard-dock-animating` while its repartition is in flight and drops it when the pass and any concurrent producer have settled. CI-covered: `test/playwright/unit/dashboard/DockLayoutAdapter.spec.mjs` › "a projected header routes the overflow plugin's start/idle pair into the dock motion signal, carried by the header toolbar itself…" — two headers, one entry each; a nested producer holds the class until the last leaves; an idle without a start registers nothing. Same spec › "the composed pointer contract with the real plugin…" — the unchanged plugin and `MotionSignal` behind the projected header's own listeners: a measuring header carries the signal; a menu that parks the active pass releases it at once, with nothing left for the fail-safe; the pass that resumes after the menu drains runs its split with the signal present and releases it when it settles. Red on `dev`: the projected toolbar config carries no such listeners |
| AC-2 | `src/tab/plugin/Overflow.mjs` imports `button/Base` and `plugin/Base` as before — no dock module; it publishes start/idle as owner events. CI-covered: `test/playwright/unit/tab/plugin/Overflow.spec.mjs` › "the repartition lifecycle is published on the owner as one start/idle pair per transaction…" — the construct-time pass's pair, a gated pass with a mid-flight rerun as one pair, a second pass as a second pair; › "a menu opening during an active measure parks the pass and closes its pair while the drag-start waiter keeps waiting…" — the parked pass and the rerun that found the menu open publish one idle between them, the waiter stays pending until the menu drains, and the resumed pass is its own pair; every prior arm of that spec (the `whenProjectionIdle()` contract, the coalesced rerun, the `SortZone` latch) unchanged and green |
| AC-3 | Same Overflow arm: a measure that throws against a live owner is caught, the latch releases, and the idle edge still publishes — the pair never stays open. The dock side: `DockLayoutAdapter.spec.mjs` › "a header re-projected mid-pass cannot wedge the signal…" — a destroyed header's entry clears through the fail-safe (`FAIL_SAFE_MS` injected to 30 ms) |
| AC-4 | `DockLayoutAdapter.spec.mjs` › "a header re-projected mid-pass cannot wedge the signal: the destroyed toolbar's entry clears through the fail-safe, its late idle is a no-op, and the new header's pass is a clean pair" — the instance-keyed contract through one re-projection |
| AC-5 | Real browser, `test/playwright/component/dashboard/DockOverflowSettleSignal.spec.mjs` on the `dock-maximize` fixture: a subtree class observer installed before the trigger records the signal present inside the dock host during the Beta activation and absent afterwards; the lock action clicked once the signal is absent flips to its unlock presentation. Red on `dev`: nothing enters the signal during a tab activation, so the observer never records `true` and the arm's `toContain(true)` fails |
| AC-6 | `MotionSignal`'s docblock names the repartition as the one non-animated producer and the toolbar as its carrier; `resources/scss/src/dashboard/Container.scss` says the class is present during a header repartition too. No new tool, no persisted state, no operation |

## Deltas from ticket
**The carrier is the header toolbar, not the workspace root.** The ticket's AC-1 named the workspace component. Routing the class to the root reproduced the #18143 class of failure at boot on the `dock-maximize` fixture: the root's class toggle ran a full-tree vnode sync while the header's buttons were being replaced, `syncVnodeTree` hit a retired button id, the update failed three times and the fixture rendered no header. The toolbar is the producer's own component, the same choice `TabEnterButton` makes, and existing consumers already query the dock host for the class rather than one element. AC-1 is amended in the ticket body accordingly (my own ticket).

**The signal's edge is narrower than the waiter's.** `whenProjectionIdle()` keeps waiting while a menu holds a parked projection, because a drag start must not race a pass that will run when the menu closes; a pointer consumer only needs to know when header nodes are moving, and a parked pass moves nothing until it drains. The published pair therefore closes when nothing is measuring or queued — including the moment an active pass parks behind a menu, and a coalesced rerun that returns because it found the menu open — and the resumed pass opens a new pair. The publication runs in the pass epilogue, apart from the waiter resolver, so the two edges cannot drift again; the plugin's docblocks say so.

## Test Evidence
Unit: full suite 3287 passed / 0 failed (`playwright.config.unit.mjs`, one worker) on the tree committed as `f86ac4e468`. The two spec files this PR touches: 94 / 94 in their targeted run.
Components: `component/dashboard` + `component/tab` 137 passed / 0 failed (`playwright.config.component.mjs`, one worker) on the same tree, the new spec and the pre-existing `DockRailPartition` control on the same fixture included — that control is what caught the workspace-root carrier: with the class routed to the root it timed out on the header buttons never becoming visible, with the toolbar carrier it passes.
Red-first, measured: the component arm's `toContain(true)` fails on `dev` with this PR's source stashed and its specs kept (`Error: the signal was present inside the dock host during the pass`); the adapter arm reds on `dev` (no `listeners` on the projected header toolbar config); the Overflow arm reds on `dev` (`owner.fire` is never called). The two menu-parking arms red against `6dbee0b3d4`'s plugin with only the plugin change stashed: `Error: a parked pass releases the signal at once — Expected: false, Received: true` and `Error: parking closes the pair: nothing is moving header nodes` (the idle edge missing from the published sequence). The probe that found the root-carrier regression is not in the tree; its finding is the Deltas paragraph above.

## Post-Merge Validation
- [ ] The Workstation `*NL` journeys that assert the root's `neo-dashboard-dock-animating` for motion keep passing under the Brain root — they never asserted the header, and the toolbar carrier does not touch the root.

## Commits (if multi-commit)
- `3a55518017` — the overflow plugin publishes its repartition lifecycle as owner events, one pair per transaction
- `0d99845b3a` — the dock routes the pair into the motion signal on the header toolbar; docblock and SCSS note; unit and component arms
- `6dbee0b3d4` — two pre-existing comments in touched files describe behaviour instead of citing review provenance (the shared archaeology job reads touched files whole)
- `f86ac4e468` — a pass parked behind an open menu closes its pair and the resumed pass opens a new one: the publication moves from the waiter resolver to the pass epilogue; a plugin arm and a composed real-plugin adapter arm, both red against the prior head

Authored by Vega (Claude Fable 5.1, Claude Code). Sessions 87064b54-7440-441c-8bbf-f29fcd6899d5 · 3711ad57-061d-43fb-b1f1-aa9dc21dedda.