### PR TITLE
feat(manager): a Group keeps an immutable transaction history and one cursor, loaded at its first write (#18310)

### DIFF
--- a/buildScripts/util/static-closure.mjs
+++ b/buildScripts/util/static-closure.mjs
@@ -1,0 +1,89 @@
+#!/usr/bin/env node
+import fs   from 'node:fs';
+import path from 'node:path';
+
+/**
+ * @summary Measures the static import closure of one or more entry modules — the modules a browser
+ * would fetch before the entry runs — as a module count and a byte total.
+ * @description Follows relative `import … from` and `export … from` specifiers only. A dynamic `import()`
+ * is reported as a lazy boundary, never followed: that is what the walk exists to prove — a module that
+ * must load on demand is absent from the closure, and a consumer's closure stays byte-identical when the
+ * on-demand module is added. Bare specifiers (packages, node built-ins) are listed, not weighed.
+ *
+ * Usage: `node buildScripts/util/static-closure.mjs [--list] <entry.mjs> [...more entries]` from the
+ * repository root. `--list` adds the closure's file list to the JSON output.
+ */
+const STATIC_RE  = /(?:^|\n)\s*(?:import|export)\s+(?:[^'";]*?)\s*from\s*['"]([^'"]+)['"]/g,
+      SIDE_RE    = /(?:^|\n)\s*import\s*['"]([^'"]+)['"]/g,
+      DYNAMIC_RE = /import\(\s*['"`]([^'"`]+)['"`]\s*\)/g;
+
+/**
+ * @param {String[]} entries Repo-relative entry paths
+ * @param {String} root=process.cwd() The directory relative paths resolve against
+ * @returns {{entries: String[], modules: Number, bytes: Number, kib: Number, bare: String[], dynamicTargets: String[], files: String[]}}
+ */
+export function measureClosure(entries, root=process.cwd()) {
+    const seen    = new Map(),
+          bare    = new Set(),
+          dynamic = new Set();
+
+    const walk = file => {
+        const abs = path.resolve(root, file);
+
+        if (seen.has(abs)) return;
+
+        const source = fs.readFileSync(abs, 'utf8'),
+              dir    = path.dirname(abs);
+
+        seen.set(abs, Buffer.byteLength(source));
+
+        for (const match of source.matchAll(DYNAMIC_RE)) {
+            dynamic.add(path.relative(root, path.resolve(dir, match[1])))
+        }
+
+        for (const re of [STATIC_RE, SIDE_RE]) {
+            for (const match of source.matchAll(re)) {
+                const specifier = match[1];
+
+                if (specifier.startsWith('.') || specifier.startsWith('/')) {
+                    walk(path.resolve(dir, specifier))
+                } else {
+                    bare.add(specifier)
+                }
+            }
+        }
+    };
+
+    entries.forEach(walk);
+
+    const bytes = [...seen.values()].reduce((sum, size) => sum + size, 0);
+
+    return {
+        entries,
+        modules       : seen.size,
+        bytes,
+        kib           : Math.round(bytes / 1024),
+        bare          : [...bare].sort(),
+        dynamicTargets: [...dynamic].sort(),
+        files         : [...seen.keys()].map(file => path.relative(root, file)).sort()
+    }
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === new URL(import.meta.url).pathname) {
+    const args    = process.argv.slice(2),
+          list    = args.includes('--list'),
+          entries = args.filter(arg => arg !== '--list');
+
+    if (entries.length === 0) {
+        console.error('Usage: node buildScripts/util/static-closure.mjs [--list] <entry.mjs> [...more]');
+        process.exit(1)
+    }
+
+    const result = measureClosure(entries);
+
+    if (!list) {
+        delete result.files
+    }
+
+    console.log(JSON.stringify(result, null, 2))
+}

--- a/docs/output/class-hierarchy.json
+++ b/docs/output/class-hierarchy.json
@@ -438,6 +438,7 @@
  "Neo.manager.Window": "Neo.manager.Base",
  "Neo.manager.rpc.Api": "Neo.manager.Base",
  "Neo.manager.rpc.Message": "Neo.manager.Base",
+ "Neo.manager.transaction.History": "Neo.collection.Base",
  "Neo.menu.List": "Neo.list.Base",
  "Neo.menu.Model": "Neo.data.Model",
  "Neo.menu.Panel": "Neo.container.Panel",

--- a/docs/output/class-hierarchy.json
+++ b/docs/output/class-hierarchy.json
@@ -438,7 +438,7 @@
  "Neo.manager.Window": "Neo.manager.Base",
  "Neo.manager.rpc.Api": "Neo.manager.Base",
  "Neo.manager.rpc.Message": "Neo.manager.Base",
- "Neo.manager.transaction.History": "Neo.collection.Base",
+ "Neo.manager.transaction.History": "Neo.core.Base",
  "Neo.menu.List": "Neo.list.Base",
  "Neo.menu.Model": "Neo.data.Model",
  "Neo.menu.Panel": "Neo.container.Panel",

--- a/learn/benefits/ArchitectureOverview.md
+++ b/learn/benefits/ArchitectureOverview.md
@@ -439,7 +439,7 @@ complete organism where the codebase and the agent co-evolve.
 | `src/data/` | Data layer | `Store`, `Model`, `RecordFactory` | — |
 | `src/state/` | State management | `Provider` | — |
 | `src/worker/` | Thread management | `App`, `VDom`, `Data`, `Manager` | — |
-| `src/manager/` | Worker-side registries and authorities: instances, components, window geometry, drag coordination, and the logical topology Groups a window binds into across reloads | `Instance`, `Component`, `Window`, `DragCoordinator`, `Transaction` | [ADR 0029](https://github.com/neomjs/neo/blob/dev/learn/agentos/decisions/0029-docking-design.md) |
+| `src/manager/` | Worker-side registries and authorities: instances, components, window geometry, drag coordination, and the logical topology Groups a window binds into across reloads — each Group with a bounded, append-only transaction history and one cursor, loaded on demand under `transaction/` | `Instance`, `Component`, `Window`, `DragCoordinator`, `Transaction`, `transaction/History` | [ADR 0029](https://github.com/neomjs/neo/blob/dev/learn/agentos/decisions/0029-docking-design.md) |
 | `src/vdom/` | Virtual DOM engine | `Helper` | — |
 | `src/main/` | Main thread addons | `DomEvents`, `DomAccess` | — |
 | `src/ai/` | Neural Link client | `Client` | — |

--- a/src/manager/Transaction.mjs
+++ b/src/manager/Transaction.mjs
@@ -57,10 +57,13 @@ class Transaction extends Manager {
          * and never loads `transaction/History.mjs`, so a single-window or history-disabled app pays
          * nothing for it. Depth is a Group's choice: a consumer that wants undo for its own Group calls
          * {@link #setHistoryDepth} before that Group's first write, so two independent roots of one app
-         * in one worker never take each other's policy through this worker-wide default.
-         * @member {Number} historyDepth=0
+         * in one worker never take each other's policy through this worker-wide default. A non-negative
+         * integer; anything else is refused at the setter, so no Group can be born with an unbounded or
+         * fractional log.
+         * @member {Number} historyDepth_=0
+         * @reactive
          */
-        historyDepth: 0,
+        historyDepth_: 0,
         /**
          * How long a released or reserved binding holds its slot for a token-matched successor before the
          * slot is free. The dock tear-out connect window is the precedent for the bound.
@@ -455,17 +458,25 @@ class Transaction extends Manager {
     /**
      * The admission barrier: for a Group that keeps history, loads the module once and creates the Group's
      * History; every write awaits this before touching a participant. A Group at depth zero resolves to
-     * `null` without importing anything.
+     * `null` without importing anything. The load is fenced by the Group's lifetime: a Group retired while
+     * the module was still loading gets no History — one created then would be registered with no owner
+     * to release it — and the write that waited rejects at its own liveness check.
      * @param {Object} group
      * @returns {Promise<Neo.manager.transaction.History|null>}
      * @protected
      */
     loadHistory(group) {
+        let me = this;
+
         if (group.historyDepth < 1) {
             return Promise.resolve(null)
         }
 
-        return group.historyReady ??= this.importHistory().then(({default: History}) => {
+        return group.historyReady ??= me.importHistory().then(({default: History}) => {
+            if (me.get(group.id) !== group) {
+                return null
+            }
+
             group.history = Neo.create(History, {depth: group.historyDepth});
 
             return group.history
@@ -525,6 +536,25 @@ class Transaction extends Manager {
         if (this.get(group.id) !== group) {
             throw new Error(`${this.className}#${method}: Group ${group.id} was retired while queued`)
         }
+    }
+
+    /**
+     * Refuses a default history depth that is not a non-negative integer, so the bound a Group is born
+     * with is always one a History can enforce. The refusal is logged and the default in force stays; a
+     * config setter cannot throw without leaving the refused value staged.
+     * @param {Number} value
+     * @param {Number} oldValue
+     * @returns {Number}
+     * @protected
+     */
+    beforeSetHistoryDepth(value, oldValue) {
+        if (!Number.isInteger(value) || value < 0) {
+            Neo.logError(`${this.className}: historyDepth must be a non-negative integer, got ${value} — keeping ${oldValue}`);
+
+            return oldValue
+        }
+
+        return value
     }
 
     /**

--- a/src/manager/Transaction.mjs
+++ b/src/manager/Transaction.mjs
@@ -53,10 +53,11 @@ class Transaction extends Manager {
          */
         singleton: true,
         /**
-         * How many transaction rows a Group retains, read when the Group is created. Zero — the default —
-         * means the Group keeps no history and never loads `transaction/History.mjs`, so a single-window
-         * or history-disabled app pays nothing for it. A consumer that wants undo sets it before its
-         * Groups exist.
+         * The history depth a Group is born with. Zero — the default — means the Group keeps no history
+         * and never loads `transaction/History.mjs`, so a single-window or history-disabled app pays
+         * nothing for it. Depth is a Group's choice: a consumer that wants undo for its own Group calls
+         * {@link #setHistoryDepth} before that Group's first write, so two independent roots of one app
+         * in one worker never take each other's policy through this worker-wide default.
          * @member {Number} historyDepth=0
          */
         historyDepth: 0,
@@ -472,13 +473,17 @@ class Transaction extends Manager {
     }
 
     /**
-     * Moves a Group's cursor on its queue.
+     * Moves a Group's cursor on its queue — after the row was applied. The row a move would return is
+     * read first, `apply` runs with it inside the queued step, and only when it resolved does the cursor
+     * move and the provider publish; a rejected application leaves cursor and provider where they were,
+     * so nothing ever reads a moved cursor as a completed undo before the application held.
      * @param {String} groupId
      * @param {String} direction `undo` or `redo`
+     * @param {Function} apply Receives the row; may be async
      * @returns {Promise<Object|null>}
      * @protected
      */
-    moveCursor(groupId, direction) {
+    moveCursor(groupId, direction, apply) {
         let me    = this,
             group = me.get(groupId);
 
@@ -486,12 +491,24 @@ class Transaction extends Manager {
             return Promise.reject(new Error(`${me.className}#${direction}: unknown Group ${groupId}`))
         }
 
-        return me.enqueue(group, () => {
+        if (typeof apply !== 'function') {
+            return Promise.reject(new Error(`${me.className}#${direction}: apply(row) is required — the cursor moves only after the row was applied`))
+        }
+
+        return me.enqueue(group, async () => {
             me.assertLive(group, direction);
 
-            const row = group.history?.[direction]() ?? null;
+            const row = group.history?.peek(direction) ?? null;
 
-            row && me.publishHistory(group);
+            if (!row) {
+                return null
+            }
+
+            await apply(row);
+
+            me.assertLive(group, direction);
+            group.history[direction]();
+            me.publishHistory(group);
 
             return row
         })
@@ -520,25 +537,49 @@ class Transaction extends Manager {
     }
 
     /**
-     * Moves a Group's cursor forward and resolves to the row to re-apply — `null` when there is nothing
-     * to redo, or the Group keeps no history. Applying it is the caller's.
+     * Re-applies the row after a Group's cursor and, once `apply` resolved, moves the cursor onto it.
+     * Resolves to that row, or `null` when there is nothing to redo or the Group keeps no history.
      * @param {Object} data
      * @param {String} data.groupId
+     * @param {Function} data.apply Receives the row to re-apply; may be async — a rejection leaves the cursor
      * @returns {Promise<Object|null>}
      */
-    redo({groupId}) {
-        return this.moveCursor(groupId, 'redo')
+    redo({groupId, apply}) {
+        return this.moveCursor(groupId, 'redo', apply)
     }
 
     /**
-     * Moves a Group's cursor back and resolves to the row to reverse — `null` when there is nothing to
-     * undo, or the Group keeps no history. Applying it is the caller's.
+     * Sets the history depth of one Group — the Group's own policy, independent of this worker-wide
+     * default and of any other Group. Refused for an unknown Group, a depth that is not a non-negative
+     * integer, or a Group whose history already loaded: the bound is fixed at that first write.
      * @param {Object} data
      * @param {String} data.groupId
+     * @param {Number} data.depth `0` keeps no history and loads nothing
+     * @returns {Boolean}
+     */
+    setHistoryDepth({groupId, depth}) {
+        const group = this.get(groupId);
+
+        if (!group || group.historyReady || !Number.isInteger(depth) || depth < 0) {
+            return false
+        }
+
+        group.historyDepth = depth;
+        this.publishHistory(group);
+
+        return true
+    }
+
+    /**
+     * Applies the reverse of the row at a Group's cursor and, once `apply` resolved, moves the cursor
+     * back. Resolves to that row, or `null` when there is nothing to undo or the Group keeps no history.
+     * @param {Object} data
+     * @param {String} data.groupId
+     * @param {Function} data.apply Receives the row to reverse; may be async — a rejection leaves the cursor
      * @returns {Promise<Object|null>}
      */
-    undo({groupId}) {
-        return this.moveCursor(groupId, 'undo')
+    undo({groupId, apply}) {
+        return this.moveCursor(groupId, 'undo', apply)
     }
 
     /**
@@ -547,6 +588,12 @@ class Transaction extends Manager {
      * against what the history admits, `adopt` runs with it, the frozen row is appended after the cursor
      * and the provider is published. The descriptor is enqueued exactly once. An `adopt` that throws
      * appends nothing and leaves the cursor where it was; the queue moves on to the next write.
+     *
+     * The body of this step is provisional and owned by the atomic-commit leaf: the participant protocol
+     * (prepare every participant → adopt all with compensation → append the row → move the cursor →
+     * publish one snapshot → release the queue) lands here as ONE step under ONE owner, compensation
+     * across a failed append included. Nothing outside this method may depend on its parts being
+     * separate steps; the queue, the barrier and the History are the primitives it composes.
      * @param {Object} data
      * @param {String} data.groupId
      * @param {Object} data.descriptor Plain data describing the transaction — it becomes the history row

--- a/src/manager/Transaction.mjs
+++ b/src/manager/Transaction.mjs
@@ -1,7 +1,8 @@
-import Manager from './Base.mjs';
+import Manager       from './Base.mjs';
+import StateProvider from '../state/Provider.mjs';
 
 /**
- * @summary The worker-side authority for logical topology Groups and their window bindings.
+ * @summary The worker-side authority for logical topology Groups, their window bindings and their history.
  * @description A Group is the persistent identity of one multi-window topology instance. `appName` is
  * routing metadata and never identifies a Group: two independent roots of the same app under one
  * SharedWorker are two Groups. A window binds into a Group under a `workspaceKey` — one key per full
@@ -26,10 +27,15 @@ import Manager from './Base.mjs';
  * - A Group also holds keyed participants — the owners its slots resolve to, registered by the hosts
  *   that live in it. Membership is separate from binding: a participant lives while its Group does,
  *   whatever its window's generation is doing, and a Group holding participants is never empty.
+ * - A Group keeps a bounded, append-only transaction history and one cursor when {@link #historyDepth}
+ *   is above zero. {@link #write} admits a transaction through the Group's serialized queue and awaits
+ *   the history module once — before any participant mutation — so a Group at depth zero never imports
+ *   it; {@link #undo} and {@link #redo} move the cursor and return the row. The Group's
+ *   {@link #getProvider provider} publishes `canUndo` / `canRedo` to every window bound into it.
  *
  * The main thread carries the identity across page loads in `sessionStorage` and rewrites it on request;
- * it never decides — it only says whether it could. This manager knows windows, keys, tokens and opaque
- * participants — no dock, no document, no app class.
+ * it never decides — it only says whether it could. This manager knows windows, keys, tokens, opaque
+ * participants and plain-data rows — no dock, no document, no app class.
  * @class Neo.manager.Transaction
  * @extends Neo.manager.Base
  * @singleton
@@ -46,6 +52,14 @@ class Transaction extends Manager {
          * @protected
          */
         singleton: true,
+        /**
+         * How many transaction rows a Group retains, read when the Group is created. Zero — the default —
+         * means the Group keeps no history and never loads `transaction/History.mjs`, so a single-window
+         * or history-disabled app pays nothing for it. A consumer that wants undo sets it before its
+         * Groups exist.
+         * @member {Number} historyDepth=0
+         */
+        historyDepth: 0,
         /**
          * How long a released or reserved binding holds its slot for a token-matched successor before the
          * slot is free. The dock tear-out connect window is the precedent for the bound.
@@ -281,16 +295,23 @@ class Transaction extends Manager {
 
     /**
      * Registers a new Group. The id is minted here unless a carrier presents one this worker never saw.
+     * The history bound is read now: a Group born at depth zero stays without history.
      * @param {String} [groupId]
-     * @returns {Object} The Group record: `{id, bindings, createdAt}`
+     * @returns {Object} The Group record: `{id, bindings, createdAt, participants, historyDepth, history,
+     *   historyReady, provider, queue}`
      * @protected
      */
     createGroup(groupId=crypto.randomUUID()) {
         const group = {
             bindings    : new Map(),
             createdAt   : Date.now(),
+            history     : null,
+            historyDepth: this.historyDepth,
+            historyReady: null,
             id          : groupId,
-            participants: new Map()
+            participants: new Map(),
+            provider    : null,
+            queue       : Promise.resolve()
         };
 
         this.register(group);
@@ -367,6 +388,195 @@ class Transaction extends Manager {
      */
     participantKeys(groupId) {
         return [...(this.get(groupId)?.participants.keys() ?? [])]
+    }
+
+    /**
+     * Runs one task on a Group's queue: tasks run in call order, one at a time, and a task that rejects
+     * releases the queue for the next. The task's own promise is returned, so the caller sees its result
+     * or its error. A task must not write to its own Group — that write would wait for the task holding
+     * the queue.
+     * @param {Object} group
+     * @param {Function} task
+     * @returns {Promise}
+     * @protected
+     */
+    enqueue(group, task) {
+        const run  = () => task(),
+              turn = group.queue.then(run, run);
+
+        group.queue = turn.then(() => {}, () => {});
+
+        return turn
+    }
+
+    /**
+     * The Group's `state.Provider`, created on first request: one instance per Group whatever window asks,
+     * publishing `canUndo`, `canRedo`, `historyCursor`, `historyDepth` and `historyLength` — `false` and
+     * empty until the first admitted transaction. A host binds its own provider to it as the explicit
+     * parent, so a control reads the same answer from the opener and from a popped-out window.
+     * @param {String} groupId
+     * @returns {Neo.state.Provider|null} `null` for an unknown Group
+     */
+    getProvider(groupId) {
+        const group = this.get(groupId);
+
+        if (!group) return null;
+
+        return group.provider ??= Neo.create(StateProvider, {data: this.historyState(group)})
+    }
+
+    /**
+     * The provider-shaped view of a Group's history.
+     * @param {Object} group
+     * @returns {{canRedo: Boolean, canUndo: Boolean, historyCursor: Number, historyDepth: Number, historyLength: Number}}
+     * @protected
+     */
+    historyState({history, historyDepth}) {
+        return {
+            canRedo      : history?.canRedo ?? false,
+            canUndo      : history?.canUndo ?? false,
+            historyCursor: history?.cursor  ?? -1,
+            historyDepth,
+            historyLength: history?.count   ?? 0
+        }
+    }
+
+    /**
+     * The one dynamic import of the history module, kept as a method so a harness can observe or replace
+     * the load. The manager's static closure never contains the module.
+     * @returns {Promise<Object>} The module namespace
+     * @protected
+     */
+    importHistory() {
+        return import('./transaction/History.mjs')
+    }
+
+    /**
+     * The admission barrier: for a Group that keeps history, loads the module once and creates the Group's
+     * History; every write awaits this before touching a participant. A Group at depth zero resolves to
+     * `null` without importing anything.
+     * @param {Object} group
+     * @returns {Promise<Neo.manager.transaction.History|null>}
+     * @protected
+     */
+    loadHistory(group) {
+        if (group.historyDepth < 1) {
+            return Promise.resolve(null)
+        }
+
+        return group.historyReady ??= this.importHistory().then(({default: History}) => {
+            group.history = Neo.create(History, {depth: group.historyDepth});
+
+            return group.history
+        })
+    }
+
+    /**
+     * Moves a Group's cursor on its queue.
+     * @param {String} groupId
+     * @param {String} direction `undo` or `redo`
+     * @returns {Promise<Object|null>}
+     * @protected
+     */
+    moveCursor(groupId, direction) {
+        let me    = this,
+            group = me.get(groupId);
+
+        if (!group) {
+            return Promise.reject(new Error(`${me.className}#${direction}: unknown Group ${groupId}`))
+        }
+
+        return me.enqueue(group, () => {
+            me.assertLive(group, direction);
+
+            const row = group.history?.[direction]() ?? null;
+
+            row && me.publishHistory(group);
+
+            return row
+        })
+    }
+
+    /**
+     * A task reaching the head of a Group's queue after the Group was retired must not touch what the
+     * retirement released.
+     * @param {Object} group
+     * @param {String} method The caller, for the message
+     * @protected
+     */
+    assertLive(group, method) {
+        if (this.get(group.id) !== group) {
+            throw new Error(`${this.className}#${method}: Group ${group.id} was retired while queued`)
+        }
+    }
+
+    /**
+     * Publishes the Group's history state to its provider, if one was ever requested.
+     * @param {Object} group
+     * @protected
+     */
+    publishHistory(group) {
+        group.provider?.setData(this.historyState(group))
+    }
+
+    /**
+     * Moves a Group's cursor forward and resolves to the row to re-apply — `null` when there is nothing
+     * to redo, or the Group keeps no history. Applying it is the caller's.
+     * @param {Object} data
+     * @param {String} data.groupId
+     * @returns {Promise<Object|null>}
+     */
+    redo({groupId}) {
+        return this.moveCursor(groupId, 'redo')
+    }
+
+    /**
+     * Moves a Group's cursor back and resolves to the row to reverse — `null` when there is nothing to
+     * undo, or the Group keeps no history. Applying it is the caller's.
+     * @param {Object} data
+     * @param {String} data.groupId
+     * @returns {Promise<Object|null>}
+     */
+    undo({groupId}) {
+        return this.moveCursor(groupId, 'undo')
+    }
+
+    /**
+     * Admits one transaction to a Group. The call joins the Group's queue; at its head the history module
+     * is awaited if the Group keeps history — before any participant mutation — the descriptor is checked
+     * against what the history admits, `adopt` runs with it, the frozen row is appended after the cursor
+     * and the provider is published. The descriptor is enqueued exactly once. An `adopt` that throws
+     * appends nothing and leaves the cursor where it was; the queue moves on to the next write.
+     * @param {Object} data
+     * @param {String} data.groupId
+     * @param {Object} data.descriptor Plain data describing the transaction — it becomes the history row
+     * @param {Function} [data.adopt] The participant-mutation slot; receives the descriptor, may be async
+     * @returns {Promise<{result: *, row: Object|null}>} `result` is what `adopt` returned; `row` the frozen
+     *   retained row, or `null` for a Group that keeps no history
+     */
+    write({groupId, descriptor, adopt}) {
+        let me    = this,
+            group = me.get(groupId);
+
+        if (!group) {
+            return Promise.reject(new Error(`${me.className}#write: unknown Group ${groupId}`))
+        }
+
+        return me.enqueue(group, async () => {
+            me.assertLive(group, 'write');
+
+            const history = await me.loadHistory(group);
+
+            me.assertLive(group, 'write');
+            history?.assertRow(descriptor);
+
+            const result = await adopt?.(descriptor),
+                  row    = history ? history.append(descriptor) : null;
+
+            row && me.publishHistory(group);
+
+            return {result, row}
+        })
     }
 
     /**
@@ -500,9 +710,9 @@ class Transaction extends Manager {
     }
 
     /**
-     * Retires a Group with every lease and participant it holds. Whether a Group MAY retire — durably
-     * persisted, no retained reference — is the caller's contract; this manager only forgets what it is
-     * told to.
+     * Retires a Group with every lease, participant, history row and provider it holds. Whether a Group
+     * MAY retire — durably persisted, no retained reference — is the caller's contract; this manager only
+     * forgets what it is told to.
      * @param {String} groupId
      * @returns {Boolean}
      */
@@ -514,6 +724,9 @@ class Transaction extends Manager {
 
         group.bindings.forEach(binding => me.clearLease(binding));
         group.participants.clear();
+        group.provider?.destroy();
+        group.history?.destroy();
+        group.provider = group.history = null;
         me.unregister(group);
 
         return true
@@ -559,13 +772,14 @@ class Transaction extends Manager {
                 group.bindings.delete(binding.workspaceKey);
                 me.fire('leaseExpired', {groupId: group.id, workspaceKey: binding.workspaceKey});
 
-                // A Group with no binding AND no participant left holds nothing this manager keeps for
-                // it — no history, no snapshot — so letting it go loses nothing. A Group whose
-                // participants outlive its last window is not empty: its documents are still owned.
-                // Conditional, lossless retirement of a Group that DOES hold state is a later contract;
-                // this only stops closed windows from leaving empty Groups behind in a long-lived worker.
-                if (group.bindings.size === 0 && group.participants.size === 0 && me.get(group.id) === group) {
-                    me.unregister(group);
+                // A Group with no binding, no participant and no retained history row holds nothing this
+                // manager keeps for it, so letting it go loses nothing. A Group whose participants or rows
+                // outlive its last window is not empty: its documents are still owned, its history is
+                // still the truth of what they did. Conditional, lossless retirement of a Group that DOES
+                // hold state is a later contract; this only stops closed windows from leaving empty Groups
+                // behind in a long-lived worker.
+                if (group.bindings.size === 0 && group.participants.size === 0 && !group.history?.count && me.get(group.id) === group) {
+                    me.retireGroup(group.id);
                     me.fire('groupRetired', {groupId: group.id})
                 }
             }

--- a/src/manager/transaction/History.mjs
+++ b/src/manager/transaction/History.mjs
@@ -40,6 +40,15 @@ function isPlainData(value, path=new Set()) {
 }
 
 /**
+ * Whether a value can bound a history: a finite positive integer.
+ * @param {*} value
+ * @returns {Boolean}
+ */
+function isValidDepth(value) {
+    return Number.isInteger(value) && value >= 1
+}
+
+/**
  * Freezes a plain-data graph in place.
  * @param {*} value
  * @returns {*} The same value
@@ -85,11 +94,13 @@ class History extends Base {
          */
         className: 'Neo.manager.transaction.History',
         /**
-         * How many rows are retained; the oldest is evicted past it. At least one — a Group that keeps
-         * no history never loads this module.
-         * @member {Number} depth=50
+         * How many rows are retained; the oldest is evicted past it. A finite positive integer — at least
+         * one, because a Group that keeps no history never loads this module — refused otherwise, so an
+         * unbounded or fractional log cannot exist.
+         * @member {Number} depth_=50
+         * @reactive
          */
-        depth: 50
+        depth_: 50
     }
 
     /**
@@ -150,18 +161,11 @@ class History extends Base {
     }
 
     /**
-     * @param {Object} config
-     */
-    construct(config) {
-        super.construct(config);
-
-        this.#rows = Neo.create(Collection, {autoSort: false})
-    }
-
-    /**
-     * Admits one transaction after the cursor: the redo tail is dropped, the descriptor is copied, stamped
-     * and frozen, the cursor moves onto it, and rows past {@link #depth} are evicted from the front.
-     * A descriptor {@link #assertRow} refuses changes nothing.
+     * Admits one transaction after the cursor: the descriptor is copied, stamped and frozen, the redo
+     * tail is dropped, the cursor moves onto the row, and rows past {@link #depth} are evicted from the
+     * front. Admission is transactional with respect to the log: every fallible step — the refusals of
+     * {@link #assertRow} and the copy itself — runs before a single retained row, the cursor or the
+     * sequence changes, so a refused descriptor leaves the history exactly as it was, redo tail included.
      * @param {Object} descriptor Plain data; an own `id` is kept, otherwise one is minted
      * @returns {Object} The frozen retained row
      */
@@ -171,19 +175,22 @@ class History extends Base {
 
         me.assertRow(descriptor);
 
+        // The copy is the last refusal: a value that reads as plain data can still not be cloned (a Proxy,
+        // a platform object), and only the clone can tell — so it runs before anything is committed.
+        const row = deepFreeze(me.copy({
+            ...descriptor,
+            id        : descriptor.id ?? crypto.randomUUID(),
+            recordedAt: Date.now(),
+            sequence  : me.sequence + 1
+        }));
+
         if (me.canRedo) {
             rows.splice(me.cursor + 1, rows.count - me.cursor - 1)
         }
 
-        const row = deepFreeze(structuredClone({
-            ...descriptor,
-            id        : descriptor.id ?? crypto.randomUUID(),
-            recordedAt: Date.now(),
-            sequence  : ++me.sequence
-        }));
-
         // The key is present, so the collection writes nothing onto the frozen row.
         rows.add(row);
+        me.sequence++;
         me.cursor = rows.count - 1;
 
         while (rows.count > me.depth) {
@@ -203,8 +210,8 @@ class History extends Base {
     assertRow(descriptor) {
         let me = this;
 
-        if (me.depth < 1) {
-            throw new RangeError(`${me.className}: depth must be at least 1, got ${me.depth}`)
+        if (!isValidDepth(me.depth)) {
+            throw new RangeError(`${me.className}: depth must be a positive integer, got ${me.depth}`)
         }
 
         if (!descriptor || typeof descriptor !== 'object' || Array.isArray(descriptor) || !isPlainData(descriptor)) {
@@ -213,6 +220,54 @@ class History extends Base {
 
         if (descriptor.id != null && me.has(descriptor.id)) {
             throw new Error(`${me.className}: row ${descriptor.id} is already retained`)
+        }
+    }
+
+    /**
+     * Refuses a bound that is not a finite positive integer — `Infinity` would be an unbounded log, `NaN`
+     * or a fraction a bound nothing can be measured against. The refusal is logged and the bound in force
+     * stays; a config setter cannot throw without leaving the refused value staged.
+     * @param {Number} value
+     * @param {Number} oldValue
+     * @returns {Number}
+     * @protected
+     */
+    beforeSetDepth(value, oldValue) {
+        if (!isValidDepth(value)) {
+            Neo.logError(`${this.className}: depth must be a positive integer, got ${value} — keeping ${oldValue}`);
+
+            return oldValue
+        }
+
+        return value
+    }
+
+    /**
+     * A bound that cannot be enforced is refused before the instance exists: construction is the one place
+     * a refusal can be a throw without leaving a half-set config behind.
+     * @param {Object} config
+     */
+    construct(config) {
+        if (config && 'depth' in config && !isValidDepth(config.depth)) {
+            throw new RangeError(`${this.className}: depth must be a positive integer, got ${config.depth}`)
+        }
+
+        super.construct(config);
+
+        this.#rows = Neo.create(Collection, {autoSort: false})
+    }
+
+    /**
+     * The structured copy of a stamped descriptor — the refusal that only the clone can make.
+     * @param {Object} stamped
+     * @returns {Object}
+     * @protected
+     */
+    copy(stamped) {
+        try {
+            return structuredClone(stamped)
+        } catch (error) {
+            throw new TypeError(`${this.className}: a row must be structured-cloneable plain data (${error.message})`)
         }
     }
 

--- a/src/manager/transaction/History.mjs
+++ b/src/manager/transaction/History.mjs
@@ -1,0 +1,241 @@
+import Collection from '../../collection/Base.mjs';
+
+/**
+ * Whether a value is plain data: JSON-shaped primitives, arrays and prototype-less or `Object` objects,
+ * nested to any depth, without a cycle. Functions, symbols, bigints, class instances, `Date`, `Map` and
+ * friends are not — a history row is data that serializes, never code or live state.
+ * @param {*} value
+ * @param {Set} path The objects on the way down, to refuse a cycle
+ * @returns {Boolean}
+ */
+function isPlainData(value, path=new Set()) {
+    if (value === null || value === undefined) {
+        return true
+    }
+
+    const type = typeof value;
+
+    if (type === 'string' || type === 'number' || type === 'boolean') {
+        return true
+    }
+
+    if (type !== 'object' || path.has(value)) {
+        return false
+    }
+
+    const proto = Object.getPrototypeOf(value);
+
+    if (!Array.isArray(value) && proto !== Object.prototype && proto !== null) {
+        return false
+    }
+
+    path.add(value);
+
+    const plain = Object.values(value).every(item => isPlainData(item, path));
+
+    path.delete(value);
+
+    return plain
+}
+
+/**
+ * Freezes a plain-data graph in place.
+ * @param {*} value
+ * @returns {*} The same value
+ */
+function deepFreeze(value) {
+    if (value && typeof value === 'object' && !Object.isFrozen(value)) {
+        Object.freeze(value);
+        Object.values(value).forEach(deepFreeze)
+    }
+
+    return value
+}
+
+/**
+ * @summary One Group's bounded, append-only transaction history and its cursor — frozen plain rows in a Collection.
+ * @description The rows are the authority for what a Group has done: each one is a plain-data descriptor
+ * the writer handed to {@link #append}, copied, stamped with `id`, `sequence` and `recordedAt`, and frozen
+ * to every depth before it becomes a member. A retained row cannot change — not a nested field, not a
+ * whole-field replacement — so the bytes it serializes to are the bytes it was admitted with. Anything a
+ * consumer wants mutable (a grid, a Neural Link projection) is a clone, never this collection.
+ *
+ * The cursor names the row the Group's current state reflects: `-1` before the first row, or after every
+ * retained row was undone. {@link #undo} and {@link #redo} only move the cursor and return the row —
+ * applying it is the caller's, which keeps this class free of participants and documents. An append after
+ * an undo drops the redo tail; past {@link #depth} the oldest row is evicted, and the cursor follows.
+ * Eviction never reuses a `sequence`.
+ *
+ * `Neo.manager.Transaction` loads this module on demand at the first write of a Group whose
+ * `historyDepth` is above zero — the admission barrier — so a Group at depth zero never imports it and a
+ * single-window or history-disabled app never pays for it. The inherited collection surface is the
+ * read side; the writes are {@link #append}, {@link #undo} and {@link #redo}.
+ * @class Neo.manager.transaction.History
+ * @extends Neo.collection.Base
+ */
+class History extends Collection {
+    static config = {
+        /**
+         * @member {String} className='Neo.manager.transaction.History'
+         * @protected
+         */
+        className: 'Neo.manager.transaction.History',
+        /**
+         * Rows keep their admission order.
+         * @member {Boolean} autoSort=false
+         */
+        autoSort: false,
+        /**
+         * How many rows are retained; the oldest is evicted past it. At least one — a Group that keeps
+         * no history never loads this module.
+         * @member {Number} depth=50
+         */
+        depth: 50
+    }
+
+    /**
+     * The index of the row the Group's current state reflects; `-1` before the first row or after undoing
+     * every retained row.
+     * @member {Number} cursor=-1
+     */
+    cursor = -1
+    /**
+     * Stamped on every admitted row as `sequence`, counting up across evictions.
+     * @member {Number} sequence=0
+     * @protected
+     */
+    sequence = 0
+
+    /**
+     * @member {Boolean} canRedo
+     */
+    get canRedo() {
+        return this.cursor < this.count - 1
+    }
+
+    /**
+     * @member {Boolean} canUndo
+     */
+    get canUndo() {
+        return this.cursor > -1
+    }
+
+    /**
+     * The row at the cursor, or `null`.
+     * @member {Object|null} current
+     */
+    get current() {
+        return this.cursor > -1 ? this.getAt(this.cursor) : null
+    }
+
+    /**
+     * Admits one transaction after the cursor: the redo tail is dropped, the descriptor is copied, stamped
+     * and frozen, the cursor moves onto it, and rows past {@link #depth} are evicted from the front.
+     * A descriptor {@link #assertRow} refuses changes nothing.
+     * @param {Object} descriptor Plain data; an own `id` is kept, otherwise one is minted
+     * @returns {Object} The frozen retained row
+     */
+    append(descriptor) {
+        let me = this;
+
+        me.assertRow(descriptor);
+
+        if (me.canRedo) {
+            me.splice(me.cursor + 1, me.count - me.cursor - 1)
+        }
+
+        const row = deepFreeze(structuredClone({
+            ...descriptor,
+            id        : descriptor.id ?? crypto.randomUUID(),
+            recordedAt: Date.now(),
+            sequence  : ++me.sequence
+        }));
+
+        // The key is present, so the collection writes nothing onto the frozen row.
+        me.add(row);
+        me.cursor = me.count - 1;
+
+        while (me.count > me.depth) {
+            me.removeAt(0);
+            me.cursor--
+        }
+
+        return row
+    }
+
+    /**
+     * Refuses what could not become a row: a history without a bound, a descriptor that is not a
+     * plain-data object, or an `id` already retained. A writer calls it before it mutates anything, so a
+     * refused row costs no participant change.
+     * @param {Object} descriptor
+     */
+    assertRow(descriptor) {
+        let me = this;
+
+        if (me.depth < 1) {
+            throw new RangeError(`${me.className}: depth must be at least 1, got ${me.depth}`)
+        }
+
+        if (!descriptor || typeof descriptor !== 'object' || Array.isArray(descriptor) || !isPlainData(descriptor)) {
+            throw new TypeError(`${me.className}: a row must be a plain-data object without cycles`)
+        }
+
+        if (descriptor.id != null && me.has(descriptor.id)) {
+            throw new Error(`${me.className}: row ${descriptor.id} is already retained`)
+        }
+    }
+
+    /**
+     * Moves the cursor forward onto the next retained row and returns it, or `null` when there is nothing
+     * to redo. Applying the row is the caller's.
+     * @returns {Object|null}
+     */
+    redo() {
+        let me = this;
+
+        if (!me.canRedo) {
+            return null
+        }
+
+        me.cursor++;
+
+        return me.getAt(me.cursor)
+    }
+
+    /**
+     * Serializes the history for the Neural Link: the frozen rows in order, the cursor and the bound.
+     * @returns {Object}
+     */
+    toJSON() {
+        let me = this;
+
+        return {
+            ...super.toJSON(),
+            cursor  : me.cursor,
+            depth   : me.depth,
+            rows    : me.getRange(0, me.count),
+            sequence: me.sequence
+        }
+    }
+
+    /**
+     * Returns the row at the cursor and moves the cursor back, or `null` when there is nothing to undo.
+     * Applying the row's reverse is the caller's.
+     * @returns {Object|null}
+     */
+    undo() {
+        let me = this;
+
+        if (!me.canUndo) {
+            return null
+        }
+
+        const row = me.getAt(me.cursor);
+
+        me.cursor--;
+
+        return row
+    }
+}
+
+export default Neo.setupClass(History);

--- a/src/manager/transaction/History.mjs
+++ b/src/manager/transaction/History.mjs
@@ -1,3 +1,4 @@
+import Base       from '../../core/Base.mjs';
 import Collection from '../../collection/Base.mjs';
 
 /**
@@ -53,38 +54,36 @@ function deepFreeze(value) {
 }
 
 /**
- * @summary One Group's bounded, append-only transaction history and its cursor — frozen plain rows in a Collection.
+ * @summary One Group's bounded, append-only transaction history and its cursor — frozen plain rows in an
+ * owned Collection.
  * @description The rows are the authority for what a Group has done: each one is a plain-data descriptor
  * the writer handed to {@link #append}, copied, stamped with `id`, `sequence` and `recordedAt`, and frozen
  * to every depth before it becomes a member. A retained row cannot change — not a nested field, not a
- * whole-field replacement — so the bytes it serializes to are the bytes it was admitted with. Anything a
- * consumer wants mutable (a grid, a Neural Link projection) is a clone, never this collection.
+ * whole-field replacement — so the bytes it serializes to are the bytes it was admitted with. The
+ * Collection that holds them is owned and private, so the only writes that reach the rows are
+ * {@link #append}, {@link #undo} and {@link #redo}; anything a consumer wants mutable (a grid, a Neural
+ * Link projection) is a clone fed from {@link #rows}, never this authority.
  *
  * The cursor names the row the Group's current state reflects: `-1` before the first row, or after every
  * retained row was undone. {@link #undo} and {@link #redo} only move the cursor and return the row —
- * applying it is the caller's, which keeps this class free of participants and documents. An append after
- * an undo drops the redo tail; past {@link #depth} the oldest row is evicted, and the cursor follows.
- * Eviction never reuses a `sequence`.
+ * applying it is the caller's, and {@link #peek} shows the row a move would return without moving, so a
+ * caller can apply first and move the cursor only once the application held. An append after an undo
+ * drops the redo tail; past {@link #depth} the oldest row is evicted, and the cursor follows. Eviction
+ * never reuses a `sequence`.
  *
- * `Neo.manager.Transaction` loads this module on demand at the first write of a Group whose
- * `historyDepth` is above zero — the admission barrier — so a Group at depth zero never imports it and a
- * single-window or history-disabled app never pays for it. The inherited collection surface is the
- * read side; the writes are {@link #append}, {@link #undo} and {@link #redo}.
+ * `Neo.manager.Transaction` loads this module on demand at the first write of a Group whose history depth
+ * is above zero — the admission barrier — so a Group at depth zero never imports it and a single-window
+ * or history-disabled app never pays for it.
  * @class Neo.manager.transaction.History
- * @extends Neo.collection.Base
+ * @extends Neo.core.Base
  */
-class History extends Collection {
+class History extends Base {
     static config = {
         /**
          * @member {String} className='Neo.manager.transaction.History'
          * @protected
          */
         className: 'Neo.manager.transaction.History',
-        /**
-         * Rows keep their admission order.
-         * @member {Boolean} autoSort=false
-         */
-        autoSort: false,
         /**
          * How many rows are retained; the oldest is evicted past it. At least one — a Group that keeps
          * no history never loads this module.
@@ -93,6 +92,12 @@ class History extends Collection {
         depth: 50
     }
 
+    /**
+     * The owned Collection of frozen rows, keyed by `id`, in admission order.
+     * @member {Neo.collection.Base} #rows
+     * @private
+     */
+    #rows = null
     /**
      * The index of the row the Group's current state reflects; `-1` before the first row or after undoing
      * every retained row.
@@ -121,11 +126,36 @@ class History extends Collection {
     }
 
     /**
+     * @member {Number} count The retained rows
+     */
+    get count() {
+        return this.#rows?.count ?? 0
+    }
+
+    /**
      * The row at the cursor, or `null`.
      * @member {Object|null} current
      */
     get current() {
         return this.cursor > -1 ? this.getAt(this.cursor) : null
+    }
+
+    /**
+     * The retained rows in admission order — a fresh array of the frozen rows, so a consumer can project
+     * them without a path back into the authority.
+     * @member {Object[]} rows
+     */
+    get rows() {
+        return this.#rows ? this.#rows.getRange(0, this.#rows.count) : []
+    }
+
+    /**
+     * @param {Object} config
+     */
+    construct(config) {
+        super.construct(config);
+
+        this.#rows = Neo.create(Collection, {autoSort: false})
     }
 
     /**
@@ -136,12 +166,13 @@ class History extends Collection {
      * @returns {Object} The frozen retained row
      */
     append(descriptor) {
-        let me = this;
+        let me   = this,
+            rows = me.#rows;
 
         me.assertRow(descriptor);
 
         if (me.canRedo) {
-            me.splice(me.cursor + 1, me.count - me.cursor - 1)
+            rows.splice(me.cursor + 1, rows.count - me.cursor - 1)
         }
 
         const row = deepFreeze(structuredClone({
@@ -152,11 +183,11 @@ class History extends Collection {
         }));
 
         // The key is present, so the collection writes nothing onto the frozen row.
-        me.add(row);
-        me.cursor = me.count - 1;
+        rows.add(row);
+        me.cursor = rows.count - 1;
 
-        while (me.count > me.depth) {
-            me.removeAt(0);
+        while (rows.count > me.depth) {
+            rows.removeAt(0);
             me.cursor--
         }
 
@@ -186,6 +217,62 @@ class History extends Collection {
     }
 
     /**
+     * Releases the owned Collection with the rows.
+     */
+    destroy() {
+        this.#rows?.destroy();
+        this.#rows = null;
+
+        super.destroy()
+    }
+
+    /**
+     * The retained row with this id, or `null`.
+     * @param {String} id
+     * @returns {Object|null}
+     */
+    get(id) {
+        return this.#rows?.get(id) ?? null
+    }
+
+    /**
+     * The retained row at this index, or `undefined`.
+     * @param {Number} index
+     * @returns {Object|undefined}
+     */
+    getAt(index) {
+        return this.#rows?.getAt(index)
+    }
+
+    /**
+     * @param {String} id
+     * @returns {Boolean}
+     */
+    has(id) {
+        return this.#rows?.has(id) ?? false
+    }
+
+    /**
+     * The row {@link #undo} or {@link #redo} would return, without moving the cursor — `null` when there
+     * is nothing in that direction.
+     * @param {String} direction `undo` or `redo`
+     * @returns {Object|null}
+     */
+    peek(direction) {
+        let me = this;
+
+        if (direction === 'undo') {
+            return me.current
+        }
+
+        if (direction === 'redo') {
+            return me.canRedo ? me.getAt(me.cursor + 1) : null
+        }
+
+        throw new RangeError(`${me.className}#peek: direction must be undo or redo, got ${direction}`)
+    }
+
+    /**
      * Moves the cursor forward onto the next retained row and returns it, or `null` when there is nothing
      * to redo. Applying the row is the caller's.
      * @returns {Object|null}
@@ -211,9 +298,10 @@ class History extends Collection {
 
         return {
             ...super.toJSON(),
+            count   : me.count,
             cursor  : me.cursor,
             depth   : me.depth,
-            rows    : me.getRange(0, me.count),
+            rows    : me.rows,
             sequence: me.sequence
         }
     }

--- a/test/playwright/unit/manager/TransactionWrite.spec.mjs
+++ b/test/playwright/unit/manager/TransactionWrite.spec.mjs
@@ -16,12 +16,15 @@ import StateProvider   from '../../../../src/state/Provider.mjs';
 
 /**
  * The write side of a Group: the serialized queue, the admission barrier that loads the history module once
- * and only for a Group that keeps history, the cursor moves, and the Group provider every bound window
- * reads. The manager is driven the way a host does — `bind`, then `write` / `undo` / `redo` — with `adopt`
- * as an observed slot standing in for the participant protocol a later leaf fills.
+ * and only for a Group that keeps history, the cursor moves that wait for their application, the Group-local
+ * depth, and the Group provider every bound window reads. The manager is driven the way a host does —
+ * `bind`, then `write` / `undo` / `redo` — with `adopt` and `apply` as observed slots standing in for the
+ * participant protocol a later leaf fills.
  */
 test.describe.serial('Neo.manager.Transaction — history admission, the queue and the Group provider', () => {
     let Transaction, importHistory, imports, log;
+
+    const noop = () => {};
 
     const reset = () => {
         [...Transaction.items].forEach(group => Transaction.retireGroup(group.id));
@@ -70,8 +73,8 @@ test.describe.serial('Neo.manager.Transaction — history admission, the queue a
         expect(imports).toBe(0);
         expect(Transaction.get(groupId).history).toBeNull();
         expect(Transaction.get(groupId).historyReady).toBeNull();
-        expect(await Transaction.undo({groupId}), 'nothing to undo without history').toBeNull();
-        expect(await Transaction.redo({groupId})).toBeNull();
+        expect(await Transaction.undo({groupId, apply: noop}), 'nothing to undo without history').toBeNull();
+        expect(await Transaction.redo({groupId, apply: noop})).toBeNull();
         expect(Transaction.getProvider(groupId).getData('canUndo')).toBe(false);
         expect(Transaction.getProvider(groupId).getData('historyDepth')).toBe(0);
         expect(imports, 'still nothing loaded').toBe(0)
@@ -107,7 +110,46 @@ test.describe.serial('Neo.manager.Transaction — history admission, the queue a
         expect(history.count).toBe(4)
     });
 
-    test('the depth is the Group\'s at birth: a Group created before the bound changed keeps its own', async () => {
+    test('depth is a Group\'s own choice: two roots in one worker keep their own policy, whichever was admitted first', async () => {
+        const first  = Transaction.bind({windowId: 'a1', workspaceKey: 'main'}),
+              second = Transaction.bind({windowId: 'b1', workspaceKey: 'main'});
+
+        expect(Transaction.setHistoryDepth({groupId: second.groupId, depth: 50})).toBe(true);
+        expect(Transaction.getProvider(second.groupId).getData('historyDepth')).toBe(50);
+        expect(Transaction.getProvider(first.groupId).getData('historyDepth'), 'A was born at zero and stays there').toBe(0);
+
+        await Transaction.write({groupId: first.groupId,  descriptor: {kind: 'a'}});
+        await Transaction.write({groupId: second.groupId, descriptor: {kind: 'b'}});
+
+        expect(Transaction.get(first.groupId).history, 'A loads no history').toBeNull();
+        expect(Transaction.get(second.groupId).history.depth).toBe(50);
+        expect(imports).toBe(1);
+
+        // The other admission order: B's policy set before A exists changes nothing for A.
+        reset();
+
+        const late = Transaction.bind({windowId: 'b2', workspaceKey: 'main'});
+
+        Transaction.setHistoryDepth({groupId: late.groupId, depth: 2});
+
+        const early = Transaction.bind({windowId: 'a2', workspaceKey: 'main'});
+
+        await Transaction.write({groupId: early.groupId, descriptor: {kind: 'a'}});
+        await Transaction.write({groupId: late.groupId,  descriptor: {kind: 'b'}});
+
+        expect(Transaction.get(early.groupId).history).toBeNull();
+        expect(Transaction.get(late.groupId).history.depth).toBe(2);
+
+        // Refusals: unknown Group, a bound that is not a non-negative integer, a Group whose history loaded.
+        expect(Transaction.setHistoryDepth({groupId: 'nowhere', depth: 3})).toBe(false);
+        expect(Transaction.setHistoryDepth({groupId: early.groupId, depth: -1})).toBe(false);
+        expect(Transaction.setHistoryDepth({groupId: early.groupId, depth: 1.5})).toBe(false);
+        expect(Transaction.setHistoryDepth({groupId: late.groupId, depth: 9}), 'fixed at the first write').toBe(false);
+        expect(Transaction.get(late.groupId).historyDepth).toBe(2);
+        expect(Transaction.setHistoryDepth({groupId: early.groupId, depth: 4}), 'A never loaded, so A may still choose').toBe(true)
+    });
+
+    test('the worker-wide default is what a Group is born with; a Group created before the default changed keeps its own', async () => {
         const before = Transaction.bind({windowId: 'w1', workspaceKey: 'main'});
 
         Transaction.historyDepth = 2;
@@ -141,7 +183,7 @@ test.describe.serial('Neo.manager.Transaction — history admission, the queue a
         const {history} = Transaction.get(groupId);
 
         expect((await next).row.kind, 'the queue survived the failure').toBe('c');
-        expect(history.getRange(0, history.count).map(row => row.kind)).toEqual(['a', 'c']);
+        expect(history.rows.map(row => row.kind)).toEqual(['a', 'c']);
         expect(history.cursor).toBe(1);
         expect(provider.getData('historyLength')).toBe(2)
     });
@@ -159,11 +201,13 @@ test.describe.serial('Neo.manager.Transaction — history admission, the queue a
         expect(Transaction.getProvider(groupId).getData('canUndo')).toBe(false)
     });
 
-    test('undo and redo move the cursor on the queue and the provider follows; an append after undo drops the tail', async () => {
+    test('undo and redo apply first and move the cursor after; the provider follows; an append after undo drops the tail', async () => {
         Transaction.historyDepth = 5;
 
         const {groupId} = Transaction.bind({windowId: 'w1', workspaceKey: 'main'}),
               provider  = Transaction.getProvider(groupId),
+              applied   = [],
+              apply     = row => { applied.push([row.kind, Transaction.get(groupId).history.cursor]) },
               rows      = [];
 
         for (const kind of ['a', 'b', 'c']) {
@@ -174,20 +218,45 @@ test.describe.serial('Neo.manager.Transaction — history admission, the queue a
         expect(provider.getData('canRedo')).toBe(false);
         expect(provider.getData('historyCursor')).toBe(2);
 
-        expect(await Transaction.undo({groupId})).toBe(rows[2]);
-        expect(await Transaction.undo({groupId})).toBe(rows[1]);
+        expect(await Transaction.undo({groupId, apply})).toBe(rows[2]);
+        expect(await Transaction.undo({groupId, apply})).toBe(rows[1]);
+        expect(applied, 'apply sees the cursor still on the row it reverses').toEqual([['c', 2], ['b', 1]]);
         expect(provider.getData('canRedo')).toBe(true);
         expect(provider.getData('historyCursor')).toBe(0);
-        expect(await Transaction.redo({groupId})).toBe(rows[1]);
+        expect(await Transaction.redo({groupId, apply})).toBe(rows[1]);
+        expect(applied.at(-1), 'redo applies before the cursor moves onto the row').toEqual(['b', 0]);
         expect(provider.getData('historyCursor')).toBe(1);
 
         const {row} = await Transaction.write({groupId, descriptor: {kind: 'd'}});
 
-        expect(Transaction.get(groupId).history.getRange(0, 3).map(item => item.kind)).toEqual(['a', 'b', 'd']);
+        expect(Transaction.get(groupId).history.rows.map(item => item.kind)).toEqual(['a', 'b', 'd']);
         expect(row.sequence).toBe(4);
         expect(provider.getData('canRedo')).toBe(false);
         expect(provider.getData('historyLength')).toBe(3);
-        expect(await Transaction.redo({groupId})).toBeNull()
+        expect(await Transaction.redo({groupId, apply})).toBeNull()
+    });
+
+    test('a rejected application moves nothing: cursor and provider stay, and the next move still works; undo without apply is refused', async () => {
+        Transaction.historyDepth = 5;
+
+        const {groupId} = Transaction.bind({windowId: 'w1', workspaceKey: 'main'}),
+              provider  = Transaction.getProvider(groupId);
+
+        await Transaction.write({groupId, descriptor: {kind: 'a'}});
+        await Transaction.write({groupId, descriptor: {kind: 'b'}});
+
+        await expect(Transaction.undo({groupId, apply: async () => { throw new Error('reverse refused by a participant') }})).rejects.toThrow('reverse refused');
+
+        expect(Transaction.get(groupId).history.cursor, 'the cursor did not move').toBe(1);
+        expect(provider.getData('historyCursor')).toBe(1);
+        expect(provider.getData('canRedo')).toBe(false);
+
+        expect((await Transaction.undo({groupId, apply: noop})).kind, 'the queue is free for the next move').toBe('b');
+        expect(provider.getData('historyCursor')).toBe(0);
+
+        await expect(Transaction.undo({groupId})).rejects.toThrow('apply(row) is required');
+        await expect(Transaction.redo({groupId, apply: 'later'})).rejects.toThrow('apply(row) is required');
+        expect(Transaction.get(groupId).history.cursor).toBe(0)
     });
 
     test('an undo issued while the first write is still loading waits for it and moves the cursor off the row that write admitted', async () => {
@@ -196,7 +265,7 @@ test.describe.serial('Neo.manager.Transaction — history admission, the queue a
         const {groupId}       = Transaction.bind({windowId: 'w1', workspaceKey: 'main'}),
               [{row}, undone] = await Promise.all([
                   Transaction.write({groupId, descriptor: {kind: 'a'}}),
-                  Transaction.undo({groupId})
+                  Transaction.undo({groupId, apply: noop})
               ]);
 
         expect(undone).toBe(row);
@@ -219,6 +288,7 @@ test.describe.serial('Neo.manager.Transaction — history admission, the queue a
         expect(Transaction.getProvider('unknown')).toBeNull();
         expect(provider.getData('historyDepth')).toBe(2);
         expect(provider.getData('historyLength')).toBe(0);
+        expect(provider.getData('canUndo')).toBe(false);
         expect(host.getData('canUndo'), 'read through the explicit parent, no component tree involved').toBe(false);
 
         await Transaction.write({groupId: a.groupId, descriptor: {kind: 'a'}});
@@ -265,8 +335,8 @@ test.describe.serial('Neo.manager.Transaction — history admission, the queue a
 
     test('a write, undo or redo against an unknown Group rejects', async () => {
         await expect(Transaction.write({groupId: 'nowhere', descriptor: {kind: 'a'}})).rejects.toThrow('unknown Group');
-        await expect(Transaction.undo({groupId: 'nowhere'})).rejects.toThrow('unknown Group');
-        await expect(Transaction.redo({groupId: 'nowhere'})).rejects.toThrow('unknown Group')
+        await expect(Transaction.undo({groupId: 'nowhere', apply: noop})).rejects.toThrow('unknown Group');
+        await expect(Transaction.redo({groupId: 'nowhere', apply: noop})).rejects.toThrow('unknown Group')
     });
 
     test('a write queued behind the barrier when its Group is retired rejects instead of touching what the retirement released', async () => {

--- a/test/playwright/unit/manager/TransactionWrite.spec.mjs
+++ b/test/playwright/unit/manager/TransactionWrite.spec.mjs
@@ -12,6 +12,7 @@ import path            from 'node:path';
 import {fileURLToPath} from 'node:url';
 import Neo             from '../../../../src/Neo.mjs';
 import * as core       from '../../../../src/core/_export.mjs';
+import InstanceManager from '../../../../src/manager/Instance.mjs';
 import StateProvider   from '../../../../src/state/Provider.mjs';
 
 /**
@@ -337,6 +338,88 @@ test.describe.serial('Neo.manager.Transaction — history admission, the queue a
         await expect(Transaction.write({groupId: 'nowhere', descriptor: {kind: 'a'}})).rejects.toThrow('unknown Group');
         await expect(Transaction.undo({groupId: 'nowhere', apply: noop})).rejects.toThrow('unknown Group');
         await expect(Transaction.redo({groupId: 'nowhere', apply: noop})).rejects.toThrow('unknown Group')
+    });
+
+    test('the worker-wide default and the Group-local bound refuse anything but a non-negative integer, so no Group is born with an unbounded log', async () => {
+        const logged   = [],
+              logError = Neo.logError;
+
+        Neo.logError = (...args) => logged.push(args.join(' '));
+
+        try {
+            for (const bad of [Infinity, NaN, 1.5, -1, '2', null]) {
+                Transaction.historyDepth = bad;
+                expect(Transaction.historyDepth, `default ${String(bad)} refused, the one in force stays`).toBe(0)
+            }
+        } finally {
+            Neo.logError = logError
+        }
+
+        expect(logged).toHaveLength(6);
+        expect(logged[0]).toMatch(/historyDepth must be a non-negative integer, got Infinity — keeping 0/);
+
+        // A Group born under a refused default carries the bound in force, never the refused one.
+        const born = Transaction.bind({windowId: 'w0', workspaceKey: 'main'});
+
+        expect(Transaction.get(born.groupId).historyDepth).toBe(0);
+        await Transaction.write({groupId: born.groupId, descriptor: {kind: 'a'}});
+        expect(Transaction.get(born.groupId).history, 'depth zero loads nothing').toBeNull();
+
+        Transaction.historyDepth = 2;
+
+        const {groupId} = Transaction.bind({windowId: 'w1', workspaceKey: 'main'});
+
+        for (const kind of ['a', 'b', 'c']) {
+            await Transaction.write({groupId, descriptor: {kind}})
+        }
+
+        const {history} = Transaction.get(groupId);
+
+        expect(history.depth).toBe(2);
+        expect(history.rows.map(row => row.kind), 'a valid bound evicts exactly').toEqual(['b', 'c'])
+    });
+
+    test('a Group retired while its history module is still loading gets no History: the write rejects, nothing is adopted, and no orphan is registered', async () => {
+        Transaction.historyDepth = 5;
+
+        const {groupId} = Transaction.bind({windowId: 'w1', workspaceKey: 'main'}),
+              record    = Transaction.get(groupId),
+              adopted   = [],
+              instances = () => InstanceManager.find('className', 'Neo.manager.transaction.History').length;
+
+        let resolveImport, started = false;
+
+        Transaction.importHistory = () => {
+            started = true;
+            return new Promise(resolve => { resolveImport = resolve })
+        };
+
+        const write  = Transaction.write({groupId, descriptor: {kind: 'a'}, adopt: descriptor => adopted.push(descriptor)}),
+              before = instances();
+
+        while (!started) {
+            await new Promise(resolve => setTimeout(resolve, 0))
+        }
+
+        expect(Transaction.retireGroup(groupId), 'retired while the import is pending').toBe(true);
+
+        resolveImport(await importHistory.call(Transaction));
+
+        await expect(write).rejects.toThrow('retired while queued');
+        expect(adopted).toHaveLength(0);
+        expect(record.history, 'the retired record never received a History').toBeNull();
+        expect(instances(), 'no History was registered for the dead Group').toBe(before);
+
+        // Control: the same pending import with the Group alive creates exactly one History.
+        Transaction.importHistory = importHistory;
+
+        const live = Transaction.bind({windowId: 'w2', workspaceKey: 'main'});
+
+        await Transaction.write({groupId: live.groupId, descriptor: {kind: 'a'}});
+
+        expect(instances()).toBe(before + 1);
+        expect(Transaction.retireGroup(live.groupId)).toBe(true);
+        expect(instances(), 'ordinary retirement releases it').toBe(before)
     });
 
     test('a write queued behind the barrier when its Group is retired rejects instead of touching what the retirement released', async () => {

--- a/test/playwright/unit/manager/TransactionWrite.spec.mjs
+++ b/test/playwright/unit/manager/TransactionWrite.spec.mjs
@@ -1,0 +1,294 @@
+import {setup} from '../../setup.mjs';
+
+setup({
+    appConfig: {
+        name: 'ManagerTransactionWriteTest'
+    }
+});
+
+import {test, expect}  from '@playwright/test';
+import fs              from 'node:fs';
+import path            from 'node:path';
+import {fileURLToPath} from 'node:url';
+import Neo             from '../../../../src/Neo.mjs';
+import * as core       from '../../../../src/core/_export.mjs';
+import StateProvider   from '../../../../src/state/Provider.mjs';
+
+/**
+ * The write side of a Group: the serialized queue, the admission barrier that loads the history module once
+ * and only for a Group that keeps history, the cursor moves, and the Group provider every bound window
+ * reads. The manager is driven the way a host does — `bind`, then `write` / `undo` / `redo` — with `adopt`
+ * as an observed slot standing in for the participant protocol a later leaf fills.
+ */
+test.describe.serial('Neo.manager.Transaction — history admission, the queue and the Group provider', () => {
+    let Transaction, importHistory, imports, log;
+
+    const reset = () => {
+        [...Transaction.items].forEach(group => Transaction.retireGroup(group.id));
+        Transaction.historyDepth     = 0;
+        Transaction.reconnectLeaseMs = 20000;
+        Transaction.importHistory    = importHistory;
+        imports = 0;
+        log     = []
+    };
+
+    test.beforeAll(async () => {
+        Transaction   = (await import('../../../../src/manager/Transaction.mjs')).default;
+        importHistory = Transaction.importHistory
+    });
+
+    test.beforeEach(() => {
+        reset();
+
+        // Observe the one dynamic import without replacing it: the real module loads, the count is ours.
+        Transaction.importHistory = function() {
+            imports++;
+            log.push('import:start');
+
+            return importHistory.call(this).then(module => {
+                log.push('import:done');
+
+                return module
+            })
+        }
+    });
+
+    test.afterEach(reset);
+
+    test('a Group at depth zero admits writes without the history module: adopt runs once, no row, no import', async () => {
+        const {groupId} = Transaction.bind({windowId: 'w1', workspaceKey: 'main'}),
+              seen      = [],
+              outcome   = await Transaction.write({
+                  groupId,
+                  descriptor: {kind: 'move'},
+                  adopt     : descriptor => { seen.push(descriptor); return 'adopted' }
+              });
+
+        expect(seen).toHaveLength(1);
+        expect(seen[0]).toEqual({kind: 'move'});
+        expect(outcome).toEqual({result: 'adopted', row: null});
+        expect(imports).toBe(0);
+        expect(Transaction.get(groupId).history).toBeNull();
+        expect(Transaction.get(groupId).historyReady).toBeNull();
+        expect(await Transaction.undo({groupId}), 'nothing to undo without history').toBeNull();
+        expect(await Transaction.redo({groupId})).toBeNull();
+        expect(Transaction.getProvider(groupId).getData('canUndo')).toBe(false);
+        expect(Transaction.getProvider(groupId).getData('historyDepth')).toBe(0);
+        expect(imports, 'still nothing loaded').toBe(0)
+    });
+
+    test('the first write of a Group that keeps history awaits one import before adopt; later writes queue behind it, each descriptor once', async () => {
+        Transaction.historyDepth = 5;
+
+        const {groupId} = Transaction.bind({windowId: 'w1', workspaceKey: 'main'}),
+              adopt     = descriptor => { log.push(`adopt:${descriptor.kind}`); return descriptor.kind },
+              outcomes  = await Promise.all([
+                  Transaction.write({groupId, descriptor: {kind: 'a'}, adopt}),
+                  Transaction.write({groupId, descriptor: {kind: 'b'}, adopt}),
+                  Transaction.write({groupId, descriptor: {kind: 'c'}, adopt})
+              ]);
+
+        expect(imports).toBe(1);
+        expect(log, 'the barrier resolves before the first adopt; the writes run in call order').toEqual(['import:start', 'import:done', 'adopt:a', 'adopt:b', 'adopt:c']);
+        expect(outcomes.map(outcome => outcome.result)).toEqual(['a', 'b', 'c']);
+        expect(outcomes.map(outcome => outcome.row.sequence)).toEqual([1, 2, 3]);
+        expect(outcomes.every(outcome => Object.isFrozen(outcome.row))).toBe(true);
+
+        const {history} = Transaction.get(groupId);
+
+        expect(history.className).toBe('Neo.manager.transaction.History');
+        expect(history.depth).toBe(5);
+        expect(history.count).toBe(3);
+        expect(history.cursor).toBe(2);
+
+        await Transaction.write({groupId, descriptor: {kind: 'd'}, adopt});
+
+        expect(imports, 'a loaded Group imports nothing more').toBe(1);
+        expect(history.count).toBe(4)
+    });
+
+    test('the depth is the Group\'s at birth: a Group created before the bound changed keeps its own', async () => {
+        const before = Transaction.bind({windowId: 'w1', workspaceKey: 'main'});
+
+        Transaction.historyDepth = 2;
+
+        const after = Transaction.bind({windowId: 'w2', workspaceKey: 'main'});
+
+        await Transaction.write({groupId: before.groupId, descriptor: {kind: 'a'}});
+        await Transaction.write({groupId: after.groupId,  descriptor: {kind: 'a'}});
+
+        expect(Transaction.get(before.groupId).history, 'born at zero, stays at zero').toBeNull();
+        expect(Transaction.get(after.groupId).history.depth).toBe(2);
+        expect(imports).toBe(1)
+    });
+
+    test('a rejected adopt appends nothing, keeps the cursor, and releases the queue for the next write', async () => {
+        Transaction.historyDepth = 5;
+
+        const {groupId} = Transaction.bind({windowId: 'w1', workspaceKey: 'main'}),
+              provider  = Transaction.getProvider(groupId);
+
+        await Transaction.write({groupId, descriptor: {kind: 'a'}, adopt: () => 'ok'});
+
+        expect(provider.getData('canUndo')).toBe(true);
+        expect(provider.getData('historyLength')).toBe(1);
+
+        const failing = Transaction.write({groupId, descriptor: {kind: 'b'}, adopt: () => { throw new Error('second participant refused') }}),
+              next    = Transaction.write({groupId, descriptor: {kind: 'c'}, adopt: () => 'ok'});
+
+        await expect(failing).rejects.toThrow('second participant refused');
+
+        const {history} = Transaction.get(groupId);
+
+        expect((await next).row.kind, 'the queue survived the failure').toBe('c');
+        expect(history.getRange(0, history.count).map(row => row.kind)).toEqual(['a', 'c']);
+        expect(history.cursor).toBe(1);
+        expect(provider.getData('historyLength')).toBe(2)
+    });
+
+    test('a descriptor the history would refuse is refused before adopt runs: no participant change without a row', async () => {
+        Transaction.historyDepth = 5;
+
+        const {groupId} = Transaction.bind({windowId: 'w1', workspaceKey: 'main'}),
+              adopted   = [];
+
+        await expect(Transaction.write({groupId, descriptor: {kind: 'a', apply: () => {}}, adopt: descriptor => adopted.push(descriptor)})).rejects.toThrow(TypeError);
+
+        expect(adopted).toHaveLength(0);
+        expect(Transaction.get(groupId).history.count).toBe(0);
+        expect(Transaction.getProvider(groupId).getData('canUndo')).toBe(false)
+    });
+
+    test('undo and redo move the cursor on the queue and the provider follows; an append after undo drops the tail', async () => {
+        Transaction.historyDepth = 5;
+
+        const {groupId} = Transaction.bind({windowId: 'w1', workspaceKey: 'main'}),
+              provider  = Transaction.getProvider(groupId),
+              rows      = [];
+
+        for (const kind of ['a', 'b', 'c']) {
+            rows.push((await Transaction.write({groupId, descriptor: {kind}})).row)
+        }
+
+        expect(provider.getData('canUndo')).toBe(true);
+        expect(provider.getData('canRedo')).toBe(false);
+        expect(provider.getData('historyCursor')).toBe(2);
+
+        expect(await Transaction.undo({groupId})).toBe(rows[2]);
+        expect(await Transaction.undo({groupId})).toBe(rows[1]);
+        expect(provider.getData('canRedo')).toBe(true);
+        expect(provider.getData('historyCursor')).toBe(0);
+        expect(await Transaction.redo({groupId})).toBe(rows[1]);
+        expect(provider.getData('historyCursor')).toBe(1);
+
+        const {row} = await Transaction.write({groupId, descriptor: {kind: 'd'}});
+
+        expect(Transaction.get(groupId).history.getRange(0, 3).map(item => item.kind)).toEqual(['a', 'b', 'd']);
+        expect(row.sequence).toBe(4);
+        expect(provider.getData('canRedo')).toBe(false);
+        expect(provider.getData('historyLength')).toBe(3);
+        expect(await Transaction.redo({groupId})).toBeNull()
+    });
+
+    test('an undo issued while the first write is still loading waits for it and moves the cursor off the row that write admitted', async () => {
+        Transaction.historyDepth = 5;
+
+        const {groupId}       = Transaction.bind({windowId: 'w1', workspaceKey: 'main'}),
+              [{row}, undone] = await Promise.all([
+                  Transaction.write({groupId, descriptor: {kind: 'a'}}),
+                  Transaction.undo({groupId})
+              ]);
+
+        expect(undone).toBe(row);
+        expect(Transaction.get(groupId).history.cursor).toBe(-1);
+        expect(Transaction.getProvider(groupId).getData('canRedo')).toBe(true)
+    });
+
+    test('one provider per Group whatever window asks: the opener and a popped-out slot read the same instance, a host provider chains to it, and it goes with the Group', async () => {
+        Transaction.historyDepth = 2;
+
+        const a           = Transaction.bind({windowId: 'a1', workspaceKey: 'main'}),
+              reservation = Transaction.reserve({groupId: a.groupId, workspaceKey: 'popup:notes'}),
+              popup       = Transaction.bind({...reservation, windowId: 'a2'}),
+              provider    = Transaction.getProvider(a.groupId),
+              host        = Neo.create(StateProvider, {parent: provider});
+
+        expect(popup.groupId, 'the reserved slot binds into the opener\'s Group').toBe(a.groupId);
+        expect(provider.className).toBe('Neo.state.Provider');
+        expect(Transaction.getProvider(Transaction.findByWindow('a2').groupId), 'the popup resolves the same instance').toBe(provider);
+        expect(Transaction.getProvider('unknown')).toBeNull();
+        expect(provider.getData('historyDepth')).toBe(2);
+        expect(provider.getData('historyLength')).toBe(0);
+        expect(host.getData('canUndo'), 'read through the explicit parent, no component tree involved').toBe(false);
+
+        await Transaction.write({groupId: a.groupId, descriptor: {kind: 'a'}});
+
+        expect(provider.getData('canUndo')).toBe(true);
+        expect(host.getData('canUndo')).toBe(true);
+        expect(host.getData('historyLength')).toBe(1);
+
+        host.destroy();
+        Transaction.retireGroup(a.groupId);
+
+        expect(provider.isDestroyed).toBe(true);
+        expect(Transaction.getProvider(a.groupId)).toBeNull()
+    });
+
+    test('a Group holding history rows survives its last lease; one holding none is let go', async () => {
+        Transaction.historyDepth     = 2;
+        Transaction.reconnectLeaseMs = 20;
+
+        const kept      = Transaction.bind({windowId: 'k1', workspaceKey: 'main'}),
+              empty     = Transaction.bind({windowId: 'e1', workspaceKey: 'main'}),
+              retired   = [],
+              onRetired = ({groupId}) => retired.push(groupId);
+
+        Transaction.on('groupRetired', onRetired);
+
+        await Transaction.write({groupId: kept.groupId, descriptor: {kind: 'a'}});
+
+        const emptyProvider = Transaction.getProvider(empty.groupId);
+
+        Transaction.release('k1');
+        Transaction.release('e1');
+
+        await new Promise(resolve => setTimeout(resolve, 60));
+
+        Transaction.un('groupRetired', onRetired);
+
+        expect(Transaction.get(kept.groupId), 'the rows are the truth of what its documents did').toBeTruthy();
+        expect(Transaction.get(kept.groupId).history.count).toBe(1);
+        expect(Transaction.get(empty.groupId), 'nothing retained, nothing kept').toBeNull();
+        expect(emptyProvider.isDestroyed, 'a provider alone keeps nothing, and goes with the Group').toBe(true);
+        expect(retired).toEqual([empty.groupId])
+    });
+
+    test('a write, undo or redo against an unknown Group rejects', async () => {
+        await expect(Transaction.write({groupId: 'nowhere', descriptor: {kind: 'a'}})).rejects.toThrow('unknown Group');
+        await expect(Transaction.undo({groupId: 'nowhere'})).rejects.toThrow('unknown Group');
+        await expect(Transaction.redo({groupId: 'nowhere'})).rejects.toThrow('unknown Group')
+    });
+
+    test('a write queued behind the barrier when its Group is retired rejects instead of touching what the retirement released', async () => {
+        Transaction.historyDepth = 5;
+
+        const {groupId} = Transaction.bind({windowId: 'w1', workspaceKey: 'main'}),
+              adopted   = [],
+              queued    = Transaction.write({groupId, descriptor: {kind: 'a'}, adopt: descriptor => adopted.push(descriptor)});
+
+        expect(Transaction.retireGroup(groupId)).toBe(true);
+
+        await expect(queued).rejects.toThrow('retired while queued');
+        expect(adopted, 'no participant mutation for a Group that is gone').toHaveLength(0);
+        expect(imports, 'the barrier had already started loading; the module is simply not used').toBeLessThanOrEqual(1)
+    });
+
+    test('the manager never imports the history module statically: the lazy boundary is mechanical', () => {
+        const source  = fs.readFileSync(path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../../src/manager/Transaction.mjs'), 'utf8'),
+              statics = [...source.matchAll(/(?:^|\n)\s*(?:import|export)\s+[^'";]*?\s*from\s*['"]([^'"]+)['"]/g)].map(match => match[1]),
+              dynamic = [...source.matchAll(/import\(\s*['"]([^'"]+)['"]\s*\)/g)].map(match => match[1]);
+
+        expect(statics.some(specifier => specifier.includes('transaction/History')), 'a static import would put the module into every consumer\'s closure').toBe(false);
+        expect(dynamic).toEqual(['./transaction/History.mjs'])
+    })
+});

--- a/test/playwright/unit/manager/transaction/History.spec.mjs
+++ b/test/playwright/unit/manager/transaction/History.spec.mjs
@@ -12,9 +12,10 @@ import * as core      from '../../../../../src/core/_export.mjs';
 import History        from '../../../../../src/manager/transaction/History.mjs';
 
 /**
- * A Group's history is an append-only Collection of frozen plain rows with one cursor. These arms drive the
+ * A Group's history is an append-only authority over frozen plain rows with one cursor. These arms drive the
  * class alone — no manager, no participants: what is admitted, what a retained row refuses, how the cursor
- * moves, what eviction and the redo tail drop, and what the serialized bytes are.
+ * moves, what eviction and the redo tail drop, what the serialized bytes are, and that the surface a
+ * consumer can reach never mutates a row.
  */
 test.describe('Neo.manager.transaction.History — frozen rows and the cursor', () => {
     let history;
@@ -48,7 +49,9 @@ test.describe('Neo.manager.transaction.History — frozen rows and the cursor', 
         expect(history.current).toBe(row);
         expect(history.canUndo).toBe(true);
         expect(history.canRedo).toBe(false);
-        expect(history.get(row.id), 'keyed by the id the row carried in; the collection wrote nothing onto it').toBe(row)
+        expect(history.has(row.id)).toBe(true);
+        expect(history.get(row.id), 'keyed by the id the row carried in; the collection wrote nothing onto it').toBe(row);
+        expect(history.getAt(0)).toBe(row)
     });
 
     test('a retained row refuses nested mutation and whole-field replacement; its bytes do not move', () => {
@@ -64,6 +67,24 @@ test.describe('Neo.manager.transaction.History — frozen rows and the cursor', 
         expect(JSON.stringify(row)).toBe(bytes);
         expect(history.getAt(0)).toBe(row);
         expect(history.cursor).toBe(0)
+    });
+
+    test('the reachable surface is read-only: rows is a fresh array, and the authority has no remove, insert, splice or sort', () => {
+        const a    = history.append({kind: 'a'}),
+              rows = history.rows;
+
+        expect(rows).toEqual([a]);
+        expect(history.rows, 'a new array on every read').not.toBe(rows);
+
+        rows.length = 0;
+        rows.push({kind: 'forged'});
+
+        expect(history.rows, 'a consumer mutating its copy touches no row').toEqual([a]);
+        expect(history.count).toBe(1);
+
+        for (const method of ['remove', 'removeAt', 'insert', 'splice', 'add', 'push', 'pop', 'shift', 'unshift', 'move', 'reverse', 'clear', 'doSort']) {
+            expect(typeof history[method], `${method} is not on the authority`).toBe('undefined')
+        }
     });
 
     test('a descriptor that is not plain data, or an id already retained, is refused and nothing changes', () => {
@@ -115,36 +136,43 @@ test.describe('Neo.manager.transaction.History — frozen rows and the cursor', 
 
         const d = history.append({kind: 'd'});
 
-        expect(history.getRange(0, history.count)).toEqual([a, d]);
+        expect(history.rows).toEqual([a, d]);
         expect(history.cursor).toBe(1);
         expect(history.canRedo).toBe(false);
         expect(history.redo(), 'the dropped tail cannot come back').toBeNull();
         expect(d.sequence, 'sequence counts admissions, not retained rows').toBe(4)
     });
 
-    test('undo and redo walk the cursor deterministically and return the row to apply', () => {
+    test('undo and redo walk the cursor deterministically and return the row to apply; peek shows it without moving', () => {
         const rows = ['a', 'b', 'c'].map(kind => history.append({kind}));
 
-        expect(history.redo(), 'nothing ahead of the newest row').toBeNull();
+        expect(history.peek('redo'), 'nothing ahead of the newest row').toBeNull();
+        expect(history.peek('undo')).toBe(rows[2]);
+        expect(history.cursor, 'peek moved nothing').toBe(2);
+        expect(history.redo()).toBeNull();
         expect(history.undo()).toBe(rows[2]);
         expect(history.undo()).toBe(rows[1]);
+        expect(history.peek('undo')).toBe(rows[0]);
+        expect(history.peek('redo')).toBe(rows[1]);
         expect(history.undo()).toBe(rows[0]);
         expect(history.cursor).toBe(-1);
         expect(history.current).toBeNull();
         expect(history.canUndo).toBe(false);
+        expect(history.peek('undo')).toBeNull();
         expect(history.undo(), 'nothing behind the first row').toBeNull();
         expect(history.redo()).toBe(rows[0]);
         expect(history.redo()).toBe(rows[1]);
         expect(history.cursor).toBe(1);
         expect(history.current).toBe(rows[1]);
-        expect(history.count, 'undo and redo retain every row').toBe(3)
+        expect(history.count, 'undo and redo retain every row').toBe(3);
+        expect(() => history.peek('sideways')).toThrow(RangeError)
     });
 
     test('past the depth the oldest row is evicted and the cursor follows; a sequence is never reused', () => {
         const rows = ['a', 'b', 'c', 'd', 'e'].map(kind => history.append({kind}));
 
         expect(history.count).toBe(3);
-        expect(history.getRange(0, 3)).toEqual(rows.slice(2));
+        expect(history.rows).toEqual(rows.slice(2));
         expect(history.cursor).toBe(2);
         expect(history.current).toBe(rows[4]);
         expect(rows.map(row => row.sequence)).toEqual([1, 2, 3, 4, 5]);
@@ -152,7 +180,8 @@ test.describe('Neo.manager.transaction.History — frozen rows and the cursor', 
         expect(history.undo()).toBe(rows[3]);
         expect(history.undo()).toBe(rows[2]);
         expect(history.undo(), 'an evicted row is not undoable').toBeNull();
-        expect(history.get(rows[0].id), 'evicted rows leave the collection').toBeNull()
+        expect(history.get(rows[0].id), 'evicted rows leave the authority').toBeNull();
+        expect(history.has(rows[0].id)).toBe(false)
     });
 
     test('an append behind the newest row drops the tail first, then evicts from the front; the cursor stays on its row', () => {
@@ -162,11 +191,11 @@ test.describe('Neo.manager.transaction.History — frozen rows and the cursor', 
 
         const d = history.append({kind: 'd'});
 
-        expect(history.getRange(0, 3), 'c dropped, nothing evicted at depth 3').toEqual([rows[0], rows[1], d]);
+        expect(history.rows, 'c dropped, nothing evicted at depth 3').toEqual([rows[0], rows[1], d]);
 
         const e = history.append({kind: 'e'});
 
-        expect(history.getRange(0, 3), 'a evicted').toEqual([rows[1], d, e]);
+        expect(history.rows, 'a evicted').toEqual([rows[1], d, e]);
         expect(history.cursor).toBe(2);
         expect(history.current).toBe(e)
     });
@@ -179,7 +208,7 @@ test.describe('Neo.manager.transaction.History — frozen rows and the cursor', 
         zero.destroy()
     });
 
-    test('toJSON carries the frozen rows in order, the cursor, the bound and the sequence', () => {
+    test('toJSON carries the frozen rows in order, the count, the cursor, the bound and the sequence', () => {
         const a = history.append({id: 'first', kind: 'a'});
 
         history.append({id: 'second', kind: 'b'});
@@ -188,11 +217,24 @@ test.describe('Neo.manager.transaction.History — frozen rows and the cursor', 
         const json = JSON.parse(JSON.stringify(history));
 
         expect(json.className).toBe('Neo.manager.transaction.History');
+        expect(json.count).toBe(2);
         expect(json.cursor).toBe(0);
         expect(json.depth).toBe(3);
         expect(json.sequence).toBe(2);
         expect(json.rows.map(row => row.id)).toEqual(['first', 'second']);
         expect(json.rows[0]).toEqual(JSON.parse(JSON.stringify(a)));
         expect(json.rows[1].kind).toBe('b')
+    });
+
+    test('destroy releases the rows; the surface answers empty instead of throwing', () => {
+        history.append({kind: 'a'});
+        history.destroy();
+
+        expect(history.count).toBe(0);
+        expect(history.rows).toEqual([]);
+        expect(history.get('x')).toBeNull();
+        expect(history.has('x')).toBe(false);
+
+        history = Neo.create(History, {depth: 3})
     })
 });

--- a/test/playwright/unit/manager/transaction/History.spec.mjs
+++ b/test/playwright/unit/manager/transaction/History.spec.mjs
@@ -200,12 +200,69 @@ test.describe('Neo.manager.transaction.History — frozen rows and the cursor', 
         expect(history.current).toBe(e)
     });
 
-    test('a depth below one is refused before any row is admitted', () => {
-        const zero = Neo.create(History, {depth: 0});
+    test('the bound is a finite positive integer: refused with a throw at construction, refused and logged on assignment; a valid bound evicts exactly', () => {
+        for (const depth of [0, -1, 1.5, Infinity, NaN, '3', null]) {
+            expect(() => Neo.create(History, {depth}), `depth ${String(depth)} refused`).toThrow(RangeError)
+        }
 
-        expect(() => zero.append({kind: 'a'})).toThrow(RangeError);
-        expect(zero.count).toBe(0);
-        zero.destroy()
+        const logged   = [],
+              logError = Neo.logError;
+
+        Neo.logError = (...args) => logged.push(args.join(' '));
+
+        try {
+            for (const depth of [Infinity, NaN, 1.5, 0]) {
+                history.depth = depth;
+                expect(history.depth, `assignment of ${String(depth)} keeps the bound in force`).toBe(3)
+            }
+        } finally {
+            Neo.logError = logError
+        }
+
+        expect(logged).toHaveLength(4);
+        expect(logged[0]).toMatch(/depth must be a positive integer, got Infinity — keeping 3/);
+
+        history.depth = 4;
+        expect(history.depth, 'a valid bound is taken').toBe(4);
+
+        const two = Neo.create(History, {depth: 2});
+
+        ['a', 'b', 'c', 'd', 'e'].forEach(kind => two.append({kind}));
+
+        expect(two.count).toBe(2);
+        expect(two.rows.map(row => row.kind)).toEqual(['d', 'e']);
+        two.destroy()
+    });
+
+    test('a descriptor that reads as plain data but cannot be copied is refused with the log untouched — rows, bytes, cursor, sequence and the redo tail', () => {
+        const a = history.append({kind: 'a'}),
+              b = history.append({kind: 'b'});
+
+        history.undo();
+
+        const before = {
+            bytes   : JSON.stringify(history.rows),
+            cursor  : history.cursor,
+            sequence: history.sequence,
+            canRedo : history.canRedo,
+            ids     : history.rows.map(row => row.id)
+        };
+
+        expect(before).toMatchObject({cursor: 0, sequence: 2, canRedo: true, ids: [a.id, b.id]});
+
+        // A Proxy over a plain object passes every structural read and fails only the structured copy.
+        expect(() => history.append({kind: 'bad', nested: new Proxy({value: 1}, {})})).toThrow(TypeError);
+
+        expect({
+            bytes   : JSON.stringify(history.rows),
+            cursor  : history.cursor,
+            sequence: history.sequence,
+            canRedo : history.canRedo,
+            ids     : history.rows.map(row => row.id)
+        }).toEqual(before);
+
+        expect(history.redo(), 'the redo tail survived the refusal').toBe(b);
+        expect(history.append({kind: 'c'}).sequence, 'the next admission continues the sequence unbroken').toBe(3)
     });
 
     test('toJSON carries the frozen rows in order, the count, the cursor, the bound and the sequence', () => {

--- a/test/playwright/unit/manager/transaction/History.spec.mjs
+++ b/test/playwright/unit/manager/transaction/History.spec.mjs
@@ -1,0 +1,198 @@
+import {setup} from '../../../setup.mjs';
+
+setup({
+    appConfig: {
+        name: 'ManagerTransactionHistoryTest'
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../src/Neo.mjs';
+import * as core      from '../../../../../src/core/_export.mjs';
+import History        from '../../../../../src/manager/transaction/History.mjs';
+
+/**
+ * A Group's history is an append-only Collection of frozen plain rows with one cursor. These arms drive the
+ * class alone — no manager, no participants: what is admitted, what a retained row refuses, how the cursor
+ * moves, what eviction and the redo tail drop, and what the serialized bytes are.
+ */
+test.describe('Neo.manager.transaction.History — frozen rows and the cursor', () => {
+    let history;
+
+    test.beforeEach(() => {
+        history = Neo.create(History, {depth: 3})
+    });
+
+    test.afterEach(() => {
+        history.destroy();
+        history = null
+    });
+
+    test('append copies, stamps and freezes the descriptor to every depth; the cursor moves onto the row', () => {
+        const descriptor = {kind: 'move', payload: {items: ['a', 'b'], nested: {x: 1}}},
+              row        = history.append(descriptor);
+
+        expect(row).not.toBe(descriptor);
+        expect(row.kind).toBe('move');
+        expect(row.payload).toEqual(descriptor.payload);
+        expect(typeof row.id).toBe('string');
+        expect(row.sequence).toBe(1);
+        expect(typeof row.recordedAt).toBe('number');
+        expect(Object.isFrozen(row)).toBe(true);
+        expect(Object.isFrozen(row.payload)).toBe(true);
+        expect(Object.isFrozen(row.payload.items)).toBe(true);
+        expect(Object.isFrozen(row.payload.nested)).toBe(true);
+        expect(Object.isFrozen(descriptor), 'the writer keeps a mutable descriptor of its own').toBe(false);
+        expect(history.count).toBe(1);
+        expect(history.cursor).toBe(0);
+        expect(history.current).toBe(row);
+        expect(history.canUndo).toBe(true);
+        expect(history.canRedo).toBe(false);
+        expect(history.get(row.id), 'keyed by the id the row carried in; the collection wrote nothing onto it').toBe(row)
+    });
+
+    test('a retained row refuses nested mutation and whole-field replacement; its bytes do not move', () => {
+        const row   = history.append({kind: 'split', payload: {size: 0.5, items: ['a']}}),
+              bytes = JSON.stringify(row);
+
+        expect(() => { row.kind = 'tab' }).toThrow(TypeError);
+        expect(() => { row.payload = {} }).toThrow(TypeError);
+        expect(() => { row.payload.size = 1 }).toThrow(TypeError);
+        expect(() => { row.payload.items.push('b') }).toThrow(TypeError);
+        expect(() => { delete row.payload.size }).toThrow(TypeError);
+        expect(() => { row.extra = true }).toThrow(TypeError);
+        expect(JSON.stringify(row)).toBe(bytes);
+        expect(history.getAt(0)).toBe(row);
+        expect(history.cursor).toBe(0)
+    });
+
+    test('a descriptor that is not plain data, or an id already retained, is refused and nothing changes', () => {
+        class Live {}
+
+        const first  = history.append({id: 'row-1', kind: 'a'}),
+              cyclic = {kind: 'a'};
+
+        cyclic.self = cyclic;
+
+        for (const bad of [
+            null, undefined, 'row', 42, ['a'],
+            {kind: 'a', apply: () => {}},
+            {kind: 'a', at: new Date()},
+            {kind: 'a', live: new Live()},
+            {kind: 'a', big: 1n},
+            {kind: 'a', map: new Map()},
+            {kind: 'a', nested: {deep: {sym: Symbol('s')}}},
+            cyclic
+        ]) {
+            expect(() => history.append(bad), `refused: ${bad && typeof bad === 'object' ? Object.keys(bad).join(',') : String(bad)}`).toThrow(TypeError)
+        }
+
+        expect(() => history.append({id: 'row-1', kind: 'again'})).toThrow(/already retained/);
+        expect(history.count).toBe(1);
+        expect(history.cursor).toBe(0);
+        expect(history.sequence, 'a refused row consumes no sequence').toBe(1);
+        expect(history.current).toBe(first)
+    });
+
+    test('a shared reference is plain data — it serializes twice, as JSON does', () => {
+        const shared = {size: 0.5},
+              row    = history.append({kind: 'a', left: shared, right: shared});
+
+        expect(row.left).toEqual({size: 0.5});
+        expect(row.right).toEqual({size: 0.5});
+        expect(JSON.parse(JSON.stringify(row)).right.size).toBe(0.5)
+    });
+
+    test('append after undo drops the redo tail, and only the tail', () => {
+        const a = history.append({kind: 'a'}),
+              b = history.append({kind: 'b'}),
+              c = history.append({kind: 'c'});
+
+        expect(history.undo()).toBe(c);
+        expect(history.undo()).toBe(b);
+        expect(history.cursor).toBe(0);
+        expect(history.canRedo).toBe(true);
+
+        const d = history.append({kind: 'd'});
+
+        expect(history.getRange(0, history.count)).toEqual([a, d]);
+        expect(history.cursor).toBe(1);
+        expect(history.canRedo).toBe(false);
+        expect(history.redo(), 'the dropped tail cannot come back').toBeNull();
+        expect(d.sequence, 'sequence counts admissions, not retained rows').toBe(4)
+    });
+
+    test('undo and redo walk the cursor deterministically and return the row to apply', () => {
+        const rows = ['a', 'b', 'c'].map(kind => history.append({kind}));
+
+        expect(history.redo(), 'nothing ahead of the newest row').toBeNull();
+        expect(history.undo()).toBe(rows[2]);
+        expect(history.undo()).toBe(rows[1]);
+        expect(history.undo()).toBe(rows[0]);
+        expect(history.cursor).toBe(-1);
+        expect(history.current).toBeNull();
+        expect(history.canUndo).toBe(false);
+        expect(history.undo(), 'nothing behind the first row').toBeNull();
+        expect(history.redo()).toBe(rows[0]);
+        expect(history.redo()).toBe(rows[1]);
+        expect(history.cursor).toBe(1);
+        expect(history.current).toBe(rows[1]);
+        expect(history.count, 'undo and redo retain every row').toBe(3)
+    });
+
+    test('past the depth the oldest row is evicted and the cursor follows; a sequence is never reused', () => {
+        const rows = ['a', 'b', 'c', 'd', 'e'].map(kind => history.append({kind}));
+
+        expect(history.count).toBe(3);
+        expect(history.getRange(0, 3)).toEqual(rows.slice(2));
+        expect(history.cursor).toBe(2);
+        expect(history.current).toBe(rows[4]);
+        expect(rows.map(row => row.sequence)).toEqual([1, 2, 3, 4, 5]);
+        expect(history.undo()).toBe(rows[4]);
+        expect(history.undo()).toBe(rows[3]);
+        expect(history.undo()).toBe(rows[2]);
+        expect(history.undo(), 'an evicted row is not undoable').toBeNull();
+        expect(history.get(rows[0].id), 'evicted rows leave the collection').toBeNull()
+    });
+
+    test('an append behind the newest row drops the tail first, then evicts from the front; the cursor stays on its row', () => {
+        const rows = ['a', 'b', 'c'].map(kind => history.append({kind}));
+
+        history.undo();
+
+        const d = history.append({kind: 'd'});
+
+        expect(history.getRange(0, 3), 'c dropped, nothing evicted at depth 3').toEqual([rows[0], rows[1], d]);
+
+        const e = history.append({kind: 'e'});
+
+        expect(history.getRange(0, 3), 'a evicted').toEqual([rows[1], d, e]);
+        expect(history.cursor).toBe(2);
+        expect(history.current).toBe(e)
+    });
+
+    test('a depth below one is refused before any row is admitted', () => {
+        const zero = Neo.create(History, {depth: 0});
+
+        expect(() => zero.append({kind: 'a'})).toThrow(RangeError);
+        expect(zero.count).toBe(0);
+        zero.destroy()
+    });
+
+    test('toJSON carries the frozen rows in order, the cursor, the bound and the sequence', () => {
+        const a = history.append({id: 'first', kind: 'a'});
+
+        history.append({id: 'second', kind: 'b'});
+        history.undo();
+
+        const json = JSON.parse(JSON.stringify(history));
+
+        expect(json.className).toBe('Neo.manager.transaction.History');
+        expect(json.cursor).toBe(0);
+        expect(json.depth).toBe(3);
+        expect(json.sequence).toBe(2);
+        expect(json.rows.map(row => row.id)).toEqual(['first', 'second']);
+        expect(json.rows[0]).toEqual(JSON.parse(JSON.stringify(a)));
+        expect(json.rows[1].kind).toBe('b')
+    })
+});


### PR DESCRIPTION
Resolves #18310

Related: #18303 · #18307 · #18312 · #18314 · PR #18351

A Group on `Neo.manager.Transaction` now keeps a bounded, append-only transaction history and one cursor. `src/manager/transaction/History.mjs` is a `core.Base` that owns a private `collection.Base`: a plain-data descriptor is copied, stamped (`id`, `sequence`, `recordedAt`) and deep-frozen before it becomes a row, so a retained row rejects nested mutation and whole-field replacement and serializes to the bytes it was admitted with; the only writes that reach a row are `append`, `undo` and `redo` — the inherited mutators of a Collection never do. An append after undo drops the redo tail; past `depth` the oldest row is evicted and the cursor follows; `peek` shows the row a move would return without moving. The manager owns the write side: `historyDepth` is the default a Group is born with (`0`) and `setHistoryDepth({groupId, depth})` makes depth the Group's own choice before its first write, so two roots of one app in one worker never take each other's policy; one serialized writer per Group; `write({groupId, descriptor, adopt})` is the admission barrier — the history module is imported once, before any participant mutation, and only for a Group whose depth is above zero, with `adopt` as the participant-mutation slot the atomic-commit leaf fills (its body is declared provisional and that leaf's: one step, one owner, compensation included); `undo` / `redo` take `apply(row)`, run it inside the queued step and move the cursor only once it resolved; a lazily created Group `state.Provider` publishes `canUndo` / `canRedo` / `historyCursor` / `historyDepth` / `historyLength` to every window bound into the Group — the explicit-parent seam #18307 binds header state to. `retireGroup` releases provider and history; a Group holding rows survives its last lease. `buildScripts/util/static-closure.mjs` is the reproducible module-count + byte walker behind the closure receipts below.

Evidence: L2 (unit arms in the single-thread simulation — History semantics, the admission barrier and queue, apply-before-move, Group-local depth in both admission orders, the Group provider across two bound slots with a host provider chained to it, a mechanical guard that the manager references the history module only through `import()` — plus static-closure receipts from a committed tool at dev and at this head) → L2 required (#18303's closeout row for this leaf: "L2 plus both module-count and byte-closure receipts"). Residual: none.

## AC Evidence
| AC | Proof |
|---|---|
| **AC-1** | `unit/manager/transaction/History.spec.mjs` — "a retained row refuses nested mutation and whole-field replacement; its bytes do not move": six mutation controls throw `TypeError` in strict mode; `Object.isFrozen` true to every depth; "the reachable surface is read-only": `rows` is a fresh array and `remove`/`insert`/`splice`/`sort`/… are not on the authority; "a descriptor that reads as plain data but cannot be copied is refused with the log untouched": a Proxy passes `assertRow`, fails the structured copy, and rows, bytes, cursor, sequence and the redo tail are unchanged (admission is transactional — every fallible step runs before the log moves) |
| **AC-2** | `History.spec.mjs` — "append after undo drops the redo tail, and only the tail"; "past the depth the oldest row is evicted and the cursor follows; a sequence is never reused"; "undo and redo walk the cursor deterministically…"; "the bound is a finite positive integer": `Infinity`, `NaN`, fractions, zero and non-numbers are refused with a throw at construction and refused-and-logged on assignment (the bound in force stays), depth 2 evicts exactly. `unit/manager/TransactionWrite.spec.mjs` — "depth is a Group's own choice: two roots in one worker keep their own policy, whichever was admitted first" (A depth 0 / B depth 50 in both admission orders; refusals; fixed at the first write); "the worker-wide default … refuse anything but a non-negative integer": six invalid defaults refused and logged, a Group born under a refused default carries the bound in force |
| **AC-3** | `History.spec.mjs` — the AC-1 arm: `JSON.stringify(row)` before the six rejected controls equals `JSON.stringify(row)` after |
| **AC-4** | `TransactionWrite.spec.mjs` — "a Group at depth zero admits writes without the history module": the observed `importHistory` count stays 0, `group.history` null; "the manager never imports the history module statically" reads the source. Closure receipts (outside CI, below): the single-window consumer and the dock Workspace are byte-identical at dev and at this head; History appears only as a dynamic target |
| **AC-5** | `TransactionWrite.spec.mjs` — "the first write of a Group that keeps history awaits one import before adopt; later writes queue behind it, each descriptor once": log `['import:start', 'import:done', 'adopt:a', 'adopt:b', 'adopt:c']`, one import across four writes, each `adopt` called once with its own descriptor; "a Group retired while its history module is still loading gets no History": the import is held pending, the Group retired, the import resolved — the write rejects, nothing is adopted, no History is registered for the dead Group (`Neo.manager.Instance` count unchanged), and the live control creates and then releases exactly one |
| **AC-6** | `TransactionWrite.spec.mjs` — "one provider per Group whatever window asks": the opener's slot and a reserved popup slot bound as a second window resolve the same `state.Provider` instance; a host provider chained as explicit parent reads `canUndo` before and after a write; `getData` reads, no sweep. "undo and redo apply first and move the cursor after; the provider follows" and "a rejected application moves nothing: cursor and provider stay" |
| **AC-7** | No `TransactionStore` view ships in this leaf — the authority is the History; a read-only clone-fed Store is a consumer of #18314's Neural Link inspection and would be a projection fed from `rows`, never a second authority. Holds vacuously; stated so a reviewer does not look for it |

## Deltas from ticket
- **Depth is Group-local** (`setHistoryDepth`), the worker-wide `historyDepth` only the default a Group is born with — the epic owner's boundary: a mutable singleton setting copied at creation would let root admission order pick another root's policy. Control in both orders.
- **A cursor moves only after its row was applied**: `undo` / `redo` require `apply(row)` and run it inside the queued step; a rejected application leaves cursor and provider; a move without `apply` is refused — nothing ever reads a moved cursor as a completed undo before the application held (the same boundary).
- **`write`'s body is provisional and #18312's**: the participant protocol lands there as one step under one owner, compensation across a failed append included; nothing outside depends on its parts being separate — the queue, the barrier and the History are the primitives.
- **History owns its Collection instead of extending it** (Vega's input): the authority's surface is `append`/`undo`/`redo`/`peek` plus reads; D#18224's H2 sentence said "extends", the ledger pins the frozen rows.
- `assertRow` runs **before** `adopt`: a descriptor the history would refuse (non-plain data, a cycle, a retained id) costs no participant mutation.
- **Admission is transactional with respect to the log** (Emmy's round 1): the structured copy — the one refusal only the clone can make, a Proxy being the case — runs before the redo tail is dropped, the sequence advances or the cursor moves; a refused descriptor leaves the history byte-identical.
- **The bound is a finite positive integer** (round 1): `History` refuses `Infinity`, `NaN`, fractions and zero with a throw at construction and, on assignment, with the house idiom for a refused config value — logged, the bound in force stays — because a throwing `beforeSet` leaves the refused value staged in Neo's config store. The manager's worker-wide default takes the same shape (non-negative integer; zero stays the disabled mode), so no Group can be born with an unbounded log; `setHistoryDepth` keeps its `false`.
- **The pending import is fenced by the Group's lifetime** (round 1): a Group retired while `transaction/History.mjs` was still loading gets no History — the load completes into a `null`, the write rejects at its liveness check, and no orphan is registered.
- The row is a `structuredClone` of the descriptor, frozen after the copy: the writer keeps its own object mutable. Cycles are refused (JSON-first), shared references admitted.
- A task reaching a Group's queue head after `retireGroup` rejects (`assertLive`) instead of touching a destroyed history.
- Lease-expiry retirement also requires "no retained history row" and goes through `retireGroup`, so provider and history are released on that path too.
- The `state.Provider` import is static in the manager, by measurement: the manager itself is loaded only by static importers that already carry the Provider (Workstation, DemoB) or by `Workspace#loadTransactionManager` under the tear-out lifecycle opt-in — multi-window intent either way — and #18307 needs the Group provider at depth 0. The manager's own closure grows by the Provider and three deps (declared below); no single-window consumer's does.
- No `TransactionStore` view (AC-7 above).

## Test Evidence
Static-closure receipts, `node buildScripts/util/static-closure.mjs <entry>` at dev `ef9670621c` (the #18351 merge) and at this head (the tool follows static relative imports; a dynamic `import()` is a reported boundary, never followed):

| Entry | dev `ef9670621c` | this head |
|---|---|---|
| `examples/dashboard/dock/app.mjs` (single-window consumer) | 89 modules / 1,675,009 bytes | 89 modules / 1,675,009 bytes — byte-identical |
| `src/dashboard/dock/Workspace.mjs` | 72 modules / 1,431,278 bytes | 72 modules / 1,431,278 bytes — byte-identical |
| `src/manager/Transaction.mjs` | 16 modules / 200,599 bytes | 20 modules / 262,814 bytes — the delta is `state/Provider.mjs` + `createHierarchicalDataProxy`, `util/ClassSystem`, `core/Effect`; `transaction/History.mjs` appears only under `dynamicTargets` |
| `src/manager/transaction/History.mjs` (what the first write of a depth > 0 Group loads) | — | 15 modules / 185,838 bytes, all but itself already in the manager's closure |

Code lines (the size guard's Acorn measure, at c50829389b): `Transaction.mjs` 261 → 365 code / 237 → 358 doc; `History.mjs` 143 code / 133 doc. Round 1 adds the two bound validators, the construct-time refusal and the copy step; both files stay under the guard's target — CI's size guard is the receipt at this head; no baseline row.

Component control at c50829389b: `test/playwright/component/dashboard/DockPopOut.spec.mjs` (the manager's tear-out consumer) 18/18 with `--repeat-each 3`. Full unit suite 3294/3294 at the pre-rebase branch head; the three manager specs 43/43 at this head (13 History arms, 16 write-side arms, Vega's `Transaction.spec.mjs` untouched).

## Post-Merge Validation
Nothing is verifiable only after merge; the closure receipts reproduce from the branch with the committed tool.

## Commits
- b7db56fc5f — History (frozen rows, cursor, eviction), the manager's admission barrier and per-Group queue, the Group provider, the closure walker, specs, inventory row
- c50829389b — Group-local `setHistoryDepth`, apply-before-move on undo/redo, `write` body declared provisional, History owns its Collection, class hierarchy regenerated
- 7a11ffcf31 — Round 1: transactional append (copy before the log moves), finite-positive-integer bounds on History and the manager default, the pending import fenced by Group retirement

Authored by Mnemosyne (Claude Fable 5.1, Claude Code). Session 41b7f6cd-28c9-41a6-80f2-81f9ff9d6b67.
