### PR TITLE
feat(test): the unit job's CI log names every passing test (#18361)

### DIFF
--- a/test/playwright/playwright.config.unit.mjs
+++ b/test/playwright/playwright.config.unit.mjs
@@ -9,6 +9,11 @@ process.env.UNIT_TEST_MODE = 'true';
 
 /**
  * @summary Builds the Engine unit-run policy for local and CI execution.
+ * @description In CI three reporters compose, each for a different reader: `github` writes the inline
+ * annotations a reviewer reads on a red run, `list` writes one line per test — the `✓` pass marks the
+ * defect ledger's producer reads from a green run's log to observe a unit test recover, which a dot
+ * progress line cannot name — and `json` writes the report the failure-only artifact carries. Locally
+ * the report alone is kept; the runner's own terminal output is the developer's reader.
  * @param {Object} options
  * @param {Boolean} options.isCI
  * @returns {Object}
@@ -16,7 +21,7 @@ process.env.UNIT_TEST_MODE = 'true';
 export function buildUnitRunPolicy({isCI}) {
     const reporter = [['json', {outputFile: path.join(__dirname, 'test-results/unit/test-results.json')}]];
 
-    isCI && reporter.unshift(['github']);
+    isCI && reporter.unshift(['github'], ['list']);
 
     return {
         failOnFlakyTests: isCI,

--- a/test/playwright/unit/test/unitRunPolicy.spec.mjs
+++ b/test/playwright/unit/test/unitRunPolicy.spec.mjs
@@ -1,0 +1,26 @@
+import {test, expect}       from '@playwright/test';
+import {buildUnitRunPolicy} from '../../playwright.config.unit.mjs';
+
+/**
+ * The unit run policy is read by three readers in CI — a reviewer (the `github` annotations), the defect
+ * ledger's producer (the `list` reporter's one line per test, whose `✓` marks are the only per-test pass
+ * evidence a green run leaves in its log) and the failure artifact (the `json` report) — and by one
+ * locally. These arms pin the reporter list in both modes, so a reporter cannot quietly drop out and
+ * take a reader with it.
+ */
+test.describe('unit run policy — the reporters each reader depends on', () => {
+    test('in CI the github annotations, the per-test list and the json report compose, in that order', () => {
+        const {reporter, failOnFlakyTests, forbidOnly, retries, workers} = buildUnitRunPolicy({isCI: true});
+
+        expect(reporter.map(entry => entry[0])).toEqual(['github', 'list', 'json']);
+        expect(reporter[2][1].outputFile.endsWith('test-results/unit/test-results.json')).toBe(true);
+        expect({failOnFlakyTests, forbidOnly, retries, workers}).toEqual({failOnFlakyTests: true, forbidOnly: true, retries: 2, workers: 4});
+    });
+
+    test('locally only the json report is configured; the runner\'s terminal output stays the developer\'s', () => {
+        const {reporter, failOnFlakyTests, forbidOnly, retries, workers} = buildUnitRunPolicy({isCI: false});
+
+        expect(reporter.map(entry => entry[0])).toEqual(['json']);
+        expect({failOnFlakyTests, forbidOnly, retries, workers}).toEqual({failOnFlakyTests: false, forbidOnly: false, retries: 0, workers: undefined});
+    });
+});


### PR DESCRIPTION
Resolves #18361

Related: neomjs/neo-agent-brain#321 · neomjs/neo-agent-brain PR #327

The unit job's CI reporter list gains the `list` reporter beside `github`: one line per test, so a green unit run's log names every passing test as `✓ N [unit-engine] › <spec>:<line>:<col> › <titles> (<duration>)` — the pass mark the defect ledger's producer reads to observe a unit test recover, which the `github` reporter's dot progress line cannot name. The `github` annotations and the `json` report stay; locally the policy is unchanged (the report alone, the runner's own terminal output the developer's). A spec under `test/playwright/unit/test/` pins both modes, beside the other specs over the harness's own modules.

Evidence: L2 (the pinning spec; the composed reporters exercised with `CI=true` on the spec itself; the Brain consumer's pass parser fed those exact lines) → L2 required (AC-1, AC-3). AC-2's dev-shaped receipt is this PR's own `unit` job log at this head, cited below once CI ran. AC-4 is post-merge by the ticket's own definition and is listed under Post-Merge Validation; no other residuals.

## AC Evidence

| AC | Proof |
|---|---|
| **AC-1** | `test/playwright/unit/test/unitRunPolicy.spec.mjs` — CI: `['github', 'list', 'json']` in that order, `retries 2`, `workers 4`, `failOnFlakyTests` and `forbidOnly` on; local: `['json']`, the flags off |
| **AC-2** | Locally `CI=true npm run test-unit -- test/playwright/unit/test/unitRunPolicy.spec.mjs` prints the `✓ N [unit-engine] › …` lines (Test Evidence); the dev-shaped receipt is this PR's own `unit` job log at this head (the `unit` check of this PR: ~3,300 `✓` lines where dev's log has dots; linked in a comment once the run is green) |
| **AC-3** | The same CI-mode run prints the `github` reporter's `::notice title=🎭 Playwright Run Summary::` line and writes `test-results/unit/test-results.json` (4,904 bytes for the two arms); `.github/workflows/test.yml` is untouched, so the failure-only artifact upload stays |
| **AC-4** | Post-merge, owned by the Brain producer's tick — the first unit-suite `[recovered]` note names its green run; reported on #18361 when it lands |

## Deltas from ticket

None substantive. The function's JSDoc names the three readers so the next edit knows what each reporter is for.

## Test Evidence

```
CI=true npm run test-unit -- test/playwright/unit/test/unitRunPolicy.spec.mjs
  ✓  1 [unit-engine] › test/playwright/unit/test/unitRunPolicy.spec.mjs:20:5 › unit run policy — the reporters each reader depends on › locally only the json report is configured; the runner's terminal output stays the developer's (2ms)
  ✓  2 [unit-engine] › test/playwright/unit/test/unitRunPolicy.spec.mjs:12:5 › unit run policy — the reporters each reader depends on › in CI the github annotations, the per-test list and the json report compose, in that order (2ms)
  ::notice title=🎭 Playwright Run Summary::  2 passed (234ms)
  test-results/unit/test-results.json written (4,904 bytes)

# the consumer (neomjs/neo-agent-brain PR #327, parsePlaywrightPasses) over those two lines:
passes: 2
 - test/playwright/unit/test/unitRunPolicy.spec.mjs › unit run policy — the reporters each reader depends on › locally only the json report is configured; the runner's terminal output stays the developer's
 - test/playwright/unit/test/unitRunPolicy.spec.mjs › unit run policy — the reporters each reader depends on › in CI the github annotations, the per-test list and the json report compose, in that order
```

## Post-Merge Validation

AC-4: the Brain producer's next ticks recover unit-suite records from green unit runs; the first `[recovered]` note is reported on #18361.

Authored by Mnemosyne (Claude Fable 5.1, Claude Code). Session 41b7f6cd-28c9-41a6-80f2-81f9ff9d6b67.
