### PR TITLE
fix(dashboard): DemoB withdraws both native sources when it is destroyed (#18314)

### DIFF
--- a/buildScripts/util/file-size-baseline.json
+++ b/buildScripts/util/file-size-baseline.json
@@ -1,6 +1,6 @@
 {
     "apps/workstation/view/Workspace.mjs": 2970,
-    "examples/dashboard/crossWindow/DemoBWorkspace.mjs": 2619,
+    "examples/dashboard/crossWindow/DemoBWorkspace.mjs": 2622,
     "src/dashboard/dock/Workspace.mjs": 1017,
     "src/main/addon/DragDrop.mjs": 1267
 }

--- a/examples/dashboard/crossWindow/DemoBWorkspace.mjs
+++ b/examples/dashboard/crossWindow/DemoBWorkspace.mjs
@@ -4564,6 +4564,13 @@ class DemoBWorkspace extends Container {
         me.crossWindowHosts.clear();
         me.crossWindowGeometry.clear();
         me.workspaceProjectionRequests.clear();
+        // Both sources withdraw their effects, or this destroyed host's callbacks stay live on a
+        // Group that outlives it — the Group keeps any native windows it still owns, which is the
+        // point of withdrawing effects rather than clearing ownership.
+        me.nativeWindows?.unregisterSource(me.vesselSourceId);
+        me.nativeWindows?.unregisterSource(me.stageSourceId);
+        me.nativeWindows = null;
+
         TransactionManager.un({
             bind        : me.onTopologyBind,
             leaseExpired: me.onTopologyLeaseExpired,

--- a/test/playwright/unit/examples/dashboard/crossWindow/DemoBWorkspace.spec.mjs
+++ b/test/playwright/unit/examples/dashboard/crossWindow/DemoBWorkspace.spec.mjs
@@ -2281,6 +2281,19 @@ test.describe.serial('Neo.examples.dashboard.crossWindow.DemoBWorkspace', () => 
         for (const registry of ['admissions', 'connections', 'owners', 'retirements']) {
             expect(vessel[registry], `${registry} is source-scoped`).not.toBe(stage[registry])
         }
+
+        // Destroying this host WITHDRAWS both sources' effects. The Group outlives the view and may
+        // still own native windows, so withdrawal deactivates the callbacks without clearing that
+        // ownership — the same split `dashboard.dock.Workspace#destroy` makes for its one source.
+        expect([vessel.active, stage.active], 'both are live before teardown').toEqual([true, true]);
+
+        workspace.destroy();
+
+        expect([vessel.active, stage.active], 'a destroyed host leaves no live effects on the Group')
+            .toEqual([false, false]);
+
+        // The registries themselves survive: withdrawal is not repossession.
+        expect(vessel.admissions, 'withdrawing effects never discards what the Group still owns').toBeTruthy()
     });
 
     test('the second popup stages through the same seams with its own continuation and window name', async () => {

--- a/test/playwright/unit/examples/dashboard/crossWindow/DemoBWorkspace.spec.mjs
+++ b/test/playwright/unit/examples/dashboard/crossWindow/DemoBWorkspace.spec.mjs
@@ -2287,13 +2287,27 @@ test.describe.serial('Neo.examples.dashboard.crossWindow.DemoBWorkspace', () => 
         // ownership — the same split `dashboard.dock.Workspace#destroy` makes for its one source.
         expect([vessel.active, stage.active], 'both are live before teardown').toEqual([true, true]);
 
+        // Read back through the OWNER after teardown, never through references captured before it.
+        // A captured registry stays truthy once emptied, so an implementation that DELETED both
+        // source records would satisfy every assertion made against those captures — the lookup is
+        // the only thing that can tell "withdrawn" from "discarded".
+        const owner    = workspace.nativeWindows,
+              vesselId = workspace.vesselSourceId,
+              stageId  = workspace.stageSourceId;
+
         workspace.destroy();
 
-        expect([vessel.active, stage.active], 'a destroyed host leaves no live effects on the Group')
+        const vesselAfter = owner.sources.get(vesselId),
+              stageAfter  = owner.sources.get(stageId);
+
+        expect([vesselAfter?.active, stageAfter?.active], 'a destroyed host leaves no live effects on the Group')
             .toEqual([false, false]);
 
-        // The registries themselves survive: withdrawal is not repossession.
-        expect(vessel.admissions, 'withdrawing effects never discards what the Group still owns').toBeTruthy()
+        // Withdrawal is not repossession: the Group KEEPS both records, because it may still own
+        // native windows this host no longer projects. Identity, not truthiness — a discarded record
+        // resolves to `undefined` here and fails, which is the control the truthiness check lost.
+        expect(vesselAfter, 'the vessel record survives its host').toBe(vessel);
+        expect(stageAfter, 'the stage record survives its host').toBe(stage)
     });
 
     test('the second popup stages through the same seams with its own continuation and window name', async () => {


### PR DESCRIPTION
Resolves #18390

`DemoBWorkspace` registers **two** native sources with its Group and withdraws **neither**, so a destroyed workspace leaves two live effect sets behind — `prepare`, `bound`, `released`, `open` and `close` all still reachable from the Group, all pointing at a component that no longer exists. The engine has always done this correctly for its single source (`dashboard.dock.Workspace#destroy`); my #18314 port added the second registration site and did not copy the teardown. This is my own defect, and #18383 merged before the follow-up existed.

Evidence: L2 (unit arm over the real `NativeLifecycle` registry, asserting effect withdrawal and ownership retention through the owner) → L2 required (#18390 AC-1..AC-4 are all CI-reachable; nothing here needs a live host, a real popup, or post-merge state). Residual: none.

Live on `dev` @ `3a0773c9a5`:

```
$ git show origin/dev:examples/dashboard/crossWindow/DemoBWorkspace.mjs | grep -c 'registerSource('    → 2
$ git show origin/dev:examples/dashboard/crossWindow/DemoBWorkspace.mjs | grep -c 'unregisterSource'   → 0
$ git show origin/dev:src/dashboard/dock/Workspace.mjs                  | grep -c 'unregisterSource'   → 1
```

**Withdrawal is not repossession.** The Group outlives the view and may still own native windows, so this deactivates the effects without clearing ownership — the same split the engine makes.

size-guard-growth: examples/dashboard/crossWindow/DemoBWorkspace.mjs — three teardown lines in `destroy`; the alternative is leaking two effect sets per destroyed workspace, and the file is an example whose whole job is to demonstrate the correct lifecycle.

## AC Evidence
| AC-1 | CI-covered: `grep -c unregisterSource examples/dashboard/crossWindow/DemoBWorkspace.mjs` → 2, in `destroy` |
| AC-2 | CI-covered: `unit/examples/dashboard/crossWindow/DemoBWorkspace.spec.mjs` — "learning the Group registers TWO native sources…", reading BOTH halves back through `owner.sources.get(<sourceId>)` after `destroy()`: `active === false` for each, and each record still identical to the one registered |
| AC-3 | Outside-CI: three-state control table in `## Test Evidence` below, including the discard control AC-2 requires to fail |
| AC-4 | CI-covered: `check-size` green with `file-size-baseline.json` at 2622 and the `size-guard-growth:` line above |

## Deltas from ticket
None substantive. Three lines in `destroy` plus one spec arm, and the baseline re-name the ratchet requires for them.

## Test Evidence
All coverage runs in CI.

The one receipt CI cannot show is the **red control**, because it required substituting a file CI never builds — `origin/dev`'s own `DemoBWorkspace.mjs`, not a reverted copy of my branch. Reverting my branch would prove the arm *can* red; it would not prove the shipped code is broken.

```
$ git show origin/dev:examples/.../DemoBWorkspace.mjs > examples/.../DemoBWorkspace.mjs
$ npx playwright test … -g "registers TWO native sources"
> 2293 |             .toEqual([false, false]);
  1 failed
$ git checkout HEAD -- examples/.../DemoBWorkspace.mjs   # fix restored
  1 passed
```

It fails on the exact `active` assertion, not a downstream symptom.

**@neo-gpt-emmy's RA-1 (`pullrequestreview-5126308098`) found the retention half could not witness its property**, and she was right. It read `expect(vessel.admissions).toBeTruthy()` — a reference captured *before* teardown — and a captured registry stays truthy once emptied. Her control, an implementation that unregisters and then **deletes** both source records, satisfied every assertion and the arm stayed green. AC-2 requires that control to fail.

Both halves now read back through the lifecycle owner by source id, and retention asserts **identity** rather than truthiness — a discarded record resolves to `undefined` there:

```js
const owner = workspace.nativeWindows, vesselId = workspace.vesselSourceId, stageId = workspace.stageSourceId;
workspace.destroy();
const vesselAfter = owner.sources.get(vesselId), stageAfter = owner.sources.get(stageId);
expect([vesselAfter?.active, stageAfter?.active]).toEqual([false, false]);  // effects withdrawn
expect(vesselAfter).toBe(vessel);                                          // NOT discarded
expect(stageAfter).toBe(stage);
```

Three states, each run:

| implementation | arm |
|---|---|
| unregisters **and deletes** both records (the discard control) | **FAIL** ← used to pass |
| the fix as written | PASS |
| `origin/dev`'s own source, no fix | **FAIL** |

No source change was requested and none was made: the fix was never what was wrong.

## Post-Merge Validation
- [ ] None required. The defect and its fix are both fully observable in CI; nothing here depends on a live host, a real popup, or post-merge state.

## Commits (if multi-commit)
- `118c1aeb67` — the fix and its arm (clean cherry-pick of `c18890a442`, no conflicts)
- `345b7eaf82` — re-baseline `DemoBWorkspace.mjs` 2619 → 2622 for the three added lines
- `0e7cac2c26` — RA-1: the retention half reads back through the owner, asserting identity (test only)

Authored by Ada (Claude Opus 5, Claude Code). Session 95f9ff6e-1ba5-43b6-860a-208fbf7f4442.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
