### PR TITLE
The settle-signal component arm asserts the consumer contract and records the bracket a fast repartition may never show

### DIFF
--- a/test/playwright/component/dashboard/DockOverflowSettleSignal.spec.mjs
+++ b/test/playwright/component/dashboard/DockOverflowSettleSignal.spec.mjs
@@ -9,12 +9,15 @@ import {test, expect} from '@playwright/test';
  * `neo-dashboard-dock-animating` inside the dock host, exactly as motion producers do, and drops it
  * when the pass settles. A consumer asks the dock host's subtree, not one carrier.
  *
- * The bracket is captured with a subtree observer installed BEFORE the trigger: a pass can be shorter
- * than a poll interval, so sampling would miss it and read as the defect. Red-first: on `dev` no
- * producer enters the signal during a tab activation, so `seen` stays `false` and the first assertion
- * reds. The click that follows is the consumer's real act — gated on the class being absent, it lands
- * on an attached header action and the lock state flips, which a click into a detached node cannot
- * produce.
+ * The bracket is captured with a subtree observer installed BEFORE the trigger, reading presence from
+ * the class value each mutation replaced as well as from the live DOM. Whether it is observable at all
+ * depends on the pass: a measurement round-trip that returns before the App Worker flushes the entering
+ * class lands enter and leave in one DOM update, so the class never appears — and no window a pointer
+ * could hit a detached node in exists either. Presence is therefore recorded as a run annotation, not
+ * asserted; the routing and the one-pair semantics are pinned deterministically by the unit arms. What
+ * this arm asserts is the consumer's contract: absent at rest, absent at settle, and the click that
+ * follows — gated on the class being absent — lands on an attached header action and flips the lock
+ * state, which a click into a detached node cannot produce.
  */
 
 const WORKSPACE = '#dock-maximize-workspace';
