### PR TITLE
Toolbar actions resolve by name through getAction(), and a repeated name is refused where the actions materialise

### DIFF
--- a/src/code/LivePreview.mjs
+++ b/src/code/LivePreview.mjs
@@ -392,7 +392,7 @@ class LivePreview extends Container {
             me.getReference('preview').removeAll()
         }
 
-        let popoutButton = me.tabContainer.getActionItem('popout');
+        let popoutButton = me.tabContainer.getAction('popout');
 
         popoutButton && (popoutButton.hidden = !isPreview);
         me.disableRunSource = false;
@@ -520,7 +520,7 @@ class LivePreview extends Container {
             me.disableRunSource = true; // will get reset after the next activeIndex change (async)
             tabContainer.activeIndex = 1;        // switch to the source view
 
-            tabContainer.getActionItem('popout').disabled = false;
+            tabContainer.getAction('popout').disabled = false;
             tabContainer.getTabAtIndex(1).disabled = false;
 
             me.connectedWindowId = null

--- a/src/dashboard/dock/interaction/RevealOverlay.mjs
+++ b/src/dashboard/dock/interaction/RevealOverlay.mjs
@@ -496,7 +496,7 @@ class RevealOverlay extends Container {
      * @returns {Neo.button.Base}
      */
     get pinButton() {
-        return this.items[0].getActionItem('pin')
+        return this.items[0].getAction('pin')
     }
 
     /**

--- a/src/dashboard/dock/plugin/Maximize.mjs
+++ b/src/dashboard/dock/plugin/Maximize.mjs
@@ -754,7 +754,7 @@ class Maximize extends Plugin {
      * @param {Boolean} maximized
      */
     syncActionPresentation(tabContainer, maximized) {
-        tabContainer?.getActionItem?.('maximize')?.set({pressed: maximized})
+        tabContainer?.getAction?.('maximize')?.set({pressed: maximized})
     }
 
     /**
@@ -963,7 +963,7 @@ class Maximize extends Plugin {
 
             // Header actions ride retained instances, so a refresh would keep projecting a toggle
             // with no owner: hide it on every live node the way the reconciler varies an action.
-            shell && Reconciler.collectProjectedTabs(shell).forEach(tab => tab.getActionItem?.('maximize')?.set({hidden: true}));
+            shell && Reconciler.collectProjectedTabs(shell).forEach(tab => tab.getAction?.('maximize')?.set({hidden: true}));
 
             owner.un({
                 beforeDockZoneDocumentChange: me.onBeforeDockZoneDocumentChange,

--- a/src/dashboard/dock/projection/LayoutAdapter.mjs
+++ b/src/dashboard/dock/projection/LayoutAdapter.mjs
@@ -1103,7 +1103,6 @@ class LayoutAdapter extends Base {
         // cost by keeping one instance and binding `hidden` to the header truth the workspace
         // publishes; a host needing per-item behaviour has the same mechanism, on actions it owns.
         const hostActions = context.resolveDockHeaderActions?.(nodeId) || [],
-              seen        = new Set(),
               // Every action name is reserved exactly while its projection flag is on. A Map (not
               // an object literal) because
               // the key is host-supplied — `constructor` and `__proto__` must miss, exactly as they do
@@ -1120,17 +1119,14 @@ class LayoutAdapter extends Base {
         for (const action of hostActions) {
             const name = action?.action;
 
-            // Semantic names address actions: `getActionItem(name)` returns the FIRST match, and
-            // intents are routed by name. A duplicate makes one of them unaddressable; a host `close`
-            // while the engine's is enabled would additionally capture the engine's own policy sync
-            // and its intent. Both are host programming errors, and both are silent — so they throw
-            // here, as malformed action configs already do in `toolbar.Base#createActionItemConfig`.
+            // Intents are routed by name, so a host header action must carry one, and the engine's own
+            // names are reserved while their flag is on — a host `close` beside the enabled engine close
+            // would capture the engine's policy sync and its intent. Both are host programming errors,
+            // and both would be silent, so they throw here. That a name is unique within the header is
+            // the toolbar's own invariant (`toolbar.Base#getAction`), enforced when the projected header
+            // materialises its actions.
             if (!name) {
                 throw new Error('Neo.dashboard.dock.projection.LayoutAdapter: a host header action requires a semantic `action` name')
-            }
-
-            if (seen.has(name)) {
-                throw new Error(`Neo.dashboard.dock.projection.LayoutAdapter: duplicate host header action "${name}" on dock node "${nodeId}"`)
             }
 
             const reservedBy = reservedActionNames.get(name);
@@ -1138,8 +1134,6 @@ class LayoutAdapter extends Base {
             if (reservedBy) {
                 throw new Error(`Neo.dashboard.dock.projection.LayoutAdapter: host header action "${name}" is reserved by ${reservedBy} (dock node "${nodeId}")`)
             }
-
-            seen.add(name)
         }
 
         // The engine actions bind their runtime state: the workspace's header-action policy hands one

--- a/src/tab/Container.mjs
+++ b/src/tab/Container.mjs
@@ -397,12 +397,12 @@ class Container extends BaseContainer {
     }
 
     /**
-     * Returns a stable header action instance by semantic action name.
-     * @param {String} action
+     * Returns the header action addressed by its `action` name — the tab bar's `toolbar.Base#getAction`.
+     * @param {String} name
      * @returns {Neo.component.Base|null}
      */
-    getActionItem(action) {
-        return this.getTabBar()?.getActionItem(action) || null
+    getAction(name) {
+        return this.getTabBar()?.getAction(name) || null
     }
 
     /**

--- a/src/toolbar/Base.mjs
+++ b/src/toolbar/Base.mjs
@@ -32,7 +32,9 @@ class Toolbar extends Container {
          */
         actionDefaults: null,
         /**
-         * Optional flat action configs appended after one toolbar-owned flex spacer.
+         * Optional flat action configs appended after one toolbar-owned flex spacer. An action's `action`
+         * name is its address ({@link #getAction}) and is unique within the toolbar: a name repeated here,
+         * or already held by a contributed action, throws when the actions materialise.
          * @member {Object[]|String[]|null} actions=null
          * @reactive
          */
@@ -490,7 +492,33 @@ class Toolbar extends Container {
             return []
         }
 
-        return [this.createActionSpacerConfig(), ...actions.map(action => this.createActionItemConfig(action))]
+        let configs = actions.map(action => this.createActionItemConfig(action));
+
+        this.assertUniqueActionNames(configs);
+
+        return [this.createActionSpacerConfig(), ...configs]
+    }
+
+    /**
+     * Refuses a repeated action name before anything is inserted. A name addresses exactly one action
+     * ({@link #getAction}); two actions sharing it would leave one unaddressable and route every intent by
+     * that name to the other. Unnamed actions cannot be addressed, so they cannot collide.
+     * @param {Object[]} configs The action configs about to be inserted.
+     * @param {Neo.component.Base[]} [existing=[]] Action instances that stay in place beside them.
+     * @protected
+     */
+    assertUniqueActionNames(configs, existing=[]) {
+        let names = new Set(existing.map(item => item.action).filter(Boolean));
+
+        configs.forEach(({action}) => {
+            if (action) {
+                if (names.has(action)) {
+                    throw new Error(this.className + ': duplicate toolbar action "' + action + '"')
+                }
+
+                names.add(action)
+            }
+        })
     }
 
     /**
@@ -537,6 +565,8 @@ class Toolbar extends Container {
             spacer        = me.getActionSpacer(),
             contribution;
 
+        me.assertUniqueActionNames([config], actionItems);
+
         if (!spacer) {
             spacer = me.insert(firstAction ? me.items.indexOf(firstAction) : me.items.length,
                 me.createActionSpacerConfig(), true)
@@ -570,12 +600,18 @@ class Toolbar extends Container {
     }
 
     /**
-     * Returns a stable action instance by semantic action name.
-     * @param {String} action
+     * Returns the action instance addressed by its `action` name — the toolbar's counterpart of
+     * `getPlugin`, `getController` and `getReference`. Names are unique within a toolbar
+     * ({@link #assertUniqueActionNames}); an unnamed action is not addressable, so no name resolves nothing.
+     * @param {String} name
      * @returns {Neo.component.Base|null}
      */
-    getActionItem(action) {
-        return this.getActionItems().find(item => item.action === action) || null
+    getAction(name) {
+        if (typeof name !== 'string' || name === '') {
+            return null
+        }
+
+        return this.getActionItems().find(item => item.action === name) || null
     }
 
     /**
@@ -631,6 +667,10 @@ class Toolbar extends Container {
                     ? actions.map(action => me.createActionItemConfig(action))
                     : []
                 : me.createActionItemConfigs(actions);
+
+        // The consumer actions are rebuilt whole, so they are checked among themselves inside
+        // createActionItemConfigs; against the contributions that stay, they are checked here.
+        contributions.length > 0 && me.assertUniqueActionNames(configs, contributions);
 
         owned
             .map(item => me.items.indexOf(item))

--- a/src/toolbar/Base.mjs
+++ b/src/toolbar/Base.mjs
@@ -553,28 +553,29 @@ class Toolbar extends Container {
     /**
      * Adds one toolbar-owned action contribution ahead of consumer actions. Contributions are not
      * written into {@link #actions}; the consumer remains the sole owner of that config, while the
-     * toolbar preserves the contributed instance across every consumer action rebuild.
+     * toolbar preserves the contributed instance across every consumer action rebuild. A name the
+     * contribution would carry — its own or one from {@link #actionDefaults} — must be unique among the
+     * live actions ({@link #assertUniqueActionNames}); a refused contribution inserts nothing.
      * @param {Object} config Action config.
      * @returns {Neo.component.Base} The stable contributed action instance.
      */
     addActionContribution(config) {
-        let me            = this,
-            actionItems   = me.getActionItems(),
-            firstAction   = actionItems[0],
-            firstConsumer = actionItems.find(item => item.isToolbarActionContribution !== true),
-            spacer        = me.getActionSpacer(),
-            contribution;
+        let me          = this,
+            actionItems = me.getActionItems(),
+            firstAction = actionItems[0],
+            // Resolved before it is checked: the name that must be unique is the one that will
+            // materialise, which `actionDefaults` may supply, and the checked config is the inserted one.
+            contribution = me.createActionItemConfig({...config, isToolbarActionContribution: true}),
+            firstConsumer;
 
-        me.assertUniqueActionNames([config], actionItems);
+        me.assertUniqueActionNames([contribution], actionItems);
 
-        if (!spacer) {
-            spacer = me.insert(firstAction ? me.items.indexOf(firstAction) : me.items.length,
-                me.createActionSpacerConfig(), true)
+        if (!me.getActionSpacer()) {
+            me.insert(firstAction ? me.items.indexOf(firstAction) : me.items.length, me.createActionSpacerConfig(), true)
         }
 
         firstConsumer = me.getActionItems().find(item => item.isToolbarActionContribution !== true);
-        contribution  = me.insert(firstConsumer ? me.items.indexOf(firstConsumer) : me.items.length,
-            me.createActionItemConfig({...config, isToolbarActionContribution: true}));
+        contribution  = me.insert(firstConsumer ? me.items.indexOf(firstConsumer) : me.items.length, contribution);
 
         me.bindActionItems([contribution]);
         me.applyContextualActionState(true);

--- a/test/playwright/e2e/dashboard/DockOperationsNL.spec.mjs
+++ b/test/playwright/e2e/dashboard/DockOperationsNL.spec.mjs
@@ -211,7 +211,7 @@ test.describe('Dock semantic operations (Neural Link, structural)', () => {
 
         expect(mainId, 'the main projected TabContainer must retain its semantic node id').toBeTruthy();
 
-        await expect.poll(async () => (await app.callMethod(mainId, 'getActionItem', ['close']))?.id, {
+        await expect.poll(async () => (await app.callMethod(mainId, 'getAction', ['close']))?.id, {
             message: 'the opt-in projection materialises one persistent close action',
             timeout: 10000
         }).toBeTruthy();
@@ -242,7 +242,7 @@ test.describe('Dock semantic operations (Neural Link, structural)', () => {
             timeout: 10000
         }).toBe(0);
 
-        const actionBefore = await app.callMethod(mainId, 'getActionItem', ['close']),
+        const actionBefore = await app.callMethod(mainId, 'getAction', ['close']),
               closeButton  = page.locator(`#${actionBefore.id}`),
               successorId  = moved.document.nodes['main-tabs'].items[1];
 
@@ -255,7 +255,7 @@ test.describe('Dock semantic operations (Neural Link, structural)', () => {
         }).toBeUndefined();
 
         const after       = await readTopology(app, holderId),
-              actionAfter = await app.callMethod(mainId, 'getActionItem', ['close']),
+              actionAfter = await app.callMethod(mainId, 'getAction', ['close']),
               successor   = await app.findInstances(
                   {className: 'Neo.tab.header.Button', dockItemId: successorId},
                   ['id', 'dockItemId']
@@ -278,7 +278,7 @@ test.describe('Dock semantic operations (Neural Link, structural)', () => {
         const terminalRecords = await app.queryComponent({dockNodeId: 'terminal-tabs'}, ['id', 'ntype']),
               terminalRecord  = Array.isArray(terminalRecords) ? terminalRecords[0] : terminalRecords,
               terminalId      = terminalRecord?.id ?? terminalRecord?.properties?.id,
-              terminalAction  = await app.callMethod(terminalId, 'getActionItem', ['close']);
+              terminalAction  = await app.callMethod(terminalId, 'getAction', ['close']);
 
         expect(terminalId, 'the single-item terminal stack must remain projected').toBeTruthy();
         await page.locator(`#${terminalAction.id}`).click();

--- a/test/playwright/e2e/dashboard/DockPinCollapseNL.spec.mjs
+++ b/test/playwright/e2e/dashboard/DockPinCollapseNL.spec.mjs
@@ -162,7 +162,7 @@ test.describe('Dock pin/collapse round-trip (Neural Link)', () => {
         expect(mainTabsId,      'the center stack projects a live TabContainer').toBeTruthy();
 
         // Product truth #1: the opt-in projects a real action instance on the edge-owned pane.
-        await expect.poll(async () => (await app.callMethod(inspectorTabsId, 'getActionItem', ['pin']))?.id, {
+        await expect.poll(async () => (await app.callMethod(inspectorTabsId, 'getAction', ['pin']))?.id, {
             message: 'the opt-in projection materialises one persistent pin action',
             timeout: 10000
         }).toBeTruthy();
@@ -171,7 +171,7 @@ test.describe('Dock pin/collapse round-trip (Neural Link)', () => {
         // action that is withdrawn has no DOM node at all (the toolbar withholds it rather than
         // hiding it, so no stylesheet can resurrect it), and this header holds no focus yet. The
         // accessible name and glyph are read below, once the gate is open.
-        const pinAction = await app.callMethod(inspectorTabsId, 'getActionItem', ['pin']),
+        const pinAction = await app.callMethod(inspectorTabsId, 'getAction', ['pin']),
               pinButton = page.locator(`#${pinAction.id}`);
 
         await expect(pinButton, 'a withdrawn action has no node before its header has focus').toHaveCount(0);
@@ -185,7 +185,7 @@ test.describe('Dock pin/collapse round-trip (Neural Link)', () => {
         // the policy under test.
         await focusPane(app, page, 'strategy');
 
-        const centerPin = await app.callMethod(mainTabsId, 'getActionItem', ['pin']);
+        const centerPin = await app.callMethod(mainTabsId, 'getAction', ['pin']);
 
         expect(centerPin?.id, 'the center stack projects the action instance').toBeTruthy();
         expect(centerPin.hidden, 'a center-owned pane must not offer the collapse').toBe(true);
@@ -193,7 +193,7 @@ test.describe('Dock pin/collapse round-trip (Neural Link)', () => {
 
         // The control arm for that gate: the close action, which opts OUT of focus gating, IS visible
         // on the very same focused header — so "hidden" above is this action's policy, not the gate.
-        const centerClose = await app.callMethod(mainTabsId, 'getActionItem', ['close']);
+        const centerClose = await app.callMethod(mainTabsId, 'getAction', ['close']);
 
         await expect(page.locator(`#${centerClose.id}`), 'the ungated close action proves the header is live').toBeVisible();
 
@@ -266,10 +266,10 @@ test.describe('Dock pin/collapse round-trip (Neural Link)', () => {
 
             const
                 inspectorTabsId = await tabsNodeId(app, 'inspector-tabs'),
-                pinAction        = await app.callMethod(inspectorTabsId, 'getActionItem', ['pin']),
-                pinButton        = page.locator(`#${pinAction.id}`),
-                inlineAction     = await readRevealPinStyle(pinButton),
-                inlineTitle      = await readInlineTitleChrome(page.locator(`#${inspectorButtonId}`));
+                pinAction       = await app.callMethod(inspectorTabsId, 'getAction', ['pin']),
+                pinButton       = page.locator(`#${pinAction.id}`),
+                inlineAction    = await readRevealPinStyle(pinButton),
+                inlineTitle     = await readInlineTitleChrome(page.locator(`#${inspectorButtonId}`));
 
             await expect(pinButton).toHaveAttribute('aria-label', 'unpin');
             await expect(pinButton.locator('.neo-button-glyph')).toHaveClass(/fa-thumbtack-slash/);

--- a/test/playwright/e2e/dashboard/DockPinCollapseNL.spec.mjs
+++ b/test/playwright/e2e/dashboard/DockPinCollapseNL.spec.mjs
@@ -161,7 +161,7 @@ test.describe('Dock pin/collapse round-trip (Neural Link)', () => {
         expect(inspectorTabsId, 'the inspector band projects a live TabContainer').toBeTruthy();
         expect(mainTabsId,      'the center stack projects a live TabContainer').toBeTruthy();
 
-        // Product truth #1: the opt-in projects a real action instance on the edge-owned pane.
+        // Product truth 1: the opt-in projects a real action instance on the edge-owned pane.
         await expect.poll(async () => (await app.callMethod(inspectorTabsId, 'getAction', ['pin']))?.id, {
             message: 'the opt-in projection materialises one persistent pin action',
             timeout: 10000
@@ -176,7 +176,7 @@ test.describe('Dock pin/collapse round-trip (Neural Link)', () => {
 
         await expect(pinButton, 'a withdrawn action has no node before its header has focus').toHaveCount(0);
 
-        // Product truth #4: §2.7's fail-safe reaches the real product — the center stack projects the
+        // Product truth 4: §2.7's fail-safe reaches the real product — the center stack projects the
         // action too, but hidden, because main content never rails.
         //
         // The center pane is FOCUSED first on purpose. The engine set is focus-gated, so an unfocused
@@ -204,7 +204,7 @@ test.describe('Dock pin/collapse round-trip (Neural Link)', () => {
         await expect(pinButton.locator('.neo-button-glyph')).toHaveClass(/fa-thumbtack-slash/);
         await pinButton.click();
 
-        // Product truth #2: worker truth carries the collapse, committed through the semantic path.
+        // Product truth 2: worker truth carries the collapse, committed through the semantic path.
         await expect.poll(async () => (await readModel())?.items?.inspector?.autoHidden, {
             message: 'the real header action commits the collapse through the model',
             timeout: 10000
@@ -224,7 +224,7 @@ test.describe('Dock pin/collapse round-trip (Neural Link)', () => {
             'the rail is the one on its OWNING edge, not merely some rail'
         ).toHaveCount(1);
 
-        // Product truth #3: the loop closes. The existing reveal path takes it from here.
+        // Product truth 3: the loop closes. The existing reveal path takes it from here.
         await railTab.click();
         await page.waitForTimeout(600);
 

--- a/test/playwright/e2e/dashboard/DockReloadActionNL.spec.mjs
+++ b/test/playwright/e2e/dashboard/DockReloadActionNL.spec.mjs
@@ -85,7 +85,7 @@ test.describe('Dock reload action — delegation into the pane (Neural Link)', (
         // the workspace's boot sync reveals it for the contract-bearing active pane — so the
         // reveal itself is the settle surface, not the action's existence.
         await expect.poll(async () => {
-            const action = await app.callMethod(mainTabsId, 'getActionItem', ['reload']);
+            const action = await app.callMethod(mainTabsId, 'getAction', ['reload']);
 
             return action ? action.hidden !== true : null
         }, {
@@ -93,7 +93,7 @@ test.describe('Dock reload action — delegation into the pane (Neural Link)', (
             timeout: 10000
         }).toBe(true);
 
-        const reloadAction = await app.callMethod(mainTabsId, 'getActionItem', ['reload']);
+        const reloadAction = await app.callMethod(mainTabsId, 'getAction', ['reload']);
 
         // The focus consequence, as its own settle surface: the engine set ungates in the DOM.
         await expect(page.locator(`#${reloadAction.id}`)).not.toHaveClass(/neo-toolbar-action-context-inactive/);
@@ -113,7 +113,7 @@ test.describe('Dock reload action — delegation into the pane (Neural Link)', (
         // opt-out) stays visible on that focused header, proving the header itself is live.
         await focusPane(app, page, 'swarm');
 
-        await expect.poll(async () => (await app.callMethod(mainTabsId, 'getActionItem', ['reload']))?.hidden, {
+        await expect.poll(async () => (await app.callMethod(mainTabsId, 'getAction', ['reload']))?.hidden, {
             message: 'a pane without the contract keeps the reload action',
             timeout: 10000
         }).toBe(false);
@@ -136,7 +136,7 @@ test.describe('Dock reload action — delegation into the pane (Neural Link)', (
 
         expect(JSON.stringify(await readModel()), 'a recreate commits nothing').toBe(swarmDoc);
 
-        const closeAction = await app.callMethod(mainTabsId, 'getActionItem', ['close']);
+        const closeAction = await app.callMethod(mainTabsId, 'getAction', ['close']);
 
         expect(closeAction?.id, 'the control arm: close projects on the same header').toBeTruthy();
         await expect(page.locator(`#${closeAction.id}`)).toBeVisible()

--- a/test/playwright/e2e/tab/TabHeaderActionsNL.spec.mjs
+++ b/test/playwright/e2e/tab/TabHeaderActionsNL.spec.mjs
@@ -57,7 +57,7 @@ test.describe('TabContainer flat header actions (Neural Link)', () => {
         expect(valueOf(nextRecord, 'wrapperCls')).not.toContain('neo-draggable');
         expect(valueOf(previousRecord, 'wrapperCls')).not.toContain('neo-draggable');
 
-        const semanticNext = await app.callMethod(tabId, 'getActionItem', ['next-tab']);
+        const semanticNext = await app.callMethod(tabId, 'getAction', ['next-tab']);
         expect(semanticNext?.id, 'semantic lookup resolves the stable action instance').toBe(nextId);
 
         await expect(page.getByRole('button', {name: 'next tab', exact: true})).toHaveCount(1);
@@ -302,7 +302,7 @@ test.describe('TabContainer flat header actions (Neural Link)', () => {
             headerActions: [{action: 'runtime-contextual', iconCls: 'fa fa-bolt'}]
         });
 
-        const runtimeActionRecord = await app.callMethod(tabId, 'getActionItem', ['runtime-contextual']),
+        const runtimeActionRecord = await app.callMethod(tabId, 'getAction', ['runtime-contextual']),
               runtimeActionId     = runtimeActionRecord?.id,
               runtimeAction       = page.locator(`#${runtimeActionId}`);
 

--- a/test/playwright/e2e/workstation/WorkstationHeaderStatePopOutNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationHeaderStatePopOutNL.spec.mjs
@@ -85,7 +85,7 @@ test.describe('Workstation pop-out — header truth resolves identically from bo
         expect(before.truth,      'and reads the published truth through it').toEqual(control);
 
         const
-            action = await app.callMethod(chrome.containerId, 'getActionItem', ['pop-out']),
+            action = await app.callMethod(chrome.containerId, 'getAction', ['pop-out']),
             popOut = page.locator(`#${action?.id}`);
 
         expect(action?.id, 'pop-out resolves on the live tab owner').toBeTruthy();

--- a/test/playwright/e2e/workstation/WorkstationNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationNL.spec.mjs
@@ -145,7 +145,7 @@ const focusDockAction = async ({app, page, workspaceId, nodeId, itemId, actionNa
 
     await page.locator(`#${buttonId}`).click();
 
-    const action  = await app.callMethod(chrome.containerId, 'getActionItem', [actionName]),
+    const action  = await app.callMethod(chrome.containerId, 'getAction', [actionName]),
           locator = page.locator(`#${action?.id}`);
 
     expect(action?.id, `${actionName} resolves on the live tab owner`).toBeTruthy();
@@ -2638,7 +2638,7 @@ test.describe('Workstation — dense living-data composition', () => {
         expect(await app.callMethod(workspaceId, 'getPaneIdentity', ['scale']),
             'maximize never recreates the pane').toBe(paneId);
 
-        const restoreAction = await app.callMethod(chrome.containerId, 'getActionItem', ['maximize']);
+        const restoreAction = await app.callMethod(chrome.containerId, 'getAction', ['maximize']);
 
         expect(restoreAction.id, 'the maximize action instance is retained for restore').toBe(action.id);
         await page.locator(`#${restoreAction.id}`).click();

--- a/test/playwright/e2e/workstation/WorkstationNativePopupOverPopupNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationNativePopupOverPopupNL.spec.mjs
@@ -196,7 +196,7 @@ async function popOut({app, page, workspaceId, itemId}) {
 
     await page.locator(`#${chrome.buttons[itemId]}`).click();
 
-    const action = await app.callMethod(chrome.containerId, 'getActionItem', ['pop-out']);
+    const action = await app.callMethod(chrome.containerId, 'getAction', ['pop-out']);
 
     expect(action?.id, `pop-out resolves on ${itemId}'s tab owner`).toBeTruthy();
     await expect(page.locator(`#${action.id}`), `pop-out is user-reachable for ${itemId}`).toBeVisible({timeout: 10000});

--- a/test/playwright/e2e/workstation/WorkstationNativeTitlebarDragNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationNativeTitlebarDragNL.spec.mjs
@@ -151,7 +151,7 @@ test.describe('Workstation — native titlebar popup drag (#18029)', () => {
 
             await page.locator(`#${chrome.buttons.commits}`).click();
 
-            const action = await app.callMethod(chrome.containerId, 'getActionItem', ['pop-out']);
+            const action = await app.callMethod(chrome.containerId, 'getAction', ['pop-out']);
 
             expect(action?.id, 'pop-out resolves on the live tab owner').toBeTruthy();
             await expect(page.locator(`#${action.id}`), 'pop-out is user-reachable').toBeVisible({timeout: 10000});

--- a/test/playwright/unit/dashboard/DockActionTooltips.spec.mjs
+++ b/test/playwright/unit/dashboard/DockActionTooltips.spec.mjs
@@ -92,12 +92,12 @@ test.describe('dock header action tooltips', () => {
               };
 
         for (const [action, text] of Object.entries(expected)) {
-            expect(tipText(main.getActionItem(action)), `${action} names itself`).toBe(text)
+            expect(tipText(main.getAction(action)), `${action} names itself`).toBe(text)
         }
 
         const rail    = workspace.down({ntype: 'dashboard-dock-rail'}),
               overlay = rail.items.at(-1),
-              pin     = overlay.items[0].getActionItem('pin');
+              pin     = overlay.items[0].getAction('pin');
 
         expect(rail.revealPinTooltip, 'the rail carries the text for its overlay').toBe('Pin back into the layout');
         expect(overlay.pinTooltip).toBe('Pin back into the layout');
@@ -110,29 +110,29 @@ test.describe('dock header action tooltips', () => {
 
         expect(overridden.dockActionTooltips.lock,  'the overridden key').toBe('Sperren');
         expect(overridden.dockActionTooltips.close, 'an untouched key keeps the engine default').toBe('Close');
-        expect(tipText(main.getActionItem('lock'))).toBe('Sperren');
-        expect(tipText(main.getActionItem('close'))).toBe('Close');
-        expect(main.getActionItem('reload').tooltip, 'a null key writes no tooltip at all').toBeNull();
+        expect(tipText(main.getAction('lock'))).toBe('Sperren');
+        expect(tipText(main.getAction('close'))).toBe('Close');
+        expect(main.getAction('reload').tooltip, 'a null key writes no tooltip at all').toBeNull();
 
         overridden.destroy();
 
         // The merge lands on the instance, never on the class default.
         create();
         expect(workspace.dockActionTooltips.lock, 'a fresh workspace keeps the engine default').toBe('Lock pane');
-        expect(tipText(tabsOf('main-tabs').getActionItem('reload'))).toBe('Reload pane')
+        expect(tipText(tabsOf('main-tabs').getAction('reload'))).toBe('Reload pane')
     });
 
     test('lock ↔ unlock flips tooltip, icon and accessible name together on the retained instance', () => {
         create();
 
         const main   = tabsOf('main-tabs'),
-              action = main.getActionItem('lock');
+              action = main.getAction('lock');
 
         expect(tipText(action)).toBe('Lock pane');
 
         expect(workspace.handleDockLockAction({dockNodeId: 'main-tabs', tabContainer: main}).errors).toEqual([]);
 
-        expect(main.getActionItem('lock'), 'the same instance').toBe(action);
+        expect(main.getAction('lock'), 'the same instance').toBe(action);
         expect(action.iconCls).toBe(workspace.dockUnlockIconCls);
         expect(action.vdom['aria-label']).toBe('unlock');
         expect(tipText(action)).toBe('Unlock pane');
@@ -148,8 +148,8 @@ test.describe('dock header action tooltips', () => {
         create({dockActionTooltips: {restore: null, unlock: null}});
 
         const main     = tabsOf('main-tabs'),
-              lock     = main.getActionItem('lock'),
-              maximize = main.getActionItem('maximize');
+              lock     = main.getAction('lock'),
+              maximize = main.getAction('maximize');
 
         expect(tipText(lock)).toBe('Lock pane');
         expect(workspace.handleDockLockAction({dockNodeId: 'main-tabs', tabContainer: main}).errors).toEqual([]);
@@ -175,7 +175,7 @@ test.describe('dock header action tooltips', () => {
         create();
 
         const main   = tabsOf('main-tabs'),
-              action = main.getActionItem('maximize'),
+              action = main.getAction('maximize'),
               plugin = workspace.getPlugin('dock-maximize');
 
         expect(action.vdom['aria-label'], 'the derived name before any toggle').toBe('maximize');
@@ -183,7 +183,7 @@ test.describe('dock header action tooltips', () => {
 
         plugin.syncActionPresentation(main, true);
 
-        expect(main.getActionItem('maximize'), 'the same instance').toBe(action);
+        expect(main.getAction('maximize'), 'the same instance').toBe(action);
         expect(action.iconCls).toBe(plugin.restoreIconCls);
         expect(action.vdom['aria-label'], 'the restore glyph is announced as restore').toBe('restore');
         expect(tipText(action)).toBe('Restore');

--- a/test/playwright/unit/dashboard/DockHeaderState.spec.mjs
+++ b/test/playwright/unit/dashboard/DockHeaderState.spec.mjs
@@ -164,10 +164,10 @@ test.describe('Neo.dashboard.dock.Workspace — header state as bound data', () 
         const tabs   = Reconciler.collectProjectedTabs(workspace.items[0]),
               center = tabs.get('center-tabs');
 
-        expect(center.getActionItem('close').hidden, 'alpha is closable').toBe(false);
-        expect(center.getActionItem('reload').hidden, 'alpha carries a dockReload() contract').toBe(false);
-        expect(center.getActionItem('pin').hidden, 'center never rails').toBe(true);
-        expect(tabs.get('side-tabs').getActionItem('pin').hidden, 'an edge-owned item can collapse').toBe(false);
+        expect(center.getAction('close').hidden, 'alpha is closable').toBe(false);
+        expect(center.getAction('reload').hidden, 'alpha carries a dockReload() contract').toBe(false);
+        expect(center.getAction('pin').hidden, 'center never rails').toBe(true);
+        expect(tabs.get('side-tabs').getAction('pin').hidden, 'an edge-owned item can collapse').toBe(false);
 
         evaluations.length = 0;
 
@@ -182,8 +182,8 @@ test.describe('Neo.dashboard.dock.Workspace — header state as bound data', () 
 
         const center = Reconciler.collectProjectedTabs(workspace.items[0]).get('center-tabs'),
               pane   = center.getActiveCard(),
-              lock   = center.getActionItem('lock'),
-              close  = center.getActionItem('close');
+              lock   = center.getAction('lock'),
+              close  = center.getAction('close');
 
         evaluations.length = 0;
 
@@ -216,8 +216,8 @@ test.describe('Neo.dashboard.dock.Workspace — header state as bound data', () 
         workspace = Neo.create(HeaderStateWorkspace, {dockModel: createDocument()});
 
         const center = Reconciler.collectProjectedTabs(workspace.items[0]).get('center-tabs'),
-              close  = center.getActionItem('close'),
-              reload = center.getActionItem('reload');
+              close  = center.getAction('close'),
+              reload = center.getAction('reload');
 
         evaluations.length = 0;
 
@@ -252,14 +252,14 @@ test.describe('Neo.dashboard.dock.Workspace — header state as bound data', () 
 
         expect(evaluationsOf(other).length, 'the other workspace evaluated its own headers').toBeGreaterThan(0);
         expect(evaluationsOf(workspace), 'this workspace evaluated nothing').toEqual([]);
-        expect(Reconciler.collectProjectedTabs(workspace.items[0]).get('center-tabs').getActionItem('lock').pressed).toBe(false)
+        expect(Reconciler.collectProjectedTabs(workspace.items[0]).get('center-tabs').getAction('lock').pressed).toBe(false)
     });
 
     test('reload follows the published pane contract, the recreate fallback and the flight', async () => {
         workspace = Neo.create(HeaderStateWorkspace, {dockModel: createDocument()});
 
         const center   = Reconciler.collectProjectedTabs(workspace.items[0]).get('center-tabs'),
-              reload   = center.getActionItem('reload'),
+              reload   = center.getAction('reload'),
               provider = workspace.stateProvider;
 
         expect(provider.getData('dock.items.alpha.reloadable'), 'the resolver published alpha\'s contract').toBe(true);
@@ -304,7 +304,7 @@ test.describe('Neo.dashboard.dock.Workspace — header state as bound data', () 
         workspace = host.items[0];
 
         const center   = Reconciler.collectProjectedTabs(workspace.items[0]).get('center-tabs'),
-              lock     = center.getActionItem('lock'),
+              lock     = center.getAction('lock'),
               pane     = center.getActiveCard(),
               provider = workspace.stateProvider;
 
@@ -390,8 +390,8 @@ test.describe('Neo.dashboard.dock.Workspace — header state as bound data', () 
         const center   = Reconciler.collectProjectedTabs(workspace.items[0]).get('center-tabs'),
               pane     = center.getActiveCard(),
               button   = center.getTabButtons()[0],
-              lock     = center.getActionItem('lock'),
-              close    = center.getActionItem('close'),
+              lock     = center.getAction('lock'),
+              close    = center.getAction('close'),
               provider = workspace.stateProvider;
 
         expect(button.dockItemId).toBe(itemId);

--- a/test/playwright/unit/dashboard/DockLayoutAdapter.spec.mjs
+++ b/test/playwright/unit/dashboard/DockLayoutAdapter.spec.mjs
@@ -337,7 +337,6 @@ test.describe('Neo.dashboard.dock.projection.LayoutAdapter', () => {
                 ...extra
             });
 
-        expect(project([{action: 'filter'}, {action: 'filter'}])).toThrow(/duplicate host header action "filter"/);
         expect(project([{iconCls: 'fa fa-x'}])).toThrow(/requires a semantic `action` name/);
 
         const defaultFlags = {

--- a/test/playwright/unit/dashboard/DockLockAction.spec.mjs
+++ b/test/playwright/unit/dashboard/DockLockAction.spec.mjs
@@ -286,8 +286,8 @@ test.describe('Neo.dashboard.dock.Workspace lock action', () => {
         const tabContainer = Reconciler.collectProjectedTabs(workspace.items[0]).get('main-tabs'),
               pane         = tabContainer.getActiveCard(),
               tabButton    = tabContainer.getTabButtons()[0],
-              lockAction   = tabContainer.getActionItem('lock'),
-              closeAction  = tabContainer.getActionItem('close');
+              lockAction   = tabContainer.getAction('lock'),
+              closeAction  = tabContainer.getAction('close');
 
         pane.vdom.inert = false;
         tabButton.addWrapperCls('neo-draggable');
@@ -360,7 +360,7 @@ test.describe('Neo.dashboard.dock.Workspace lock action', () => {
               pane         = tabContainer.getActiveCard(),
               beta         = tabContainer.getCardContainer().items[1],
               tabButton    = tabContainer.getTabButtons()[0],
-              closeAction  = tabContainer.getActionItem('close');
+              closeAction  = tabContainer.getAction('close');
 
         expect(pane.lockCalls, 'the fixture pane carries the hook').toEqual([]);
         expect(typeof beta.dockLock, 'and its sibling does not').toBe('undefined');

--- a/test/playwright/unit/dashboard/DockMaximizePlugin.spec.mjs
+++ b/test/playwright/unit/dashboard/DockMaximizePlugin.spec.mjs
@@ -165,7 +165,7 @@ test.describe('dock maximize as a declinable plugin', () => {
         expect(plugin.resizeObserved, 'no observation before a presentation exists').toBe(false);
 
         expect(actionNames('main-tabs').slice(-2), 'the toggle sits in its frozen slot before close').toEqual(['maximize', 'close']);
-        expect(tabsOf('main-tabs').getActionItem('maximize').iconCls).toBe(plugin.iconCls);
+        expect(tabsOf('main-tabs').getAction('maximize').iconCls).toBe(plugin.iconCls);
 
         const escape = workspace.keys.keys.find(entry => entry.key === 'Escape');
 
@@ -193,7 +193,7 @@ test.describe('dock maximize as a declinable plugin', () => {
 
         expect(maximizePlugins(), 'the switch installs nothing beside the supplied instance').toHaveLength(1);
         expect(plugin.iconCls).toBe('fa fa-expand');
-        expect(tabsOf('main-tabs').getActionItem('maximize').iconCls, 'its options reached the projection').toBe('fa fa-expand')
+        expect(tabsOf('main-tabs').getAction('maximize').iconCls, 'its options reached the projection').toBe('fa fa-expand')
     });
 
     test('a committed operation is announced to collaborators before it applies', () => {
@@ -307,7 +307,7 @@ test.describe('dock maximize as a declinable plugin', () => {
 
         workspace = Neo.create(HookWorkspace, {dockModel: createDocument()});
 
-        expect(tabsOf('main-tabs').getActionItem('maximize').iconCls, 'the hook overrides the collaborator key').toBe('fa fa-host')
+        expect(tabsOf('main-tabs').getAction('maximize').iconCls, 'the hook overrides the collaborator key').toBe('fa fa-host')
     });
 
     test('a collaborator whose refresh sync rejects is reported and skipped, and the refresh still settles', async () => {

--- a/test/playwright/unit/dashboard/DockProjectionReconciler.spec.mjs
+++ b/test/playwright/unit/dashboard/DockProjectionReconciler.spec.mjs
@@ -261,7 +261,7 @@ test.describe('Neo.dashboard.dock.projection.Reconciler', () => {
 
         tab.headerActions = [{action: 'pin', contextual: false, iconCls: 'fa fa-thumbtack'}];
 
-        const action = tab.getActionItem('pin'),
+        const action = tab.getAction('pin'),
               spacer = bar.getActionSpacer();
 
         next.items.beta = {componentRef: 'beta', kind: 'panel', title: 'Beta'};
@@ -291,7 +291,7 @@ test.describe('Neo.dashboard.dock.projection.Reconciler', () => {
 
             expect(host.items[0]).toBe(tab);
             expect(tab.getTabButtons().map(button => button.text)).toEqual(['Alpha', 'Beta']);
-            expect(tab.getActionItem('pin'), 'the exact action instance survives projection').toBe(action);
+            expect(tab.getAction('pin'), 'the exact action instance survives projection').toBe(action);
             expect(bar.getActionSpacer(), 'the exact spacer instance survives projection').toBe(spacer);
             expect(bar.items.slice(-2)).toEqual([spacer, action]);
             expect(action.wrapperCls).not.toContain('neo-draggable');

--- a/test/playwright/unit/dashboard/DockWorkspace.spec.mjs
+++ b/test/playwright/unit/dashboard/DockWorkspace.spec.mjs
@@ -874,7 +874,7 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
         // across nothing happening.
         const nodeId       = 'side-tabs',
               tabContainer = tabsOf(workspace.items[0]).get(nodeId),
-              action       = tabContainer.getActionItem('pin');
+              action       = tabContainer.getAction('pin');
 
         // The adapter-level arms prove the projection CONFIG carries the action. This proves the
         // config became a real toolbar item on a live workspace that supplied the resolver through
@@ -913,7 +913,7 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
             'a reprojection was actually scheduled by that commit').not.toBe(refreshBefore);
 
         const afterReproject = [...tabsOf(workspace.items[0]).entries()]
-            .find(([id]) => id === nodeId)?.[1]?.getActionItem('pin');
+            .find(([id]) => id === nodeId)?.[1]?.getAction('pin');
 
         expect(afterReproject, 'the action survives reprojection').toBeTruthy();
         expect(afterReproject, 'and it is the SAME instance, not a rebuilt group').toBe(action);
@@ -1936,7 +1936,7 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
         const
             tabs         = tabsOf(workspace.items[0]),
             side         = tabs.get('side-tabs'),
-            closeAction  = side.getActionItem('close'),
+            closeAction  = side.getAction('close'),
             terminalTab  = side.getTabButtons()[1],
             focusTargets = [],
             commits      = [],
@@ -1962,7 +1962,7 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
         expect(refused.errors).toEqual(['item "terminal" is not closable']);
         expect(workspace.getDockZoneDocument().nodes['side-tabs'].activeItemId).toBe('terminal');
         expect(side.activeIndex).toBe(1);
-        expect(side.getActionItem('close')).toBe(closeAction);
+        expect(side.getAction('close')).toBe(closeAction);
         expect(focusTargets).toEqual([]);
 
         const activationRefresh = workspace.refreshPromise;
@@ -1992,7 +1992,7 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
         ]);
         expect(workspace.getDockZoneDocument().nodes['side-tabs'].items).toEqual(['terminal']);
         expect(retainedSide).toBe(side);
-        expect(retainedSide.getActionItem('close')).toBe(closeAction);
+        expect(retainedSide.getAction('close')).toBe(closeAction);
         expect(closeAction.hidden).toBe(true);
         expect(focusTargets).toEqual(['terminal'])
     });
@@ -2012,7 +2012,7 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
         const
             tabs      = tabsOf(workspace.items[0]),
             inspector = tabs.get('inspector-tabs'),
-            pinAction = inspector.getActionItem('pin'),
+            pinAction = inspector.getAction('pin'),
             commits   = [],
             apply     = workspace.applyDockZoneOperation.bind(workspace);
 
@@ -2072,7 +2072,7 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
             return apply(descriptor)
         };
 
-        inspector.getActionItem('pin').handler({component: inspector.getActionItem('pin')});
+        inspector.getAction('pin').handler({component: inspector.getAction('pin')});
         await workspace.refreshPromise;
 
         expect(commits.map(descriptor => descriptor.operation)).toEqual(['setItemAutoHidden']);
@@ -2113,9 +2113,9 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
 
         // ONE post-settle sweep ran. It reached the retained node — that is the control — and it
         // has to reach the node the projection just created.
-        expect(tabs.get('center-tabs').getActionItem('reload').hidden,
+        expect(tabs.get('center-tabs').getAction('reload').hidden,
             'the post-settle sweep reached the retained node').toBe(false);
-        expect(returned.getActionItem('reload')?.hidden,
+        expect(returned.getAction('reload')?.hidden,
             'the returned node offers reload exactly like a never-railed one').toBe(false)
     });
 
@@ -2157,7 +2157,7 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
         expect(flowPane.isDestroyed, 'and it is alive').toBeFalsy();
         expect(Neo.get('fixed-id-pane-inspector'), 'registered under it — the only holder').toBe(flowPane);
         expect(revealPane.isDestroyed, 'the reveal pane was released before the flow pane was minted').toBe(true);
-        expect(returned.getActionItem('reload')?.hidden, 'and the post-settle sweep ran on the returned node').toBe(false)
+        expect(returned.getAction('reload')?.hidden, 'and the post-settle sweep ran on the returned node').toBe(false)
     });
 
     test('a pin retires only its own item — a rail still holding another auto-hidden item survives', async () => {
@@ -2253,7 +2253,7 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
             tabs       = tabsOf(workspace.items[0]),
             inspector  = tabs.get('inspector-tabs'),
             center     = tabs.get('center-tabs'),
-            pinAction  = inspector.getActionItem('pin'),
+            pinAction  = inspector.getAction('pin'),
             visibility = [],
             // The EMITTER of each signal, not just its payload. "The group was not replaced" is a
             // claim about which instance spoke, and a rebuilt group would announce itself here by
@@ -2268,11 +2268,11 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
         // Center-owned: §2.7's fail-safe — main content never rails, so the affordance is not offered.
         // Asserted BOTH where the adapter computed it and, below, after the workspace recomputes it:
         // the two derive it independently, and only the switch exercises the workspace's own sync.
-        expect(center.getActionItem('pin').hidden, 'a center-owned pane cannot collapse').toBe(true);
+        expect(center.getAction('pin').hidden, 'a center-owned pane cannot collapse').toBe(true);
 
         await center.set({activeIndex: 1});
 
-        expect(center.getActionItem('pin').hidden, 'still no collapse after the workspace re-syncs a center pane')
+        expect(center.getAction('pin').hidden, 'still no collapse after the workspace re-syncs a center pane')
             .toBe(true);
 
         expect(pinAction.hidden).toBe(false);
@@ -2280,7 +2280,7 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
         await inspector.set({activeIndex: 1});
 
         expect(pinAction.hidden, '`pinnable: false` is refused by the model, so it is not offered').toBe(true);
-        expect(inspector.getActionItem('pin'), 'the SAME instance moved, the group was not replaced').toBe(pinAction);
+        expect(inspector.getAction('pin'), 'the SAME instance moved, the group was not replaced').toBe(pinAction);
         expect(visibility, 'Overflow gets its signal from the instance, not a rebuilt group')
             .toEqual([['pin', true]]);
 
@@ -2307,7 +2307,7 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
         const reconciledTabs = tabsOf(workspace.items[0]).get('inspector-tabs');
 
         expect(reconciledTabs, 'the tabs node is retained across reconciliation').toBe(inspector);
-        expect(reconciledTabs.getActionItem('pin'), 'and so is the action instance on it')
+        expect(reconciledTabs.getAction('pin'), 'and so is the action instance on it')
             .toBe(pinAction);
         expect(pinAction.hidden, 'converging on the active item\'s real policy').toBe(false);
 
@@ -2372,7 +2372,7 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
 
         const tabs      = tabsOf(workspace.items[0]),
               inspector = tabs.get('inspector-tabs'),
-              pinAction = inspector.getActionItem('pin');
+              pinAction = inspector.getAction('pin');
 
         expect(pinAction, 'the action really was projected in the second run').toBeTruthy();
 
@@ -2439,7 +2439,7 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
 
         const offTabs = tabsOf(workspace.items[0]).get('inspector-tabs');
 
-        expect(offTabs.getActionItem('pin'), 'nothing is projected while the opt-in is off').toBeFalsy();
+        expect(offTabs.getAction('pin'), 'nothing is projected while the opt-in is off').toBeFalsy();
         expect(workspace.onDockHeaderAction({
             action: 'pin', dockNodeId: 'inspector-tabs', tabContainer: offTabs
         })).toBe(null);
@@ -2470,8 +2470,8 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
 
         const tabs        = tabsOf(workspace.items[0]),
               center      = tabs.get('center-tabs'),
-              pinAction   = center.getActionItem('pin'),
-              closeAction = center.getActionItem('close');
+              pinAction   = center.getAction('pin'),
+              closeAction = center.getAction('close');
 
         expect(pinAction,   'the host projected `pin` through the documented hook').toBeTruthy();
         expect(closeAction, 'and `close` beside it').toBeTruthy();
@@ -2487,7 +2487,7 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
 
         expect([closeAction.hidden, pinAction.hidden], 'and so does an active-item change')
             .toEqual([false, false]);
-        expect(center.getActionItem('pin'), 'the same host instances, never replaced').toBe(pinAction)
+        expect(center.getAction('pin'), 'the same host instances, never replaced').toBe(pinAction)
     });
 
     /**
@@ -2509,7 +2509,7 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
 
         const tabs      = tabsOf(workspace.items[0]),
               inspector = tabs.get('inspector-tabs'),
-              pinAction = inspector.getActionItem('pin');
+              pinAction = inspector.getAction('pin');
 
         expect(pinAction.hidden, 'an edge-owned pane can collapse, so the action is live').toBe(false);
 
@@ -2539,7 +2539,7 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
         // Once the refresh settled, the center header agrees with the document on its own.
         await workspace.refreshPromise;
 
-        expect(tabs.get('center-tabs')?.getActionItem('pin')?.hidden ?? true,
+        expect(tabs.get('center-tabs')?.getAction('pin')?.hidden ?? true,
             'a center-owned pane offers no collapse').toBe(true)
     });
 
@@ -2561,7 +2561,7 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
             return apply(descriptor)
         };
 
-        expect(side.getActionItem?.('close')).toBeFalsy();
+        expect(side.getAction?.('close')).toBeFalsy();
 
         await side.set({activeIndex: 1});
         await workspace.refreshPromise;
@@ -2641,7 +2641,7 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
 
         const
             side         = tabsOf(workspace.items[0]).get('side-tabs'),
-            closeAction  = side.getActionItem('close'),
+            closeAction  = side.getAction('close'),
             focusTargets = [];
 
         workspace.focus = () => focusTargets.push('workspace');
@@ -3350,7 +3350,7 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
         // The projection published the header truth before the chrome constructed, so the actions
         // bound to it are right at their first run — no mount-time correction is owed or scheduled.
         expect(['close', 'reload'].map(name => items.filter(item => item.action === name).length), 'one of each').toEqual([1, 1]);
-        expect(side.getActionItem('close').hidden, 'an unclosable active item hides close from the first paint').toBe(true);
+        expect(side.getAction('close').hidden, 'an unclosable active item hides close from the first paint').toBe(true);
 
         workspace.refreshPromise = null;
 
@@ -3518,7 +3518,7 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
             workspace = Neo.create(PlainWorkspace, {dockModel: createDocument(), enableDockPopOutAction: true});
 
             const side   = tabsOf(workspace.items[0]).get('side-tabs'),
-                  popOut = side.getActionItem('pop-out');
+                  popOut = side.getAction('pop-out');
 
             // pop-out was the one engine action with no sync. Its hidden state was projected once and
             // then lived on a RETAINED instance, so it was correct at boot and silently gone after the
@@ -3530,7 +3530,7 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
             workspace.stateProvider.setData('dock.popOutAvailable', true);
 
             expect(popOut.hidden, 'the capability reaches the retained instance').toBe(false);
-            expect(side.getActionItem('pop-out'), 'the same instance, the group was not replaced').toBe(popOut);
+            expect(side.getAction('pop-out'), 'the same instance, the group was not replaced').toBe(popOut);
 
             workspace.stateProvider.setData('dock.nodes.side-tabs.activeItemId', null);
 

--- a/test/playwright/unit/tab/HeaderActions.spec.mjs
+++ b/test/playwright/unit/tab/HeaderActions.spec.mjs
@@ -259,7 +259,7 @@ test.describe.serial('Neo tab header actions', () => {
 
         toolbar.actions = [{action: 'replaced', contextual: true, iconCls: 'fa fa-x'}];
 
-        const replaced = toolbar.getActionItem('replaced');
+        const replaced = toolbar.getAction('replaced');
 
         expect(replaced.vdom.removeDom, 'a replaced gated action is withdrawn before it renders').toBe(true);
         expect(late.vdom.removeDom, 'the contribution survives the replacement, still withdrawn').toBe(true);
@@ -488,8 +488,8 @@ test.describe.serial('Neo tab header actions', () => {
                   ],
                   items        : [{module: Component, header: {text: 'One'}}]
               })),
-              action = tabs.getActionItem('reversible'),
-              sibling = tabs.getActionItem('sibling'),
+              action = tabs.getAction('reversible'),
+              sibling = tabs.getAction('sibling'),
               bar    = tabs.getTabBar();
 
         // The tab header defaults to gated and starts outside focus.
@@ -589,8 +589,8 @@ test.describe.serial('Neo tab header actions', () => {
             livePreview = Neo.create(LivePreview, {enableFullscreen: true});
 
             const tabs       = livePreview.tabContainer,
-                  fullscreen = tabs.getActionItem('fullscreen'),
-                  popout     = tabs.getActionItem('popout'),
+                  fullscreen = tabs.getAction('fullscreen'),
+                  popout     = tabs.getAction('popout'),
                   handler    = fullscreen.handler;
 
             expect(tabs.getCount()).toBe(2);
@@ -603,8 +603,8 @@ test.describe.serial('Neo tab header actions', () => {
             tabs.activeIndex = 1;
             await new Promise(resolve => setTimeout(resolve, 0));
 
-            expect(tabs.getActionItem('fullscreen')).toBe(fullscreen);
-            expect(tabs.getActionItem('popout')).toBe(popout);
+            expect(tabs.getAction('fullscreen')).toBe(fullscreen);
+            expect(tabs.getAction('popout')).toBe(popout);
             expect(fullscreen.handler).toBe(handler);
             expect(popout.hidden).toBe(false);
 

--- a/test/playwright/unit/toolbar/ActionButton.spec.mjs
+++ b/test/playwright/unit/toolbar/ActionButton.spec.mjs
@@ -142,7 +142,7 @@ test.describe('Neo.toolbar.ActionButton', () => {
             }]
         });
 
-        const action = toolbar.getActionItem('lock');
+        const action = toolbar.getAction('lock');
 
         // Focus has not arrived, so a gated action is withdrawn: same instance, no node.
         expect(action.vdom.removeDom, 'withdrawn while resting and unfocused').toBe(true);

--- a/test/playwright/unit/toolbar/Actions.spec.mjs
+++ b/test/playwright/unit/toolbar/Actions.spec.mjs
@@ -1,0 +1,123 @@
+import {setup} from '../../setup.mjs';
+
+const appName = 'ToolbarActionsTest';
+
+setup({
+    appConfig: {
+        name: appName
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../src/Neo.mjs';
+import * as core      from '../../../../src/core/_export.mjs';
+import Component      from '../../../../src/component/Base.mjs';
+import DialogToolbar  from '../../../../src/dialog/header/Toolbar.mjs';
+import Toolbar        from '../../../../src/toolbar/Base.mjs';
+
+/**
+ * @summary An action's name is its address. `getAction(name)` resolves exactly one action, so a toolbar
+ * refuses a repeated name at the moment its actions materialise — among the consumer's own configs, or
+ * against a contributed action that stays — and an action without a name is not addressable at all.
+ */
+test.describe('Neo.toolbar.Base — actions resolve by name, and names are unique', () => {
+    const owned = [];
+    const own   = instance => {
+        owned.push(instance);
+        return instance
+    };
+
+    test.afterEach(() => {
+        owned.splice(0).forEach(instance => instance?.destroy?.())
+    });
+
+    /** The toolbar's item order by address: a spacer, an action's name, or an ordinary item's flag. */
+    const names = toolbar => toolbar.items.map(item => item.isToolbarActionSpacer ? 'spacer' : (item.action ?? item.flag ?? item.text));
+
+    test('getAction(name) is the address of exactly one action, and no name resolves nothing — even while an unnamed action exists', () => {
+        const toolbar = own(Neo.create(Toolbar, {
+            appName,
+            actions: [{action: 'save', iconCls: 'fa fa-save'}, {text: 'Plain', handler: () => {}}],
+            items  : [{module: Component, flag: 'ordinary'}]
+        }));
+
+        const save = toolbar.getAction('save');
+
+        expect(save?.action).toBe('save');
+        expect(save.isToolbarAction).toBe(true);
+        expect(toolbar.getAction('missing')).toBeNull();
+        expect(toolbar.getAction(), 'no name is not an address').toBeNull();
+        expect(toolbar.getAction(''), 'an empty name is not an address').toBeNull();
+
+        // the unnamed action is materialised and stays; it is simply not addressable
+        expect(toolbar.getActionItems()).toHaveLength(2);
+        expect(names(toolbar)).toEqual(['ordinary', 'spacer', 'save', 'Plain'])
+    });
+
+    test('unnamed actions cannot collide: two text actions without a name coexist', () => {
+        const toolbar = own(Neo.create(Toolbar, {
+            appName,
+            actions: [{text: 'A', handler() {}}, {text: 'B', handler() {}}]
+        }));
+
+        expect(toolbar.getActionItems().map(item => item.text)).toEqual(['A', 'B'])
+    });
+
+    test('a repeated name among the consumer\'s own actions throws when they materialise — at construction and at reassignment — and a refused reassignment changes no item', () => {
+        expect(() => Neo.create(Toolbar, {
+            appName,
+            actions: [{action: 'save', iconCls: 'fa fa-save'}, {action: 'save', text: 'Save again'}]
+        })).toThrow(/duplicate toolbar action "save"/);
+
+        const toolbar = own(Neo.create(Toolbar, {
+            appName,
+            actions: [{action: 'save', iconCls: 'fa fa-save'}],
+            items  : [{module: Component, flag: 'ordinary'}]
+        }));
+
+        const before = [...toolbar.items];
+
+        expect(() => {
+            toolbar.actions = [{action: 'open', text: 'Open'}, {action: 'open', text: 'Open twice'}]
+        }).toThrow(/duplicate toolbar action "open"/);
+
+        expect(toolbar.items, 'nothing was removed or inserted before the refusal').toEqual(before);
+        expect(toolbar.getAction('save')).toBe(before[2])
+    });
+
+    test('a contribution whose name is already present is refused before the spacer or the contribution is inserted; a distinct name inserts ahead of the consumer actions, and the consumer cannot take it back', () => {
+        const toolbar = own(Neo.create(Toolbar, {
+            appName,
+            actions: [{action: 'save', iconCls: 'fa fa-save'}],
+            items  : [{module: Component, flag: 'ordinary'}]
+        }));
+
+        const before = [...toolbar.items];
+
+        expect(() => toolbar.addActionContribution({action: 'save', iconCls: 'fa fa-clone', handler: Neo.emptyFn}))
+            .toThrow(/duplicate toolbar action "save"/);
+        expect(toolbar.items).toEqual(before);
+
+        const overflow = toolbar.addActionContribution({action: 'overflow', iconCls: 'fa fa-ellipsis', handler: Neo.emptyFn});
+
+        expect(toolbar.getAction('overflow')).toBe(overflow);
+        expect(names(toolbar)).toEqual(['ordinary', 'spacer', 'overflow', 'save']);
+
+        // a consumer rebuild that names the contribution is refused whole: the contribution and the
+        // consumer's previous actions both stay
+        expect(() => {
+            toolbar.actions = [{action: 'overflow', text: 'Mine now'}]
+        }).toThrow(/duplicate toolbar action "overflow"/);
+
+        expect(toolbar.getAction('overflow')).toBe(overflow);
+        expect(toolbar.getAction('save'), 'the refused rebuild removed nothing').toBe(before[2])
+    });
+
+    test('the dialog header resolves its mapped string actions by name', () => {
+        const header = own(Neo.create(DialogToolbar, {appName}));
+
+        expect(header.getAction('close')?.action).toBe('close');
+        expect(header.getAction('maximize')?.action).toBe('maximize');
+        expect(header.getAction('close')).toBe(header.getActionItems().find(item => item.action === 'close'))
+    })
+});

--- a/test/playwright/unit/toolbar/Actions.spec.mjs
+++ b/test/playwright/unit/toolbar/Actions.spec.mjs
@@ -113,6 +113,27 @@ test.describe('Neo.toolbar.Base — actions resolve by name, and names are uniqu
         expect(toolbar.getAction('save'), 'the refused rebuild removed nothing').toBe(before[2])
     });
 
+    test('a contribution whose name arrives from actionDefaults is refused like an explicit one: the config that would materialise is checked, not the raw one', () => {
+        const toolbar = own(Neo.create(Toolbar, {
+            appName,
+            actionDefaults: {action: 'save'},
+            actions       : [{text: 'Save'}],
+            items         : [{module: Component, flag: 'ordinary'}]
+        }));
+
+        const
+            before = [...toolbar.items],
+            save   = toolbar.getAction('save');
+
+        expect(save?.text, 'the consumer action took its name from the defaults').toBe('Save');
+
+        expect(() => toolbar.addActionContribution({text: 'Inherited duplicate', handler: Neo.emptyFn}))
+            .toThrow(/duplicate toolbar action "save"/);
+
+        expect(toolbar.items, 'neither a spacer nor the contribution was inserted').toEqual(before);
+        expect(toolbar.getAction('save'), 'the address still resolves the consumer action').toBe(save)
+    });
+
     test('the dialog header resolves its mapped string actions by name', () => {
         const header = own(Neo.create(DialogToolbar, {appName}));
 


### PR DESCRIPTION
Resolves #18363
Related: #17418 #17876 #18241

🌿 A toolbar action is now something you can ask for by name and get exactly one of, and the second action to claim a name is refused on arrival instead of winning silently.

Plugins, controllers and references resolve by name; toolbar actions already did too, through `getActionItem`, but nothing kept the names unique, so a collision degraded to first-match: the second action became unaddressable and every intent by that name landed on the first. The dock had built its own duplicate check for host header actions and hand-worked around first-match for `reload`. This PR moves the invariant to where the action set is closed and gives the lookup the family's name.

`toolbar.Base#getAction(name)` replaces `getActionItem` (`tab.Container` delegates under the same name); a lookup without a name resolves nothing rather than the first unnamed action. `assertUniqueActionNames` runs before anything is removed or inserted: `createActionItemConfigs` checks the consumer's configs among themselves (construction and reassignment), `syncActions` checks them against the contributions that stay, `addActionContribution` checks the one contribution as it will materialise — resolved once through `createActionItemConfig`, so a name it inherits from `actionDefaults` counts — against every live action, and inserts that same resolved config — each throwing `Neo.toolbar.Base: duplicate toolbar action "<name>"`, the idiom `createActionItemConfig` already uses for malformed actions. Unnamed actions cannot be addressed and cannot collide. The dock's `LayoutAdapter` duplicate branch retires; its name-required and reserved-name branches stay as dock policy the toolbar cannot know.

Evidence: L2 achieved → L2 required (AC-1 to AC-7). Residual: none — the downstream measurement (below) found no caller outside this repository, so the rename is hard and carries no alias.

## AC Evidence
| AC-1 | `test/playwright/unit/toolbar/Actions.spec.mjs` › "a repeated name among the consumer's own actions throws when they materialise…" — construction with two `save` actions throws naming `save`; reassigning `actions` to two `open` actions throws naming `open`, and `toolbar.items` equals its pre-assignment snapshot (nothing removed or inserted). Red on `dev`: `toolbar.getAction is not a function` and the two `toThrow` expectations |
| AC-2 | Same spec › "a contribution whose name is already present is refused before the spacer or the contribution is inserted…" — `addActionContribution({action: 'save'})` throws with items unchanged; `overflow` inserts ahead of the consumer actions (`ordinary, spacer, overflow, save`); a consumer rebuild naming `overflow` is refused whole and both `overflow` and `save` stay. › "a contribution whose name arrives from actionDefaults is refused like an explicit one…" — `actionDefaults: {action: 'save'}` names the consumer's `{text: 'Save'}`; `addActionContribution({text: 'Inherited duplicate'})` throws, items are unchanged and `getAction('save')` still resolves the consumer action (red on the previous head, where the raw config was checked and two `save` actions resulted) |
| AC-3 | `toolbar.Base#getAction(name)` and `tab.Container#getAction(name)` are the lookups; `grep -rnw "getActionItem" src apps examples test` returns zero lines — the word matcher, because `getActionItems`, the collection, stays (56 lines) — (eleven source call lines, one prototype-stub assignment and every spec call and `callMethod` string renamed, twenty files). Downstream, measured by @neo-opus-ada with `git grep` over tracked files (so no vendored engine copy under `node_modules` could count as a consumer): zero callers in every consumer repository — the institution on both her checkouts and on its `origin/dev`, the brain at `dev@a9e010d`, the skills repo — so no deprecated alias is admitted. Caveat she named: the institution pins an engine version, so its zero says the pinned consumer does not use the lookup; a pin bump in flight would deserve one more grep on the bumping branch |
| AC-4 | Same spec › "getAction(name) is the address of exactly one action, and no name resolves nothing — even while an unnamed action exists" — `getAction()` and `getAction('')` return `null` beside a materialised unnamed action; the unnamed action stays in the toolbar |
| AC-5 | `src/dashboard/dock/projection/LayoutAdapter.mjs` no longer throws "duplicate host header action" (the `seen` set is gone); the name-required and reserved-name arms in `DockLayoutAdapter.spec.mjs` and `DockLockAction.spec.mjs` are unchanged and green; the retired branch's one expectation line is removed from the reservation arm |
| AC-6 | Same spec › "the dialog header resolves its mapped string actions by name" — `Neo.dialog.header.Toolbar#getAction('close')` and `'maximize'` return the instances its `actionMap` minted |
| AC-7 | Full unit suite 3326 / 1 (the one red is dev's own `DockProjectionDestroySentinel.spec.mjs:213`), `component/dashboard` + `component/tab` 136 / 1 (a load flake green alone), both one worker on the committed tree — Test Evidence below |

## Deltas from ticket
None. The ticket's `getPlugin` symmetry note stays out of scope as written.

## Test Evidence
Unit: full suite 3326 passed / 1 failed (`playwright.config.unit.mjs`, one worker) on the committed tree — the red is `DockProjectionDestroySentinel.spec.mjs:213`, identical on pure `dev@308388fef0`. The toolbar, tab, dashboard, dialog and code unit suites after the rename: 917 passed / 1 failed — the red is `DockProjectionDestroySentinel.spec.mjs:213`, a baseline condition identical on pure `dev@308388fef0` (defect-noted to its author).
Components: `component/dashboard` + `component/tab` 136 passed / 1 failed (`playwright.config.component.mjs`, one worker) — the red, `OverflowAction.spec.mjs:253` "the restored split settles", passes alone (5 / 5) and is one of the four single-arm load reds the swarm's components-job defect-note lists for today's runs.
End-to-end (`playwright.config.e2e.mjs`, one worker; the journeys whose `callMethod` strings were renamed): `DockOperationsNL` 8 / 8, `DockReloadActionNL` 1 / 1, `DockPinCollapseNL` 3 / 5 and `TabHeaderActionsNL` 0 / 1 — the three reds (two golden-screenshot theme variants of the reveal pin, and a `toHaveCSS('visibility')` on `#neo-button-2`, a focus-gated action that has had no DOM node since withdrawn actions stopped rendering one) fail identically on pure `dev@308388fef0` from a detached checkout on this seat, so they are baseline conditions, defect-noted, not this change. The renamed `getAction` lookups in those journeys resolve: `next tab` is found by name before the stale assertion runs.
Red-first, measured: with `src` stashed and the specs kept, the new toolbar arms fail against `dev`'s source — `toolbar.getAction is not a function`, `header.getAction is not a function`, and both `toThrow` expectations (5 failures) — and pass with it.

## Post-Merge Validation
- [ ] Downstream consumers: none call `getActionItem` today (measured above); a consumer adopting header actions after this merge finds `getAction(name)` and the uniqueness throw in the toolbar docblocks.

## Commits (if multi-commit)
- `d7ed79e8d7` — the lookup becomes `getAction(name)`, a repeated name is refused where the actions materialise, the dock's local duplicate check retires; call sites, specs and the new toolbar spec
- `d0192aee9f` — the pin/collapse journey numbers its four product truths without a hash (a pre-existing label the shared archaeology job reads as a tracking ref; the job reads touched files whole)
- `f6a6cd11da` — the contribution path checks the config it will materialise: resolved once, checked against the live actions, the same result inserted; the inherited-name arm

Authored by Vega (Claude Fable 5.1, Claude Code). Session 3711ad57-061d-43fb-b1f1-aa9dc21dedda.