### PR TITLE
feat(transaction): commit Group state with compensation (#18312)

### DIFF
--- a/apps/workstation/view/Workspace.mjs
+++ b/apps/workstation/view/Workspace.mjs
@@ -501,7 +501,7 @@ class Workspace extends DockWorkspace {
         // through `afterSetTopologyGroupId`, which registers the main participant then. The Group is
         // kept for the instance's lifetime: releasing the window's slot never loses the documents.
         // Vessel workspaces register lazily on first dock-INTO (Edit 2).
-        me.workspaceSet = createDockWorkspaceSet({manager: TransactionManager, getGroupId: () => me.topologyGroupId});
+        me.workspaceSet = createDockWorkspaceSet({manager: TransactionManager, getGroupId: () => me.topologyGroupId, documentModel: WorkspaceDocument});
         me.registerMainWorkspace();
 
         me.crossWindowParticipationPromise = me.refreshCrossWindowParticipation(Workspace.MAIN_WORKSPACE_ID)
@@ -918,6 +918,8 @@ class Workspace extends DockWorkspace {
         let me = this;
 
         return me.workspaceSet.register(Workspace.MAIN_WORKSPACE_ID, {
+            bindingKey : 'main',
+            componentId: me.id,
             getDocument: () => me.dockModel,
             setDocument: document => me.dockModel = document
         })

--- a/buildScripts/util/file-size-baseline.json
+++ b/buildScripts/util/file-size-baseline.json
@@ -1,6 +1,6 @@
 {
-    "apps/workstation/view/Workspace.mjs": 3202,
-    "examples/dashboard/crossWindow/DemoBWorkspace.mjs": 2645,
+    "apps/workstation/view/Workspace.mjs": 3204,
+    "examples/dashboard/crossWindow/DemoBWorkspace.mjs": 2646,
     "src/dashboard/dock/Workspace.mjs": 1289,
     "src/main/addon/DragDrop.mjs": 1267
 }

--- a/docs/output/class-hierarchy.json
+++ b/docs/output/class-hierarchy.json
@@ -439,6 +439,7 @@
  "Neo.manager.Window": "Neo.manager.Base",
  "Neo.manager.rpc.Api": "Neo.manager.Base",
  "Neo.manager.rpc.Message": "Neo.manager.Base",
+ "Neo.manager.transaction.Commit": "Neo.core.Base",
  "Neo.manager.transaction.History": "Neo.core.Base",
  "Neo.menu.List": "Neo.list.Base",
  "Neo.menu.Model": "Neo.data.Model",

--- a/examples/dashboard/crossWindow/DemoBWorkspace.mjs
+++ b/examples/dashboard/crossWindow/DemoBWorkspace.mjs
@@ -518,7 +518,7 @@ class DemoBWorkspace extends Container {
         // admitted at registration, and a Group the carrier already held is known before this
         // constructor runs; a first boot's minted identity arrives with its accepted binding, and
         // `onTopologyBind` registers the participants then.
-        me.workspaceSet = createDockWorkspaceSet({manager: TransactionManager, getGroupId: () => me.topologyGroupId});
+        me.workspaceSet = createDockWorkspaceSet({manager: TransactionManager, getGroupId: () => me.topologyGroupId, documentModel: WorkspaceDocument});
         me.adoptTopologyGroup(TransactionManager.findByWindow(me.windowId)?.groupId ?? null);
 
         me.dockPreviewProducer = Neo.create(DockPreviewProducer);
@@ -3014,6 +3014,7 @@ class DemoBWorkspace extends Container {
         me.topologyGroupId = groupId;
 
         me.workspaceSet.register(DemoBWorkspace.MAIN_WORKSPACE_ID, {
+            bindingKey : 'main',
             getDocument: () => me.dockModel,
             setDocument: document => me.dockModel = document
         });

--- a/learn/benefits/ArchitectureOverview.md
+++ b/learn/benefits/ArchitectureOverview.md
@@ -439,7 +439,7 @@ complete organism where the codebase and the agent co-evolve.
 | `src/data/` | Data layer | `Store`, `Model`, `RecordFactory` | — |
 | `src/state/` | State management | `Provider` | — |
 | `src/worker/` | Thread management | `App`, `VDom`, `Data`, `Manager` | — |
-| `src/manager/` | Worker-side registries and authorities: instances, components, window geometry, drag coordination, and the logical topology Groups a window binds into across reloads — each Group with a bounded, append-only transaction history and one cursor, loaded on demand under `transaction/` | `Instance`, `Component`, `Window`, `DragCoordinator`, `Transaction`, `transaction/History` | [ADR 0029](https://github.com/neomjs/neo/blob/dev/learn/agentos/decisions/0029-docking-design.md) |
+| `src/manager/` | Worker-side registries and authorities: instances, components, window geometry, drag coordination, and logical topology Groups — with serialized compensating writes, immutable snapshots, bounded transaction history and one cursor under `transaction/` | `Instance`, `Component`, `Window`, `DragCoordinator`, `Transaction`, `transaction/Commit`, `transaction/History` | [ADR 0029](https://github.com/neomjs/neo/blob/dev/learn/agentos/decisions/0029-docking-design.md) |
 | `src/vdom/` | Virtual DOM engine | `Helper` | — |
 | `src/main/` | Main thread addons | `DomEvents`, `DomAccess` | — |
 | `src/ai/` | Neural Link client | `Client` | — |

--- a/src/dashboard/dock/window/WorkspaceSet.mjs
+++ b/src/dashboard/dock/window/WorkspaceSet.mjs
@@ -27,15 +27,16 @@
  *   is it now" — reconcile ordering, generation guards, and render-target sync remain the workspace
  *   container's own contract.
  *
- * Dependency-free beyond its two seams — the manager and the Group resolver are injected — so
- * witnesses drive the full contract without a browser or a model import.
+ * The manager, Group resolver and document model are injected. Synchronous adoption remains available;
+ * write() enters the Group's complete transaction protocol without importing its machinery here.
  */
 
 /**
- * Creates the dock's view of one Group's participant membership.
+ * @summary Creates the dock's view of one Group's participant membership and transaction entry.
  * @param {Object} seams
  * @param {Neo.manager.Transaction} seams.manager The worker-wide topology manager.
  * @param {Function} seams.getGroupId `() => String|null` — the host's Group, `null` while its window has not bound.
+ * @param {Object} [seams.documentModel] WorkspaceDocument's pure validate/clone surface, required for writes.
  * @returns {Object} workspaceSet
  * @returns {Function} workspaceSet.adoptAll       `(workspaces)` all-or-nothing adoption of one document per registered key; Boolean.
  * @returns {Function} workspaceSet.adoptTransfer  `({sourceWorkspaceId, sourceDocument, targetWorkspaceId, targetDocument})` both-or-neither pair adoption; Boolean.
@@ -45,8 +46,9 @@
  * @returns {Function} workspaceSet.register       `(workspaceId, {getDocument, setDocument})` registers-or-replaces a participant; Boolean.
  * @returns {Number}   workspaceSet.size           Registered participant count.
  * @returns {Function} workspaceSet.unregister     `(workspaceId)` explicit retirement; Boolean.
+ * @returns {Function} workspaceSet.write          `(workspaces, options)` queued atomic adoption of keyed documents; Promise.
  */
-export function createDockWorkspaceSet({manager, getGroupId}) {
+export function createDockWorkspaceSet({manager, getGroupId, documentModel}) {
     const
         groupId     = () => getGroupId?.() ?? null,
         participant = workspaceId => {
@@ -210,7 +212,7 @@ export function createDockWorkspaceSet({manager, getGroupId}) {
         },
 
         /**
-         * Registers-or-replaces one workspace participant in the host's Group. Replacement is
+         * @summary Registers-or-replaces one workspace participant in the host's Group. Replacement is
          * deliberate: a re-embodied vessel re-registers the SAME stable workspace id with fresh
          * accessor seams, and the stale seams must not survive it. Refused while the host has no
          * Group — there is no membership to join yet.
@@ -219,22 +221,99 @@ export function createDockWorkspaceSet({manager, getGroupId}) {
          * @param {Function} seams.getDocument `()` → the workspace's current committed document.
          * @param {Function} [seams.setDocument] `(document)` adopts a committed document; a
          *     participant without one is read-only to `adoptTransfer` (fail closed).
+         * @param {Function} [seams.getRevision] Owner-supplied revision stamp; otherwise reference changes are counted.
+         * @param {Function} [seams.project] Post-commit projection receiving the transaction context.
+         * @param {String} [seams.bindingKey=workspaceId] Window slot whose generation fences this document.
+         * @param {String} [seams.componentId] Opaque live owner lookup; excluded from captured document truth.
          * @returns {Boolean} true when registered
          */
-        register(workspaceId, {getDocument, setDocument} = {}) {
+        register(workspaceId, {getDocument, setDocument, getRevision, project, bindingKey = workspaceId, componentId} = {}) {
             const id = groupId();
 
-            if (!id || !workspaceId || typeof workspaceId !== 'string' || typeof getDocument !== 'function') {
+            if (!id || !workspaceId || typeof workspaceId !== 'string' || typeof getDocument !== 'function' ||
+                (getRevision !== undefined && typeof getRevision !== 'function')) {
                 return false
             }
 
+            let initialized = false, lastDocument, revision = 0;
+
+            // Registration never reads a document: the first transaction establishes the reference.
+            const observeDocument = () => {
+                const value = getDocument();
+                if (!getRevision && initialized && value !== lastDocument) revision++;
+                initialized = true;
+                lastDocument = value;
+                return value
+            };
+            const cloneDocument = value => {
+                if (typeof documentModel?.clone !== 'function' || typeof documentModel?.validate !== 'function') {
+                    throw new TypeError('WorkspaceSet transactions require an injected documentModel')
+                }
+                return documentModel.clone(value)
+            };
+            const entry = {
+                domain     : 'dock',
+                getDocument,
+                setDocument: typeof setDocument === 'function' ? setDocument : null,
+                capture    : () => ({
+                    value     : observeDocument(),
+                    generation: manager.getBinding(id, bindingKey)?.generation || 0,
+                    revision  : getRevision ? getRevision() : revision
+                }),
+                prepare: input => {
+                    const candidate = cloneDocument(input), errors = documentModel.validate(candidate);
+                    if (errors.length) throw new TypeError(`invalid dock document: ${errors.join('; ')}`);
+                    return candidate
+                }
+            };
+
+            if (entry.setDocument) {
+                entry.adopt = (candidate, context) => {
+                    const result = setDocument(cloneDocument(candidate), context);
+                    if (result === false || result?.then) return result;
+                    observeDocument();
+                    return result
+                };
+                entry.compensate = (captured, context) => {
+                    const result = setDocument(cloneDocument(captured.value), context);
+                    if (result === false || result?.then) return result;
+                    lastDocument = getDocument();
+                    initialized = true;
+                    if (!getRevision) revision = captured.revision;
+                    return result
+                }
+            }
+
+            if (typeof project === 'function') entry.project = project;
+            if (componentId !== undefined) entry.componentId = componentId;
+
             return manager.registerParticipant({
-                groupId    : id,
-                participant: {
-                    getDocument,
-                    setDocument: typeof setDocument === 'function' ? setDocument : null
-                },
+                groupId     : id,
+                participant : entry,
                 workspaceKey: workspaceId
+            })
+        },
+
+        /**
+         * @summary Queues keyed document candidates through the Group's participant protocol.
+         * @param {Object<String,Object>} workspaces The workspace keys changed by this transaction.
+         * @param {Object} options Cause, provenance, descriptor and cursorAction for the Group write.
+         * @returns {Promise<Object>} The manager's complete transaction result.
+         */
+        async write(workspaces, {cause, provenance = {}, descriptor = {}, cursorAction = 'append'} = {}) {
+            const id = groupId();
+            if (!id) throw new Error('WorkspaceSet.write requires a bound Group');
+            if (!workspaces || typeof workspaces !== 'object' || Array.isArray(workspaces) ||
+                (Object.getPrototypeOf(workspaces) !== Object.prototype && Object.getPrototypeOf(workspaces) !== null)) {
+                throw new TypeError('WorkspaceSet.write requires documents keyed by workspace')
+            }
+            return manager.write({
+                groupId: id,
+                cause,
+                provenance,
+                descriptor,
+                cursorAction,
+                changes: Object.entries(workspaces).map(([workspaceKey, input]) => ({workspaceKey, input}))
             })
         },
 

--- a/src/manager/Transaction.mjs
+++ b/src/manager/Transaction.mjs
@@ -1,5 +1,6 @@
 import Manager       from './Base.mjs';
 import StateProvider from '../state/Provider.mjs';
+import Commit        from './transaction/Commit.mjs';
 
 /**
  * @summary The worker-side authority for logical topology Groups, their window bindings and their history.
@@ -299,7 +300,7 @@ class Transaction extends Manager {
 
     /**
      * Registers a new Group. The id is minted here unless a carrier presents one this worker never saw.
-     * The history bound is read now: a Group born at depth zero stays without history.
+     * The default history bound is sampled now; the Group may choose its own before loading history.
      * @param {String} [groupId]
      * @returns {Object} The Group record: `{id, bindings, createdAt, participants, historyDepth, history,
      *   historyReady, provider, queue}`
@@ -480,48 +481,9 @@ class Transaction extends Manager {
             group.history = Neo.create(History, {depth: group.historyDepth});
 
             return group.history
-        })
-    }
-
-    /**
-     * Moves a Group's cursor on its queue — after the row was applied. The row a move would return is
-     * read first, `apply` runs with it inside the queued step, and only when it resolved does the cursor
-     * move and the provider publish; a rejected application leaves cursor and provider where they were,
-     * so nothing ever reads a moved cursor as a completed undo before the application held.
-     * @param {String} groupId
-     * @param {String} direction `undo` or `redo`
-     * @param {Function} apply Receives the row; may be async
-     * @returns {Promise<Object|null>}
-     * @protected
-     */
-    moveCursor(groupId, direction, apply) {
-        let me    = this,
-            group = me.get(groupId);
-
-        if (!group) {
-            return Promise.reject(new Error(`${me.className}#${direction}: unknown Group ${groupId}`))
-        }
-
-        if (typeof apply !== 'function') {
-            return Promise.reject(new Error(`${me.className}#${direction}: apply(row) is required — the cursor moves only after the row was applied`))
-        }
-
-        return me.enqueue(group, async () => {
-            me.assertLive(group, direction);
-
-            const row = group.history?.peek(direction) ?? null;
-
-            if (!row) {
-                return null
-            }
-
-            await apply(row);
-
-            me.assertLive(group, direction);
-            group.history[direction]();
-            me.publishHistory(group);
-
-            return row
+        }).catch(error => {
+            group.historyReady = null;
+            throw error
         })
     }
 
@@ -567,15 +529,17 @@ class Transaction extends Manager {
     }
 
     /**
-     * Re-applies the row after a Group's cursor and, once `apply` resolved, moves the cursor onto it.
-     * Resolves to that row, or `null` when there is nothing to redo or the Group keeps no history.
+     * @summary Re-applies the next row through the complete compensating participant protocol.
      * @param {Object} data
      * @param {String} data.groupId
-     * @param {Function} data.apply Receives the row to re-apply; may be async — a rejection leaves the cursor
-     * @returns {Promise<Object|null>}
+     * @param {String} [data.cause='redo']
+     * @param {Object} [data.provenance={}]
+     * @param {Object[]} [data.effects=[]]
+     * @returns {Promise<Object>} The same result as write(); row is null at the cursor bound.
      */
-    redo({groupId, apply}) {
-        return this.moveCursor(groupId, 'redo', apply)
+    redo({groupId, cause = 'redo', provenance = {}, effects = [], apply}) {
+        if (apply !== undefined) return Promise.reject(new TypeError('redo applies registered participants; an external apply callback is not supported'));
+        return this.write({groupId, cause, provenance, effects, cursorAction: 'redo'})
     }
 
     /**
@@ -601,58 +565,61 @@ class Transaction extends Manager {
     }
 
     /**
-     * Applies the reverse of the row at a Group's cursor and, once `apply` resolved, moves the cursor
-     * back. Resolves to that row, or `null` when there is nothing to undo or the Group keeps no history.
+     * @summary Reverses the current row through the complete compensating participant protocol.
      * @param {Object} data
      * @param {String} data.groupId
-     * @param {Function} data.apply Receives the row to reverse; may be async — a rejection leaves the cursor
-     * @returns {Promise<Object|null>}
+     * @param {String} [data.cause='undo']
+     * @param {Object} [data.provenance={}]
+     * @param {Object[]} [data.effects=[]]
+     * @returns {Promise<Object>} The same result as write(); row is null at the cursor bound.
      */
-    undo({groupId, apply}) {
-        return this.moveCursor(groupId, 'undo', apply)
+    undo({groupId, cause = 'undo', provenance = {}, effects = [], apply}) {
+        if (apply !== undefined) return Promise.reject(new TypeError('undo applies registered participants; an external apply callback is not supported'));
+        return this.write({groupId, cause, provenance, effects, cursorAction: 'undo'})
     }
 
     /**
-     * Admits one transaction to a Group. The call joins the Group's queue; at its head the history module
-     * is awaited if the Group keeps history — before any participant mutation — the descriptor is checked
-     * against what the history admits, `adopt` runs with it, the frozen row is appended after the cursor
-     * and the provider is published. The descriptor is enqueued exactly once. An `adopt` that throws
-     * appends nothing and leaves the cursor where it was; the queue moves on to the next write.
-     *
-     * The body of this step is provisional and owned by the atomic-commit leaf: the participant protocol
-     * (prepare every participant → adopt all with compensation → append the row → move the cursor →
-     * publish one snapshot → release the queue) lands here as ONE step under ONE owner, compensation
-     * across a failed append included. Nothing outside this method may depend on its parts being
-     * separate steps; the queue, the barrier and the History are the primitives it composes.
-     * @param {Object} data
-     * @param {String} data.groupId
-     * @param {Object} data.descriptor Plain data describing the transaction — it becomes the history row
-     * @param {Function} [data.adopt] The participant-mutation slot; receives the descriptor, may be async
-     * @returns {Promise<{result: *, row: Object|null}>} `result` is what `adopt` returned; `row` the frozen
-     *   retained row, or `null` for a Group that keeps no history
+     * @summary Captures and prepares at the queue head, then commits participants, history and snapshot
+     * in one compensating critical section. Request data is copied at admission; participants remain
+     * live owners until capture. Presentation runs after queue release and cannot reject the commit.
+     * @param {Object} request
+     * @param {String} request.groupId
+     * @param {String} request.cause Explicit reason for this write, separate from cursorAction.
+     * @param {Object} [request.provenance={}] Plain origin metadata.
+     * @param {Object} [request.descriptor={}] Plain transaction metadata.
+     * @param {Object[]} [request.changes=[]] Unique {workspaceKey, input} entries.
+     * @param {String} [request.cursorAction='append'] append, preserve, undo or redo.
+     * @param {Object[]} [request.effects=[]] {effectId, run} callbacks, invoked after semantic commit.
+     * @returns {Promise<Object>} {row, snapshot, transactionId, notificationErrors}; row/snapshot may be null.
      */
-    write({groupId, descriptor, adopt}) {
+    write(request) {
         let me    = this,
-            group = me.get(groupId);
+            group = me.get(request.groupId);
 
         if (!group) {
-            return Promise.reject(new Error(`${me.className}#write: unknown Group ${groupId}`))
+            return Promise.reject(new Error(`${me.className}#write: unknown Group ${request.groupId}`))
         }
 
-        return me.enqueue(group, async () => {
-            me.assertLive(group, 'write');
+        try {
+            request = Object.freeze({
+                ...request,
+                changes   : Commit.copy(request.changes ?? []),
+                descriptor: Commit.copy(request.descriptor ?? {}),
+                provenance: Commit.copy(request.provenance ?? {}),
+                effects   : (request.effects ?? []).map(effect => Object.freeze({...effect}))
+            })
+        } catch (error) {
+            return Promise.reject(error)
+        }
 
-            const history = await me.loadHistory(group);
-
-            me.assertLive(group, 'write');
-            history?.assertRow(descriptor);
-
-            const result = await adopt?.(descriptor),
-                  row    = history ? history.append(descriptor) : null;
-
-            row && me.publishHistory(group);
-
-            return {result, row}
+        return me.enqueue(group, () => Commit.run(me, group, request)).then(result => {
+            Commit.complete(me, group, result);
+            return {
+                row               : result.row,
+                snapshot          : result.snapshot,
+                transactionId     : result.transactionId,
+                notificationErrors: result.notificationErrors.map(error => error.message)
+            }
         })
     }
 

--- a/src/manager/transaction/Commit.mjs
+++ b/src/manager/transaction/Commit.mjs
@@ -1,0 +1,205 @@
+import Base          from '../../core/Base.mjs';
+import EffectManager from '../../core/EffectManager.mjs';
+
+/**
+ * @summary Executes one Group's semantic write, with presentation outside its critical section.
+ * @description The manager supplies serialization and participant ownership. This executor prepares
+ * immutable endpoints before invoking synchronous, compensatable adopters. History and the current
+ * snapshot join that same rollback boundary; observers run only after all semantic truth agrees.
+ * @class Neo.manager.transaction.Commit
+ * @extends Neo.core.Base
+ */
+class Commit extends Base {
+    static config = {
+        /**
+         * @member {String} className='Neo.manager.transaction.Commit'
+         * @protected
+         */
+        className: 'Neo.manager.transaction.Commit'
+    }
+
+    /**
+     * @summary Copies and freezes a finite JSON value before it reaches a semantic write.
+     * @param {*} value
+     * @returns {*}
+     */
+    static copy(value) {
+        const copy   = structuredClone(value), path = new Set();
+        const freeze = entry => {
+            if (entry === null || typeof entry === 'string' || typeof entry === 'boolean') return entry;
+            if (typeof entry === 'number' && Number.isFinite(entry)) return entry;
+            if (!entry || typeof entry !== 'object' || path.has(entry)) {
+                throw new TypeError('transaction values must be finite JSON data without cycles')
+            }
+            if (!Array.isArray(entry) && Object.getPrototypeOf(entry) !== Object.prototype && Object.getPrototypeOf(entry) !== null) {
+                throw new TypeError('transaction values must contain only plain objects and arrays')
+            }
+            path.add(entry);
+            Object.values(entry).forEach(freeze);
+            path.delete(entry);
+            return Object.freeze(entry)
+        };
+        return freeze(copy)
+    }
+
+    /**
+     * @summary Captures a participant's value and its opaque generation/revision stamps.
+     * @param {Object} participant
+     * @returns {Object}
+     */
+    static capture(participant) {
+        const captured = participant.capture();
+        if (!captured || typeof captured.then === 'function' || !['value', 'generation', 'revision'].every(key => Object.hasOwn(captured, key))) {
+            throw new TypeError('participant capture must synchronously return value, generation and revision')
+        }
+        return this.copy({value: captured.value, generation: captured.generation, revision: captured.revision})
+    }
+
+    /**
+     * @summary Runs at the Group queue head; no awaited work occurs inside adoption/rollback.
+     * @param {Neo.manager.Transaction} manager
+     * @param {Object} group
+     * @param {Object} request
+     * @returns {Promise<Object>}
+     */
+    static async run(manager, group, request) {
+        manager.assertLive(group, 'write');
+        const {
+            cause,
+            cursorAction = 'append',
+            descriptor = {},
+            provenance = {},
+            effects = []
+        } = request;
+        if (!['append', 'preserve', 'undo', 'redo'].includes(cursorAction) || typeof cause !== 'string' || !cause.trim()) {
+            throw new TypeError('a transaction needs a valid cursorAction and an explicit cause')
+        }
+        if (request.adopt !== undefined) {
+            throw new TypeError('write uses registered compensatable participants, not an adopt callback')
+        }
+        const transactionId = crypto.randomUUID();
+        const priorRow      = cursorAction === 'undo' || cursorAction === 'redo' ? group.history?.peek(cursorAction) : null;
+        if ((cursorAction === 'undo' || cursorAction === 'redo') && !priorRow) {
+            return {row: null, snapshot: group.snapshot ?? null, transactionId, notificationErrors: [], plans: [], effects: []}
+        }
+        const changes = priorRow
+            ? priorRow.participants.map(entry => ({workspaceKey: entry.workspaceKey, input: entry[cursorAction === 'undo' ? 'before' : 'after']}))
+            : request.changes ?? [];
+        if (!Array.isArray(changes) || !Array.isArray(effects)) throw new TypeError('changes and effects must be arrays');
+        if (effects.some(effect => typeof effect.effectId !== 'string' || !effect.effectId || typeof effect.run !== 'function') ||
+            new Set(effects.map(effect => effect.effectId)).size !== effects.length) {
+            throw new TypeError('each effect needs a unique effectId and a run callback')
+        }
+        const members = [...group.participants.entries()].sort(([a], [b]) => a.localeCompare(b));
+        const byKey   = new Map(members), changedKeys = new Set();
+        for (const change of changes) {
+            const entry = byKey.get(change.workspaceKey);
+            if (!entry || changedKeys.has(change.workspaceKey) || !['capture', 'prepare', 'adopt', 'compensate'].every(key => typeof entry[key] === 'function')) {
+                throw new TypeError('every changed participant must be unique, registered and compensatable')
+            }
+            changedKeys.add(change.workspaceKey)
+        }
+        const domains = new Set(changes.map(change => byKey.get(change.workspaceKey).domain));
+        if ([...domains].some(domain => typeof domain !== 'string' || !domain.trim()) || domains.size > 1) {
+            throw new TypeError('mixed or undeclared participant domains are not supported')
+        }
+        if (changes.some(change => ['adopt', 'compensate'].some(key =>
+            Object.prototype.toString.call(byKey.get(change.workspaceKey)[key]) === '[object AsyncFunction]'
+        ))) throw new TypeError('participant adoption and compensation must be synchronous');
+        const captures = new Map(members.map(([key, entry]) => [key, this.capture(entry)]));
+        const metadata = this.copy({cause, provenance, descriptor});
+        const plans    = [];
+        for (const change of [...changes].sort((a, b) => a.workspaceKey.localeCompare(b.workspaceKey))) {
+            const participant = byKey.get(change.workspaceKey), captured = captures.get(change.workspaceKey);
+            const context     = Object.freeze({transactionId, cursorAction, ...metadata, workspaceKey: change.workspaceKey, captured});
+            const after       = this.copy(await participant.prepare(this.copy(change.input), captured, context));
+            plans.push({workspaceKey: change.workspaceKey, participant, captured, after, context})
+        }
+        const endpoints = this.copy(plans.map(plan => ({workspaceKey: plan.workspaceKey, before: plan.captured.value, after: plan.after})));
+        const rowData   = this.copy({...descriptor, transactionId, cause, provenance, participants: endpoints});
+        const values    = Object.fromEntries(members.map(([key]) => [key, captures.get(key).value]));
+        plans.forEach(plan => values[plan.workspaceKey] = plan.after);
+        const snapshot = this.copy({version: (group.snapshot?.version ?? 0) + 1, participants: values});
+        const history  = cursorAction === 'preserve' ? group.history : await manager.loadHistory(group);
+        if (cursorAction === 'append') history?.assertRow(rowData);
+        if (cursorAction === 'preserve' && history?.count) throw new Error('preserve is only valid for an empty history baseline');
+        manager.assertLive(group, 'write');
+        if (group.participants.size !== members.length || members.some(([key, entry]) => {
+            if (group.participants.get(key) !== entry) return true;
+            const now = this.capture(entry), captured = captures.get(key);
+            return now.generation !== captured.generation || now.revision !== captured.revision
+        })) throw new Error('participant membership, generation or revision changed during preparation');
+
+        const checkpoint = history?.captureState(), previousSnapshot = group.snapshot ?? null;
+        const invoked    = [], notificationErrors = [], queuedBefore = new Set(EffectManager.queuedEffects);
+        let   row        = priorRow, failed = false, failure;
+        EffectManager.pause();
+        try {
+            for (const plan of plans) {
+                invoked.push(plan);
+                const result = plan.participant.adopt(plan.after, plan.context);
+                if (result === false || result?.then) throw new Error(`participant ${plan.workspaceKey} adoption must be synchronous and accepted`)
+            }
+            if (cursorAction === 'append') row = history ? history.append(rowData) : null;
+            else if (cursorAction === 'undo' || cursorAction === 'redo') history[cursorAction]();
+            group.snapshot = snapshot
+        } catch (error) {
+            failed = true;
+            const rollbackErrors = [];
+            try { checkpoint && history.restoreState(checkpoint) } catch (rollbackError) { rollbackErrors.push(rollbackError) }
+            for (const plan of invoked.reverse()) {
+                try {
+                    const result = plan.participant.compensate(plan.captured, plan.context);
+                    if (result === false || result?.then) throw new Error(`participant ${plan.workspaceKey} compensation must be synchronous and accepted`)
+                } catch (rollbackError) { rollbackErrors.push(rollbackError) }
+            }
+            group.snapshot = previousSnapshot;
+            for (const effect of EffectManager.queuedEffects) {
+                if (!queuedBefore.has(effect)) EffectManager.queuedEffects.delete(effect)
+            }
+            failure = rollbackErrors.length ? new AggregateError([error, ...rollbackErrors], String(error?.message ?? error)) : error
+        }
+        if (!failed) {
+            try { manager.publishHistory(group) } catch (error) { notificationErrors.push(error) }
+        }
+        try { EffectManager.resume() } catch (error) { notificationErrors.push(error) }
+        if (failed) throw failure;
+
+        const result = {row, snapshot, transactionId, notificationErrors, plans, effects};
+        try { manager.fire('commit', {groupId: group.id, row, snapshot, transactionId}) } catch (error) { notificationErrors.push(error) }
+        return result
+    }
+
+    /**
+     * @summary Schedules presentation after queue release; failures never reject the committed write.
+     * @param {Neo.manager.Transaction} manager
+     * @param {Object} group
+     * @param {Object} result
+     */
+    static complete(manager, group, result) {
+        const receipt = (kind, id, observation, error = null) => {
+            const value = this.copy({transactionId: result.transactionId, kind, id, observation: observation ?? null, error: error?.message ?? null});
+            try { manager.fire('effectReceipt', {groupId: group.id, receipt: value}) } catch (notificationError) { Neo.logError(notificationError) }
+        };
+        for (const plan of result.plans) {
+            if (typeof plan.participant.project === 'function') {
+                Promise.resolve().then(() => {
+                    if (manager.get(group.id) !== group || group.snapshot !== result.snapshot ||
+                        group.participants.get(plan.workspaceKey) !== plan.participant ||
+                        plan.participant.capture().generation !== plan.captured.generation) return;
+                    return plan.participant.project({...plan.context, snapshot: result.snapshot})
+                })
+                    .catch(error => receipt('projection', plan.workspaceKey, null, error))
+            }
+        }
+        for (const effect of result.effects) {
+            Promise.resolve().then(() => {
+                if (manager.get(group.id) !== group) throw new Error('effect Group was retired');
+                return effect.run({transactionId: result.transactionId, snapshot: result.snapshot})
+            }).then(observation => receipt('native', effect.effectId, observation))
+                .catch(error => receipt('native', effect.effectId, null, error))
+        }
+    }
+}
+
+export default Neo.setupClass(Commit);

--- a/src/manager/transaction/Commit.mjs
+++ b/src/manager/transaction/Commit.mjs
@@ -57,6 +57,7 @@ class Commit extends Base {
 
     /**
      * @summary Runs at the Group queue head; no awaited work occurs inside adoption/rollback.
+     * Transaction id, cause, provenance and participant endpoints override descriptor fields in the retained row.
      * @param {Neo.manager.Transaction} manager
      * @param {Object} group
      * @param {Object} request

--- a/src/manager/transaction/History.mjs
+++ b/src/manager/transaction/History.mjs
@@ -70,8 +70,9 @@ function deepFreeze(value) {
  * to every depth before it becomes a member. A retained row cannot change — not a nested field, not a
  * whole-field replacement — so the bytes it serializes to are the bytes it was admitted with. The
  * Collection that holds them is owned and private, so the only writes that reach the rows are
- * {@link #append}, {@link #undo} and {@link #redo}; anything a consumer wants mutable (a grid, a Neural
- * Link projection) is a clone fed from {@link #rows}, never this authority.
+ * {@link #append}, {@link #undo} and {@link #redo}, plus queued-write rollback through an issued
+ * {@link #captureState} checkpoint. Anything a consumer wants mutable (a grid, a Neural Link projection)
+ * is a clone fed from {@link #rows}, never this authority.
  *
  * The cursor names the row the Group's current state reflects: `-1` before the first row, or after every
  * retained row was undone. {@link #undo} and {@link #redo} only move the cursor and return the row —
@@ -109,6 +110,13 @@ class History extends Base {
      * @private
      */
     #rows = null
+    /**
+     * Rollback state keyed by the opaque checkpoint held by a queued writer. Weak keys release it
+     * when that writer finishes without rollback; no second retained log survives the token.
+     * @member {WeakMap<Object, Object>} #checkpoints
+     * @private
+     */
+    #checkpoints = new WeakMap()
     /**
      * The index of the row the Group's current state reflects; `-1` before the first row or after undoing
      * every retained row.
@@ -243,6 +251,26 @@ class History extends Base {
     }
 
     /**
+     * @summary Captures the exact rows, cursor and sequence for one queued write's rollback.
+     * @returns {Object} Frozen opaque checkpoint, usable once by this live History only.
+     */
+    captureState() {
+        if (!this.#rows || this.isDestroying) {
+            throw new TypeError(`${this.className}: cannot checkpoint a retired history`)
+        }
+
+        const checkpoint = Object.freeze({});
+
+        this.#checkpoints.set(checkpoint, Object.freeze({
+            cursor  : this.cursor,
+            rows    : Object.freeze(this.rows),
+            sequence: this.sequence
+        }));
+
+        return checkpoint
+    }
+
+    /**
      * A bound that cannot be enforced is refused before the instance exists: construction is the one place
      * a refusal can be a throw without leaving a half-set config behind.
      * @param {Object} config
@@ -272,11 +300,12 @@ class History extends Base {
     }
 
     /**
-     * Releases the owned Collection with the rows.
+     * @summary Releases the owned Collection and invalidates issued checkpoints.
      */
     destroy() {
         this.#rows?.destroy();
         this.#rows = null;
+        this.#checkpoints = new WeakMap();
 
         super.destroy()
     }
@@ -342,6 +371,36 @@ class History extends Base {
         me.cursor++;
 
         return me.getAt(me.cursor)
+    }
+
+    /**
+     * @summary Rolls back one issued checkpoint without cloning rows or publishing a Collection
+     * mutation. The queued writer owns observer publication; a failed restore keeps its token.
+     * @param {Object} checkpoint The unmodified token returned by this History's captureState().
+     */
+    restoreState(checkpoint) {
+        const
+            rows  = this.#rows,
+            state = this.#checkpoints.get(checkpoint);
+
+        if (!rows || this.isDestroying || !state) {
+            throw new TypeError(`${this.className}: checkpoint must belong to this live history`)
+        }
+
+        rows.startUpdate(true);
+
+        try {
+            rows.splice(0, rows.getRange().length);
+            rows.add(state.rows);
+            // Silent update brackets leave count unchanged; restore its public cache explicitly.
+            rows.count = state.rows.length;
+            this.cursor = state.cursor;
+            this.sequence = state.sequence
+        } finally {
+            rows.endUpdate(true)
+        }
+
+        this.#checkpoints.delete(checkpoint)
     }
 
     /**

--- a/test/playwright/unit/dashboard/DockWorkspaceSet.spec.mjs
+++ b/test/playwright/unit/dashboard/DockWorkspaceSet.spec.mjs
@@ -72,7 +72,7 @@ test.describe('Neo.dashboard.dock.window.WorkspaceSet — the dock adapter over 
 
         expect(set.register('main', holder.seams)).toBe(true);
         expect(TransactionManager.getParticipant(groupId, 'main'), 'the adapter kept no entry of its own — the Group holds it')
-            .toEqual({getDocument: holder.seams.getDocument, setDocument: holder.seams.setDocument});
+            .toMatchObject({getDocument: holder.seams.getDocument, setDocument: holder.seams.setDocument});
 
         // The host window dies; its binding is released and its lease runs out.
         TransactionManager.reconnectLeaseMs = 20;

--- a/test/playwright/unit/dashboard/DockWorkspaceSetTransaction.spec.mjs
+++ b/test/playwright/unit/dashboard/DockWorkspaceSetTransaction.spec.mjs
@@ -1,0 +1,204 @@
+import {setup} from '../../setup.mjs';
+
+setup({appConfig: {name: 'DockWorkspaceSetTransactionTest'}});
+
+import {expect, test}           from '@playwright/test';
+import Neo                      from '../../../../src/Neo.mjs';
+import * as core                from '../../../../src/core/_export.mjs';
+import TransactionManager       from '../../../../src/manager/Transaction.mjs';
+import WorkspaceDocument        from '../../../../src/dashboard/dock/model/WorkspaceDocument.mjs';
+import {createDockWorkspaceSet} from '../../../../src/dashboard/dock/window/WorkspaceSet.mjs';
+
+/** @summary Creates a valid, item-disjoint dock document. @param {String} key @param {String} title @returns {Object} */
+function document(key, title = 'before') {
+    return {
+        schema: WorkspaceDocument.SCHEMA,
+        root  : 'root',
+        items : {[key]: {componentRef: key, title, kind: 'panel'}},
+        nodes : {root: {type: 'tabs', items: [key], activeItemId: key}}
+    }
+}
+
+/** @summary Exercises the dock adapter through the real Group writer and document validator. */
+test.describe.serial('Dock WorkspaceSet transaction participants', () => {
+    let binding, groupId, set;
+
+    test.beforeEach(() => {
+        binding = TransactionManager.bind({windowId: 'workspace-set-transaction-root', workspaceKey: 'main'});
+        groupId = binding.groupId;
+        TransactionManager.setHistoryDepth({groupId, depth: 5});
+        const popup = TransactionManager.reserve({groupId, workspaceKey: 'popup'});
+        TransactionManager.bind({...popup, windowId: 'workspace-set-transaction-popup'});
+        set = createDockWorkspaceSet({manager: TransactionManager, getGroupId: () => groupId, documentModel: WorkspaceDocument})
+    });
+
+    test.afterEach(() => TransactionManager.retireGroup(groupId));
+
+    /** @summary Registers a document holder without reading it during registration. @param {String} key @param {Object} options @returns {Object} */
+    function holder(key, {project, fail} = {}) {
+        const state = {document: document(key), reads: 0, writes: []};
+        state.seams = {
+            getDocument: () => { state.reads++; return state.document },
+            setDocument: value => {
+                state.writes.push(value);
+                state.document = value;
+                if (fail?.(value)) throw new Error('second setter refused')
+            },
+            project
+        };
+        expect(set.register(key, state.seams)).toBe(true);
+        expect(state.reads).toBe(0);
+        return state
+    }
+
+    const write = (workspaces, options = {}) => set.write(workspaces, {cause: 'replace-workspaces', provenance: {origin: 'unit'}, ...options});
+
+    test('two valid documents commit once through the Group; projection observes both committed owners', async () => {
+        const projected = [];
+        const main      = holder('main', {project: context => projected.push({
+            transactionId: context.transactionId,
+            main         : main.document.items.main.title,
+            popup        : popup.document.items.popup.title,
+            count        : TransactionManager.get(groupId).history.count
+        })});
+        const popup    = holder('popup');
+        const mainNext = document('main', 'after'), popupNext = document('popup', 'after');
+
+        const result = await write({popup: popupNext, main: mainNext}, {descriptor: {kind: 'paired-layout'}});
+
+        expect(main.document).toEqual(mainNext);
+        expect(popup.document).toEqual(popupNext);
+        expect(main.document).not.toBe(mainNext);
+        expect(main.document).not.toBe(result.row.participants[0].after);
+        expect(result.row.kind).toBe('paired-layout');
+        expect(result.row.participants.map(entry => entry.workspaceKey)).toEqual(['main', 'popup']);
+        expect(result.row.participants[0].before).toEqual(document('main'));
+        expect(result.snapshot.participants).toEqual({main: mainNext, popup: popupNext});
+        expect(TransactionManager.getParticipant(groupId, 'main').capture().revision).toBe(1);
+        await expect.poll(() => projected.length).toBe(1);
+        expect(projected[0]).toEqual({transactionId: result.transactionId, main: 'after', popup: 'after', count: 1})
+    });
+
+    test('an invalid second candidate refuses before either document is written', async () => {
+        const main    = holder('main'), popup = holder('popup');
+        const invalid = {...document('popup'), root: 'missing'};
+
+        await expect(write({main: document('main', 'after'), popup: invalid})).rejects.toThrow(/invalid dock document/);
+
+        expect(main.writes).toEqual([]);
+        expect(popup.writes).toEqual([]);
+        expect(main.document).toEqual(document('main'));
+        expect(popup.document).toEqual(document('popup'));
+        expect(TransactionManager.get(groupId).history?.count ?? 0).toBe(0)
+    });
+
+    test('a second setter that mutates then throws compensates both documents and restores reference revisions', async () => {
+        let   refuse = true;
+        const main   = holder('main');
+        const popup  = holder('popup', {fail: value => refuse && value.items.popup.title === 'after'});
+
+        await expect(write({main: document('main', 'after'), popup: document('popup', 'after')})).rejects.toThrow('second setter refused');
+
+        expect(main.document).toEqual(document('main'));
+        expect(popup.document).toEqual(document('popup'));
+        expect(main.writes.map(value => value.items.main.title)).toEqual(['after', 'before']);
+        expect(popup.writes.map(value => value.items.popup.title)).toEqual(['after', 'before']);
+        expect(TransactionManager.getParticipant(groupId, 'main').capture().revision).toBe(0);
+        expect(TransactionManager.getParticipant(groupId, 'popup').capture().revision).toBe(0);
+        expect(TransactionManager.get(groupId).history?.count ?? 0).toBe(0);
+        expect(TransactionManager.get(groupId).snapshot ?? null).toBeNull();
+
+        refuse = false;
+        await write({main: document('main', 'next'), popup: document('popup', 'next')});
+        expect(TransactionManager.get(groupId).history.count).toBe(1);
+        expect(TransactionManager.getParticipant(groupId, 'main').capture().revision).toBe(1)
+    });
+
+    test('a generation changing during preparation refuses before document adoption', async () => {
+        const main        = holder('main'), popup = holder('popup');
+        const participant = TransactionManager.getParticipant(groupId, 'main'), prepare = participant.prepare;
+        let entered, release;
+        const started = new Promise(resolve => entered = resolve), gate = new Promise(resolve => release = resolve);
+        participant.prepare = async (...args) => { const candidate = prepare(...args); entered(); await gate; return candidate };
+
+        const pending = write({main: document('main', 'after'), popup: document('popup', 'after')});
+        await started;
+        TransactionManager.release(binding.windowId);
+        TransactionManager.bind({...binding, windowId: 'workspace-set-transaction-reloaded'});
+        expect(TransactionManager.getBinding(groupId, 'main').generation).toBe(2);
+        release();
+
+        await expect(pending).rejects.toThrow(/changed/);
+        expect(main.writes).toEqual([]);
+        expect(popup.writes).toEqual([]);
+        expect(TransactionManager.get(groupId).history?.count ?? 0).toBe(0)
+    });
+
+    test('a document key distinct from its window binding rejects a reload during preparation', async () => {
+        const main = holder('workstation-main');
+        set.register('workstation-main', {...main.seams, bindingKey: 'main', componentId: 'live-workspace'});
+        const participant = TransactionManager.getParticipant(groupId, 'workstation-main');
+        const prepare     = participant.prepare;
+        let entered, release;
+        const started = new Promise(resolve => entered = resolve), gate = new Promise(resolve => release = resolve);
+        participant.prepare = async (...args) => { const candidate = prepare(...args); entered(); await gate; return candidate };
+
+        const pending = write({'workstation-main': document('workstation-main', 'after')});
+        await started;
+        TransactionManager.release(binding.windowId);
+        TransactionManager.bind({...binding, windowId: 'workspace-set-transaction-reloaded'});
+        release();
+
+        await expect(pending).rejects.toThrow(/changed/);
+        expect(main.writes).toEqual([]);
+        expect(participant.capture().generation).toBe(2);
+        expect(participant.componentId).toBe('live-workspace');
+        expect(participant.capture()).not.toHaveProperty('componentId');
+        participant.prepare = prepare;
+        const result = await write({'workstation-main': document('workstation-main', 'next')});
+        expect(JSON.stringify(result.snapshot)).not.toContain('live-workspace')
+    });
+
+    test('reference revisions observe outside document replacements, while an explicit revision getter remains authoritative', () => {
+        const main        = holder('main');
+        const participant = TransactionManager.getParticipant(groupId, 'main');
+        expect(participant.capture().revision).toBe(0);
+        main.document = WorkspaceDocument.clone(main.document);
+        expect(participant.capture().revision).toBe(1);
+        expect(participant.capture().revision).toBe(1);
+
+        let revision = 42, reads = 0;
+        set.register('main', {...main.seams, getRevision: () => { reads++; return revision }});
+        expect(reads).toBe(0);
+        const explicit = TransactionManager.getParticipant(groupId, 'main');
+        expect(explicit.capture().revision).toBe(42);
+        revision++;
+        expect(explicit.capture().revision).toBe(43)
+    });
+
+    test('read-only slots contribute capture to the Group snapshot but cannot receive a write', async () => {
+        const main = holder('main'), popup = holder('popup');
+        set.register('popup', {getDocument: popup.seams.getDocument});
+        const readOnly = TransactionManager.getParticipant(groupId, 'popup');
+        expect(typeof readOnly.capture).toBe('function');
+        expect(readOnly.adopt).toBeUndefined();
+        expect(readOnly.compensate).toBeUndefined();
+
+        const result = await write({main: document('main', 'after')});
+        expect(result.snapshot.participants.popup).toEqual(document('popup'));
+        await expect(write({popup: document('popup', 'after')})).rejects.toThrow(/compensatable/);
+        expect(main.document.items.main.title).toBe('after');
+        expect(popup.writes).toEqual([])
+    });
+
+    test('the model seam is required by queued writes without changing synchronous adoption', async () => {
+        const main   = holder('main');
+        const legacy = createDockWorkspaceSet({manager: TransactionManager, getGroupId: () => groupId});
+        legacy.register('main', main.seams);
+
+        expect(legacy.adoptAll({main: document('main', 'synchronous')})).toBe(true);
+        await expect(legacy.write({main: document('main', 'queued')}, {cause: 'test'})).rejects.toThrow(/injected documentModel/);
+        expect(main.document.items.main.title).toBe('synchronous');
+        expect(main.writes).toHaveLength(1)
+    })
+});

--- a/test/playwright/unit/manager/TransactionAtomic.spec.mjs
+++ b/test/playwright/unit/manager/TransactionAtomic.spec.mjs
@@ -1,0 +1,271 @@
+import {setup} from '../../setup.mjs';
+
+setup({appConfig: {name: 'TransactionAtomicTest'}});
+
+import {expect, test} from '@playwright/test';
+import Neo            from '../../../../src/Neo.mjs';
+import * as core      from '../../../../src/core/_export.mjs';
+
+/**
+ * @summary Failure controls for one Group's complete semantic write, through the real manager.
+ */
+test.describe.serial('Neo.manager.Transaction atomic participant writes', () => {
+    let manager;
+
+    test.beforeAll(async () => {
+        manager = (await import('../../../../src/manager/Transaction.mjs')).default
+    });
+
+    test.beforeEach(() => {
+        [...manager.items].forEach(group => manager.retireGroup(group.id));
+        manager.historyDepth = 0
+    });
+
+    test.afterEach(() => {
+        [...manager.items].forEach(group => manager.retireGroup(group.id))
+    });
+
+    /**
+     * @summary Registers a versioned, effect-free participant with observable protocol steps.
+     * @param {String} groupId
+     * @param {String} key
+     * @param {Array} log
+     * @param {Object} options
+     * @returns {Object}
+     */
+    function participant(groupId, key, log, options = {}) {
+        const state = {value: {count: 0}, revision: 0, generation: 1};
+        const entry = {
+            domain : options.domain || 'dock',
+            capture: () => ({...state, value: structuredClone(state.value)}),
+            prepare: async (input, captured) => {
+                log.push(`prepare:${key}:${captured.value.count}`);
+                return options.prepare ? options.prepare(input, captured) : input
+            },
+            adopt: value => {
+                log.push(`adopt:${key}`);
+                state.value = structuredClone(value);
+                state.revision++;
+                if (options.failAdopt) throw new Error(`adopt:${key}:refused`)
+            },
+            compensate: captured => {
+                log.push(`compensate:${key}`);
+                Object.assign(state, captured, {value: structuredClone(captured.value)})
+            },
+            project: () => log.push(`project:${key}`)
+        };
+
+        manager.registerParticipant({groupId, workspaceKey: key, participant: entry});
+        return {entry, state}
+    }
+
+    /** @summary Creates a Group with enabled bounded history. @returns {String} */
+    function group() {
+        const {groupId} = manager.bind({windowId: 'atomic-root', workspaceKey: 'main'});
+        manager.setHistoryDepth({groupId, depth: 5});
+        return groupId
+    }
+
+    /** @summary Supplies explicit cause/provenance for a semantic write. @param {Object} data @returns {Promise<Object>} */
+    const write = data => manager.write({cause: 'test-operation', provenance: {origin: 'unit'}, ...data});
+
+    test('a second adopter that mutates then throws compensates both in reverse order and publishes nothing', async () => {
+        const groupId = group(), log = [];
+        const a       = participant(groupId, 'a', log);
+        const b       = participant(groupId, 'b', log, {failAdopt: true});
+        const events  = [], listener = event => events.push(event);
+        manager.on('commit', listener);
+        try {
+            await expect(write({groupId, changes: [
+                {workspaceKey: 'b', input: {count: 2}},
+                {workspaceKey: 'a', input: {count: 1}}
+            ]})).rejects.toThrow('adopt:b:refused');
+            expect(a.state).toEqual({value: {count: 0}, revision: 0, generation: 1});
+            expect(b.state).toEqual({value: {count: 0}, revision: 0, generation: 1});
+            expect(log).toEqual(['prepare:a:0', 'prepare:b:0', 'adopt:a', 'adopt:b', 'compensate:b', 'compensate:a']);
+            expect(manager.get(groupId).history?.count ?? 0).toBe(0);
+            expect(manager.get(groupId).snapshot ?? null).toBeNull();
+            expect(events).toEqual([])
+        } finally {
+            manager.un('commit', listener)
+        }
+    });
+
+    test('a prepare refusal touches no participant and the next queued write captures the current value', async () => {
+        const groupId = group(), log = [];
+        const a       = participant(groupId, 'a', log, {
+            prepare: (input, captured) => {
+                if (input.fail) throw new Error('prepare refused');
+                return {count: captured.value.count + input.increment}
+            }
+        });
+        const failed = write({groupId, changes: [{workspaceKey: 'a', input: {fail: true}}]});
+        const next   = write({groupId, changes: [{workspaceKey: 'a', input: {increment: 1}}]});
+        await expect(failed).rejects.toThrow('prepare refused');
+        const result = await next;
+        expect(a.state.value.count).toBe(1);
+        expect(result.row.participants[0].before).toEqual({count: 0});
+        expect(manager.get(groupId).history.count).toBe(1)
+    });
+
+    test('a queued write captures at its own head, and generation drift refuses before adoption', async () => {
+        const groupId = group(), log = [];
+        let release, started;
+        const entered = new Promise(resolve => started = resolve);
+        const gate    = new Promise(resolve => release = resolve);
+        const a       = participant(groupId, 'a', log, {
+            prepare: async (input, captured) => {
+                if (input.wait) { started(); await gate }
+                return {count: captured.value.count + 1}
+            }
+        });
+        const first  = write({groupId, changes: [{workspaceKey: 'a', input: {wait: true}}]});
+        const second = write({groupId, changes: [{workspaceKey: 'a', input: {}}]});
+        await entered;
+        release();
+        const results = await Promise.all([first, second]);
+        expect(results.map(result => result.row.participants[0].before.count)).toEqual([0, 1]);
+        expect(a.state.value.count).toBe(2);
+
+        a.entry.prepare = async () => { a.state.generation++; return {count: 9} };
+        await expect(write({groupId, changes: [{workspaceKey: 'a', input: {}}]})).rejects.toThrow(/changed/);
+        expect(a.state.value.count).toBe(2);
+        expect(manager.get(groupId).history.count).toBe(2)
+    });
+
+    test('history failure after adoption restores history, participant revisions and the previous snapshot', async () => {
+        const groupId = group(), log = [];
+        const a       = participant(groupId, 'a', log);
+        await write({groupId, changes: [{workspaceKey: 'a', input: {count: 1}}]});
+        const record   = manager.get(groupId), history = record.history;
+        const snapshot = record.snapshot, before = JSON.stringify(history.toJSON());
+        const append   = history.append;
+        history.append = function(descriptor) { append.call(this, descriptor); throw new Error('append failed after mutation') };
+        try {
+            await expect(write({groupId, changes: [{workspaceKey: 'a', input: {count: 2}}]})).rejects.toThrow('append failed');
+            expect(a.state.value.count).toBe(1);
+            expect(a.state.revision).toBe(1);
+            expect(JSON.stringify(history.toJSON())).toBe(before);
+            expect(record.snapshot).toBe(snapshot)
+        } finally { history.append = append }
+        await write({groupId, changes: [{workspaceKey: 'a', input: {count: 3}}]});
+        expect(a.state.value.count).toBe(3)
+    });
+
+    test('a falsy thrown refusal still rolls back and never publishes a commit', async () => {
+        const groupId = group(), log = [];
+        const a       = participant(groupId, 'a', log), adopt = a.entry.adopt;
+        const events  = [], listener = event => events.push(event);
+        manager.on('commit', listener);
+        try {
+            for (const refusal of [null, false, 0, '']) {
+                a.entry.adopt = value => { adopt(value); throw refusal };
+                await expect(write({groupId, changes: [{workspaceKey: 'a', input: {count: 1}}]})).rejects.toBe(refusal);
+                expect(a.state.value.count).toBe(0);
+                expect(manager.get(groupId).snapshot ?? null).toBeNull();
+                expect(events).toEqual([])
+            }
+            a.entry.adopt = adopt;
+            await write({groupId, changes: [{workspaceKey: 'a', input: {count: 2}}]});
+            expect(a.state.value.count).toBe(2)
+        } finally { manager.un('commit', listener) }
+    });
+
+    test('mixed participant domains refuse before prepare and adoption', async () => {
+        const groupId = group(), log = [];
+        participant(groupId, 'dock', log);
+        participant(groupId, 'command', log, {domain: 'command'});
+        await expect(write({groupId, changes: [
+            {workspaceKey: 'dock', input: {count: 1}},
+            {workspaceKey: 'command', input: {count: 1}}
+        ]})).rejects.toThrow(/mixed/);
+        expect(log).toEqual([])
+    });
+
+    test('cold preserve, append, undo and redo share adoption while retaining their row-count rules', async () => {
+        const groupId = group(), log = [];
+        const a       = participant(groupId, 'a', log);
+        const cold    = await write({groupId, cursorAction: 'preserve', changes: [{workspaceKey: 'a', input: {count: 4}}]});
+        expect(cold.row).toBeNull();
+        expect(manager.get(groupId).history).toBeNull();
+        expect(a.state.value.count).toBe(4);
+        await write({groupId, cause: 'user-restore', changes: [{workspaceKey: 'a', input: {count: 7}}]});
+        const history = manager.get(groupId).history;
+        const row     = history.current;
+        expect((await manager.undo({groupId})).row).toBe(row);
+        expect(a.state.value.count).toBe(4);
+        expect(history.cursor).toBe(-1);
+        expect(history.count).toBe(1);
+        expect((await manager.redo({groupId})).row).toBe(row);
+        expect(a.state.value.count).toBe(7);
+        expect(history.cursor).toBe(0);
+        expect(history.count).toBe(1)
+    });
+
+    test('a cursor update throwing after it moved rolls back participant, cursor and snapshot', async () => {
+        const groupId = group(), log = [];
+        const a       = participant(groupId, 'a', log);
+        await write({groupId, changes: [{workspaceKey: 'a', input: {count: 1}}]});
+        const record = manager.get(groupId), history = record.history, snapshot = record.snapshot;
+        const before = JSON.stringify(history.toJSON()), undo = history.undo;
+        history.undo = function() { undo.call(this); throw new Error('cursor failed after mutation') };
+        try {
+            await expect(manager.undo({groupId})).rejects.toThrow('cursor failed');
+            expect(a.state.value.count).toBe(1);
+            expect(a.state.revision).toBe(1);
+            expect(JSON.stringify(history.toJSON())).toBe(before);
+            expect(record.snapshot).toBe(snapshot)
+        } finally { history.undo = undo }
+    });
+
+    test('a synchronous observer sees complete frozen truth, can enqueue, and cannot reject the committed write', async () => {
+        const groupId = group(), log = [];
+        const a       = participant(groupId, 'a', log), provider = manager.getProvider(groupId);
+        let next;
+        const listener = ({snapshot, row}) => {
+            expect(Object.isFrozen(snapshot)).toBe(true);
+            expect(Object.isFrozen(snapshot.participants.a)).toBe(true);
+            expect(Object.isFrozen(row.participants[0].after)).toBe(true);
+            expect(a.state.value).toEqual(snapshot.participants.a);
+            expect(provider.getData('historyLength')).toBe(manager.get(groupId).history.count);
+            if (snapshot.version === 1) {
+                next = write({groupId, changes: [{workspaceKey: 'a', input: {count: 2}}]});
+                throw new Error('observer failed')
+            }
+        };
+        manager.on('commit', listener);
+        try {
+            const first = await write({groupId, changes: [{workspaceKey: 'a', input: {count: 1}}]});
+            expect(first.notificationErrors).toEqual(['observer failed']);
+            expect(first.snapshot.participants.a.count).toBe(1);
+            await next;
+            expect(a.state.value.count).toBe(2);
+            expect(manager.get(groupId).history.count).toBe(2)
+        } finally { manager.un('commit', listener) }
+    });
+
+    test('pending native work and rejected projection cannot block or undo a later semantic write', async () => {
+        const groupId = group(), log = [], receipts = [];
+        const a       = participant(groupId, 'a', log);
+        a.entry.project = () => Promise.reject(new Error('projection failed'));
+        let rejectEffect, effectStarted;
+        const started  = new Promise(resolve => effectStarted = resolve);
+        const held     = new Promise((resolve, reject) => rejectEffect = reject);
+        const listener = ({receipt}) => receipts.push(receipt);
+        manager.on('effectReceipt', listener);
+        try {
+            const first = await write({groupId, changes: [{workspaceKey: 'a', input: {count: 1}}], effects: [
+                {effectId: 'native-close', run: () => { effectStarted(); return held }}
+            ]});
+            await started;
+            const second = await write({groupId, changes: [{workspaceKey: 'a', input: {count: 2}}]});
+            expect(second.snapshot.participants.a.count).toBe(2);
+            rejectEffect(new Error('native refused'));
+            await new Promise(resolve => setTimeout(resolve, 0));
+            expect(receipts.some(receipt => receipt.transactionId === first.transactionId && receipt.error === 'native refused')).toBe(true);
+            expect(receipts.some(receipt => receipt.error === 'projection failed')).toBe(true);
+            expect(a.state.value.count).toBe(2);
+            expect(manager.get(groupId).history.count).toBe(2)
+        } finally { manager.un('effectReceipt', listener) }
+    })
+});

--- a/test/playwright/unit/manager/TransactionWrite.spec.mjs
+++ b/test/playwright/unit/manager/TransactionWrite.spec.mjs
@@ -19,13 +19,49 @@ import StateProvider   from '../../../../src/state/Provider.mjs';
  * The write side of a Group: the serialized queue, the admission barrier that loads the history module once
  * and only for a Group that keeps history, the cursor moves that wait for their application, the Group-local
  * depth, and the Group provider every bound window reads. The manager is driven the way a host does —
- * `bind`, then `write` / `undo` / `redo` — with `adopt` and `apply` as observed slots standing in for the
- * participant protocol a later leaf fills.
+ * `bind`, then `write` / `undo` / `redo` — with registered, versioned participants applying their own
+ * prepared values and the history's retained endpoints.
  */
 test.describe.serial('Neo.manager.Transaction — history admission, the queue and the Group provider', () => {
     let Transaction, importHistory, imports, log;
 
-    const noop = () => {};
+    /** @summary Supplies write metadata while retaining explicit participant changes. @param {Object} data @returns {Promise<Object>} */
+    const write = data => Transaction.write({cause: 'test-write', provenance: {origin: 'unit'}, changes: [], ...data});
+    /** @summary Reverses retained participant endpoints through the queued command. @param {Object} data @returns {Promise<Object>} */
+    const undo = data => Transaction.undo({cause: 'undo', provenance: {origin: 'unit'}, ...data});
+    /** @summary Reapplies retained participant endpoints through the queued command. @param {Object} data @returns {Promise<Object>} */
+    const redo = data => Transaction.redo({cause: 'redo', provenance: {origin: 'unit'}, ...data});
+
+    /** @summary Writes one prepared value through the registered main participant. @param {String} groupId @param {String} kind @returns {Promise<Object>} */
+    const writeValue = (groupId, kind) => write({
+        groupId,
+        descriptor: {kind},
+        changes   : [{workspaceKey: 'main', input: {kind}}]
+    });
+
+    /**
+     * @summary Registers a versioned value owner whose adoption can be observed or refused.
+     * @param {String} groupId
+     * @param {Function} [onAdopt]
+     * @returns {Object} The participant's mutable source state.
+     */
+    const registerValue = (groupId, onAdopt = () => {}) => {
+        const state = {value: {kind: 'initial'}, generation: 1, revision: 0};
+
+        expect(Transaction.registerParticipant({groupId, workspaceKey: 'main', participant: {
+            domain : 'dock',
+            capture: () => ({...state, value: structuredClone(state.value)}),
+            prepare: input => input,
+            adopt  : (value, context) => {
+                onAdopt(value, context);
+                state.value = structuredClone(value);
+                state.revision++
+            },
+            compensate: captured => Object.assign(state, captured, {value: structuredClone(captured.value)})
+        }})).toBe(true);
+
+        return state
+    };
 
     const reset = () => {
         [...Transaction.items].forEach(group => Transaction.retireGroup(group.id));
@@ -59,44 +95,45 @@ test.describe.serial('Neo.manager.Transaction — history admission, the queue a
 
     test.afterEach(reset);
 
-    test('a Group at depth zero admits writes without the history module: adopt runs once, no row, no import', async () => {
+    test('a Group at depth zero admits participant writes without the history module: one adoption, no row, no import', async () => {
         const {groupId} = Transaction.bind({windowId: 'w1', workspaceKey: 'main'}),
               seen      = [],
-              outcome   = await Transaction.write({
-                  groupId,
-                  descriptor: {kind: 'move'},
-                  adopt     : descriptor => { seen.push(descriptor); return 'adopted' }
-              });
+              state     = registerValue(groupId, value => seen.push(value)),
+              outcome   = await writeValue(groupId, 'move');
 
-        expect(seen).toHaveLength(1);
-        expect(seen[0]).toEqual({kind: 'move'});
-        expect(outcome).toEqual({result: 'adopted', row: null});
+        expect(seen).toEqual([{kind: 'move'}]);
+        expect(state.value).toEqual({kind: 'move'});
+        expect(outcome).toMatchObject({
+            row               : null,
+            snapshot          : {version: 1, participants: {main: {kind: 'move'}}},
+            transactionId     : expect.any(String),
+            notificationErrors: []
+        });
+        expect(outcome).not.toHaveProperty('result');
         expect(imports).toBe(0);
         expect(Transaction.get(groupId).history).toBeNull();
         expect(Transaction.get(groupId).historyReady).toBeNull();
-        expect(await Transaction.undo({groupId, apply: noop}), 'nothing to undo without history').toBeNull();
-        expect(await Transaction.redo({groupId, apply: noop})).toBeNull();
+        expect((await undo({groupId})).row, 'nothing to undo without history').toBeNull();
+        expect((await redo({groupId})).row).toBeNull();
         expect(Transaction.getProvider(groupId).getData('canUndo')).toBe(false);
         expect(Transaction.getProvider(groupId).getData('historyDepth')).toBe(0);
         expect(imports, 'still nothing loaded').toBe(0)
     });
 
-    test('the first write of a Group that keeps history awaits one import before adopt; later writes queue behind it, each descriptor once', async () => {
+    test('the first write of a Group that keeps history awaits one import before adoption; queued descriptors are applied once in order', async () => {
         Transaction.historyDepth = 5;
 
         const {groupId} = Transaction.bind({windowId: 'w1', workspaceKey: 'main'}),
-              adopt     = descriptor => { log.push(`adopt:${descriptor.kind}`); return descriptor.kind },
-              outcomes  = await Promise.all([
-                  Transaction.write({groupId, descriptor: {kind: 'a'}, adopt}),
-                  Transaction.write({groupId, descriptor: {kind: 'b'}, adopt}),
-                  Transaction.write({groupId, descriptor: {kind: 'c'}, adopt})
-              ]);
+              state     = registerValue(groupId, value => log.push(`adopt:${value.kind}`)),
+              outcomes  = await Promise.all(['a', 'b', 'c'].map(kind => writeValue(groupId, kind)));
 
         expect(imports).toBe(1);
-        expect(log, 'the barrier resolves before the first adopt; the writes run in call order').toEqual(['import:start', 'import:done', 'adopt:a', 'adopt:b', 'adopt:c']);
-        expect(outcomes.map(outcome => outcome.result)).toEqual(['a', 'b', 'c']);
+        expect(log, 'the barrier resolves before the first adoption; writes keep call order').toEqual(['import:start', 'import:done', 'adopt:a', 'adopt:b', 'adopt:c']);
+        expect(outcomes.map(outcome => outcome.row.kind)).toEqual(['a', 'b', 'c']);
+        expect(outcomes.map(outcome => outcome.snapshot.participants.main.kind)).toEqual(['a', 'b', 'c']);
         expect(outcomes.map(outcome => outcome.row.sequence)).toEqual([1, 2, 3]);
         expect(outcomes.every(outcome => Object.isFrozen(outcome.row))).toBe(true);
+        expect(state.value.kind).toBe('c');
 
         const {history} = Transaction.get(groupId);
 
@@ -105,10 +142,11 @@ test.describe.serial('Neo.manager.Transaction — history admission, the queue a
         expect(history.count).toBe(3);
         expect(history.cursor).toBe(2);
 
-        await Transaction.write({groupId, descriptor: {kind: 'd'}, adopt});
+        await writeValue(groupId, 'd');
 
         expect(imports, 'a loaded Group imports nothing more').toBe(1);
-        expect(history.count).toBe(4)
+        expect(history.count).toBe(4);
+        expect(state.value.kind).toBe('d')
     });
 
     test('depth is a Group\'s own choice: two roots in one worker keep their own policy, whichever was admitted first', async () => {
@@ -119,8 +157,8 @@ test.describe.serial('Neo.manager.Transaction — history admission, the queue a
         expect(Transaction.getProvider(second.groupId).getData('historyDepth')).toBe(50);
         expect(Transaction.getProvider(first.groupId).getData('historyDepth'), 'A was born at zero and stays there').toBe(0);
 
-        await Transaction.write({groupId: first.groupId,  descriptor: {kind: 'a'}});
-        await Transaction.write({groupId: second.groupId, descriptor: {kind: 'b'}});
+        await write({groupId: first.groupId,  descriptor: {kind: 'a'}});
+        await write({groupId: second.groupId, descriptor: {kind: 'b'}});
 
         expect(Transaction.get(first.groupId).history, 'A loads no history').toBeNull();
         expect(Transaction.get(second.groupId).history.depth).toBe(50);
@@ -135,8 +173,8 @@ test.describe.serial('Neo.manager.Transaction — history admission, the queue a
 
         const early = Transaction.bind({windowId: 'a2', workspaceKey: 'main'});
 
-        await Transaction.write({groupId: early.groupId, descriptor: {kind: 'a'}});
-        await Transaction.write({groupId: late.groupId,  descriptor: {kind: 'b'}});
+        await write({groupId: early.groupId, descriptor: {kind: 'a'}});
+        await write({groupId: late.groupId,  descriptor: {kind: 'b'}});
 
         expect(Transaction.get(early.groupId).history).toBeNull();
         expect(Transaction.get(late.groupId).history.depth).toBe(2);
@@ -157,119 +195,143 @@ test.describe.serial('Neo.manager.Transaction — history admission, the queue a
 
         const after = Transaction.bind({windowId: 'w2', workspaceKey: 'main'});
 
-        await Transaction.write({groupId: before.groupId, descriptor: {kind: 'a'}});
-        await Transaction.write({groupId: after.groupId,  descriptor: {kind: 'a'}});
+        await write({groupId: before.groupId, descriptor: {kind: 'a'}});
+        await write({groupId: after.groupId,  descriptor: {kind: 'a'}});
 
         expect(Transaction.get(before.groupId).history, 'born at zero, stays at zero').toBeNull();
         expect(Transaction.get(after.groupId).history.depth).toBe(2);
         expect(imports).toBe(1)
     });
 
-    test('a rejected adopt appends nothing, keeps the cursor, and releases the queue for the next write', async () => {
+    test('a rejected participant adoption appends nothing, keeps the cursor, and releases the queue for the next write', async () => {
         Transaction.historyDepth = 5;
 
         const {groupId} = Transaction.bind({windowId: 'w1', workspaceKey: 'main'}),
-              provider  = Transaction.getProvider(groupId);
+              provider  = Transaction.getProvider(groupId),
+              state     = registerValue(groupId, value => {
+                  if (value.kind === 'b') throw new Error('participant refused')
+              });
 
-        await Transaction.write({groupId, descriptor: {kind: 'a'}, adopt: () => 'ok'});
+        await writeValue(groupId, 'a');
 
         expect(provider.getData('canUndo')).toBe(true);
         expect(provider.getData('historyLength')).toBe(1);
 
-        const failing = Transaction.write({groupId, descriptor: {kind: 'b'}, adopt: () => { throw new Error('second participant refused') }}),
-              next    = Transaction.write({groupId, descriptor: {kind: 'c'}, adopt: () => 'ok'});
+        const failing = writeValue(groupId, 'b'),
+              next    = writeValue(groupId, 'c');
 
-        await expect(failing).rejects.toThrow('second participant refused');
+        await expect(failing).rejects.toThrow('participant refused');
 
         const {history} = Transaction.get(groupId);
 
         expect((await next).row.kind, 'the queue survived the failure').toBe('c');
         expect(history.rows.map(row => row.kind)).toEqual(['a', 'c']);
         expect(history.cursor).toBe(1);
+        expect(state.value.kind).toBe('c');
+        expect(state.revision).toBe(2);
         expect(provider.getData('historyLength')).toBe(2)
     });
 
-    test('a descriptor the history would refuse is refused before adopt runs: no participant change without a row', async () => {
+    test('a descriptor that cannot become immutable data is refused before participant adoption', async () => {
         Transaction.historyDepth = 5;
 
         const {groupId} = Transaction.bind({windowId: 'w1', workspaceKey: 'main'}),
-              adopted   = [];
+              adopted   = [],
+              state     = registerValue(groupId, value => adopted.push(value));
 
-        await expect(Transaction.write({groupId, descriptor: {kind: 'a', apply: () => {}}, adopt: descriptor => adopted.push(descriptor)})).rejects.toThrow(TypeError);
+        await expect(write({
+            groupId,
+            descriptor: {kind: 'a', apply: () => {}},
+            changes   : [{workspaceKey: 'main', input: {kind: 'a'}}]
+        })).rejects.toThrow(/clon|plain|JSON/i);
 
         expect(adopted).toHaveLength(0);
-        expect(Transaction.get(groupId).history.count).toBe(0);
+        expect(state.value.kind).toBe('initial');
+        expect(Transaction.get(groupId).history?.count ?? 0).toBe(0);
         expect(Transaction.getProvider(groupId).getData('canUndo')).toBe(false)
     });
 
-    test('undo and redo apply first and move the cursor after; the provider follows; an append after undo drops the tail', async () => {
+    test('undo and redo adopt stored participant endpoints before moving the cursor; the provider follows and append drops the redo tail', async () => {
         Transaction.historyDepth = 5;
 
         const {groupId} = Transaction.bind({windowId: 'w1', workspaceKey: 'main'}),
               provider  = Transaction.getProvider(groupId),
               applied   = [],
-              apply     = row => { applied.push([row.kind, Transaction.get(groupId).history.cursor]) },
+              state     = registerValue(groupId, (value, context) => {
+                  if (context.cursorAction !== 'append') {
+                      applied.push([context.cursorAction, value.kind, Transaction.get(groupId).history.cursor])
+                  }
+              }),
               rows      = [];
 
         for (const kind of ['a', 'b', 'c']) {
-            rows.push((await Transaction.write({groupId, descriptor: {kind}})).row)
+            rows.push((await writeValue(groupId, kind)).row)
         }
 
         expect(provider.getData('canUndo')).toBe(true);
         expect(provider.getData('canRedo')).toBe(false);
         expect(provider.getData('historyCursor')).toBe(2);
 
-        expect(await Transaction.undo({groupId, apply})).toBe(rows[2]);
-        expect(await Transaction.undo({groupId, apply})).toBe(rows[1]);
-        expect(applied, 'apply sees the cursor still on the row it reverses').toEqual([['c', 2], ['b', 1]]);
+        expect((await undo({groupId})).row).toBe(rows[2]);
+        expect((await undo({groupId})).row).toBe(rows[1]);
+        expect(applied, 'adoption sees the cursor before the move').toEqual([['undo', 'b', 2], ['undo', 'a', 1]]);
+        expect(state.value.kind).toBe('a');
         expect(provider.getData('canRedo')).toBe(true);
         expect(provider.getData('historyCursor')).toBe(0);
-        expect(await Transaction.redo({groupId, apply})).toBe(rows[1]);
-        expect(applied.at(-1), 'redo applies before the cursor moves onto the row').toEqual(['b', 0]);
+        expect((await redo({groupId})).row).toBe(rows[1]);
+        expect(applied.at(-1), 'redo adopts before moving onto its row').toEqual(['redo', 'b', 0]);
+        expect(state.value.kind).toBe('b');
         expect(provider.getData('historyCursor')).toBe(1);
 
-        const {row} = await Transaction.write({groupId, descriptor: {kind: 'd'}});
+        const {row} = await writeValue(groupId, 'd');
 
         expect(Transaction.get(groupId).history.rows.map(item => item.kind)).toEqual(['a', 'b', 'd']);
         expect(row.sequence).toBe(4);
         expect(provider.getData('canRedo')).toBe(false);
         expect(provider.getData('historyLength')).toBe(3);
-        expect(await Transaction.redo({groupId, apply})).toBeNull()
+        expect((await redo({groupId})).row).toBeNull()
     });
 
-    test('a rejected application moves nothing: cursor and provider stay, and the next move still works; undo without apply is refused', async () => {
+    test('a rejected endpoint adoption leaves participant, cursor and provider unchanged, and the next move still works', async () => {
         Transaction.historyDepth = 5;
+        let refuseUndo = true;
 
         const {groupId} = Transaction.bind({windowId: 'w1', workspaceKey: 'main'}),
-              provider  = Transaction.getProvider(groupId);
+              provider  = Transaction.getProvider(groupId),
+              state     = registerValue(groupId, (value, context) => {
+                  if (context.cursorAction === 'undo' && refuseUndo) throw new Error('reverse refused by a participant')
+              });
 
-        await Transaction.write({groupId, descriptor: {kind: 'a'}});
-        await Transaction.write({groupId, descriptor: {kind: 'b'}});
+        await writeValue(groupId, 'a');
+        await writeValue(groupId, 'b');
 
-        await expect(Transaction.undo({groupId, apply: async () => { throw new Error('reverse refused by a participant') }})).rejects.toThrow('reverse refused');
+        await expect(undo({groupId})).rejects.toThrow('reverse refused');
 
         expect(Transaction.get(groupId).history.cursor, 'the cursor did not move').toBe(1);
+        expect(state.value.kind).toBe('b');
+        expect(state.revision).toBe(2);
         expect(provider.getData('historyCursor')).toBe(1);
         expect(provider.getData('canRedo')).toBe(false);
 
-        expect((await Transaction.undo({groupId, apply: noop})).kind, 'the queue is free for the next move').toBe('b');
+        refuseUndo = false;
+        expect((await undo({groupId})).row.kind, 'the queue is free for the next move').toBe('b');
+        expect(state.value.kind).toBe('a');
         expect(provider.getData('historyCursor')).toBe(0);
-
-        await expect(Transaction.undo({groupId})).rejects.toThrow('apply(row) is required');
-        await expect(Transaction.redo({groupId, apply: 'later'})).rejects.toThrow('apply(row) is required');
         expect(Transaction.get(groupId).history.cursor).toBe(0)
     });
 
-    test('an undo issued while the first write is still loading waits for it and moves the cursor off the row that write admitted', async () => {
+    test('an undo issued while the first write is loading waits for its stored participant endpoints', async () => {
         Transaction.historyDepth = 5;
 
-        const {groupId}       = Transaction.bind({windowId: 'w1', workspaceKey: 'main'}),
-              [{row}, undone] = await Promise.all([
-                  Transaction.write({groupId, descriptor: {kind: 'a'}}),
-                  Transaction.undo({groupId, apply: noop})
+        const {groupId}         = Transaction.bind({windowId: 'w1', workspaceKey: 'main'}),
+              state             = registerValue(groupId),
+              [written, undone] = await Promise.all([
+                  writeValue(groupId, 'a'),
+                  undo({groupId})
               ]);
 
-        expect(undone).toBe(row);
+        expect(undone.row).toBe(written.row);
+        expect(state.value.kind).toBe('initial');
         expect(Transaction.get(groupId).history.cursor).toBe(-1);
         expect(Transaction.getProvider(groupId).getData('canRedo')).toBe(true)
     });
@@ -292,7 +354,7 @@ test.describe.serial('Neo.manager.Transaction — history admission, the queue a
         expect(provider.getData('canUndo')).toBe(false);
         expect(host.getData('canUndo'), 'read through the explicit parent, no component tree involved').toBe(false);
 
-        await Transaction.write({groupId: a.groupId, descriptor: {kind: 'a'}});
+        await write({groupId: a.groupId, descriptor: {kind: 'a'}});
 
         expect(provider.getData('canUndo')).toBe(true);
         expect(host.getData('canUndo')).toBe(true);
@@ -316,7 +378,7 @@ test.describe.serial('Neo.manager.Transaction — history admission, the queue a
 
         Transaction.on('groupRetired', onRetired);
 
-        await Transaction.write({groupId: kept.groupId, descriptor: {kind: 'a'}});
+        await write({groupId: kept.groupId, descriptor: {kind: 'a'}});
 
         const emptyProvider = Transaction.getProvider(empty.groupId);
 
@@ -335,9 +397,9 @@ test.describe.serial('Neo.manager.Transaction — history admission, the queue a
     });
 
     test('a write, undo or redo against an unknown Group rejects', async () => {
-        await expect(Transaction.write({groupId: 'nowhere', descriptor: {kind: 'a'}})).rejects.toThrow('unknown Group');
-        await expect(Transaction.undo({groupId: 'nowhere', apply: noop})).rejects.toThrow('unknown Group');
-        await expect(Transaction.redo({groupId: 'nowhere', apply: noop})).rejects.toThrow('unknown Group')
+        await expect(write({groupId: 'nowhere', descriptor: {kind: 'a'}})).rejects.toThrow('unknown Group');
+        await expect(undo({groupId: 'nowhere'})).rejects.toThrow('unknown Group');
+        await expect(redo({groupId: 'nowhere'})).rejects.toThrow('unknown Group')
     });
 
     test('the worker-wide default and the Group-local bound refuse anything but a non-negative integer, so no Group is born with an unbounded log', async () => {
@@ -362,7 +424,7 @@ test.describe.serial('Neo.manager.Transaction — history admission, the queue a
         const born = Transaction.bind({windowId: 'w0', workspaceKey: 'main'});
 
         expect(Transaction.get(born.groupId).historyDepth).toBe(0);
-        await Transaction.write({groupId: born.groupId, descriptor: {kind: 'a'}});
+        await write({groupId: born.groupId, descriptor: {kind: 'a'}});
         expect(Transaction.get(born.groupId).history, 'depth zero loads nothing').toBeNull();
 
         Transaction.historyDepth = 2;
@@ -370,7 +432,7 @@ test.describe.serial('Neo.manager.Transaction — history admission, the queue a
         const {groupId} = Transaction.bind({windowId: 'w1', workspaceKey: 'main'});
 
         for (const kind of ['a', 'b', 'c']) {
-            await Transaction.write({groupId, descriptor: {kind}})
+            await write({groupId, descriptor: {kind}})
         }
 
         const {history} = Transaction.get(groupId);
@@ -379,12 +441,13 @@ test.describe.serial('Neo.manager.Transaction — history admission, the queue a
         expect(history.rows.map(row => row.kind), 'a valid bound evicts exactly').toEqual(['b', 'c'])
     });
 
-    test('a Group retired while its history module is still loading gets no History: the write rejects, nothing is adopted, and no orphan is registered', async () => {
+    test('a Group retired while its history module loads gets no History, no adoption and no registered orphan', async () => {
         Transaction.historyDepth = 5;
 
         const {groupId} = Transaction.bind({windowId: 'w1', workspaceKey: 'main'}),
               record    = Transaction.get(groupId),
               adopted   = [],
+              state     = registerValue(groupId, value => adopted.push(value)),
               instances = () => InstanceManager.find('className', 'Neo.manager.transaction.History').length;
 
         let resolveImport, started = false;
@@ -394,46 +457,44 @@ test.describe.serial('Neo.manager.Transaction — history admission, the queue a
             return new Promise(resolve => { resolveImport = resolve })
         };
 
-        const write  = Transaction.write({groupId, descriptor: {kind: 'a'}, adopt: descriptor => adopted.push(descriptor)}),
-              before = instances();
+        const pendingWrite = writeValue(groupId, 'a'),
+              before       = instances();
 
-        while (!started) {
-            await new Promise(resolve => setTimeout(resolve, 0))
-        }
-
+        await expect.poll(() => started).toBe(true);
         expect(Transaction.retireGroup(groupId), 'retired while the import is pending').toBe(true);
-
         resolveImport(await importHistory.call(Transaction));
 
-        await expect(write).rejects.toThrow('retired while queued');
+        await expect(pendingWrite).rejects.toThrow('retired while queued');
         expect(adopted).toHaveLength(0);
+        expect(state.value.kind).toBe('initial');
         expect(record.history, 'the retired record never received a History').toBeNull();
         expect(instances(), 'no History was registered for the dead Group').toBe(before);
 
-        // Control: the same pending import with the Group alive creates exactly one History.
+        // The same import with a live Group creates one History and ordinary retirement releases it.
         Transaction.importHistory = importHistory;
-
         const live = Transaction.bind({windowId: 'w2', workspaceKey: 'main'});
 
-        await Transaction.write({groupId: live.groupId, descriptor: {kind: 'a'}});
+        await write({groupId: live.groupId, descriptor: {kind: 'a'}});
 
         expect(instances()).toBe(before + 1);
         expect(Transaction.retireGroup(live.groupId)).toBe(true);
-        expect(instances(), 'ordinary retirement releases it').toBe(before)
+        expect(instances()).toBe(before)
     });
 
-    test('a write queued behind the barrier when its Group is retired rejects instead of touching what the retirement released', async () => {
+    test('a write queued behind the barrier rejects after Group retirement without mutating a participant', async () => {
         Transaction.historyDepth = 5;
 
         const {groupId} = Transaction.bind({windowId: 'w1', workspaceKey: 'main'}),
               adopted   = [],
-              queued    = Transaction.write({groupId, descriptor: {kind: 'a'}, adopt: descriptor => adopted.push(descriptor)});
+              state     = registerValue(groupId, value => adopted.push(value)),
+              queued    = writeValue(groupId, 'a');
 
         expect(Transaction.retireGroup(groupId)).toBe(true);
 
         await expect(queued).rejects.toThrow('retired while queued');
-        expect(adopted, 'no participant mutation for a Group that is gone').toHaveLength(0);
-        expect(imports, 'the barrier had already started loading; the module is simply not used').toBeLessThanOrEqual(1)
+        expect(adopted).toHaveLength(0);
+        expect(state.value.kind).toBe('initial');
+        expect(imports, 'at most the one barrier import could have started').toBeLessThanOrEqual(1)
     });
 
     test('the manager never imports the history module statically: the lazy boundary is mechanical', () => {
@@ -442,6 +503,6 @@ test.describe.serial('Neo.manager.Transaction — history admission, the queue a
               dynamic = [...source.matchAll(/import\(\s*['"]([^'"]+)['"]\s*\)/g)].map(match => match[1]);
 
         expect(statics.some(specifier => specifier.includes('transaction/History')), 'a static import would put the module into every consumer\'s closure').toBe(false);
-        expect(dynamic).toEqual(['./transaction/History.mjs'])
+        expect(dynamic.filter(specifier => specifier.includes('transaction/History'))).toEqual(['./transaction/History.mjs'])
     })
 });

--- a/test/playwright/unit/manager/TransactionWrite.spec.mjs
+++ b/test/playwright/unit/manager/TransactionWrite.spec.mjs
@@ -503,6 +503,6 @@ test.describe.serial('Neo.manager.Transaction — history admission, the queue a
               dynamic = [...source.matchAll(/import\(\s*['"]([^'"]+)['"]\s*\)/g)].map(match => match[1]);
 
         expect(statics.some(specifier => specifier.includes('transaction/History')), 'a static import would put the module into every consumer\'s closure').toBe(false);
-        expect(dynamic.filter(specifier => specifier.includes('transaction/History'))).toEqual(['./transaction/History.mjs'])
+        expect(dynamic).toEqual(['./transaction/History.mjs'])
     })
 });

--- a/test/playwright/unit/manager/transaction/History.spec.mjs
+++ b/test/playwright/unit/manager/transaction/History.spec.mjs
@@ -9,6 +9,7 @@ setup({
 import {test, expect} from '@playwright/test';
 import Neo            from '../../../../../src/Neo.mjs';
 import * as core      from '../../../../../src/core/_export.mjs';
+import Collection     from '../../../../../src/collection/Base.mjs';
 import History        from '../../../../../src/manager/transaction/History.mjs';
 
 /**
@@ -122,6 +123,132 @@ test.describe('Neo.manager.transaction.History — frozen rows and the cursor', 
         expect(row.left).toEqual({size: 0.5});
         expect(row.right).toEqual({size: 0.5});
         expect(JSON.parse(JSON.stringify(row)).right.size).toBe(0.5)
+    });
+
+    test('a checkpoint restores a partially admitted append and its redo tail without mutation events, then normal notifications resume', () => {
+        const originalAdd = Collection.prototype.add;
+        let collection, first;
+
+        try {
+            Collection.prototype.add = function(item) {
+                collection = this;
+                return originalAdd.call(this, item)
+            };
+            first = history.append({id: 'a', payload: {value: 1}})
+        } finally {
+            Collection.prototype.add = originalAdd
+        }
+
+        const
+            rows          = [first, history.append({id: 'b'}), history.append({id: 'c'})],
+            notifications = [],
+            scope         = {id: 'history-checkpoint-observer'};
+
+        history.undo();
+        history.undo();
+
+        const checkpoint = history.captureState(),
+              bytes      = JSON.stringify(history);
+
+        collection.on('mutate', event => {
+            notifications.push(event);
+            if (event.addedItems?.some(row => row.id === 'failed')) {
+                throw new Error('failure after Collection admission')
+            }
+        }, scope);
+
+        expect(() => history.append({id: 'failed'})).toThrow('failure after Collection admission');
+        expect(history.rows.map(row => row.id)).toEqual(['a', 'failed']);
+        notifications.length = 0;
+
+        history.restoreState(checkpoint);
+
+        expect(JSON.stringify(history)).toBe(bytes);
+        history.rows.forEach((row, index) => expect(row).toBe(rows[index]));
+        expect(history.get('failed')).toBeNull();
+        expect(history.canRedo).toBe(true);
+        expect(notifications).toEqual([]);
+
+        // A restore error must release its silent bracket and leave the checkpoint retryable.
+        const retry  = history.captureState(),
+              splice = collection.splice;
+
+        history.redo();
+        collection.splice = () => { throw new Error('restore fault') };
+
+        try {
+            expect(() => history.restoreState(retry)).toThrow('restore fault')
+        } finally {
+            collection.splice = splice
+        }
+
+        history.restoreState(retry);
+        expect(JSON.stringify(history)).toBe(bytes);
+        expect(notifications).toEqual([]);
+
+        history.append({id: 'next'});
+        expect(notifications.some(event => event.addedItems?.some(row => row.id === 'next'))).toBe(true)
+    });
+
+    test('checkpoints restore evicted row identities, cursor moves and an empty initial history', () => {
+        const empty = history.captureState(),
+              rows  = ['a', 'b', 'c'].map(id => history.append({id, payload: {id}}));
+
+        history.undo();
+
+        const checkpoint = history.captureState(),
+              bytes      = JSON.stringify(history);
+
+        expect(Object.isFrozen(checkpoint)).toBe(true);
+        expect(() => { checkpoint.rows = [] }).toThrow(TypeError);
+
+        history.redo();
+        history.append({id: 'd'});
+        history.append({id: 'e'});
+        history.undo();
+        expect(history.has('a')).toBe(false);
+
+        history.restoreState(checkpoint);
+
+        expect(JSON.stringify(history)).toBe(bytes);
+        rows.forEach((row, index) => expect(history.getAt(index)).toBe(row));
+        expect(history.peek('redo')).toBe(rows[2]);
+
+        history.restoreState(empty);
+
+        expect(history.rows).toEqual([]);
+        expect(history.count).toBe(0);
+        expect(history.cursor).toBe(-1);
+        expect(history.sequence).toBe(0);
+        expect(history.canUndo).toBe(false);
+        expect(history.canRedo).toBe(false);
+        expect(history.append({id: 'first-again'}).sequence).toBe(1)
+    });
+
+    test('foreign, forged, consumed and retired checkpoints cannot mutate a History', () => {
+        const other = Neo.create(History, {depth: 3});
+
+        try {
+            history.append({id: 'owned'});
+            const checkpoint = history.captureState(),
+                  bytes      = JSON.stringify(history);
+
+            for (const invalid of [null, {}, {...checkpoint}, other.captureState()]) {
+                expect(() => history.restoreState(invalid)).toThrow(/belong to this live history/);
+                expect(JSON.stringify(history)).toBe(bytes)
+            }
+
+            history.restoreState(checkpoint);
+            expect(() => history.restoreState(checkpoint)).toThrow(/belong to this live history/);
+
+            const retired = other.captureState();
+
+            other.destroy();
+            expect(() => other.restoreState(retired)).toThrow(/belong to this live history/);
+            expect(() => other.captureState()).toThrow(/retired history/)
+        } finally {
+            !other.isDestroyed && other.destroy()
+        }
     });
 
     test('append after undo drops the redo tail, and only the tail', () => {


### PR DESCRIPTION
Resolves #18312

Related: #18303, #18314, #18315

A Group now prepares every changed participant at its queue head, adopts synchronously with reverse compensation, and commits history, cursor and one frozen snapshot together. A refused adopter—including one that mutates before throwing—or a failed history/cursor update restores the previous state. Projection and native-effect receipts run after queue release and cannot reject the semantic commit.

`transaction/Commit` replaces the provisional write/apply callbacks; History supplies opaque rollback checkpoints. The dock `WorkspaceSet` supplies validated document participants and a queued `write` entry. Both hosts inject their existing document model and map their main document to the `main` window binding. Opaque `componentId` metadata stays out of snapshots. No dock imports enter the generic manager.

Evidence: L2 (real Group writer, History, WorkspaceDocument and WorkspaceSet in the unit runtime) → L2 required. Residual: none for this leaf. UI/Neural Link ingress migration remains with the linked sibling, and real native geometry with its separate owner.

## AC Evidence

| AC | Evidence |
|---|---|
| AC-1 | CI-covered: `TransactionAtomic.spec.mjs` prepare-refusal control and `DockWorkspaceSetTransaction.spec.mjs` invalid-second-document control assert zero adoption. |
| AC-2 | CI-covered: both specs inject a second adopter/setter that mutates then throws; reverse compensation restores values, revisions, history, cursor and snapshot without publication. |
| AC-3 | CI-covered: `TransactionAtomic.spec.mjs` protocol log and synchronous-observer assertions establish preparation before adoption and consistent publication; the writer rejects async adopters. |
| AC-4 | CI-covered: prepare/history/falsy-refusal controls enqueue a later successful write. |
| AC-5 | CI-covered: `TransactionAtomic.spec.mjs` cold-preserve/append/undo/redo matrix; `TransactionWrite.spec.mjs` admission/depth/cursor tests; `Transaction.spec.mjs` warm binding retains Group ownership. |
| AC-6 | CI-covered: `TransactionAtomic.spec.mjs` holds a native effect across a later write and rejects projection/effect promises; receipts remain separate from committed truth. |
| AC-7 | CI-covered: mixed domains reject before preparation; the real dock adapter's paired-document control enters the same manager protocol. Existing command/gesture ingress migration belongs to #18314. |
| AC-8 | CI-covered: delayed A/B queue-head capture and generation drift in `TransactionAtomic.spec.mjs`; the adapter tests real manager rebind with both matching and distinct document/binding keys. |
| AC-9 | CI-covered: post-mutation append/cursor failures in `TransactionAtomic.spec.mjs`; checkpoint tests in `manager/transaction/History.spec.mjs` preserve row identity, sequence, redo tail and cursor. |
| AC-10 | CI-covered: the synchronous commit observer reads recursively frozen complete truth, enqueues a second operation and throws without rejecting the first commit. History checkpoint restoration emits no Collection mutation. |

Spec roots: `test/playwright/unit/manager/` and `test/playwright/unit/dashboard/`.

## Deltas from ticket

None substantive. The measured main-slot mismatch needs an explicit adapter `bindingKey`: `workstation-main` and `demo-b-main` are document keys, while the root carrier binds `main`. Registration metadata remains opaque to the generic manager. The existing synchronous adapter entries remain until the separately owned command/projection migration replaces their callers.

## Test Evidence

size-guard-growth: apps/workstation/view/Workspace.mjs — two lines map the document participant to its root binding and preserve the existing live owner's component id
size-guard-growth: examples/dashboard/crossWindow/DemoBWorkspace.mjs — one line maps the main document participant to the root carrier's binding key

Two red-to-green controls were executed against the unfinished implementation: a reload under a distinct binding key incorrectly resolved a stale write; an adopter throwing `null` incorrectly returned a commit after rollback. Both now reject, publish nothing and permit a later write. Commands: `npm run test-unit -- test/playwright/unit/dashboard/DockWorkspaceSetTransaction.spec.mjs --grep 'distinct from' --workers=1 --reporter=dot` and the equivalent `manager/TransactionAtomic.spec.mjs --grep 'falsy thrown'`. The latter also covers `false`, `0` and an empty string. All ongoing coverage runs in CI.

Component failure retained: [head `2ef73ef0e5`, initial component job](https://github.com/neomjs/neo/actions/runs/33983004528/job/101351535170) failed `DockMaximize.spec.mjs:333` with `ghost-tabs` instead of `null` (248 passed). The same assertion had already failed in the [independent Monaco PR's job](https://github.com/neomjs/neo/actions/runs/33976234664/job/101333319066), before this branch existed. The exact-head isolated command `npx playwright test -c test/playwright/playwright.config.component.mjs test/playwright/component/dashboard/DockMaximize.spec.mjs --grep 'inside-the-node' --workers=1 --reporter=dot` passed locally. One hosted failed-job rerun was requested; these receipts establish the observed failure and isolated pass, not a diagnosed root cause.

## Post-Merge Validation

No production-only validation is required for this semantic-write leaf. The linked hydration and command-migration leaves supply their consumer journeys; no live window effect is claimed here.

## Commits

- `f1c891c174` — atomic Group writer, History rollback, dock adapter and failure controls
- `49697eab5b` — measured host-registration size baseline, preserving current dev's Workspace reduction
- `ed820bcea5` — exact dynamic-import guard and documented descriptor precedence

## Signal Ledger

| Family | Identity | Signal | Source |
|---|---|---|---|
| Claude | Grace | AUTHOR_SIGNAL | D#18224 folded body at `131c782ca8` |
| GPT | Emmy | GRADUATION_APPROVED | `DC_kwDODSospM4BFyRA`, source body `2026-09-04T17:53:27Z` |

The [graduated Discussion](https://github.com/neomjs/neo/discussions/18224) and [Epic signal ledger](https://github.com/neomjs/neo/issues/18303) retain the version-bound quorum and superseded deferrals. Independent Epic entry review: [Grace's greenlight](https://github.com/neomjs/neo/issues/18303#issuecomment-5544825646).

## Unresolved Dissent

None for the graduated transaction contract.

## Unresolved Liveness

No inactive-family signal is counted. A concrete falsifier against the accepted contract reopens its premise.

Authored by Emmy (GPT-6 Astra, Codex). Session 01a072b1-c820-7651-931d-8bc0b278193e. Continues implementation from session 01a0713f-33eb-7f00-876f-bfda58c92b3e.

