### PR TITLE
feat(dock): persist topology Groups across cold and warm reloads (#18315)

### DIFF
--- a/apps/workstation/README.md
+++ b/apps/workstation/README.md
@@ -24,3 +24,21 @@ Pane, store, component, and relevant DOM identities remain stable while the layo
 
 The data-only screenplay lives in `apps/workstation/tour/denseWorkstation.mjs`; the mounted
 whitebox journey is the runtime and visual falsifier.
+
+## Save and reopen a workspace
+
+**Save workspace** stores the complete keyed topology in IndexedDB, separately from undo history.
+Each logical root has its own collection. Cold boot uses its saved active layout; `?layout=<id>`
+explicitly selects another record in that collection. An unusable selection offers **Start a new
+workspace**, which preserves the saved collection and creates a new root.
+
+Saved window documents hydrate before presentation. **Open … as window** requests a popup from
+the button click; **Show … here** presents the same document in the root if a popup is unavailable.
+Reloading a root or a restored popup while its SharedWorker survives reuses the live Workspace,
+host and pane instances without replaying history or writing a new topology.
+
+**Close workspace** waits for a current durable save, clears its windows' session carriers, and
+ends each render target. Browser-owned tabs that cannot close return to a blank document. The
+Group keeps its existing reconnect lease and only retires after storage acknowledges current
+truth and no retained reference remains. A failed final write keeps a `headless-dirty` Group and
+retries instead of discarding its documents.

--- a/apps/workstation/app.mjs
+++ b/apps/workstation/app.mjs
@@ -1,4 +1,5 @@
-import Viewport from './view/Viewport.mjs';
+import Viewport    from './view/Viewport.mjs';
+import Transaction from '../../src/manager/Transaction.mjs';
 
 /**
  * @summary Resolves one Workstation window's carried Neo theme against that window's configured themes.
@@ -25,6 +26,13 @@ export const onStart = () => {
             search: config.url?.search,
             themes: config.themes
         });
+
+    const params  = new URLSearchParams(config.url?.search ?? ''),
+          carried = config.topologyIdentity;
+    // A popup cannot cold-create its absent root before that root selects durable truth.
+    if ((params.has('popout') || params.has('workspace')) && carried?.groupId && !Transaction.get(carried.groupId)) {
+        config.topologyIdentity = {}
+    }
 
     return Neo.app({
         mainView: {module: Viewport, theme},

--- a/apps/workstation/view/Viewport.mjs
+++ b/apps/workstation/view/Viewport.mjs
@@ -1,4 +1,5 @@
 import BaseViewport from '../../../src/container/Viewport.mjs';
+import Transaction  from '../../../src/manager/Transaction.mjs';
 import Workspace    from './Workspace.mjs';
 
 /**
@@ -14,6 +15,7 @@ import Workspace    from './Workspace.mjs';
  * - `?popout=<id>`  → an EMPTY pop-out host: this window carries no workspace of its own; the
  *   opener's workspace reparents the live pane into this viewport (the shared-heap contract —
  *   one App Worker, two render targets; the dockdemo vessel-shell sibling pattern).
+ * - `?workspace=<key>` → a render target for an already hydrated keyed document.
  *
  * @class Workstation.view.Viewport
  * @extends Neo.container.Viewport
@@ -36,8 +38,8 @@ class Viewport extends BaseViewport {
     }
 
     /**
-     * Resolves the boot mode from the window URL and mounts the workspace — or nothing:
-     * a pop-out vessel is a render target waiting for its live pane.
+     * @summary Resolves the boot mode and mounts the Group's retained Workspace on a warm rebind. A fresh
+     * root creates its Workspace; a pop-out vessel waits for its live pane instead.
      */
     async onConstructed() {
         super.onConstructed();
@@ -53,10 +55,123 @@ class Viewport extends BaseViewport {
             return
         }
 
-        me.add({
-            module: Workspace,
-            flex  : 1
-        })
+        if (params.has('workspace')) {
+            const binding = Transaction.findByWindow(me.windowId),
+                  owner   = binding && Transaction.getParticipant(binding.groupId, binding.workspaceKey),
+                  root    = owner?.componentId && Neo.getComponent(owner.componentId);
+            if (root && binding.workspaceKey === params.get('workspace')) {
+                await root.getController().mountTopologyWorkspace(binding.workspaceKey, me)
+            } else {
+                me.add({ntype: 'component', html: 'This saved window is waiting for its original workspace.'})
+            }
+            return
+        }
+
+        const binding     = Transaction.findByWindow(me.windowId),
+              participant = binding && Transaction.getParticipant(binding.groupId, Workspace.MAIN_WORKSPACE_ID),
+              workspace   = participant?.componentId && Neo.getComponent(participant.componentId);
+
+        if (workspace) {
+            // The old render target is gone; detach silently before the ordinary cross-window add.
+            workspace.parent?.remove(workspace, false, true);
+            me.add(workspace)
+        } else {
+            await me.createRoot(binding, params.get('layout') ?? undefined)
+        }
+    }
+
+    /**
+     * @summary Hydrates one explicitly selected topology before mounting its root render target.
+     * @description Only a root binding can read storage. Popup carriers never select saved roots.
+     * The library is reused with the Workspace on warm F5; this path runs only for a new heap owner.
+     * @param {Object} binding The admitted Group binding.
+     * @param {String} [layoutId] Omission uses only the persisted activeLayoutId.
+     * @returns {Promise<void>}
+     */
+    async createRoot(binding, layoutId) {
+        const me = this;
+        if (!binding || binding.workspaceKey !== 'main') {
+            me.add({ntype: 'component', html: 'This window is waiting for its original workspace.'});
+            return
+        }
+
+        const {default: TopologyLibrary} = await import('../../../src/dashboard/dock/persistence/TopologyLibrary.mjs'),
+              library                    = Neo.create(TopologyLibrary, {
+                  persistenceAdapter: TopologyLibrary.createIndexedDBAdapter(binding.groupId)
+              }),
+              loaded = await library.hydrate();
+
+        let selection = {topology: null, errors: []}, workspace;
+        if (loaded.hydrated || layoutId !== undefined) selection = library.prepareSelection(layoutId);
+
+        const errors = [...loaded.errors, ...selection.errors];
+        if (selection.topology && !selection.topology.workspaces[Workspace.MAIN_WORKSPACE_ID]) {
+            errors.push('saved topology has no Workstation root')
+        }
+
+        if (me.isDestroyed || errors.length) {
+            library.destroy();
+            if (!me.isDestroyed) me.showRootFailure();
+            return
+        }
+
+        try {
+            workspace = Neo.create(Workspace, {
+                flex           : 1,
+                initialTopology: selection.topology,
+                topologyGroupId: binding.groupId,
+                topologyLibrary: library,
+                windowId       : me.windowId
+            });
+
+            if (selection.topology) {
+                await Transaction.write({
+                    cause       : 'cold-hydrate',
+                    changes     : Object.entries(selection.topology.workspaces).map(([workspaceKey, document]) => ({workspaceKey, input: document})),
+                    cursorAction: 'preserve',
+                    descriptor  : {operation: 'hydrateTopology', layoutId: selection.topology.layoutId},
+                    groupId     : binding.groupId,
+                    provenance  : {source: 'cold-hydrate'}
+                });
+                library.adoptCollection(selection.collection, {expectedVersion: selection.version})
+            }
+
+            if (me.isDestroyed) {
+                workspace.destroy();
+                return
+            }
+
+            workspace.getController().attachTopologyLibrary();
+            me.add(workspace);
+            if (!selection.topology) await workspace.saveTopology()
+        } catch (error) {
+            workspace?.destroy();
+            library.destroy();
+            if (!me.isDestroyed) me.showRootFailure();
+            throw error
+        }
+    }
+
+    /**
+     * @summary Offers an explicit fresh root when a persisted selection cannot be used.
+     */
+    showRootFailure() {
+        this.add([
+            {ntype: 'component', html: 'The saved workspace could not be loaded.'},
+            {ntype: 'button', text: 'Start a new workspace', handler: () => this.startBlankRoot()}
+        ])
+    }
+
+    /**
+     * @summary Starts a new logical root without replacing the refused saved collection.
+     * @returns {Promise<void>}
+     */
+    async startBlankRoot() {
+        Transaction.release(this.windowId);
+        const binding = await Transaction.admit({topologyIdentity: {}, windowId: this.windowId});
+        if (binding.outcome === 'refused' || this.isDestroyed) return;
+        this.removeAll();
+        await this.createRoot(binding)
     }
 }
 

--- a/apps/workstation/view/Workspace.mjs
+++ b/apps/workstation/view/Workspace.mjs
@@ -9,10 +9,12 @@ import DockDragAffordances      from '../../../src/dashboard/dock/interaction/Dr
 import DockDropIndicators       from '../../../src/dashboard/dock/interaction/DropIndicators.mjs';
 import DockLayoutAdapter        from '../../../src/dashboard/dock/projection/LayoutAdapter.mjs';
 import PerspectiveLibrary       from '../../../src/dashboard/dock/persistence/PerspectiveLibrary.mjs';
+import TopologyLibrary          from '../../../src/dashboard/dock/persistence/TopologyLibrary.mjs';
 import DockPreview              from '../../../src/dashboard/dock/interaction/Preview.mjs';
 import DockProjectionReconciler from '../../../src/dashboard/dock/projection/Reconciler.mjs';
 import DockService              from '../../../src/ai/client/DockService.mjs';
 import WorkspaceDocument        from '../../../src/dashboard/dock/model/WorkspaceDocument.mjs';
+import WorkspaceController      from './WorkspaceController.mjs';
 import Operations               from '../../../src/dashboard/dock/model/Operations.mjs';
 import Persistence              from '../../../src/dashboard/dock/model/Persistence.mjs';
 import InteractionService       from '../../../src/ai/client/InteractionService.mjs';