@@ -28,19 +31,30 @@ const actionButton = (node, glyph) => node.locator(`.neo-tab-header-toolbar .neo
 
 /**
  * Records whether any element inside the workspace carries the signal class, at install time and at
- * every class mutation in the subtree, so a bracket shorter than one poll is still seen.
+ * every class mutation in the subtree. Presence is read at callback time OR from the class value a
+ * mutation replaced, so a class that entered and left across two DOM updates is seen even when the
+ * callback runs after it left. A pass whose enter and leave land in ONE update leaves no trace here —
+ * the class never reaches the DOM — and no window a pointer could hit a detached node in either.
  * @param {import('@playwright/test').Page} page
  * @returns {Promise<void>}
  */
 const watchSignal = page => page.evaluate(selector => {
     const
-        root     = document.querySelector(selector),
-        log      = [],
-        record   = () => log.push(!!root.querySelector('.neo-dashboard-dock-animating') || root.classList.contains('neo-dashboard-dock-animating')),
+        root    = document.querySelector(selector),
+        cls     = 'neo-dashboard-dock-animating',
+        present = () => root.classList.contains(cls) || !!root.querySelector(`.${cls}`),
+        log     = [],
+        // `before`: the class stood in a value this batch replaced; `after`: it stands in the live DOM now.
+        // The leave itself is a mutation whose replaced value carries the class, so a settled pass ends
+        // on `{before: true, after: false}` — the two are kept apart so settle is read from `after`.
+        record   = records => log.push({
+            before: records.some(record => (record.oldValue || '').includes(cls)),
+            after : present()
+        }),
         observer = new MutationObserver(record);
 
-    observer.observe(root, {attributes: true, attributeFilter: ['class'], subtree: true});
-    record();
+    observer.observe(root, {attributes: true, attributeFilter: ['class'], attributeOldValue: true, subtree: true});
+    log.push({before: false, after: present()});
 
     globalThis.__dockSignalWatch = {log, stop: () => observer.disconnect()}
 }, WORKSPACE);
@@ -49,7 +63,8 @@ const signalCarriers = page => page.locator(`${WORKSPACE} .neo-dashboard-dock-an
 
 /**
  * @param {import('@playwright/test').Page} page
- * @returns {Promise<Boolean[]>} The recorded presence values, first entry the state at install.
+ * @returns {Promise<Array<{before: Boolean, after: Boolean}>>} The recorded presence per mutation batch,
+ *     first entry the state at install.
  */
 const readSignal = page => page.evaluate(() => {
     const watch = globalThis.__dockSignalWatch;
@@ -58,6 +73,18 @@ const readSignal = page => page.evaluate(() => {
 
     return watch.log
 });
+
+/**
+ * Waits until the recorded timeline ends with the signal absent. A pass can be in flight at any instant
+ * — boot leaves late passes behind, an activation triggers one — so "settled" is a state to wait for,
+ * never a sample to assert.
+ * @param {import('@playwright/test').Page} page
+ * @returns {Promise<void>}
+ */
+const awaitSettled = page => expect.poll(
+    () => page.evaluate(() => globalThis.__dockSignalWatch.log.at(-1).after),
+    {message: 'the timeline ends with the signal absent', timeout: 5000}
+).toBe(false);
 
 test.beforeEach(async ({page}) => {
     await page.goto('test/playwright/component/apps/dock-maximize/index.html');
@@ -81,11 +108,21 @@ test('a tab activation\'s header repartition brackets the header with the dock m
     await expect(tabButton(main, 'Beta')).toHaveAttribute('aria-selected', 'true');
     await expect(signalCarriers(page)).toHaveCount(0);
 
+    // Settled is waited for, not sampled: a late boot pass or the activation's own pass may still be in
+    // flight at any instant, so the assertion is that the timeline REACHES an absent state.
+    await awaitSettled(page);
+
     const log = await readSignal(page);
 
-    expect(log[0], 'installed at rest').toBe(false);
-    expect(log, 'the signal was present inside the dock host during the pass').toContain(true);
-    expect(log.at(-1), 'and absent once the pass settled').toBe(false);
+    // The state at install is recorded for the run's evidence, not asserted, for the same reason.
+    test.info().annotations.push({type: 'dock-signal-at-install', description: String(log[0].after)});
+
+    // Whether the bracket was observable depends on the pass: when the measurement round-trip returns
+    // before the App Worker flushes the entering class, enter and leave land in one DOM update and the
+    // class never appears — nor does a window a pointer could hit a detached node in. Presence is
+    // therefore recorded for the run's evidence, not required; what the consumer relies on is that the
+    // signal is absent at rest and at settle, and that a click gated on its absence lands — below.
+    test.info().annotations.push({type: 'dock-signal-observed', description: String(log.some(entry => entry.before || entry.after))});
 
     // The consumer's act: a header action clicked once the signal is absent lands on an attached node,
     // and the lock policy flips the action to its unlock presentation.


### PR DESCRIPTION
Resolves #18371
Related: #18356 #18358 #18366

🌿 The settle-signal arm now asserts what a pointer can rely on and records what a fast pass may never show, so a repartition that finishes inside one DOM update no longer reds another lane's CI.

`test/playwright/component/dashboard/DockOverflowSettleSignal.spec.mjs` asserted that the `neo-dashboard-dock-animating` class was *seen* inside the dock host during a tab activation's header repartition. Whether it can be seen depends on the pass: when the overflow plugin's measurement round-trip returns before the App Worker flushes the entering class, enter and leave land in one DOM update whose net class delta is empty — the class never reaches the DOM, and no window a pointer could hit a detached node in exists either. On a loaded runner that is the common case (#18366's components job: `log=[false,false,false,false]`, four tab-selection class mutations and no signal); on a workstation the slower pass usually shows the bracket. The unit arms in `DockLayoutAdapter.spec.mjs` and `Overflow.spec.mjs` already pin the routing and the one-pair semantics deterministically, so the component arm's job is the consumer's contract, not the timing of one pass.

The arm now observes with `attributeOldValue: true` and records, per mutation batch, whether the class stood in a value the batch replaced (`before`) and whether it stands in the live DOM (`after`), so a bracket spanning two updates is seen even when the callback runs after it closed. Settled is *waited for* — the timeline must reach an `after: false` state — never sampled, because a late boot pass or the activation's own pass can be in flight at any instant. Whether the bracket was observed, and the state at install, are recorded as run annotations (`dock-signal-observed`, `dock-signal-at-install`) for the run's evidence. What is asserted: the timeline reaches absence, and the lock click gated on absence lands on an attached action and flips it.

Evidence: L3 achieved → L3 required (the arm keeps its real-browser fixture and real click). Residual: none — the bracket's visibility is a property of pass timing, recorded per run, not of the product.

## AC Evidence
| AC-1 | The unconditional `toContain(true)` is gone; the arm asserts the timeline reaches `after: false` (`awaitSettled`) and that the gated lock click flips the action (`fa-lock` → `fa-lock-open`), with no signal carrier left afterwards |
| AC-2 | `watchSignal` observes with `attributeOldValue: true` and records `{before, after}` per batch; `test.info()` carries `dock-signal-observed` (whether any batch showed the class before or after) and `dock-signal-at-install` |
| AC-3 | Eight consecutive local runs pass (`playwright.config.component.mjs`, one worker), quoted below |
| AC-4 | `DockLayoutAdapter.spec.mjs` and `Overflow.spec.mjs` untouched |

## Deltas from ticket
**Two more timing-dependent assertions surfaced while running the battery, both removed for the same reason.** Reading presence from `oldValue` alone made the *leave* mutation read as present, so `log.at(-1)` was `true` whenever the bracket had been observable — the log now keeps `before` and `after` apart. And "installed at rest" (`log[0] === false`) failed once in six runs because the fixture's boot still ran a late pass at install time — the state at install is now recorded, not asserted. The ticket's AC-1 wording ("absence at rest") is met by the `beforeEach` wait for zero carriers, which is a wait, not a sample.

## Test Evidence
Battery (`playwright.config.component.mjs`, one worker), the final arm: 8 runs, 8 passed. The diagnostic batteries that shaped it: the first rewrite failed 3 of 5 on `absent once the pass settled` (the leave's `oldValue`), the second failed 1 of 6 on `installed at rest` (a late boot pass) — both are the same class of assertion the ticket removes, and both are gone.
Red-first: the retired assertions are the ones redding CI on `dev`'s arm, which is the control. #18366's components job (101334624069) failed on `toContain(true)` — the coalesced pass, quoted in the ticket. #18368's components job (101358388937, 19:01Z, after a rebase onto `dev@3d713cc8a6`) failed on `installed at rest` — the late boot pass, the second mode this PR removes; until then it was seen once locally in six runs.

## Post-Merge Validation
- [ ] Re-run the components job of any open PR whose only red is this arm on `dev`'s spec (#18368 at the time of writing).

## Commits (if multi-commit)
- `d4a229c669` — the arm asserts the consumer contract and records the bracket

Authored by Vega (Claude Fable 5.1, Claude Code). Session 3711ad57-061d-43fb-b1f1-aa9dc21dedda.