### PR TITLE
refactor(dock): the pane-handoff choreography moves into window/TearOut.mjs (#18311)

### DIFF
--- a/apps/workstation/view/Workspace.mjs
+++ b/apps/workstation/view/Workspace.mjs
@@ -3577,8 +3577,6 @@ class Workspace extends DockWorkspace {
     }
 
     /**
-
-    /**
      * Retirement authority is established before any awaited close: a vessel that binds while its
      * retirement is in flight is cleanup-only, and no content is ever staged into a closing realm.
      * The engine's `retireTearOutVessel` holds the fence; this host only reads it.

--- a/apps/workstation/view/Workspace.mjs
+++ b/apps/workstation/view/Workspace.mjs
@@ -1581,7 +1581,7 @@ class Workspace extends DockWorkspace {
             sourceItemId    = sourceWorkspace === Workspace.MAIN_WORKSPACE_ID
                 ? itemId
                 : sourceState?.itemId,
-            storedHome      = sourceItemId && me.tearOutPlacements[sourceItemId]?.tabsNodeId,
+            storedHome      = sourceItemId && me.tearOutHandlers?.peekPlacement(sourceItemId)?.tabsNodeId,
             targetNodeId    = isMain
                 ? (me.dockModel.nodes?.[storedHome]?.type === 'tabs'
                     ? storedHome
@@ -2060,7 +2060,7 @@ class Workspace extends DockWorkspace {
         if (!state?.committed || !me.workspaceSet.has(workspaceId)) return false;
         if (!itemIds.length) return true;
 
-        let placement  = me.tearOutPlacements[itemId],
+        let placement  = me.tearOutHandlers?.peekPlacement(itemId),
             storedHome = placement && me.dockModel.nodes?.[placement.tabsNodeId]?.type === 'tabs'
                 ? placement.tabsNodeId
                 : null,
@@ -3474,29 +3474,6 @@ class Workspace extends DockWorkspace {
         return rect && {height: rect.height, width: rect.width, x: rect.x, y: rect.y}
     }
 
-    /**
-     * @summary The tear-out commit seam with exact-position capture riding it: the
-     * `{tabsNodeId, index}` pair is readable only BEFORE a detach commit removes the item from
-     * the tree, and a refused commit deletes its own capture — no stale placement outlives a
-     * gesture that never committed. Every non-detach descriptor passes through untouched.
-     * @param {Object} descriptor
-     * @returns {{document: Object, errors: String[]}|null}
-     * @protected
-     */
-    applyTearOutOperation(descriptor) {
-        let me       = this,
-            isDetach = descriptor?.operation === 'detachItem',
-            captured = isDetach ? WorkspaceDocument.captureItemPlacement(me.dockModel, descriptor.itemId) : null,
-            result;
-
-        captured && (me.tearOutPlacements[descriptor.itemId] = captured);
-
-        result = me.applyDockZoneOperation(descriptor);
-
-        isDetach && result?.errors?.length && delete me.tearOutPlacements[descriptor.itemId];
-
-        return result
-    }
 
     /**
      * @summary Commits a detached terminal without sacrificing the live pane to projection order.
@@ -3522,20 +3499,27 @@ class Workspace extends DockWorkspace {
             operation      : operation.operation,
             preserveItemIds: me.tearOutEmbodiment.isStaged(itemId) ? [] : [itemId]
         });
-        me.adoptTearOutPane(itemId, vessel)
+        me.tearOutHandlers.adoptPane(itemId, vessel, me.tearOutConnects[itemId] || null)
     }
 
     /**
      * The vessel owns the pane now. If it had already bound (the long-drag order) it also becomes a
      * dock target — a vessel workspace registers lazily on its first dock-INTO, this only opens the
      * door. A vessel that binds later registers from {@link #afterTearOutWindowConnect}.
-     * @param {Object} data
-     * @param {Object|null} data.connection The connection the engine adopted, when the vessel had already bound.
-     * @param {String} data.itemId
+     *
+     * Overriding the ownership WRITE rather than a dedicated adoption hook is the whole point of the
+     * seam: one override, at the one moment ownership actually changes, instead of a hook that
+     * existed only so this app could learn about it.
+     * @param {String} itemId
+     * @param {Object|null} entry
+     * @param {Object|null} [connection=null] The connection the engine adopted, when the vessel had already bound.
+     * @param {Boolean} [isMerge=false]
      * @protected
      */
-    afterTearOutPaneAdopt({connection, itemId}) {
+    recordDockPaneOwner(itemId, entry, connection=null, isMerge=false) {
         let me = this;
+
+        super.recordDockPaneOwner(itemId, entry, connection, isMerge);
 
         connection && me.registerVesselWorkspaceTarget({
             app     : Neo.apps[connection.windowId],
@@ -3556,63 +3540,21 @@ class Workspace extends DockWorkspace {
      * @returns {Boolean}
      * @protected
      */
-    reparentTearOutPane(itemId, target) {
+    reparentDockPane(pane, target={}, itemId) {
         let me         = this,
-            {windowId} = target,
-            app        = Neo.apps[windowId],
-            pane       = me.paneCache[itemId];
+            {windowId} = target;
 
-        me.tearOutPanes[itemId] && Object.assign(me.tearOutPanes[itemId], target);
-
+        // Answered by IDENTITY, not by the component the engine resolved: a pane the connect-first
+        // order already staged into the vessel stays where it is, and the exact-slot placeholder
+        // retires with the promotion instead of the pane moving twice.
         if (me.tearOutEmbodiment.isStaged(itemId)) {
             return me.tearOutEmbodiment.promote({itemId, windowId}) !== false
         }
 
-        if (!app || !pane || pane.isDestroyed) return false;
-
-        if (pane.parent !== app.mainView) {
-            pane.parent?.remove(pane, false);
-            app.mainView.add(pane)
-        }
-
-        return true
+        return super.reparentDockPane(me.paneCache[itemId] || pane, target, itemId)
     }
 
     /**
-     * @summary Brings a torn-out item HOME on vessel death — the exact-position return.
-     *
-     * The stored `{tabsNodeId, index}` pair (captured at the detach terminal) is the placement
-     * truth; recovery is SEMANTIC, never geometric: a stored home node that left the tree falls
-     * back to the first surviving tabs node (append). Exact-once and idempotent: an item some
-     * other flow already re-treed is left where it is, and the placement record is consumed
-     * regardless. An item whose document no longer catalogs it, or a document with no surviving
-     * tabs node, stays catalog-only — the honest terminal, with zero mutation.
-     * @param {String} itemId
-     * @protected
-     */
-    reintegrateTearOutItem(itemId) {
-        let me         = this,
-            placement  = me.tearOutPlacements[itemId],
-            doc        = me.dockModel,
-            storedHome = placement && doc.nodes?.[placement.tabsNodeId]?.type === 'tabs' ? placement.tabsNodeId : null,
-            fallback   = storedHome || Object.entries(doc.nodes || {}).find(([, node]) => node.type === 'tabs')?.[0],
-            result;
-
-        delete me.tearOutPlacements[itemId];
-
-        if (!doc.items?.[itemId] || !fallback || WorkspaceDocument.findContainingTabsId(doc, itemId)) {
-            return
-        }
-
-        result = me.applyDockZoneOperation({
-            operation : 'addTab',
-            itemId,
-            tabsNodeId: fallback,
-            ...(storedHome ? {index: placement.index} : {})
-        });
-
-        result?.errors?.length === 0 && me.onDockZoneDocumentChange(result.document)
-    }
 
     /**
      * Retirement authority is established before any awaited close: a vessel that binds while its
@@ -4724,7 +4666,7 @@ class Workspace extends DockWorkspace {
             // The film gesture aims at the semantic return target itself: the indicator
             // menu's active candidate is selected geometrically, so the synthetic cursor
             // hovers the stored-home tabs node (window center can lie outside it).
-            let storedHome   = me.tearOutPlacements[state.itemId]?.tabsNodeId,
+            let storedHome   = me.tearOutHandlers?.peekPlacement(state.itemId)?.tabsNodeId,
                 returnNodeId = me.dockModel.nodes?.[storedHome]?.type === 'tabs'
                     ? storedHome
                     : Object.entries(me.dockModel.nodes || {}).find(([, node]) => node.type === 'tabs')?.[0],

--- a/apps/workstation/view/Workspace.mjs
+++ b/apps/workstation/view/Workspace.mjs
@@ -3531,16 +3531,6 @@ class Workspace extends DockWorkspace {
     }
 
     /**
-     * Moves the LIVE cached pane into a bound tear-out vessel — pure render-target work; the model
-     * already committed at the terminal. A pane the connect-first order already staged into the
-     * vessel stays where it is: the exact-slot placeholder retires with the promotion instead of the
-     * pane moving twice.
-     * @param {String} itemId
-     * @param {Object} target `{windowId}`
-     * @returns {Boolean}
-     * @protected
-     */
-    /**
      * @summary Semantic recovery that never resurrects a node.
      *
      * The stored `{tabsNodeId, index}` pair captured at the detach terminal is the placement truth,
@@ -3558,6 +3548,20 @@ class Workspace extends DockWorkspace {
         return Operations.appendingReturnDescriptor(document, itemId, placement)
     }
 
+    /**
+     * @summary Moves the LIVE cached pane into a bound tear-out vessel — pure render-target work;
+     * the model already committed at the terminal.
+     *
+     * Answered by IDENTITY, not by the component the choreography resolved: a pane the connect-first
+     * order already staged into the vessel stays where it is, so the exact-slot placeholder retires
+     * with the promotion instead of the pane moving twice. That is also why the offered `pane` may be
+     * null here and the answer still be yes — this app knows about panes the projected tree does not.
+     * @param {Neo.component.Base|null} pane The pane the choreography resolved, which may be null.
+     * @param {Object} target `{windowId}`
+     * @param {String} itemId
+     * @returns {Boolean}
+     * @protected
+     */
     reparentDockPane(pane, target={}, itemId) {
         let me         = this,
             {windowId} = target;

--- a/apps/workstation/view/Workspace.mjs
+++ b/apps/workstation/view/Workspace.mjs
@@ -1581,7 +1581,7 @@ class Workspace extends DockWorkspace {
             sourceItemId    = sourceWorkspace === Workspace.MAIN_WORKSPACE_ID
                 ? itemId
                 : sourceState?.itemId,
-            storedHome      = sourceItemId && me.tearOutHandlers?.peekPlacement(sourceItemId)?.tabsNodeId,
+            storedHome      = sourceItemId && me.tearOutHandlers?.peekPlacement?.(sourceItemId)?.tabsNodeId,
             targetNodeId    = isMain
                 ? (me.dockModel.nodes?.[storedHome]?.type === 'tabs'
                     ? storedHome
@@ -2060,7 +2060,7 @@ class Workspace extends DockWorkspace {
         if (!state?.committed || !me.workspaceSet.has(workspaceId)) return false;
         if (!itemIds.length) return true;
 
-        let placement  = me.tearOutHandlers?.peekPlacement(itemId),
+        let placement  = me.tearOutHandlers?.peekPlacement?.(itemId),
             storedHome = placement && me.dockModel.nodes?.[placement.tabsNodeId]?.type === 'tabs'
                 ? placement.tabsNodeId
                 : null,
@@ -3540,6 +3540,24 @@ class Workspace extends DockWorkspace {
      * @returns {Boolean}
      * @protected
      */
+    /**
+     * @summary Semantic recovery that never resurrects a node.
+     *
+     * The stored `{tabsNodeId, index}` pair captured at the detach terminal is the placement truth,
+     * and recovery is SEMANTIC, never geometric: a stored home that left the tree falls back to the
+     * first surviving tabs node and appends. The engine's default answers with `restoreTab`, which
+     * re-mints the remembered parent/slot — the exact position back, but a node the user watched
+     * collapse comes back with it. This app's contract is the other one.
+     * @param {Object} document
+     * @param {String} itemId
+     * @param {Object|null} placement
+     * @returns {Object|null}
+     * @protected
+     */
+    resolveDockReturnDescriptor(document, itemId, placement) {
+        return Operations.appendingReturnDescriptor(document, itemId, placement)
+    }
+
     reparentDockPane(pane, target={}, itemId) {
         let me         = this,
             {windowId} = target;
@@ -4666,7 +4684,7 @@ class Workspace extends DockWorkspace {
             // The film gesture aims at the semantic return target itself: the indicator
             // menu's active candidate is selected geometrically, so the synthetic cursor
             // hovers the stored-home tabs node (window center can lie outside it).
-            let storedHome   = me.tearOutHandlers?.peekPlacement(state.itemId)?.tabsNodeId,
+            let storedHome   = me.tearOutHandlers?.peekPlacement?.(state.itemId)?.tabsNodeId,
                 returnNodeId = me.dockModel.nodes?.[storedHome]?.type === 'tabs'
                     ? storedHome
                     : Object.entries(me.dockModel.nodes || {}).find(([, node]) => node.type === 'tabs')?.[0],

--- a/buildScripts/util/file-size-baseline.json
+++ b/buildScripts/util/file-size-baseline.json
@@ -1,6 +1,6 @@
 {
-    "apps/workstation/view/Workspace.mjs": 3250,
-    "examples/dashboard/crossWindow/DemoBWorkspace.mjs": 2663,
-    "src/dashboard/dock/Workspace.mjs": 1294,
+    "apps/workstation/view/Workspace.mjs": 3214,
+    "examples/dashboard/crossWindow/DemoBWorkspace.mjs": 2652,
+    "src/dashboard/dock/Workspace.mjs": 1209,
     "src/main/addon/DragDrop.mjs": 1267
 }

--- a/buildScripts/util/file-size-baseline.json
+++ b/buildScripts/util/file-size-baseline.json
@@ -1,6 +1,6 @@
 {
-    "apps/workstation/view/Workspace.mjs": 3214,
-    "examples/dashboard/crossWindow/DemoBWorkspace.mjs": 2652,
-    "src/dashboard/dock/Workspace.mjs": 1209,
+    "apps/workstation/view/Workspace.mjs": 3217,
+    "examples/dashboard/crossWindow/DemoBWorkspace.mjs": 2662,
+    "src/dashboard/dock/Workspace.mjs": 1214,
     "src/main/addon/DragDrop.mjs": 1267
 }

--- a/examples/dashboard/crossWindow/DemoBWorkspace.mjs
+++ b/examples/dashboard/crossWindow/DemoBWorkspace.mjs
@@ -646,11 +646,12 @@ class DemoBWorkspace extends Container {
             openVessel      : request => me.openTearOutVessel(request),
             reparentPane    : (pane, target, itemId) => me.reparentDockPane(pane, target, itemId),
             resolvePane     : itemId => me.paneCache[itemId] || null,
+            // NEVER a resurrected node: the engine's default re-mints the remembered parent/slot,
+            // and the user watched that node collapse.
+            resolveReturnDescriptor: (document, itemId, placement) =>
+                Operations.appendingReturnDescriptor(document, itemId, placement),
             settlePane      : pane => {
-                if (pane && !pane.isDestroyed) {
-                    pane.parent?.remove(pane, false);
-                    pane.destroy()
-                }
+                pane && !pane.isDestroyed && (pane.parent?.remove(pane, false), pane.destroy())
             }
         });
 

--- a/examples/dashboard/crossWindow/DemoBWorkspace.mjs
+++ b/examples/dashboard/crossWindow/DemoBWorkspace.mjs
@@ -431,16 +431,6 @@ class DemoBWorkspace extends Container {
      */
     tearOutAcquisitionAttempts = 0
     /**
-     * Exact-position return truth: `tearOutPlacements[itemId] = {tabsNodeId, index}`, captured
-     * at the detach terminal BEFORE the commit removes the item from the tree (`addTab` appends
-     * by default, so this pair is the only way home). Consumed exact-once by
-     * {@link #reintegrateTearOutItem} on vessel death; a refused detach commit deletes its own
-     * capture, so no stale placement outlives a gesture that never committed.
-     * @member {Object} tearOutPlacements={}
-     * @protected
-     */
-    tearOutPlacements = {}
-    /**
      * Supersession token for the async keyboard-cycle highlight: every highlight call bumps it,
      * and a paint whose measured geometry resolves after a newer call (or a clear) loses — a
      * fast candidate cycle must never leave a stale zone lit.
@@ -639,10 +629,29 @@ class DemoBWorkspace extends Container {
         // cancelled tear-out is zero-mutation by GUARD. Post-commit adoption uses its own
         // bookkeeping (`tearOutPanes` / `tearOutConnects`).
         me.tearOutHandlers = createDockTearOutHandlers({
-            applyOperation  : descriptor => me.applyTearOutOperation(descriptor),
-            closeVessel     : vessel => me.closeTearOutVessel(vessel),
+            applyOperation: descriptor => me.applyTearOutOperation(descriptor),
+            awaitRefresh  : () => me.refreshPromise,
+            closeVessel   : vessel => me.closeTearOutVessel(vessel),
+            // This host is MULTI-workspace: every document seam names MAIN explicitly, which is the
+            // current product reason its return path stays its own rather than the engine's.
+            commitReturn        : document => me.onWorkspaceDocumentChange(DemoBWorkspace.MAIN_WORKSPACE_ID, document),
+            findContainingTabsId: (document, itemId) => WorkspaceDocument.findContainingTabsId(document, itemId),
+            getDocument         : () => me.dockModel,
+            onAdoptionFailed    : ({itemId, reintegrated}) => console.warn(
+                `Dock tear-out: "${itemId}" could not enter its admitted vessel; the pane ${reintegrated ? 'returned' : 'was NOT returned'}`, me.id
+            ),
             onDocumentChange: (document, operation, vessel) => me.onTearOutDocumentChange(document, operation, vessel),
-            openVessel      : request => me.openTearOutVessel(request)
+            onPaneAdopted   : (itemId, entry, connection, isMerge) => me.recordDockPaneOwner(itemId, entry, connection, isMerge),
+            onPaneReturn    : () => {},
+            openVessel      : request => me.openTearOutVessel(request),
+            reparentPane    : (pane, target, itemId) => me.reparentDockPane(pane, target, itemId),
+            resolvePane     : itemId => me.paneCache[itemId] || null,
+            settlePane      : pane => {
+                if (pane && !pane.isDestroyed) {
+                    pane.parent?.remove(pane, false);
+                    pane.destroy()
+                }
+            }
         });
 
         // Conversion never reacquires a popup. The source-owned admission machines retain the
@@ -2687,7 +2696,7 @@ class DemoBWorkspace extends Container {
      * a `?popout=` vessel, then — gated on that vessel's ACTUAL birth
      * ({@link #onWindowConnect} → {@link #tearOutConnects}) — survives deliberate post-birth moves
      * (the reap-regression survival probe) and either releases while detached (`dockTearOutTerminal`
-     * → the host's `detachItem` commit + {@link #adoptTearOutPane}) or cancels via Escape
+     * → the host's `detachItem` commit + the choreography's `adoptPane`) or cancels via Escape
      * (`dockTearOutCancel` → zero-mutation vessel close).
      *
      * The proof is OBSERVABLE-ONLY — committed document truth + vessel bookkeeping. It never reads
@@ -2867,7 +2876,7 @@ class DemoBWorkspace extends Container {
             }
 
             // Terminal: release while detached → dockTearOutTerminal → the host's detachItem commit
-            // + adoptTearOutPane (the vessel owns the pane now).
+            // + the choreography's adoptPane (the vessel owns the pane now).
             await me.interactionService.simulateEvent({events: [{
                 targetId: button.id, type: 'mouseup', windowId: button.windowId,
                 options : opt(outX, outY, outSX, outSY, 0)
@@ -3205,7 +3214,7 @@ class DemoBWorkspace extends Container {
             if (staged) {
                 me.tearOutEmbodiment.promote({itemId, windowId})
             } else {
-                me.reparentTearOutPane(itemId, connection)
+                me.tearOutHandlers.reparentAdopted(itemId, connection)
             }
         } else {
             me.tearOutConnects[itemId] = connection
@@ -3259,7 +3268,7 @@ class DemoBWorkspace extends Container {
                     me.vesselParkHandlers.onVesselRetired({itemId, retirement: true});
                     me.tearOutRetirements.delete(itemId);
                     delete me.tearOutPanes[itemId];
-                    committed && me.reintegrateTearOutItem(itemId);
+                    committed && me.tearOutHandlers.reintegrateItem(itemId, null);
                     return
                 }
             }
@@ -3371,7 +3380,7 @@ class DemoBWorkspace extends Container {
                 me.tearOutRetirements.delete(itemId);
                 me.tearOutHandlers.onVesselRetired({...entry, itemId, windowName: entry.windowName ?? `tearout-${itemId}`});
                 me.vesselParkHandlers.onVesselRetired({itemId, retirement: true});
-                me.reintegrateTearOutItem(itemId);
+                me.tearOutHandlers.reintegrateItem(itemId, null);
                 break
             }
         }
@@ -3401,7 +3410,7 @@ class DemoBWorkspace extends Container {
         me.onWorkspaceDocumentChange(DemoBWorkspace.MAIN_WORKSPACE_ID, document, {
             preserveItemIds: me.tearOutEmbodiment.isStaged(itemId) ? [] : [itemId]
         });
-        me.adoptTearOutPane(itemId, vessel)
+        me.tearOutHandlers.adoptPane(itemId, vessel, me.tearOutConnects[itemId] || null)
     }
 
     /**
@@ -3419,54 +3428,15 @@ class DemoBWorkspace extends Container {
             captured = isDetach ? WorkspaceDocument.captureItemPlacement(me.dockModel, descriptor.itemId) : null,
             result;
 
-        captured && (me.tearOutPlacements[descriptor.itemId] = captured);
+        captured && me.tearOutHandlers.recordPlacement(descriptor.itemId, captured);
 
         result = me.applyWorkspaceOperation(DemoBWorkspace.MAIN_WORKSPACE_ID, descriptor);
 
-        isDetach && result?.errors?.length && delete me.tearOutPlacements[descriptor.itemId];
+        isDetach && result?.errors?.length && me.tearOutHandlers.forgetPlacement(descriptor.itemId);
 
         return result
     }
 
-    /**
-     * @summary Brings a torn-out item HOME on vessel death — the exact-position return of the
-     * vessel close policy (docking design record §2.8; the disposition this host's
-     * pre-vessel-lifecycle comment deferred).
-     *
-     * The stored `{tabsNodeId, index}` pair (captured at the detach terminal) is the placement
-     * truth; recovery is SEMANTIC, never geometric: a stored home node that left the tree falls
-     * back to the first surviving tabs node (append), mirroring the click path's
-     * `reattachPane` fallback. Exact-once and idempotent: an item some other flow already
-     * re-treed is left where it is, and the placement record is consumed regardless — a second
-     * vessel death for the same item finds nothing to do. An item whose document no longer
-     * catalogs it, or a document with no surviving tabs node, stays catalog-only/absent — the
-     * honest terminal, with zero mutation.
-     * @param {String} itemId
-     * @protected
-     */
-    reintegrateTearOutItem(itemId) {
-        let me         = this,
-            placement  = me.tearOutPlacements[itemId],
-            doc        = me.dockModel,
-            storedHome = placement && doc.nodes?.[placement.tabsNodeId]?.type === 'tabs' ? placement.tabsNodeId : null,
-            fallback   = storedHome || Object.entries(doc.nodes || {}).find(([, node]) => node.type === 'tabs')?.[0],
-            result;
-
-        delete me.tearOutPlacements[itemId];
-
-        if (!doc.items?.[itemId] || !fallback || WorkspaceDocument.findContainingTabsId(doc, itemId)) {
-            return
-        }
-
-        result = me.applyWorkspaceOperation(DemoBWorkspace.MAIN_WORKSPACE_ID, {
-            operation : 'addTab',
-            itemId,
-            tabsNodeId: fallback,
-            ...(storedHome ? {index: placement.index} : {})
-        });
-
-        result?.errors?.length === 0 && me.onWorkspaceDocumentChange(DemoBWorkspace.MAIN_WORKSPACE_ID, result.document)
-    }
 
     /**
      * The pop-out moment: atomically transfers the item record + placement from the primary
@@ -4199,59 +4169,66 @@ class DemoBWorkspace extends Container {
     }
 
     /**
-     * The post-commit adoption: the detached terminal committed `detachItem` (the item left the
-     * tree, catalog preserved), so the vessel now OWNS the pane. Writes the {@link #tearOutPanes}
-     * entry and — if the vessel already bound ({@link #tearOutConnects}, the long-drag order) —
-     * reparents the live pane into it immediately; otherwise {@link #onTopologyBind} adopts on
-     * arrival (the fast-terminal order). Close-after-adoption reintegration is the vessel-lifecycle
-     * leaf's scope, deliberately not handled here.
+     * The post-commit ownership write: the detached terminal committed `detachItem` (the item left
+     * the tree, catalog preserved), so the vessel now OWNS the pane. The REPARENT that used to
+     * follow this write now belongs to the choreography, which calls `reparentPane` right after —
+     * so the long-drag and fast-terminal orders converge on one sequence instead of two.
      * @param {String} itemId
-     * @param {Object} [vessel={}] The admitted identity for terminal-first adoption: its lineage token and slot.
+     * @param {Object|null} entry The admitted identity for terminal-first adoption, or null to withdraw.
+     * @param {Object|null} [connection=null] The bound vessel connection, when one arrived first.
+     * @param {Boolean} [isMerge=false] Fold into the existing record instead of replacing it.
      * @protected
      */
-    adoptTearOutPane(itemId, vessel={}) {
-        let me        = this,
-            connected = me.tearOutConnects[itemId];
+    recordDockPaneOwner(itemId, entry, connection=null, isMerge=false) {
+        let me = this;
 
-        me.tearOutPanes[itemId] = connected
-            ? {...connected}
+        if (isMerge) {
+            me.tearOutPanes[itemId] && Object.assign(me.tearOutPanes[itemId], entry);
+            return
+        }
+
+        if (entry === null) {
+            delete me.tearOutPanes[itemId];
+            delete me.tearOutConnects[itemId];
+            return
+        }
+
+        me.tearOutPanes[itemId] = connection
+            ? {...connection}
             : {
-                generationToken: vessel.generationToken ?? null,
+                generationToken: entry.generationToken ?? null,
                 windowId       : null,
                 windowName     : `tearout-${itemId}`,
-                workspaceKey   : vessel.workspaceKey ?? `popup:${itemId}`
+                workspaceKey   : entry.workspaceKey ?? `popup:${itemId}`
             };
 
-        if (connected) {
-            // Promotion is synchronous and single-owner: committed disconnects may only match
-            // tearOutPanes from this point onward, never the pre-terminal connect branch first.
-            delete me.tearOutConnects[itemId];
-
-            if (me.tearOutEmbodiment.isStaged(itemId)) {
-                me.tearOutEmbodiment.promote({itemId, windowId: connected.windowId})
-            } else {
-                me.reparentTearOutPane(itemId, connected)
-            }
-        }
+        // Promotion is synchronous and single-owner: committed disconnects may only match
+        // tearOutPanes from this point onward, never the pre-terminal connect branch first.
+        connection && delete me.tearOutConnects[itemId]
     }
 
     /**
      * Moves the LIVE cached pane into a connected tear-out vessel — the same instance-moving
      * reparent the click-pop-out uses, minus every document write (the model already committed
      * at the terminal; this is pure render-target work).
-     * @param {String} itemId
+     * @param {Neo.component.Base} pane
      * @param {Object} target `{windowId}`
+     * @param {String} itemId
+     * @returns {Boolean}
      * @protected
      */
-    reparentTearOutPane(itemId, target) {
+    reparentDockPane(pane, target={}, itemId) {
         let me         = this,
             {windowId} = target,
-            app        = Neo.apps[windowId],
-            pane       = me.paneCache[itemId];
+            app        = Neo.apps[windowId];
+
+        if (me.tearOutEmbodiment.isStaged(itemId)) {
+            return me.tearOutEmbodiment.promote({itemId, windowId}) !== false
+        }
+
+        pane = me.paneCache[itemId] || pane;
 
         if (!app || !pane || pane.isDestroyed) return false;
-
-        me.tearOutPanes[itemId] && Object.assign(me.tearOutPanes[itemId], target);
 
         if (pane.parent !== app.mainView) {
             pane.parent?.remove(pane, false);

--- a/src/dashboard/dock/Workspace.mjs
+++ b/src/dashboard/dock/Workspace.mjs
@@ -395,20 +395,6 @@ class Workspace extends Container {
     tearOutPanes = {}
 
     /**
-     * Live pane handles captured before detach re-projection, owned by the generic lifecycle.
-     * @member {Object} tearOutPaneHandles={}
-     * @protected
-     */
-    tearOutPaneHandles = {}
-
-    /**
-     * Exact semantic return positions captured before detach removes an item from its tabs node.
-     * @member {Object} tearOutPlacements={}
-     * @protected
-     */
-    tearOutPlacements = {}
-
-    /**
      * Platform vessels whose close hook explicitly refused or threw. Retained by exact item/window
      * identity so exceptional cleanup never turns a live OS resource into untracked state; the
      * next acquisition retries these before opening another vessel.
@@ -416,14 +402,6 @@ class Workspace extends Container {
      * @protected
      */
     tearOutRetirements = new Map()
-
-    /**
-     * One-refresh same-instance return slots. {@link #resolveProjectedPane} consumes each slot
-     * before asking the app resolver, so a dead vessel can never strand its live pane.
-     * @member {Object} returningTearOutPanes={}
-     * @protected
-     */
-    returningTearOutPanes = {}
 
     /**
      * Item ids with a `dockReload()` invocation in flight — the single-flight guard: a second
@@ -473,10 +451,23 @@ class Workspace extends Container {
 
         if (this.enableDockTearOutLifecycle) {
             this.tearOutHandlers = createDockTearOutHandlers({
-                applyOperation  : descriptor => this.applyTearOutOperation(descriptor),
-                closeVessel     : vessel => this.retireTearOutVessel(vessel),
-                onDocumentChange: (document, operation, vessel) => this.onTearOutDocumentChange(document, operation, vessel),
-                openVessel      : request => this.acquireTearOutVessel(request)
+                applyOperation      : descriptor => this.applyTearOutOperation(descriptor),
+                awaitRefresh        : () => this.refreshPromise,
+                closeVessel         : vessel => this.retireTearOutVessel(vessel),
+                commitReturn        : document => this.onDockZoneDocumentChange(document),
+                findContainingTabsId: (document, itemId) => WorkspaceDocument.findContainingTabsId(document, itemId),
+                getDocument         : () => this.dockModel,
+                onAdoptionFailed    : data => this.reportDockAdoptionFailure(data),
+                onDocumentChange    : (document, operation, vessel) => this.onTearOutDocumentChange(document, operation, vessel),
+                onPaneAdopted       : (itemId, entry, connection, isMerge) => this.recordDockPaneOwner(itemId, entry, connection, isMerge),
+                onPaneReturn        : data => this.fire('dockPaneReturn', {component: this, ...data}),
+                openVessel          : request => this.acquireTearOutVessel(request),
+                // The three below are GENERIC pane capabilities, not tear-out members: a consumer
+                // that owns its pane lifecycle overrides these three and nothing else, which is the
+                // Ownership test's third question answered in the signature rather than in prose.
+                reparentPane: (pane, target, itemId) => this.reparentDockPane(pane, target, itemId),
+                resolvePane : itemId => this.resolveLivePane(itemId),
+                settlePane  : pane => this.settleDockPane(pane)
             });
 
             // One worker lifecycle subscriber exists — `Neo.manager.Transaction`. This workspace only
@@ -762,10 +753,10 @@ class Workspace extends Container {
         !entry && admission.sortZone?.endWindowDrag();
 
         if (entry && !entry.windowId) {
-            const pane = me.releaseTearOutPane(itemId);
+            const pane = me.tearOutHandlers.releasePane(itemId);
 
             delete me.tearOutPanes[itemId];
-            await me.reintegrateTearOutItem(itemId, pane);
+            await me.tearOutHandlers.reintegrateItem(itemId, pane);
             me.afterTearOutWindowDisconnect({committed: true, entry, expired: true, itemId, pane})
         }
     }
@@ -937,11 +928,11 @@ class Workspace extends Container {
             captured = isDetach ? WorkspaceDocument.captureItemPlacement(me.dockModel, descriptor.itemId) : null,
             result;
 
-        captured && (me.tearOutPlacements[descriptor.itemId] = captured);
+        captured && me.tearOutHandlers.recordPlacement(descriptor.itemId, captured);
 
         result = me.applyDockZoneOperation(descriptor);
 
-        isDetach && result?.errors?.length && delete me.tearOutPlacements[descriptor.itemId];
+        isDetach && result?.errors?.length && me.tearOutHandlers.forgetPlacement(descriptor.itemId);
 
         return result
     }
@@ -959,109 +950,63 @@ class Workspace extends Container {
             detached = operation?.operation === 'detachItem',
             itemId   = operation?.itemId;
 
-        detached && me.captureTearOutPane(itemId);
+        detached && me.tearOutHandlers.capturePane(itemId);
         me.onDockZoneDocumentChange(document, operation, me);
-        detached && me.adoptTearOutPane(itemId, vessel)
+        detached && me.tearOutHandlers.adoptPane(itemId, vessel, me.tearOutConnects[itemId] || null)
     }
 
     /**
-     * @summary Captures the app-resolved live pane before detach re-projection can retire it.
+     * @summary Records post-terminal vessel ownership for one item, or withdraws it.
+     *
+     * The vessel-ownership map stays HERE while the choreography that decides its transitions lives
+     * in {@link Neo.dashboard.dock.window.TearOut}: `window/Participation` and the admission and
+     * retirement paths all read `tearOutPanes`, and that lifecycle belongs to the Group, not to this
+     * extraction. Moving the map with the choreography would have moved it twice.
+     *
+     * Consuming the connection is part of the write, not a step after it — the reparent that follows
+     * must not race an admission that still looks open.
      * @param {String} itemId
+     * @param {Object|null} entry The ownership record, or null to withdraw one.
+     * @param {Object|null} [connection=null] The admitted connection this write consumes.
+     * @param {Boolean} [isMerge=false] Fold into the existing record instead of replacing it.
      * @protected
      */
-    captureTearOutPane(itemId) {
-        const pane = this.resolveTearOutPane(itemId);
+    recordDockPaneOwner(itemId, entry, connection=null, isMerge=false) {
+        const me = this;
 
-        pane && !pane.isDestroyed && (this.tearOutPaneHandles[itemId] = pane)
-    }
+        if (isMerge) {
+            me.tearOutPanes[itemId] && Object.assign(me.tearOutPanes[itemId], entry);
+            return
+        }
 
-    /**
-     * @summary Promotes one committed item into post-terminal vessel ownership.
-     * @param {String} itemId
-     * @param {Object} [vessel={}]
-     * @protected
-     */
-    adoptTearOutPane(itemId, vessel={}) {
-        let me         = this,
-            connection = me.tearOutConnects[itemId],
-            entry      = {
-                generation     : vessel.generation ?? connection?.generation ?? null,
-                generationToken: vessel.generationToken ?? connection?.generationToken ?? null,
-                gestureToken   : vessel.gestureToken ?? connection?.gestureToken ?? null,
-                windowId       : connection?.windowId ?? null,
-                windowName     : vessel.windowName || connection?.windowName || `tearout-${itemId}`,
-                workspaceKey   : vessel.workspaceKey ?? connection?.workspaceKey ?? null
-            };
+        if (entry === null) {
+            delete me.tearOutPanes[itemId];
+            delete me.tearOutConnects[itemId];
+            return
+        }
 
         me.tearOutPanes[itemId] = entry;
 
         if (connection) {
             delete me.tearOutConnects[itemId];
-            me.clearTearOutAdmission(itemId);
-
-            if (!me.reparentTearOutPane(itemId, connection)) {
-                me.compensateFailedTearOutAdoption(itemId, entry);
-                throw new Error(`Workspace ${me.id}: tear-out pane "${itemId}" could not enter its admitted vessel`)
-            }
+            me.clearTearOutAdmission(itemId)
         }
-
-        me.afterTearOutPaneAdopt({connection, entry, itemId, vessel})
     }
 
     /**
-     * Hook: observes the post-commit adoption moment after engine ownership state is written.
-     * @param {Object} data
-     * @protected
-     */
-    afterTearOutPaneAdopt(data) {}
-
-    /**
-     * @summary Resolves the live pane a vessel should embody, defaulting to the engine's own projection.
+     * @summary The live component currently rendering one dock item, or null.
      *
-     * This was a hook whose default declined, and the decline was not survivable: `captureTearOutPane`
-     * stores nothing, so `reparentTearOutPane` finds no pane, returns `false`, and
-     * `compensateFailedTearOutAdoption` CLOSES the vessel the consumer was just asked to open. A host
-     * that writes no pane resolver therefore gets a pop-out that opens a window and kills it — measured
-     * at ~530ms on a real consumer, with no signal anywhere.
+     * The two resolver-shaped members this folds together — the tree lookup and the stand-in
+     * exclusion — never belonged to the tear-out concern: both answer "which live component IS this
+     * item", which only the host can know. The choreography asks; it no longer decides.
      *
-     * The engine does not need to be told: `projection.LayoutAdapter` stamps `dockItemId` on every
-     * projected pane it emits, so the live component is a lookup away.
+     * `projection.LayoutAdapter` stamps `dockItemId` on every projected pane it emits, so the live
+     * component is a lookup away — but the same identity is stamped on more than the pane, and every
+     * stand-in carrying it would reparent into a vessel and report success while the real content
+     * stayed behind:
      *
-     * **The lookup excludes tab header buttons deliberately.** The adapter stamps the SAME identity on
-     * the header it builds from the pane's config, so the button carries `dockItemId` structurally too
-     * (that is what makes keyboard identity work). An unqualified `down()` returns whichever comes
-     * first, and a header button reparented into a vessel is a defect that would look like a success.
-     *
-     * A consumer that owns its pane lifecycle still overrides this; the override remains authoritative.
-     * @param {String} itemId
-     * @returns {Neo.component.Base|null}
-     * @protected
-     */
-    resolveTearOutPane(itemId) {
-        const held = this.tearOutPaneHandles[itemId];
-
-        // The held handle FIRST, and this is what makes the default actually adopt. The tear-out
-        // sequence is capture → re-project → adopt: `captureTearOutPane` stores the pane while it is
-        // still in the tree, the detach re-projection then removes it, and adoption runs afterwards.
-        // A tree-only lookup therefore succeeds at capture and returns null at the moment it matters,
-        // so a hook-free consumer got a vessel window that opened and never received its pane.
-        if (held && !held.isDestroyed) {
-            return held
-        }
-
-        const matches = this.getDockHost()?.down({dockItemId: itemId}, false) || [];
-
-        return matches.find(component => this.isDockTearOutCandidate(component)) || null
-    }
-
-    /**
-     * @summary Whether one component carrying a dock item's identity is the PANE, not a stand-in.
-     *
-     * `dockItemId` is stamped on more than the pane, and every stand-in that carries it would
-     * reparent into a vessel and report success while the real content stayed behind:
-     *
-     * - **the tab header button** — `LayoutAdapter` stamps the pane's identity onto the header it
-     *   builds from the pane's own config, which is what makes keyboard identity work;
+     * - **the tab header button** — the adapter stamps the pane's identity onto the header it builds
+     *   from the pane's own config, which is what makes keyboard identity work;
      * - **the projection placeholder** — `LayoutAdapter.createPlaceholder` mints an
      *   `ntype: 'dashboard-panel'` node carrying the same `dockItemId`, so it passes any check that
      *   only excludes the button.
@@ -1069,73 +1014,30 @@ class Workspace extends Container {
      * The placeholder is the dangerous one, and not as an edge case: a placeholder exists exactly
      * when a pane could not be materialized, which is the ordinary state for a host that writes no
      * {@link #resolvePane}. Tearing one out would open a vessel holding a titled blank.
-     * @param {Neo.component.Base} component
-     * @returns {Boolean}
-     * @protected
-     */
-    isDockTearOutCandidate(component) {
-        const cls = component?.cls || [];
-
-        // Excluded by CATEGORY, not one instance at a time. Every stand-in found so far is a
-        // BUTTON — the tab header button and the rail tab both carry the pane's `dockItemId` so a
-        // click can resolve the item without id bookkeeping — and naming them individually lost
-        // twice in one night. A dock pane is never a button, so the category is safe to refuse.
-        return !cls.includes('neo-button')
-            && !component?.ntype?.endsWith('button')
-            && !cls.includes('neo-dashboard-dock-rail-tab')
-            && !cls.includes('neo-dashboard-dock-placeholder')
-            && component?.data?.missingComponentRef !== true
-    }
-
-    /**
-     * Hook: releases one app-owned pane handle for return. The default resolves without retaining
-     * a second owner; consumers with handle maps override and delete atomically.
+     *
+     * Exclusion is by CATEGORY, not one instance at a time. Every stand-in found so far is a
+     * BUTTON — the tab header button and the rail tab both carry the pane's `dockItemId` so a click
+     * can resolve the item without id bookkeeping — and naming them individually lost twice in one
+     * night. A dock pane is never a button, so the category is safe to refuse.
+     *
+     * A consumer that owns its pane lifecycle overrides this one method; the override is
+     * authoritative and no tear-out member has to be touched to supply it.
      * @param {String} itemId
      * @returns {Neo.component.Base|null}
      * @protected
      */
-    releaseTearOutPane(itemId) {
-        const pane = this.tearOutPaneHandles[itemId] || null;
+    resolveLivePane(itemId) {
+        const matches = this.getDockHost()?.down({dockItemId: itemId}, false) || [];
 
-        delete this.tearOutPaneHandles[itemId];
+        return matches.find(component => {
+            const cls = component?.cls || [];
 
-        return pane
-    }
-
-    /**
-     * @summary Compensates an admitted connection that cannot embody its live pane.
-     *
-     * Returns the reporting promise. Both callers throw immediately after and ignore it, but the
-     * compensation's own completion is otherwise unobservable — and an outcome nothing can await is
-     * an outcome nothing can assert.
-     * @param {String} itemId
-     * @param {Object} entry
-     * @returns {Promise<void>}
-     * @protected
-     */
-    compensateFailedTearOutAdoption(itemId, entry={}) {
-        let me     = this,
-            pane   = me.releaseTearOutPane(itemId),
-            vessel = {...entry, itemId};
-
-        delete me.tearOutPanes[itemId];
-        delete me.tearOutConnects[itemId];
-        Promise.resolve(me.retireTearOutVessel(vessel)).then(closed => {
-            closed && me.tearOutHandlers?.onVesselRetired(vessel)
-        });
-        // Reported HERE because this is the one place both failing paths already meet: the
-        // document-change adoption and the window-connect adoption each call it before throwing.
-        // Their throws do not reach anyone — `onTopologyBind` is registered as a manager event
-        // listener, so an async throw becomes a rejected promise the emitter drops, which is why a
-        // vessel could die with nothing but an unattributed unhandled rejection in the console.
-        //
-        // The report waits for the return to actually resolve, matching the `retireTearOutVessel`
-        // line above. Reading a pane HANDLE instead would answer a different question — one that is
-        // true in exactly the case worth alarming on, since a failed adoption is precisely when a
-        // pane was held and could still fail to come home.
-        return Promise.resolve(me.reintegrateTearOutItem(itemId, pane)).then(reintegrated => {
-            me.onTearOutAdoptionFailed({entry, itemId, pane, reintegrated})
-        })
+            return !cls.includes('neo-button')
+                && !component?.ntype?.endsWith('button')
+                && !cls.includes('neo-dashboard-dock-rail-tab')
+                && !cls.includes('neo-dashboard-dock-placeholder')
+                && component?.data?.missingComponentRef !== true
+        }) || null
     }
 
     /**
@@ -1146,9 +1048,9 @@ class Workspace extends Container {
      * nothing". That sequence must be attributable, and a throw into an event listener is not:
      * it names no item, reaches no consumer, and cannot be told from an unrelated rejection.
      *
-     * Fires `dockTearOutAdoptionFailed` and warns. A consumer that wants to surface it in its own
-     * UI listens; one that wants silence overrides. `reintegrated` distinguishes the recoverable
-     * case (the pane came home) from the one worth alarming on (it did not).
+     * Fires `dockTearOutAdoptionFailed` and warns. A consumer that wants to surface it in its own UI
+     * listens; one that wants silence supplies its own handler. `reintegrated` distinguishes the
+     * recoverable case (the pane came home) from the one worth alarming on (it did not).
      * @param {Object} data
      * @param {Object} data.entry The vessel record the adoption was attempting.
      * @param {String} data.itemId
@@ -1156,7 +1058,7 @@ class Workspace extends Container {
      * @param {Boolean} data.reintegrated
      * @protected
      */
-    onTearOutAdoptionFailed(data) {
+    reportDockAdoptionFailure(data) {
         const me = this;
 
         console.warn(
@@ -1168,19 +1070,22 @@ class Workspace extends Container {
     }
 
     /**
-     * @summary Moves one live pane into a connected vessel without changing document truth.
-     * @param {String} itemId
+     * @summary Moves one live pane into a connected window without changing document truth.
+     *
+     * Render topology only: the pane arrives or it does not, and `false` is the honest answer the
+     * choreography compensates against. A failed move restores the pane to its old parent when it
+     * still has none — the engine keeps the live handle either way, so a semantic return is still
+     * possible after a refused reparent.
+     * @param {Neo.component.Base} pane The live pane, already resolved by the caller.
      * @param {Object} target
      * @param {String} target.windowId
+     * @param {String} [itemId] The item this pane renders — for hosts that answer by identity.
      * @returns {Boolean}
      * @protected
      */
-    reparentTearOutPane(itemId, target={}) {
-        let me         = this,
-            {windowId} = target,
-            app        = Neo.apps[windowId],
-            pane       = me.resolveTearOutPane(itemId),
-            oldParent  = pane?.parent;
+    reparentDockPane(pane, target={}, itemId) {
+        const app       = Neo.apps[target.windowId],
+              oldParent = pane?.parent;
 
         if (!app || !pane || pane.isDestroyed) return false;
 
@@ -1196,8 +1101,6 @@ class Workspace extends Container {
 
             return false
         }
-
-        me.tearOutPanes[itemId] && Object.assign(me.tearOutPanes[itemId], target);
 
         return true
     }
@@ -1341,8 +1244,8 @@ class Workspace extends Container {
         admission.windowId  = windowId;
 
         if (me.tearOutPanes[itemId]) {
-            if (!me.reparentTearOutPane(itemId, connection)) {
-                me.compensateFailedTearOutAdoption(itemId, me.tearOutPanes[itemId]);
+            if (!me.tearOutHandlers.reparentAdopted(itemId, connection)) {
+                me.tearOutHandlers.compensateFailedAdoption(itemId, me.tearOutPanes[itemId]);
                 throw new Error(`Workspace ${me.id}: tear-out pane "${itemId}" could not enter its admitted vessel`)
             }
 
@@ -1355,103 +1258,20 @@ class Workspace extends Container {
     }
 
     /**
-     * Hook: app-owned pane preparation immediately before semantic return starts.
-     * @param {Object} data
-     * @protected
-     */
-    beforeTearOutPaneReturn(data) {}
-
-    /**
-     * Hook: observes the semantic return disposition.
-     * @param {Object} data
-     * @protected
-     */
-    afterTearOutPaneReturn(data) {}
-
-    /**
      * @summary Settles a live pane only when no semantic home can own it.
+     *
+     * The one place a dock pane is destroyed rather than returned. The choreography decides WHEN;
+     * this decides what destroying means, because only the host owns component lifetime.
      * @param {Neo.component.Base|null} pane
      * @protected
      */
-    settleTearOutPane(pane) {
+    settleDockPane(pane) {
         if (pane && !pane.isDestroyed) {
             pane.parent?.remove(pane, false);
             pane.destroy()
         }
     }
 
-    /**
-     * @summary Returns a dead vessel's item to its exact semantic position and same live pane.
-     * @param {String} itemId
-     * @param {Neo.component.Base|null} pane
-     * @protected
-     */
-    async reintegrateTearOutItem(itemId, pane) {
-        let me        = this,
-            placement = me.tearOutPlacements[itemId],
-            doc       = me.dockModel,
-            // The first tabs node in document order is not a placement — it is wherever enumeration
-            // happens to start. It stands in only for an item with NO record at all, because a pane
-            // somewhere valid beats a pane dropped out of the tree.
-            lastResort = () => Object.entries(doc?.nodes || {}).find(([, node]) => node.type === 'tabs')?.[0],
-            target     = placement || {tabsNodeId: lastResort()},
-            live       = pane && !pane.isDestroyed,
-            result;
-
-        delete me.tearOutPlacements[itemId];
-
-        if (!doc?.items?.[itemId] || !target.tabsNodeId) {
-            me.settleTearOutPane(pane);
-            me.afterTearOutPaneReturn({itemId, pane, returned: false});
-            return false
-        }
-
-        if (live) {
-            pane.parent?.remove(pane, false);
-            me.returningTearOutPanes[itemId] = pane
-        }
-
-        me.beforeTearOutPaneReturn({itemId, pane});
-
-        if (WorkspaceDocument.findContainingTabsId(doc, itemId)) {
-            me.onDockZoneDocumentChange(doc);
-
-            try {
-                await me.refreshPromise;
-                me.afterTearOutPaneReturn({itemId, pane, returned: true});
-                return true
-            } catch (error) {
-                me.afterTearOutPaneReturn({error, itemId, pane, returned: false});
-                return false
-            }
-        }
-
-        result = me.applyDockZoneOperation({operation: 'restoreTab', itemId, ...target});
-
-        if (result?.errors?.length > 0 && placement) {
-            // The recorded home resolved to nothing — its zone AND the sibling it collapsed into are
-            // both gone. Losing the position is bad; losing the pane is worse.
-            result = me.applyDockZoneOperation({operation: 'restoreTab', itemId, tabsNodeId: lastResort()})
-        }
-
-        if (result?.errors?.length === 0) {
-            me.onDockZoneDocumentChange(result.document);
-
-            try {
-                await me.refreshPromise;
-                me.afterTearOutPaneReturn({itemId, pane, returned: true});
-                return true
-            } catch (error) {
-                me.afterTearOutPaneReturn({error, itemId, pane, returned: false});
-                return false
-            }
-        } else {
-            delete me.returningTearOutPanes[itemId];
-            me.settleTearOutPane(pane);
-            me.afterTearOutPaneReturn({errors: result?.errors || [], itemId, pane, returned: false});
-            return false
-        }
-    }
 
     /**
      * @summary Reconciles a released vessel binding against pre-terminal or committed ownership.
@@ -1471,13 +1291,13 @@ class Workspace extends Container {
 
         for (const [itemId, entry] of Object.entries(me.tearOutPanes)) {
             if (entry.windowId === data.windowId) {
-                const pane = me.releaseTearOutPane(itemId);
+                const pane = me.tearOutHandlers.releasePane(itemId);
 
                 delete me.tearOutPanes[itemId];
                 delete me.tearOutConnects[itemId];
                 me.clearTearOutAdmission(itemId);
                 me.tearOutHandlers?.onVesselRetired({...entry, itemId});
-                await me.reintegrateTearOutItem(itemId, pane);
+                await me.tearOutHandlers.reintegrateItem(itemId, pane);
                 me.afterTearOutWindowDisconnect({committed: true, data, entry, itemId, pane});
                 return
             }
@@ -1531,20 +1351,16 @@ class Workspace extends Container {
             Promise.resolve(me.closeTearOutVessel(vessel)).catch(() => {})
         });
 
-        const panes = new Set([
-            ...Object.values(me.returningTearOutPanes || {}),
-            ...Object.values(me.tearOutPaneHandles || {})
-        ]);
+        // The choreography returns the panes it held and forgets them in one call; destroying them
+        // stays here, because component lifetime is never the decision machine's to own.
+        const panes = new Set(me.tearOutHandlers?.retirePaneState() || []);
 
-        panes.forEach(pane => me.settleTearOutPane(pane));
+        panes.forEach(pane => me.settleDockPane(pane));
 
         me.tearOutAdmissions?.forEach((entry, itemId) => me.clearTearOutAdmission(itemId, entry));
-        me.tearOutConnects       = {};
-        me.tearOutPaneHandles    = {};
-        me.tearOutPanes          = {};
-        me.tearOutPlacements     = {};
-        me.tearOutRetirements    = new Map();
-        me.returningTearOutPanes = {}
+        me.tearOutConnects    = {};
+        me.tearOutPanes       = {};
+        me.tearOutRetirements = new Map()
     }
 
     /**
@@ -2944,7 +2760,7 @@ class Workspace extends Container {
             placeholders,
             preserveItemIds: [...new Set([
                 ...me.getPreservedItemIds(),
-                ...(me.enableDockTearOutLifecycle ? Object.keys(me.tearOutPaneHandles) : []),
+                ...(me.enableDockTearOutLifecycle ? (me.tearOutHandlers?.heldPaneIds() || []) : []),
                 ...(refreshOptions.preserveItemIds || [])
             ])],
             resolveItem    : itemId => {
@@ -3107,11 +2923,9 @@ class Workspace extends Container {
      * @protected
      */
     resolveProjectedPane(itemId, item) {
-        const returning = this.returningTearOutPanes?.[itemId];
+        const returning = this.tearOutHandlers?.takeReturningPane(itemId);
 
         if (returning) {
-            delete this.returningTearOutPanes[itemId];
-
             if (!returning.isDestroyed) {
                 returning.parent?.remove(returning, false);
                 return returning

--- a/src/dashboard/dock/Workspace.mjs
+++ b/src/dashboard/dock/Workspace.mjs
@@ -460,14 +460,15 @@ class Workspace extends Container {
                 onAdoptionFailed    : data => this.reportDockAdoptionFailure(data),
                 onDocumentChange    : (document, operation, vessel) => this.onTearOutDocumentChange(document, operation, vessel),
                 onPaneAdopted       : (itemId, entry, connection, isMerge) => this.recordDockPaneOwner(itemId, entry, connection, isMerge),
-                onPaneReturn        : data => this.fire('dockPaneReturn', {component: this, ...data}),
+                onPaneReturn        : data => this.onDockPaneReturn(data),
                 openVessel          : request => this.acquireTearOutVessel(request),
                 // The three below are GENERIC pane capabilities, not tear-out members: a consumer
                 // that owns its pane lifecycle overrides these three and nothing else, which is the
                 // Ownership test's third question answered in the signature rather than in prose.
-                reparentPane: (pane, target, itemId) => this.reparentDockPane(pane, target, itemId),
-                resolvePane : itemId => this.resolveLivePane(itemId),
-                settlePane  : pane => this.settleDockPane(pane)
+                reparentPane           : (pane, target, itemId) => this.reparentDockPane(pane, target, itemId),
+                resolvePane            : itemId => this.resolveLivePane(itemId),
+                resolveReturnDescriptor: (document, itemId, placement) => this.resolveDockReturnDescriptor(document, itemId, placement),
+                settlePane             : pane => this.settleDockPane(pane)
             });
 
             // One worker lifecycle subscriber exists — `Neo.manager.Transaction`. This workspace only
@@ -753,10 +754,10 @@ class Workspace extends Container {
         !entry && admission.sortZone?.endWindowDrag();
 
         if (entry && !entry.windowId) {
-            const pane = me.tearOutHandlers.releasePane(itemId);
+            const pane = me.tearOutHandlers?.releasePane?.(itemId) || null;
 
             delete me.tearOutPanes[itemId];
-            await me.tearOutHandlers.reintegrateItem(itemId, pane);
+            await me.tearOutHandlers?.reintegrateItem?.(itemId, pane);
             me.afterTearOutWindowDisconnect({committed: true, entry, expired: true, itemId, pane})
         }
     }
@@ -928,11 +929,14 @@ class Workspace extends Container {
             captured = isDetach ? WorkspaceDocument.captureItemPlacement(me.dockModel, descriptor.itemId) : null,
             result;
 
-        captured && me.tearOutHandlers.recordPlacement(descriptor.itemId, captured);
+        // Optional by CONTRACT, not defensively: the choreography exists only under
+        // `enableDockTearOutLifecycle`, so a workspace that declined it records no placement — which
+        // is the declinability itself, not a missing collaborator to guard against.
+        captured && me.tearOutHandlers?.recordPlacement(descriptor.itemId, captured);
 
         result = me.applyDockZoneOperation(descriptor);
 
-        isDetach && result?.errors?.length && me.tearOutHandlers.forgetPlacement(descriptor.itemId);
+        isDetach && result?.errors?.length && me.tearOutHandlers?.forgetPlacement(descriptor.itemId);
 
         return result
     }
@@ -1067,6 +1071,48 @@ class Workspace extends Container {
         );
 
         me.fire('dockTearOutAdoptionFailed', {component: me, ...data})
+    }
+
+    /**
+     * @summary WHERE a returning item lands — the return POLICY, which is the host's, not the
+     * choreography's.
+     *
+     * The engine answers with `restoreTab`, which re-mints the remembered parent/slot when the home
+     * node itself is gone: the exact position back, at the cost of resurrecting a node the user
+     * watched collapse. A consumer whose contract is "never resurrect a node" overrides this one
+     * method and answers with an append instead — which is what both shipped consumers do, and the
+     * reason each carried a whole forked return before this seam existed.
+     * @param {Object} document The committed document the item is returning into.
+     * @param {String} itemId
+     * @param {Object|null} placement The recorded `{tabsNodeId, index, home}`, or null.
+     * @returns {Object|null} A reducer descriptor, or null when no home can be found at all.
+     * @protected
+     */
+    resolveDockReturnDescriptor(document, itemId, placement) {
+        const target = placement || {
+            tabsNodeId: Object.entries(document?.nodes || {}).find(([, node]) => node.type === 'tabs')?.[0]
+        };
+
+        return target.tabsNodeId ? {operation: 'restoreTab', itemId, ...target} : null
+    }
+
+    /**
+     * @summary Observes a pane's semantic return, on the lifecycle's own channel.
+     *
+     * One method for both ends of the return: `phase` is `'before'` (the pane is about to travel,
+     * app-owned preparation belongs here) or `'after'` (`returned` carries the disposition). Two
+     * hooks used to exist for this and neither could see the other's half.
+     * @param {Object} data
+     * @param {Error} [data.error] Present when the projection rejected.
+     * @param {String[]} [data.errors] Present when the reducer refused.
+     * @param {String} data.itemId
+     * @param {Neo.component.Base|null} data.pane
+     * @param {String} data.phase `'before'` or `'after'`.
+     * @param {Boolean} [data.returned] Only on `'after'`.
+     * @protected
+     */
+    onDockPaneReturn(data) {
+        this.fire('dockPaneReturn', {component: this, ...data})
     }
 
     /**
@@ -1291,13 +1337,13 @@ class Workspace extends Container {
 
         for (const [itemId, entry] of Object.entries(me.tearOutPanes)) {
             if (entry.windowId === data.windowId) {
-                const pane = me.tearOutHandlers.releasePane(itemId);
+                const pane = me.tearOutHandlers?.releasePane?.(itemId) || null;
 
                 delete me.tearOutPanes[itemId];
                 delete me.tearOutConnects[itemId];
                 me.clearTearOutAdmission(itemId);
                 me.tearOutHandlers?.onVesselRetired({...entry, itemId});
-                await me.tearOutHandlers.reintegrateItem(itemId, pane);
+                await me.tearOutHandlers?.reintegrateItem?.(itemId, pane);
                 me.afterTearOutWindowDisconnect({committed: true, data, entry, itemId, pane});
                 return
             }
@@ -1353,7 +1399,7 @@ class Workspace extends Container {
 
         // The choreography returns the panes it held and forgets them in one call; destroying them
         // stays here, because component lifetime is never the decision machine's to own.
-        const panes = new Set(me.tearOutHandlers?.retirePaneState() || []);
+        const panes = new Set(me.tearOutHandlers?.retirePaneState?.() || []);
 
         panes.forEach(pane => me.settleDockPane(pane));
 
@@ -2760,7 +2806,7 @@ class Workspace extends Container {
             placeholders,
             preserveItemIds: [...new Set([
                 ...me.getPreservedItemIds(),
-                ...(me.enableDockTearOutLifecycle ? (me.tearOutHandlers?.heldPaneIds() || []) : []),
+                ...(me.enableDockTearOutLifecycle ? (me.tearOutHandlers?.heldPaneIds?.() || []) : []),
                 ...(refreshOptions.preserveItemIds || [])
             ])],
             resolveItem    : itemId => {
@@ -2923,7 +2969,7 @@ class Workspace extends Container {
      * @protected
      */
     resolveProjectedPane(itemId, item) {
-        const returning = this.tearOutHandlers?.takeReturningPane(itemId);
+        const returning = this.tearOutHandlers?.takeReturningPane?.(itemId);
 
         if (returning) {
             if (!returning.isDestroyed) {

--- a/src/dashboard/dock/model/Operations.mjs
+++ b/src/dashboard/dock/model/Operations.mjs
@@ -194,6 +194,34 @@ class Operations extends Base {
      * @returns {{document:Object, errors:String[]}}
      * @static
      */
+    /**
+     * @summary A return descriptor that NEVER resurrects a node — the append policy.
+     *
+     * The counterpart to {@link #restoreTab}, and the difference is the whole choice: `restoreTab`
+     * re-mints the remembered parent/slot when the home node is gone, buying the exact position back
+     * at the price of a node the user watched collapse. This one keeps the exact index only while the
+     * recorded home is still a live tabs node, and otherwise appends to the first surviving one.
+     *
+     * It lives here rather than in either consumer because both shipped hosts hold this contract and
+     * were carrying identical copies of it — and because "where does a returning item belong in this
+     * document" is a document question.
+     * @param {Object} document
+     * @param {String} itemId
+     * @param {Object|null} placement The recorded `{tabsNodeId, index}`, or null.
+     * @returns {Object|null} An `addTab` descriptor, or null when the document has no tabs node.
+     */
+    static appendingReturnDescriptor(document, itemId, placement) {
+        const storedHome = placement && document?.nodes?.[placement.tabsNodeId]?.type === 'tabs'
+                  ? placement.tabsNodeId
+                  : null,
+              tabsNodeId = storedHome
+                  || Object.entries(document?.nodes || {}).find(([, node]) => node.type === 'tabs')?.[0];
+
+        return tabsNodeId
+            ? {operation: 'addTab', itemId, tabsNodeId, ...(storedHome ? {index: placement.index} : {})}
+            : null
+    }
+
     static restoreTab(document, {home, index, itemId, tabsNodeId} = {}) {
         if (!document.items?.[itemId]) return {document, errors: [`unknown item "${itemId}"`]};
 

--- a/src/dashboard/dock/model/Operations.mjs
+++ b/src/dashboard/dock/model/Operations.mjs
@@ -194,6 +194,30 @@ class Operations extends Base {
      * @returns {{document:Object, errors:String[]}}
      * @static
      */
+    static restoreTab(document, {home, index, itemId, tabsNodeId} = {}) {
+        if (!document.items?.[itemId]) return {document, errors: [`unknown item "${itemId}"`]};
+
+        if (document.nodes?.[tabsNodeId]?.type === 'tabs') {
+            return Operations.addTab(document, {itemId, index, tabsNodeId})
+        }
+
+        if (!tabsNodeId) return {document, errors: ['restoreTab requires a tabsNodeId']};
+
+        let doc = WorkspaceDocument.clone(document),
+            // Reuse the recorded id when nothing has claimed it, so a round trip leaves the document
+            // it started from rather than one that merely looks like it.
+            nodeId = doc.nodes[tabsNodeId] ? WorkspaceDocument.genId(doc, tabsNodeId) : tabsNodeId,
+            errors;
+
+        WorkspaceDocument.detachFromTabs(doc, itemId);
+
+        doc.nodes[nodeId] = {activeItemId: itemId, items: [itemId], type: 'tabs'};
+
+        errors = WorkspaceDocument.restoreNodeHome(doc, nodeId, home);
+
+        return errors.length > 0 ? {document, errors} : WorkspaceDocument.commit(document, doc)
+    }
+
     /**
      * @summary A return descriptor that NEVER resurrects a node — the append policy.
      *
@@ -220,30 +244,6 @@ class Operations extends Base {
         return tabsNodeId
             ? {operation: 'addTab', itemId, tabsNodeId, ...(storedHome ? {index: placement.index} : {})}
             : null
-    }
-
-    static restoreTab(document, {home, index, itemId, tabsNodeId} = {}) {
-        if (!document.items?.[itemId]) return {document, errors: [`unknown item "${itemId}"`]};
-
-        if (document.nodes?.[tabsNodeId]?.type === 'tabs') {
-            return Operations.addTab(document, {itemId, index, tabsNodeId})
-        }
-
-        if (!tabsNodeId) return {document, errors: ['restoreTab requires a tabsNodeId']};
-
-        let doc = WorkspaceDocument.clone(document),
-            // Reuse the recorded id when nothing has claimed it, so a round trip leaves the document
-            // it started from rather than one that merely looks like it.
-            nodeId = doc.nodes[tabsNodeId] ? WorkspaceDocument.genId(doc, tabsNodeId) : tabsNodeId,
-            errors;
-
-        WorkspaceDocument.detachFromTabs(doc, itemId);
-
-        doc.nodes[nodeId] = {activeItemId: itemId, items: [itemId], type: 'tabs'};
-
-        errors = WorkspaceDocument.restoreNodeHome(doc, nodeId, home);
-
-        return errors.length > 0 ? {document, errors} : WorkspaceDocument.commit(document, doc)
     }
 
     /**

--- a/src/dashboard/dock/window/TearOut.mjs
+++ b/src/dashboard/dock/window/TearOut.mjs
@@ -46,10 +46,55 @@
  *     the host performs the platform work (URL, geometry, `windowOpen`) and resolves FALSY on any
  *     failed admission (`windowOpen` returns a Boolean — a blocked popup never throws, so the host
  *     must check the Boolean, not catch).
- * @returns {Object} `{activeVessel, onDockTearOutCancel, onDockTearOutEntry,
- *     onDockTearOutExit, onDockTearOutTerminal, onVesselRetired, retireActiveVessel}`
+ *
+ * The pane-handoff seams below carry the live-component half. Every one of them is host-supplied
+ * for the same reason the four above are: this module resolves, reparents and destroys nothing
+ * itself, so it keeps zero imports and every witness drives it without a browser.
+ * @param {Function} seams.awaitRefresh Host settle seam: `() => Promise<void>` — resolves when the
+ *     host's projection has applied the document this machine just committed. Rejection means the
+ *     return did not render, which is a failed reintegration, not a thrown gesture.
+ * @param {Function} seams.commitReturn Host return commit: `(document) => void` — publishes a
+ *     RETURNED document. Deliberately NOT `onDocumentChange`: that seam carries the detach
+ *     operation and the vessel generation, and a return has neither. Routing a return through it
+ *     would hand the host's zone-change path an operation and a source the return never had.
+ * @param {Function} seams.findContainingTabsId Host document query:
+ *     `(document, itemId) => String|null` — the tabs node currently holding an item, or null when
+ *     the tree does not hold it. Supplied rather than imported: `model/WorkspaceDocument` is the
+ *     only thing this choreography would otherwise need, and one import would cost the property
+ *     that lets every witness drive it without a browser.
+ * @param {Function} seams.getDocument Host document read: `() => Object|null` — the committed dock
+ *     document a return resolves its semantic home against.
+ * @param {Function} seams.onAdoptionFailed Host report seam:
+ *     `({entry, itemId, pane, reintegrated}) => void` — an admitted connection that could not embody
+ *     its live pane, after the compensating return resolved. `reintegrated` separates the
+ *     recoverable case from the one worth alarming on.
+ * @param {Function} seams.onPaneAdopted Host vessel-ownership write:
+ *     `(itemId, entry|null) => void` — `entry` records post-terminal vessel ownership, `null`
+ *     withdraws it. Vessel bookkeeping stays with the host deliberately: `window/Participation` and
+ *     the admission/retirement paths read it, and that lifecycle is a different owner's leaf.
+ * @param {Function} seams.onPaneReturn Host return observation:
+ *     `({error, errors, itemId, pane, phase, returned}) => void` — `phase` is `'before'` or
+ *     `'after'`. The one channel a consumer listens on to observe a pane coming home.
+ * @param {Function} seams.reparentPane Host render-topology move:
+ *     `(pane, target, itemId) => Boolean` — moves one live pane into the target window's view
+ *     without changing document truth. `false` means the pane did not arrive. `itemId` travels with
+ *     the pane because a host that staged the move already (a vessel embodiment) answers by
+ *     identity, not by component reference.
+ * @param {Function} seams.resolvePane Host pane resolution: `(itemId) => Neo.component.Base|null` —
+ *     the live pane a vessel should embody. The stand-in exclusion that used to live here folded
+ *     into the host's own resolver, which is the only place that knows what a pane is.
+ * @param {Function} seams.settlePane Host pane teardown: `(pane) => void` — destroys a live pane
+ *     only when no semantic home can own it.
+ * @returns {Object} `{activeVessel, adoptPane, capturePane, forgetPlacement, onDockTearOutCancel,
+ *     onDockTearOutEntry, onDockTearOutExit, onDockTearOutTerminal, onVesselRetired, recordPlacement,
+ *     reintegrateItem, releasePane, retireActiveVessel, retirePaneState, takeReturningPane,
+ *     updateAdoptedPane}`
  */
-export function createDockTearOutHandlers({applyOperation, closeVessel, onDocumentChange, openVessel}) {
+export function createDockTearOutHandlers({
+    applyOperation, awaitRefresh, closeVessel, commitReturn, findContainingTabsId, getDocument,
+    onAdoptionFailed, onDocumentChange, onPaneAdopted, onPaneReturn, openVessel, reparentPane,
+    resolvePane, settlePane
+}) {
     // The admitted slot is deliberately separate from provisional acquisition and cleanup-only
     // late authority. A terminal can invalidate an in-flight host Promise before it settles; its
     // result may then be retired, but can never become active/committable for a dead gesture.
@@ -58,6 +103,15 @@ export function createDockTearOutHandlers({applyOperation, closeVessel, onDocume
         lateVessel          = null,
         pendingAdmission    = null,
         retirement          = null;
+
+    // The pane-handoff state. It lives in this closure for the same reason the vessel slot does:
+    // it is gesture bookkeeping, and a host that holds it has to be told when to clear it.
+    //   paneHandles — the live pane captured BEFORE detach re-projection can retire it;
+    //   placements  — the exact semantic home a return restores into;
+    //   returning   — a pane in flight home, which the host's resolver must prefer over a fresh build.
+    let paneHandles = {},
+        placements  = {},
+        returning   = {};
 
     /**
      * @summary Creates the exact vessel identity without widening its enumerable public payload.
@@ -144,12 +198,323 @@ export function createDockTearOutHandlers({applyOperation, closeVessel, onDocume
         return state.promise
     };
 
-    return {
+    /**
+     * @summary The live pane for one item: the captured handle first, the host's resolver second.
+     *
+     * Handle-first is what makes adoption work at all. The sequence is capture → re-project → adopt:
+     * the capture stores the pane while it is still in the tree, the detach re-projection then
+     * removes it, and adoption runs afterwards. A resolver-only lookup therefore succeeds at capture
+     * and returns null at the exact moment it matters.
+     * @param {String} itemId
+     * @returns {Neo.component.Base|null}
+     */
+    const livePane = itemId => {
+        const held = paneHandles[itemId];
+
+        if (held && !held.isDestroyed) return held;
+
+        return resolvePane(itemId) || null
+    };
+
+    /**
+     * @summary The first tabs node in document order — a home for an item with no record at all.
+     *
+     * Not a placement: it is wherever enumeration happens to start. It stands in only because a pane
+     * somewhere valid beats a pane dropped out of the tree.
+     * @param {Object} document
+     * @returns {String|undefined}
+     */
+    const lastResortTabsId = document =>
+        Object.entries(document?.nodes || {}).find(([, node]) => node.type === 'tabs')?.[0];
+
+    // Named, not `this`: two hosts SPREAD this bundle into a projection context
+    // (`dock/Workspace#getDockProjectionOptions`, `DemoBWorkspace`), and a spread rebinds `this` to
+    // the copy. Every internal call therefore goes through the closure reference, which survives it.
+    const api = {
         /**
          * @member {Object|null} activeVessel
          */
         get activeVessel() {
             return activeVessel
+        },
+
+        /**
+         * @summary Captures the host-resolved live pane before detach re-projection can retire it.
+         * @param {String} itemId
+         * @returns {Boolean} Whether a live pane was held.
+         */
+        capturePane(itemId) {
+            const pane = livePane(itemId);
+
+            if (!pane || pane.isDestroyed) return false;
+
+            paneHandles[itemId] = pane;
+
+            return true
+        },
+
+        /**
+         * @summary Releases one held pane handle for return, without retaining a second owner.
+         * @param {String} itemId
+         * @returns {Neo.component.Base|null}
+         */
+        releasePane(itemId) {
+            const pane = paneHandles[itemId] || null;
+
+            delete paneHandles[itemId];
+
+            return pane
+        },
+
+        /**
+         * @summary Records the exact semantic home a return restores into.
+         * @param {String} itemId
+         * @param {Object} placement `{tabsNodeId, index}` captured before the detach applies.
+         * @returns {void}
+         */
+        recordPlacement(itemId, placement) {
+            placement && (placements[itemId] = placement)
+        },
+
+        /**
+         * @summary Drops a recorded home — a refused detach never earned one.
+         * @param {String} itemId
+         * @returns {void}
+         */
+        forgetPlacement(itemId) {
+            delete placements[itemId]
+        },
+
+        /**
+         * @summary Reads a recorded home WITHOUT consuming it.
+         *
+         * Hosts render the stored home in their own affordances — a return-here hint, a preview
+         * target — and reading must not disturb the record the actual return depends on.
+         * @param {String} itemId
+         * @returns {Object|null}
+         */
+        peekPlacement(itemId) {
+            return placements[itemId] || null
+        },
+
+        /**
+         * @summary Hands one in-flight returning pane to the host's resolver, exactly once.
+         *
+         * The host's projection asks for this while rebuilding: a pane coming home must be reused,
+         * never rebuilt, or the return silently swaps the user's live component for a fresh one.
+         * @param {String} itemId
+         * @returns {Neo.component.Base|null}
+         */
+        takeReturningPane(itemId) {
+            const pane = returning[itemId] || null;
+
+            pane && delete returning[itemId];
+
+            return pane
+        },
+
+        /**
+         * @summary Every live pane this machine still holds — the host's teardown sweep reads it.
+         * @returns {Neo.component.Base[]}
+         */
+        heldPanes() {
+            return [...Object.values(returning), ...Object.values(paneHandles)]
+        },
+
+        /**
+         * @summary Item ids with a captured handle, for the host's own projection bookkeeping.
+         * @returns {String[]}
+         */
+        heldPaneIds() {
+            return Object.keys(paneHandles)
+        },
+
+        /**
+         * @summary Promotes one committed item into post-terminal vessel ownership.
+         *
+         * The host writes the ownership record through {@link seams.onPaneAdopted} and clears its own
+         * admission bookkeeping in the same call — the connection is consumed here, so nothing may
+         * observe it afterwards. A connection that cannot embody its pane compensates and throws:
+         * the caller is an event listener, and a silent failure here is a window that opened, took
+         * the pane and died with the pane still inside it.
+         * @param {String} itemId
+         * @param {Object} [vessel={}]
+         * @param {Object|null} [connection=null] The admitted window connection, when one bound.
+         * @returns {void}
+         */
+        adoptPane(itemId, vessel={}, connection=null) {
+            const entry = {
+                generation     : vessel.generation      ?? connection?.generation      ?? null,
+                generationToken: vessel.generationToken ?? connection?.generationToken ?? null,
+                gestureToken   : vessel.gestureToken    ?? connection?.gestureToken    ?? null,
+                windowId       : connection?.windowId ?? null,
+                windowName     : vessel.windowName || connection?.windowName || `tearout-${itemId}`,
+                workspaceKey   : vessel.workspaceKey ?? connection?.workspaceKey ?? null
+            };
+
+            onPaneAdopted(itemId, entry, connection);
+
+            if (connection) {
+                const pane = livePane(itemId);
+
+                if (!pane || pane.isDestroyed || !reparentPane(pane, connection, itemId)) {
+                    api.compensateFailedAdoption(itemId, entry);
+                    throw new Error(`Dock tear-out: pane "${itemId}" could not enter its admitted vessel`)
+                }
+
+                onPaneAdopted(itemId, {...entry, ...connection})
+            }
+        },
+
+        /**
+         * @summary Folds a later-arriving window binding into an existing ownership record.
+         * @param {String} itemId
+         * @param {Object} target
+         * @returns {void}
+         */
+        updateAdoptedPane(itemId, target) {
+            target && onPaneAdopted(itemId, target, null, true)
+        },
+
+        /**
+         * @summary Moves an ALREADY-adopted item's live pane into a window that bound afterwards.
+         *
+         * The connect-race partner of {@link #adoptPane}: the terminal adopted with no connection,
+         * and the window bound later. Same decision, different arrival order — so it lives here
+         * rather than being re-derived by every host that can hit the race.
+         * @param {String} itemId
+         * @param {Object} connection
+         * @returns {Boolean} Whether the pane arrived.
+         */
+        reparentAdopted(itemId, connection) {
+            const pane = livePane(itemId);
+
+            if (!pane || pane.isDestroyed || !reparentPane(pane, connection, itemId)) return false;
+
+            onPaneAdopted(itemId, connection, null, true);
+
+            return true
+        },
+
+        /**
+         * @summary Compensates an admitted connection that cannot embody its live pane.
+         *
+         * Returns the reporting promise. Both callers throw immediately after and ignore it, but the
+         * compensation's own completion is otherwise unobservable — and an outcome nothing can await
+         * is an outcome nothing can assert.
+         *
+         * The vessel retires through this machine's OWN retirement rather than back out through the
+         * host: the slot being cleared is the one held here, so the round-trip the extraction removed
+         * was never carrying information.
+         * @param {String} itemId
+         * @param {Object} [entry={}]
+         * @returns {Promise<void>}
+         */
+        compensateFailedAdoption(itemId, entry={}) {
+            const pane   = api.releasePane(itemId),
+                  vessel = {...entry, itemId};
+
+            onPaneAdopted(itemId, null);
+
+            Promise.resolve(retireVessel(vessel)).then(closed => {
+                closed && api.onVesselRetired(vessel)
+            });
+
+            // The report waits for the return to actually resolve. Reading a pane HANDLE instead
+            // would answer a different question — one that is true in exactly the case worth
+            // alarming on, since a failed adoption is precisely when a pane was held and could
+            // still fail to come home.
+            return Promise.resolve(api.reintegrateItem(itemId, pane)).then(reintegrated => {
+                onAdoptionFailed({entry, itemId, pane, reintegrated})
+            })
+        },
+
+        /**
+         * @summary Returns a dead vessel's item to its exact semantic position and same live pane.
+         * @param {String} itemId
+         * @param {Neo.component.Base|null} pane
+         * @returns {Promise<Boolean>}
+         */
+        async reintegrateItem(itemId, pane) {
+            const document  = getDocument(),
+                  placement = placements[itemId],
+                  target    = placement || {tabsNodeId: lastResortTabsId(document)},
+                  live      = Boolean(pane && !pane.isDestroyed);
+
+            let result;
+
+            delete placements[itemId];
+
+            if (!document?.items?.[itemId] || !target.tabsNodeId) {
+                settlePane(pane);
+                onPaneReturn({itemId, pane, phase: 'after', returned: false});
+                return false
+            }
+
+            if (live) {
+                pane.parent?.remove(pane, false);
+                returning[itemId] = pane
+            }
+
+            onPaneReturn({itemId, pane, phase: 'before'});
+
+            /**
+             * @summary Awaits the host projection, reporting the settle as the return's outcome.
+             * @param {Object} nextDocument
+             * @returns {Promise<Boolean>}
+             */
+            const settle = async nextDocument => {
+                commitReturn(nextDocument);
+
+                try {
+                    await awaitRefresh();
+                    onPaneReturn({itemId, pane, phase: 'after', returned: true});
+                    return true
+                } catch (error) {
+                    onPaneReturn({error, itemId, pane, phase: 'after', returned: false});
+                    return false
+                }
+            };
+
+            // Already in the tree: the document needs no operation, only a projection pass.
+            if (findContainingTabsId(document, itemId)) {
+                return settle(document)
+            }
+
+            result = applyOperation({operation: 'restoreTab', itemId, ...target});
+
+            if (result?.errors?.length > 0 && placement) {
+                // The recorded home resolved to nothing — its zone AND the sibling it collapsed into
+                // are both gone. Losing the position is bad; losing the pane is worse.
+                result = applyOperation({operation: 'restoreTab', itemId, tabsNodeId: lastResortTabsId(document)})
+            }
+
+            if (result?.errors?.length === 0) {
+                return settle(result.document)
+            }
+
+            delete returning[itemId];
+            settlePane(pane);
+            onPaneReturn({errors: result?.errors || [], itemId, pane, phase: 'after', returned: false});
+
+            return false
+        },
+
+        /**
+         * @summary Drops every pane-handoff record this machine holds, returning the live panes.
+         *
+         * The host destroys them: this machine resolves and reparents nothing itself, and teardown
+         * is the one moment where that boundary would otherwise be tempting to cross.
+         * @returns {Neo.component.Base[]} The panes that were still held.
+         */
+        retirePaneState() {
+            const held = [...Object.values(returning), ...Object.values(paneHandles)];
+
+            paneHandles = {};
+            placements  = {};
+            returning   = {};
+
+            return held
         },
 
         /**
@@ -349,5 +714,7 @@ export function createDockTearOutHandlers({applyOperation, closeVessel, onDocume
                 return retireVessel(vessel)
             }
         }
-    }
+    };
+
+    return api
 }

--- a/src/dashboard/dock/window/TearOut.mjs
+++ b/src/dashboard/dock/window/TearOut.mjs
@@ -80,6 +80,14 @@
  *     without changing document truth. `false` means the pane did not arrive. `itemId` travels with
  *     the pane because a host that staged the move already (a vessel embodiment) answers by
  *     identity, not by component reference.
+ * @param {Function} seams.resolveReturnDescriptor Host return POLICY:
+ *     `(document, itemId, placement|null) => Object|null` — the reducer descriptor that brings an
+ *     item home, or null when nothing can. The choreography owns WHEN a return happens; WHERE it
+ *     lands when the recorded home is gone is a product decision and stays with the host.
+ *     `Operations.restoreTab` MINTS a node at the remembered parent/slot, which is right for a host
+ *     that wants the exact position back and wrong for one whose contract is "never resurrect a
+ *     node" — both shipped consumers hold the second contract, which is why both carried their own
+ *     return before this seam existed.
  * @param {Function} seams.resolvePane Host pane resolution: `(itemId) => Neo.component.Base|null` —
  *     the live pane a vessel should embody. The stand-in exclusion that used to live here folded
  *     into the host's own resolver, which is the only place that knows what a pane is.
@@ -93,7 +101,7 @@
 export function createDockTearOutHandlers({
     applyOperation, awaitRefresh, closeVessel, commitReturn, findContainingTabsId, getDocument,
     onAdoptionFailed, onDocumentChange, onPaneAdopted, onPaneReturn, openVessel, reparentPane,
-    resolvePane, settlePane
+    resolvePane, resolveReturnDescriptor, settlePane
 }) {
     // The admitted slot is deliberately separate from provisional acquisition and cleanup-only
     // late authority. A terminal can invalidate an in-flight host Promise before it settles; its
@@ -216,17 +224,6 @@ export function createDockTearOutHandlers({
         return resolvePane(itemId) || null
     };
 
-    /**
-     * @summary The first tabs node in document order — a home for an item with no record at all.
-     *
-     * Not a placement: it is wherever enumeration happens to start. It stands in only because a pane
-     * somewhere valid beats a pane dropped out of the tree.
-     * @param {Object} document
-     * @returns {String|undefined}
-     */
-    const lastResortTabsId = document =>
-        Object.entries(document?.nodes || {}).find(([, node]) => node.type === 'tabs')?.[0];
-
     // Named, not `this`: two hosts SPREAD this bundle into a projection context
     // (`dock/Workspace#getDockProjectionOptions`, `DemoBWorkspace`), and a spread rebinds `this` to
     // the copy. Every internal call therefore goes through the closure reference, which survives it.
@@ -251,6 +248,30 @@ export function createDockTearOutHandlers({
             paneHandles[itemId] = pane;
 
             return true
+        },
+
+        /**
+         * @summary The pane adoption WOULD use for one item — the held handle, else the host's.
+         *
+         * Reads without consuming, so asking the question cannot change the answer.
+         * @param {String} itemId
+         * @returns {Neo.component.Base|null}
+         */
+        peekPane(itemId) {
+            return livePane(itemId)
+        },
+
+        /**
+         * @summary ONLY the captured handle — never the host's resolver.
+         *
+         * The distinction matters: {@link #peekPane} answers "what would adoption use", which falls
+         * through to the tree. This answers "is a handle actually held", and a caller asking whether
+         * capture happened must not be told yes by a pane that was merely findable.
+         * @param {String} itemId
+         * @returns {Neo.component.Base|null}
+         */
+        heldPane(itemId) {
+            return paneHandles[itemId] || null
         },
 
         /**
@@ -283,6 +304,19 @@ export function createDockTearOutHandlers({
          */
         forgetPlacement(itemId) {
             delete placements[itemId]
+        },
+
+        /**
+         * @summary Every recorded home, as a plain copy.
+         *
+         * A GETTER rather than a method on purpose: the end-to-end witnesses read lifecycle state by
+         * property path (`tearOutHandlers.placements`, exactly as they already read
+         * `tearOutHandlers.activeVessel`), so this keeps the closure observable without the host
+         * carrying an accessor for state it no longer owns.
+         * @member {Object} placements
+         */
+        get placements() {
+            return {...placements}
         },
 
         /**
@@ -362,7 +396,9 @@ export function createDockTearOutHandlers({
                     throw new Error(`Dock tear-out: pane "${itemId}" could not enter its admitted vessel`)
                 }
 
-                onPaneAdopted(itemId, {...entry, ...connection})
+                // MERGE, never replace: a replace re-derives the record from `entry` alone, which
+                // silently drops the `windowId` the connection just supplied.
+                onPaneAdopted(itemId, connection, null, true)
             }
         },
 
@@ -437,15 +473,19 @@ export function createDockTearOutHandlers({
          */
         async reintegrateItem(itemId, pane) {
             const document  = getDocument(),
-                  placement = placements[itemId],
-                  target    = placement || {tabsNodeId: lastResortTabsId(document)},
+                  placement = placements[itemId] || null,
                   live      = Boolean(pane && !pane.isDestroyed);
 
             let result;
 
             delete placements[itemId];
 
-            if (!document?.items?.[itemId] || !target.tabsNodeId) {
+            // WHERE the item lands is the host's policy — see `resolveReturnDescriptor`. Asking
+            // before the guard below means a host that can find no home says so once, here, rather
+            // than by returning a descriptor the reducer then refuses.
+            const descriptor = document ? resolveReturnDescriptor(document, itemId, placement) : null;
+
+            if (!document?.items?.[itemId] || !descriptor) {
                 settlePane(pane);
                 onPaneReturn({itemId, pane, phase: 'after', returned: false});
                 return false
@@ -476,17 +516,28 @@ export function createDockTearOutHandlers({
                 }
             };
 
-            // Already in the tree: the document needs no operation, only a projection pass.
+            // Already in the tree — some other flow re-treed it, typically an atomic recovery that
+            // ran first. The document needs no operation; it needs a projection pass ONLY if a live
+            // pane is coming home to be re-projected. With no pane there is nothing to show, and
+            // committing anyway publishes a second, optionless projection over the recovery's own.
             if (findContainingTabsId(document, itemId)) {
+                if (!live) {
+                    onPaneReturn({itemId, pane, phase: 'after', returned: true});
+                    return true
+                }
+
                 return settle(document)
             }
 
-            result = applyOperation({operation: 'restoreTab', itemId, ...target});
+            result = applyOperation(descriptor);
 
             if (result?.errors?.length > 0 && placement) {
-                // The recorded home resolved to nothing — its zone AND the sibling it collapsed into
-                // are both gone. Losing the position is bad; losing the pane is worse.
-                result = applyOperation({operation: 'restoreTab', itemId, tabsNodeId: lastResortTabsId(document)})
+                // The host's first answer resolved to nothing — its zone AND the sibling it
+                // collapsed into are both gone. Losing the position is bad; losing the pane is
+                // worse, so ask again with no remembered home and take whatever the host offers.
+                const fallback = resolveReturnDescriptor(document, itemId, null);
+
+                fallback && (result = applyOperation(fallback))
             }
 
             if (result?.errors?.length === 0) {
@@ -706,13 +757,41 @@ export function createDockTearOutHandlers({
                 result = {document: null, errors: [`detachItem threw: ${error?.message || error}`]}
             }
 
-            if (result && !result.errors?.length && result.document) {
-                activeVessel = null;
-                onDocumentChange(result.document, operation, vessel);
-                return true
-            } else {
+            if (!result || result.errors?.length || !result.document) {
                 return retireVessel(vessel)
             }
+
+            activeVessel = null;
+
+            /**
+             * @summary Routes a refused publication back onto the existing retirement path.
+             *
+             * The slot is restored FIRST: `retireVessel` clears by identity, so a vessel that was
+             * already nulled would retire without ever releasing the slot.
+             * @returns {Boolean|Promise<Boolean>}
+             */
+            const refuse = () => {
+                activeVessel = vessel;
+                return retireVessel(vessel)
+            };
+
+            let published;
+
+            try {
+                published = onDocumentChange(result.document, operation, vessel)
+            } catch {
+                return refuse()
+            }
+
+            // A host that publishes synchronously returns undefined and is admitted unchanged —
+            // only an explicit `false` or a rejected Promise is a refusal. An asynchronous owner
+            // (the Group's admission barrier) is awaited, so the terminal never reports a commit
+            // that has not actually landed, and never swallows a structured refusal.
+            if (typeof published?.then !== 'function') {
+                return published === false ? refuse() : true
+            }
+
+            return published.then(settled => settled === false ? refuse() : true, refuse)
         }
     };
 

--- a/src/dashboard/dock/window/TearOut.mjs
+++ b/src/dashboard/dock/window/TearOut.mjs
@@ -394,9 +394,14 @@ export function createDockTearOutHandlers({
             onPaneAdopted(itemId, entry, connection);
 
             if (connection) {
-                const pane = livePane(itemId);
-
-                if (!pane || pane.isDestroyed || !reparentPane(pane, connection, itemId)) {
+                // The pane is OFFERED, never required. A host may answer by identity rather than by
+                // the component this machine can see — `apps/workstation` promotes an already-staged
+                // vessel embodiment and otherwise reads its own `paneCache`, neither of which is
+                // reachable from the projected tree. Refusing here when `livePane` finds nothing
+                // reinstates the failure the resolver default was written to remove: the vessel
+                // opens, adoption declines, compensation closes it, and the user sees a pop-out that
+                // does nothing. Only the host's own `false` is a refusal.
+                if (!reparentPane(livePane(itemId), connection, itemId)) {
                     api.compensateFailedAdoption(itemId, entry);
                     throw new Error(`Dock tear-out: pane "${itemId}" could not enter its admitted vessel`)
                 }
@@ -428,9 +433,9 @@ export function createDockTearOutHandlers({
          * @returns {Boolean} Whether the pane arrived.
          */
         reparentAdopted(itemId, connection) {
-            const pane = livePane(itemId);
-
-            if (!pane || pane.isDestroyed || !reparentPane(pane, connection, itemId)) return false;
+            // Offered, not required — same reason as {@link #adoptPane}: the host may resolve by
+            // identity where this machine sees no component.
+            if (!reparentPane(livePane(itemId), connection, itemId)) return false;
 
             onPaneAdopted(itemId, connection, null, true);
 

--- a/src/dashboard/dock/window/TearOut.mjs
+++ b/src/dashboard/dock/window/TearOut.mjs
@@ -53,10 +53,15 @@
  * @param {Function} seams.awaitRefresh Host settle seam: `() => Promise<void>` — resolves when the
  *     host's projection has applied the document this machine just committed. Rejection means the
  *     return did not render, which is a failed reintegration, not a thrown gesture.
- * @param {Function} seams.commitReturn Host return commit: `(document) => void` — publishes a
- *     RETURNED document. Deliberately NOT `onDocumentChange`: that seam carries the detach
- *     operation and the vessel generation, and a return has neither. Routing a return through it
- *     would hand the host's zone-change path an operation and a source the return never had.
+ * @param {Function} seams.commitReturn Host return commit:
+ *     `(document) => void|Boolean|Promise<void|Boolean>` — publishes a RETURNED document. **Awaited,
+ *     and an explicit `false`, a throw or a rejection fails the return**; every other resolution
+ *     admits it, so a host that publishes without opinion is unaffected. An asynchronous host must
+ *     not resolve before its publication has actually landed — that promise is the only thing
+ *     standing between an unlanded return and a `returned: true` report.
+ *     Deliberately NOT `onDocumentChange`: that seam carries the detach operation and the vessel
+ *     generation, and a return has neither. Routing a return through it would hand the host's
+ *     zone-change path an operation and a source the return never had.
  * @param {Function} seams.findContainingTabsId Host document query:
  *     `(document, itemId) => String|null` — the tabs node currently holding an item, or null when
  *     the tree does not hold it. Supplied rather than imported: `model/WorkspaceDocument` is the
@@ -504,9 +509,26 @@ export function createDockTearOutHandlers({
              * @returns {Promise<Boolean>}
              */
             const settle = async nextDocument => {
-                commitReturn(nextDocument);
-
                 try {
+                    // A return has TWO barriers, and awaiting only the second is what made this
+                    // report success early. `commitReturn` is the publication barrier — a host whose
+                    // publish is asynchronous (the Group) resolves it only once its own projection is
+                    // installed, so a return that skipped it reported `returned: true` against a
+                    // publication that had not landed and could still refuse. The refresh below is
+                    // the projection barrier, and it cannot stand in for the first: with an
+                    // already-settled previous refresh it resolves immediately and witnesses nothing.
+                    //
+                    // Inside the `try` deliberately: a synchronous throw from `commitReturn` used to
+                    // escape this function entirely, past the failure report the caller relies on.
+                    const published = await commitReturn(nextDocument);
+
+                    // Only an explicit `false` refuses. Every host today returns undefined, and a
+                    // host that publishes without opinion must not be read as refusing.
+                    if (published === false) {
+                        onPaneReturn({itemId, pane, phase: 'after', returned: false});
+                        return false
+                    }
+
                     await awaitRefresh();
                     onPaneReturn({itemId, pane, phase: 'after', returned: true});
                     return true

--- a/test/playwright/component/apps/dock-popout/app.mjs
+++ b/test/playwright/component/apps/dock-popout/app.mjs
@@ -268,7 +268,7 @@ class PopOutFixtureWorkspace extends DockWorkspace {
             return
         }
 
-        this.compensateFailedTearOutAdoption(value, {windowName: `dock-popout-vessel-${value}`})
+        this.tearOutHandlers.compensateFailedAdoption(value, {windowName: `dock-popout-vessel-${value}`})
     }
 
     /**

--- a/test/playwright/e2e/dashboard/DemoBDockTearOutNL.spec.mjs
+++ b/test/playwright/e2e/dashboard/DemoBDockTearOutNL.spec.mjs
@@ -206,7 +206,7 @@ test.describe('Dashboard Demo B — real dock tear-out gesture', () => {
 
         await expect.poll(async () => {
             const state = await ctx.app.getComponent(ctx.wsId, [
-                      'tearOutConnects', 'tearOutPanes', 'tearOutPlacements'
+                      'tearOutConnects', 'tearOutHandlers.placements', 'tearOutPanes'
                   ]),
                   pane  = await getCounter(ctx.app);
 
@@ -214,22 +214,21 @@ test.describe('Dashboard Demo B — real dock tear-out gesture', () => {
                 connects: Object.keys(state.tearOutConnects).length,
                 paneId  : pane.id,
                 panes   : Object.keys(state.tearOutPanes).length,
-                places  : Object.keys(state.tearOutPlacements).length
+                places  : Object.keys(state['tearOutHandlers.placements']).length
             }
         }, {
             message: 'cancel must retire every vessel record while preserving the live pane',
             timeout: 5000
         }).toEqual({connects: 0, paneId: paneBefore.id, panes: 0, places: 0});
 
-        const settled = await ctx.app.getComponent(ctx.wsId, [
-            'dockModel', 'tearOutConnects', 'tearOutPanes', 'tearOutPlacements'
-        ]);
+        const lifecycleState = () => ctx.app.getComponent(ctx.wsId, [
+                  'dockModel', 'tearOutConnects', 'tearOutHandlers.placements', 'tearOutPanes'
+              ]),
+              settled        = await lifecycleState();
 
         await ctx.app.callMethod(ctx.wsId, 'onWindowDisconnect', [{windowId: vesselWindowId}]);
 
-        expect(await ctx.app.getComponent(ctx.wsId, [
-            'dockModel', 'tearOutConnects', 'tearOutPanes', 'tearOutPlacements'
-        ]), 'repeating the closed vessel terminal is a no-op').toEqual(settled);
+        expect(await lifecycleState(), 'repeating the closed vessel terminal is a no-op').toEqual(settled);
         expect((await getCounter(ctx.app)).id).toBe(paneBefore.id);
         expect(ctx.runtimeErrors).toEqual([]);
         expect(ctx.pageErrors).toEqual([]);

--- a/test/playwright/e2e/dashboard/TearOutMatrixRows4To7NL.spec.mjs
+++ b/test/playwright/e2e/dashboard/TearOutMatrixRows4To7NL.spec.mjs
@@ -41,7 +41,7 @@ test.describe('tear-out portability matrix — Demo B dock lifecycle, headed', (
             'dockModel',
             'tearOutConnects',
             'tearOutPanes',
-            'tearOutPlacements'
+            'tearOutHandlers.placements'
         ])
     }
 
@@ -73,7 +73,7 @@ test.describe('tear-out portability matrix — Demo B dock lifecycle, headed', (
             'tearOutConnects',
             'tearOutHandlers.activeVessel',
             'tearOutPanes',
-            'tearOutPlacements',
+            'tearOutHandlers.placements',
             'tearOutRetirements.size',
             'vesselReservations.size'
         ])
@@ -172,7 +172,7 @@ test.describe('tear-out portability matrix — Demo B dock lifecycle, headed', (
             'vesselReservations.size'     : 0,
             tearOutConnects               : {},
             tearOutPanes                  : {},
-            tearOutPlacements             : {}
+            'tearOutHandlers.placements'  : {}
         });
         expect(snapshot.homeCount).toBe(1);
         expect(snapshot.mainRenderCount).toBe(1);
@@ -363,7 +363,7 @@ test.describe('tear-out portability matrix — Demo B dock lifecycle, headed', (
                 homes   : homes.length,
                 panes   : Object.keys(state.tearOutPanes).length,
                 paneId  : pane?.id,
-                places  : Object.keys(state.tearOutPlacements).length,
+                places  : Object.keys(state['tearOutHandlers.placements']).length,
                 rendered: await page.locator('.agentos-dockdemo-counter-pane').count()
             }
         }, {
@@ -474,7 +474,7 @@ test.describe('tear-out portability matrix — Demo B dock lifecycle, headed', (
             tearOutConnects               : {}
         });
         expect(Object.keys(committed.lifecycle.tearOutPanes)).toEqual(['workbench']);
-        expect(Object.keys(committed.lifecycle.tearOutPlacements)).toEqual(['workbench']);
+        expect(Object.keys(committed.lifecycle['tearOutHandlers.placements'])).toEqual(['workbench']);
         expect(committed.homeCount).toBe(0);
         expect(committed.mainRenderCount).toBe(0);
         expect(committed.pane).toEqual({
@@ -502,7 +502,7 @@ test.describe('tear-out portability matrix — Demo B dock lifecycle, headed', (
                 connects: Object.keys(snapshot.lifecycle.tearOutConnects).length,
                 homes   : snapshot.homeCount,
                 panes   : Object.keys(snapshot.lifecycle.tearOutPanes).length,
-                places  : Object.keys(snapshot.lifecycle.tearOutPlacements).length,
+                places  : Object.keys(snapshot.lifecycle['tearOutHandlers.placements']).length,
                 popups  : snapshot.popupUrls.length,
                 rendered: snapshot.mainRenderCount
             }

--- a/test/playwright/e2e/workstation/WorkstationNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationNL.spec.mjs
@@ -2505,12 +2505,12 @@ test.describe('Workstation — dense living-data composition', () => {
 
             await expect.poll(async () => {
                 const state = await app.getComponent(workspaceId, [
-                    'lastVesselOpen', 'tearOutPanes', 'tearOutPlacements', 'tearOutVesselDims'
+                    'lastVesselOpen', 'tearOutHandlers.placements', 'tearOutPanes', 'tearOutVesselDims'
                 ]);
 
                 return {
                     dims     : state.tearOutVesselDims,
-                    placement: state.tearOutPlacements?.commits,
+                    placement: state['tearOutHandlers.placements']?.commits,
                     stage    : state.lastVesselOpen?.stage,
                     windowId : state.tearOutPanes?.commits?.windowId
                 }
@@ -2552,13 +2552,15 @@ test.describe('Workstation — dense living-data composition', () => {
             }).toBe(true);
 
             await expect.poll(async () => {
-                const state = await app.getComponent(workspaceId, ['dockModel', 'tearOutPanes', 'tearOutPlacements']);
+                const state = await app.getComponent(workspaceId, [
+                    'dockModel', 'tearOutHandlers.placements', 'tearOutPanes'
+                ]);
 
                 return {
                     inTree   : Object.values(state.dockModel.nodes)
                         .some(node => node.type === 'tabs' && node.items?.includes('commits')),
                     pane     : state.tearOutPanes?.commits ?? null,
-                    placement: state.tearOutPlacements?.commits ?? null
+                    placement: state['tearOutHandlers.placements']?.commits ?? null
                 }
             }, {
                 message  : 'physical vessel death clears lifecycle owners and reintegrates Commit Stream',

--- a/test/playwright/e2e/workstation/WorkstationPopOutPaneIdentityNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationPopOutPaneIdentityNL.spec.mjs
@@ -1,0 +1,173 @@
+import {expect, test} from '../../fixtures.mjs';
+
+/**
+ * @summary A nested pane subtree survives a REAL pop-out and return with its component, provider,
+ * store and descendant identities intact.
+ *
+ * The three identities are deliberately separate claims, because they fail separately. A hop that
+ * rebuilt the component would break every one of them at once and is the easy case. The interesting
+ * failures are quieter: a pane that keeps its own id while its `state.Provider` is re-resolved in the
+ * popup reads different truth from the same expression, and a pane that keeps component AND provider
+ * while its `data.Store` is re-created shows the same rows re-fetched rather than the rows the user
+ * was looking at. Asserting only the component id certifies none of that.
+ *
+ * The witness is the Feed pane — a `grid.Container` whose item tree carries real descendants — rather
+ * than a leaf panel, because "the same instance made the hop" is trivially true for a component with
+ * nothing under it. The descendant census is what makes the subtree claim non-vacuous, and it is read
+ * from the App Worker's own instance graph, not from DOM: DOM nodes are necessarily rebuilt in the
+ * target document, so a DOM-identity claim would be false by construction and a DOM-count claim
+ * proves only that something rendered.
+ *
+ * The return leg is not decoration. Adoption and reintegration are different code paths with
+ * different owners, and a pane can survive the outbound hop and come home rebuilt.
+ *
+ * Requires a Neural Link runtime root:
+ *
+ *      NEO_AGENTOS_RUNTIME_ROOT=<neo-agent-brain> \
+ *      npx playwright test workstation/WorkstationPopOutPaneIdentityNL -c test/playwright/playwright.config.e2e.mjs --workers=1
+ *
+ * Without it `playwright.config.e2e.mjs` EXCLUDES every neuralLink-fixture spec from selection, so
+ * the command selects zero tests and reports success.
+ */
+const
+    ACTION     = '.neo-toolbar-action',
+    FEED_ITEM  = 'feed',
+    FEED_TITLE = 'Live Event Stream',
+    HEADER     = '.neo-tab-header-toolbar',
+    POP_OUT    = 'window-restore',
+    TAB        = '.neo-tab-header-button';
+
+/**
+ * @summary The identity triple plus the descendant census, read from the App Worker instance graph.
+ * @param {Object} app Neural Link app wrapper.
+ * @param {String} paneId
+ * @returns {Promise<{componentId: String, providerId: String|null, storeId: String|null, descendants: String[]}>}
+ */
+const readIdentity = async (app, paneId) => {
+    const props    = await app.getComponent(paneId, ['id', 'store.id']),
+          provider = await app.callMethod(paneId, 'getStateProvider'),
+          response = await app.getComponentTree(paneId, -1, true),
+          // The service answers `{tree: node}`; the node itself is `{className, id, items?}`.
+          // Walking the envelope instead of the node yields an empty census that reads exactly like
+          // a leaf — which is why the subtree guard below exists at all.
+          root     = response?.tree ?? response;
+
+    /** Every id under the pane, the pane itself excluded — the subtree the claim is about. */
+    const walk = node => node ? [node.id, ...(node.items || []).flatMap(walk)] : [];
+
+    return {
+        componentId: props.id,
+        descendants: walk(root).filter(id => id && id !== paneId).sort(),
+        providerId : provider?.id ?? provider?.properties?.id ?? null,
+        storeId    : props['store.id'] ?? null
+    }
+};
+
+test.describe('Workstation pop-out — a nested pane subtree keeps its identities across the hop and back', () => {
+    test.setTimeout(120000);
+    test.use({viewport: {height: 900, width: 1600}});
+
+    test('component, provider, store and descendant identities survive pop-out AND return', async ({page, context, neuralLink}, testInfo) => {
+        const pageErrors = [];
+
+        page.on('pageerror', error => pageErrors.push(String(error.stack || error.message || error)));
+
+        await page.goto('/apps/workstation/index.html');
+        await page.waitForSelector('.workstation-dock-host', {timeout: 60000});
+        await page.waitForSelector('.neo-tab-header-button.neo-draggable', {timeout: 60000});
+
+        const app         = await neuralLink.connectToApp('Workstation'),
+              workspaces  = await app.findInstances({className: 'Workstation.view.Workspace'}, ['id']),
+              workspaceId = (Array.isArray(workspaces) ? workspaces[0] : workspaces)?.id;
+
+        expect(workspaceId, 'the App Worker owns one Workstation workspace').toBeTruthy();
+
+        const header = page.locator(HEADER).filter({has: page.locator(TAB, {hasText: FEED_TITLE})}).first();
+
+        await expect(header, 'the Feed pane must have a projected tab header').toBeVisible({timeout: 30000});
+        await header.locator(TAB, {hasText: FEED_TITLE}).first().click();
+
+        const paneId = await app.callMethod(workspaceId, 'getPaneIdentity', [FEED_ITEM]);
+
+        expect(paneId, 'the Feed pane owns a live instance before the gesture').toBeTruthy();
+
+        const before = await readIdentity(app, paneId);
+
+        // The arm is only meaningful over a real subtree; a leaf would make every claim below
+        // trivially true. This is the census the identity assertions are measured against.
+        expect(before.descendants.length, 'the Feed pane is a real subtree, not a leaf').toBeGreaterThan(0);
+        expect(before.providerId, 'the pane resolves a state provider in the opener').toBeTruthy();
+        expect(before.storeId, 'the Feed grid owns a store in the opener').toBeTruthy();
+
+        const popOut = header.locator(`${ACTION}:has(span[class*="${POP_OUT}"])`).first();
+
+        await expect(popOut, 'the Feed pane offers the pop-out action').toBeVisible({timeout: 10000});
+
+        // Subscribed before the click: the vessel can open faster than the next await.
+        const vesselPromise = context.waitForEvent('page', {timeout: 45000});
+
+        let vessel;
+
+        try {
+            await popOut.click();
+
+            vessel = await vesselPromise;
+
+            await vessel.waitForLoadState('domcontentloaded');
+            await vessel.waitForSelector('.workstation-viewport', {timeout: 45000});
+
+            expect(new URL(vessel.url()).searchParams.get('popout'), 'the vessel carries the Feed identity').toBe(FEED_ITEM);
+            await expect(vessel.locator(`#${paneId}`), 'the popup adopts the exact live pane').toBeVisible({timeout: 30000});
+            await expect(page.locator(`#${paneId}`), 'and the opener released it').toHaveCount(0);
+
+            const detached = await readIdentity(app, paneId);
+
+            expect(detached.componentId, 'the SAME component made the hop').toBe(before.componentId);
+            expect(detached.providerId, 'and it resolves the SAME provider from inside the popup').toBe(before.providerId);
+            expect(detached.storeId, 'and its store was not re-created').toBe(before.storeId);
+            expect(detached.descendants, 'and every descendant travelled as the same instance').toEqual(before.descendants);
+
+            // The return leg, through the production retirement seam rather than a synthetic close.
+            expect(await app.callMethod(workspaceId, 'closeTearOutVessel', [{
+                itemId    : FEED_ITEM,
+                windowName: `tearout-${FEED_ITEM}`
+            }]), 'the production retirement seam closes the adopted vessel').toBe(true);
+
+            await expect.poll(() => vessel.isClosed(), {
+                message: 'the physical popup closes after the native acknowledgement',
+                timeout: 15000
+            }).toBe(true);
+
+            await expect.poll(async () => {
+                const state = await app.getComponent(workspaceId, ['dockModel']);
+
+                return Object.values(state.dockModel.nodes)
+                    .some(node => node.type === 'tabs' && node.items?.includes(FEED_ITEM))
+            }, {
+                intervals: [50, 100, 250],
+                message  : 'vessel death reintegrates the Feed pane into a tab flow',
+                timeout  : 30000
+            }).toBe(true);
+
+            await expect(page.locator(`#${paneId}`), 'the exact live pane returns to the main window').toBeVisible({timeout: 30000});
+
+            const returned = await readIdentity(app, paneId);
+
+            expect(returned.componentId, 'the SAME component came home').toBe(before.componentId);
+            expect(returned.providerId, 'resolving the SAME provider again').toBe(before.providerId);
+            expect(returned.storeId, 'with its store intact — not re-created on the way back').toBe(before.storeId);
+            expect(returned.descendants, 'and the whole subtree returned as the same instances').toEqual(before.descendants);
+
+            // The receipt carries its own magnitudes, so a reader never has to take "passed" as the
+            // measurement. A census of one would satisfy every assertion above and mean nothing.
+            testInfo.annotations.push({
+                type       : 'ac-4-identity-receipt',
+                description: `component ${before.componentId} · provider ${before.providerId} · store ${before.storeId} · ${before.descendants.length} descendants, identical across pop-out and return`
+            })
+        } finally {
+            vessel && !vessel.isClosed() && await vessel.close()
+        }
+
+        expect(pageErrors, 'the journey raises no page errors').toEqual([])
+    })
+});

--- a/test/playwright/unit/apps/workstation/Workspace.spec.mjs
+++ b/test/playwright/unit/apps/workstation/Workspace.spec.mjs
@@ -1168,7 +1168,7 @@ test.describe.serial('Workstation.view.Workspace', () => {
 
             workspace.windowId = 'window-main';
             workspace.vesselWorkspaces.set(sourceWorkspaceId, {itemId: 'queues'});
-            workspace.tearOutPlacements.queues = {index: 0, tabsNodeId: 'left-tabs'};
+            workspace.tearOutHandlers.recordPlacement('queues', {index: 0, tabsNodeId: 'left-tabs'});
 
             try {
                 WindowManager.get = () => ({innerRect: {x: 0, y: 0, width: 1280, height: 720}});
@@ -1217,7 +1217,7 @@ test.describe.serial('Workstation.view.Workspace', () => {
 
                 // Off every zone but inside the window: the stored home acquires the drop as a
                 // tab-into, painted on the home's exact rect — never on the pointer's empty position.
-                workspace.tearOutPlacements.queues = {index: 1, tabsNodeId: 'right-top-tabs'};
+                workspace.tearOutHandlers.recordPlacement('queues', {index: 1, tabsNodeId: 'right-top-tabs'});
 
                 const offZone = render({x: 450, y: 500}, Workspace.MAIN_WORKSPACE_ID);
 
@@ -1257,7 +1257,7 @@ test.describe.serial('Workstation.view.Workspace', () => {
                 renderer.applyTargetGeometry = originalApplyTargetRect;
                 workspace.windowId           = originalWindowId;
                 workspace.vesselWorkspaces.delete(sourceWorkspaceId);
-                delete workspace.tearOutPlacements.queues
+                workspace.tearOutHandlers.forgetPlacement('queues')
             }
         } finally {
             workspace.destroy()
@@ -1276,7 +1276,7 @@ test.describe.serial('Workstation.view.Workspace', () => {
 
             workspace.windowId = 'window-main';
             workspace.vesselWorkspaces.set(sourceWorkspaceId, {itemId: 'queues'});
-            workspace.tearOutPlacements.queues = {index: 0, tabsNodeId: 'left-tabs'};
+            workspace.tearOutHandlers.recordPlacement('queues', {index: 0, tabsNodeId: 'left-tabs'});
 
             // The construct-time participation resolves before windowId exists in this
             // harness — refresh it now that the window identity is set.
@@ -1329,7 +1329,7 @@ test.describe.serial('Workstation.view.Workspace', () => {
                 host.getDomRect    = originalGetDomRect;
                 workspace.windowId = originalWindowId;
                 workspace.vesselWorkspaces.delete(sourceWorkspaceId);
-                delete workspace.tearOutPlacements.queues
+                workspace.tearOutHandlers.forgetPlacement('queues')
             }
         } finally {
             workspace.destroy()
@@ -1919,13 +1919,23 @@ test.describe.serial('Workstation.view.Workspace', () => {
             projections            = [];
 
         try {
-            workspace.tearOutPlacements.alerts = {index: 0, tabsNodeId: 'heavy-tabs'};
+            workspace.tearOutHandlers.recordPlacement('alerts', {index: 0, tabsNodeId: 'heavy-tabs'});
             workspace.tearOutPanes.alerts = {
                 generationToken: 'lineage-3',
                 windowId       : 'window-alerts',
                 windowName     : 'tearout-alerts'
             };
-            workspace.tearOutHandlers = {onVesselRetired() {}};
+            // Only the RETIREMENT is stubbed out — the arm is about recovery, not about the vessel
+            // machinery. The pane-handoff half delegates to the real bundle, which is where
+            // placement consumption happens: a bare stub would leave the record uneaten and the
+            // assertions below would be reading a return that never ran.
+            workspace.tearOutHandlers = {
+                forgetPlacement: itemId => originalTearOut.forgetPlacement(itemId),
+                onVesselRetired() {},
+                peekPlacement  : itemId => originalTearOut.peekPlacement(itemId),
+                reintegrateItem: (itemId, pane) => originalTearOut.reintegrateItem(itemId, pane),
+                releasePane    : itemId => originalTearOut.releasePane(itemId)
+            };
             workspace.vesselParkHandlers = {onVesselRetired() {}};
             workspace.onDockZoneDocumentChange = (document, options) => {
                 projections.push({document, options})
@@ -1939,7 +1949,7 @@ test.describe.serial('Workstation.view.Workspace', () => {
             expect(workspace.vesselWorkspaces.has(workspaceId)).toBe(false);
             expect(workspace.workspaceSet.has(workspaceId)).toBe(false);
             expect(workspace.tearOutPanes.alerts).toBeUndefined();
-            expect(workspace.tearOutPlacements.alerts).toBeUndefined();
+            expect(workspace.tearOutHandlers.peekPlacement('alerts')).toBeNull();
             expect(workspace.lastCrossWindowTransfer).toMatchObject({
                 applied              : true,
                 recoveredOnDisconnect: true,
@@ -1966,13 +1976,23 @@ test.describe.serial('Workstation.view.Workspace', () => {
             originalPark         = workspace.vesselParkHandlers;
 
         try {
-            workspace.tearOutPlacements.alerts = {index: 0, tabsNodeId: 'heavy-tabs'};
+            workspace.tearOutHandlers.recordPlacement('alerts', {index: 0, tabsNodeId: 'heavy-tabs'});
             workspace.tearOutPanes.alerts = {
                 generationToken: 'lineage-3',
                 windowId       : 'window-alerts',
                 windowName     : 'tearout-alerts'
             };
-            workspace.tearOutHandlers = {onVesselRetired() {}};
+            // Only the RETIREMENT is stubbed out — the arm is about recovery, not about the vessel
+            // machinery. The pane-handoff half delegates to the real bundle, which is where
+            // placement consumption happens: a bare stub would leave the record uneaten and the
+            // assertions below would be reading a return that never ran.
+            workspace.tearOutHandlers = {
+                forgetPlacement: itemId => originalTearOut.forgetPlacement(itemId),
+                onVesselRetired() {},
+                peekPlacement  : itemId => originalTearOut.peekPlacement(itemId),
+                reintegrateItem: (itemId, pane) => originalTearOut.reintegrateItem(itemId, pane),
+                releasePane    : itemId => originalTearOut.releasePane(itemId)
+            };
             workspace.vesselParkHandlers = {onVesselRetired() {}};
             workspace.workspaceSet.adoptTransfer = () => false;
 
@@ -1991,7 +2011,7 @@ test.describe.serial('Workstation.view.Workspace', () => {
                 preview     : null,
                 windowId    : null
             });
-            expect(workspace.tearOutPlacements.alerts).toEqual({index: 0, tabsNodeId: 'heavy-tabs'});
+            expect(workspace.tearOutHandlers.peekPlacement('alerts')).toEqual({index: 0, tabsNodeId: 'heavy-tabs'});
             expect(workspace.lastCrossWindowTransfer).toMatchObject({
                 applied: false,
                 errors : ['workspace-set refused disconnected-vessel recovery']
@@ -2038,7 +2058,7 @@ test.describe.serial('Workstation.view.Workspace', () => {
 
             state.participation = {destroy: () => participantRetirements.push('destroy')};
             workspace.crossWindowParticipations.set(workspaceId, state.participation);
-            workspace.tearOutPlacements.alerts = {index: 0, tabsNodeId: 'heavy-tabs'};
+            workspace.tearOutHandlers.recordPlacement('alerts', {index: 0, tabsNodeId: 'heavy-tabs'});
             workspace.tearOutPanes.alerts = {
                 generationToken: 'lineage-3',
                 windowId       : 'window-alerts',
@@ -2072,7 +2092,17 @@ test.describe.serial('Workstation.view.Workspace', () => {
             });
             expect(participantRetirements).toEqual(['destroy']);
 
-            workspace.tearOutHandlers = {onVesselRetired() {}};
+            // Only the RETIREMENT is stubbed out — the arm is about recovery, not about the vessel
+            // machinery. The pane-handoff half delegates to the real bundle, which is where
+            // placement consumption happens: a bare stub would leave the record uneaten and the
+            // assertions below would be reading a return that never ran.
+            workspace.tearOutHandlers = {
+                forgetPlacement: itemId => originalTearOut.forgetPlacement(itemId),
+                onVesselRetired() {},
+                peekPlacement  : itemId => originalTearOut.peekPlacement(itemId),
+                reintegrateItem: (itemId, pane) => originalTearOut.reintegrateItem(itemId, pane),
+                releasePane    : itemId => originalTearOut.releasePane(itemId)
+            };
             workspace.vesselParkHandlers = {onVesselRetired() {}};
             await releaseVessel(workspace, 'window-alerts');
 

--- a/test/playwright/unit/dashboard/DockTearOut.spec.mjs
+++ b/test/playwright/unit/dashboard/DockTearOut.spec.mjs
@@ -338,6 +338,71 @@ test.describe('Neo.dashboard.dock.window.TearOut — createDockTearOutHandlers',
         expect(calls.synced).toHaveLength(1)
     });
 
+    test('a host that answers by IDENTITY adopts even when this machine can see no pane', () => {
+        // The regression this pins was caught by a real pop-out e2e, not here, and e2e does not run
+        // in the PR matrix — so the guard belongs at this tier or it does not exist.
+        //
+        // Adoption used to resolve the pane itself and refuse when it found none. `apps/workstation`
+        // answers by identity: it promotes an already-staged vessel embodiment, and otherwise reads
+        // its own `paneCache` — neither reachable from the projected tree this machine searches. The
+        // refusal therefore compensated, closed the just-opened vessel, and the user saw a pop-out
+        // that opened a window and killed it. The pane is OFFERED; only the host's `false` refuses.
+        const adopted = [];
+
+        const handlers = createDockTearOutHandlers({
+            applyOperation         : () => ({document: {}, errors: []}),
+            awaitRefresh           : () => Promise.resolve(),
+            closeVessel            : () => true,
+            commitReturn           : () => {},
+            findContainingTabsId   : () => null,
+            getDocument            : () => ({items: {}, nodes: {}}),
+            onAdoptionFailed       : () => {},
+            onDocumentChange       : () => {},
+            onPaneAdopted          : (itemId, entry) => adopted.push({itemId, entry}),
+            onPaneReturn           : () => {},
+            openVessel             : async () => null,
+            resolvePane            : () => null,          // this machine can see nothing
+            reparentPane           : () => true,          // the host answers by identity anyway
+            resolveReturnDescriptor: () => null,
+            settlePane             : () => {}
+        });
+
+        expect(() => handlers.adoptPane('commits', {}, {windowId: 'vessel-win'}),
+            'a host that says yes must not be overruled by a null lookup').not.toThrow();
+
+        expect(adopted.at(-1), 'and the window binding still merges into the ownership record')
+            .toMatchObject({itemId: 'commits', entry: {windowId: 'vessel-win'}});
+
+        expect(handlers.reparentAdopted('commits', {windowId: 'vessel-win'}),
+            'the connect-race partner offers the pane the same way').toBe(true);
+    });
+
+    test('control: a host that REFUSES still compensates, so the offer is not a blanket admission', () => {
+        const closed = [];
+
+        const handlers = createDockTearOutHandlers({
+            applyOperation         : () => ({document: {}, errors: []}),
+            awaitRefresh           : () => Promise.resolve(),
+            closeVessel            : vessel => {closed.push(vessel); return true},
+            commitReturn           : () => {},
+            findContainingTabsId   : () => null,
+            getDocument            : () => ({items: {}, nodes: {}}),
+            onAdoptionFailed       : () => {},
+            onDocumentChange       : () => {},
+            onPaneAdopted          : () => {},
+            onPaneReturn           : () => {},
+            openVessel             : async () => null,
+            resolvePane            : () => null,
+            reparentPane           : () => false,         // the host itself declines
+            resolveReturnDescriptor: () => null,
+            settlePane             : () => {}
+        });
+
+        expect(() => handlers.adoptPane('commits', {}, {windowId: 'vessel-win'})).toThrow(/could not enter its admitted vessel/);
+        expect(closed, 'the vessel the host refused is retired').toHaveLength(1);
+        expect(handlers.reparentAdopted('commits', {windowId: 'vessel-win'})).toBe(false)
+    });
+
     test.describe('the return waits for its PUBLICATION, not only for the refresh', () => {
         // The defect these pin: `settle()` published without awaiting, then awaited a refresh that
         // — already settled — resolved immediately, so the return reported `returned: true` against

--- a/test/playwright/unit/dashboard/DockTearOut.spec.mjs
+++ b/test/playwright/unit/dashboard/DockTearOut.spec.mjs
@@ -24,8 +24,11 @@ import {createDockTearOutHandlers} from '../../../../src/dashboard/dock/window/T
  * assertion surface — the machine exposes nothing else.
  */
 test.describe('Neo.dashboard.dock.window.TearOut — createDockTearOutHandlers', () => {
-    const harness = ({admit = true, closeResult = true, commitErrors = [], commitThrows = false, openResult = null} = {}) => {
-        const calls = {applied: [], closed: [], ended: 0, opened: [], started: [], synced: []};
+    const harness = ({
+        admit = true, closeResult = true, commitErrors = [], commitThrows = false, openResult = null,
+        commitReturn = null, refresh = null
+    } = {}) => {
+        const calls = {applied: [], closed: [], ended: 0, opened: [], published: [], returns: [], started: [], synced: []};
 
         const sortZone = {
             endWindowDrag  : () => calls.ended++,
@@ -49,7 +52,25 @@ test.describe('Neo.dashboard.dock.window.TearOut — createDockTearOutHandlers',
                 calls.opened.push(request);
                 if (openResult) return openResult(request);
                 return admit ? {popupHeight: 480, popupWidth: 640, windowName: `vessel-${request.itemId}`} : null
-            }
+            },
+
+            // The return path's seams. `awaitRefresh` defaults to an ALREADY-SETTLED promise on
+            // purpose: that is the production shape when no projection is pending, and it is the
+            // condition under which awaiting only the refresh witnesses nothing at all.
+            awaitRefresh: () => refresh ? refresh() : Promise.resolve(),
+            commitReturn: document => {
+                calls.published.push(document);
+                return commitReturn ? commitReturn(document) : undefined
+            },
+            findContainingTabsId   : () => null,
+            getDocument            : () => ({items: {graph: {}}, nodes: {'tabs-1': {type: 'tabs', items: []}}}),
+            onAdoptionFailed       : () => {},
+            onPaneAdopted          : () => {},
+            onPaneReturn           : data => calls.returns.push(data),
+            reparentPane           : () => true,
+            resolvePane            : () => null,
+            resolveReturnDescriptor: (document, itemId) => ({operation: 'restoreTab', itemId, tabsNodeId: 'tabs-1'}),
+            settlePane             : () => {}
         });
 
         return {calls, handlers, sortZone}
@@ -315,6 +336,69 @@ test.describe('Neo.dashboard.dock.window.TearOut — createDockTearOutHandlers',
         expect(calls.closed).toHaveLength(1);
         expect(calls.applied).toEqual([{operation: 'detachItem', itemId: 'graph'}]);
         expect(calls.synced).toHaveLength(1)
+    });
+
+    test.describe('the return waits for its PUBLICATION, not only for the refresh', () => {
+        // The defect these pin: `settle()` published without awaiting, then awaited a refresh that
+        // — already settled — resolved immediately, so the return reported `returned: true` against
+        // a publication that had not landed and could still refuse. The
+        // already-settled refresh is the default here for exactly that reason: it is the condition
+        // under which the second barrier witnesses nothing, so these arms fail if the first is dropped.
+
+        test('a DELAYED publication holds the return pending — the settled refresh cannot stand in for it', async () => {
+            let release;
+
+            const {calls, handlers} = harness({commitReturn: () => new Promise(resolve => {release = resolve})});
+
+            let settled = false;
+
+            const pending = handlers.reintegrateItem('graph', null).then(result => {
+                settled = true;
+                return result
+            });
+
+            // Two microtask turns: enough for the already-settled `awaitRefresh` to have resolved
+            // several times over, which is precisely what the defect rode on.
+            await Promise.resolve();
+            await Promise.resolve();
+
+            expect(calls.published, 'the host WAS asked to publish').toHaveLength(1);
+            expect(settled, 'the return must NOT have reported while publication is in flight').toBe(false);
+            expect(calls.returns.some(entry => entry.phase === 'after'),
+                'and no after-report may exist yet').toBe(false);
+
+            release();
+
+            expect(await pending, 'once publication lands, the return succeeds').toBe(true);
+            expect(calls.returns.at(-1)).toMatchObject({phase: 'after', returned: true})
+        });
+
+        test('a REFUSED publication fails the return rather than reporting success', async () => {
+            const {calls, handlers} = harness({commitReturn: () => Promise.resolve(false)});
+
+            expect(await handlers.reintegrateItem('graph', null)).toBe(false);
+            expect(calls.returns.at(-1)).toMatchObject({phase: 'after', returned: false})
+        });
+
+        test('a publication that THROWS synchronously is a failed return, not an escaped throw', async () => {
+            const {calls, handlers} = harness({
+                commitReturn: () => { throw new Error('host publication exploded') }
+            });
+
+            // Before the repair this throw left `settle()` entirely, past the failure report the
+            // caller depends on — a rejected promise where a `false` was owed.
+            expect(await handlers.reintegrateItem('graph', null)).toBe(false);
+            expect(calls.returns.at(-1)).toMatchObject({phase: 'after', returned: false});
+            expect(calls.returns.at(-1).error, 'the cause travels with the failure').toBeTruthy()
+        });
+
+        test('control: a synchronous publication still succeeds, so the barrier is not simply refusing', async () => {
+            const {calls, handlers} = harness();
+
+            expect(await handlers.reintegrateItem('graph', null)).toBe(true);
+            expect(calls.published).toHaveLength(1);
+            expect(calls.returns.at(-1)).toMatchObject({phase: 'after', returned: true})
+        });
     });
 
     test('a terminal for a DIFFERENT item than the admitted vessel commits nothing (stale-identity guard)', async () => {

--- a/test/playwright/unit/dashboard/DockWorkspace.spec.mjs
+++ b/test/playwright/unit/dashboard/DockWorkspace.spec.mjs
@@ -366,7 +366,9 @@ class TearOutWorkspace extends DockWorkspace {
         return this.grant ? this.grant(context) : true
     }
 
-    afterTearOutPaneReturn(data) {
+    onDockPaneReturn(data) {
+        if (data.phase !== 'after') return;
+
         const landed = data.returned && this.getReference(`tearout-pane-${data.itemId}`) === data.pane;
 
         this.lifecycleEvents.push(`return:${data.returned}:${Boolean(landed)}`)
@@ -396,8 +398,8 @@ class TearOutWorkspace extends DockWorkspace {
         return {module: Container, reference: `tearout-pane-${itemId}`}
     }
 
-    resolveTearOutPane(itemId) {
-        return this.tearOutPaneHandles[itemId] || this.getReference(`tearout-pane-${itemId}`)
+    resolveLivePane(itemId) {
+        return this.getReference(`tearout-pane-${itemId}`) || null
     }
 }
 
@@ -643,7 +645,7 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
                 'applyDockZoneOperation',
                 'openTearOutVessel',   // nor acquire a vessel outside the pair
                 'acquireTearOutVessel',
-                'reintegrateTearOutItem',
+                'reintegrateItem',
                 'retireTearOutVessel',
                 'onVesselRetired'
             ]) {
@@ -931,15 +933,26 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
     });
 
     test('#17681 owns the reusable tear-out lifecycle on DockWorkspace, not on application hosts', () => {
+        // This surface is split in two, so the ownership claim has to be made twice.
+        // The HOST keeps what only a component can do — resolve, reparent, destroy, record, report;
+        // the choreography that sequences them is engine-owned in `window/TearOut.mjs`. An app that
+        // re-implements either half is the defect this test exists to catch.
         for (const method of [
-            'adoptTearOutPane',
             'applyTearOutOperation',
+            'onDockPaneReturn',
             'onTopologyBind',
             'onTopologyRelease',
-            'reintegrateTearOutItem',
-            'reparentTearOutPane'
+            'recordDockPaneOwner',
+            'reparentDockPane',
+            'reportDockAdoptionFailure',
+            'resolveLivePane',
+            'settleDockPane'
         ]) {
-            expect(typeof DockWorkspace.prototype[method], `${method} is engine-owned`).toBe('function')
+            expect(typeof DockWorkspace.prototype[method], `${method} is an engine-owned host seam`).toBe('function')
+        }
+
+        for (const moved of ['adoptTearOutPane', 'reintegrateTearOutItem', 'reparentTearOutPane', 'resolveTearOutPane']) {
+            expect(DockWorkspace.prototype[moved], `${moved} moved to the choreography and left no wrapper`).toBeUndefined()
         }
 
         workspace = Neo.create(PlainWorkspace, {dockModel: createDocument()});
@@ -951,22 +964,28 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
         /**
          * Drives the real detach through `applyTearOutOperation` — the wrapper that records the
          * placement — and commits it, so reintegration reads exactly the state a closed vessel
-         * leaves behind. Anything less (hand-writing `tearOutPlacements`) would test the record I
+         * leaves behind. Anything less (hand-writing the placement) would test the record I
          * wrote rather than the one the engine keeps.
          * @param {String} itemId
          * @returns {Object} the committed post-detach document
          */
-        const detach = itemId => {
-            const result = workspace.applyTearOutOperation({operation: 'detachItem', itemId});
+        // Placement recording is part of the tear-out lifecycle rather than unconditional state on
+        // every workspace — that IS the declinability contract. These arms exercise the return,
+        // so they opt the lifecycle in explicitly instead of relying on a workspace that declined it.
+        const armed = (document=createDocument()) =>
+                  Neo.create(PlainWorkspace, {dockModel: document, enableDockTearOutLifecycle: true}),
 
-            expect(result.errors).toEqual([]);
-            workspace.onDockZoneDocumentChange(result.document);
+              detach = itemId => {
+                  const result = workspace.applyTearOutOperation({operation: 'detachItem', itemId});
 
-            return result.document
-        };
+                  expect(result.errors).toEqual([]);
+                  workspace.onDockZoneDocumentChange(result.document);
+
+                  return result.document
+              };
 
         test('AC-1/AC-4 a pane ALONE in its split child returns to that side, not to the first tabs node', async () => {
-            workspace = Neo.create(PlainWorkspace, {dockModel: createDocument()});
+            workspace = armed();
 
             // `editor` is alone in `editor-tabs`, the left child of a two-child split — the exact
             // shape the operator's consumer reported, and the common tear-out rather than the rare one.
@@ -975,7 +994,7 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
             expect(detached.nodes['editor-tabs'], 'the emptied home is gone').toBeUndefined();
             expect(detached.nodes['root-split'],  'and the split collapsed with it').toBeUndefined();
 
-            expect(await workspace.reintegrateTearOutItem('editor', null)).toBe(true);
+            expect(await workspace.tearOutHandlers.reintegrateItem('editor', null)).toBe(true);
 
             const doc     = workspace.dockModel,
                   splitId = Object.keys(doc.nodes).find(id => doc.nodes[id].type === 'split'),
@@ -993,28 +1012,30 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
         });
 
         test('AC-3 a pane with SIBLINGS returns to its own node at its own index', async () => {
-            workspace = Neo.create(PlainWorkspace, {dockModel: createDocument()});
+            workspace = armed();
 
             const detached = detach('preview');
 
             expect(detached.nodes['side-tabs'], 'the home survived — terminal held it open').toBeTruthy();
 
-            expect(await workspace.reintegrateTearOutItem('preview', null)).toBe(true);
+            expect(await workspace.tearOutHandlers.reintegrateItem('preview', null)).toBe(true);
             expect(workspace.dockModel.nodes['side-tabs'].items, 'index 0, not appended').toEqual(['preview', 'terminal'])
         });
 
         test('AC-5 the SAME pane instance comes home — asserted on the component id', async () => {
-            workspace = Neo.create(PlainWorkspace, {dockModel: createDocument()});
+            workspace = armed();
 
             const pane   = Neo.create(Container, {}),
                   paneId = pane.id,
                   seen   = [];
 
-            workspace.afterTearOutPaneReturn = data => seen.push(data);
+            // One hook carries both ends of the return now, so the arm filters to the disposition
+            // half — the 'before' beat has no `returned` to assert and would inflate the count.
+            workspace.onDockPaneReturn = data => data.phase === 'after' && seen.push(data);
 
             detach('editor');
 
-            expect(await workspace.reintegrateTearOutItem('editor', pane)).toBe(true);
+            expect(await workspace.tearOutHandlers.reintegrateItem('editor', pane)).toBe(true);
 
             // A node moved between documents is necessarily re-created, so DOM identity cannot carry
             // this. The instance is what survives, and its id is how that is honestly read.
@@ -1027,15 +1048,15 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
         });
 
         test('AC-6 an item with NO recorded placement still lands somewhere valid', async () => {
-            workspace = Neo.create(PlainWorkspace, {dockModel: createDocument()});
+            workspace = armed();
 
             const detached = detach('editor');
 
             // The record is the thing being taken away here: without it there is no home to rebuild,
             // and the first tabs node in document order is a last resort rather than a placement.
-            delete workspace.tearOutPlacements.editor;
+            workspace.tearOutHandlers.forgetPlacement('editor');
 
-            expect(await workspace.reintegrateTearOutItem('editor', null)).toBe(true);
+            expect(await workspace.tearOutHandlers.reintegrateItem('editor', null)).toBe(true);
 
             expect(WorkspaceDocument.findContainingTabsId(workspace.dockModel, 'editor'), 'somewhere beats nowhere').toBeTruthy();
             expect(WorkspaceDocument.validate(workspace.dockModel)).toEqual([]);
@@ -1043,7 +1064,7 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
         });
 
         test('a pane docked into the recorded home while the vessel is open is NOT displaced', async () => {
-            workspace = Neo.create(PlainWorkspace, {dockModel: createEdgeDocument()});
+            workspace = armed(createEdgeDocument());
 
             const placement = WorkspaceDocument.captureItemPlacement(workspace.dockModel, 'inspector'),
                   detached  = workspace.applyTearOutOperation({operation: 'detachItem', itemId: 'inspector'});
@@ -1062,7 +1083,7 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
             WorkspaceDocument.setZoneNodeId(occupied.nodes[placement.home.parentId], placement.home.slot, 'late-right');
             workspace.onDockZoneDocumentChange(occupied);
 
-            expect(await workspace.reintegrateTearOutItem('inspector', null)).toBe(true);
+            expect(await workspace.tearOutHandlers.reintegrateItem('inspector', null)).toBe(true);
 
             const doc = workspace.dockModel;
 
@@ -1074,15 +1095,15 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
         });
 
         test('a recorded home that resolves to NOTHING falls back rather than dropping the pane', async () => {
-            workspace = Neo.create(PlainWorkspace, {dockModel: createDocument()});
+            workspace = armed();
 
             detach('editor');
 
             // Both halves of the record point at nodes that no longer exist — the zone AND the
             // sibling its split collapsed into. The restore fails closed; the return path must not.
-            Object.assign(workspace.tearOutPlacements.editor.home, {parentId: 'gone', siblingId: 'gone-too'});
+            Object.assign(workspace.tearOutHandlers.peekPlacement('editor').home, {parentId: 'gone', siblingId: 'gone-too'});
 
-            expect(await workspace.reintegrateTearOutItem('editor', null)).toBe(true);
+            expect(await workspace.tearOutHandlers.reintegrateItem('editor', null)).toBe(true);
             expect(WorkspaceDocument.findContainingTabsId(workspace.dockModel, 'editor')).toBeTruthy()
         })
     });
@@ -1253,7 +1274,7 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
 
             // The rollback half of the real wrapper: a refused detach keeps no placement record,
             // which is what lets a later attempt capture a fresh one.
-            expect(workspace.tearOutPlacements.preview, 'a refused detach records no placement').toBeUndefined()
+            expect(workspace.tearOutHandlers.peekPlacement('preview'), 'a refused detach records no placement').toBeNull()
         });
 
         // A click is asynchronous across two awaits while `destroy()` is synchronous, so the window
@@ -1409,7 +1430,7 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
 
             expect(workspace.tearOutHandlers.onDockTearOutTerminal({itemId: 'preview', sortZone: zone})).toBe(true);
             expect(workspace.tearOutPanes.preview).toMatchObject({windowId: null});
-            expect(workspace.tearOutPaneHandles.preview).toBe(pane);
+            expect(workspace.tearOutHandlers.heldPane('preview')).toBe(pane);
             await workspace.refreshPromise;
 
             const mainView = addWindow('terminal-first');
@@ -1561,7 +1582,7 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
 
             expect(workspace.closeRequests).toEqual([]);
             expect(workspace.tearOutHandlers.onDockTearOutTerminal({itemId: 'preview', sortZone: zone})).toBe(true);
-            expect(mainView.items).toContain(workspace.tearOutPaneHandles.preview)
+            expect(mainView.items).toContain(workspace.tearOutHandlers.heldPane('preview'))
         });
 
         test('a foreign Group, a stranger token and an unreserved slot never reach product continuation or ownership', async () => {
@@ -1769,8 +1790,8 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
             expect(JSON.stringify(workspace.dockModel)).toBe(before);
             expect(workspace.closeRequests).toHaveLength(1);
             expect(workspace.closeRequests[0]).toMatchObject({itemId: 'preview', workspaceKey: 'popup:preview'});
-            expect(workspace.tearOutPlacements.preview).toBeUndefined();
-            expect(workspace.tearOutPaneHandles.preview).toBeUndefined()
+            expect(workspace.tearOutHandlers.peekPlacement('preview')).toBeNull();
+            expect(workspace.tearOutHandlers.heldPane('preview')).toBeNull()
         });
 
         test('a pre-terminal disconnect retires only provisional ownership with zero document mutation', async () => {
@@ -3417,20 +3438,25 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
     });
 
     test.describe('#18153 the engine resolves its own tear-out pane', () => {
-        test('a workspace that overrides nothing resolves the live projected pane', () => {
-            workspace = Neo.create(PlainWorkspace, {dockModel: createDocument()});
+        // The resolution lives behind the choreography, and the choreography only exists
+        // under `enableDockTearOutLifecycle` — so these arms arm it, rather than asserting against a
+        // workspace that declined the whole concern.
+        const armed = () => Neo.create(PlainWorkspace, {dockModel: createDocument(), enableDockTearOutLifecycle: true});
 
-            const pane = workspace.resolveTearOutPane('editor');
+        test('a workspace that overrides nothing resolves the live projected pane', () => {
+            workspace = armed();
+
+            const pane = workspace.tearOutHandlers.peekPane('editor');
 
             // Before this default the hook returned null, and the decline was not survivable:
-            // captureTearOutPane stores nothing, reparentTearOutPane finds no pane and returns false,
-            // and compensateFailedTearOutAdoption CLOSES the vessel the consumer was asked to open.
+            // `capturePane` stores nothing, the reparent finds no pane and returns false, and
+            // `compensateFailedAdoption` CLOSES the vessel the consumer was just asked to open.
             expect(pane, 'the engine finds the projected pane without a consumer hook').toBeTruthy();
             expect(pane.dockItemId, 'and it is the pane for the requested item').toBe('editor')
         });
 
         test('it returns the PANE, never the tab header button that carries the same identity', () => {
-            workspace = Neo.create(PlainWorkspace, {dockModel: createDocument()});
+            workspace = armed();
 
             // LayoutAdapter stamps dockItemId on the header it builds from the pane's own config, so
             // the button carries the identity structurally too. An unqualified down() can return it,
@@ -3442,25 +3468,25 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
             expect(matches.length, 'the identity is stamped on more than one component').toBeGreaterThan(1);
             expect(buttons.length, 'and one of them is a tab header button — the arm is not vacuous').toBeGreaterThan(0);
 
-            expect(workspace.resolveTearOutPane('editor').ntype,
+            expect(workspace.tearOutHandlers.peekPane('editor').ntype,
                 'the resolver skips the button').not.toBe('tab-header-button')
         });
 
-        test('captureTearOutPane now retains a handle, which is what makes the vessel survivable', () => {
-            workspace = Neo.create(PlainWorkspace, {dockModel: createDocument()});
+        test('capturePane retains a handle, which is what makes the vessel survivable', () => {
+            workspace = armed();
 
-            workspace.captureTearOutPane('editor');
+            workspace.tearOutHandlers.capturePane('editor');
 
             // The whole failure chain starts here: an empty handle map is what makes the reparent
             // fail and the engine close its own vessel.
-            expect(workspace.tearOutPaneHandles.editor, 'the handle map is populated').toBeTruthy();
-            expect(workspace.releaseTearOutPane('editor'), 'and the pane is releasable for return').toBeTruthy()
+            expect(workspace.tearOutHandlers.heldPane('editor'), 'the handle map is populated').toBeTruthy();
+            expect(workspace.tearOutHandlers.releasePane('editor'), 'and the pane is releasable for return').toBeTruthy()
         });
 
         test('an unknown itemId still resolves to null rather than an arbitrary component', () => {
-            workspace = Neo.create(PlainWorkspace, {dockModel: createDocument()});
+            workspace = armed();
 
-            expect(workspace.resolveTearOutPane('no-such-item')).toBeNull()
+            expect(workspace.tearOutHandlers.peekPane('no-such-item')).toBeNull()
         });
 
         test('a projection PLACEHOLDER is never torn out, however it carries the identity', () => {
@@ -3473,23 +3499,31 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
             // blank and loses the pane, silently. The hook is `resolvePane`, not `resolveFreshPane`:
             // the recreate hook now delegates to it, so writing no recreate hook no longer implies
             // an unresolvable pane.
-            expect(workspace.isDockTearOutCandidate({cls: ['neo-dashboard-dock-placeholder'], ntype: 'dashboard-panel'}),
+            // The standalone predicate is folded into `resolveLivePane`, so the exclusion is
+            // exercised where it actually runs: through the engine resolver, over a stubbed dock
+            // host that offers exactly one component carrying the identity. Testing the predicate
+            // alone would have certified a method the tear-out path no longer calls.
+            const admits = component => Boolean(DockWorkspace.prototype.resolveLivePane.call(
+                {getDockHost: () => ({down: () => [component]})}, 'editor'
+            ));
+
+            expect(admits({cls: ['neo-dashboard-dock-placeholder'], ntype: 'dashboard-panel'}),
                 'a placeholder is not a tear-out candidate').toBe(false);
 
-            expect(workspace.isDockTearOutCandidate({data: {missingComponentRef: true}, ntype: 'dashboard-panel'}),
+            expect(admits({data: {missingComponentRef: true}, ntype: 'dashboard-panel'}),
                 'nor is one identified by its unresolved componentRef').toBe(false);
 
-            expect(workspace.isDockTearOutCandidate({ntype: 'tab-header-button'}),
+            expect(admits({ntype: 'tab-header-button'}),
                 'the header button stays excluded').toBe(false);
 
-            expect(workspace.isDockTearOutCandidate({cls: ['neo-panel'], ntype: 'dashboard-panel'}),
+            expect(admits({cls: ['neo-panel'], ntype: 'dashboard-panel'}),
                 'a real pane still qualifies — the guard is not simply refusing everything').toBe(true)
         });
 
         test('the held handle wins, so adoption still finds the pane after the detach re-projection', () => {
-            workspace = Neo.create(PlainWorkspace, {dockModel: createDocument()});
+            workspace = armed();
 
-            const treePane = workspace.resolveTearOutPane('editor');
+            const treePane = workspace.tearOutHandlers.peekPane('editor');
 
             expect(treePane, 'the pane is in the tree before the detach').toBeTruthy();
 
@@ -3500,16 +3534,24 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
             // passed. Asserting the handle wins over a live tree answer cannot no-op.
             const held = Neo.create(Container, {items: []});
 
-            workspace.tearOutPaneHandles.editor = held;
+            // Injected through the REAL capture path rather than by writing the handle map: the
+            // host resolver answers with the distinct instance for exactly one capture, then goes
+            // back to the tree. Hand-writing the record would test the one I wrote, not the one the
+            // choreography keeps — and the map is no longer the host's to write anyway.
+            const treeResolver = workspace.resolveLivePane.bind(workspace);
+
+            workspace.resolveLivePane = () => held;
+            workspace.tearOutHandlers.capturePane('editor');
+            workspace.resolveLivePane = treeResolver;
 
             // The sequence is capture -> re-project -> adopt: the capture stores the pane while it
             // is still in the tree, the detach re-projection removes it, adoption runs afterwards.
             // A tree-only resolver therefore succeeds at capture and returns null when it matters —
             // measured on a real consumer as adopted=NULL with the vessel window open.
-            expect(workspace.resolveTearOutPane('editor'), 'the held handle answers first').toBe(held);
-            expect(workspace.resolveTearOutPane('editor')).not.toBe(treePane);
+            expect(workspace.tearOutHandlers.peekPane('editor'), 'the held handle answers first').toBe(held);
+            expect(workspace.tearOutHandlers.peekPane('editor')).not.toBe(treePane);
 
-            expect(workspace.releaseTearOutPane('editor'), 'and it is releasable for return').toBe(held);
+            expect(workspace.tearOutHandlers.releasePane('editor'), 'and it is releasable for return').toBe(held);
 
             held.destroy()
         });
@@ -3538,26 +3580,33 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
         });
 
         test('a destroyed handle does not shadow the tree', () => {
-            workspace = Neo.create(PlainWorkspace, {dockModel: createDocument()});
+            workspace = armed();
 
             // A stale handle must not win over a live pane, or a re-created pane would be
-            // unreachable behind a corpse.
-            workspace.tearOutPaneHandles.editor = {isDestroyed: true};
+            // unreachable behind a corpse. Captured ALIVE and then destroyed, which is the only way
+            // this state actually arises — a handle that was never live could never have been held.
+            const treeResolver = workspace.resolveLivePane.bind(workspace),
+                  doomed       = Neo.create(Container, {});
 
-            const resolved = workspace.resolveTearOutPane('editor');
+            workspace.resolveLivePane = () => doomed;
+            workspace.tearOutHandlers.capturePane('editor');
+            workspace.resolveLivePane = treeResolver;
+            doomed.destroy();
+
+            const resolved = workspace.tearOutHandlers.peekPane('editor');
 
             expect(resolved, 'the tree answers instead').toBeTruthy();
             expect(resolved.isDestroyed).toBeFalsy()
         });
 
         test('a failed adoption is reported on the lifecycle channel, not thrown into a listener', async () => {
-            workspace = Neo.create(PlainWorkspace, {dockModel: createDocument()});
+            workspace = armed();
 
             const events = [];
 
             workspace.on('dockTearOutAdoptionFailed', event => events.push(event));
 
-            await workspace.compensateFailedTearOutAdoption('editor', {windowName: 'neo-dock-tearout-editor'});
+            await workspace.tearOutHandlers.compensateFailedAdoption('editor', {windowName: 'neo-dock-tearout-editor'});
 
             // Both failing paths throw AFTER compensating, and neither throw reaches anyone:
             // onWindowConnect is registered as a worker event listener, so its async throw becomes
@@ -3569,20 +3618,25 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
         });
 
         test('`reintegrated` reports the RETURN, not that a pane handle existed', async () => {
-            workspace = Neo.create(PlainWorkspace, {dockModel: createDocument()});
+            workspace = armed();
 
             const events = [],
                   pane   = Neo.create(Container, {});
 
-            workspace.tearOutPaneHandles.editor = pane;
+            const treeResolver = workspace.resolveLivePane.bind(workspace);
+
+            workspace.resolveLivePane = () => pane;
+            workspace.tearOutHandlers.capturePane('editor');
+            workspace.resolveLivePane = treeResolver;
+
             workspace.on('dockTearOutAdoptionFailed', event => events.push(event));
 
             // The distinguishing case, and the one a handle check cannot see: a held pane whose
             // return then FAILS. `!!pane` answers true here — and a failed adoption is precisely
             // when a pane was held, so the field would have read `true` on every firing it has.
-            workspace.reintegrateTearOutItem = async () => false;
+            workspace.tearOutHandlers.reintegrateItem = async () => false;
 
-            await workspace.compensateFailedTearOutAdoption('editor', {windowName: 'neo-dock-tearout-editor'});
+            await workspace.tearOutHandlers.compensateFailedAdoption('editor', {windowName: 'neo-dock-tearout-editor'});
 
             expect(events.length).toBe(1);
             expect(events[0].pane, 'the pane is still reported — it was held').toBeTruthy();
@@ -3667,13 +3721,13 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
         });
 
         test('a failed adoption returns the item to the document, not only the pane handle', async () => {
-            workspace = Neo.create(PlainWorkspace, {dockModel: createDocument()});
+            workspace = armed();
 
-            const pane = workspace.resolveTearOutPane('editor');
+            const pane = workspace.tearOutHandlers.peekPane('editor');
 
             expect(pane, 'the fixture must project the pane, or this proves nothing').toBeTruthy();
 
-            workspace.captureTearOutPane('editor');
+            workspace.tearOutHandlers.capturePane('editor');
 
             // Commit the detach the tear-out gesture commits, so the item is out of every tabs node
             // exactly as it is when an adoption then fails.
@@ -3685,9 +3739,9 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
             expect(WorkspaceDocument.findContainingTabsId(workspace.dockModel, 'editor'),
                 'the item is genuinely out of the tree at this point').toBeFalsy();
 
-            // The vessel died. compensateFailedTearOutAdoption is what must put it back — the user
+            // The vessel died. `compensateFailedAdoption` is what must put it back — the user
             // is left with a pane that vanished from the shell otherwise.
-            workspace.compensateFailedTearOutAdoption('editor', {windowName: 'neo-dock-tearout-editor'});
+            workspace.tearOutHandlers.compensateFailedAdoption('editor', {windowName: 'neo-dock-tearout-editor'});
 
             await workspace.refreshPromise;
 
@@ -3703,13 +3757,17 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
             // click resolves the item without id bookkeeping — it cleared an exclusion that named
             // only the header button and the placeholder. Naming stand-ins one at a time lost twice,
             // so the guard refuses the CATEGORY: a dock pane is never a button.
-            expect(workspace.isDockTearOutCandidate({cls: ['neo-dashboard-dock-rail-tab', 'neo-button'], ntype: 'button'}),
+            const admits = component => Boolean(DockWorkspace.prototype.resolveLivePane.call(
+                {getDockHost: () => ({down: () => [component]})}, 'editor'
+            ));
+
+            expect(admits({cls: ['neo-dashboard-dock-rail-tab', 'neo-button'], ntype: 'button'}),
                 'a rail tab is refused').toBe(false);
 
-            expect(workspace.isDockTearOutCandidate({cls: ['neo-button'], ntype: 'button'}),
+            expect(admits({cls: ['neo-button'], ntype: 'button'}),
                 'and so is any other button carrying the identity').toBe(false);
 
-            expect(workspace.isDockTearOutCandidate({cls: ['neo-panel'], ntype: 'dashboard-panel'}),
+            expect(admits({cls: ['neo-panel'], ntype: 'dashboard-panel'}),
                 'while a real pane is untouched by the widening').toBe(true)
         });
 

--- a/test/playwright/unit/examples/dashboard/crossWindow/DemoBWorkspace.spec.mjs
+++ b/test/playwright/unit/examples/dashboard/crossWindow/DemoBWorkspace.spec.mjs
@@ -662,7 +662,7 @@ test.describe.serial('Neo.examples.dashboard.crossWindow.DemoBWorkspace', () => 
                 .toHaveLength(3);
             expect(sourceParent.items[sourceIndex].cls).toContain('neo-dashboard-dock-vessel-placeholder');
 
-            workspace.adoptTearOutPane('timeline');
+            workspace.tearOutHandlers.adoptPane('timeline', {}, workspace.tearOutConnects.timeline || null);
             expect(harness.addedTo('tear-child'), 'terminal promotion never reparents twice').toEqual([pane]);
             expect(workspace.tearOutPanes.timeline.windowId).toBe('tear-child');
             expect(workspace.tearOutConnects.timeline, 'committed ownership has only one lifecycle map').toBeUndefined();
@@ -1781,7 +1781,7 @@ test.describe.serial('Neo.examples.dashboard.crossWindow.DemoBWorkspace', () => 
         expect(result.errors).toEqual([]);
         // `home` carries the tabs node's OWN position, so the record can rebuild a zone the detach
         // collapsed rather than only find one that survived.
-        expect(workspace.tearOutPlacements.timeline).toEqual({tabsNodeId: 'side-tabs', index: 1, home: {parentId: 'root', slot: 'right'}});
+        expect(workspace.tearOutHandlers.peekPlacement('timeline')).toEqual({tabsNodeId: 'side-tabs', index: 1, home: {parentId: 'root', slot: 'right'}});
 
         workspace.onWorkspaceDocumentChange('demo-b-main', result.document);
         expect(workspace.getDockZoneDocument().nodes['side-tabs'].items).toEqual(['inspector', 'console']);
@@ -1792,7 +1792,7 @@ test.describe.serial('Neo.examples.dashboard.crossWindow.DemoBWorkspace', () => 
 
         expect(workspace.getDockZoneDocument().nodes['side-tabs'].items, 'identical order, not append order').toEqual(['inspector', 'timeline', 'console']);
         expect(workspace.tearOutPanes.timeline).toBeUndefined();
-        expect(workspace.tearOutPlacements.timeline, 'the placement record is consumed exact-once').toBeUndefined();
+        expect(workspace.tearOutHandlers.peekPlacement('timeline'), 'the placement record is consumed exact-once').toBeNull();
 
         // idempotent: a duplicate disconnect for the same window finds nothing and mutates nothing
         const stable = JSON.stringify(workspace.getDockZoneDocument());
@@ -1833,7 +1833,7 @@ test.describe.serial('Neo.examples.dashboard.crossWindow.DemoBWorkspace', () => 
         const result = workspace.applyTearOutOperation({operation: 'detachItem', itemId: 'ghost-item'});
 
         expect(result.errors.length).toBeGreaterThan(0);
-        expect(workspace.tearOutPlacements['ghost-item']).toBeUndefined()
+        expect(workspace.tearOutHandlers.peekPlacement('ghost-item')).toBeNull()
     });
 
     test('reintegration is idempotent against an item some other flow already re-treed', () => {
@@ -1855,7 +1855,7 @@ test.describe.serial('Neo.examples.dashboard.crossWindow.DemoBWorkspace', () => 
 
         expect(WorkspaceDocument.findContainingTabsId(doc, 'timeline')).toBe('workbench-tabs');
         expect(doc.nodes['workbench-tabs'].items.filter(id => id === 'timeline')).toHaveLength(1);
-        expect(workspace.tearOutPlacements.timeline).toBeUndefined()
+        expect(workspace.tearOutHandlers.peekPlacement('timeline')).toBeNull()
     });
 
     test('resolveDockWorkspaceId answers by host containment, in either window, and fails closed outside', () => {


### PR DESCRIPTION
Resolves #18311
Related: #18304

The tear-out pane-handoff choreography now lives in `window/TearOut.mjs`, and the two consumers that had forked it no longer carry their own copies. The module still imports **nothing** — the choreography moved as seam-injected decision logic, not as pasted methods, so every witness still drives it without a browser.

The ticket asked me to name whatever kept the cluster in `Workspace.mjs` for months. It was not the missing destination: **both shipped consumers had forked the choreography**, `DemoBWorkspace` down to declaring its own duplicate `tearOutPlacements`. A destination cannot pull behaviour that two hosts have already reimplemented.

Evidence: L3 (native pop-out/return identity hop executed on this candidate) → L3 required (AC-4). Residual: AC-2, Residual-Owner: #18314 — **accepted** by its owner at [issuecomment-5559138656](https://github.com/neomjs/neo/issues/18311#issuecomment-5559138656), not yet delivered.

> **Correction to this body's first published version.** It stated that CI would be the migrated e2e files' first run. That was false — the PR matrix runs `unit` and `components` only, and never runs e2e. The claim is retracted here rather than quietly edited away; the reviewer caught it, and running those files locally then found a regression this branch had introduced (`b1042261e1`).

## AC Evidence
| AC | Evidence |
|---|---|
| AC-1 capture/adopt/reparent/release/settle/return + placements live in `window/TearOut.mjs`; the resolver-shaped lines fold rather than move | CI-covered: `unit/dashboard/DockTearOut.spec.mjs` and `DockWorkspace.spec.mjs` › `#17681 owns the reusable tear-out lifecycle`, which asserts BOTH halves — the host seams exist and the four moved members left no wrapper |
| AC-2 `Workspace.mjs` retains no tear-out method, config or state field | **PARTIAL — mapped and ACCEPTED.** Every choreography member is gone (`tearOut*` references 226 → 169). Five members remain: admissions, the connect cache, committed vessel ownership, retained retirements, and the handler bundle. @neo-gpt applied the D#18150 Group lifecycle boundary and **accepted** them — state *and* methods — as leaving `Workspace` directly for the settled Group under #18314, with no intermediate extraction ([issuecomment-5559138656](https://github.com/neomjs/neo/issues/18311#issuecomment-5559138656), plus the #18314 body). **Accepted, not delivered.** Residual-Owner: #18314 |
| AC-3 Ownership test, Stage 0 = yes, four questions, q4 with before/after cross-concern counts | Answered below under **Ownership test** |
| AC-4 identity survives a real hop — component, provider and store instance ids, nested-subtree witness | **DELIVERED.** Outside-CI: `e2e/workstation/WorkstationPopOutPaneIdentityNL.spec.mjs` — **1 passed** on this candidate. Feed pane (`grid.Container`), real popup window, all four dimensions across pop-out **and** return |
| AC-5 a consumer with `enableDockTearOutLifecycle: false` registers ZERO tear-out state | CI-covered: `DockWorkspace.spec.mjs` asserts `tearOutHandlers` is null and `getDockProjectionOptions()` is `{}` on a declining workspace. Stronger than before — placement recording is now lifecycle-gated where it used to be unconditional state on every workspace |
| AC-6 `retireTearOutState` still wipes its paths; no placement outlives its workspace | CI-covered: `retirePaneState()` returns the held panes and forgets all three maps in one call; the host destroys them, since component lifetime is never the decision machine's |

## Ownership test (AC-3)

Stage 0 — does the unit own state? **Yes** (`paneHandles`, `placements`, `returning`).

1. **Did `Workspace` lose the methods, configs and mutable state?** For the choreography, yes — 12 methods and 3 state fields, no forwarding wrapper, asserted mechanically.
2. **Can the owner be instantiated and destroyed independently under a bounded interface?** Yes — `createDockTearOutHandlers(seams)` and `retirePaneState()`; the unit spec drives all of it with no browser and no component.
3. **Can a consumer replace or disable it without overriding a dozen methods?** Yes. `apps/workstation` overrides **three** generic methods where it previously reimplemented four tear-out-named ones.
4. **Did cross-concern calls fall?** `dock/Workspace.mjs` **226 → 169**, `apps/workstation` **163 → 154**, `DemoBWorkspace` **154 → 141**.

## Deltas from ticket

**AC-2 is not met as written, and is now mapped rather than open.** Out of Scope names the lifecycle *subscription*, birth and geometry — not vessel state; my first justification was broader than the ticket and the reviewer was right to reject it. The binding disposition is in the graduation approval itself (`DC_kwDODSospM4BFyRC`): *"multi-window lifecycle enters the settled Group… No intermediate 'dock controller'"* and *"lifecycle extraction waits for the Group"*. So relocating those members into `window/TearOut.mjs` would be the owner the consensus refused, and the reviewer withdrew the second-extraction requirement on that evidence.

@neo-gpt has since **accepted** the retained members onto #18314 ([issuecomment-5559138656](https://github.com/neomjs/neo/issues/18311#issuecomment-5559138656) and the #18314 body) — *"Accepted, not falsely claimed delivered."* The obligation now has both a mapping and an owner who took it. Nothing was transferred on my say-so, and nothing is claimed delivered here.

**A correction to my own first commit.** It deleted `apps/workstation`'s forked return claiming `Operations.restoreTab` was a strict superset. It is not: `restoreTab` **re-mints** the remembered parent/slot, and both consumers hold the opposite contract — *"never resurrect a node"*, which `DemoBWorkspace.spec` states verbatim. The return **policy** is now a seam, and because both consumers carried identical copies it became one primitive, `Operations.appendingReturnDescriptor`.

**Three defects found by arms rather than by reading:** the ownership record was *replaced* instead of merged after a reparent, silently dropping the `windowId` the connection had just supplied; the already-in-tree return published a second, optionless projection over an atomic recovery's own; and adoption *required* a pane it resolved itself, so a host that answers by identity was never asked and its just-opened vessel was closed.

**One integration seam added at #18314's owner's request:** the detached terminal awaits `onDocumentChange` and routes explicit `false` / throw / rejection onto the existing retirement path. No-op for every host today.

**Not run:** `npm run agent-preflight` — the script moved to the Brain in #17239 and the skill payload still names the engine invocation.

## Test Evidence

Outside-CI, executed on this candidate with `NEO_AGENTOS_RUNTIME_ROOT` set to a verified Brain checkout (unset, `playwright.config.e2e.mjs` **excludes 83 of 103 spec files from selection** and the run reports "No tests found" while exiting 0):

| spec | this branch | unmodified `dev@eb778c8230` |
|---|---|---|
| `WorkstationPopOutPaneIdentityNL` — **AC-4**, all four dimensions | ✅ 1 passed | (new) |
| `WorkstationHeaderStatePopOutNL` — provider identity from the popup | ✅ 1 passed | — |
| `WorkstationNL:2477` — pop-out + reintegrate same live pane | ✅ (**was ❌ — the regression `b1042261e1` fixes**) | ✅ |
| `TearOutMatrixRows4To7NL` | ✅ 4/4 | ✅ 4/4 |
| `DemoBDockTearOutNL` witness 3 | ❌ | ❌ base-relative |
| `WorkstationNL:595` tour · `:2274` theme goldens ×2 · `:2667` overflow menu | ❌ | ❌ base-relative |

**Zero remaining e2e failures attributable to this branch.** The reviewer additionally re-executed RA-1's repair from the exact GitHub blob in an isolated Node module — success/false/sync-throw/rejection/delayed-true/delayed-false all pass.

## Signal Ledger

| | |
|---|---|
| **Source** | [D#18150](https://github.com/neomjs/neo/discussions/18150) — *"dashboard.dock.Workspace is 4000 LOC: the v13.2 anatomy landed as folders, not as ownership"*, opened 2026-09-02T22:23:55Z, 25 comments |
| **Graduated Epic** | #18304 · this PR delivers its leaf #18311 |
| **Families with signal** | **claude** — @neo-opus-grace (author), @neo-opus-ada, @neo-opus-vega, @neo-fable · **gpt** — @neo-gpt, @neo-gpt-emmy |
| **Non-author-family approval** | `[GRADUATION_APPROVED by @neo-gpt-emmy]` @ `DC_kwDODSospM4BFyRC` (2026-09-04T17:59Z), terminal 8-point Step-Back, all PASS |
| **Quorum** | **MET** — two active families signalled; a non-author family approved |

Verified live against the Discussion at author time, not carried from the Epic body.

## Unresolved Dissent

**None on this leaf.** The source Discussion's forks were resolved before graduation: Option A vs B by @neo-fable's precedent audit, the B-vs-E fork by `[OQ_RESOLVED]` at `DC_kwDODSospM4BFv_G` on a direct operator answer, and OQ1 by @neo-opus-vega's blocker discharge at `DC_kwDODSospM4BFuI_`.

One disagreement arose *during implementation* and is closed: I claimed `Operations.restoreTab` was a strict superset of the consumers' return and deleted a fork on it. `DemoBWorkspace.spec` contradicts that in the words *"never a resurrected node"*. Withdrawn; the policy is a seam and one shared primitive.

## Unresolved Liveness

**AC-2's ownership boundary is open, and its disposition is anchored in the graduation approval rather than in my judgement.** `DC_kwDODSospM4BFyRC` states two things this PR relies on:

> *"Path determinism — PASS. … multi-window lifecycle enters the settled Group; Workspace remains the façade. **No intermediate 'dock controller.'**"*

> *"Migration — PASS as an ordered DAG. … **lifecycle extraction waits for the Group**; every leaf deletes or moves its owned Workspace surface in the same PR."*

So the retained vessel-lifecycle members are not an omission this leaf may close by moving them into `window/TearOut.mjs` — that destination would be the intermediate owner the consensus explicitly refused. What is genuinely unresolved is the **source mapping**: which of `tearOutAdmissions` / `tearOutConnects` (the subscription's cached data, distinguished from the subscription itself) / `tearOutRetirements` / `tearOutPanes` land on the Group leaf, and which owner accepts them.

**Resolved.** @neo-gpt accepted the boundary on #18314 at [issuecomment-5559138656](https://github.com/neomjs/neo/issues/18311#issuecomment-5559138656), applying it to both source tickets: admissions, the connect cache, committed vessel ownership and retained retirements leave `Workspace` directly for the settled Group — state and methods — with no intermediate extraction. His framing, preserved here because it is the honest state: *"Accepted, not falsely claimed delivered."*

The earlier author ruling I requested from @neo-opus-grace ([issuecomment-5558866777](https://github.com/neomjs/neo/issues/18311#issuecomment-5558866777)) is superseded by that acceptance and needs no answer. **No inactive family's silence was read as consent, and nothing was transferred, renamed or deferred on my say-so.**

## Post-Merge Validation
- [x] #18314 **delivers** the accepted lifecycle cut — the mapping is agreed and the owner has taken it; the deletion from `Workspace` has not happened yet
- [ ] e2e is not in the PR matrix; the four specs above need a scheduled or manual run to stay honest

## Commits
- `1dd7e02542` — the engine-side extraction: seams, closure state, `dock/Workspace` deletions
- `3f5c14293b` — RA-1: the return waits for its publication, not only the refresh
- `b1042261e1` — RA-3: adoption offers the pane instead of requiring one (the regression fix)
- `1f91c4c451` — AC-4's nested component/provider/store identity witness

## Evolution

I opened this lane intending to implement AC-1 literally and stopped when `window/TearOut.mjs` turned out to have zero imports by design. My instinct was a new `plugin/` vehicle — which D#18150 had already named and rejected twice as "an intermediate noun that keeps today's ownership". Reading the source Discussion rather than reasoning from the ticket produced the seam-injection shape, and the same discipline later produced the ordering evidence that settled RA-2.

The failure mode repeated twice more inside the lane: a `restoreTab` "superset" claim a spec contradicted, and a scope exclusion broader than the ticket's own text. Both were caught by a reviewer or a test rather than by me. The pattern is reading a contract generously in my own favour, and it is why AC-2 now goes to its author rather than to my judgement.

Ratchet: `apps/workstation` 3250 → 3217, `DemoBWorkspace` 2663 → 2662, `dock/Workspace` 1294 → 1214. Every guarded file shrinks.

Authored by Ada (Claude Opus 5, Claude Code). Session 95f9ff6e-1ba5-43b6-860a-208fbf7f4442.


