### PR TITLE
feat(dock): converge sibling topology projections (#18272)

### DIFF
--- a/apps/workstation/view/Workspace.mjs
+++ b/apps/workstation/view/Workspace.mjs
@@ -951,7 +951,8 @@ class Workspace extends DockWorkspace {
             bindingKey : 'main',
             componentId: me.id,
             getDocument: () => me.dockModel,
-            setDocument: document => me.dockModel = document
+            setDocument: document => me.dockModel = document,
+            project    : context => me.projectDockZoneDocument(context.snapshot.participants[Workspace.MAIN_WORKSPACE_ID], context.descriptor)
         });
         if (registered) me.dockPlacement ??= Placement.forGroup({
             groupId: me.topologyGroupId, initialHints: me.initialTopology?.placementHints, mainWorkspaceKey: Workspace.MAIN_WORKSPACE_ID

--- a/apps/workstation/view/Workspace.mjs
+++ b/apps/workstation/view/Workspace.mjs
@@ -952,7 +952,9 @@ class Workspace extends DockWorkspace {
             componentId: me.id,
             getDocument: () => me.dockModel,
             setDocument: document => me.dockModel = document,
-            project    : context => me.projectDockZoneDocument(context.snapshot.participants[Workspace.MAIN_WORKSPACE_ID], context.descriptor)
+            project    : context => me.projectDockZoneDocument(context.snapshot.participants[Workspace.MAIN_WORKSPACE_ID], context.descriptor, me, {
+                preserveItemIds: context.preserveItemIds
+            })
         });
         if (registered) me.dockPlacement ??= Placement.forGroup({
             groupId: me.topologyGroupId, initialHints: me.initialTopology?.placementHints, mainWorkspaceKey: Workspace.MAIN_WORKSPACE_ID

--- a/buildScripts/util/file-size-baseline.json
+++ b/buildScripts/util/file-size-baseline.json
@@ -1,6 +1,6 @@
 {
-    "apps/workstation/view/Workspace.mjs": 3247,
-    "examples/dashboard/crossWindow/DemoBWorkspace.mjs": 2653,
-    "src/dashboard/dock/Workspace.mjs": 1289,
+    "apps/workstation/view/Workspace.mjs": 3250,
+    "examples/dashboard/crossWindow/DemoBWorkspace.mjs": 2663,
+    "src/dashboard/dock/Workspace.mjs": 1294,
     "src/main/addon/DragDrop.mjs": 1267
 }

--- a/examples/dashboard/crossWindow/DemoBWorkspace.mjs
+++ b/examples/dashboard/crossWindow/DemoBWorkspace.mjs
@@ -7,6 +7,7 @@ import DockLayoutAdapter                    from '../../../src/dashboard/dock/pr
 import DockMotionSignal                     from '../../../src/dashboard/dock/projection/MotionSignal.mjs';
 import PerspectiveLibrary                   from '../../../src/dashboard/dock/persistence/PerspectiveLibrary.mjs';
 import Placement                            from '../../../src/dashboard/dock/window/Placement.mjs';
+import TopologySeams                        from '../../../src/dashboard/dock/window/TopologySeams.mjs';
 import DockPreview                          from '../../../src/dashboard/dock/interaction/Preview.mjs';
 import DockPreviewProducer                  from '../../../src/dashboard/dock/interaction/PreviewProducer.mjs';
 import DockProjectionReconciler             from '../../../src/dashboard/dock/projection/Reconciler.mjs';
@@ -172,6 +173,8 @@ class DemoBWorkspace extends Container {
          * @protected
          */
         className: 'Neo.examples.dashboard.crossWindow.DemoBWorkspace',
+        /** @member {Neo.core.Base[]} mixins=[TopologySeams] */
+        mixins: [TopologySeams],
         /**
          * Theme dependencies: the example-owned palette, the dock motion/token contract file (the
          * projected tree is plain containers; nothing loads it per-class), and Demo A's skin
@@ -1165,14 +1168,14 @@ class DemoBWorkspace extends Container {
             return me.workspaceSet.register(workspaceId, {
                 getDocument: () => me.popup2Document,
                 setDocument: document => me.popup2Document = document,
-                project    : context => me.projectWorkspaceDocument(workspaceId, context.snapshot.participants[workspaceId])
+                project    : context => me.projectWorkspaceDocument(workspaceId, context.snapshot.participants[workspaceId], context)
             })
         }
 
         return me.workspaceSet.register(DemoBWorkspace.POPUP_WORKSPACE_ID, {
             getDocument: () => me.popupDocument,
             setDocument: document => me.popupDocument = document,
-            project    : context => me.projectWorkspaceDocument(DemoBWorkspace.POPUP_WORKSPACE_ID, context.snapshot.participants[DemoBWorkspace.POPUP_WORKSPACE_ID])
+            project    : context => me.projectWorkspaceDocument(DemoBWorkspace.POPUP_WORKSPACE_ID, context.snapshot.participants[DemoBWorkspace.POPUP_WORKSPACE_ID], context)
         })
     }
 
@@ -3036,19 +3039,19 @@ class DemoBWorkspace extends Container {
             bindingKey : 'main',
             getDocument: () => me.dockModel,
             setDocument: document => me.dockModel = document,
-            project    : context => me.projectWorkspaceDocument(DemoBWorkspace.MAIN_WORKSPACE_ID, context.snapshot.participants[DemoBWorkspace.MAIN_WORKSPACE_ID])
+            project    : context => me.projectWorkspaceDocument(DemoBWorkspace.MAIN_WORKSPACE_ID, context.snapshot.participants[DemoBWorkspace.MAIN_WORKSPACE_ID], context)
         });
 
         me.workspaceSet.register(DemoBWorkspace.POPUP_WORKSPACE_ID, {
             getDocument: () => me.popupDocument,
             setDocument: document => me.popupDocument = document,
-            project    : context => me.projectWorkspaceDocument(DemoBWorkspace.POPUP_WORKSPACE_ID, context.snapshot.participants[DemoBWorkspace.POPUP_WORKSPACE_ID])
+            project    : context => me.projectWorkspaceDocument(DemoBWorkspace.POPUP_WORKSPACE_ID, context.snapshot.participants[DemoBWorkspace.POPUP_WORKSPACE_ID], context)
         });
 
         me.workspaceSet.register(DemoBWorkspace.POPUP2_WORKSPACE_ID, {
             getDocument: () => me.popup2Document,
             setDocument: document => me.popup2Document = document,
-            project    : context => me.projectWorkspaceDocument(DemoBWorkspace.POPUP2_WORKSPACE_ID, context.snapshot.participants[DemoBWorkspace.POPUP2_WORKSPACE_ID])
+            project    : context => me.projectWorkspaceDocument(DemoBWorkspace.POPUP2_WORKSPACE_ID, context.snapshot.participants[DemoBWorkspace.POPUP2_WORKSPACE_ID], context)
         });
         me.dockPlacement ??= Placement.forGroup({groupId, mainWorkspaceKey: DemoBWorkspace.MAIN_WORKSPACE_ID})
     }

--- a/examples/dashboard/crossWindow/DemoBWorkspace.mjs
+++ b/examples/dashboard/crossWindow/DemoBWorkspace.mjs
@@ -1164,13 +1164,15 @@ class DemoBWorkspace extends Container {
         if (workspaceId === DemoBWorkspace.POPUP2_WORKSPACE_ID) {
             return me.workspaceSet.register(workspaceId, {
                 getDocument: () => me.popup2Document,
-                setDocument: document => me.popup2Document = document
+                setDocument: document => me.popup2Document = document,
+                project    : context => me.projectWorkspaceDocument(workspaceId, context.snapshot.participants[workspaceId])
             })
         }
 
         return me.workspaceSet.register(DemoBWorkspace.POPUP_WORKSPACE_ID, {
             getDocument: () => me.popupDocument,
-            setDocument: document => me.popupDocument = document
+            setDocument: document => me.popupDocument = document,
+            project    : context => me.projectWorkspaceDocument(DemoBWorkspace.POPUP_WORKSPACE_ID, context.snapshot.participants[DemoBWorkspace.POPUP_WORKSPACE_ID])
         })
     }
 
@@ -1478,8 +1480,7 @@ class DemoBWorkspace extends Container {
      * @protected
      */
     onWorkspaceDocumentChange(workspaceId, document, {preserveItemIds = []} = {}) {
-        let me      = this,
-            request = {document, preserveItemIds: [...preserveItemIds]};
+        let me = this;
 
         if (workspaceId === DemoBWorkspace.MAIN_WORKSPACE_ID) {
             me.dockModel = document
@@ -1491,8 +1492,22 @@ class DemoBWorkspace extends Container {
             return Promise.reject(new Error(`unknown Demo-B workspace "${workspaceId}"`))
         }
 
-        me.workspaceProjectionRequests.set(workspaceId, request);
-        me.refreshPromise = me.refreshPromise
+        return me.projectWorkspaceDocument(workspaceId, document, {preserveItemIds})
+    }
+
+    /**
+     * @summary Serializes one workspace's presentation without changing its committed document.
+     * @param {String} workspaceId
+     * @param {Object} document
+     * @param {Object} [options={}]
+     * @param {Iterable<String>} [options.preserveItemIds=[]] Owner-held panes to retain.
+     * @returns {Promise} The projection outcome, independent of later queued refreshes.
+     * @protected
+     */
+    projectWorkspaceDocument(workspaceId, document, {preserveItemIds = []} = {}) {
+        const me = this;
+        me.workspaceProjectionRequests.set(workspaceId, {document, preserveItemIds: [...preserveItemIds]});
+        me.refreshPromise = me.refreshPromise.catch(() => {})
             .then(() => me.timeout(0))
             .then(() => {
                 if (!me.isDestroyed) {
@@ -3020,17 +3035,20 @@ class DemoBWorkspace extends Container {
         me.workspaceSet.register(DemoBWorkspace.MAIN_WORKSPACE_ID, {
             bindingKey : 'main',
             getDocument: () => me.dockModel,
-            setDocument: document => me.dockModel = document
+            setDocument: document => me.dockModel = document,
+            project    : context => me.projectWorkspaceDocument(DemoBWorkspace.MAIN_WORKSPACE_ID, context.snapshot.participants[DemoBWorkspace.MAIN_WORKSPACE_ID])
         });
 
         me.workspaceSet.register(DemoBWorkspace.POPUP_WORKSPACE_ID, {
             getDocument: () => me.popupDocument,
-            setDocument: document => me.popupDocument = document
+            setDocument: document => me.popupDocument = document,
+            project    : context => me.projectWorkspaceDocument(DemoBWorkspace.POPUP_WORKSPACE_ID, context.snapshot.participants[DemoBWorkspace.POPUP_WORKSPACE_ID])
         });
 
         me.workspaceSet.register(DemoBWorkspace.POPUP2_WORKSPACE_ID, {
             getDocument: () => me.popup2Document,
-            setDocument: document => me.popup2Document = document
+            setDocument: document => me.popup2Document = document,
+            project    : context => me.projectWorkspaceDocument(DemoBWorkspace.POPUP2_WORKSPACE_ID, context.snapshot.participants[DemoBWorkspace.POPUP2_WORKSPACE_ID])
         });
         me.dockPlacement ??= Placement.forGroup({groupId, mainWorkspaceKey: DemoBWorkspace.MAIN_WORKSPACE_ID})
     }

--- a/src/ai/client/DockService.mjs
+++ b/src/ai/client/DockService.mjs
@@ -506,7 +506,7 @@ class DockService extends Service {
     }
 
     /**
-     * Reconciles one keyed topology against the holder's registered workspaces and commits the
+     * @summary Reconciles one keyed topology against registered workspaces and commits the
      * complete result once. The activated topology-collection candidate validates before commit;
      * its active pointer is assigned only after the workspace write succeeds.
      * @param {Object} config
@@ -514,10 +514,10 @@ class DockService extends Service {
      * @param {String} config.name               The perspective name being restored
      * @param {Object} config.record             The stored `neo.dock.topology.v1` record
      * @param {Object} config.collection         The containing topology collection
-     * @returns {Object} `{switched, schema, errors, document, workspaces, restored, unrestored, displaced}`
+     * @returns {Promise<Object>} `{switched, schema, errors, document, workspaces, restored, unrestored, displaced}`
      * @protected
      */
-    restoreTopologyPerspective({collection, holder, name, record}) {
+    async restoreTopologyPerspective({collection, holder, name, record}) {
         const missing = ['getDockTopologyWorkspaces', 'commitDockTopologyWorkspaces']
             .filter(seam => typeof holder[seam] !== 'function');
 
@@ -557,7 +557,7 @@ class DockService extends Service {
             return refusal(activated.errors, result)
         }
 
-        const commit = holder.commitDockTopologyWorkspaces(result.workspaces, {
+        const commit = await holder.commitDockTopologyWorkspaces(result.workspaces, {
             name,
             operation: 'restorePerspective'
         });

--- a/src/dashboard/dock/Workspace.mjs
+++ b/src/dashboard/dock/Workspace.mjs
@@ -2656,7 +2656,7 @@ class Workspace extends Container {
     }
 
     /**
-     * The view-sync half of the holder contract, called by every committing surface on success
+     * @summary The view-sync half of the holder contract, called by committing surfaces on success
      * (a splitter, a rail, the cross-zone drop, the Neural Link dock service): stores the committed
      * document and schedules the re-projection.
      *
@@ -2674,24 +2674,32 @@ class Workspace extends Container {
      *     toward the empty projection.
      * @param {Object|null} [descriptor=null] The semantic operation that produced `document`.
      * @param {Object|null} [source=null] The committing surface, when it identifies itself.
+     * @returns {Promise} The scheduled projection's outcome.
      */
     onDockZoneDocumentChange(document, descriptor=null, source=null) {
+        const projection = this.projectDockZoneDocument(document, descriptor, source);
+        this.dockModel = document;
+        return projection
+    }
+
+    /**
+     * @summary Projects an adopted document without admitting another semantic write.
+     * @param {Object|null} document The committed document to present.
+     * @param {Object|null} [descriptor=null] The operation associated with the committed document.
+     * @param {Object|null} [source=null] The originating interaction surface.
+     * @returns {Promise} This projection's outcome; later projections survive its failure.
+     * @protected
+     */
+    projectDockZoneDocument(document, descriptor=null, source=null) {
         let me = this,
             tabInsertDescriptor, refreshOptions, tail;
 
-        // A committed operation is announced BEFORE it applies, so a collaborator holding runtime
-        // presentation over the outgoing projection (the maximize plugin) can clear it terminally;
-        // the re-projection continuity in refreshDockWorkspace() re-applies only what survived.
-        // Synchronous, listeners in subscription order, the outgoing document still committed; a
-        // listener writes its own state and never throws — a throw here aborts the commit, as it
-        // would on any listener.
+        // Presentation owners release transient state before the outgoing shell is reconciled.
         me.fire('beforeDockZoneDocumentChange', {descriptor, document, source});
 
         tabInsertDescriptor = me.getTabInsertProjectionDescriptor(document, descriptor);
         refreshOptions      = me.getRefreshOptions(descriptor, source);
         tail                = me.refreshPromise?.catch(() => {}) || Promise.resolve();
-
-        me.dockModel = document;
 
         // Header truth is written at the commit boundary: every leaf self-diffs, so the bindings
         // whose inputs this commit changed re-evaluate now — a lock reaches its header, its pane and
@@ -2705,7 +2713,9 @@ class Workspace extends Container {
                 if (!me.isDestroyed) {
                     return me.refreshDockWorkspace(tabInsertDescriptor, document, refreshOptions)
                 }
-            })
+            });
+
+        return me.refreshPromise
     }
 
     /**

--- a/src/dashboard/dock/Workspace.mjs
+++ b/src/dashboard/dock/Workspace.mjs
@@ -2687,10 +2687,11 @@ class Workspace extends Container {
      * @param {Object|null} document The committed document to present.
      * @param {Object|null} [descriptor=null] The operation associated with the committed document.
      * @param {Object|null} [source=null] The originating interaction surface.
+     * @param {Object} [projectionOptions={}] Committed topology's pane-preservation policy.
      * @returns {Promise} This projection's outcome; later projections survive its failure.
      * @protected
      */
-    projectDockZoneDocument(document, descriptor=null, source=null) {
+    projectDockZoneDocument(document, descriptor=null, source=null, projectionOptions={}) {
         let me = this,
             tabInsertDescriptor, refreshOptions, tail;
 
@@ -2698,7 +2699,7 @@ class Workspace extends Container {
         me.fire('beforeDockZoneDocumentChange', {descriptor, document, source});
 
         tabInsertDescriptor = me.getTabInsertProjectionDescriptor(document, descriptor);
-        refreshOptions      = me.getRefreshOptions(descriptor, source);
+        refreshOptions      = {...me.getRefreshOptions(descriptor, source), ...projectionOptions};
         tail                = me.refreshPromise?.catch(() => {}) || Promise.resolve();
 
         // Header truth is written at the commit boundary: every leaf self-diffs, so the bindings

--- a/src/dashboard/dock/window/TopologySeams.mjs
+++ b/src/dashboard/dock/window/TopologySeams.mjs
@@ -57,9 +57,9 @@ class TopologySeams extends Base {
      * instead of a declared refusal — the same distinction `executeDockOperation` draws for the
      * single-document path.
      * @param {Object<String,Object>} workspaces Documents keyed by registered workspace identity.
-     * @returns {Object} `{errors}` — empty when every workspace committed.
+     * @returns {Promise<Object>} `{errors, transactionId}` — projection failures use effect receipts.
      */
-    commitDockTopologyWorkspaces(workspaces) {
+    async commitDockTopologyWorkspaces(workspaces) {
         let me  = this,
             set = me.workspaceSet;
 
@@ -70,36 +70,23 @@ class TopologySeams extends Base {
             return {errors: ['a topology commit needs one committed document per registered workspace key']}
         }
 
-        if (typeof set?.adoptAll !== 'function') {
+        if (typeof set?.write !== 'function') {
             return {errors: ['this workspace exposes no registered workspace key for topology adoption']}
         }
 
+        const keys = set.ids();
+        if (Object.keys(workspaces).length !== keys.length || keys.some(key => !Object.hasOwn(workspaces, key))) {
+            return {errors: ['the topology must name exactly the registered workspace keys']}
+        }
+
         try {
-            if (!set.adoptAll(workspaces)) {
-                return {errors: [
-                    'the workspace set refused the topology: its workspace keys do not exactly match the ' +
-                    'registered workspace keys, a document is missing, or a workspace is read-only'
-                ]}
-            }
+            const result = await set.write(workspaces, {
+                cause: 'restore-topology', provenance: {origin: 'perspective'}, descriptor: {operation: 'restorePerspective'}
+            });
+            return {errors: [], transactionId: result.transactionId}
         } catch (error) {
             return {errors: [`topology commit rolled back: ${error.message}`]}
         }
-
-        // The set writes each workspace through its registered `setDocument`, and every such writer in
-        // the codebase is a plain assignment — `me.dockModel = document`, `me.popupDocument =
-        // document`, `targetState.document = document`. `dockModel` is not a reactive config, so
-        // nothing projects off the write; the document advances only inside
-        // `onDockZoneDocumentChange`, which is why the primary needs this call.
-        //
-        // ONLY the primary converges here. A sibling workspace document is written and never
-        // projected: the `register` contract carries no projection seam, and no consumer has a
-        // vessel-side projection to hand it — `targetState.document` is written in five places and
-        // read only by its own `getDocument`. So this restores N documents and one view. Making the
-        // second window visibly converge is a missing layer, not a missing call, and it is owed
-        // beyond this seam.
-        me.onDockZoneDocumentChange(me.dockModel, null, me);
-
-        return {errors: []}
     }
 }
 

--- a/src/dashboard/dock/window/WorkspaceSet.mjs
+++ b/src/dashboard/dock/window/WorkspaceSet.mjs
@@ -224,7 +224,7 @@ export function createDockWorkspaceSet({manager, getGroupId, documentModel}) {
          * @param {Function} [seams.setDocument] `(document)` adopts a committed document; a
          *     participant without one is read-only to `adoptTransfer` (fail closed).
          * @param {Function} [seams.getRevision] Owner-supplied revision stamp; otherwise reference changes are counted.
-         * @param {Function} [seams.project] Post-commit projection receiving the transaction context.
+         * @param {Function} [seams.project] Post-commit context includes `preserveItemIds` owned by sibling documents.
          * @param {String} [seams.bindingKey=workspaceId] Window slot whose generation fences this document.
          * @param {String} [seams.componentId] Opaque live owner lookup; excluded from captured document truth.
          * @returns {Boolean} true when registered
@@ -286,7 +286,11 @@ export function createDockWorkspaceSet({manager, getGroupId, documentModel}) {
                 }
             }
 
-            if (typeof project === 'function') entry.project = project;
+            if (typeof project === 'function') entry.project = context => project({
+                ...context,
+                preserveItemIds: keys().filter(key => key !== workspaceId)
+                    .flatMap(key => Object.keys(context.snapshot.participants[key]?.items ?? {}))
+            });
             if (componentId !== undefined) entry.componentId = componentId;
 
             return manager.registerParticipant({

--- a/src/dashboard/dock/window/WorkspaceSet.mjs
+++ b/src/dashboard/dock/window/WorkspaceSet.mjs
@@ -25,7 +25,8 @@
  *   named by the reintegration tier (§2.8.3), through {@link #unregister}.
  * - **Projection choreography stays with the owner.** The adapter answers "whose document, and what
  *   is it now" — reconcile ordering, generation guards, and render-target sync remain the workspace
- *   container's own contract.
+ *   container's own contract. `register({project})` supplies that owner's post-commit callback;
+ *   it must return the projection promise and must not admit another document write.
  *
  * The manager, Group resolver and document model are injected. Synchronous adoption remains available;
  * write() enters the Group's complete transaction protocol without importing its machinery here.
@@ -43,7 +44,7 @@
  * @returns {Function} workspaceSet.getDocument    `(workspaceId)` → the participant's current document, or `null` (fail closed).
  * @returns {Function} workspaceSet.has            `(workspaceId)` → Boolean.
  * @returns {Function} workspaceSet.ids            `()` → registered workspace ids.
- * @returns {Function} workspaceSet.register       `(workspaceId, {getDocument, setDocument})` registers-or-replaces a participant; Boolean.
+ * @returns {Function} workspaceSet.register       `(workspaceId, {getDocument, setDocument, project})` registers-or-replaces a participant; Boolean.
  * @returns {Number}   workspaceSet.size           Registered participant count.
  * @returns {Function} workspaceSet.unregister     `(workspaceId)` explicit retirement; Boolean.
  * @returns {Function} workspaceSet.write          `(workspaces, options)` queued atomic adoption of keyed documents; Promise.

--- a/test/playwright/e2e/dashboard/DemoBPerspectiveToolsNL.spec.mjs
+++ b/test/playwright/e2e/dashboard/DemoBPerspectiveToolsNL.spec.mjs
@@ -1,30 +1,71 @@
 import {test, expect, loadNeuralLinkModules} from '../../fixtures.mjs';
+import Operations                            from '../../../../src/dashboard/dock/model/Operations.mjs';
+import WorkspaceDocument                     from '../../../../src/dashboard/dock/model/WorkspaceDocument.mjs';
 
 const {NeuralLink_DockService} = await loadNeuralLinkModules();
 
 /**
- * @summary Whitebox E2E witness for the agent-driven Neural Link perspective path on Demo B.
- *
- * The sibling `DemoBPerspectivesNL.spec.mjs` proves the app's OWN tour/store path
- * (capture + topology reconcile). This spec is the first witness driving the NL tools
- * themselves — the seam agent-driven screenplay automation rides:
- *
- *   capture_perspective → list_perspectives → execute_dock_operation (mutation)
- *   → restore_perspective (exact baseline document equality, activeItemIds included)
- *   → restore_perspective on an unknown name (the perspectives contract's
- *     fail-closed path: switched:false, structured error, live document untouched)
- *
- * All assertions read worker truth (dockZone.v1 documents), never the DOM.
- * The baseline is read live, so the spec does not pin the demo's initial layout —
- * it pins the restore-fidelity contract.
- *
- * Run: NEO_E2E_PORT=8117 npx playwright test dashboard/DemoBPerspectiveToolsNL -c test/playwright/playwright.config.e2e.mjs --workers=1
+ * @summary Neural Link perspective round-trips preserve document truth and real-window projections.
+ * The single-window arm verifies exact document restoration and unknown-name refusal. The topology
+ * arm moves an existing CounterPane into a real sibling, then requires the same instance to return
+ * visibly after restore. Empty staging tabs obey the document model's canonical normalization.
+ * `NEO_TEST_DROP_SIBLING_PROJECTION=1` removes only that test worker's sibling projection; the same
+ * visibility assertion must fail. The ordinary run changes no runtime method.
  */
 test.describe('Dashboard Demo B — NL perspective tools: capture → list → restore + fail-closed', () => {
     test.setTimeout(60000);
     test.use({
         contextOptions: {screen: {height: 1080, width: 1920}},
         viewport      : {height: 720, width: 760}
+    });
+
+    test('a topology restore moves the same live pane out of the sibling and presents both captured documents', async ({page, neuralLink}) => {
+        await page.goto('/examples/dashboard/crossWindow/index.html');
+        await expect(page.locator('.agentos-dockdemo-counter-pane')).toBeVisible({timeout: 30000});
+        const app     = await neuralLink.connectToApp('Neo.examples.dashboard.crossWindow');
+        const records = await app.findInstances({className: 'Neo.examples.dashboard.crossWindow.DemoBWorkspace'}, ['id']);
+        const wsId    = (Array.isArray(records) ? records[0] : records).id;
+        const panes   = await app.findInstances({className: 'Neo.examples.dashboard.crossWindow.CounterPane'}, ['id']);
+        const paneId  = (Array.isArray(panes) ? panes[0] : panes).id;
+        const opened  = await app.callMethod(wsId, 'openCrossWindowStage');
+        expect(opened).toMatchObject({workspaceId: 'demo-b-popup'});
+        const popup = page.context().pages().find(candidate => candidate !== page);
+        expect(popup).toBeTruthy();
+        await expect(popup.locator('.neo-tab-container')).toBeVisible({timeout: 30000});
+        const baseline = await app.callMethod(wsId, 'getDockTopologyWorkspaces');
+        const expected = Object.fromEntries(Object.entries(baseline).map(([key, document]) => [key, WorkspaceDocument.normalizeTree(document)]));
+        expect(await NeuralLink_DockService.capturePerspective({
+            captureScope: 'topology', componentId: wsId, layoutId: 'sibling-restore',
+            sessionId   : app.sessionId, title: 'Sibling restore'
+        })).toMatchObject({captured: true, stored: true, errors: []});
+        const moved = Operations.transferItem(baseline['demo-b-main'], baseline['demo-b-popup'], {
+            itemId: 'workbench', sourceWorkspaceId: 'demo-b-main', targetWorkspaceId: 'demo-b-popup',
+            target: {operation: 'addTab', tabsNodeId: 'popup-tabs'}
+        });
+        expect(moved.errors).toEqual([]);
+        expect(await app.callMethod(wsId, 'commitDockTopologyWorkspaces', [{
+            ...baseline, 'demo-b-main': moved.sourceDocument, 'demo-b-popup': moved.targetDocument
+        }])).toMatchObject({errors: []});
+        await expect(popup.locator(`[id="${paneId}"]`), 'the existing pane is presented in the changed sibling').toBeVisible({timeout: 10000});
+        await expect(page.locator(`[id="${paneId}"]`)).toHaveCount(0);
+
+        if (process.env.NEO_TEST_DROP_SIBLING_PROJECTION === '1') {
+            const className = 'Neo.examples.dashboard.crossWindow.DemoBWorkspace';
+            const {source}  = await app.getMethodSource(className, 'projectWorkspaceDocument');
+            expect(source).toContain('const me = this;');
+            await app.manageNeoConfig('set', {enableHotPatching: true});
+            expect(await app.patchCode(className, 'projectWorkspaceDocument', 'function ' + source.replace(
+                'const me = this;',
+                "if (workspaceId === 'demo-b-popup') return Promise.resolve(); const me = this;"
+            ))).toMatchObject({success: true})
+        }
+        expect(await NeuralLink_DockService.restorePerspective({componentId: wsId, name: 'sibling-restore', sessionId: app.sessionId}))
+            .toMatchObject({switched: true, errors: []});
+        expect(await app.callMethod(wsId, 'getDockTopologyWorkspaces')).toEqual(expected);
+        await expect(page.locator(`[id="${paneId}"]`), 'the original pane returns through the captured primary projection').toBeVisible({timeout: 10000});
+        await expect(popup.locator(`[id="${paneId}"]`), 'the sibling no longer presents the moved-away pane').toHaveCount(0);
+        await expect(popup.locator('.neo-tab-header-button'), 'the restored empty sibling has no stale Workbench tab').toHaveCount(0);
+        await expect(popup.locator('.neo-tab-container'), 'the normalized empty sibling has no retired tabs projection').toHaveCount(0)
     });
 
     test('NL capture/list/restore round-trip returns the exact baseline; unknown names fail closed', async ({page, neuralLink}) => {

--- a/test/playwright/e2e/workstation/WorkstationTopologyGroupsNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationTopologyGroupsNL.spec.mjs
@@ -124,10 +124,10 @@ const carriedPage = async (context, carrier) => {
 
 /**
  * @summary Saves two finite topologies through the live library's real IndexedDB adapter.
- * @description A retains the original composition; B moves the real Feed record to keyed details.
+ * @description A retains the original composition; B moves the selected real pane records to keyed details.
  * B is explicitly active although A was inserted first. No live document is hand-constructed.
  */
-const savedColdFixture = async (page, context, neuralLink) => {
+const savedColdFixture = async (page, context, neuralLink, itemIds = ['feed']) => {
     await bootRoot(page);
     const app         = await neuralLink.connectToApp('Workstation'),
           workspaceId = await workspaceFor(app, await readWindowId(page)),
@@ -140,10 +140,18 @@ const savedColdFixture = async (page, context, neuralLink) => {
                   'details-tabs': {type: 'tabs', items: [], activeItemId: null}
               }
           },
-          moved = Operations.transferItem(document, empty, {
-              itemId: 'feed', sourceWorkspaceId: 'workstation-main', targetWorkspaceId: 'details',
-              target: {operation: 'addTab', tabsNodeId: 'details-tabs'}
-          });
+          moved = itemIds.reduce((previous, itemId) => {
+              const next = Operations.transferItem(previous.sourceDocument, previous.targetDocument, {
+                  itemId, sourceWorkspaceId: 'workstation-main', targetWorkspaceId: 'details',
+                  target: {operation: 'addTab', tabsNodeId: 'details-tabs'}
+              });
+              expect(next.errors).toEqual([]);
+              return next
+          }, {sourceDocument: document, targetDocument: empty});
+
+    moved.targetDocument = Operations.setActiveItem(moved.targetDocument, {
+        tabsNodeId: 'details-tabs', itemId: itemIds[0]
+    }).document;
 
     expect(moved.errors).toEqual([]);
     const a = Persistence.captureTopologyPerspective({'workstation-main': document}, {layoutId: 'layout-a'}),
@@ -198,6 +206,39 @@ const expectColdTopology = async (root, record) => {
 test.describe('Workstation topology Groups — two roots under one SharedWorker (Neural Link)', () => {
     test.setTimeout(180000);
     test.use({viewport: {width: 1600, height: 900}});
+
+    test('topology restore presents the captured active pane in the real sibling window', async ({page, context, browser, baseURL, neuralLink}) => {
+        const seed = await savedColdFixture(page, context, neuralLink, ['feed', 'alerts']);
+        await context.close();
+        const coldContext = await browser.newContext({baseURL, storageState: seed.storageState, viewport: {width: 1600, height: 900}});
+
+        try {
+            const root         = await coldRoot(coldContext, neuralLink, seed.carrier);
+            const popupPromise = coldContext.waitForEvent('page', {timeout: 45000});
+            await root.page.getByRole('button', {name: 'Open details as window', exact: true}).click();
+            const popup = await popupPromise;
+            await expect(popup.locator(TAB, {hasText: FEED_TITLE})).toBeVisible({timeout: 60000});
+            const feedId   = await root.app.callMethod(root.workspaceId, 'getPaneIdentity', ['feed']);
+            const alertsId = await root.app.callMethod(root.workspaceId, 'getPaneIdentity', ['alerts']);
+            await expect(popup.locator(`[id="${feedId}"]`)).toBeVisible();
+
+            await popup.locator(TAB, {hasText: 'Priority Alert Observatory'}).click();
+            await expect(popup.locator(`[id="${alertsId}"]`)).toBeVisible();
+            await expect(popup.locator(`[id="${feedId}"]`)).toBeHidden();
+            await expect.poll(async () => (await root.app.callMethod(root.workspaceId, 'getDockTopologyWorkspaces')).details.nodes['details-tabs'].activeItemId).toBe('alerts');
+
+            const restored = await root.app.callMethod(root.workspaceId, 'dockService.restorePerspective', [{
+                componentId: root.workspaceId, name: 'layout-b'
+            }]);
+            expect(restored).toMatchObject({switched: true, errors: []});
+            expect((await root.app.callMethod(root.workspaceId, 'getDockTopologyWorkspaces')).details).toEqual(seed.records.b.workspaces.details);
+            await expect(popup.locator(`[id="${feedId}"]`), 'the saved pane must be visible in the sibling, not only restored in its document').toBeVisible({timeout: 10000});
+            await expect(popup.locator(`[id="${alertsId}"]`)).toBeHidden();
+            expect(await root.app.callMethod(root.workspaceId, 'getPaneIdentity', ['feed'])).toBe(feedId)
+        } finally {
+            await coldContext.close()
+        }
+    });
 
     test('warm F5 preserves the Workspace and its live panes while the Group rebinds', async ({page, context, neuralLink}) => {
         const keeper = await context.newPage();

--- a/test/playwright/e2e/workstation/WorkstationTopologyGroupsNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationTopologyGroupsNL.spec.mjs
@@ -222,13 +222,22 @@ test.describe('Workstation topology Groups — two roots under one SharedWorker 
             const alertsId = await root.app.callMethod(root.workspaceId, 'getPaneIdentity', ['alerts']);
             await expect(popup.locator(`[id="${feedId}"]`)).toBeVisible();
 
+            expect(await root.app.callMethod(root.workspaceId, 'dockService.capturePerspective', [{
+                captureScope: 'topology', componentId: root.workspaceId, layoutId: 'sibling-capture', title: 'Sibling capture'
+            }])).toMatchObject({captured: true, stored: true, errors: []});
+            // Capture selects its new record; resume the working layout before its automatic saves.
+            expect(await root.app.callMethod(root.workspaceId, 'saveTopology', ['layout-b']))
+                .toMatchObject({persisted: true, current: true, errors: []});
+
             await popup.locator(TAB, {hasText: 'Priority Alert Observatory'}).click();
             await expect(popup.locator(`[id="${alertsId}"]`)).toBeVisible();
             await expect(popup.locator(`[id="${feedId}"]`)).toBeHidden();
             await expect.poll(async () => (await root.app.callMethod(root.workspaceId, 'getDockTopologyWorkspaces')).details.nodes['details-tabs'].activeItemId).toBe('alerts');
+            expect((await root.app.getComponent(root.workspaceId, ['topologyCollection'])).topologyCollection.topologies['sibling-capture'].workspaces.details)
+                .toEqual(seed.records.b.workspaces.details);
 
             const restored = await root.app.callMethod(root.workspaceId, 'dockService.restorePerspective', [{
-                componentId: root.workspaceId, name: 'layout-b'
+                componentId: root.workspaceId, name: 'sibling-capture'
             }]);
             expect(restored).toMatchObject({switched: true, errors: []});
             expect((await root.app.callMethod(root.workspaceId, 'getDockTopologyWorkspaces')).details).toEqual(seed.records.b.workspaces.details);

--- a/test/playwright/unit/dashboard/DockTabEnterButton.spec.mjs
+++ b/test/playwright/unit/dashboard/DockTabEnterButton.spec.mjs
@@ -185,6 +185,7 @@ test.describe('Neo.dashboard.dock.interaction.TabEnterButton', () => {
                 onDockHeaderAction() {},
                 onDockCrossZoneDrop() {},
                 onDockZoneDocumentChange: DockWorkspace.prototype.onDockZoneDocumentChange,
+                projectDockZoneDocument : DockWorkspace.prototype.projectDockZoneDocument,
                 refreshDockWorkspace    : transient => refreshes.push(transient),
                 publishPaneContract     : DockWorkspace.prototype.publishPaneContract,
                 resolvePane             : DockWorkspace.prototype.resolvePane,

--- a/test/playwright/unit/dashboard/DockTopologySeams.spec.mjs
+++ b/test/playwright/unit/dashboard/DockTopologySeams.spec.mjs
@@ -16,6 +16,7 @@ import Persistence              from '../../../../src/dashboard/dock/model/Persi
 import TopologyReconciler       from '../../../../src/dashboard/dock/model/TopologyReconciler.mjs';
 import {createDockWorkspaceSet} from '../../../../src/dashboard/dock/window/WorkspaceSet.mjs';
 import TransactionManager       from '../../../../src/manager/Transaction.mjs';
+import WorkspaceDocument        from '../../../../src/dashboard/dock/model/WorkspaceDocument.mjs';
 
 /**
  * @summary The holder seam pair a multi-window perspective restore reaches an app through.
@@ -107,13 +108,14 @@ test.describe('Neo.dashboard.dock.window.TopologySeams — the multi-window rest
         const
             groupId = TransactionManager.bind({windowId: `seams-host-${groups.length + 1}`, workspaceKey: 'main'}).groupId,
             vessel  = {document: vesselDoc()},
-            set     = createDockWorkspaceSet({manager: TransactionManager, getGroupId: () => groupId});
+            set     = createDockWorkspaceSet({manager: TransactionManager, getGroupId: () => groupId, documentModel: WorkspaceDocument});
 
         groups.push(groupId);
 
         set.register('main', {
             getDocument: () => host.dockModel,
-            setDocument: document => host.dockModel = document
+            setDocument: document => host.dockModel = document,
+            project    : context => host.projectDockZoneDocument(context.snapshot.participants.main, context.descriptor)
         });
 
         set.register('vessel', {
@@ -184,7 +186,7 @@ test.describe('Neo.dashboard.dock.window.TopologySeams — the multi-window rest
         // one — this arm is what fails if that stops being true.
         expect(result.workspaces.main.nodes['main-tabs'].activeItemId, 'captured active tab wins over live').toBe('strategy');
 
-        const commit = workspace.commitDockTopologyWorkspaces(result.workspaces, {operation: 'restorePerspective'});
+        const commit = await workspace.commitDockTopologyWorkspaces(result.workspaces, {operation: 'restorePerspective'});
 
         expect(commit.errors).toEqual([]);
 
@@ -195,17 +197,42 @@ test.describe('Neo.dashboard.dock.window.TopologySeams — the multi-window rest
         await workspace.refreshPromise
     });
 
-    test('a commit refuses rather than dropping slots it cannot hold', () => {
+    test('a commit refuses rather than dropping slots it cannot hold', async () => {
         workspace = Neo.create(TopologyWorkspace, {dockModel: primaryDoc()});
 
         // no set: a single-document workspace must never silently swallow a two-window record
-        const refused = workspace.commitDockTopologyWorkspaces({main: primaryDoc(), vessel: vesselDoc()});
+        const refused = await workspace.commitDockTopologyWorkspaces({main: primaryDoc(), vessel: vesselDoc()});
 
         expect(refused.errors).toHaveLength(1);
         expect(refused.errors[0]).toContain('registered workspace key');
 
-        expect(workspace.commitDockTopologyWorkspaces({}).errors).toHaveLength(1);
-        expect(workspace.commitDockTopologyWorkspaces({main: null}).errors).toHaveLength(1);
-        expect(workspace.commitDockTopologyWorkspaces(null).errors).toHaveLength(1)
+        expect((await workspace.commitDockTopologyWorkspaces({})).errors).toHaveLength(1);
+        expect((await workspace.commitDockTopologyWorkspaces({main: null})).errors).toHaveLength(1);
+        expect((await workspace.commitDockTopologyWorkspaces(null)).errors).toHaveLength(1)
+    });
+
+    test('a failed sibling projection reports an effect failure without rolling back adopted documents', async () => {
+        workspace = Neo.create(TopologyWorkspace, {dockModel: primaryDoc()});
+        const {set, vessel} = createSet(workspace), receipts = [], groupId = groups.at(-1);
+        workspace.workspaceSet = set;
+        set.register('vessel', {
+            getDocument: () => vessel.document,
+            setDocument: document => vessel.document = document,
+            project    : () => { throw new Error('sibling render failed') }
+        });
+        const listener = event => { if (event.groupId === groupId) receipts.push(event.receipt) };
+        TransactionManager.on('effectReceipt', listener);
+        try {
+            const next      = {main: primaryRearranged(), vessel: vesselDoc()};
+            const committed = await workspace.commitDockTopologyWorkspaces(next);
+            expect(committed.errors).toEqual([]);
+            await expect.poll(() => receipts.find(receipt => receipt.kind === 'projection' && receipt.id === 'vessel'))
+                .toMatchObject({transactionId: committed.transactionId, error: 'sibling render failed'});
+            expect(workspace.getDockTopologyWorkspaces()).toEqual(next);
+            expect(TransactionManager.get(groupId).snapshot.participants).toEqual(next);
+            await workspace.refreshPromise
+        } finally {
+            TransactionManager.un('effectReceipt', listener)
+        }
     })
 });


### PR DESCRIPTION
Resolves #18272
Related: #18303, #18314, #18316

A topology restore now commits through the Group, which runs the registered owners' projection callbacks. Each projection preserves panes owned by sibling documents in the committed snapshot, so a source refresh cannot destroy a pane before its destination adopts it. Projection failure is reported as an effect receipt while the committed documents remain authoritative.

`Workspace.projectDockZoneDocument` and Demo B's `projectWorkspaceDocument` expose their existing presentation queues without admitting another write. Demo B consumes the existing `TopologySeams` mixin; its Neural Link topology interface was previously unreachable. `DockService` awaits the holder's semantic result.

Evidence: L3 (real Chrome source and popup, same-instance transfer/restore, applied missing-sibling-projection mutation) → L3 required (AC-1/2/4). Residual: Workstation full-Workspace birth and all-origin admission, Residual-Owner: #18314; final composed product journey, Residual-Owner: #18316. The paired Workstation receipt below exercises the actual producer and projection changes together; it does not close either producer/integration ticket.

## AC Evidence

| AC | Evidence |
|---|---|
| AC-1 | Outside-CI: `e2e/dashboard/DemoBPerspectiveToolsNL.spec.mjs` restores all three registered documents, returns the original CounterPane from a real popup to main, and removes the sibling's stale tab and tabs projection. The paired Workstation arm restores its saved active pane visibly. |
| AC-2 | Both browser arms use the shipped Demo B or Workstation hosts and native popup windows. Pane IDs are discovered from their live App Worker. |
| AC-3 | `WorkspaceSet.register({project})` documents the post-commit callback and its snapshot-derived sibling `preserveItemIds`; the owner returns its projection promise. CI-covered: `unit/dashboard/DockTopologySeams.spec.mjs` verifies a failed sibling projection produces an effect receipt without reverting either document. |
| AC-4 | Outside-CI: the same Demo B arm with `NEO_TEST_DROP_SIBLING_PROJECTION=1` confirms that the live patch applied, then fails on stale popup tab count `1` instead of `0`, after document restoration and main-pane return have passed. |

Spec paths above are relative to `test/playwright/`.

## Deltas from ticket

The Group's `project` seam already existed; this change connects the owners and replaces the primary-only imperative restore. The live Demo B probe exposed its missing holder mixin and the need to preserve sibling-owned panes during source-first refresh. Both are implemented through existing engine primitives.

The ungrouped pre-change event still sees the outgoing document. A dedicated Maximize control caught an initial ordering error; it remains unchanged and passes. The existing duck-typed tab-entry fixture now borrows the extracted presentation method as well as the admission method.

Decision Record impact: aligned with ADR 0029's worker-owned documents and post-commit render-target effects. No decision change.

size-guard-growth: src/dashboard/dock/Workspace.mjs — exposes the existing presentation queue separately for Group participants; 1289 to 1294 code lines
size-guard-growth: apps/workstation/view/Workspace.mjs — connects its existing renderer and sibling-preservation options; 3247 to 3250 code lines
size-guard-growth: examples/dashboard/crossWindow/DemoBWorkspace.mjs — connects existing renderers and the shared topology holder contract; 2653 to 2663 code lines

## Test Evidence

Commands use `NEO_AGENTOS_RUNTIME_ROOT=<Brain checkout>` and `npx playwright test -c test/playwright/playwright.config.e2e.mjs --workers=1 --headed --reporter=dot`.

- `e2e/dashboard/DemoBPerspectiveToolsNL.spec.mjs`: 2/2 passed, 3.6s, normal exit. Covers the existing single-window path and the new multi-window path.
- Same file, `--grep 'a topology restore moves'` with `NEO_TEST_DROP_SIBLING_PROJECTION=1`: expected failure on the stale sibling Workbench tab after the patch returned `success: true`. No production method is modified in the normal run.
- `e2e/workstation/WorkstationTopologyGroupsNL.spec.mjs --grep 'topology restore presents'`: 1/1 passed, 5.2s, normal exit on frozen combined checkpoint `ecfeedddb9423428af2c1adc54d608c16cb0907b`, containing the full-popup producer under #18314 and this branch's two implementation commits. The test captures a separate perspective, reselects its working layout before autosave, clicks Alerts, verifies both the changed document and preserved capture, then restores the visible original Feed pane. The fixture's Git state was clean before and after; source changes during earlier development probes were not counted as receipts.

An earlier Demo B control lost the original pane before sibling preservation was added. The retained assertion requires the same instance throughout. Empty staging tabs are compared using the document model's established normalization; visible state is asserted independently.

Generated class hierarchy was regenerated and is unchanged.

## Post-Merge Validation

Consume this projection seam with #18314's full popup owners and all dock origins, then retain the complete save/reload/undo journey under #18316. These existing tickets keep their full acceptance criteria.

## Commits

- `1fd0d43819` — Group topology restore and presentation-only owner callbacks
- `95990698cb` — sibling pane preservation and real-window positive/mutation controls
- `cadccb4b9a` — stable named-capture witness and measured host-size receipt

## Signal Ledger

| Family | Identity | Signal | Source |
|---|---|---|---|
| Claude | Grace | AUTHOR_SIGNAL | D#18224 final folded body |
| GPT | Emmy | GRADUATION_APPROVED | [Terminal source approval](https://github.com/neomjs/neo/discussions/18224#discussioncomment-18293824), body version 2026-09-04T17:53:27Z |

The [Epic](https://github.com/neomjs/neo/issues/18303) retains the contract and [independent entry review](https://github.com/neomjs/neo/issues/18303#issuecomment-5544825646).

## Unresolved Dissent

None against the graduated projection contract.

## Unresolved Liveness

No inactive-family signal is treated as consent. A failure of the retained source/sibling controls reopens the corresponding implementation claim.

Authored by Emmy (GPT-6 Astra, Codex). Session 01a07609-7277-73d1-a959-f6db8617f17c.