@@ -121,6 +123,8 @@ class Workspace extends DockWorkspace {
          * @protected
          */
         className: 'Workstation.view.Workspace',
+        /** @member {Neo.controller.Component} controller */
+        controller: WorkspaceController,
         /**
          * The engine's tear-out lifecycle: the workspace reserves each vessel's slot in its Group and
          * admits the window that binds it. This host supplies the platform seams and its own receipts.
@@ -198,12 +202,15 @@ class Workspace extends DockWorkspace {
      */
     perspectiveStore = null
     /**
-     * Keyed multi-workspace records remain separate from the Workspace layout library. The future
-     * Group owner adopts this collection; until then DockService can capture/list/restore the wire
-     * without widening `PerspectiveLibrary`.
-     * @member {Object|null} topologyCollection=null
+     * One Group's durable keyed records, independent of the single-Workspace perspective library.
+     * @member {Neo.dashboard.dock.persistence.TopologyLibrary|null} topologyLibrary=null
      */
-    topologyCollection = null
+    topologyLibrary = null
+    /**
+     * Validated cold-boot input. Every keyed semantic document exists before its render host mounts.
+     * @member {Object|null} initialTopology=null
+     */
+    initialTopology = null
     /**
      * @member {Neo.ai.client.TourRunner|null} tourRunner=null
      */
@@ -404,6 +411,7 @@ class Workspace extends DockWorkspace {
     #feedIntervalId = null
 
     /**
+     * @summary Creates all cold semantic owners before constructing their presentation.
      * @param {Object} config
      */
     construct(config) {
@@ -411,10 +419,31 @@ class Workspace extends DockWorkspace {
 
         let me = this;
 
-        me.dockModel         = WorkspaceDocument.clone(initialDocument);
+        me.dockModel         = WorkspaceDocument.clone(me.initialTopology?.workspaces[Workspace.MAIN_WORKSPACE_ID] ?? initialDocument);
         me.dockService       = Neo.create(DockService, {});
         me.perspectiveStore  = Neo.create(PerspectiveLibrary, {});
-        me.topologyCollection = Persistence.createTopologyCollection().collection;
+        me.topologyLibrary ??= Neo.create(TopologyLibrary, {
+            collection: Persistence.createTopologyCollection([], {activeLayoutId: null}).collection
+        });
+        me.workspaceSet = createDockWorkspaceSet({documentModel: WorkspaceDocument, manager: TransactionManager, getGroupId: () => me.topologyGroupId});
+        me.registerMainWorkspace();
+
+        for (const [workspaceId, document] of Object.entries(me.initialTopology?.workspaces ?? {})) {
+            if (workspaceId === Workspace.MAIN_WORKSPACE_ID) continue;
+            const state = {
+                committed   : true,
+                disconnected: true,
+                document    : WorkspaceDocument.clone(document),
+                windowId    : null,
+                workspaceId
+            };
+            me.vesselWorkspaces.set(workspaceId, state);
+            me.workspaceSet.register(workspaceId, {
+                componentId: me.id,
+                getDocument: () => state.document,
+                setDocument: value => state.document = value
+            })
+        }
 
         me.tourRunner  = Neo.create(TourRunner, {
             componentId   : me.id,
@@ -435,7 +464,7 @@ class Workspace extends DockWorkspace {
 
         me.appendFeedBatch(25);
 
-        me.add([me.createTourBar(), me.createStatusBar(), {
+        me.add([me.createTourBar(), me.createStatusBar(), me.getController().createTopologyBar(), {
             module: Container,
             cls   : ['workstation-dock-host', 'neo-dashboard', 'neo-dashboard-dock-query-host'],
             flex  : 1,
@@ -501,9 +530,6 @@ class Workspace extends DockWorkspace {
         // through `afterSetTopologyGroupId`, which registers the main participant then. The Group is
         // kept for the instance's lifetime: releasing the window's slot never loses the documents.
         // Vessel workspaces register lazily on first dock-INTO (Edit 2).
-        me.workspaceSet = createDockWorkspaceSet({manager: TransactionManager, getGroupId: () => me.topologyGroupId, documentModel: WorkspaceDocument});
-        me.registerMainWorkspace();
-
         me.crossWindowParticipationPromise = me.refreshCrossWindowParticipation(Workspace.MAIN_WORKSPACE_ID)
             .catch(error => {
                 me.lastCrossWindowTransfer = {applied: false, errors: [error.message]};
@@ -923,6 +949,31 @@ class Workspace extends DockWorkspace {
             getDocument: () => me.dockModel,
             setDocument: document => me.dockModel = document
         })
+    }
+
+    /**
+     * @summary The topology collection belongs to the Group library, including writes from DockService.
+     * @returns {Object|null}
+     */
+    get topologyCollection() {
+        return this.topologyLibrary?.collection ?? null
+    }
+
+    /**
+     * @summary Routes a validated collection adoption through its one owner.
+     * @param {Object} value
+     */
+    set topologyCollection(value) {
+        this.topologyLibrary.collection = value
+    }
+
+    /**
+     * @summary Saves the current topology through the root controller and waits for durability.
+     * @param {String} [layoutId]
+     * @returns {Promise<Object>}
+     */
+    saveTopology(layoutId) {
+        return this.getController().saveTopology(layoutId)
     }
 
     /**
@@ -1867,7 +1918,7 @@ class Workspace extends DockWorkspace {
         let me       = this,
             state    = me.vesselWorkspaces.get(workspaceId),
             document = state?.document,
-            mainView = state?.app?.mainView;
+            mainView = state?.renderTarget ?? state?.app?.mainView;
 
         if (!state || !document || !mainView || mainView.isDestroyed) return false;
         if (state.host && !state.host.isDestroyed) return false;
@@ -5245,7 +5296,7 @@ class Workspace extends DockWorkspace {
     }
 
     /**
-     * Tears down the workspace-owned producer, tour seams, and cached pane instances.
+     * @summary Tears down the workspace-owned producer, topology library, tour seams, and panes.
      * @param {...*} args
      */
     destroy(...args) {
@@ -5268,6 +5319,7 @@ class Workspace extends DockWorkspace {
         me.tourRunner?.destroy();
         me.dockService?.destroy();
         me.perspectiveStore?.destroy();
+        me.topologyLibrary?.destroy();
         me.dragAffordances?.destroy();
         me.interactionService?.destroy();
         me.vesselProxyEmbodiment?.destroy();

--- a/apps/workstation/view/WorkspaceController.mjs
+++ b/apps/workstation/view/WorkspaceController.mjs
@@ -1,0 +1,203 @@
+import Controller         from '../../../src/controller/Component.mjs';
+import Persistence        from '../../../src/dashboard/dock/model/Persistence.mjs';
+import TransactionManager from '../../../src/manager/Transaction.mjs';
+
+/**
+ * @summary Workstation's durable topology selection and user-activated render targets.
+ * @class Workstation.view.WorkspaceController
+ * @extends Neo.controller.Component
+ */
+class WorkspaceController extends Controller {
+    static config = {
+        /** @member {String} className='Workstation.view.WorkspaceController' */
+        className: 'Workstation.view.WorkspaceController'
+    }
+
+    /**
+     * @summary Captures the full keyed composition under its explicit active layout identity.
+     * @param {String} [layoutId] Defaults to the selected layout, or the new-root name `default`.
+     * @returns {Object} The finite topology producer receipt.
+     */
+    captureTopology(layoutId=this.component.topologyCollection?.activeLayoutId ?? 'default') {
+        const selected = this.component.topologyCollection?.topologies?.[layoutId];
+        return Persistence.captureTopologyPerspective(this.component.getDockTopologyWorkspaces(), {
+            layoutId,
+            metadata      : selected?.metadata ?? {},
+            placementHints: selected?.placementHints ?? {},
+            title         : selected?.title ?? layoutId,
+            ...(selected && Object.hasOwn(selected, 'revision') && {revision: selected.revision}),
+            ...(selected && Object.hasOwn(selected, 'perspectiveName') && {perspectiveName: selected.perspectiveName})
+        })
+    }
+
+    /**
+     * @summary Saves a named multi-workspace composition and waits for durable acknowledgement.
+     * @param {String} [layoutId]
+     * @returns {Promise<Object>}
+     */
+    async saveTopology(layoutId) {
+        const group = TransactionManager.get(this.component.topologyGroupId);
+        if (!group || this.isDestroyed) return {persisted: false, current: false, errors: ['workspace is no longer open']};
+        const queue = group.queue;
+        await queue;
+        if (TransactionManager.get(group.id) !== group || group.queue !== queue) {
+            return {persisted: false, current: false, errors: ['workspace changed while waiting to save']}
+        }
+        const {topology, errors} = this.captureTopology(layoutId);
+        if (errors.length) return {persisted: false, errors};
+        const saved = this.component.topologyLibrary.save(topology, {activate: true, replace: true});
+        if (saved.errors.length) return {persisted: false, errors: saved.errors};
+        const result  = await this.component.topologyLibrary.persist(),
+              current = this.captureTopology(topology.layoutId);
+        return {
+            ...result,
+            current: result.current && group.queue === queue && !current.errors.length &&
+                JSON.stringify(current.topology) === JSON.stringify(topology)
+        }
+    }
+
+    /**
+     * @summary Lets the Group library own the reconnect lease and durable disposal of this root.
+     * @returns {Boolean}
+     */
+    attachTopologyLibrary() {
+        return this.component.topologyLibrary.attachGroup({
+            capture: () => this.captureTopology(),
+            dispose: () => this.component.destroy(),
+            groupId: this.component.topologyGroupId,
+            manager: TransactionManager
+        })
+    }
+
+    /**
+     * @summary Provides explicit save/close and user-activated recovery for headless saved windows.
+     * @returns {Object} Toolbar configuration.
+     */
+    createTopologyBar() {
+        const me    = this,
+              items = [{ntype: 'button', text: 'Save workspace', handler: () => me.saveTopology()},
+                  {ntype: 'button', text: 'Close workspace', handler: () => me.closeTopology()}];
+
+        for (const workspaceKey of me.component.vesselWorkspaces.keys()) {
+            items.push(
+                {ntype: 'button', text: `Open ${workspaceKey} as window`, handler: () => me.openTopologyWorkspace(workspaceKey)},
+                {ntype: 'button', text: `Show ${workspaceKey} here`, handler: () => me.mountTopologyWorkspace(workspaceKey, me.component)}
+            )
+        }
+
+        return {
+            ntype    : 'toolbar',
+            cls      : ['workstation-topologybar'],
+            flex     : 'none',
+            items,
+            layout   : {ntype: 'flexbox', align: 'center', direction: 'row', wrap: 'wrap'},
+            reference: 'topology-toolbar'
+        }
+    }
+
+    /**
+     * @summary Presents an already hydrated participant without changing its document or history.
+     * @param {String} workspaceKey
+     * @param {Neo.container.Base} target A user-activated window or the root's inline fallback.
+     * @returns {Promise<Boolean>}
+     */
+    async mountTopologyWorkspace(workspaceKey, target) {
+        const state = this.component.vesselWorkspaces.get(workspaceKey);
+        if (!state || !target || target.isDestroyed) return false;
+
+        state.renderTarget = target;
+        state.windowId = target.windowId;
+        state.app = Neo.apps[target.windowId];
+        if (state.host && !state.host.isDestroyed) {
+            state.host.parent?.remove(state.host, false, true);
+            target.add(state.host);
+            state.disconnected = false;
+            return true
+        }
+        const mounted = await this.component.mountVesselWorkspace(workspaceKey);
+        if (mounted) state.disconnected = false;
+        return mounted
+    }
+
+    /**
+     * @summary Requests a render target only from an explicit user action; refusal keeps its owner.
+     * @param {String} workspaceKey
+     * @returns {Promise<Object>} A separate native-effect receipt, never semantic restore success.
+     */
+    async openTopologyWorkspace(workspaceKey) {
+        const state = this.component.vesselWorkspaces.get(workspaceKey);
+        if (!state) return {opened: false, errors: ['unknown workspace']};
+        const reservation = TransactionManager.reserve({groupId: this.component.topologyGroupId, workspaceKey});
+        if (!reservation) return {opened: false, errors: ['workspace already has a window']};
+
+        const url = new URL('../index.html', import.meta.url);
+        url.searchParams.set('workspace', workspaceKey);
+        url.searchParams.set('theme', this.component.theme);
+
+        let opened = false;
+        try {
+            opened = await Neo.Main.windowOpen({
+                topologyIdentity: reservation,
+                url             : url.href,
+                windowFeatures  : 'width=700,height=600',
+                windowId        : this.component.windowId,
+                windowName      : `workstation-restored-${crypto.randomUUID()}`
+            }) === true
+        } catch {
+            opened = false
+        }
+        if (!opened) TransactionManager.revoke(reservation);
+        return {opened, errors: opened ? [] : ['window was refused; the workspace remains available here']}
+    }
+
+    /**
+     * @summary Durably saves before clearing every carried Group identity and releasing its windows.
+     * @returns {Promise<Object>} Persistence or carrier refusal leaves the Workspace open.
+     */
+    async closeTopology() {
+        const saved = await this.saveTopology();
+        if (!saved.persisted || !saved.current) return {closed: false, errors: saved.errors};
+        const group    = TransactionManager.get(this.component.topologyGroupId),
+              queue    = group.queue,
+              bindings = [...group.bindings.values()].filter(binding => binding.windowId).map(binding => ({...binding})),
+              windows  = bindings.map(binding => binding.windowId);
+        const cleared = await Promise.all(windows.map(windowId =>
+            Neo.Main.clearTopologyIdentity({groupId: group.id, windowId}).then(value => value === true, () => false)
+        ));
+        if (cleared.some(value => value !== true) || group.queue !== queue) {
+            await Promise.allSettled(bindings.filter((binding, index) => cleared[index] === true).map(binding =>
+                Neo.Main.setTopologyIdentity({...binding, groupId: group.id, onlyIfEmpty: true})
+            ));
+            return {closed: false, errors: ['workspace changed or a window refused to clear its identity']}
+        }
+
+        windows.forEach(windowId => {
+            Neo.Main.closeTopologyWindow({windowId}).catch(() => {});
+        });
+        return {closing: true, errors: []}
+    }
+
+    /**
+     * @summary Reports semantic boot and persistence state without exposing live owner references.
+     * @returns {Object}
+     */
+    getTopologyState() {
+        const group = TransactionManager.get(this.component.topologyGroupId);
+        return {
+            groupId       : group.id,
+            historyCount  : group.history?.count ?? 0,
+            historyCursor : group.history?.cursor ?? -1,
+            libraryVersion: this.component.topologyLibrary.version,
+            snapshot      : group.snapshot ?? null,
+            workspaceHosts: Object.fromEntries([...this.component.vesselWorkspaces].map(([key, state]) => [key, {
+                disconnected: state.disconnected,
+                hostId      : state.host?.id ?? null,
+                windowId    : state.windowId
+            }])),
+            workspaceKeys: TransactionManager.participantKeys(group.id)
+        }
+    }
+
+}
+
+export default Neo.setupClass(WorkspaceController);

--- a/buildScripts/util/file-size-baseline.json
+++ b/buildScripts/util/file-size-baseline.json
@@ -1,5 +1,5 @@
 {
-    "apps/workstation/view/Workspace.mjs": 3204,
+    "apps/workstation/view/Workspace.mjs": 3236,
     "examples/dashboard/crossWindow/DemoBWorkspace.mjs": 2646,
     "src/dashboard/dock/Workspace.mjs": 1289,
     "src/main/addon/DragDrop.mjs": 1267

--- a/docs/output/class-hierarchy.json
+++ b/docs/output/class-hierarchy.json
@@ -240,6 +240,7 @@
  "Neo.dashboard.dock.model.WorkspaceDocument": "Neo.core.Base",
  "Neo.dashboard.dock.persistence.PerspectiveLibrary": "Neo.core.Base",
  "Neo.dashboard.dock.persistence.RestorePlanner": "Neo.core.Base",
+ "Neo.dashboard.dock.persistence.TopologyLibrary": "Neo.core.Base",
  "Neo.dashboard.dock.plugin.Maximize": "Neo.plugin.Base",
  "Neo.dashboard.dock.projection.HeaderActionPolicy": "Neo.core.Base",
  "Neo.dashboard.dock.projection.LayoutAdapter": "Neo.core.Base",

--- a/resources/scss/src/apps/workstation/Workspace.scss
+++ b/resources/scss/src/apps/workstation/Workspace.scss
@@ -116,6 +116,21 @@
 
 }
 
+.workstation-topologybar {
+    background   : var(--workstation-panel);
+    border-bottom: 1px solid var(--workstation-line);
+    gap          : 6px;
+    padding      : 6px 12px;
+
+    .neo-button {
+        --button-background-color      : var(--workstation-panel-2);
+        --button-background-color-hover: color-mix(in srgb, var(--workstation-signal) 12%, var(--workstation-panel-2));
+        --button-border                : 1px solid var(--workstation-line);
+        --button-height                : 32px;
+        --button-text-color            : var(--workstation-ink);
+    }
+}
+
 .workstation-tourbar {
     --button-height: 34px;
 

--- a/src/Main.mjs
+++ b/src/Main.mjs
@@ -142,6 +142,8 @@ class Main extends core.Base {
                 'setNeoConfig',
                 'setRoute',
                 'setTopologyIdentity',
+                'clearTopologyIdentity',
+                'closeTopologyWindow',
                 'windowClose',
                 'windowCloseAll',
                 'windowFocus',
@@ -340,7 +342,7 @@ class Main extends core.Base {
     }
 
     /**
-     * Writes the identity the App Worker bound this window to, so the next page load presents it again
+     * @summary Writes the identity the App Worker bound this window to, so the next page load presents it again
      * (the worker manager reads it into every worker registration). `Neo.manager.Transaction` asks for
      * this after it minted, cold-created or forked a Group for the window; a plain bind or rebind writes
      * nothing, because the carrier already holds what it presented.
@@ -348,15 +350,51 @@ class Main extends core.Base {
      * @param {String} data.groupId
      * @param {String} data.workspaceKey
      * @param {String} data.generationToken
+     * @param {Boolean} [data.onlyIfEmpty=false] Compensates a refused close without overwriting a newer carrier.
      * @returns {Boolean} Whether the carrier accepted the write.
      */
-    setTopologyIdentity({generationToken, groupId, workspaceKey}) {
+    setTopologyIdentity({generationToken, groupId, workspaceKey, onlyIfEmpty=false}) {
         try {
+            if (onlyIfEmpty && window.sessionStorage.getItem(WorkerManager.topologyIdentityStorageKey) !== null) return false;
             window.sessionStorage.setItem(WorkerManager.topologyIdentityStorageKey, JSON.stringify({generationToken, groupId, workspaceKey}));
             return true
         } catch {
             return false
         }
+    }
+
+    /**
+     * @summary Clears only the closing Group's carrier; a different root's identity is untouched.
+     * @param {Object} data
+     * @param {String} data.groupId The Group whose close-all operation was durably acknowledged.
+     * @returns {Boolean}
+     */
+    clearTopologyIdentity({groupId}) {
+        try {
+            const key     = WorkerManager.topologyIdentityStorageKey,
+                  current = JSON.parse(window.sessionStorage.getItem(key) || 'null');
+            if (current?.groupId !== groupId) return false;
+            window.sessionStorage.removeItem(key);
+            return true
+        } catch {
+            return false
+        }
+    }
+
+    /**
+     * @summary Ends this render target after its Group's durable close cleared the carrier.
+     * @description Each realm closes itself, including popups whose opener reloaded. A browser-owned
+     * tab that refuses close navigates to a blank document, releasing its worker port just the same.
+     * The scheduled effect lets the remote response leave first; Group disconnect is the receipt.
+     * @returns {Boolean} Whether closure was scheduled; a carried identity refuses the request.
+     */
+    closeTopologyWindow() {
+        if (window.sessionStorage.getItem(WorkerManager.topologyIdentityStorageKey) !== null) return false;
+        setTimeout(() => {
+            window.close();
+            if (!window.closed) window.location.replace('about:blank')
+        }, 0);
+        return true
     }
 
     /**

--- a/src/dashboard/dock/persistence/TopologyLibrary.mjs
+++ b/src/dashboard/dock/persistence/TopologyLibrary.mjs
@@ -1,0 +1,455 @@
+import Base              from '../../../core/Base.mjs';
+import Persistence       from '../model/Persistence.mjs';
+import WorkspaceDocument from '../model/WorkspaceDocument.mjs';
+
+/**
+ * @summary One Group's named topology records and persistence seam.
+ * @description The owning bootstrap creates this library lazily and supplies its storage adapter.
+ * All wire rules remain in Persistence: this class holds one validated topology collection, with
+ * isolated reads and explicit selection. It creates no Workspace, window, Group, or history row.
+ *
+ * prepareSelection() returns an isolated candidate without changing the active selection;
+ * adoptCollection() is the explicit adopter a transaction owner can compose with other participants.
+ * The local version fences stale candidates and storage reads. Persistence calls serialize, and an
+ * acknowledgement for an older version never makes newer state clean. An optional Group attachment
+ * retains its truth across reconnect leases and retires only after a current durable acknowledgement.
+ *
+ * @class Neo.dashboard.dock.persistence.TopologyLibrary
+ * @extends Neo.core.Base
+ */
+class TopologyLibrary extends Base {
+    /**
+     * @summary Creates a window-independent browser storage adapter for one logical root.
+     * @description IndexedDB is available in the App Worker after its last render target leaves.
+     * A write resolves on transaction completion, never merely on the put request's success.
+     * Each operation closes its connection, so no database handle outlives the library owner.
+     * @param {String} key Stable storage identity, independent of the current window generation.
+     * @returns {{read: Function, write: Function}}
+     * @static
+     */
+    static createIndexedDBAdapter(key) {
+        if (typeof key !== 'string' || !key.trim()) throw new Error('topology storage requires a root key');
+
+        const transact = (mode, value) => new Promise((resolve, reject) => {
+            const request = indexedDB.open('neo-dock-topologies', 1);
+
+            request.onupgradeneeded = () => request.result.createObjectStore('collections');
+            request.onerror = () => reject(request.error);
+            request.onsuccess = () => {
+                const database = request.result;
+                let transaction;
+
+                try {
+                    transaction = database.transaction('collections', mode);
+                    const store     = transaction.objectStore('collections'),
+                          operation = mode === 'readonly' ? store.get(key) : store.put(value, key);
+
+                    transaction.oncomplete = () => {
+                        database.close();
+                        resolve(mode === 'readonly' ? operation.result ?? null : undefined)
+                    };
+                    transaction.onabort = () => {
+                        database.close();
+                        reject(transaction.error ?? new Error('topology storage transaction aborted'))
+                    }
+                } catch (error) {
+                    transaction?.abort();
+                    database.close();
+                    reject(error)
+                }
+            }
+        });
+
+        return {read: () => transact('readonly'), write: collection => transact('readwrite', collection)}
+    }
+
+    static config = {
+        /** @member {String} className='Neo.dashboard.dock.persistence.TopologyLibrary' */
+        className: 'Neo.dashboard.dock.persistence.TopologyLibrary',
+        /**
+         * The validated neo.dock.topologyCollection.v1 document; null means nothing has been adopted.
+         * @member {Object|null} collection_=null
+         * @reactive
+         */
+        collection_: null,
+        /**
+         * Storage wiring. read() resolves to a collection or null; write(collection) acknowledges
+         * those bytes by resolving and reports failure by rejecting. Only plain JSON crosses it.
+         * @member {Object|null} persistenceAdapter=null
+         */
+        persistenceAdapter: null
+    }
+
+    /** @member {String[]} lastErrors=[] */
+    lastErrors = []
+    /** @member {Promise} #ioQueue */
+    #ioQueue = Promise.resolve()
+    /** @member {Number} #persistedVersion=0 */
+    #persistedVersion = 0
+    /** @member {Number} #version=0 */
+    #version = 0
+    /** @member {Object|null} #attachment=null */
+    #attachment = null
+    /** @member {Promise<Boolean>|null} #retirement=null */
+    #retirement = null
+    /** @member {Number|null} #retryTimer=null */
+    #retryTimer = null
+
+    /**
+     * @summary Retains one Group and observes its existing binding lease, independently of windows.
+     * @param {Object} options
+     * @param {Neo.manager.Transaction} options.manager The generic Group authority.
+     * @param {String} options.groupId
+     * @param {Function} options.capture Returns the current `{topology, errors}` snapshot.
+     * @param {Function} options.dispose Releases the host's components after Group retirement.
+     * @param {Number} [options.retryDelayMs=1000] Bounded delay between failed persistence attempts.
+     * @returns {Boolean}
+     */
+    attachGroup({manager, groupId, capture, dispose, retryDelayMs=1000}) {
+        if (this.#attachment || this.isDestroyed || !Number.isFinite(retryDelayMs) || retryDelayMs < 1) return false;
+        const group = manager.get(groupId);
+        if (!group || typeof capture !== 'function' || typeof dispose !== 'function' || !manager.retainGroup(groupId, this)) return false;
+
+        const listener = {
+            commit: data => {
+                if (data.groupId === groupId) this.persistCurrent()
+            },
+            bind: data => {
+                if (data.groupId === groupId) {
+                    this.#clearRetry();
+                    group.persistenceState = 'active'
+                }
+            },
+            leaseExpired: data => {
+                if (data.groupId === groupId) this.retireIfHeadless()
+            },
+            scope: this
+        };
+
+        this.#attachment = {capture, dispose, group, groupId, listener, manager, retryDelayMs};
+        manager.on(listener);
+        group.persistenceState = 'active';
+        return true
+    }
+
+    /**
+     * @summary Cancels the persistence retry when a binder returns or the owner retires.
+     * @private
+     */
+    #clearRetry() {
+        if (this.#retryTimer !== null) clearTimeout(this.#retryTimer);
+        this.#retryTimer = null
+    }
+
+    /**
+     * @summary Captures committed Group truth before asking storage to acknowledge it.
+     * @returns {Promise<Object>} The persistence receipt; capture failure preserves the held library.
+     */
+    async persistCurrent() {
+        const attachment = this.#attachment;
+        if (!attachment || this.isDestroyed) return {persisted: false, current: false, errors: ['no live Group attachment']};
+
+        try {
+            const {topology, errors} = attachment.capture();
+            if (errors.length) return {persisted: false, current: false, errors};
+            const saved = this.save(topology, {activate: true, replace: true});
+            if (saved.errors.length) return {persisted: false, current: false, errors: saved.errors};
+            return {...await this.persist(), topology}
+        } catch (error) {
+            return {persisted: false, current: false, errors: [String(error?.message ?? error)]}
+        }
+    }
+
+    /**
+     * @summary Retires after the Group queue, reconnect lease, references and storage all permit it.
+     * @description Concurrent callers share the attempt. A bind or queued write arriving during I/O
+     * invalidates retirement. Failure keeps the same Group and retries; it never replays history.
+     * @returns {Promise<Boolean>} Whether this attempt retired the Group.
+     */
+    retireIfHeadless() {
+        if (this.#retirement) return this.#retirement;
+        const attachment = this.#attachment;
+        if (!attachment || this.isDestroyed) return Promise.resolve(false);
+
+        const {group, groupId, manager} = attachment,
+              live                      = () => !this.isDestroyed && this.#attachment === attachment && manager.get(groupId) === group;
+
+        this.#retirement = (async () => {
+            const queue = group.queue;
+            await queue;
+            if (!live() || group.bindings.size || group.queue !== queue) return false;
+
+            const result = await this.persistCurrent();
+            if (!live() || group.bindings.size) return false;
+
+            const latest    = attachment.capture(),
+                  unchanged = !latest.errors.length && JSON.stringify(latest.topology) === JSON.stringify(result.topology);
+
+            group.persistenceState = result.persisted && result.current && unchanged && !this.dirty ? 'headless-clean' : 'headless-dirty';
+            group.provider?.setData({persistenceState: group.persistenceState});
+
+            if (!result.persisted || !result.current || !unchanged || this.dirty || group.queue !== queue ||
+                group.retainedReferences.size !== 1 || !group.retainedReferences.has(this)) return false;
+
+            manager.releaseGroup(groupId, this);
+            manager.retireGroup(groupId);
+            manager.fire('groupRetired', {groupId});
+            attachment.dispose();
+            return true
+        })().finally(() => {
+            this.#retirement = null;
+            if (live() && !group.bindings.size) {
+                this.#clearRetry();
+                this.#retryTimer = setTimeout(() => {
+                    this.#retryTimer = null;
+                    this.retireIfHeadless()
+                }, attachment.retryDelayMs)
+            }
+        });
+
+        return this.#retirement
+    }
+
+    /**
+     * @summary Releases only this library's listener, retry and retained reference.
+     */
+    destroy() {
+        this.#clearRetry();
+        const attachment = this.#attachment;
+        this.#attachment = null;
+        if (attachment) {
+            attachment.manager.un(attachment.listener);
+            attachment.manager.releaseGroup(attachment.groupId, this)
+        }
+        super.destroy()
+    }
+
+    /**
+     * @summary Whether the current collection differs from the last acknowledged storage version.
+     * @returns {Boolean}
+     */
+    get dirty() {
+        return this.#version !== this.#persistedVersion
+    }
+
+    /**
+     * @summary The local adoption version; it is never added to the persisted schema.
+     * @returns {Number}
+     */
+    get version() {
+        return this.#version
+    }
+
+    /**
+     * @summary Validates assignments before cloning; a refused candidate preserves the held document.
+     * @param {Object|null} value
+     * @param {Object|null} oldValue
+     * @returns {Object|null}
+     * @protected
+     */
+    beforeSetCollection(value, oldValue) {
+        const errors = value == null ? [] : Persistence.validateTopologyCollection(value);
+
+        this.lastErrors = errors;
+
+        return errors.length ? oldValue ?? null : value == null ? null : WorkspaceDocument.clone(value)
+    }
+
+    /**
+     * @summary Counts adopted changes; initializing an unobserved library is not a dirty write.
+     * @param {Object|null} value
+     * @param {Object|null} oldValue
+     * @protected
+     */
+    afterSetCollection(value, oldValue) {
+        if (oldValue !== undefined || value !== null) this.#version++
+    }
+
+    /**
+     * @summary Public collection reads are isolated JSON.
+     * @param {Object|null} value
+     * @returns {Object|null}
+     * @protected
+     */
+    beforeGetCollection(value) {
+        return value === null ? null : WorkspaceDocument.clone(value)
+    }
+
+    /**
+     * @summary Prepares an explicit or persisted active selection without adopting it.
+     * @param {String} [layoutId] Omission uses the validated activeLayoutId, never the first key.
+     * @returns {{collection: Object|null, topology: Object|null, version: Number, errors: String[]}}
+     */
+    prepareSelection(layoutId) {
+        const collection = this.collection,
+              version    = this.#version;
+
+        if (collection && layoutId !== undefined) collection.activeLayoutId = layoutId;
+
+        const {topology, errors} = Persistence.restoreActiveTopology(collection);
+
+        return {collection: errors.length ? null : collection, topology, version, errors}
+    }
+
+    /**
+     * @summary Resolves an isolated topology without changing the selection.
+     * @param {String} [layoutId]
+     * @returns {{topology: Object|null, errors: String[]}}
+     */
+    resolve(layoutId) {
+        const {topology, errors} = this.prepareSelection(layoutId);
+
+        return {topology, errors}
+    }
+
+    /**
+     * @summary Adopts one complete candidate; an optional version fence rejects a stale preparation.
+     * @param {Object} collection A complete topology collection, including its explicit active id.
+     * @param {Object} [options={}]
+     * @param {Number} [options.expectedVersion] The version returned by prepareSelection().
+     * @returns {{adopted: Boolean, version: Number, errors: String[]}}
+     */
+    adoptCollection(collection, {expectedVersion} = {}) {
+        const errors = this.isDestroyed
+            ? ['topology library is destroyed']
+            : expectedVersion !== undefined && expectedVersion !== this.#version
+                ? ['topology collection changed after preparation']
+                : Persistence.validateTopologyCollection(collection);
+
+        if (errors.length) {
+            if (!this.isDestroyed) this.lastErrors = errors;
+            return {adopted: false, version: this.#version, errors}
+        }
+
+        this.collection = collection;
+        return {adopted: true, version: this.#version, errors: []}
+    }
+
+    /**
+     * @summary Stores one normalized record. Replacing an id and activating it are explicit choices.
+     * A first save requires activate:true because a nonempty collection must name its active topology.
+     * @param {Object} topology A neo.dock.topology.v1 record.
+     * @param {Object} [options={}]
+     * @param {Boolean} [options.replace=false] Permit replacement of this exact layoutId.
+     * @param {Boolean} [options.activate=false] Select this record in the resulting collection.
+     * @returns {{saved: Boolean, layoutId: String|null, collision: Object|null, errors: String[]}}
+     */
+    save(topology, {replace = false, activate = false} = {}) {
+        const result = Persistence.restoreTopology(topology);
+
+        if (result.errors.length) {
+            this.lastErrors = result.errors;
+            return {saved: false, layoutId: null, collision: null, errors: result.errors}
+        }
+
+        const record    = result.topology,
+              layoutId  = record.layoutId,
+              candidate = this.collection ?? Persistence.createTopologyCollection([], {activeLayoutId: null}).collection;
+
+        if (Object.hasOwn(candidate.topologies, layoutId) && replace !== true) {
+            const errors = [`topology "${layoutId}" already exists; replacement must be explicit`];
+
+            this.lastErrors = errors;
+            return {saved: false, layoutId, collision: {layoutId, title: candidate.topologies[layoutId].title}, errors}
+        }
+
+        candidate.topologies[layoutId] = record;
+        if (activate === true) candidate.activeLayoutId = layoutId;
+
+        const {adopted, errors} = this.adoptCollection(candidate);
+
+        return {saved: adopted, layoutId, collision: null, errors}
+    }
+
+    /**
+     * @summary Serializes storage operations without turning a failed operation into a poisoned tail.
+     * @param {Function} operation
+     * @returns {Promise<Object>}
+     * @private
+     */
+    #enqueue(operation) {
+        const result = this.#ioQueue.then(operation);
+
+        this.#ioQueue = result.then(() => {}, () => {});
+        return result
+    }
+
+    /**
+     * @summary Hydrates only a validated collection. A late read cannot replace a newer local adoption.
+     * Missing storage leaves the current state untouched; warm reuse should not call this method.
+     * @returns {Promise<{hydrated: Boolean, errors: String[]}>}
+     */
+    async hydrate() {
+        const version = this.#version,
+              adapter = this.persistenceAdapter;
+
+        if (typeof adapter?.read !== 'function') {
+            return {hydrated: false, errors: ['no persistence adapter with a read() seam is configured']}
+        }
+
+        const read = adapter.read.bind(adapter);
+
+        return this.#enqueue(async () => {
+            if (this.isDestroyed) return {hydrated: false, errors: ['topology library is destroyed']};
+
+            let payload;
+            try {
+                payload = await read()
+            } catch (error) {
+                const errors = [error?.message || 'the persistence adapter rejected the read'];
+                if (!this.isDestroyed) this.lastErrors = errors;
+                return {hydrated: false, errors}
+            }
+
+            if (payload == null) return {hydrated: false, errors: []};
+
+            const {adopted, errors} = this.adoptCollection(payload, {expectedVersion: version});
+
+            if (adopted) this.#persistedVersion = this.#version;
+            return {hydrated: adopted, errors}
+        })
+    }
+
+    /**
+     * @summary Writes a validated snapshot in request order. persisted acknowledges that version;
+     * current additionally proves it still matches the held collection. Failure never discards truth.
+     * @returns {Promise<{persisted: Boolean, current: Boolean, version: Number, errors: String[]}>}
+     */
+    async persist() {
+        const version = this.#version,
+              adapter = this.persistenceAdapter,
+              errors  = this.isDestroyed
+                  ? ['topology library is destroyed']
+                  : typeof adapter?.write !== 'function'
+                      ? ['no persistence adapter with a write() seam is configured']
+                      : Persistence.validateTopologyCollection(this._collection);
+
+        if (errors.length) {
+            if (!this.isDestroyed) this.lastErrors = errors;
+            return {persisted: false, current: false, version, errors}
+        }
+
+        const snapshot = WorkspaceDocument.clone(this._collection),
+              write    = adapter.write.bind(adapter);
+
+        return this.#enqueue(async () => {
+            if (this.isDestroyed) return {persisted: false, current: false, version, errors: ['topology library is destroyed']};
+
+            try {
+                await write(snapshot)
+            } catch (error) {
+                const errors = [error?.message || 'the persistence adapter rejected the write'];
+                if (!this.isDestroyed) this.lastErrors = errors;
+                return {persisted: false, current: false, version, errors}
+            }
+
+            if (this.isDestroyed) return {persisted: true, current: false, version, errors: []};
+
+            this.#persistedVersion = version;
+            this.lastErrors = [];
+            return {persisted: true, current: version === this.#version, version, errors: []}
+        })
+    }
+}
+
+export default Neo.setupClass(TopologyLibrary);

--- a/src/manager/Transaction.mjs
+++ b/src/manager/Transaction.mjs
@@ -299,24 +299,25 @@ class Transaction extends Manager {
     }
 
     /**
-     * Registers a new Group. The id is minted here unless a carrier presents one this worker never saw.
+     * @summary Registers a new Group. The id is minted here unless a carrier presents one this worker never saw.
      * The default history bound is sampled now; the Group may choose its own before loading history.
      * @param {String} [groupId]
      * @returns {Object} The Group record: `{id, bindings, createdAt, participants, historyDepth, history,
-     *   historyReady, provider, queue}`
+     *   historyReady, provider, queue, retainedReferences}`
      * @protected
      */
     createGroup(groupId=crypto.randomUUID()) {
         const group = {
-            bindings    : new Map(),
-            createdAt   : Date.now(),
-            history     : null,
-            historyDepth: this.historyDepth,
-            historyReady: null,
-            id          : groupId,
-            participants: new Map(),
-            provider    : null,
-            queue       : Promise.resolve()
+            bindings          : new Map(),
+            createdAt         : Date.now(),
+            history           : null,
+            historyDepth      : this.historyDepth,
+            historyReady      : null,
+            id                : groupId,
+            participants      : new Map(),
+            provider          : null,
+            queue             : Promise.resolve(),
+            retainedReferences: new Set()
         };
 
         this.register(group);
@@ -695,6 +696,16 @@ class Transaction extends Manager {
     }
 
     /**
+     * @summary Releases one exact ownership token without deciding whether the Group may retire.
+     * @param {String} groupId
+     * @param {*} reference The same non-null token supplied to retainGroup().
+     * @returns {Boolean} Whether that token was retained and removed.
+     */
+    releaseGroup(groupId, reference) {
+        return reference != null && (this.get(groupId)?.retainedReferences.delete(reference) ?? false)
+    }
+
+    /**
      * Reserves a slot for a window the caller is about to open. The returned identity is what the opener
      * writes into the child's carrier; the child's `connect` then binds with the reserved token. A slot
      * with a live binder cannot be reserved.
@@ -727,6 +738,21 @@ class Transaction extends Manager {
         me.startLease(group, binding);
 
         return {generationToken: binding.generationToken, groupId, workspaceKey}
+    }
+
+    /**
+     * @summary Retains a Group for an opaque owner independently of windows, participants and history.
+     * @param {String} groupId
+     * @param {*} reference A non-null ownership token, compared by Set identity.
+     * @returns {Boolean} Whether a new token was retained; duplicates and absent Groups return false.
+     */
+    retainGroup(groupId, reference) {
+        const group = this.get(groupId);
+
+        if (!group || reference == null || group.retainedReferences.has(reference)) return false;
+
+        group.retainedReferences.add(reference);
+        return true
     }
 
     /**
@@ -798,7 +824,7 @@ class Transaction extends Manager {
     }
 
     /**
-     * Holds a released or reserved slot for its lineage; on expiry the slot is free.
+     * @summary Holds a released or reserved slot for its lineage; on expiry the slot is free.
      * @param {Object} group
      * @param {Object} binding
      * @protected
@@ -816,13 +842,11 @@ class Transaction extends Manager {
                 group.bindings.delete(binding.workspaceKey);
                 me.fire('leaseExpired', {groupId: group.id, workspaceKey: binding.workspaceKey});
 
-                // A Group with no binding, no participant and no retained history row holds nothing this
-                // manager keeps for it, so letting it go loses nothing. A Group whose participants or rows
-                // outlive its last window is not empty: its documents are still owned, its history is
-                // still the truth of what they did. Conditional, lossless retirement of a Group that DOES
-                // hold state is a later contract; this only stops closed windows from leaving empty Groups
-                // behind in a long-lived worker.
-                if (group.bindings.size === 0 && group.participants.size === 0 && !group.history?.count && me.get(group.id) === group) {
+                // Only empty, unreferenced Groups may expire automatically. Owners decide when a
+                // Group retaining participants, history or external references can be retired.
+                if (group.bindings.size === 0 && group.participants.size === 0 &&
+                    group.retainedReferences.size === 0 && !group.history?.count && me.get(group.id) === group
+                ) {
                     me.retireGroup(group.id);
                     me.fire('groupRetired', {groupId: group.id})
                 }

--- a/test/playwright/e2e/utils/dockGeometry.mjs
+++ b/test/playwright/e2e/utils/dockGeometry.mjs
@@ -77,29 +77,33 @@ export function intersectsRect(first, second) {
  * displacement broke: when the indicator layer rooted at the viewport instead of the host,
  * the header bands were the first surface it bled into.
  *
- * Asserts: tourBar.bottom = statusBar.top, statusBar.bottom = dockHost.top (adjacency, ±1px),
+ * Asserts adjacency through tour, status and topology bars into the dock host (±1px),
  * and the dock host reaches the window's bottom edge.
  *
  * @param {Object} app the connected neuralLink app wrapper
- * @param {Object} ids {tourBarId, statusBarId, dockHostId} component ids (the tour bar needs
+ * @param {Object} ids {tourBarId, statusBarId, topologyBarId, dockHostId} component ids (the tour bar needs
  *   `reference: 'tour-bar'` on the workspace — added with this family)
  * @param {Object} [options] {viewportHeight} expected window inner height; omit to skip the
  *   bottom-edge leg (e.g. when the host's own bottom chrome is intentional)
  */
-export async function assertBootContainmentChain(app, {tourBarId, statusBarId, dockHostId}, {viewportHeight} = {}) {
-    const rects  = await readComponentRects(app, [tourBarId, statusBarId, dockHostId]),
-          tour   = rects[tourBarId],
-          status = rects[statusBarId],
-          host   = rects[dockHostId];
+export async function assertBootContainmentChain(app, {tourBarId, statusBarId, topologyBarId, dockHostId}, {viewportHeight} = {}) {
+    const rects    = await readComponentRects(app, [tourBarId, statusBarId, topologyBarId, dockHostId]),
+          tour     = rects[tourBarId],
+          status   = rects[statusBarId],
+          topology = rects[topologyBarId],
+          host     = rects[dockHostId];
 
     expect(tour?.height,   'tour bar must render with height').toBeGreaterThan(0);
     expect(status?.height, 'status bar must render with height').toBeGreaterThan(0);
+    expect(topology?.height, 'topology bar must render with height').toBeGreaterThan(0);
     expect(host?.height,   'dock host must render with height').toBeGreaterThan(0);
 
     expect(Math.abs(tour.bottom - status.top),
         'tour bar and status bar must tile without gap or overlap').toBeLessThanOrEqual(1);
-    expect(Math.abs(status.bottom - host.top),
-        'status bar and dock host must tile without gap or overlap').toBeLessThanOrEqual(1);
+    expect(Math.abs(status.bottom - topology.top),
+        'status bar and topology bar must tile without gap or overlap').toBeLessThanOrEqual(1);
+    expect(Math.abs(topology.bottom - host.top),
+        'topology bar and dock host must tile without gap or overlap').toBeLessThanOrEqual(1);
 
     if (viewportHeight !== undefined) {
         expect(Math.abs(host.bottom - viewportHeight),

--- a/test/playwright/e2e/workstation/WorkstationDragAffordancesNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationDragAffordancesNL.spec.mjs
@@ -634,12 +634,13 @@ test.describe('Workstation drag affordances — the flagship journey (Neural Lin
 
         const readId = result => result?.properties?.id ?? result?.id ?? (Array.isArray(result) ? readId(result[0]) : null);
 
-        const [tourBar, statusBar, dockHost] = await Promise.all([
+        const [tourBar, statusBar, topologyBar, dockHost] = await Promise.all([
                 app.queryComponent({reference: 'tour-bar'},   ['id']),
                 app.queryComponent({reference: 'status-bar'}, ['id']),
+                app.queryComponent({reference: 'topology-toolbar'}, ['id']),
                 app.queryComponent({reference: 'dock-host'},  ['id'])
             ]),
-            ids = {dockHostId: readId(dockHost), statusBarId: readId(statusBar), tourBarId: readId(tourBar)};
+            ids = {dockHostId: readId(dockHost), statusBarId: readId(statusBar), topologyBarId: readId(topologyBar), tourBarId: readId(tourBar)};
 
         expect(ids.tourBarId,   'the tour bar must expose a component id (reference: tour-bar)').toBeTruthy();
         expect(ids.statusBarId, 'the status bar must expose a component id').toBeTruthy();

--- a/test/playwright/e2e/workstation/WorkstationTopologyGroupsNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationTopologyGroupsNL.spec.mjs
@@ -1,4 +1,6 @@
 import {test, expect} from '../../fixtures.mjs';
+import Operations     from '../../../../src/dashboard/dock/model/Operations.mjs';
+import Persistence    from '../../../../src/dashboard/dock/model/Persistence.mjs';
 
 /**
  * @summary Whitebox E2E witness: two Workstation roots under one SharedWorker are two logical topology
@@ -46,8 +48,8 @@ const readCarrier = page => page.evaluate(key => JSON.parse(sessionStorage.getIt
 const readWindowId = page => page.evaluate(() => Neo.worker.Manager.windowId);
 
 /** Boots the full Workstation in a page and waits for its dock to project. */
-const bootRoot = async page => {
-    await page.goto('/apps/workstation/index.html');
+const bootRoot = async (page, search = '') => {
+    await page.goto(`/apps/workstation/index.html${search}`);
     await page.waitForSelector('.workstation-dock-host',               {timeout: 60000});
     await page.waitForSelector('.neo-tab-header-button.neo-draggable', {timeout: 60000})
 };
@@ -60,8 +62,8 @@ const bootPaneHost = async page => {
 };
 
 /**
- * The live Workspace projected for one window, or `null`. A reloaded root is a new instance; the one
- * its superseded generation created stays in the worker, so the lookup is by window, never "the first".
+ * The live Workspace projected for one window, or `null`. Warm reload moves its retained owner to the
+ * successor window, so the lookup is by current window, never "the first".
  */
 const workspaceFor = async (app, windowId) => {
     const records = await app.findInstances({className: WORKSPACE}, ['id', 'windowId']);
@@ -90,9 +92,318 @@ const focusPane = async (page, title) => {
     return header
 };
 
+/** @summary Reads the worker's semantic boot receipt without inspecting projection internals. */
+const topologyState = (app, workspaceId) => app.callMethod(workspaceId, 'controller.getTopologyState');
+
+/** @summary Resolves the exact App Worker, including remotes which return a reply envelope. */
+const readWorkerId = async page => {
+    let workerId;
+    await expect.poll(async () => {
+        const reply = await page.evaluate(async () => {
+            const appWorker = window.Neo?.worker?.App;
+            return appWorker?.getWorkerId ? await appWorker.getWorkerId() : null
+        });
+        workerId = typeof reply === 'string' ? reply : reply?.data;
+        return typeof workerId === 'string' && workerId.length > 0
+    }, {message: 'the exact App Worker remote is ready', timeout: 30000}).toBe(true);
+
+    return workerId
+};
+
+/** @summary Creates a page with its prior session carrier, leaving popup reservation carriers untouched. */
+const carriedPage = async (context, carrier) => {
+    const page = await context.newPage();
+
+    await page.addInitScript(({key, identity}) => {
+        if (location.protocol === 'http:' || location.protocol === 'https:') {
+            if (!sessionStorage.getItem(key)) sessionStorage.setItem(key, JSON.stringify(identity))
+        }
+    }, {key: CARRIER, identity: carrier});
+    return page
+};
+
+/**
+ * @summary Saves two finite topologies through the live library's real IndexedDB adapter.
+ * @description A retains the original composition; B moves the real Feed record to keyed details.
+ * B is explicitly active although A was inserted first. No live document is hand-constructed.
+ */
+const savedColdFixture = async (page, context, neuralLink) => {
+    await bootRoot(page);
+    const app         = await neuralLink.connectToApp('Workstation'),
+          workspaceId = await workspaceFor(app, await readWindowId(page)),
+          carrier     = await readCarrier(page),
+          document    = (await app.getComponent(workspaceId, ['dockModel'])).dockModel,
+          empty       = {
+              schema: 'neo.dock.zone.v1', root: 'details-root', items: {},
+              nodes : {
+                  'details-root': {type: 'edge-zone', zones: {center: {nodeId: 'details-tabs'}}},
+                  'details-tabs': {type: 'tabs', items: [], activeItemId: null}
+              }
+          },
+          moved = Operations.transferItem(document, empty, {
+              itemId: 'feed', sourceWorkspaceId: 'workstation-main', targetWorkspaceId: 'details',
+              target: {operation: 'addTab', tabsNodeId: 'details-tabs'}
+          });
+
+    expect(moved.errors).toEqual([]);
+    const a = Persistence.captureTopologyPerspective({'workstation-main': document}, {layoutId: 'layout-a'}),
+          b = Persistence.captureTopologyPerspective({'workstation-main': moved.sourceDocument, details: moved.targetDocument}, {
+              layoutId      : 'layout-b',
+              placementHints: {details: {dx: 240, dy: 80, fallbackTarget: {workspaceKey: 'workstation-main', nodeId: 'root'}}}
+          });
+    expect(a.errors).toEqual([]);
+    expect(b.errors).toEqual([]);
+    const saved = Persistence.createTopologyCollection([a.topology, b.topology], {activeLayoutId: 'layout-b'});
+    expect(saved.errors).toEqual([]);
+
+    await app.callMethod(workspaceId, 'topologyLibrary.persist');
+    expect(await app.callMethod(workspaceId, 'topologyLibrary.adoptCollection', [saved.collection])).toMatchObject({adopted: true, errors: []});
+    expect(await app.callMethod(workspaceId, 'topologyLibrary.persist')).toMatchObject({persisted: true, current: true, errors: []});
+
+    const popupCarrier = await app.callMethod(workspaceId, 'transactionManager.reserve', [{groupId: carrier.groupId, workspaceKey: 'details'}]);
+    return {
+        carrier, popupCarrier, sessionId: app.sessionId,
+        storageState: await context.storageState({indexedDB: true}),
+        records     : {a: a.topology, b: b.topology}
+    }
+};
+
+/** @summary Boots a carried root and identity-binds NL after the original fixture page was closed. */
+const coldRoot = async (context, neuralLink, carrier, search = '') => {
+    const page = await carriedPage(context, carrier);
+    await bootRoot(page, search);
+    const app      = await neuralLink.connectToApp(await readWorkerId(page)),
+          windowId = await readWindowId(page);
+    await expect.poll(() => workspaceFor(app, windowId), {timeout: 15000}).toBeTruthy();
+    return {page, app, workspaceId: await workspaceFor(app, windowId)}
+};
+
+/** @summary Verifies semantic cold materialization and the atomic writer's empty-history baseline. */
+const expectColdTopology = async (root, record) => {
+    const state      = await topologyState(root.app, root.workspaceId),
+          collection = (await root.app.getComponent(root.workspaceId, ['topologyLibrary.collection']))['topologyLibrary.collection'];
+    expect(state.workspaceKeys.slice().sort()).toEqual(Object.keys(record.workspaces).sort());
+    expect(state.snapshot?.participants, 'cold truth was published through the atomic Group writer').toEqual(record.workspaces);
+    expect(state.historyCount).toBe(0);
+    expect(state.historyCursor).toBe(-1);
+    expect(collection.activeLayoutId).toBe(record.layoutId);
+    expect(Object.keys(collection.topologies).sort()).toEqual(['layout-a', 'layout-b']);
+    expect(await root.app.callMethod(root.workspaceId, 'getDockTopologyWorkspaces')).toEqual(record.workspaces);
+    return state
+};
+
 test.describe('Workstation topology Groups — two roots under one SharedWorker (Neural Link)', () => {
     test.setTimeout(180000);
     test.use({viewport: {width: 1600, height: 900}});
+
+    test('warm F5 preserves the Workspace and its live panes while the Group rebinds', async ({page, context, neuralLink}) => {
+        const keeper = await context.newPage();
+
+        await bootRoot(page);
+        await bootPaneHost(keeper);
+
+        const app      = await neuralLink.connectToApp('Workstation'),
+              windowId = await readWindowId(page),
+              carrier  = await readCarrier(page),
+              before   = await workspaceFor(app, windowId);
+
+        expect(before, 'the first root has a live Workspace').toBeTruthy();
+
+        const initial = (await app.getComponent(before, ['dockModel'])).dockModel,
+              first   = structuredClone(initial), second = structuredClone(initial);
+        first.items.feed.title = 'Retained history first';
+        second.items.feed.title = 'Retained history second';
+        expect(await app.callMethod(before, 'transactionManager.setHistoryDepth', [{groupId: carrier.groupId, depth: 5}])).toBe(true);
+        for (const candidate of [first, second]) {
+            await app.callMethod(before, 'workspaceSet.write', [{'workstation-main': candidate}, {
+                cause: 'warm-reload-witness', provenance: {source: 'test'}, descriptor: {operation: 'applyDocument'}
+            }])
+        }
+        await app.callMethod(before, 'transactionManager.undo', [{groupId: carrier.groupId}]);
+
+        const paneId     = await app.callMethod(before, 'getPaneIdentity', ['feed']),
+              pane       = await app.getComponent(paneId, ['cls']),
+              document   = (await app.getComponent(before, ['dockModel'])).dockModel,
+              groupState = await topologyState(app, before);
+        expect(groupState.historyCount).toBe(2);
+        expect(groupState.historyCursor, 'one retained row is undone, so redo remains available').toBe(0);
+        expect(groupState.snapshot.participants['workstation-main']).toEqual(first);
+        expect(document).toEqual(first);
+
+        // Instance state distinguishes reuse from recreating a component under the same id.
+        await app.setProperties(paneId, {cls: [...(pane.cls ?? []), 'reload-retained-witness']});
+        await expect(page.locator('.reload-retained-witness')).toBeVisible();
+
+        await page.reload();
+        await page.waitForSelector('.workstation-dock-host', {timeout: 60000});
+
+        const nextWindowId = await readWindowId(page);
+
+        expect(nextWindowId).not.toBe(windowId);
+        expect(await readCarrier(page), 'the Group carrier is the unchanged positive control').toEqual(carrier);
+        await expect.poll(() => workspaceFor(app, nextWindowId), {timeout: 15000}).toBeTruthy();
+
+        const after = await workspaceFor(app, nextWindowId);
+
+        expect(after, 'warm reload reuses the worker-owned Workspace').toBe(before);
+        expect(await app.callMethod(after, 'getPaneIdentity', ['feed']), 'the live pane is not recreated').toBe(paneId);
+        expect((await app.getComponent(paneId, ['cls'])).cls).toContain('reload-retained-witness');
+        expect((await app.getComponent(after, ['dockModel'])).dockModel).toEqual(document);
+        expect(await topologyState(app, after), 'warm rebind changes neither library version nor Group history/snapshot').toEqual(groupState);
+        await expect(page.locator('.reload-retained-witness')).toBeVisible();
+
+        await app.callMethod(after, 'transactionManager.redo', [{groupId: carrier.groupId}]);
+        expect((await app.getComponent(after, ['dockModel'])).dockModel).toEqual(second);
+        expect((await topologyState(app, after)).historyCursor).toBe(1);
+        expect(await app.callMethod(after, 'getPaneIdentity', ['feed'])).toBe(paneId);
+
+        await keeper.close()
+    });
+
+    test('cold active selection hydrates keyed truth, survives popup refusal and F5, and saves another cold round-trip', async ({page, context, browser, baseURL, neuralLink}) => {
+        test.setTimeout(300000);
+        const seed = await savedColdFixture(page, context, neuralLink), contexts = [];
+        await context.close();
+
+        try {
+            const coldContext = await browser.newContext({baseURL, storageState: seed.storageState, viewport: {width: 1600, height: 900}});
+            contexts.push(coldContext);
+            const root = await coldRoot(coldContext, neuralLink, seed.carrier);
+            expect(root.app.sessionId, 'cold restore has a new App Worker').not.toBe(seed.sessionId);
+            const hydrated = await expectColdTopology(root, seed.records.b);
+            expect(coldContext.pages(), 'semantic hydrate opens no popup').toHaveLength(1);
+            expect(hydrated.workspaceHosts.details.hostId).toBeNull();
+
+            await root.page.setViewportSize({width: 800, height: 900});
+            const recoveryButtons = ['Save workspace', 'Close workspace', 'Open details as window', 'Show details here']
+                .map(name => root.page.getByRole('button', {name, exact: true}));
+            for (const button of recoveryButtons) await expect(button).toBeVisible();
+            await expect.poll(async () => {
+                const boxes = await Promise.all(recoveryButtons.map(button => button.boundingBox()));
+                return boxes.every(box => box && box.x >= 0 && box.y >= 0 && box.x + box.width <= 800 && box.y + box.height <= 900)
+            }, {message: 'all recovery actions remain inside the narrow viewport'}).toBe(true);
+            const topologyToolbar = root.page.locator('.neo-toolbar').filter({has: recoveryButtons[0]}),
+                  dock            = root.page.locator('.workstation-dock-host');
+            await expect.poll(async () => (await topologyToolbar.boundingBox())?.height, {
+                message: 'the topology toolbar stays compact at 800px'
+            }).toBeLessThanOrEqual(96);
+            await expect.poll(async () => (await dock.boundingBox())?.height, {
+                message: 'the dock retains at least 600px of usable height in a 900px viewport'
+            }).toBeGreaterThanOrEqual(600);
+            await root.page.screenshot({path: test.info().outputPath('cold-topology.png'), fullPage: true});
+            await root.page.setViewportSize({width: 1600, height: 900});
+
+            await root.page.evaluate(() => {
+                window.__topologyPopupControl = {calls: 0, open: window.open};
+                window.open = () => { window.__topologyPopupControl.calls++; return null }
+            });
+            await root.page.getByRole('button', {name: 'Open details as window', exact: true}).click();
+            await root.page.waitForFunction(() => window.__topologyPopupControl.calls === 1);
+            expect(coldContext.pages()).toHaveLength(1);
+            expect(await root.app.callMethod(root.workspaceId, 'getDockTopologyWorkspaces'), 'native refusal keeps both keyed documents').toEqual(seed.records.b.workspaces);
+
+            await root.page.getByRole('button', {name: 'Show details here', exact: true}).click();
+            await expect.poll(async () => (await topologyState(root.app, root.workspaceId)).workspaceHosts.details.hostId).toBeTruthy();
+            const inline = await topologyState(root.app, root.workspaceId),
+                  paneId = await root.app.callMethod(root.workspaceId, 'getPaneIdentity', ['feed']);
+            await expect(root.page.locator(`[id="${paneId}"]`), 'refusal has an inline recovery path').toBeVisible();
+            await root.page.evaluate(() => { window.open = window.__topologyPopupControl.open });
+
+            const popupPromise = coldContext.waitForEvent('page', {timeout: 45000});
+            await root.page.getByRole('button', {name: 'Open details as window', exact: true}).click();
+            const popup = await popupPromise;
+            await expect(popup.locator(`[id="${paneId}"]`)).toBeVisible({timeout: 60000});
+            const beforePopup = await topologyState(root.app, root.workspaceId), popupCarrier = await readCarrier(popup);
+            expect(beforePopup.workspaceHosts.details.hostId).toBe(inline.workspaceHosts.details.hostId);
+            expect(beforePopup.snapshot).toEqual(hydrated.snapshot);
+
+            await popup.reload();
+            await expect(popup.locator(`[id="${paneId}"]`)).toBeVisible({timeout: 60000});
+            const afterPopup = await topologyState(root.app, root.workspaceId);
+            expect(await readCarrier(popup)).toEqual(popupCarrier);
+            expect(await root.app.callMethod(root.workspaceId, 'getPaneIdentity', ['feed'])).toBe(paneId);
+            expect(afterPopup.workspaceHosts.details.hostId).toBe(beforePopup.workspaceHosts.details.hostId);
+            expect(afterPopup.workspaceHosts.details.windowId).not.toBe(beforePopup.workspaceHosts.details.windowId);
+            expect(afterPopup.libraryVersion).toBe(beforePopup.libraryVersion);
+            expect(afterPopup.snapshot).toEqual(beforePopup.snapshot);
+            expect(afterPopup.historyCount).toBe(beforePopup.historyCount);
+            expect(afterPopup.historyCursor).toBe(beforePopup.historyCursor);
+
+            expect(await root.app.executeDockOperation(root.workspaceId, {operation: 'setActiveItem', tabsNodeId: 'heavy-tabs', itemId: 'activity'})).toMatchObject({applied: true, errors: []});
+            const changed = await root.app.callMethod(root.workspaceId, 'getDockTopologyWorkspaces');
+            expect(changed['workstation-main'].nodes['heavy-tabs'].activeItemId).toBe('activity');
+            await root.page.getByRole('button', {name: 'Save workspace', exact: true}).click();
+            await expect.poll(async () => (await root.app.callMethod(root.workspaceId, 'topologyLibrary.persistenceAdapter.read')).topologies['layout-b'].workspaces, {timeout: 15000}).toEqual(changed);
+            const savedAgain = await coldContext.storageState({indexedDB: true}), carrierAgain = await readCarrier(root.page);
+
+            const beforeRootReload = await topologyState(root.app, root.workspaceId);
+            await root.page.reload();
+            await root.page.waitForSelector('.workstation-dock-host', {timeout: 60000});
+            expect(await workspaceFor(root.app, await readWindowId(root.page))).toBe(root.workspaceId);
+            expect(await topologyState(root.app, root.workspaceId), 'root F5 preserves truth after losing its opener registry').toEqual(beforeRootReload);
+
+            const keeper = await coldContext.newPage();
+            await bootPaneHost(keeper);
+            const keeperCarrier  = await readCarrier(keeper), keeperWindowId = await readWindowId(keeper),
+                  managerId      = (await root.app.getComponent(root.workspaceId, ['transactionManager.id']))['transactionManager.id'],
+                  carriersAtExit = {};
+            expect(keeperCarrier.groupId).not.toBe(carrierAgain.groupId);
+            for (const [label, target] of [['root', root.page], ['popup', popup]]) {
+                const marker = `topology-carrier-at-exit:${label}:`;
+                target.on('console', message => {
+                    if (message.text().startsWith(marker)) carriersAtExit[label] = JSON.parse(message.text().slice(marker.length))
+                });
+                await target.evaluate(({key, marker}) => {
+                    window.addEventListener('beforeunload', () => console.log(marker + String(sessionStorage.getItem(key))), {once: true})
+                }, {key: CARRIER, marker})
+            }
+            await root.page.getByRole('button', {name: 'Close workspace', exact: true}).click();
+            await expect.poll(() => popup.isClosed(), {message: 'close-all reaches the retained popup through its own realm', timeout: 15000}).toBe(true);
+            await expect.poll(() => root.page.isClosed() || root.page.url() === 'about:blank', {message: 'close-all ends the root document', timeout: 15000}).toBe(true);
+            expect(carriersAtExit, 'every Group carrier cleared before its document left').toEqual({root: null, popup: null});
+            await expect.poll(async () => (await root.app.getComponent(managerId, ['items.length']))['items.length'], {
+                message: 'durable retirement after the reconnect lease leaves only the independent keeper Group', timeout: 45000
+            }).toBe(1);
+            expect(await root.app.findInstances({className: WORKSPACE}, ['id']), 'the retired Group disposes its retained Workspace').toEqual([]);
+            expect(await readCarrier(keeper)).toEqual(keeperCarrier);
+            expect(await root.app.callMethod(managerId, 'findByWindow', [keeperWindowId])).toMatchObject({groupId: keeperCarrier.groupId});
+            await coldContext.close();
+
+            const secondContext = await browser.newContext({baseURL, storageState: savedAgain, viewport: {width: 1600, height: 900}});
+            contexts.push(secondContext);
+            const second = await coldRoot(secondContext, neuralLink, carrierAgain);
+            expect(second.app.sessionId).not.toBe(root.app.sessionId);
+            await expectColdTopology(second, {...seed.records.b, workspaces: changed});
+            expect(secondContext.pages()).toHaveLength(1)
+        } finally {
+            await Promise.allSettled(contexts.map(current => current.close()))
+        }
+    });
+
+    test('a stale popup arriving first cannot choose a cold topology and the root can explicitly select the other saved layout', async ({page, context, browser, baseURL, neuralLink}) => {
+        test.setTimeout(240000);
+        const seed = await savedColdFixture(page, context, neuralLink);
+        await context.close();
+        const coldContext = await browser.newContext({baseURL, storageState: seed.storageState, viewport: {width: 1600, height: 900}});
+
+        try {
+            const stale = await carriedPage(coldContext, seed.popupCarrier);
+            await stale.goto('/apps/workstation/index.html?workspace=details');
+            await stale.waitForFunction(() => Boolean(window.Neo?.worker?.Manager?.windowId), null, {timeout: 60000});
+            const popupApp = await neuralLink.connectToApp(await readWorkerId(stale));
+            expect(popupApp.sessionId).not.toBe(seed.sessionId);
+            expect(await popupApp.findInstances({className: WORKSPACE}, ['id']), 'a stale popup does not hydrate a root').toEqual([]);
+            expect(await popupApp.findInstances({className: 'Neo.dashboard.dock.persistence.TopologyLibrary'}, ['id']), 'a stale popup never reads saved topology storage').toEqual([]);
+
+            const root = await coldRoot(coldContext, neuralLink, seed.carrier, '?layout=layout-a');
+            expect(root.app.sessionId, 'popup-first and root use the same fresh worker').toBe(popupApp.sessionId);
+            expect(await readCarrier(root.page)).toEqual(seed.carrier);
+            await expectColdTopology(root, seed.records.a);
+            expect(coldContext.pages(), 'no replacement popup was opened').toHaveLength(2)
+        } finally {
+            await coldContext.close()
+        }
+    });
 
     test('A and its pop-out share one Group, B shares only the app name, and reloading A moves one generation and touches nothing else', async ({page, context, neuralLink}) => {
         const pageA = page,
@@ -170,7 +481,7 @@ test.describe('Workstation topology Groups — two roots under one SharedWorker 
         expect(aId2, 'a reload is a new runtime generation').not.toBe(aId);
         expect(await readCarrier(pageA), 'the identity survived the reload unchanged').toEqual(carrierA);
 
-        // The reloaded root is a new Workspace instance; the manager behind it is the same singleton.
+        // The reloaded root reuses its Workspace; the manager behind it is the same singleton.
         await expect.poll(() => workspaceFor(app, aId2), {message: 'the reloaded root projects a Workspace', timeout: 15000}).toBeTruthy();
         manager = managerOf(app, await workspaceFor(app, aId2));
 

--- a/test/playwright/unit/apps/workstation/WorkspaceController.spec.mjs
+++ b/test/playwright/unit/apps/workstation/WorkspaceController.spec.mjs
@@ -1,0 +1,99 @@
+import {setup} from '../../../setup.mjs';
+
+setup({appConfig: {name: 'WorkstationTopologyControllerTest'}});
+
+import {test, expect}      from '@playwright/test';
+import Neo                 from '../../../../../src/Neo.mjs';
+import * as core           from '../../../../../src/core/_export.mjs';
+import Transaction         from '../../../../../src/manager/Transaction.mjs';
+import TopologyLibrary     from '../../../../../src/dashboard/dock/persistence/TopologyLibrary.mjs';
+import WorkspaceController from '../../../../../apps/workstation/view/WorkspaceController.mjs';
+
+/**
+ * @summary An event-driven storage boundary for a write already in flight.
+ * @returns {{promise: Promise, resolve: Function}}
+ */
+const deferred = () => {
+    let resolve;
+    const promise = new Promise(done => {resolve = done});
+    return {promise, resolve}
+};
+
+test.describe('Workstation topology save and close coordination', () => {
+    test('a partial carrier refusal compensates cleared windows and closes none', async () => {
+        const root      = Transaction.bind({windowId: 'controller-close-root'}),
+              popup     = Transaction.bind({...Transaction.reserve({groupId: root.groupId, workspaceKey: 'details'}), windowId: 'controller-close-popup'}),
+              restored  = [], closed = [],
+              main      = Neo.ns('Neo.Main', true),
+              originals = Object.fromEntries(['clearTopologyIdentity', 'setTopologyIdentity', 'closeTopologyWindow'].map(key => [key, main[key]]));
+
+        main.clearTopologyIdentity = ({windowId}) => windowId === root.windowId ? Promise.resolve(true) : Promise.reject(new Error('gone port'));
+        main.setTopologyIdentity = data => {restored.push(data); return Promise.resolve(true)};
+        main.closeTopologyWindow = data => {closed.push(data); return Promise.resolve(true)};
+
+        try {
+            const result = await WorkspaceController.prototype.closeTopology.call({
+                component   : {topologyGroupId: root.groupId},
+                saveTopology: async () => ({persisted: true, current: true, errors: []})
+            });
+
+            expect(result.closed).toBe(false);
+            expect(closed).toEqual([]);
+            expect(restored).toEqual([expect.objectContaining({
+                generationToken: root.generationToken,
+                groupId        : root.groupId,
+                onlyIfEmpty    : true,
+                windowId       : root.windowId,
+                workspaceKey   : root.workspaceKey
+            })]);
+            expect(Transaction.findByWindow(root.windowId)?.groupId).toBe(root.groupId);
+            expect(Transaction.findByWindow(popup.windowId)?.groupId).toBe(root.groupId)
+        } finally {
+            for (const [key, value] of Object.entries(originals)) {
+                if (value === undefined) delete main[key];
+                else main[key] = value
+            }
+            Transaction.retireGroup(root.groupId)
+        }
+    });
+
+    test('a queued document write during storage makes the save stale before close can clear carriers', async () => {
+        const root     = Transaction.bind({windowId: 'controller-save-root'}),
+              group    = Transaction.get(root.groupId),
+              started  = deferred(), acknowledgement = deferred(),
+              document = {
+                  schema: 'neo.dock.zone.v1', root: 'tabs',
+                  items : {a: {componentRef: 'a', title: 'before'}},
+                  nodes : {tabs: {type: 'tabs', items: ['a'], activeItemId: 'a'}}
+              },
+              library = Neo.create(TopologyLibrary, {persistenceAdapter: {
+                  read : async () => null,
+                  write: () => {started.resolve(); return acknowledgement.promise}
+              }}),
+              context = {
+                  component: {
+                      getDockTopologyWorkspaces: () => ({main: document}),
+                      topologyGroupId          : root.groupId,
+                      topologyLibrary          : library,
+                      get topologyCollection() {return library.collection}
+                  },
+                  captureTopology: WorkspaceController.prototype.captureTopology,
+                  saveTopology   : WorkspaceController.prototype.saveTopology
+              };
+
+        try {
+            const closing = WorkspaceController.prototype.closeTopology.call(context);
+            await started.promise;
+            await Transaction.enqueue(group, () => {document.items.a.title = 'newer'});
+            acknowledgement.resolve();
+
+            expect((await closing).closed).toBe(false);
+            expect(Transaction.findByWindow(root.windowId)?.groupId).toBe(root.groupId);
+            expect(document.items.a.title).toBe('newer');
+            expect(library.resolve().topology.workspaces.main.items.a.title, 'only the older bytes were acknowledged').toBe('before')
+        } finally {
+            library.destroy();
+            Transaction.retireGroup(root.groupId)
+        }
+    })
+});

--- a/test/playwright/unit/dashboard/TopologyLibrary.spec.mjs
+++ b/test/playwright/unit/dashboard/TopologyLibrary.spec.mjs
@@ -1,0 +1,523 @@
+import {setup} from '../../setup.mjs';
+
+setup({appConfig: {name: 'DashboardTopologyLibraryTest'}});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../src/Neo.mjs';
+import * as core      from '../../../../src/core/_export.mjs';
+
+/**
+ * @summary A controlled I/O boundary; no timer or live storage enters these tests.
+ * @returns {{promise: Promise, resolve: Function}}
+ */
+const deferred = () => {
+    let resolve;
+    const promise = new Promise(done => { resolve = done });
+
+    return {promise, resolve}
+};
+
+test.describe('Neo.dashboard.dock.persistence.TopologyLibrary', () => {
+    let Persistence, TopologyLibrary, Transaction, library, libraries, groupIds;
+
+    /**
+     * @summary Creates an owned test instance, cleaned up after each arm.
+     * @param {Object} [config]
+     * @returns {Neo.dashboard.dock.persistence.TopologyLibrary}
+     */
+    const create = config => {
+        const instance = Neo.create(TopologyLibrary, config || {});
+
+        libraries.push(instance);
+        return instance
+    };
+
+    /**
+     * @summary Captures two real keyed workspace documents through the shipped wire producer.
+     * @param {String} layoutId
+     * @param {String} [suffix=layoutId]
+     * @returns {Object}
+     */
+    const topology = (layoutId, suffix = layoutId) => {
+        const document = id => ({
+            schema: 'neo.dock.zone.v1',
+            root  : 'root',
+            items : {[id]: {componentRef: id, title: id}},
+            nodes : {root: {type: 'tabs', items: [id], activeItemId: id}}
+        });
+        const result = Persistence.captureTopologyPerspective({
+            main  : document(`${suffix}-main`),
+            detail: document(`${suffix}-detail`)
+        }, {layoutId, title: layoutId});
+
+        expect(result.errors).toEqual([]);
+        return result.topology
+    };
+
+    /**
+     * @summary Makes the persisted active choice explicit, independently of key insertion order.
+     * @param {Object[]} records
+     * @param {String|null} activeLayoutId
+     * @returns {Object}
+     */
+    const collection = (records, activeLayoutId) => {
+        const result = Persistence.createTopologyCollection(records, {activeLayoutId});
+
+        expect(result.errors).toEqual([]);
+        return result.collection
+    };
+
+    /**
+     * @summary Registers an isolated real Group, retained in the cleanup list even after a failed arm.
+     * @returns {Object}
+     */
+    const createGroup = () => {
+        const identity = Transaction.bind({windowId: `topology-library-${crypto.randomUUID()}`});
+
+        groupIds.push(identity.groupId);
+        return Transaction.get(identity.groupId)
+    };
+
+    /**
+     * @summary Lets the real reconnect lease expire before attaching persistence, without losing the Group.
+     * @param {Object} group
+     * @returns {Promise<void>}
+     */
+    const expireBinding = async group => {
+        const expired  = deferred(),
+              owner    = {},
+              prior    = Transaction.reconnectLeaseMs,
+              listener = {
+                  leaseExpired: ({groupId}) => groupId === group.id && expired.resolve(),
+                  scope       : {id: `topology-library-lease-${group.id}`}
+              };
+
+        Transaction.retainGroup(group.id, owner);
+        Transaction.on(listener);
+        Transaction.reconnectLeaseMs = 0;
+
+        try {
+            expect(Transaction.release(Transaction.getBinding(group.id, 'main').windowId)).toBe(true);
+            Transaction.reconnectLeaseMs = prior;
+            await expired.promise;
+            expect(group.bindings.size).toBe(0)
+        } finally {
+            Transaction.reconnectLeaseMs = prior;
+            Transaction.un(listener);
+            Transaction.releaseGroup(group.id, owner)
+        }
+    };
+
+    /**
+     * @summary Attaches the library to a real Group with observable capture, storage and disposal boundaries.
+     * @param {Object} group
+     * @param {Function} [write]
+     * @returns {Object}
+     */
+    const attachGroup = (group, write = async () => {}) => {
+        const state = {captures: 0, disposals: [], record: topology('retirement'), writes: []};
+
+        library.save(state.record, {activate: true});
+        library.persistenceAdapter = {write: async value => {
+            state.writes.push(value);
+            await write(value)
+        }};
+        library.attachGroup({
+            capture: () => {
+                state.captures++;
+                return {topology: state.record, errors: []}
+            },
+            dispose     : () => state.disposals.push(Transaction.get(group.id)),
+            groupId     : group.id,
+            manager     : Transaction,
+            retryDelayMs: 60000
+        });
+
+        return state
+    };
+
+    test.beforeAll(async () => {
+        Persistence = (await import('../../../../src/dashboard/dock/model/Persistence.mjs')).default;
+        TopologyLibrary = (await import('../../../../src/dashboard/dock/persistence/TopologyLibrary.mjs')).default;
+        Transaction = (await import('../../../../src/manager/Transaction.mjs')).default
+    });
+
+    test.beforeEach(() => {
+        libraries = [];
+        groupIds = [];
+        library = create()
+    });
+
+    test.afterEach(() => {
+        libraries.forEach(instance => instance.destroy());
+        groupIds.forEach(groupId => Transaction.retireGroup(groupId))
+    });
+
+    test('selection uses the validated active id or an explicit id, never key insertion order', () => {
+        const a = topology('a'), b = topology('b');
+
+        for (const records of [[a, b], [b, a]]) {
+            const current = create({collection: collection(records, 'b')});
+
+            expect(current.resolve().topology.layoutId).toBe('b');
+            expect(current.resolve('a').topology.layoutId).toBe('a');
+            expect(current.collection.activeLayoutId, 'read-only resolution never activates').toBe('b');
+            expect(current.resolve('missing').errors.length).toBeGreaterThan(0);
+            expect(current.collection.activeLayoutId).toBe('b')
+        }
+
+        const invalid = collection([a, b], 'b');
+        delete invalid.activeLayoutId;
+        expect(library.adoptCollection(invalid).adopted).toBe(false);
+        expect(library.collection).toBeNull();
+        expect(library.resolve().topology).toBeNull()
+    });
+
+    test('save requires explicit first activation and explicit replacement; later saves retain the selection', () => {
+        const a = topology('a');
+
+        expect(library.save(a).saved, 'a first save cannot infer an active key').toBe(false);
+        expect(library.collection).toBeNull();
+        expect(library.save(a, {activate: true}).saved).toBe(true);
+        expect(library.save(topology('b')).saved).toBe(true);
+        expect(library.collection.activeLayoutId).toBe('a');
+
+        const before   = JSON.stringify(library.collection);
+        const changedA = topology('a', 'replacement');
+
+        expect(library.save(changedA).collision).toMatchObject({layoutId: 'a'});
+        expect(JSON.stringify(library.collection)).toBe(before);
+        expect(library.save(changedA, {replace: true}).saved).toBe(true);
+        expect(library.resolve('a').topology.workspaces.main.items).toHaveProperty('replacement-main');
+        expect(library.collection.activeLayoutId).toBe('a');
+
+        const invalid = {...topology('c'), schema: 'neo.dock.layout.v1'};
+        expect(library.save(invalid, {activate: true}).saved).toBe(false);
+        expect(Object.keys(library.collection.topologies)).toEqual(['a', 'b'])
+    });
+
+    test('collection adoption, public reads, and resolved records are isolated JSON', () => {
+        const incoming = collection([topology('a')], 'a');
+
+        expect(library.adoptCollection(incoming).adopted).toBe(true);
+        const before = JSON.stringify(library.collection);
+
+        incoming.topologies.a.title = 'external mutation';
+        const exposed = library.collection;
+        exposed.activeLayoutId = 'missing';
+        exposed.topologies.a.workspaces.main.items['a-main'].title = 'external mutation';
+        library.resolve().topology.workspaces.detail.items['a-detail'].title = 'external mutation';
+
+        expect(JSON.stringify(library.collection)).toBe(before);
+        expect(library.adoptCollection({...library.collection, activeLayoutId: 'missing'}).adopted).toBe(false);
+        expect(JSON.stringify(library.collection)).toBe(before);
+        expect(library.dirty).toBe(true)
+    });
+
+    test('selection preparation changes nothing until explicit adoption and refuses a stale version', () => {
+        library.adoptCollection(collection([topology('a'), topology('b')], 'a'));
+        const before   = JSON.stringify(library.collection), version = library.version;
+        const prepared = library.prepareSelection('b');
+
+        expect(prepared.errors).toEqual([]);
+        expect(prepared.topology.layoutId).toBe('b');
+        expect(prepared.collection.activeLayoutId).toBe('b');
+        expect(prepared.version).toBe(version);
+        expect(JSON.stringify(library.collection)).toBe(before);
+        expect(library.version).toBe(version);
+
+        library.save(topology('c'), {activate: true});
+        const current = JSON.stringify(library.collection);
+        expect(library.adoptCollection(prepared.collection, {expectedVersion: prepared.version}).adopted).toBe(false);
+        expect(JSON.stringify(library.collection)).toBe(current);
+
+        const fresh = library.prepareSelection('b');
+        expect(library.adoptCollection(fresh.collection, {expectedVersion: fresh.version}).adopted).toBe(true);
+        expect(library.collection.activeLayoutId).toBe('b')
+    });
+
+    test('hydrate adopts only validated storage and keeps its explicit active choice', async () => {
+        let stored = collection([topology('a'), topology('b')], 'b');
+        library.persistenceAdapter = {read: async () => stored};
+
+        expect((await library.hydrate()).hydrated).toBe(true);
+        expect(library.resolve().topology.layoutId).toBe('b');
+        expect(library.dirty).toBe(false);
+        stored.topologies.b.title = 'adapter retained a reference';
+        expect(library.resolve().topology.title).toBe('b');
+
+        const before = JSON.stringify(library.collection), version = library.version;
+        stored = null;
+        expect(await library.hydrate()).toMatchObject({hydrated: false, errors: []});
+        expect(JSON.stringify(library.collection)).toBe(before);
+        stored = {schema: 'old-topology', topologies: {}};
+        expect((await library.hydrate()).errors.length).toBeGreaterThan(0);
+        expect(JSON.stringify(library.collection)).toBe(before);
+        expect(library.version).toBe(version)
+    });
+
+    test('a failed read and a late read never replace newer in-memory truth', async () => {
+        library.save(topology('a'), {activate: true});
+        library.persistenceAdapter = {read: async () => { throw new Error('storage unavailable') }};
+        expect((await library.hydrate()).errors).toContain('storage unavailable');
+        expect(library.resolve().topology.layoutId).toBe('a');
+
+        const started = deferred(), answer = deferred();
+        library.persistenceAdapter = {read: () => { started.resolve(); return answer.promise }};
+        const pending = library.hydrate();
+        await started.promise;
+        library.save(topology('b'), {activate: true});
+        answer.resolve(collection([topology('old')], 'old'));
+
+        expect((await pending).hydrated).toBe(false);
+        expect(library.resolve().topology.layoutId).toBe('b');
+        expect(library.dirty).toBe(true)
+    });
+
+    test('missing or rejected persistence preserves dirty truth and a later retry succeeds', async () => {
+        library.save(topology('a'), {activate: true});
+        const before = JSON.stringify(library.collection);
+
+        expect((await library.persist()).persisted).toBe(false);
+        library.persistenceAdapter = {write: async () => { throw new Error('quota exceeded') }};
+        expect((await library.persist()).errors).toContain('quota exceeded');
+        expect(JSON.stringify(library.collection)).toBe(before);
+        expect(library.dirty).toBe(true);
+
+        let written;
+        library.persistenceAdapter = {write: async value => { written = value }};
+        expect(await library.persist()).toMatchObject({persisted: true, current: true, errors: []});
+        expect(library.dirty).toBe(false);
+        expect(JSON.stringify(written)).toBe(before);
+        written.topologies.a.title = 'adapter mutation';
+        expect(JSON.stringify(library.collection)).toBe(before)
+    });
+
+    test('an older acknowledgement cannot mark a newer collection durably current', async () => {
+        library.save(topology('a'), {activate: true});
+        const started = deferred(), answer = deferred();
+        library.persistenceAdapter = {write: () => { started.resolve(); return answer.promise }};
+
+        const pending = library.persist();
+        await started.promise;
+        library.save(topology('b'), {activate: true});
+        answer.resolve();
+
+        expect(await pending).toMatchObject({persisted: true, current: false});
+        expect(library.dirty).toBe(true);
+        library.persistenceAdapter = {write: async () => {}};
+        expect(await library.persist()).toMatchObject({persisted: true, current: true});
+        expect(library.dirty).toBe(false)
+    });
+
+    test('writes serialize so an older slow write cannot overwrite the newer stored collection', async () => {
+        library.save(topology('a'), {activate: true});
+        const started = deferred(), answer = deferred(), calls = [];
+        let stored;
+        library.persistenceAdapter = {write: async value => {
+            calls.push(value.activeLayoutId);
+            if (calls.length === 1) { started.resolve(); await answer.promise }
+            stored = value
+        }};
+
+        const first = library.persist();
+        await started.promise;
+        library.save(topology('b'), {activate: true});
+        const second = library.persist();
+        await Promise.resolve();
+        expect(calls).toEqual(['a']);
+        answer.resolve();
+        await Promise.all([first, second]);
+
+        expect(calls).toEqual(['a', 'b']);
+        expect(stored.activeLayoutId).toBe('b');
+        expect(library.dirty).toBe(false)
+    });
+
+    test('persist revalidates held bytes and sends no invalid candidate to the adapter', async () => {
+        const writes = [];
+        library.persistenceAdapter = {write: async value => writes.push(value)};
+        library.save(topology('a'), {activate: true});
+        // Whitebox corruption control: public access cannot reach this backing field.
+        library._collection = {schema: 'invalid'};
+
+        expect((await library.persist()).persisted).toBe(false);
+        expect(writes).toEqual([])
+    });
+
+    test('Group retirement refuses a live binding without capturing, writing or disposing', async () => {
+        const group = createGroup(), state = attachGroup(group);
+
+        expect(group.retainedReferences.has(library)).toBe(true);
+        expect(await library.retireIfHeadless()).toBe(false);
+        expect(Transaction.get(group.id)).toBe(group);
+        expect(state.captures).toBe(0);
+        expect(state.writes).toEqual([]);
+        expect(state.disposals).toEqual([])
+    });
+
+    test('a warm Group release and rebind performs no topology storage write', async () => {
+        const group    = createGroup(), state = attachGroup(group),
+              binding  = group.bindings.get('main'),
+              identity = {groupId: group.id, workspaceKey: 'main', generationToken: binding.generationToken};
+
+        expect(Transaction.release(binding.windowId)).toBe(true);
+        const rebound = Transaction.bind({...identity, windowId: `warm-${group.id}`});
+
+        expect(rebound.outcome).toBe('rebound');
+        expect(await library.retireIfHeadless()).toBe(false);
+        expect(Transaction.get(group.id)).toBe(group);
+        expect(state.captures).toBe(0);
+        expect(state.writes).toEqual([]);
+        expect(state.disposals).toEqual([])
+    });
+
+    test('Group retirement waits for a current durable acknowledgement after lease expiry and disposes once', async () => {
+        const group = createGroup(), started = deferred(), answer = deferred();
+        const state = attachGroup(group, () => { started.resolve(); return answer.promise });
+
+        await expireBinding(group);
+        await started.promise;
+        const pending = library.retireIfHeadless();
+        expect(Transaction.get(group.id), 'pending storage still retains the only semantic truth').toBe(group);
+        expect(state.disposals).toEqual([]);
+        answer.resolve();
+
+        expect(await pending).toBe(true);
+        expect(Transaction.get(group.id)).toBeNull();
+        expect(state.writes).toHaveLength(1);
+        expect(state.writes[0].topologies.retirement.workspaces).toEqual(state.record.workspaces);
+        expect(state.disposals, 'disposal sees an already retired Group').toEqual([null]);
+        expect(await library.retireIfHeadless()).toBe(false);
+        expect(state.disposals).toHaveLength(1)
+    });
+
+    test('Group retirement preserves headless-dirty truth on rejected storage and an explicit retry succeeds', async () => {
+        const group = createGroup();
+        let   fail  = true;
+
+        await expireBinding(group);
+        const state = attachGroup(group, async () => {
+            if (fail) throw new Error('retirement storage unavailable')
+        });
+        const before = library.collection;
+
+        expect(await library.retireIfHeadless()).toBe(false);
+        expect(Transaction.get(group.id)).toBe(group);
+        expect(group.persistenceState).toBe('headless-dirty');
+        expect(group.retainedReferences.has(library)).toBe(true);
+        expect(library.collection).toEqual(before);
+        expect(library.dirty).toBe(true);
+        expect(state.disposals).toEqual([]);
+
+        fail = false;
+        expect(await library.retireIfHeadless()).toBe(true);
+        expect(state.writes).toHaveLength(2);
+        expect(Transaction.get(group.id)).toBeNull();
+        expect(state.disposals).toEqual([null])
+    });
+
+    test('headless persistence failure automatically retries on the bounded timer', async () => {
+        const group  = createGroup(), disposed = deferred(), record = topology('automatic-retry');
+        let   writes = 0;
+        await expireBinding(group);
+
+        library.persistenceAdapter = {
+            read : async () => null,
+            write: async () => {
+                if (++writes === 1) throw new Error('first write refused')
+            }
+        };
+        expect(library.attachGroup({
+            manager     : Transaction,
+            groupId     : group.id,
+            capture     : () => ({topology: record, errors: []}),
+            dispose     : () => disposed.resolve(),
+            retryDelayMs: 1
+        })).toBe(true);
+
+        expect(await library.retireIfHeadless()).toBe(false);
+        expect(group.persistenceState).toBe('headless-dirty');
+        await disposed.promise;
+        expect(writes).toBe(2);
+        expect(Transaction.get(group.id)).toBeNull()
+    });
+
+    test('Group retirement cannot discard an external reference and succeeds after its exact release', async () => {
+        const group = createGroup(), owner = {};
+
+        await expireBinding(group);
+        const state = attachGroup(group);
+        Transaction.retainGroup(group.id, owner);
+
+        expect(await library.retireIfHeadless()).toBe(false);
+        expect(Transaction.get(group.id)).toBe(group);
+        expect(group.retainedReferences.has(owner)).toBe(true);
+        expect(group.retainedReferences.has(library)).toBe(true);
+        expect(state.disposals).toEqual([]);
+
+        expect(Transaction.releaseGroup(group.id, owner)).toBe(true);
+        expect(await library.retireIfHeadless()).toBe(true);
+        expect(state.disposals).toEqual([null])
+    });
+
+    test('Group retirement rechecks a late live binder after a pending write acknowledges', async () => {
+        const group = createGroup(), started = deferred(), answer = deferred();
+
+        await expireBinding(group);
+        const state   = attachGroup(group, () => { started.resolve(); return answer.promise });
+        const pending = library.retireIfHeadless();
+
+        await started.promise;
+        const reserved = Transaction.reserve({groupId: group.id, workspaceKey: 'main'});
+        const bound    = Transaction.bind({...reserved, windowId: `late-${group.id}`});
+        expect(bound.groupId).toBe(group.id);
+        answer.resolve();
+
+        expect(await pending).toBe(false);
+        expect(Transaction.get(group.id)).toBe(group);
+        expect(group.persistenceState).toBe('active');
+        expect(group.retainedReferences.has(library)).toBe(true);
+        expect(state.disposals).toEqual([])
+    });
+
+    test('Group retirement waits for the existing queue before capturing its final topology', async () => {
+        const group = createGroup(), queue = deferred();
+
+        await expireBinding(group);
+        const state = attachGroup(group);
+        group.queue = queue.promise;
+        const pending = library.retireIfHeadless();
+
+        await Promise.resolve();
+        expect(state.captures).toBe(0);
+        expect(state.writes).toEqual([]);
+        state.record = topology('retirement', 'committed-after-queue');
+        queue.resolve();
+
+        expect(await pending).toBe(true);
+        expect(state.writes[0].topologies.retirement.workspaces.main.items).toHaveProperty('committed-after-queue-main');
+        expect(state.disposals).toEqual([null])
+    });
+
+    test('Group retirement refuses a changed queue during storage and a new attempt captures its truth', async () => {
+        const group = createGroup(), started = deferred(), answer = deferred();
+
+        await expireBinding(group);
+        const state   = attachGroup(group, () => { started.resolve(); return answer.promise });
+        const pending = library.retireIfHeadless();
+
+        await started.promise;
+        state.record = topology('retirement', 'new-queue');
+        group.queue = Promise.resolve();
+        answer.resolve();
+
+        expect(await pending).toBe(false);
+        expect(Transaction.get(group.id)).toBe(group);
+        expect(state.disposals).toEqual([]);
+        expect(await library.retireIfHeadless()).toBe(true);
+        expect(state.writes).toHaveLength(2);
+        expect(state.writes[1].topologies.retirement.workspaces.main.items).toHaveProperty('new-queue-main');
+        expect(state.disposals).toEqual([null])
+    });
+});

--- a/test/playwright/unit/main/MainNativeWindowRoute.spec.mjs
+++ b/test/playwright/unit/main/MainNativeWindowRoute.spec.mjs
@@ -355,6 +355,24 @@ async function runNativeWindowRouteProbe(scenario) {
             const empty    = WorkerManager.readTopologyIdentity();
             const accepted = Main.setTopologyIdentity({generationToken: 't1', groupId: 'g1', workspaceKey: 'main'});
             const carried  = WorkerManager.readTopologyIdentity();
+            const foreignClear = Main.clearTopologyIdentity({groupId: 'unrelated'});
+            const protectedCarrier = WorkerManager.readTopologyIdentity();
+            const ownClear = Main.clearTopologyIdentity({groupId: 'g1'});
+            const restored = Main.setTopologyIdentity({...carried, onlyIfEmpty: true});
+            Main.setTopologyIdentity({generationToken: 't2', groupId: 'g2', workspaceKey: 'main'});
+            const staleRestore = Main.setTopologyIdentity({...carried, onlyIfEmpty: true});
+            const newerCarrier = WorkerManager.readTopologyIdentity();
+            const closeWithCarrier = Main.closeTopologyWindow();
+            Main.clearTopologyIdentity({groupId: 'g2'});
+            let closeEffect;
+            const closeEvents = [];
+            globalThis.setTimeout = fn => {closeEffect = fn; return 1};
+            globalThis.close = () => closeEvents.push('close');
+            globalThis.closed = false;
+            globalThis.location.replace = url => closeEvents.push(url);
+            const closeScheduled = Main.closeTopologyWindow();
+            const beforeCloseEffect = closeEvents.length;
+            closeEffect();
             storage.set('neo-topology-identity', '{not json');
             const malformed = WorkerManager.readTopologyIdentity();
             storage.set('neo-topology-identity', JSON.stringify({groupId: 'g1'}));
@@ -381,7 +399,9 @@ async function runNativeWindowRouteProbe(scenario) {
             inherited();
             Main.windowOpen({url: './popup.html', windowName: 'plain'});
             const cleared = !childStorage.has('neo-topology-identity');
-            console.log(JSON.stringify({accepted, carried, cleared, empty, malformed, partial, reserved}))
+            console.log(JSON.stringify({accepted, carried, cleared, empty, malformed, partial, reserved,
+                foreignClear, protectedCarrier, ownClear, restored, staleRestore, newerCarrier,
+                closeWithCarrier, closeScheduled, beforeCloseEffect, closeEvents}))
         } else {
             const
                 events   = [],
@@ -860,6 +880,16 @@ test.describe('Neo.Main native window routes (#15396)', () => {
         expect(result.malformed, 'a broken record boots a fresh root').toEqual({});
         expect(result.partial, 'an incomplete record boots a fresh root').toEqual({});
         expect(result.reserved, 'the staged child carries the slot its opener reserved').toEqual({generationToken: 't2', groupId: 'g1', workspaceKey: 'popup:documents'});
-        expect(result.cleared, 'a child opened without a reservation boots as its own root').toBe(true)
+        expect(result.cleared, 'a child opened without a reservation boots as its own root').toBe(true);
+        expect(result.foreignClear).toBe(false);
+        expect(result.protectedCarrier).toEqual(result.carried);
+        expect(result.ownClear).toBe(true);
+        expect(result.restored, 'a partial close can compensate an emptied carrier').toBe(true);
+        expect(result.staleRestore, 'compensation cannot overwrite a newer Group').toBe(false);
+        expect(result.newerCarrier.groupId).toBe('g2');
+        expect(result.closeWithCarrier).toBe(false);
+        expect(result.closeScheduled).toBe(true);
+        expect(result.beforeCloseEffect, 'the reply precedes the close effect').toBe(0);
+        expect(result.closeEvents).toEqual(['close', 'about:blank'])
     })
 });

--- a/test/playwright/unit/manager/Transaction.spec.mjs
+++ b/test/playwright/unit/manager/Transaction.spec.mjs
@@ -152,6 +152,76 @@ test.describe.serial('Neo.manager.Transaction — Groups and token-matched windo
         expect(Transaction.getBinding(a.groupId, 'main'), 'the root still binds').toEqual({generation: 1, windowId: 'a1', workspaceKey: 'main'})
     });
 
+    test('retained references require an existing Group and release only the exact owner token', () => {
+        const a     = Transaction.bind({windowId: 'a1'}),
+              b     = Transaction.bind({windowId: 'b1'}),
+              first = {owner: 'same-name'},
+              next  = {owner: 'same-name'},
+              group = Transaction.get(a.groupId);
+
+        expect(Transaction.retainGroup('unknown', first)).toBe(false);
+        expect(Transaction.retainGroup(a.groupId, null)).toBe(false);
+        expect(Transaction.retainGroup(a.groupId, undefined)).toBe(false);
+        expect(Transaction.retainGroup(a.groupId, first)).toBe(true);
+        expect(Transaction.retainGroup(a.groupId, first), 'one token retains once').toBe(false);
+        expect(Transaction.retainGroup(a.groupId, next)).toBe(true);
+
+        expect(Transaction.releaseGroup('unknown', first)).toBe(false);
+        expect(Transaction.releaseGroup(b.groupId, first), 'another Group cannot release this ownership').toBe(false);
+        expect(Transaction.releaseGroup(a.groupId, null)).toBe(false);
+        expect(Transaction.releaseGroup(a.groupId, undefined)).toBe(false);
+        expect(Transaction.releaseGroup(a.groupId, {owner: 'same-name'}), 'equal-looking tokens are distinct owners').toBe(false);
+        expect(group.retainedReferences.size).toBe(2);
+        expect(Transaction.get(b.groupId).retainedReferences.size).toBe(0);
+
+        expect(Transaction.releaseGroup(a.groupId, first)).toBe(true);
+        expect(Transaction.releaseGroup(a.groupId, first), 'one release cannot consume another owner').toBe(false);
+        expect(group.retainedReferences.size).toBe(1);
+        expect(group.retainedReferences.has(next)).toBe(true);
+        expect(Transaction.releaseGroup(a.groupId, next)).toBe(true);
+        expect(group.retainedReferences.size).toBe(0);
+        expect(Transaction.get(a.groupId), 'releasing ownership does not force retirement').toBe(group)
+    });
+
+    test('retained references keep an otherwise empty Group through lease expiry while an unreferenced Group retires', async () => {
+        Transaction.reconnectLeaseMs = 20;
+
+        const held     = Transaction.bind({windowId: 'held'}),
+              ordinary = Transaction.bind({windowId: 'ordinary'}),
+              group    = Transaction.get(held.groupId),
+              owner    = {},
+              expired  = new Set();
+        let listener;
+
+        const leasesExpired = new Promise(resolve => {
+            listener = {
+                leaseExpired: ({groupId}) => {
+                    if (groupId === held.groupId || groupId === ordinary.groupId) expired.add(groupId);
+                    if (expired.size === 2) resolve()
+                },
+                scope: {id: 'transaction-spec-retained-reference-lease'}
+            };
+            Transaction.on(listener)
+        });
+
+        try {
+            expect(Transaction.retainGroup(held.groupId, owner)).toBe(true);
+            Transaction.release('held');
+            Transaction.release('ordinary');
+            await leasesExpired;
+
+            expect(Transaction.getBinding(held.groupId, 'main')).toBeNull();
+            expect(group.participants.size).toBe(0);
+            expect(group.history).toBeNull();
+            expect(Transaction.get(held.groupId), 'the owner still retains its headless Group').toBe(group);
+            expect(Transaction.get(ordinary.groupId), 'ordinary empty Groups still retire').toBeNull();
+            expect(Transaction.releaseGroup(held.groupId, owner)).toBe(true);
+            expect(group.retainedReferences.size).toBe(0)
+        } finally {
+            Transaction.un(listener)
+        }
+    });
+
     test('participants are the Group\'s and outlive its bindings: opaque, replaced by key, kept through release and lease expiry, gone only with the Group', async () => {
         Transaction.reconnectLeaseMs = 20;
 


### PR DESCRIPTION
Resolves #18315

Related: #18303, #18304, #18312, #18313, #18316

Workstation now saves a Group's keyed topology in a separate IndexedDB-backed library. Cold boot selects the persisted active layout or an explicit layout id, hydrates every semantic participant through the Group writer before mounting, and starts with empty history. Warm root and popup reload reuse their live owners. Saved windows open only from a user action and have an inline fallback. Close-all waits for current durability, compensates partial carrier refusal, and closes each current realm; retirement observes the existing reconnect lease and retained references.

Rebased onto `dev@9fd3250bd0` after #18370 merged. This diff contains only the #18315 reload/persistence change; the prerequisite's commits are no longer included.

Evidence: L3 (real Chrome, SharedWorker, IndexedDB, popup refusal and fresh-worker round-trip) → L3 required. Residual: none in this leaf.

## AC Evidence

| Criterion | Evidence |
|---|---|
| AC-1 | CI-covered: `TopologyLibrary.spec.mjs` explicit/active selection and rejected selection. Outside-CI: `WorkstationTopologyGroupsNL.spec.mjs` cold active-B and popup-first explicit-A arms. |
| AC-2 | Outside-CI: fresh worker id, complete committed `snapshot.participants`, keyed owners and empty history in both cold arms. |
| AC-3 | Outside-CI: two real Group writes, one undo, F5, unchanged owner/pane/library/history/cursor/snapshot, then redo; restored popup retains its host and pane too. |
| AC-4 | Outside-CI: refused `window.open`, unchanged keyed composition, inline fallback, then user-activated popup. |
| AC-5 | Outside-CI: a stale popup boots first and cannot select or divert the returning root's saved topology. |
| AC-6 | CI-covered: exact retained-reference and lease guards plus partial-close compensation. Outside-CI: root F5, close-all, cleared carrier receipts, popup closure, same-worker Group and Workspace retirement. |
| AC-7 | CI-covered: failed persistence retains `headless-dirty` truth; stale acknowledgements, late binding and queue changes prevent disposal; bounded timer retries successfully. |
| AC-8 | Outside-CI: open a restored workspace, save via the consumer action, transfer actual IndexedDB storage into another fresh browser context, and prove the keyed composition and empty history again. |

## Deltas from ticket

size-guard-growth: apps/workstation/view/Workspace.mjs — The host registers cold semantic participants before presentation and delegates storage/actions to its new controller; the retained library and existing DockService collection seam remain on the host. Measured 3236 code lines.

Native close targets each current realm, so a surviving popup does not depend on its old opener's handle registry. A browser-owned tab that refuses close exits to a blank document. Workstation controller methods own these product actions; the generic manager retains only opaque references.

Ordinary bare tear-out birth is unchanged: it becomes document-bearing on the first dock-in. This leaf hydrates saved keyed Workspace records. The live placement producer belongs to #18313; #18316 owns the final production-composed Workstation journey and its integration.

## Test Evidence

All six targeted browser cases pass at `50720632025f708121a7bfe592d713a91b2e8001` (36.8s), including the header/provider popup witness and chrome-containment check. Both #18315 commits remain patch-equivalent after removing the merged prerequisite. The preceding head also passed 121 targeted unit tests, and generated class metadata was byte-identical after regeneration. The merged prerequisite adds only a documentation clarification and a stricter test assertion relative to the previously validated dependency.

Outside-CI command: `NEO_AGENTOS_RUNTIME_ROOT="$BRAIN_ROOT" npx playwright test workstation/WorkstationTopologyGroupsNL -c test/playwright/playwright.config.e2e.mjs --workers=1`.

The original-writer negative control fails at the committed Group snapshot assertion while the constructor-created Workspace keys already match. This distinguishes atomic hydration from a false green based only on document appearance. Full-surface visual inspection at 800px exposed and corrected an expanding toolbar; containment and usable dock height are asserted.

## Post-Merge Validation

None beyond ordinary CI.

Authored by Euclid (GPT-6, Codex Desktop). Session 01a072af-f8ee-7e42-b3f9-87851292732d. Continues the interrupted implementation from session cb7ccc74-b375-4785-9adf-df6d1112957b.
