### PR TITLE
test(dashboard): the maximize ghost-id assertion reports the pending side at failure (#18378)

### DIFF
--- a/test/playwright/component/dashboard/DockMaximize.spec.mjs
+++ b/test/playwright/component/dashboard/DockMaximize.spec.mjs
@@ -84,6 +84,47 @@ const expectMaximizedCount = async (page, count) => {
 };
 
 /**
+ * The fail-safe clear of an unresolvable id is eventual by contract: the transition waits for the
+ * owner's live refresh before it applies and fails. When that wait outlives the poll, the bare
+ * `expected null, received "ghost-tabs"` cannot say which side is pending, and the two are different
+ * defects: a refresh that has not settled (the settle probe, which awaits the live `refreshPromise`,
+ * does not answer) or a transition still parked behind a refresh that has. The assertion is
+ * unchanged; the failure carries the discriminator and the plugin's observer state.
+ * @param {Object} page
+ * @returns {Promise<void>}
+ */
+const expectIdCleared = async page => {
+    try {
+        await expect.poll(async () => (await readPlugin(page, ['maximizedNodeId']))[0]).toBe(null)
+    } catch (error) {
+        let diagnosis;
+
+        try {
+            const [settleBefore] = await readWorkspace(page, ['settleJson']);
+
+            await setWorkspace(page, {settleProbeCount: Date.now()});
+
+            let refreshSettled = true;
+
+            try {
+                await expect.poll(async () => (await readWorkspace(page, ['settleJson']))[0], {timeout: 2000}).not.toBe(settleBefore)
+            } catch (settleError) {
+                refreshSettled = false
+            }
+
+            const [nodeId, resizeObserved] = await readPlugin(page, ['maximizedNodeId', 'resizeObserved']);
+
+            diagnosis = `maximizedNodeId=${JSON.stringify(nodeId)} resizeObserved=${resizeObserved} refreshSettledWithin2s=${refreshSettled}`
+        } catch (readError) {
+            diagnosis = `<unreadable: ${readError.message}>`
+        }
+
+        error.message += `\n\nat failure: ${diagnosis}`;
+        throw error
+    }
+};
+
+/**
  * The maximized node fills the DOCK AREA inset by the gap token on every side — not the workspace
  * root, not the viewport. The fixture workspace is its own host and frames the projected shell
  * with a 42px chrome bar at index 0 (`dockShellIndex: 1`), so the root and the shell have different
@@ -330,7 +371,7 @@ test.describe('dock maximize — presentation, never topology', () => {
         // contract: the clear is deterministic, not synchronous with the config write.
         await setPlugin(page, {maximizedNodeId: 'ghost-tabs'});
         await page.waitForFunction(() => document.querySelectorAll('.neo-dock-maximized').length === 0);
-        await expect.poll(async () => (await readPlugin(page, ['maximizedNodeId']))[0]).toBe(null)
+        await expectIdCleared(page)
     });
 
     test('a superseding maximize waits for the prior clear and its refresh', async ({page}) => {


### PR DESCRIPTION
Resolves #18378
Related: #18003 #18305

🌿 The maximize spec's eventual fail-safe assertion now says which side is still waiting when it reds, so the next CI red of this arm is a diagnosis and not another rerun.

`DockMaximize.spec.mjs` › "inside-the-node operations…" redded the components job twice on 2026-09-05 with `expected null, received "ghost-tabs"` at its final `expect.poll`, five seconds after the markers had already cleared. In `Maximize#afterSetMaximizedNodeId` that state has exactly one place: the ghost transition has cleared the prior presentation and is parked at `await me.owner.refreshPromise`, behind the refresh the arm triggered two lines earlier through the fixture's fire-and-forget `refreshCount` hook. Which side is late — a refresh that has not settled, or a transition still parked behind one that has — is what the bare assertion could not say.

Two candidate causes were measured before touching the spec, and both fell. An orphaned FLIP window cannot hold the wait: `DockFlip#play` rides a 100 ms timer dam per frame for at most 15 frames plus the token duration, under two seconds even with no frame ever serviced. Uniform slowness cannot either: a probe replaying the arm's exact steps under Chromium CPU throttling measured the ghost id surviving 20 ms at 1×, 60 ms at 8× and 102 ms at 20×, the refresh settled before the ghost write every time. What remains is event-shaped, observable only where it happens, and the failing runs' logs were already replaced by their green reruns.

So the arm keeps its assertion and its budget and gains a failure report. `expectIdCleared` polls the id to `null` exactly as before; on timeout it bumps the fixture's settle probe — `afterSetSettleProbeCount` awaits the live `refreshPromise` before it snapshots — and records whether that probe answered within two seconds, together with `maximizedNodeId` and `resizeObserved` at failure. `refreshSettledWithin2s=false` names the refresh; `true` with the id still set names the transition. The plugin, the fixture and every other arm are untouched.

Evidence: L2 achieved → L2 required (a component spec's failure report; the assertion under CI is the same one). Residual: none — the phenomenon itself stays open as the post-merge item below, and its fix belongs to the ticket the first diagnosed red files.

## AC Evidence
| AC-1 | The two falsifications are recorded in #18378's body with their receipts (the FLIP bound from `DockFlip.mjs#nextFrame` / `play`; the throttle probe's 20 / 60 / 102 ms survivals). `expectIdCleared` in `DockMaximize.spec.mjs` keeps `expect.poll(...).toBe(null)` with its default budget and appends `at failure: maximizedNodeId=… resizeObserved=… refreshSettledWithin2s=…` |
| AC-2 | Instrumented arm 10 / 10 (`--repeat-each 10`, `playwright.config.component.mjs`, one worker); the whole spec 16 / 16 once, quoted below. Positive control: with the poll's expectation deliberately broken to a value the id never takes, the failure carried `at failure: maximizedNodeId=null resizeObserved=false refreshSettledWithin2s=true` — the report path runs and reads live state; the expectation was restored before the commit |
| AC-3 | Post-Merge Validation below: the next red's diagnosis line files the fix as its own ticket citing #18378; a fortnight without one is recorded on #18378 |
| AC-4 | No source file changes; the fifteen other arms of the spec pass unchanged (16 / 16 above) |

## Deltas from ticket
**The ticket's original title named a cause** — "the fail-safe clear waits on a refresh that never settles" — **that this PR does not establish.** Both mechanisms proposed for it were measured and fell (body); the title and AC-3 were rewritten to what the PR delivers: the discriminating report and the recorded falsifications, with the fix routed to the ticket the first diagnosed red files.

## Test Evidence
Components (`playwright.config.component.mjs`, one worker): the instrumented arm alone `--repeat-each 10` → 10 passed; the whole `DockMaximize.spec.mjs` → 16 passed. Positive control of the report path as in AC-2. Probe receipts (not committed): the CPU-throttle replay at 1× / 8× / 20× — ghost id survived 20 / 60 / 102 ms; `settleJson` at refresh settle showed `maximizedNodeId: "main-tabs"` in every run, so the refresh settled before the ghost write.

## Post-Merge Validation
- [ ] The next components-job red of this arm quotes its `at failure:` line on #18378 and files the fix for the named side as its own ticket; a fortnight of runs without a red is recorded there instead.

## Commits (if multi-commit)
- `6ee04d9fc8` — the ghost-id assertion reports the pending side at failure

Authored by Vega (Claude Fable 5.1, Claude Code). Session 3711ad57-061d-43fb-b1f1-aa9dc21dedda.