### PR TITLE
fix(test): await Monaco registry initialization (#18365)

### DIFF
--- a/test/playwright/component/wrapper/MonacoEditor.spec.mjs
+++ b/test/playwright/component/wrapper/MonacoEditor.spec.mjs
@@ -30,7 +30,7 @@ const readConfigs = async (page, id, keys) => {
 const expectEditor = async page => {
     await expect.poll(() => page.evaluate(id => {
         const addon  = globalThis.Neo?.main?.addon?.MonacoEditor,
-              editor = addon?.map[id];
+              editor = addon?.map?.[id];
 
         return !!(addon?.isReady && editor?.getModel())
     }, EDITOR_ID), {message: 'the real Monaco AMD module and native editor become ready', timeout: 20000}).toBe(true);


### PR DESCRIPTION
Resolves #18365

Related: #5822 · #18354 · #18360

The readiness poll can observe the Monaco addon namespace before its instance creates the editor registry. Guarding the registry lookup makes that state return false so polling continues. A ready editor still succeeds, and genuine editor-method exceptions still propagate.

Evidence: L3 (the existing real Neo wrapper browser cases plus isolated callback-state controls) → L3 required (AC-3). Residual: none.

Micro-review eligible: contained — one optional-chain correction in the existing test predicate.

## AC Evidence

| AC | Evidence |
|---|---|
| AC-1 | Outside CI: evaluated the exact callback with absent addon, namespace-before-registry, empty registry and ready editor; results below. |
| AC-2 | Outside CI: a ready editor whose getModel throws still propagates the original Error. |
| AC-3 | CI-covered: the six existing cases in test/playwright/component/wrapper/MonacoEditor.spec.mjs; locally passed using playwright.config.component.mjs. |

## Deltas from ticket

None substantive.

## Test Evidence

The exact page.evaluate callback was read from the spec and executed with controlled addon states:

| State | Before | After |
|---|---|---|
| Addon absent | false | false |
| Namespace exists, registry absent | TypeError | false |
| Empty registry | false | false |
| Ready editor with model | true | true |
| Existing getModel throws | original Error | original Error |

The before failure matches the exception in [the reported component job](https://github.com/neomjs/neo/actions/runs/33973844177/job/101328008490).

## Post-Merge Validation

None required; the callback states and browser behavior are directly verifiable before merge.

Authored by Euclid (GPT-6 Astra, Codex Desktop). Session cb7ccc74-b375-4785-9adf-df6d1112957b.
