### PR TITLE
feat(dock): observe relative popup placement (#18313)

### DIFF
--- a/apps/workstation/view/Workspace.mjs
+++ b/apps/workstation/view/Workspace.mjs
@@ -10,6 +10,7 @@ import DockDropIndicators       from '../../../src/dashboard/dock/interaction/Dr
 import DockLayoutAdapter        from '../../../src/dashboard/dock/projection/LayoutAdapter.mjs';
 import PerspectiveLibrary       from '../../../src/dashboard/dock/persistence/PerspectiveLibrary.mjs';
 import TopologyLibrary          from '../../../src/dashboard/dock/persistence/TopologyLibrary.mjs';
+import Placement                from '../../../src/dashboard/dock/window/Placement.mjs';
 import DockPreview              from '../../../src/dashboard/dock/interaction/Preview.mjs';
 import DockProjectionReconciler from '../../../src/dashboard/dock/projection/Reconciler.mjs';
 import DockService              from '../../../src/ai/client/DockService.mjs';
@@ -285,6 +286,8 @@ class Workspace extends DockWorkspace {
      * @protected
      */
     workspaceSet = null
+    /** @member {Neo.dashboard.dock.window.Placement|null} dockPlacement=null Group-owned relative hints. */
+    dockPlacement = null
     /**
      * Target-side adapters keyed by stable workspace identity. The main workspace registers during
      * construction; vessel targets register only after their exact child window joins.
@@ -943,12 +946,19 @@ class Workspace extends DockWorkspace {
     registerMainWorkspace() {
         let me = this;
 
-        return me.workspaceSet.register(Workspace.MAIN_WORKSPACE_ID, {
+        const registered = me.workspaceSet.register(Workspace.MAIN_WORKSPACE_ID, {
             bindingKey : 'main',
             componentId: me.id,
             getDocument: () => me.dockModel,
             setDocument: document => me.dockModel = document
-        })
+        });
+        if (registered) me.dockPlacement ??= Placement.forGroup({groupId: me.topologyGroupId, mainWorkspaceKey: Workspace.MAIN_WORKSPACE_ID});
+        return registered
+    }
+
+    /** @summary Returns the Group's current relative hints for topology persistence. @returns {Object} */
+    getPlacementHints() {
+        return this.dockPlacement?.hints ?? {}
     }
 
     /**

--- a/apps/workstation/view/Workspace.mjs
+++ b/apps/workstation/view/Workspace.mjs
@@ -429,7 +429,6 @@ class Workspace extends DockWorkspace {
             collection: Persistence.createTopologyCollection([], {activeLayoutId: null}).collection
         });
         me.workspaceSet = createDockWorkspaceSet({documentModel: WorkspaceDocument, manager: TransactionManager, getGroupId: () => me.topologyGroupId});
-        me.registerMainWorkspace();
 
         for (const [workspaceId, document] of Object.entries(me.initialTopology?.workspaces ?? {})) {
             if (workspaceId === Workspace.MAIN_WORKSPACE_ID) continue;
@@ -447,6 +446,8 @@ class Workspace extends DockWorkspace {
                 setDocument: value => state.document = value
             })
         }
+
+        me.registerMainWorkspace();
 
         me.tourRunner  = Neo.create(TourRunner, {
             componentId   : me.id,
@@ -952,7 +953,9 @@ class Workspace extends DockWorkspace {
             getDocument: () => me.dockModel,
             setDocument: document => me.dockModel = document
         });
-        if (registered) me.dockPlacement ??= Placement.forGroup({groupId: me.topologyGroupId, mainWorkspaceKey: Workspace.MAIN_WORKSPACE_ID});
+        if (registered) me.dockPlacement ??= Placement.forGroup({
+            groupId: me.topologyGroupId, initialHints: me.initialTopology?.placementHints, mainWorkspaceKey: Workspace.MAIN_WORKSPACE_ID
+        });
         return registered
     }
 

--- a/apps/workstation/view/WorkspaceController.mjs
+++ b/apps/workstation/view/WorkspaceController.mjs
@@ -23,7 +23,7 @@ class WorkspaceController extends Controller {
         return Persistence.captureTopologyPerspective(this.component.getDockTopologyWorkspaces(), {
             layoutId,
             metadata      : selected?.metadata ?? {},
-            placementHints: selected?.placementHints ?? {},
+            placementHints: this.component.getPlacementHints(),
             title         : selected?.title ?? layoutId,
             ...(selected && Object.hasOwn(selected, 'revision') && {revision: selected.revision}),
             ...(selected && Object.hasOwn(selected, 'perspectiveName') && {perspectiveName: selected.perspectiveName})
@@ -108,6 +108,10 @@ class WorkspaceController extends Controller {
         state.renderTarget = target;
         state.windowId = target.windowId;
         state.app = Neo.apps[target.windowId];
+        await this.component.observeWindowGeometry(target.windowId);
+        if (TransactionManager.getBinding(this.component.topologyGroupId, workspaceKey)?.windowId === target.windowId) {
+            await this.component.dockPlacement.restoreBinding(workspaceKey)
+        }
         if (state.host && !state.host.isDestroyed) {
             state.host.parent?.remove(state.host, false, true);
             target.add(state.host);
@@ -194,7 +198,7 @@ class WorkspaceController extends Controller {
                 hostId      : state.host?.id ?? null,
                 windowId    : state.windowId
             }])),
-            workspaceKeys: TransactionManager.participantKeys(group.id)
+            workspaceKeys: this.component.workspaceSet.ids()
         }
     }
 

--- a/buildScripts/util/file-size-baseline.json
+++ b/buildScripts/util/file-size-baseline.json
@@ -1,6 +1,6 @@
 {
-    "apps/workstation/view/Workspace.mjs": 3238,
-    "examples/dashboard/crossWindow/DemoBWorkspace.mjs": 2647,
+    "apps/workstation/view/Workspace.mjs": 3245,
+    "examples/dashboard/crossWindow/DemoBWorkspace.mjs": 2653,
     "src/dashboard/dock/Workspace.mjs": 1289,
     "src/main/addon/DragDrop.mjs": 1267
 }

--- a/buildScripts/util/file-size-baseline.json
+++ b/buildScripts/util/file-size-baseline.json
@@ -1,5 +1,5 @@
 {
-    "apps/workstation/view/Workspace.mjs": 3245,
+    "apps/workstation/view/Workspace.mjs": 3247,
     "examples/dashboard/crossWindow/DemoBWorkspace.mjs": 2653,
     "src/dashboard/dock/Workspace.mjs": 1289,
     "src/main/addon/DragDrop.mjs": 1267

--- a/docs/output/class-hierarchy.json
+++ b/docs/output/class-hierarchy.json
@@ -248,6 +248,7 @@
  "Neo.dashboard.dock.projection.Reconciler": "Neo.core.Base",
  "Neo.dashboard.dock.window.DragTarget": "Neo.core.Base",
  "Neo.dashboard.dock.window.Participation": "Neo.core.Base",
+ "Neo.dashboard.dock.window.Placement": "Neo.core.Base",
  "Neo.dashboard.dock.window.TopologySeams": "Neo.core.Base",
  "Neo.data.Model": "Neo.core.Base",
  "Neo.data.Pipeline": "Neo.core.Base",

--- a/examples/dashboard/crossWindow/DemoBWorkspace.mjs
+++ b/examples/dashboard/crossWindow/DemoBWorkspace.mjs
@@ -6,6 +6,7 @@ import DockDropIndicators                   from '../../../src/dashboard/dock/in
 import DockLayoutAdapter                    from '../../../src/dashboard/dock/projection/LayoutAdapter.mjs';
 import DockMotionSignal                     from '../../../src/dashboard/dock/projection/MotionSignal.mjs';
 import PerspectiveLibrary                   from '../../../src/dashboard/dock/persistence/PerspectiveLibrary.mjs';
+import Placement                            from '../../../src/dashboard/dock/window/Placement.mjs';
 import DockPreview                          from '../../../src/dashboard/dock/interaction/Preview.mjs';
 import DockPreviewProducer                  from '../../../src/dashboard/dock/interaction/PreviewProducer.mjs';
 import DockProjectionReconciler             from '../../../src/dashboard/dock/projection/Reconciler.mjs';
@@ -220,6 +221,8 @@ class DemoBWorkspace extends Container {
      * @member {Object|null} workspaceSet=null
      */
     workspaceSet = null
+    /** @member {Neo.dashboard.dock.window.Placement|null} dockPlacement=null Group-owned relative hints. */
+    dockPlacement = null
     /**
      * The app-side Neural Link dock seam (tour + agent drivability).
      * @member {Neo.ai.client.DockService|null} dockService=null
@@ -1209,10 +1212,10 @@ class DemoBWorkspace extends Container {
         }
 
         created = scope === 'topology'
-            ? Persistence.captureTopologyPerspective({
-                [DemoBWorkspace.MAIN_WORKSPACE_ID] : me.dockModel,
-                [DemoBWorkspace.POPUP_WORKSPACE_ID]: me.popupDocument
-            }, metadata)
+            ? Persistence.captureTopologyPerspective(
+                Object.fromEntries(me.workspaceSet.ids().map(key => [key, me.workspaceSet.getDocument(key)])),
+                {...metadata, placementHints: me.getPlacementHints()}
+            )
             : Persistence.createSavedLayout(me.dockModel, metadata);
 
         if (created.errors.length) {
@@ -3028,7 +3031,13 @@ class DemoBWorkspace extends Container {
         me.workspaceSet.register(DemoBWorkspace.POPUP2_WORKSPACE_ID, {
             getDocument: () => me.popup2Document,
             setDocument: document => me.popup2Document = document
-        })
+        });
+        me.dockPlacement ??= Placement.forGroup({groupId, mainWorkspaceKey: DemoBWorkspace.MAIN_WORKSPACE_ID})
+    }
+
+    /** @summary Returns the Group's current relative hints for topology persistence. @returns {Object} */
+    getPlacementHints() {
+        return this.dockPlacement?.hints ?? {}
     }
 
     /**

--- a/learn/agentos/decisions/0029-docking-design.md
+++ b/learn/agentos/decisions/0029-docking-design.md
@@ -80,6 +80,18 @@ Its durable half lives in the keyed topology envelope; it does not mint a standa
 
 **Fallback is semantic recovery, not geometry:** restoring a detached item whose window cannot be re-created re-enters the item at its `fallbackTarget`; if that node no longer exists, at the nearest surviving ancestor placement; never at stored pixel coordinates.
 
+**Observed placement transactions.** A Group-owned placement participant captures only relative hints.
+Free movement of a document-bearing popup slot appends one before/after row after the native quiet
+period; movement of the main frame rebases the live popup hints in one preserve write, without
+changing history, its cursor or redo tail, and without moving the popups. Headless hints remain
+semantic intent until their render target exists. The main slot has no placement hint.
+
+Undo/redo adopts the relative hint before requesting the native effect. Resulting geometry reports
+carry the request's transaction/effect identity only while that exact native operation owns them;
+they produce an observed receipt rather than another free-movement row. Refusal and screen clamping
+are reported from observed coordinates, and a late result from a retired binding never updates its
+successor. Runtime effect markers, native handles and screen rectangles stay outside persisted hints.
+
 #### The SharedWorker seam — normative state-class table
 
 | State class | Examples | Owner | Persistence |

--- a/learn/benefits/ArchitectureOverview.md
+++ b/learn/benefits/ArchitectureOverview.md
@@ -435,7 +435,7 @@ complete organism where the codebase and the agent co-evolve.
 | `src/container/` | Layout containers | `Base`, `Viewport` | — |
 | `src/list/` | Store-bound semantic lists, including fixed-height buffered component pools | `Base`, `Component`, `Buffered` | — |
 | `src/grid/` | Buffered data grids | `Container`, `View` | — |
-| `src/dashboard/` | Generic dashboard roots plus the DockLayouts domain package: committed dock documents, semantic operations, projection, interaction affordances, perspectives, cross-window choreography, and declinable owner plugins the Workspace installs under `dock/{model,projection,interaction,persistence,window,plugin}` | `Container`, `Panel`, `dock.Workspace`, `dock.model.WorkspaceDocument`, `dock.model.Operations`, `dock.persistence.PerspectiveLibrary`, `dock.plugin.Maximize` | [0029](../agentos/decisions/0029-docking-design.md) |
+| `src/dashboard/` | Generic dashboard roots plus the DockLayouts domain package: committed dock documents, semantic operations, projection, interaction affordances, perspectives, cross-window choreography and observed relative placement, and declinable owner plugins the Workspace installs under `dock/{model,projection,interaction,persistence,window,plugin}` | `Container`, `Panel`, `dock.Workspace`, `dock.model.WorkspaceDocument`, `dock.model.Operations`, `dock.persistence.PerspectiveLibrary`, `dock.window.Placement`, `dock.plugin.Maximize` | [0029](../agentos/decisions/0029-docking-design.md) |
 | `src/data/` | Data layer | `Store`, `Model`, `RecordFactory` | — |
 | `src/state/` | State management | `Provider` | — |
 | `src/worker/` | Thread management | `App`, `VDom`, `Data`, `Manager` | — |

--- a/src/Main.mjs
+++ b/src/Main.mjs
@@ -1016,7 +1016,6 @@ class Main extends core.Base {
      * @param {String} data.windowName
      * @param {Number|String} data.x
      * @param {Number|String} data.y
-     * @param {Object} [data.nativeEffect] Transaction/effect identity carried by resulting geometry reports.
      * @returns {Promise<Boolean>} True when the popup reaches the requested screen coordinates.
      */
     async windowMoveTo(data) {
@@ -1115,6 +1114,7 @@ class Main extends core.Base {
      * @param {String} data.targetWindowId
      * @param {Number|String} data.x
      * @param {Number|String} data.y
+     * @param {Object} [data.nativeEffect] Transaction/effect identity carried by resulting geometry reports.
      * @returns {Promise<Boolean>}
      */
     async windowNativeMoveTo(data) {

--- a/src/Main.mjs
+++ b/src/Main.mjs
@@ -323,6 +323,7 @@ class Main extends core.Base {
             mozInnerScreenX: win.mozInnerScreenX, // Firefox specific
             mozInnerScreenY: win.mozInnerScreenY, // Firefox specific
             nativeRoute    : resolveNativeWindowRoute(win),
+            nativeEffect   : win.neoNativeGeometryEffects?.at(-1) ?? null,
             outerHeight    : win.outerHeight,
             outerWidth     : win.outerWidth,
             screen         : {
@@ -1015,6 +1016,7 @@ class Main extends core.Base {
      * @param {String} data.windowName
      * @param {Number|String} data.x
      * @param {Number|String} data.y
+     * @param {Object} [data.nativeEffect] Transaction/effect identity carried by resulting geometry reports.
      * @returns {Promise<Boolean>} True when the popup reaches the requested screen coordinates.
      */
     async windowMoveTo(data) {
@@ -1117,12 +1119,25 @@ class Main extends core.Base {
      */
     async windowNativeMoveTo(data) {
         const route = this.#getNativeWindowRoute(data, 'position');
-
-        if (!route || !await this.#moveWindow(route.entry.win, data.x, data.y)) {
-            return false
+        if (!route) return false;
+        if (data.nativeEffect && !['transactionId', 'effectId'].every(key =>
+            typeof data.nativeEffect[key] === 'string' && data.nativeEffect[key].length
+        )) return false;
+        const win    = route.entry.win;
+        const effect = data.nativeEffect && {
+            transactionId: data.nativeEffect.transactionId,
+            effectId     : data.nativeEffect.effectId
+        };
+        if (effect) (win.neoNativeGeometryEffects ??= []).push(effect);
+        try {
+            return await this.#moveWindow(win, data.x, data.y) && this.#getNativeWindowRoute(data, 'position') === route
+        } finally {
+            if (effect) {
+                const effects = win.neoNativeGeometryEffects;
+                effects.splice(effects.indexOf(effect), 1);
+                if (!effects.length) delete win.neoNativeGeometryEffects
+            }
         }
-
-        return this.#getNativeWindowRoute(data, 'position') === route
     }
 
     /**

--- a/src/dashboard/dock/persistence/TopologyLibrary.mjs
+++ b/src/dashboard/dock/persistence/TopologyLibrary.mjs
@@ -193,7 +193,6 @@ class TopologyLibrary extends Base {
 
             manager.releaseGroup(groupId, this);
             manager.retireGroup(groupId);
-            manager.fire('groupRetired', {groupId});
             attachment.dispose();
             return true
         })().finally(() => {

--- a/src/dashboard/dock/window/Placement.mjs
+++ b/src/dashboard/dock/window/Placement.mjs
@@ -2,6 +2,7 @@ import Base            from '../../../core/Base.mjs';
 import Transaction     from '../../../manager/Transaction.mjs';
 import WindowManager   from '../../../manager/Window.mjs';
 import DragCoordinator from '../../../manager/DragCoordinator.mjs';
+import InstanceManager from '../../../manager/Instance.mjs';
 import {buffer}        from '../../../util/Function.mjs';
 import Persistence     from '../model/Persistence.mjs';
 
@@ -16,6 +17,20 @@ import Persistence     from '../model/Persistence.mjs';
  * @extends Neo.core.Base
  */
 class Placement extends Base {
+    /**
+     * @summary Reuses the Group-owned placement controller across render-host replacement.
+     * @param {Object} config Group and main-workspace identity.
+     * @returns {Neo.dashboard.dock.window.Placement}
+     * @static
+     */
+    static forGroup(config) {
+        const entry = Transaction.getParticipant(config.groupId, config.participantKey ?? 'placementHints');
+        if (!entry) return Neo.create(Placement, config);
+        const owner = InstanceManager.get(entry.componentId);
+        if (!(owner instanceof Placement)) throw new Error('the placement participant key belongs to another owner');
+        return owner
+    }
+
     static config = {
         /** @member {String} className='Neo.dashboard.dock.window.Placement' @protected */
         className: 'Neo.dashboard.dock.window.Placement',
@@ -39,6 +54,8 @@ class Placement extends Base {
     #pending = new Map()
     /** @member {Function|null} #listener=null @private */
     #listener = null
+    /** @member {Object|null} #groupListeners=null @private */
+    #groupListeners = null
     /** @member {Object|null} #participant=null @private */
     #participant = null
     /** @member {Map<String,Object>} #receipts @private */
@@ -59,8 +76,9 @@ class Placement extends Base {
 
         me.#hints = me.prepare(me.initialHints ?? me.observedHints());
         me.#participant = {
-            domain : 'dock',
-            capture: () => ({
+            domain     : 'dock',
+            componentId: me.id,
+            capture    : () => ({
                 value     : me.#hints,
                 generation: me.generation(),
                 revision  : me.#revision
@@ -72,7 +90,18 @@ class Placement extends Base {
         };
         Transaction.registerParticipant({groupId: me.groupId, workspaceKey: me.participantKey, participant: me.#participant});
         me.#listener = event => me.onGeometry(event);
-        WindowManager.on('positionchange', me.#listener)
+        WindowManager.on('positionchange', me.#listener);
+        me.#groupListeners = {
+            groupRetired: ({groupId}) => { if (groupId === me.groupId) me.destroy() },
+            bind        : ({groupId, workspaceKey}) => {
+                if (groupId !== me.groupId || !me.#hints[workspaceKey]) return;
+                const group = Transaction.get(groupId);
+                me.applyHint(workspaceKey, me.#hints[workspaceKey], {
+                    transactionId: group.history?.current?.transactionId ?? `${groupId}:snapshot:${group.snapshot?.version ?? 0}`
+                }).catch(error => Neo.logError(error))
+            }
+        };
+        Transaction.on(me.#groupListeners)
     }
 
     /**
@@ -323,6 +352,7 @@ class Placement extends Base {
      */
     destroy() {
         WindowManager.un('positionchange', this.#listener);
+        Transaction.un(this.#groupListeners);
         this.#pending.forEach(pending => pending.flush.cancel());
         this.#pending.clear();
         if (Transaction.getParticipant(this.groupId, this.participantKey) === this.#participant) {

--- a/src/dashboard/dock/window/Placement.mjs
+++ b/src/dashboard/dock/window/Placement.mjs
@@ -95,10 +95,7 @@ class Placement extends Base {
             groupRetired: ({groupId}) => { if (groupId === me.groupId) me.destroy() },
             bind        : ({groupId, workspaceKey}) => {
                 if (groupId !== me.groupId || !me.#hints[workspaceKey]) return;
-                const group = Transaction.get(groupId);
-                me.applyHint(workspaceKey, me.#hints[workspaceKey], {
-                    transactionId: group.history?.current?.transactionId ?? `${groupId}:snapshot:${group.snapshot?.version ?? 0}`
-                }).catch(error => Neo.logError(error))
+                me.restoreBinding(workspaceKey).catch(error => Neo.logError(error))
             }
         };
         Transaction.on(me.#groupListeners)
@@ -262,6 +259,19 @@ class Placement extends Base {
                 await this.applyHint(key, hint, context)
             }
         }
+    }
+
+    /**
+     * @summary Projects the current saved hint when a bound window's native geometry becomes available.
+     * @param {String} workspaceKey
+     * @returns {Promise<Object|null>} The native outcome, or null for an unbound or unhinted slot.
+     */
+    async restoreBinding(workspaceKey) {
+        const group = Transaction.get(this.groupId), hint = this.#hints[workspaceKey];
+        if (!hint || !group?.bindings.get(workspaceKey)?.windowId) return null;
+        return this.applyHint(workspaceKey, hint, {
+            transactionId: group.history?.current?.transactionId ?? `${this.groupId}:snapshot:${group.snapshot?.version ?? 0}`
+        })
     }
 
     /**

--- a/src/dashboard/dock/window/Placement.mjs
+++ b/src/dashboard/dock/window/Placement.mjs
@@ -1,0 +1,335 @@
+import Base            from '../../../core/Base.mjs';
+import Transaction     from '../../../manager/Transaction.mjs';
+import WindowManager   from '../../../manager/Window.mjs';
+import DragCoordinator from '../../../manager/DragCoordinator.mjs';
+import {buffer}        from '../../../util/Function.mjs';
+import Persistence     from '../model/Persistence.mjs';
+
+/**
+ * @summary Owns a Group's relative placement hints and observes native movement without recording
+ * requested geometry as an outcome.
+ * @description Documents remain independent participants. This participant contains only keyed
+ * relative offsets and semantic fallback targets; window routes, rectangles and pending effects
+ * stay on this live owner. A free popup move appends after quiescence. A main-frame move rebases
+ * current hints through a preserve write, leaving history and the redo tail intact.
+ * @class Neo.dashboard.dock.window.Placement
+ * @extends Neo.core.Base
+ */
+class Placement extends Base {
+    static config = {
+        /** @member {String} className='Neo.dashboard.dock.window.Placement' @protected */
+        className: 'Neo.dashboard.dock.window.Placement',
+        /** @member {String|null} groupId=null */
+        groupId: null,
+        /** @member {String} mainBindingKey='main' */
+        mainBindingKey: 'main',
+        /** @member {String|null} mainWorkspaceKey=null */
+        mainWorkspaceKey: null,
+        /** @member {String} participantKey='placementHints' */
+        participantKey: 'placementHints',
+        /** @member {Object|null} initialHints=null */
+        initialHints: null
+    }
+
+    /** @member {Object} #hints @private */
+    #hints = Object.freeze({})
+    /** @member {Number} #revision=0 @private */
+    #revision = 0
+    /** @member {Map<String,Object>} #pending @private */
+    #pending = new Map()
+    /** @member {Function|null} #listener=null @private */
+    #listener = null
+    /** @member {Object|null} #participant=null @private */
+    #participant = null
+    /** @member {Map<String,Object>} #receipts @private */
+    #receipts = new Map()
+    /** @member {Promise<Object>|null} lastWrite=null */
+    lastWrite = null
+
+    /**
+     * @summary Registers this auxiliary participant separately from the Group's documents.
+     * @param {Object} config
+     */
+    construct(config) {
+        super.construct(config);
+        const me = this, group = Transaction.get(me.groupId);
+        if (!group || !me.mainWorkspaceKey || group.participants.has(me.participantKey)) {
+            throw new Error('Placement requires a live Group, a main workspace and an unused participant key')
+        }
+
+        me.#hints = me.prepare(me.initialHints ?? me.observedHints());
+        me.#participant = {
+            domain : 'dock',
+            capture: () => ({
+                value     : me.#hints,
+                generation: me.generation(),
+                revision  : me.#revision
+            }),
+            prepare   : hints => me.prepare(hints),
+            adopt     : hints => { me.#hints = hints; me.#revision++ },
+            compensate: captured => { me.#hints = captured.value; me.#revision = captured.revision },
+            project   : context => me.project(context)
+        };
+        Transaction.registerParticipant({groupId: me.groupId, workspaceKey: me.participantKey, participant: me.#participant});
+        me.#listener = event => me.onGeometry(event);
+        WindowManager.on('positionchange', me.#listener)
+    }
+
+    /**
+     * @summary The immutable committed relative hints, suitable for topology capture.
+     * @member {Object} hints
+     */
+    get hints() {
+        return this.#hints
+    }
+
+    /** @member {Object[]} receipts Latest observed effect per semantic workspace. */
+    get receipts() {
+        return [...this.#receipts.values()]
+    }
+
+    /**
+     * @summary Resolves only document-bearing participants, excluding this auxiliary value.
+     * @returns {Object<String,Object>}
+     */
+    documents() {
+        return Object.fromEntries([...Transaction.get(this.groupId).participants]
+            .filter(([, participant]) => typeof participant.getDocument === 'function')
+            .map(([key, participant]) => [key, participant.getDocument()]))
+    }
+
+    /**
+     * @summary Fences a prepare against changes to any live binding in this Group.
+     * @returns {String} Runtime-only stamp; never a field in a placement hint.
+     */
+    generation() {
+        const group = Transaction.get(this.groupId);
+        return JSON.stringify(group ? [...group.bindings].map(([key, binding]) => [key, binding.windowId, binding.generation]) : null)
+    }
+
+    /**
+     * @summary Validates hints through the existing topology wire boundary.
+     * @param {Object} hints
+     * @returns {Object}
+     */
+    prepare(hints) {
+        const {topology, errors} = Persistence.captureTopologyPerspective(this.documents(), {
+            layoutId: 'placement-validation', title: 'Placement', placementHints: hints
+        });
+        if (errors.length) throw new Error(errors.join('; '));
+        if (Object.hasOwn(topology.placementHints, this.mainWorkspaceKey)) throw new Error('the main workspace has no placement hint');
+        Object.values(topology.placementHints).forEach(hint => {
+            Object.freeze(hint.fallbackTarget);
+            Object.freeze(hint)
+        });
+        return Object.freeze(topology.placementHints)
+    }
+
+    /**
+     * @summary Derives popup offsets from current observed outer rectangles.
+     * @returns {Object}
+     */
+    observedHints() {
+        const me   = this, group = Transaction.get(me.groupId), documents = me.documents();
+        const main = WindowManager.get(group.bindings.get(me.mainBindingKey)?.windowId)?.outerRect;
+        if (!main) return {};
+        const hints = Object.fromEntries(Object.entries(me.#hints).filter(([key]) => documents[key]));
+        for (const [key, binding] of group.bindings) {
+            const rect = WindowManager.get(binding.windowId)?.outerRect;
+            if (key === me.mainBindingKey || !rect || !documents[key]) continue;
+            hints[key] = me.relativeHint(rect, main, me.#hints[key]?.fallbackTarget)
+        }
+        return hints
+    }
+
+    /**
+     * @summary Converts a runtime rectangle pair into the durable relative representation.
+     * @param {Object} rect
+     * @param {Object} main
+     * @param {Object} [fallbackTarget]
+     * @returns {Object}
+     */
+    relativeHint(rect, main, fallbackTarget) {
+        return {
+            dx            : rect.x - main.x,
+            dy            : rect.y - main.y,
+            fallbackTarget: fallbackTarget ?? {workspaceKey: this.mainWorkspaceKey, nodeId: this.documents()[this.mainWorkspaceKey].root}
+        }
+    }
+
+    /**
+     * @summary Coalesces a burst using the same quiet-period policy as native drop settling.
+     * @param {Object} event
+     * @param {String} event.windowId
+     * @param {Object|null} event.before
+     * @param {Object} event.after
+     */
+    onGeometry({windowId, before, after, nativeEffect}) {
+        const me = this, binding = Transaction.findByWindow(windowId);
+        if (nativeEffect) return;
+        if (!binding || binding.groupId !== me.groupId || !before || before.x === after.x && before.y === after.y) return;
+        let pending = me.#pending.get(windowId);
+        if (!pending) {
+            pending = {windowId, before, after, generation: me.generation()};
+            pending.flush = buffer(() => {
+                me.#pending.delete(windowId);
+                me.lastWrite = me.ingest(pending);
+                me.lastWrite.catch(error => Neo.logError(error))
+            }, me, DragCoordinator.nativeWindowDropSettleMs);
+            me.#pending.set(windowId, pending)
+        }
+        pending.after = after;
+        pending.flush()
+    }
+
+    /**
+     * @summary Records a settled free move, or rebases the main frame without a history row.
+     * @param {Object} movement The generation-fenced, quiesced observation.
+     * @returns {Promise<Object|null>}
+     */
+    async ingest({windowId, before, after, generation}) {
+        const me = this, binding = Transaction.findByWindow(windowId);
+        if (!binding || binding.groupId !== me.groupId || me.generation() !== generation || me.isDestroyed) return null;
+        const group  = Transaction.get(me.groupId);
+        const isMain = binding.workspaceKey === me.mainBindingKey;
+        if (!isMain && DragCoordinator.nativeWindowDropCandidates.has(windowId)) return null;
+        const main = WindowManager.get(group.bindings.get(me.mainBindingKey)?.windowId)?.outerRect;
+        if (!main) return null;
+        const key = binding.workspaceKey;
+        if (!isMain && !me.documents()[key]) return null;
+        if (!isMain && !Object.hasOwn(me.#hints, key)) {
+            await me.write({...me.#hints, [key]: me.relativeHint(before, main)}, 'placement-baseline', 'preserve')
+        }
+        return me.write(isMain ? me.observedHints() : {
+            ...me.#hints, [key]: me.relativeHint(after, main, me.#hints[key].fallbackTarget)
+        }, isMain ? 'main-frame-rebase' : 'native-popup-move', isMain ? 'preserve' : 'append')
+    }
+
+    /**
+     * @summary Adopts validated hints through the same compensating Group writer as documents.
+     * @param {Object} hints
+     * @param {String} cause
+     * @param {String} [cursorAction='append']
+     * @returns {Promise<Object>}
+     */
+    write(hints, cause, cursorAction='append') {
+        return Transaction.write({
+            groupId: this.groupId, cause, cursorAction, provenance: {origin: 'observed-geometry'},
+            changes: [{workspaceKey: this.participantKey, input: hints}]
+        })
+    }
+
+    /**
+     * @summary Applies semantic undo/redo or explicit placement after the Group queue releases.
+     * @param {Object} context Committed participant context.
+     * @returns {Promise<void>}
+     */
+    async project(context) {
+        if (context.cursorAction === 'preserve' || context.cause === 'native-popup-move') return;
+        const hints = context.snapshot.participants[this.participantKey];
+        for (const [key, hint] of Object.entries(hints)) {
+            const before = context.captured.value[key];
+            if (!before || before.dx !== hint.dx || before.dy !== hint.dy) {
+                await this.applyHint(key, hint, context)
+            }
+        }
+    }
+
+    /**
+     * @summary Resolves a relative hint inside the current screen's usable bounds.
+     * @param {Object} hint
+     * @param {Object} main Observed main outer rectangle.
+     * @param {Object} popup Observed popup outer rectangle.
+     * @param {Object} screen Current usable screen bounds.
+     * @returns {Object|null} Runtime coordinates, or null for semantic fallback.
+     * @static
+     */
+    static resolvePosition(hint, main, popup, screen) {
+        const {availLeft, availTop, availWidth, availHeight} = screen ?? {};
+        if (![availLeft, availTop, availWidth, availHeight].every(Number.isFinite) || availWidth <= 0 || availHeight <= 0) return null;
+        return {
+            x: Math.min(Math.max(main.x + hint.dx, availLeft), availLeft + Math.max(0, availWidth - popup.width)),
+            y: Math.min(Math.max(main.y + hint.dy, availTop), availTop + Math.max(0, availHeight - popup.height))
+        }
+    }
+
+    /**
+     * @summary Projects onto one exact live generation and records its observed result separately.
+     * @param {String} workspaceKey
+     * @param {Object} hint
+     * @param {Object} context
+     * @returns {Promise<Object>}
+     */
+    async applyHint(workspaceKey, hint, context) {
+        const me         = this, group = Transaction.get(me.groupId);
+        const binding    = group?.bindings.get(workspaceKey), windowId = binding?.windowId;
+        const generation = binding?.generation, popup = WindowManager.get(windowId);
+        const route      = popup?.nativeRoute, mainBinding = group?.bindings.get(me.mainBindingKey);
+        const effectId   = crypto.randomUUID();
+        const live       = () => !me.isDestroyed && Transaction.get(me.groupId) === group &&
+            group.bindings.get(workspaceKey)?.windowId === windowId &&
+            group.bindings.get(workspaceKey)?.generation === generation &&
+            WindowManager.get(windowId)?.nativeRoute === route;
+        let status = 'fallback', observed = null, error = null;
+        try {
+            if (windowId && route && popup.capabilities?.position && mainBinding?.windowId) {
+                const screen   = await me.readScreen(windowId);
+                const main     = WindowManager.get(mainBinding.windowId)?.outerRect;
+                const position = main && Placement.resolvePosition(hint, main, popup.outerRect, screen);
+                if (!live()) status = 'stale';
+                else if (position) {
+                    const admitted = await me.moveWindow(route, position, {transactionId: context.transactionId, effectId});
+                    const rect     = live() ? await me.readGeometry(route) : null;
+                    if (!live()) status = 'stale';
+                    else {
+                        const currentMain = WindowManager.get(mainBinding.windowId)?.outerRect;
+                        observed = rect && currentMain ? {dx: rect.x - currentMain.x, dy: rect.y - currentMain.y} : null;
+                        status = admitted === true && observed ? 'applied' : 'refused'
+                    }
+                }
+            }
+        } catch (failure) {
+            status = live() ? 'refused' : 'stale';
+            error = String(failure?.message ?? failure)
+        }
+        const receipt = Object.freeze({
+            transactionId : context.transactionId, effectId, workspaceKey, status,
+            observed      : observed && Object.freeze(observed),
+            fallbackTarget: hint.fallbackTarget,
+            error
+        });
+        if (live()) me.#receipts.set(workspaceKey, receipt);
+        try { Transaction.fire('effectReceipt', {groupId: me.groupId, receipt}) } catch (failure) { Neo.logError(failure) }
+        return receipt
+    }
+
+    /** @summary Reads current screen facts from the addressed realm. @param {String} windowId @returns {Promise<Object>} */
+    async readScreen(windowId) {
+        return (await Neo.Main.getWindowData({windowId})).screen
+    }
+
+    /** @summary Requests one generation-fenced native effect. @param {Object} route @param {Object} position @param {Object} nativeEffect @returns {Promise<Boolean>} */
+    moveWindow(route, position, nativeEffect) {
+        return Neo.Main.windowNativeMoveTo({...route, ...position, nativeEffect, windowId: route.ownerWindowId})
+    }
+
+    /** @summary Reads what the exact native handle actually did. @param {Object} route @returns {Promise<Object|null>} */
+    readGeometry(route) {
+        return Neo.Main.windowNativeGetGeometry({...route, windowId: route.ownerWindowId})
+    }
+
+    /**
+     * @summary Cancels pending movement and releases only this owner's registration.
+     */
+    destroy() {
+        WindowManager.un('positionchange', this.#listener);
+        this.#pending.forEach(pending => pending.flush.cancel());
+        this.#pending.clear();
+        if (Transaction.getParticipant(this.groupId, this.participantKey) === this.#participant) {
+            Transaction.unregisterParticipant({groupId: this.groupId, workspaceKey: this.participantKey})
+        }
+        super.destroy()
+    }
+}
+
+export default Neo.setupClass(Placement);

--- a/src/dashboard/dock/window/WorkspaceSet.mjs
+++ b/src/dashboard/dock/window/WorkspaceSet.mjs
@@ -54,12 +54,13 @@ export function createDockWorkspaceSet({manager, getGroupId, documentModel}) {
         participant = workspaceId => {
             const id = groupId();
 
-            return id ? manager.getParticipant(id, workspaceId) : null
+            const entry = id ? manager.getParticipant(id, workspaceId) : null;
+            return typeof entry?.getDocument === 'function' ? entry : null
         },
         keys        = () => {
             const id = groupId();
 
-            return id ? manager.participantKeys(id) : []
+            return id ? manager.participantKeys(id).filter(key => participant(key)) : []
         };
 
     return {

--- a/src/main/addon/WindowPosition.mjs
+++ b/src/main/addon/WindowPosition.mjs
@@ -175,6 +175,12 @@ class WindowPosition extends Base {
         let {Manager} = Neo.worker,
             winData   = Neo.Main.getWindowData();
 
+        // A native operation explicitly publishes before its effect marker is released. Advancing
+        // this baseline prevents the poll from echoing that same position as an untagged user move.
+        if (winData.nativeEffect) {
+            this.set({screenLeft: winData.screenLeft, screenTop: winData.screenTop})
+        }
+
         Manager.sendMessage('app', {
             action: 'windowPositionChange',
             data  : {

--- a/src/manager/DragCoordinator.mjs
+++ b/src/manager/DragCoordinator.mjs
@@ -2,6 +2,7 @@ import {createGestureClaimArbiter} from './GestureClaimArbiter.mjs';
 import Manager                     from './Base.mjs';
 import Rectangle                   from '../util/Rectangle.mjs';
 import Window                      from './Window.mjs';
+import {buffer}                    from '../util/Function.mjs';
 
 /**
  * @class Neo.manager.DragCoordinator
@@ -203,6 +204,7 @@ class DragCoordinator extends Manager {
             candidate.registrationRefreshes?.clear();
             candidate.registrationRefreshes = null;
             clearTimeout(candidate.timeoutId);
+            candidate.settle?.cancel();
             candidate.resolveHandoff?.();
 
             if (candidate.embodied) {
@@ -1322,11 +1324,12 @@ class DragCoordinator extends Manager {
         dwellRemaining = Math.max(0, me.nativeWindowDropDwellMs - (now - firstSeenAt));
         delay          = Math.max(me.nativeWindowDropSettleMs, dwellRemaining);
 
-        candidate.timeoutId = setTimeout(() => {
+        candidate.settle = buffer(() => {
             me.commitNativeWindowDrop(windowId, candidate).catch(error => {
                 (Neo.logError || console.error)('Native window drop failed', error)
             })
-        }, delay);
+        }, me, delay);
+        candidate.settle();
 
         me.nativeWindowDropCandidates.set(windowId, candidate)
     }

--- a/src/manager/DragCoordinator.mjs
+++ b/src/manager/DragCoordinator.mjs
@@ -1254,6 +1254,15 @@ class DragCoordinator extends Manager {
             current    = me.nativeWindowDropCandidates.get(windowId),
             sourceDrag, candidate, dwellRemaining, firstSeenAt, delay, now, preview, previewId;
 
+        if (data.nativeEffect) {
+            if (!current?.phase) {
+                me.updateNativeHover(windowId, null);
+                me.clearNativeWindowDropCandidate(windowId);
+                me.endNativeGesture(windowId)
+            }
+            return
+        }
+
         // Parking, embodiment, target settlement, and strict source retry can all publish geometry
         // of their own. Their retained generation owns the terminal; never reinterpret those
         // effects as a fresh titlebar gesture.

--- a/src/manager/Transaction.mjs
+++ b/src/manager/Transaction.mjs
@@ -583,6 +583,8 @@ class Transaction extends Manager {
      * @summary Captures and prepares at the queue head, then commits participants, history and snapshot
      * in one compensating critical section. Request data is copied at admission; participants remain
      * live owners until capture. Presentation runs after queue release and cannot reject the commit.
+     * Preserve writes publish current state without changing history, including an existing redo tail;
+     * cold hydration and observed reference-frame rebasing use this mode.
      * @param {Object} request
      * @param {String} request.groupId
      * @param {String} request.cause Explicit reason for this write, separate from cursorAction.

--- a/src/manager/Transaction.mjs
+++ b/src/manager/Transaction.mjs
@@ -800,6 +800,7 @@ class Transaction extends Manager {
         group.history?.destroy();
         group.provider = group.history = null;
         me.unregister(group);
+        me.fire('groupRetired', {groupId});
 
         return true
     }
@@ -850,7 +851,6 @@ class Transaction extends Manager {
                     group.retainedReferences.size === 0 && !group.history?.count && me.get(group.id) === group
                 ) {
                     me.retireGroup(group.id);
-                    me.fire('groupRetired', {groupId: group.id})
                 }
             }
         }, me.reconnectLeaseMs))

--- a/src/manager/Window.mjs
+++ b/src/manager/Window.mjs
@@ -188,8 +188,9 @@ class Window extends Manager {
      */
     onWindowPositionChange(data) {
         const
-            me   = this,
-            item = me.get(data.windowId);
+            me     = this,
+            item   = me.get(data.windowId),
+            before = item?.outerRect ?? null;
 
         const {chrome, innerRect, outerRect} = me.calculateGeometry(data);
 
@@ -207,6 +208,8 @@ class Window extends Manager {
                 outerRect
             })
         }
+
+        me.fire('positionchange', {windowId: data.windowId, before, after: outerRect, nativeEffect: data.nativeEffect ?? null})
     }
 
     /**

--- a/src/manager/transaction/Commit.mjs
+++ b/src/manager/transaction/Commit.mjs
@@ -123,7 +123,6 @@ class Commit extends Base {
         const snapshot = this.copy({version: (group.snapshot?.version ?? 0) + 1, participants: values});
         const history  = cursorAction === 'preserve' ? group.history : await manager.loadHistory(group);
         if (cursorAction === 'append') history?.assertRow(rowData);
-        if (cursorAction === 'preserve' && history?.count) throw new Error('preserve is only valid for an empty history baseline');
         manager.assertLive(group, 'write');
         if (group.participants.size !== members.length || members.some(([key, entry]) => {
             if (group.participants.get(key) !== entry) return true;

--- a/test/playwright/e2e/dashboard/DockPlacementNL.spec.mjs
+++ b/test/playwright/e2e/dashboard/DockPlacementNL.spec.mjs
@@ -1,0 +1,114 @@
+import {test, expect} from '../../fixtures.mjs';
+
+/**
+ * @summary Real-window proof of the Group placement participant: native movement, main-frame
+ * rebasing, correlated undo/redo effects, durable hints and popup generation replacement.
+ * @description CDP supplies physical window movement only. The real WindowPosition publisher,
+ * manager, placement participant and Group history carry every semantic observation.
+ */
+test.describe('observed dock popup placement', () => {
+    test.setTimeout(180000);
+    test.use({viewport: null});
+
+    test('free movement records once, main rebasing preserves history, and undo never records its own native effect', async ({page, neuralLink}) => {
+        await page.goto('/examples/dashboard/crossWindow/index.html');
+        await page.waitForSelector('.agentos-dockdemo-counter-pane', {timeout: 30000});
+        const app         = await neuralLink.connectToApp('Neo.examples.dashboard.crossWindow');
+        const [workspace] = await app.findInstances({className: 'Neo.examples.dashboard.crossWindow.DemoBWorkspace'}, ['id', 'topologyGroupId', 'dockPlacement.id']);
+        const [manager]   = await app.findInstances({className: 'Neo.manager.Transaction'}, ['id']);
+        const wsId        = workspace.id, groupId = workspace.properties.topologyGroupId;
+        const placementId = workspace.properties['dockPlacement.id'];
+        expect(placementId).toBeTruthy();
+
+        const readHints    = () => app.callMethod(wsId, 'getPlacementHints');
+        const readGroup    = () => app.callMethod(manager.id, 'get', [groupId]);
+        const readReceipts = () => app.getComponent(placementId, ['receipts']).then(value => value.receipts);
+        const readRect     = target => target.evaluate(() => ({x: screenX, y: screenY, width: outerWidth, height: outerHeight}));
+        const rootCdp      = await page.context().newCDPSession(page);
+        const rootWindow   = await rootCdp.send('Browser.getWindowForTarget');
+        const screen       = await page.evaluate(() => ({left: window.screen.availLeft, top: window.screen.availTop, width: window.screen.availWidth, height: window.screen.availHeight}));
+        await rootCdp.send('Browser.setWindowBounds', {windowId: rootWindow.windowId, bounds: {left: screen.left + 30, top: screen.top + 30, width: 800, height: 700}});
+
+        const popupPromise = page.waitForEvent('popup');
+        const opened       = app.callMethod(wsId, 'openCrossWindowStage', ['demo-b-popup']);
+        const popup        = await popupPromise;
+        await opened;
+        await popup.waitForFunction(() => globalThis.Neo?.main?.addon?.WindowPosition?.observeMovement === true);
+        const popupCdp    = await page.context().newCDPSession(popup);
+        const popupWindow = await popupCdp.send('Browser.getWindowForTarget');
+        const root        = await readRect(page);
+        const initial     = {left: root.x + root.width + 40, top: root.y + 30, width: 600, height: 450};
+        expect(initial.left + initial.width + 150).toBeLessThanOrEqual(screen.left + screen.width);
+        await popupCdp.send('Browser.setWindowBounds', {windowId: popupWindow.windowId, bounds: initial});
+        await expect.poll(async () => (await readHints())['demo-b-popup']?.dx).toBe(initial.left - root.x);
+        expect(await app.callMethod(manager.id, 'setHistoryDepth', [{groupId, depth: 6}])).toBe(true);
+        const before = await readHints();
+
+        await Promise.all([20, 40, 60].map(delta => popupCdp.send('Browser.setWindowBounds', {
+            windowId: popupWindow.windowId, bounds: {left: initial.left + delta, top: initial.top + 20}
+        })));
+        await expect.poll(async () => (await readGroup()).history?.count).toBe(1);
+        const moved          = await readRect(popup), main = await readRect(page);
+        const groupAfterMove = await readGroup();
+        expect((await readHints())['demo-b-popup']).toMatchObject({dx: moved.x - main.x, dy: moved.y - main.y});
+        expect(groupAfterMove.history.rows[0].participants[0].before['demo-b-popup']).toEqual(before['demo-b-popup']);
+        expect(groupAfterMove.history.rows[0].cause).toBe('native-popup-move');
+        const historyBeforeRebase = JSON.stringify(groupAfterMove.history);
+
+        await rootCdp.send('Browser.setWindowBounds', {windowId: rootWindow.windowId, bounds: {left: root.x + 40, top: root.y + 20}});
+        await expect.poll(async () => (await readHints())['demo-b-popup']?.dx).toBe(moved.x - root.x - 40);
+        expect(await readRect(popup)).toEqual(moved);
+        expect(JSON.stringify((await readGroup()).history)).toBe(historyBeforeRebase);
+
+        const [coordinator] = await app.findInstances({className: 'Neo.manager.DragCoordinator'}, ['nativeWindowDropSettleMs']);
+        const quietMs       = coordinator.properties.nativeWindowDropSettleMs;
+        await popup.evaluate(() => {
+            const original = Neo.Main.getWindowData;
+            Neo.Main.getWindowData = function(...args) {
+                const data = original.apply(this, args);
+                window.placementGeometryObservation = {at: Date.now(), effectId: data.nativeEffect?.effectId ?? null};
+                return data
+            }
+        });
+        const waitForEffectQuiet = async transactionId => {
+            const receipt = (await readReceipts()).find(row => row.transactionId === transactionId);
+            await popup.waitForFunction(({effectId, quietMs}) =>
+                window.placementGeometryObservation?.effectId === effectId &&
+                Date.now() - window.placementGeometryObservation.at >= quietMs,
+            {effectId: receipt.effectId, quietMs}, {timeout: 5000}).catch(async error => {
+                const observation = await popup.evaluate(() => window.placementGeometryObservation);
+                throw new Error(`${error.message}; receipt=${JSON.stringify(receipt)}; observation=${JSON.stringify(observation)}`)
+            })
+        };
+
+        const undo = await app.callMethod(manager.id, 'undo', [{groupId}]);
+        await expect.poll(async () => (await readReceipts()).find(row => row.transactionId === undo.transactionId)?.status).toBe('applied');
+        await waitForEffectQuiet(undo.transactionId);
+        const undone = await readGroup();
+        expect(undone.history.count).toBe(1);
+        expect(undone.history.cursor).toBe(-1);
+        const redo = await app.callMethod(manager.id, 'redo', [{groupId}]);
+        await expect.poll(async () => (await readReceipts()).find(row => row.transactionId === redo.transactionId)?.status).toBe('applied');
+        await waitForEffectQuiet(redo.transactionId);
+        expect((await readGroup()).history.count).toBe(1);
+        expect((await readGroup()).history.cursor).toBe(0);
+
+        const afterRedo = await readRect(popup);
+        await popupCdp.send('Browser.setWindowBounds', {windowId: popupWindow.windowId, bounds: {left: afterRedo.x + 20, top: afterRedo.y}});
+        await expect.poll(async () => (await readGroup()).history?.count).toBe(2);
+        expect(await app.callMethod(wsId, 'capturePerspective', ['Placement', {scope: 'topology'}])).toMatchObject({saved: true, errors: []});
+        const collection = (await app.getComponent(wsId, ['topologyCollection'])).topologyCollection;
+        expect(collection.topologies['demo-b-placement'].placementHints).toEqual(await readHints());
+        expect(JSON.stringify(collection.topologies['demo-b-placement'].placementHints)).not.toMatch(/windowId|outerRect|screen|nativeEffect/);
+
+        const hintsBeforeReload = await readHints(), historyBeforeReload = JSON.stringify((await readGroup()).history);
+        await popup.reload();
+        await popup.waitForFunction(() => globalThis.Neo?.worker?.Manager?.windowId);
+        await expect.poll(async () => (await app.callMethod(manager.id, 'getBinding', [groupId, 'demo-b-popup']))?.generation).toBe(2);
+        expect(await readHints()).toEqual(hintsBeforeReload);
+        expect(JSON.stringify((await readGroup()).history)).toBe(historyBeforeReload);
+        await page.screenshot({path: 'test/playwright/test-results/dock-placement-main.png'});
+        await popup.screenshot({path: 'test/playwright/test-results/dock-placement-popup.png'});
+        await popup.close()
+    });
+});

--- a/test/playwright/e2e/workstation/WorkstationTopologyGroupsNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationTopologyGroupsNL.spec.mjs
@@ -183,7 +183,10 @@ const expectColdTopology = async (root, record) => {
     const state      = await topologyState(root.app, root.workspaceId),
           collection = (await root.app.getComponent(root.workspaceId, ['topologyLibrary.collection']))['topologyLibrary.collection'];
     expect(state.workspaceKeys.slice().sort()).toEqual(Object.keys(record.workspaces).sort());
-    expect(state.snapshot?.participants, 'cold truth was published through the atomic Group writer').toEqual(record.workspaces);
+    expect(state.snapshot?.participants, 'cold truth includes the auxiliary placement participant').toEqual({
+        ...record.workspaces, placementHints: record.placementHints
+    });
+    expect(await root.app.callMethod(root.workspaceId, 'getPlacementHints')).toEqual(record.placementHints);
     expect(state.historyCount).toBe(0);
     expect(state.historyCursor).toBe(-1);
     expect(collection.activeLayoutId).toBe(record.layoutId);
@@ -329,11 +332,27 @@ test.describe('Workstation topology Groups — two roots under one SharedWorker 
             expect(afterPopup.historyCount).toBe(beforePopup.historyCount);
             expect(afterPopup.historyCursor).toBe(beforePopup.historyCursor);
 
+            const mainRect    = await root.page.evaluate(() => ({x: screenX, y: screenY, width: outerWidth})),
+                  popupCdp    = await coldContext.newCDPSession(popup),
+                  popupWindow = await popupCdp.send('Browser.getWindowForTarget'),
+                  movedLeft   = mainRect.x + mainRect.width + 60;
+            await popupCdp.send('Browser.setWindowBounds', {
+                windowId: popupWindow.windowId, bounds: {left: movedLeft, top: mainRect.y + 60}
+            });
+            await expect.poll(async () => (await root.app.callMethod(root.workspaceId, 'getPlacementHints')).details.dx).toBe(movedLeft - mainRect.x).catch(async error => {
+                const native    = await popup.evaluate(() => ({x: screenX, y: screenY, observed: Neo.main.addon.WindowPosition.observeMovement})),
+                      placement = await root.app.getComponent(root.workspaceId, ['dockPlacement.receipts']);
+                throw new Error(`${error.message}; native=${JSON.stringify(native)}; placement=${JSON.stringify(placement)}`)
+            });
+            const observedHints = await root.app.callMethod(root.workspaceId, 'getPlacementHints');
+            expect(observedHints).not.toEqual(seed.records.b.placementHints);
+
             expect(await root.app.executeDockOperation(root.workspaceId, {operation: 'setActiveItem', tabsNodeId: 'heavy-tabs', itemId: 'activity'})).toMatchObject({applied: true, errors: []});
             const changed = await root.app.callMethod(root.workspaceId, 'getDockTopologyWorkspaces');
             expect(changed['workstation-main'].nodes['heavy-tabs'].activeItemId).toBe('activity');
             await root.page.getByRole('button', {name: 'Save workspace', exact: true}).click();
             await expect.poll(async () => (await root.app.callMethod(root.workspaceId, 'topologyLibrary.persistenceAdapter.read')).topologies['layout-b'].workspaces, {timeout: 15000}).toEqual(changed);
+            expect((await root.app.callMethod(root.workspaceId, 'topologyLibrary.persistenceAdapter.read')).topologies['layout-b'].placementHints).toEqual(observedHints);
             const savedAgain = await coldContext.storageState({indexedDB: true}), carrierAgain = await readCarrier(root.page);
 
             const beforeRootReload = await topologyState(root.app, root.workspaceId);
@@ -373,7 +392,7 @@ test.describe('Workstation topology Groups — two roots under one SharedWorker 
             contexts.push(secondContext);
             const second = await coldRoot(secondContext, neuralLink, carrierAgain);
             expect(second.app.sessionId).not.toBe(root.app.sessionId);
-            await expectColdTopology(second, {...seed.records.b, workspaces: changed});
+            await expectColdTopology(second, {...seed.records.b, workspaces: changed, placementHints: observedHints});
             expect(secondContext.pages()).toHaveLength(1)
         } finally {
             await Promise.allSettled(contexts.map(current => current.close()))

--- a/test/playwright/e2e/workstation/WorkstationTopologyGroupsNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationTopologyGroupsNL.spec.mjs
@@ -339,6 +339,7 @@ test.describe('Workstation topology Groups — two roots under one SharedWorker 
             await popupCdp.send('Browser.setWindowBounds', {
                 windowId: popupWindow.windowId, bounds: {left: movedLeft, top: mainRect.y + 60}
             });
+            await popupCdp.detach();
             await expect.poll(async () => (await root.app.callMethod(root.workspaceId, 'getPlacementHints')).details.dx).toBe(movedLeft - mainRect.x).catch(async error => {
                 const native    = await popup.evaluate(() => ({x: screenX, y: screenY, observed: Neo.main.addon.WindowPosition.observeMovement})),
                       placement = await root.app.getComponent(root.workspaceId, ['dockPlacement.receipts']);

--- a/test/playwright/unit/apps/workstation/WorkspaceController.spec.mjs
+++ b/test/playwright/unit/apps/workstation/WorkspaceController.spec.mjs
@@ -20,6 +20,29 @@ const deferred = () => {
 };
 
 test.describe('Workstation topology save and close coordination', () => {
+    test('topology capture uses live placement instead of the previously stored offsets', () => {
+        const document = {
+            schema: 'neo.dock.zone.v1', root: 'tabs',
+            items : {a: {componentRef: 'a'}},
+            nodes : {tabs: {type: 'tabs', items: ['a'], activeItemId: 'a'}}
+        },
+              fallbackTarget = {workspaceKey: 'main', nodeId: 'tabs'},
+              stored = {details: {dx: 10, dy: 20, fallbackTarget}},
+              live = {details: {dx: 450, dy: 80, fallbackTarget}},
+              component = {
+                  getDockTopologyWorkspaces: () => ({main: document, details: {
+                      ...document, items: {b: {componentRef: 'b'}}, nodes: {tabs: {type: 'tabs', items: ['b'], activeItemId: 'b'}}
+                  }}),
+                  getPlacementHints : () => live,
+                  topologyCollection: {activeLayoutId: 'saved', topologies: {saved: {title: 'Saved', placementHints: stored}}}
+              },
+              result = WorkspaceController.prototype.captureTopology.call({component});
+
+        expect(result.errors).toEqual([]);
+        expect(result.topology.placementHints).toEqual(live);
+        expect(component.topologyCollection.topologies.saved.placementHints).toEqual(stored)
+    });
+
     test('a partial carrier refusal compensates cleared windows and closes none', async () => {
         const root      = Transaction.bind({windowId: 'controller-close-root'}),
               popup     = Transaction.bind({...Transaction.reserve({groupId: root.groupId, workspaceKey: 'details'}), windowId: 'controller-close-popup'}),
@@ -73,6 +96,7 @@ test.describe('Workstation topology save and close coordination', () => {
               context = {
                   component: {
                       getDockTopologyWorkspaces: () => ({main: document}),
+                      getPlacementHints        : () => ({}),
                       topologyGroupId          : root.groupId,
                       topologyLibrary          : library,
                       get topologyCollection() {return library.collection}

--- a/test/playwright/unit/dashboard/DockPlacement.spec.mjs
+++ b/test/playwright/unit/dashboard/DockPlacement.spec.mjs
@@ -1,0 +1,184 @@
+import {setup} from '../../setup.mjs';
+setup({appConfig: {name: 'DockPlacementTest'}});
+
+import {expect, test}           from '@playwright/test';
+import Neo                      from '../../../../src/Neo.mjs';
+import * as core                from '../../../../src/core/_export.mjs';
+import Transaction              from '../../../../src/manager/Transaction.mjs';
+import WindowManager            from '../../../../src/manager/Window.mjs';
+import DragCoordinator          from '../../../../src/manager/DragCoordinator.mjs';
+import WorkspaceDocument        from '../../../../src/dashboard/dock/model/WorkspaceDocument.mjs';
+import Placement                from '../../../../src/dashboard/dock/window/Placement.mjs';
+import {createDockWorkspaceSet} from '../../../../src/dashboard/dock/window/WorkspaceSet.mjs';
+
+/** @summary Creates one item-disjoint, validated dock document. @param {String} key @returns {Object} */
+function document(key) {
+    return {
+        schema: WorkspaceDocument.SCHEMA,
+        root  : 'root',
+        items : {[key]: {componentRef: key, kind: 'panel'}},
+        nodes : {root: {type: 'tabs', items: [key], activeItemId: key}}
+    }
+}
+
+/** @summary Emits a real window-manager geometry report. @param {String} windowId @param {Number} x @param {Number} y */
+function move(windowId, x, y) {
+    WindowManager.onWindowPositionChange({windowId, screenLeft: x, screenTop: y, outerWidth: 420, outerHeight: 340, innerWidth: 400, innerHeight: 300})
+}
+
+test.describe.serial('Dock relative placement participant', () => {
+    let groupId, placement, workspaces, settleMs;
+    const mainWindow = 'placement-main-window', popupWindow = 'placement-popup-window';
+
+    test.beforeEach(() => {
+        settleMs = DragCoordinator.nativeWindowDropSettleMs;
+        DragCoordinator.nativeWindowDropSettleMs = 10;
+        ({groupId} = Transaction.bind({windowId: mainWindow, workspaceKey: 'main'}));
+        Transaction.setHistoryDepth({groupId, depth: 5});
+        const reserved = Transaction.reserve({groupId, workspaceKey: 'popup'});
+        Transaction.bind({...reserved, windowId: popupWindow});
+        workspaces = createDockWorkspaceSet({manager: Transaction, getGroupId: () => groupId, documentModel: WorkspaceDocument});
+        const docs = {'workstation-main': document('main'), popup: document('popup')};
+        for (const key of Object.keys(docs)) {
+            workspaces.register(key, {getDocument: () => docs[key], setDocument: value => docs[key] = value})
+        }
+        move(mainWindow, 100, 80);
+        move(popupWindow, 500, 300);
+        placement = Neo.create(Placement, {groupId, mainWorkspaceKey: 'workstation-main'})
+    });
+
+    test.afterEach(() => {
+        placement?.destroy();
+        Transaction.retireGroup(groupId);
+        WindowManager.unregister(mainWindow);
+        WindowManager.unregister(popupWindow);
+        DragCoordinator.nativeWindowDropSettleMs = settleMs
+    });
+
+    test('the hint is relative, frozen and separate from workspace documents', () => {
+        expect(placement.hints).toEqual({popup: {dx: 400, dy: 220, fallbackTarget: {workspaceKey: 'workstation-main', nodeId: 'root'}}});
+        expect(Object.isFrozen(placement.hints.popup.fallbackTarget)).toBe(true);
+        expect(workspaces.ids()).toEqual(['workstation-main', 'popup']);
+        expect(workspaces.has('placementHints')).toBe(false);
+        expect(workspaces.getDocument('placementHints')).toBeNull();
+        expect(() => placement.prepare({'workstation-main': placement.hints.popup})).toThrow(/main workspace/);
+        expect(() => placement.prepare({popup: {...placement.hints.popup, windowId: popupWindow}})).toThrow(/unexpected/)
+    });
+
+    test('a free popup burst appends one observed before/after row after quiescence', async () => {
+        move(popupWindow, 510, 310);
+        move(popupWindow, 540, 320);
+        move(popupWindow, 560, 350);
+        expect(Transaction.get(groupId).history).toBeNull();
+        await expect.poll(() => Transaction.get(groupId).history?.count).toBe(1);
+        const row = Transaction.get(groupId).history.current;
+        expect(row.cause).toBe('native-popup-move');
+        expect(row.participants[0].before.popup).toMatchObject({dx: 400, dy: 220});
+        expect(row.participants[0].after.popup).toMatchObject({dx: 460, dy: 270});
+        expect(placement.hints.popup).toEqual(row.participants[0].after.popup);
+        expect(Transaction.get(groupId).snapshot.participants.placementHints).toEqual(placement.hints)
+    });
+
+    test('moving the main frame rebases hints and snapshot without changing history or popup geometry', async () => {
+        move(popupWindow, 550, 330);
+        await expect.poll(() => Transaction.get(groupId).history?.count).toBe(1);
+        const group = Transaction.get(groupId), history = JSON.stringify(group.history.toJSON());
+        const popup = WindowManager.get(popupWindow).outerRect;
+        move(mainWindow, 200, 120);
+        await expect.poll(() => placement.hints.popup.dx).toBe(350);
+        expect(placement.hints.popup.dy).toBe(210);
+        expect(JSON.stringify(group.history.toJSON())).toBe(history);
+        expect(WindowManager.get(popupWindow).outerRect).toBe(popup);
+        expect(group.snapshot.participants.placementHints.popup).toMatchObject({dx: 350, dy: 210});
+        expect(placement.hints).not.toHaveProperty('workstation-main')
+    });
+
+    test('a binding generation changing before settle prevents a stale write', async () => {
+        move(popupWindow, 560, 350);
+        const old = Transaction.getBinding(groupId, 'popup');
+        Transaction.release(popupWindow);
+        Transaction.bind({groupId, workspaceKey: 'popup', generationToken: old.generationToken, windowId: 'placement-popup-reloaded'});
+        await expect.poll(() => placement.lastWrite !== null).toBe(true);
+        expect(await placement.lastWrite).toBeNull();
+        expect(Transaction.get(groupId).history).toBeNull();
+        expect(placement.hints.popup.dx).toBe(400)
+    });
+
+    test('undo and redo observe their native effects without recording them again; a later free move still appends', async () => {
+        const popup = WindowManager.get(popupWindow);
+        popup.nativeRoute = {ownerWindowId: mainWindow, targetWindowId: popupWindow, nativeHandleKey: 'popup-route'};
+        popup.capabilities = {position: true};
+        placement.readScreen = async () => ({availLeft: 0, availTop: 0, availWidth: 2000, availHeight: 1400});
+        placement.readGeometry = async () => WindowManager.get(popupWindow).outerRect;
+        placement.moveWindow = async (route, position, nativeEffect) => {
+            WindowManager.onWindowPositionChange({
+                windowId  : route.targetWindowId, nativeEffect,
+                screenLeft: position.x, screenTop: position.y,
+                outerWidth: 420, outerHeight: 340, innerWidth: 400, innerHeight: 300
+            });
+            return true
+        };
+        move(popupWindow, 600, 400);
+        await expect.poll(() => Transaction.get(groupId).history?.count).toBe(1);
+        const group = Transaction.get(groupId), row = group.history.current;
+        await Transaction.undo({groupId});
+        await expect.poll(() => placement.receipts[0]?.status).toBe('applied');
+        expect(placement.receipts[0].observed).toEqual({dx: 400, dy: 220});
+        expect(group.history.cursor).toBe(-1);
+        expect(group.history.canRedo).toBe(true);
+        expect(group.history.count).toBe(1);
+        expect(group.history.getAt(0)).toBe(row);
+
+        await Transaction.redo({groupId});
+        await expect.poll(() => placement.receipts[0]?.observed.dx).toBe(500);
+        expect(group.history.count).toBe(1);
+        expect(group.history.cursor).toBe(0);
+        move(popupWindow, 700, 440);
+        await expect.poll(() => group.history.count).toBe(2);
+        expect(group.history.current.cause).toBe('native-popup-move');
+        expect(group.history.current.participants[0].after.popup).toMatchObject({dx: 600, dy: 360})
+    });
+
+    test('clamping uses the usable screen and a refused move records the observed coordinates, never the request', async () => {
+        const popup = WindowManager.get(popupWindow);
+        popup.nativeRoute = {ownerWindowId: mainWindow, targetWindowId: popupWindow, nativeHandleKey: 'popup-route'};
+        popup.capabilities = {position: true};
+        placement.readScreen = async () => ({availLeft: 0, availTop: 20, availWidth: 1000, availHeight: 800});
+        let requested;
+        placement.moveWindow = async (route, position) => { requested = position; return false };
+        placement.readGeometry = async () => ({x: 510, y: 310, width: 420, height: 340});
+        const hint    = {...placement.hints.popup, dx: 5000, dy: -5000};
+        const receipt = await placement.applyHint('popup', hint, {transactionId: 'clamp-test'});
+        expect(requested).toEqual({x: 580, y: 20});
+        expect(receipt.status).toBe('refused');
+        expect(receipt.observed).toEqual({dx: 410, dy: 230});
+        expect(receipt).not.toHaveProperty('x');
+        expect(receipt).not.toHaveProperty('windowId');
+
+        requested = null;
+        placement.readScreen = async () => null;
+        const fallback = await placement.applyHint('popup', hint, {transactionId: 'fallback-test'});
+        expect(fallback.status).toBe('fallback');
+        expect(fallback.fallbackTarget).toEqual({workspaceKey: 'workstation-main', nodeId: 'root'});
+        expect(requested).toBeNull()
+    });
+
+    test('a native completion from a retired binding cannot update the successor receipt', async () => {
+        const popup = WindowManager.get(popupWindow);
+        popup.nativeRoute = {ownerWindowId: mainWindow, targetWindowId: popupWindow, nativeHandleKey: 'popup-route'};
+        popup.capabilities = {position: true};
+        placement.readScreen = async () => ({availLeft: 0, availTop: 0, availWidth: 2000, availHeight: 1400});
+        let release, started;
+        const entered = new Promise(resolve => started = resolve);
+        placement.moveWindow = () => { started(); return new Promise(resolve => release = resolve) };
+        placement.readGeometry = async () => { throw new Error('a retired handle must not be read') };
+        const pending = placement.applyHint('popup', placement.hints.popup, {transactionId: 'retired-test'});
+        await entered;
+        const old = Transaction.getBinding(groupId, 'popup');
+        Transaction.release(popupWindow);
+        Transaction.bind({groupId, workspaceKey: 'popup', generationToken: old.generationToken, windowId: 'placement-popup-reloaded'});
+        release(true);
+        expect((await pending).status).toBe('stale');
+        expect(placement.receipts).toEqual([])
+    })
+});

--- a/test/playwright/unit/dashboard/DockPlacement.spec.mjs
+++ b/test/playwright/unit/dashboard/DockPlacement.spec.mjs
@@ -65,6 +65,12 @@ test.describe.serial('Dock relative placement participant', () => {
         expect(() => placement.prepare({popup: {...placement.hints.popup, windowId: popupWindow}})).toThrow(/unexpected/)
     });
 
+    test('render-host replacement reuses one owner and explicit Group retirement destroys it', () => {
+        expect(Placement.forGroup({groupId, mainWorkspaceKey: 'workstation-main'})).toBe(placement);
+        Transaction.retireGroup(groupId);
+        expect(placement.isDestroyed).toBe(true)
+    });
+
     test('a free popup burst appends one observed before/after row after quiescence', async () => {
         move(popupWindow, 510, 310);
         move(popupWindow, 540, 320);
@@ -91,6 +97,30 @@ test.describe.serial('Dock relative placement participant', () => {
         expect(WindowManager.get(popupWindow).outerRect).toBe(popup);
         expect(group.snapshot.participants.placementHints.popup).toMatchObject({dx: 350, dy: 210});
         expect(placement.hints).not.toHaveProperty('workstation-main')
+    });
+
+    test('one main-frame observation rebases two popup hints in one snapshot and keeps headless hints', async () => {
+        let secondDocument = document('second');
+        workspaces.register('popup-two', {getDocument: () => secondDocument, setDocument: value => secondDocument = value});
+        const reserved = Transaction.reserve({groupId, workspaceKey: 'popup-two'});
+        Transaction.bind({...reserved, windowId: 'placement-popup-two'});
+        move('placement-popup-two', 700, 400);
+        await placement.write(placement.observedHints(), 'placement-baseline', 'preserve');
+        move(popupWindow, 560, 350);
+        await expect.poll(() => Transaction.get(groupId).history?.count).toBe(1);
+        const group   = Transaction.get(groupId), version = group.snapshot.version;
+        const history = JSON.stringify(group.history.toJSON());
+        move(mainWindow, 150, 100);
+        await expect.poll(() => placement.hints['popup-two']?.dx).toBe(550);
+        expect(placement.hints.popup).toMatchObject({dx: 410, dy: 250});
+        expect(group.snapshot.version).toBe(version + 1);
+        expect(JSON.stringify(group.history.toJSON())).toBe(history);
+        Transaction.release('placement-popup-two');
+        const headless = placement.hints['popup-two'];
+        move(mainWindow, 180, 110);
+        await expect.poll(() => placement.hints.popup.dx).toBe(380);
+        expect(placement.hints['popup-two']).toEqual(headless);
+        WindowManager.unregister('placement-popup-two')
     });
 
     test('a binding generation changing before settle prevents a stale write', async () => {

--- a/test/playwright/unit/dashboard/DockProjectionDestroySentinel.spec.mjs
+++ b/test/playwright/unit/dashboard/DockProjectionDestroySentinel.spec.mjs
@@ -54,38 +54,44 @@ const moveTerminalAcross = document => {
 };
 
 /**
- * A workspace whose FIRST projection fails inside the staging try block, through the public
- * `onProjectionStaged` seam — no static override, and the throw is synchronous, so the update
- * lifecycle is never left mid-flight.
- * @param {*} thrown The value to throw: an Error, or the destroy sentinel.
- * @returns {Neo.dashboard.dock.Workspace}
+ * @summary Registers one fixture class whose first staged projection throws its instance's failure.
  */
-const createFailingFirstProjection = thrown => {
-    class FailingFirstProjectionWorkspace extends DockWorkspace {
-        static config = {
-            className: 'Neo.dashboard.dock.SentinelSpec.FailingFirstProjectionWorkspace'
-        }
+class FailingFirstProjectionWorkspace extends DockWorkspace {
+    static config = {
+        className: 'Neo.dashboard.dock.SentinelSpec.FailingFirstProjectionWorkspace'
+    }
 
-        firstProjectionFailed = false
+    firstProjectionFailed = false
+    /** @member {*} projectionFailure=null The error or sentinel injected before mounting. */
+    projectionFailure = null
 
-        getReconcileOptions(document, refreshOptions) {
-            const me = this;
+    /** @summary Fails once through the real synchronous staging seam. @param {Object} document @param {Object} refreshOptions @returns {Object} */
+    getReconcileOptions(document, refreshOptions) {
+        const me = this;
 
-            return {
-                ...super.getReconcileOptions(document, refreshOptions),
-                onProjectionStaged() {
-                    if (!me.firstProjectionFailed) {
-                        me.firstProjectionFailed = true;
-                        throw thrown
-                    }
+        return {
+            ...super.getReconcileOptions(document, refreshOptions),
+            onProjectionStaged() {
+                if (!me.firstProjectionFailed) {
+                    me.firstProjectionFailed = true;
+                    throw me.projectionFailure
                 }
             }
         }
     }
+}
 
-    FailingFirstProjectionWorkspace = Neo.setupClass(FailingFirstProjectionWorkspace);
+FailingFirstProjectionWorkspace = Neo.setupClass(FailingFirstProjectionWorkspace);
 
-    return Neo.create(FailingFirstProjectionWorkspace, {dockModel: createDocument()})
+/**
+ * @summary Gives each headless fixture its own injected value before the first projection starts.
+ * @param {*} thrown The value to throw: an Error, or the destroy sentinel.
+ * @returns {Neo.dashboard.dock.Workspace}
+ */
+const createFailingFirstProjection = thrown => {
+    const workspace = Neo.create(FailingFirstProjectionWorkspace, {dockModel: createDocument()});
+    workspace.projectionFailure = thrown;
+    return workspace
 };
 
 /**

--- a/test/playwright/unit/dashboard/TopologyLibrary.spec.mjs
+++ b/test/playwright/unit/dashboard/TopologyLibrary.spec.mjs
@@ -356,6 +356,20 @@ test.describe('Neo.dashboard.dock.persistence.TopologyLibrary', () => {
         expect(state.disposals).toEqual([])
     });
 
+    test('durable retirement publishes exactly one Group retirement event', async () => {
+        const group    = createGroup(), events = [],
+              listener = ({groupId}) => groupId === group.id && events.push(groupId);
+        await expireBinding(group);
+        attachGroup(group);
+        Transaction.on('groupRetired', listener);
+        try {
+            expect(await library.retireIfHeadless()).toBe(true);
+            expect(events).toEqual([group.id])
+        } finally {
+            Transaction.un('groupRetired', listener)
+        }
+    });
+
     test('a warm Group release and rebind performs no topology storage write', async () => {
         const group    = createGroup(), state = attachGroup(group),
               binding  = group.bindings.get('main'),

--- a/test/playwright/unit/examples/dashboard/crossWindow/DemoBWorkspace.spec.mjs
+++ b/test/playwright/unit/examples/dashboard/crossWindow/DemoBWorkspace.spec.mjs
@@ -1562,7 +1562,7 @@ test.describe.serial('Neo.examples.dashboard.crossWindow.DemoBWorkspace', () => 
             const detachedLayout = workspace.topologyCollection.topologies['demo-b-detached'];
 
             expect(detachedLayout.schema).toBe(Persistence.TOPOLOGY_SCHEMA);
-            expect(Object.keys(detachedLayout.workspaces)).toEqual(['demo-b-main', 'demo-b-popup']);
+            expect(Object.keys(detachedLayout.workspaces)).toEqual(['demo-b-main', 'demo-b-popup', 'demo-b-popup-2']);
 
             const reattached = await workspace.reattachPane('workbench', {windowAlreadyClosed: true});
 

--- a/test/playwright/unit/main/MainNativeWindowRoute.spec.mjs
+++ b/test/playwright/unit/main/MainNativeWindowRoute.spec.mjs
@@ -409,6 +409,7 @@ async function runNativeWindowRouteProbe(scenario) {
                 state    = {
                     closed   : false,
                     height   : 600,
+                    effects  : [],
                     published: 0,
                     token    : null,
                     width    : 900,
@@ -445,7 +446,8 @@ async function runNativeWindowRouteProbe(scenario) {
                             WindowPosition: {
                                 publishGeometry() {
                                     events.push('publish');
-                                    state.published++
+                                    state.published++;
+                                    state.effects.push(popup.neoNativeGeometryEffects?.at(-1) ?? null)
                                 }
                             }
                         }
@@ -527,7 +529,14 @@ async function runNativeWindowRouteProbe(scenario) {
                 geometry = null,
                 resize   = null;
 
-            if (scenario === 'native-focus-stale') {
+            if (scenario === 'native-move-effect') {
+                popup.moveTo = (x, y) => { state.x = x; state.y = y };
+                exactCompletion = await Main.windowNativeMoveTo({
+                    ...route, x: 420, y: 320,
+                    nativeEffect: {transactionId: 'transaction-1', effectId: 'effect-1'}
+                });
+                geometry = {markerRetired: !Object.hasOwn(popup, 'neoNativeGeometryEffects')}
+            } else if (scenario === 'native-focus-stale') {
                 popup.document = {hasFocus: () => true};
                 popup.focus    = () => Main.releaseNativeWindowRoute({
                     nativeHandleKey: route.nativeHandleKey,
@@ -603,6 +612,7 @@ async function runNativeWindowRouteProbe(scenario) {
             console.log(JSON.stringify({
                 closed   : state.closed,
                 events,
+                effects: state.effects,
                 exactCompletion,
                 geometry,
                 hasEntry : Object.hasOwn(Main.openWindows, 'tear-out'),
@@ -751,6 +761,13 @@ test.describe('Neo.Main native window routes (#15396)', () => {
             ownerWindowId : expect.any(String),
             targetWindowId: 'child-window'
         })
+    });
+
+    test('an admitted placement publishes its effect identity and removes it before a later free move', async () => {
+        const result = await runNativeWindowRouteProbe('native-move-effect');
+        expect(result.exactCompletion).toBe(true);
+        expect(result.effects).toEqual([{transactionId: 'transaction-1', effectId: 'effect-1'}]);
+        expect(result.geometry.markerRetired).toBe(true)
     });
 
     test('resize authority verifies exact outer dimensions and publishes the observed target geometry', async () => {

--- a/test/playwright/unit/main/addon/WindowPosition.spec.mjs
+++ b/test/playwright/unit/main/addon/WindowPosition.spec.mjs
@@ -86,6 +86,26 @@ test.describe('Neo.main.addon.WindowPosition — live geometry publication', () 
         }]])
     });
 
+    test('a tagged native publication advances the poll baseline without losing the next independent move', () => {
+        let nativeEffect = {transactionId: 'transaction-1', effectId: 'effect-1'};
+        Neo.Main.getWindowData = () => ({screenLeft: window.screenLeft, screenTop: window.screenTop, nativeEffect});
+        const addon = {
+            adjustWindowPositions: false,
+            publishGeometry      : WindowPosition.prototype.publishGeometry,
+            screenLeft           : window.screenLeft - 20,
+            screenTop            : window.screenTop,
+            set(config) { Object.assign(this, config) }
+        };
+        addon.publishGeometry();
+        nativeEffect = null;
+        WindowPosition.prototype.checkMovement.call(addon);
+        expect(sent).toHaveLength(1);
+        window.screenLeft++;
+        WindowPosition.prototype.checkMovement.call(addon);
+        expect(sent).toHaveLength(2);
+        expect(sent[1][1].data.nativeEffect).toBeNull()
+    });
+
     test('movement remains change-driven and shares the same publication authority', () => {
         const addon = {
             adjustWindowPositions: false,

--- a/test/playwright/unit/manager/DragCoordinator.spec.mjs
+++ b/test/playwright/unit/manager/DragCoordinator.spec.mjs
@@ -472,6 +472,18 @@ test.describe('Neo.manager.DragCoordinator — teardown hygiene (#15248)', () =>
         expect(DragCoordinator.nativeWindowDropCandidates.has(13)).toBe(true)
     });
 
+    test('geometry from an admitted placement effect never starts a native user gesture', () => {
+        const resolve = DragCoordinator.getNativeWindowDragSource;
+        let   calls   = 0;
+        DragCoordinator.getNativeWindowDragSource = () => { calls++; return null };
+        try {
+            DragCoordinator.onWindowPositionChange({
+                windowId: 'effect-window', nativeEffect: {transactionId: 'transaction-1', effectId: 'effect-1'}
+            });
+            expect(calls).toBe(0)
+        } finally { DragCoordinator.getNativeWindowDragSource = resolve }
+    });
+
     test('a mid-gesture vessel departure resolves to a clean terminal, not a commit into a dead window', () => {
         const
             source = createSourceZone(),

--- a/test/playwright/unit/manager/DragCoordinator.spec.mjs
+++ b/test/playwright/unit/manager/DragCoordinator.spec.mjs
@@ -268,10 +268,7 @@ test.describe('Neo.manager.DragCoordinator — teardown hygiene (#15248)', () =>
     });
 
     test('an ASYNC target resolving null does NOT retire — a Promise is truthy, so testing it IS the defect', async () => {
-        // `onDragEnd` is synchronous; `draggable/dashboard/SortZone.onRemoteDrop` is async. `if (operation)`
-        // on a Promise is `if (true)` — so an outcome-aware gate that tests the raw return value reads EVERY
-        // async target as committed and retires the source anyway. A sync-only stub cannot see this shape;
-        // only an async target resolving null does.
+        // Await the async target's outcome: a Promise itself cannot certify a committed operation.
         const
             source = createSourceZone(),
             target = {

--- a/test/playwright/unit/manager/TransactionAtomic.spec.mjs
+++ b/test/playwright/unit/manager/TransactionAtomic.spec.mjs
@@ -202,6 +202,30 @@ test.describe.serial('Neo.manager.Transaction atomic participant writes', () => 
         expect(history.count).toBe(1)
     });
 
+    test('a main-frame rebase preserves existing history, cursor and redo while publishing current hints', async () => {
+        const groupId   = group(), log = [];
+        const placement = participant(groupId, 'placementHints', log);
+        await write({groupId, changes: [{workspaceKey: 'placementHints', input: {count: 100}}]});
+        await write({groupId, changes: [{workspaceKey: 'placementHints', input: {count: 200}}]});
+        await manager.undo({groupId});
+        const history = manager.get(groupId).history, before = JSON.stringify(history.toJSON());
+
+        const result = await write({
+            groupId,
+            cause       : 'main-frame-rebase',
+            cursorAction: 'preserve',
+            changes     : [{workspaceKey: 'placementHints', input: {count: 80}}]
+        });
+
+        expect(placement.state.value.count).toBe(80);
+        expect(result.snapshot.participants.placementHints.count).toBe(80);
+        expect(result.row).toBeNull();
+        expect(JSON.stringify(history.toJSON())).toBe(before);
+        expect(history.canRedo).toBe(true);
+        await manager.redo({groupId});
+        expect(placement.state.value.count).toBe(200)
+    });
+
     test('a cursor update throwing after it moved rolls back participant, cursor and snapshot', async () => {
         const groupId = group(), log = [];
         const a       = participant(groupId, 'a', log);


### PR DESCRIPTION
Resolves #18313
Related: #18303, #18314, #18315, #18316

A Group-owned placement participant records settled popup movement as relative offsets. Main-window movement rebases current hints without adding history or moving popups. Undo/redo commits the hint first, moves the exact native generation, and retains the observed outcome separately.

Both hosts acquire one placement owner per Group. Workstation now saves live hints, seeds saved hints after all workspace documents register, and enables the existing geometry stream when a restored window mounts or reloads. Its native position is then restored through the placement owner. `WorkspaceSet` excludes auxiliary participants from document operations; diagnostics retain the full snapshot while listing only document keys. `Transaction.retireGroup` owns the single retirement event.

Rebased onto the merged ownership-admission change at `dev@1182a7cf11`. The placement implementation patches are preserved; conflicts were the measured host baselines and an inherited test comment.

The [ticket's producer boundary](https://github.com/neomjs/neo/issues/18313) assigns placement to registered semantic workspace documents. The all-origin migration owns full-Workspace birth and its first shared-history write; the final Workstation journey proves the composition. All seven placement ACs remain required.

Evidence: L3 (real Chrome popup geometry, SharedWorker state through Neural Link, IndexedDB save and fresh cold boot) → L3 required (native movement and causal undo/redo). Refusal, clamp, missing-screen, N-popup and retired-generation controls are L2. Residual: ordinary Workstation tear-out document admission and the final all-origin journey; Residual-Owner: #18314, #18316.

## AC Evidence

| AC | Evidence |
|---|---|
| AC-1 | Outside-CI: `e2e/dashboard/DockPlacementNL.spec.mjs` moves a real popup and checks one observed before/after row. `e2e/workstation/WorkstationTopologyGroupsNL.spec.mjs` moves a restored Workstation popup, saves the new offset, and verifies it after a new App Worker cold boot. |
| AC-2 | The native placement journey sends a three-position burst; CI-covered `unit/dashboard/DockPlacement.spec.mjs` verifies coalescing through the existing buffer and settle interval. |
| AC-3 | Native journey: main-only movement preserves the popup rectangle and history. CI-covered placement spec: two bound popups plus a headless hint. |
| AC-4 | Native journey: undo → native effect → full configured quiet period → redo, then a later independent move. CI-covered placement, DragCoordinator and WindowPosition controls preserve cursor and redo tail. |
| AC-5 | CI-covered placement refusal/clamp and stale-completion controls; `unit/main/MainNativeWindowRoute.spec.mjs` checks operation-scoped native metadata. |
| AC-6 | Both native journeys retain relative hints and semantic fallback targets, with no runtime window fields. Workstation cold hydration publishes the hints alongside document participants; warm reload preserves both. |
| AC-7 | CI-covered missing-screen semantic-fallback and observed clamp/refusal receipts. The Workstation journey keeps composition accessible after popup refusal and restores it in a fresh cold boot. |

All spec paths above are relative to `test/playwright/`.

## Deltas from ticket

The [document-bearing-slot boundary](https://github.com/neomjs/neo/issues/18313) follows the wire contract: every hint key must name a workspace document. An ordinary bare vessel has no such document yet. Placement creates no second document owner.

Incidental CI cleanup: the existing destroy-sentinel spec now registers its fixture class once and injects the failure per instance. Repeated cases no longer collide in the same worker; the engine namespace guard and recovery assertions are unchanged.

`preserve` now permits a current-state rebase with existing history while retaining row identity and the redo tail. The native coordinator uses the existing buffer instead of its bespoke settle timer. Tagged geometry publication advances the polling baseline, preventing an untagged echo.

Decision Record impact: ADR 0029 documents observed relative placement, main-frame rebasing and correlated native outcomes.

## Test Evidence

Outside-CI commands use `NEO_AGENTOS_RUNTIME_ROOT=<Brain checkout>` and `npx playwright test -c test/playwright/playwright.config.e2e.mjs --workers=1 --headed --reporter=dot`:

- `test/playwright/e2e/dashboard/DockPlacementNL.spec.mjs`: native movement, main rebase and causal undo/redo passed on the integrated rebase.
- `test/playwright/e2e/workstation/WorkstationTopologyGroupsNL.spec.mjs --grep 'cold active selection'`: prior integrated tree `c9107d0442`, 1/1 passed, normal exit, 36.0s at 2026-09-05 22:05Z. Includes actual popup move → live hint → IndexedDB save → warm F5 → durable close → fresh cold restore.

After the ownership-admission merge, both journeys were rerun together at `10e455d5e8`: 2/2 passed, normal exit, 49.1s. The original native undo/redo control and the Workstation native save/cold-restore control both hold on the combined tree.

Executed controls found and repaired two integration failures: retirement emitted twice, and a restored popup had `observeMovement:false`, leaving its saved offset unchanged after a real move. An earlier native quiet-period control likewise exposed the untagged polling echo. These are retained as unit/browser assertions. One successful test case initially hung during final runner shutdown; the runner was interrupted (exit 130). The final run explicitly releases its CDP control session and exits successfully.

The [unit job at `10e455d5e8`](https://github.com/neomjs/neo/actions/runs/33996407174/job/101387628697) reproduced the known `DockProjectionDestroySentinel` class-name collision; its fresh-worker retry passed, and fail-on-flaky policy correctly kept CI red. Before `b504173715`, running that file with `--workers=1 --retries=0` produced 1 failure and 3 passes. After the fixture repair, `--repeat-each=3` passed all 12 cases with no retries. No guard was relaxed or assertion skipped.

size-guard-growth: apps/workstation/view/Workspace.mjs — acquires the Group placement owner after cold document registration and exposes live hints
size-guard-growth: examples/dashboard/crossWindow/DemoBWorkspace.mjs — acquires the placement owner and captures registered documents with live hints

## Post-Merge Validation

The all-dock-origin migration must admit ordinary tear-out documents, and the final integration journey must combine that producer with save/reload/undo. The current real Workstation receipt covers already registered, restored documents.

## Commits

- `7fa3d8a882` — placement participant, native correlation, relative contract and failure controls
- `dde51a0c70` — host ownership, effect quiescence and native journey
- `12cc714a05` — measured host-size baseline
- `81a3c83384` — inherited source-comment cleanup
- `9b0932847d` — live persistence, cold seeding, restored-window observation and single retirement event
- `10e455d5e8` — release native test control before teardown
- `b504173715` — register the sentinel test class once, with per-instance failure injection

## Signal Ledger

| Family | Identity | Signal | Source |
|---|---|---|---|
| Claude | Grace | AUTHOR_SIGNAL | D#18224 folded body at `131c782ca8` |
| GPT | Emmy | GRADUATION_APPROVED | `DC_kwDODSospM4BFyRA`, source body `2026-09-04T17:53:27Z` |

The [graduated Discussion](https://github.com/neomjs/neo/discussions/18224) and [Epic ledger](https://github.com/neomjs/neo/issues/18303) retain the version-bound quorum. Independent Epic review: [Grace's greenlight](https://github.com/neomjs/neo/issues/18303#issuecomment-5544825646).

## Unresolved Dissent

None. The ticket author applied the producer boundary to the existing placement and all-origin migration tickets; no acceptance criterion was removed.

## Unresolved Liveness

No inactive-family signal is counted. A concrete falsifier against the accepted placement or native-effect contract reopens its premise.

Authored by Emmy (GPT-6 Astra, Codex). Session 01a072b1-c820-7651-931d-8bc0b278193e.

