### PR TITLE
feat(dock): make vessel conversion policy overridable (#18388)

### DIFF
--- a/docs/output/class-hierarchy.json
+++ b/docs/output/class-hierarchy.json
@@ -250,6 +250,7 @@
  "Neo.dashboard.dock.window.Participation": "Neo.core.Base",
  "Neo.dashboard.dock.window.Placement": "Neo.core.Base",
  "Neo.dashboard.dock.window.TopologySeams": "Neo.core.Base",
+ "Neo.dashboard.dock.window.VesselConversion": "Neo.core.Base",
  "Neo.data.Model": "Neo.core.Base",
  "Neo.data.Pipeline": "Neo.core.Base",
  "Neo.data.RecordFactory": "Neo.core.Base",

--- a/src/dashboard/dock/interaction/TabSortZone.mjs
+++ b/src/dashboard/dock/interaction/TabSortZone.mjs
@@ -1,5 +1,5 @@
-import {createVesselConversionSensor} from '../window/VesselConversion.mjs';
-import TabHeaderSortZone              from '../../../draggable/tab/header/toolbar/SortZone.mjs';
+import VesselConversion  from '../window/VesselConversion.mjs';
+import TabHeaderSortZone from '../../../draggable/tab/header/toolbar/SortZone.mjs';
 
 /**
  * @class Neo.dashboard.dock.interaction.TabSortZone
@@ -455,13 +455,13 @@ class TabSortZone extends TabHeaderSortZone {
 
     /**
      * @summary Returns the source-owned conversion sensor, creating it lazily for an active drag.
-     * @returns {Object}
+     * @returns {Neo.dashboard.dock.window.VesselConversion}
      * @protected
      */
     getVesselConversionSensor() {
         let me = this;
 
-        return me.vesselConversionSensor ??= createVesselConversionSensor({
+        return me.vesselConversionSensor ??= Neo.create(VesselConversion, {
             convertThreshold: me.vesselConversionConvertThreshold,
             revertThreshold : me.vesselConversionRevertThreshold,
             onConvertIn(record) {
@@ -1386,10 +1386,12 @@ class TabSortZone extends TabHeaderSortZone {
     }
 
     /**
-     * Resets the pure binding before the ordinary SortZone teardown.
+     * @summary Destroys the owned conversion sensor before ordinary SortZone teardown.
      * @param {...*} args
      */
     destroy(...args) {
+        this.vesselConversionSensor?.destroy();
+        this.vesselConversionSensor = null;
         this.resetVesselConversion();
         super.destroy(...args)
     }

--- a/src/dashboard/dock/window/VesselConversion.mjs
+++ b/src/dashboard/dock/window/VesselConversion.mjs
@@ -1,352 +1,262 @@
-/**
- * @module Neo.dashboard.dock.window.VesselConversion
- * @summary The dual-window conversion decision authority — the pure sensor deciding WHEN a dragged
- * popup converts into a semi-transparent drag proxy over a target vessel, and when it converts back.
- *
- * The landed tear-out grammar's intersection ratio ({@link Neo.draggable.container.SortZone#checkWindowBoundary},
- * `area(intersection) / area(dragged)`) is a SELF-retention measure against one window and is
- * mathematically broken for popup-over-vessel: with the dragged window as denominator, a large
- * window over a small target caps at `area(target) / area(dragged)` — for a 2× size difference the
- * ratio can never exceed 0.5, so any usable threshold is UNREACHABLE; the mirror denominator fails
- * the mirror case. Both windows are freely resizable mid-session, so no creation-time basis works
- * either. This module's metric is reachable for EVERY size pair in both directions: per-axis
- * overlap normalized by the SMALLER extent per axis — `rx = overlapWidth / min(widthA, widthB)`,
- * `ry` likewise — composed through an injectable seam (default `min(rx, ry)`: both axes must
- * substantially cover the smaller footprint). Composed = 1.0 exactly when the smaller per-axis
- * footprint is fully covered, whichever window is bigger. Ratios derive from the LIVE rects of
- * every sample, so a mid-session resize re-normalizes on the next frame.
- *
- * The choreography contract this implements (the docking design record, multi-window amendment):
- * - **Conversion is a transition predicate, never a new state.** Convert-in IS the geometric
- *   condition for the outcome machine's existing `DETACHED_MOVING → HOVERING_CLAIM` transition;
- *   convert-out is its inverse. The design record's source-hook pair (`suspendWindowDrag` /
- *   `resumeWindowDrag`) is the contract-named actuator set a host binds the two seams to — the
- *   record's outcome machine gains NO state and needs NO amendment for this capability.
- * - **The pointer gate is asymmetric, deliberately.** Rect overlap alone never converts: intent
- *   stays pointer-owned, so convert-in requires a LIVE claim on the target's dock-accepting region.
- *   Convert-OUT is different — it requires an OBSERVED exit or a geometric retreat, never the mere
- *   absence of a claim. A claim expires 300ms after its last refresh, and a stationary pointer
- *   refreshes nothing, so an ordinary pause over the drop target used to un-convert a vessel that
- *   had not moved at all. An un-converted vessel still cannot be pinned by a stale claim, because
- *   convert-in kept its live-claim requirement.
- * - **The dead band IS the Schmitt trigger.** `convertThreshold` (in) sits strictly above
- *   `revertThreshold` (out), validated fail-loud; a decision fires only on crossing its OWN
- *   threshold, so the convert-in moment lies above the revert band by construction — the false-flip
- *   class the landed grammar needed an arming flag for (its exit fires INSIDE its reattach zone)
- *   is structurally excluded here, no arming state required.
- * - **Terminals are not the sensor's business.** `reset()` clears conversion state SILENTLY and
- *   idempotently: gesture terminals (commit, cancel, vessel close, park) are choreographed by the
- *   outcome machine and the vessel-lifecycle leaves; a sensor emitting on reset would double-drive
- *   the actuators the terminal choreography already owns.
- * - **Garbage geometry fails CLOSED and DOMINATES composition.** Missing, zero-extent, or
- *   non-finite rects force the sample to 0 WITHOUT consulting the composition seam — an injected
- *   composer (average, weighted sum, anything non-`min`-shaped) can never elevate a degenerate
- *   axis's valid-looking `0` back above a threshold. A converted sensor fed garbage REVERTS.
- *   Without the non-finite guard, `NaN` would additionally poison both threshold comparisons to
- *   false and freeze a converted sensor forever.
- *
- * The shipped thresholds are REVIEWABLE PLACEHOLDERS: the dead-band width mirrors the landed
- * grammar's proven 0.2 spread; the absolute positions and the composition pick (`min` vs product)
- * await the parent leaf's empirical calibration on the headed matrix harness. Calibration swaps
- * config values and the `composeRatios` seam — never this contract.
- */
+import Base from '../../../core/Base.mjs';
 
 /**
- * Validates one threshold config value: a finite number in (0, 1].
- * @param {String} name The config key, for the fail-loud message
- * @param {Number} value
- * @private
+ * @summary Owns one vessel's transient conversion decision and asynchronous admission.
+ * Geometry and decision methods are overridable independently of transition ownership. The default
+ * uses overlap divided by the smaller extent on each axis, with a live pointer claim for entry and
+ * an observed exit or geometric retreat for reversion. Reset and destruction invalidate pending
+ * admission without firing either actuator; no conversion state enters the dock document.
+ * @class Neo.dashboard.dock.window.VesselConversion
+ * @extends Neo.core.Base
  */
-function assertThreshold(name, value) {
-    if (!Number.isFinite(value) || value <= 0 || value > 1) {
-        throw new Error(`createVesselConversionSensor: ${name} must be a finite number in (0, 1] — got ${value}`)
-    }
-}
-
-/**
- * Clamps one ratio into [0, 1], failing CLOSED on non-finite input: garbage geometry must read as
- * "no overlap", never as "hold the current decision" (NaN compares false against every threshold,
- * which would freeze a converted sensor permanently).
- * @param {Number} value
- * @returns {Number}
- * @private
- */
-function clampRatio(value) {
-    return Number.isFinite(value) ? Math.min(1, Math.max(0, value)) : 0
-}
-
-/**
- * Whether one `{x, y, width, height}` rect is measurable window geometry: every field finite,
- * both extents strictly positive. The VALIDITY gate the composition seam sits behind — a
- * degenerate axis yields a valid-LOOKING `0` ratio, and an injected composer that is not
- * `min`-shaped (an average, a weighted sum) could elevate that zero back above a threshold, so
- * invalid geometry must dominate BEFORE composition, never inside it.
- * @param {Object} rect
- * @returns {Boolean}
- * @private
- */
-function isMeasurableRect(rect) {
-    return Boolean(rect) &&
-        Number.isFinite(rect.x) && Number.isFinite(rect.y) &&
-        Number.isFinite(rect.width)  && rect.width  > 0 &&
-        Number.isFinite(rect.height) && rect.height > 0
-}
-
-/**
- * One axis of the min-extent-normalized overlap metric over `{x, y, width, height}` rects.
- * @param {Object} a
- * @param {Object} b
- * @param {String} axis 'x' or 'y'
- * @param {String} extent 'width' or 'height'
- * @returns {Number} overlap along the axis divided by the smaller extent, clamped fail-closed
- * @private
- */
-function axisRatio(a, b, axis, extent) {
-    const
-        overlap   = Math.min(a[axis] + a[extent], b[axis] + b[extent]) - Math.max(a[axis], b[axis]),
-        minExtent = Math.min(a[extent], b[extent]);
-
-    return minExtent > 0 ? clampRatio(Math.max(0, overlap) / minExtent) : 0
-}
-
-/**
- * Creates one dual-window conversion sensor for one gesture surface, closed over one conversion
- * flag. One sensor serves one drag surface — a pointer drives at most one window-drag per window
- * (the same single-slot reasoning as the tear-out choreography), so the flag never needs a map.
- *
- * Decisions flow through the two injected seams exclusively; the per-sample geometry record is the
- * observability surface. A host binds the seams to the design record's named source-hook actuators:
- * `onConvertIn → suspendWindowDrag` territory (the popup yields, the proxy embodies over the
- * target), `onConvertOut → resumeWindowDrag` territory (the popup embodiment resumes — the emitted
- * record's `sourceRect` is the live rect to resume at).
- * @param {Object} config
- * @param {Function} [config.composeRatios] `({rx, ry}) => Number` — composes the two per-axis
- *     ratios into the one decision ratio. Defaults to `Math.min(rx, ry)` (both axes must cover the
- *     smaller footprint). The calibration seam: the parent leaf's empirical pick lands here. A
- *     non-finite return fails closed to 0.
- * @param {Number} [config.convertThreshold=0.55] Composed ratio at/above which — pointer gate
- *     satisfied — a detached vessel converts to a proxy. Must sit strictly above `revertThreshold`.
- * @param {Number} [config.revertThreshold=0.35] Composed ratio below which a converted vessel
- *     reverts to its detached embodiment. The gap to `convertThreshold` is the flicker-free dead band.
- * @param {Function} config.onConvertIn Strict admission seam, fired exactly once per conversion
- *     attempt with the proposed final sample record. `true` admits synchronously;
- *     `Promise<true>` admits only when it settles. Every other result refuses without changing
- *     conversion ownership.
- * @param {Function} config.onConvertOut Strict admission seam, fired exactly once per reversion
- *     attempt with the proposed final sample record. Re-show refusal preserves conversion
- *     ownership so the exact same vessel remains recoverable and the transition may be retried.
- * @returns {Object} `{converted, reset, sample, targetConverted, transitioning,
- *     transitionPromise}` — live admitted state plus the source-owned async admission latch
- */
-export function createVesselConversionSensor(config = {}) {
-    const {
-        composeRatios   = ({rx, ry}) => Math.min(rx, ry),
-        convertThreshold = 0.55,
-        revertThreshold  = 0.35,
-        onConvertIn,
-        onConvertOut
-    } = config;
-
-    assertThreshold('convertThreshold', convertThreshold);
-    assertThreshold('revertThreshold',  revertThreshold);
-
-    if (convertThreshold <= revertThreshold) {
-        throw new Error(
-            'createVesselConversionSensor: convertThreshold must sit strictly above revertThreshold — ' +
-            `the dead band between them is the flicker-free hysteresis contract (got in: ${convertThreshold}, out: ${revertThreshold})`
-        )
+class VesselConversion extends Base {
+    static config = {
+        /**
+         * @member {String} className='Neo.dashboard.dock.window.VesselConversion'
+         * @protected
+         */
+        className: 'Neo.dashboard.dock.window.VesselConversion',
+        /**
+         * Inclusive entry threshold; strictly greater than revertThreshold.
+         * @member {Number} convertThreshold=0.55
+         */
+        convertThreshold: 0.55,
+        /**
+         * Strict entry admission: only true or Promise<true> accepts the proposal.
+         * @member {Function|null} onConvertIn=null
+         */
+        onConvertIn: null,
+        /**
+         * Strict reversion admission; refusal retains conversion for retry.
+         * @member {Function|null} onConvertOut=null
+         */
+        onConvertOut: null,
+        /**
+         * A converted vessel reverts below this threshold, leaving a dead band.
+         * @member {Number} revertThreshold=0.35
+         */
+        revertThreshold: 0.35
     }
 
-    if (typeof composeRatios !== 'function') {
-        throw new Error('createVesselConversionSensor: composeRatios must be a function seam')
+    /**
+     * @member {Boolean} conversionAccepted=false
+     * @protected
+     */
+    conversionAccepted = false
+    /**
+     * @member {Number} generation=0
+     * @protected
+     */
+    generation = 0
+    /**
+     * @member {Object|null} transition=null
+     * @protected
+     */
+    transition = null
+
+    /**
+     * The admitted conversion state.
+     * @member {Boolean} converted
+     */
+    get converted() {
+        return this.conversionAccepted === true
     }
 
-    if (typeof onConvertIn !== 'function' || typeof onConvertOut !== 'function') {
-        throw new Error(
-            'createVesselConversionSensor: onConvertIn and onConvertOut are required function seams — ' +
-            'decisions flow through the actuators, never through polling'
-        )
+    /**
+     * The pending proposal, or the admitted state.
+     * @member {Boolean} targetConverted
+     */
+    get targetConverted() {
+        return this.transition?.targetConverted ?? this.converted
     }
 
-    // The admitted single-gesture conversion flag plus one generation-scoped platform transition.
-    // The coordinator still consumes a synchronous policy record; the promise never leaves this
-    // source owner. A reset invalidates the generation so a predecessor completion cannot mutate
-    // its successor gesture.
-    let converted  = false,
-        generation = 0,
-        transition = null;
+    /**
+     * Whether actuator admission is pending.
+     * @member {Boolean} transitioning
+     */
+    get transitioning() {
+        return Boolean(this.transition)
+    }
 
-    return {
-        /**
-         * @member {Boolean} converted
-         */
-        get converted() {
-            return converted
-        },
+    /**
+     * Pending strict admission.
+     * @member {Promise<Boolean>|null} transitionPromise
+     */
+    get transitionPromise() {
+        return this.transition?.promise ?? null
+    }
 
-        /**
-         * The proposed state of an in-flight transition, otherwise the admitted state.
-         * @member {Boolean} targetConverted
-         */
-        get targetConverted() {
-            return transition?.targetConverted ?? converted
-        },
+    /**
+     * @summary Validates effective policy before allocating a registered instance.
+     * @param {Object} [config={}]
+     */
+    construct(config={}) {
+        this.validateConfig({...this.constructor.config, composeRatios: this.composeRatios, ...config});
+        super.construct(config)
+    }
 
-        /**
-         * @member {Boolean} transitioning
-         */
-        get transitioning() {
-            return transition !== null
-        },
+    /**
+     * @summary Requires a finite threshold in (0, 1].
+     * @param {String} name
+     * @param {Number} value
+     * @protected
+     */
+    assertThreshold(name, value) {
+        if (!Number.isFinite(value) || value <= 0 || value > 1) {
+            throw new Error(`${this.className}: ${name} must be a finite number in (0, 1] — got ${value}`)
+        }
+    }
 
-        /**
-         * The current strict-admission settlement, or `null` when no platform effect is pending.
-         * @member {Promise<Boolean>|null} transitionPromise
-         */
-        get transitionPromise() {
-            return transition?.promise ?? null
-        },
+    /**
+     * @summary Measures one axis against the smaller live extent.
+     * @param {Object} a
+     * @param {Object} b
+     * @param {String} axis
+     * @param {String} extent
+     * @returns {Number}
+     */
+    axisRatio(a, b, axis, extent) {
+        const overlap = Math.min(a[axis] + a[extent], b[axis] + b[extent]) - Math.max(a[axis], b[axis]),
+              minimum = Math.min(a[extent], b[extent]);
+        return minimum > 0 ? this.clampRatio(Math.max(0, overlap) / minimum) : 0
+    }
 
-        /**
-         * Terminal reset — SILENT and idempotent by contract: gesture terminals (commit, cancel,
-         * close, park) are the outcome machine's choreography; the sensor only forgets. The next
-         * gesture's samples decide fresh.
-         */
-        reset() {
-            generation++;
-            converted  = false;
-            transition = null
-        },
+    /**
+     * @summary Bounds a ratio, treating non-finite geometry as no overlap.
+     * @param {Number} value
+     * @returns {Number}
+     */
+    clampRatio(value) {
+        return Number.isFinite(value) ? Math.min(1, Math.max(0, value)) : 0
+    }
 
-        /**
-         * One gesture-frame decision over the LIVE rects. Fires at most one seam per sample:
-         * convert-in on crossing `convertThreshold` with the pointer inside the target,
-         * convert-out on crossing below `revertThreshold` OR the pointer leaving the target.
-         * Samples inside the dead band (gate unchanged) fire nothing — the hysteresis hold.
-         * @param {Object} data
-         * @param {Boolean} data.pointerInTarget The claim-protocol feed: a LIVE claim on the
-         *     target's dock-accepting region. It answers "is there a live claim?", NOT "is the
-         *     pointer inside?" — a claim expires 300ms after its last refresh, and a stationary
-         *     pointer refreshes nothing. Gates convert-IN unconditionally; gates convert-OUT only
-         *     when `pointerExitedTarget` is absent.
-         * @param {Boolean} [data.pointerExitedTarget] TRI-STATE observed departure, and absence
-         *     fails SAFE. `true` is an observed exit and reverts at any ratio. `false` is an
-         *     observed still-inside and HOLDS the conversion through a lapsed claim — the only
-         *     state that suppresses the pause flicker. ABSENT (`undefined`/`null`) means the host
-         *     cannot distinguish a real exit from an expired claim, and falls back to the landed
-         *     contract where losing the claim reverts. Absence must never buy the permissive
-         *     reading: defaulting it to "not exited" would let rect overlap alone HOLD a
-         *     conversion for every caller not yet taught this signal, deleting the
-         *     both-directions gate by omission rather than by decision.
-         * @param {Object} data.sourceRect Live `{x, y, width, height}` of the dragged vessel
-         * @param {Object} data.targetRect Live `{x, y, width, height}` of the target vessel
-         * @returns {Object} The sample record `{composed, converted, pointerInTarget, rx, ry,
-         *     sourceRect, targetRect}`. While strict async admission is pending it additionally
-         *     carries `transitioning: true`, and `converted` remains the prior admitted state.
-         */
-        sample({pointerExitedTarget, pointerInTarget, sourceRect, targetRect} = {}) {
-            // Invalid geometry DOMINATES: a missing, degenerate, or non-finite rect forces the
-            // whole sample to zero WITHOUT consulting the composition seam — a degenerate axis
-            // produces a valid-looking 0 ratio, and a non-min injected composer could elevate it
-            // back above the convert threshold, silently defeating the fail-closed contract.
-            const
-                measurable = isMeasurableRect(sourceRect) && isMeasurableRect(targetRect),
-                pointer    = pointerInTarget === true,
-                // A CONVERTED vessel reverts on a genuine exit, never on mere claim absence — but
-                // ONLY when the host can actually tell those apart.
-                //
-                // `pointerInTarget` is the claim arbiter's live resolution, and a claim expires
-                // `claimTtlMs` (300ms) after its last refresh. A stationary pointer fires no move
-                // events, so an ordinary human pause over the drop target lets the claim lapse
-                // while the vessel sits fully inside the target — measured: `composed` stays at
-                // 1.000 while `converted` flips true→false→true per pause. That is a user-visible
-                // convert/revert flicker on every hover, not a stale claim. `pointerInTarget`
-                // answers "is there a live claim?" while this decision needs "did the pointer
-                // leave?", and a lapsed timer is not a departure.
-                //
-                // So `pointerExitedTarget` is TRI-STATE, and absence fails SAFE rather than
-                // permissive. `true` is an observed exit and reverts. `false` is an observed
-                // still-inside — the flicker fix, and the only state that holds a conversion
-                // through a lapsed claim. ABSENT means the host cannot distinguish the two, and
-                // must never silently buy the permissive reading: it falls back to the landed
-                // contract where losing the claim reverts. Defaulting absence to "not exited"
-                // would let rect overlap alone HOLD a conversion for every caller that has not
-                // been taught the new signal — deleting the documented both-directions gate by
-                // omission rather than by decision.
-                //
-                // Convert-IN is deliberately unchanged and still demands a live claim, so a stale
-                // claim can never pin a vessel that was never converted.
-                exitObserved = pointerExitedTarget === true,
-                exitUnknown  = pointerExitedTarget === undefined || pointerExitedTarget === null,
-                exited       = exitObserved || (exitUnknown && !pointer),
-                rx         = measurable ? axisRatio(sourceRect, targetRect, 'x', 'width')  : 0,
-                ry         = measurable ? axisRatio(sourceRect, targetRect, 'y', 'height') : 0,
-                composed   = measurable ? clampRatio(composeRatios({rx, ry})) : 0;
+    /**
+     * @summary Requires both axes to cover the smaller footprint by default.
+     * @param {Object} ratios
+     * @param {Number} ratios.rx
+     * @param {Number} ratios.ry
+     * @returns {Number}
+     */
+    composeRatios({rx, ry}) {
+        return Math.min(rx, ry)
+    }
 
-            let event = null,
-                next  = converted;
+    /**
+     * @summary Invalidates pending admission before Base unregisters this sensor.
+     */
+    destroy() {
+        this.reset();
+        super.destroy()
+    }
 
-            // Convert-IN still requires a live claim: an un-converted vessel must never be pinned
-            // by a claim that is not currently valid.
-            if (!transition && !converted) {
-                if (pointer && composed >= convertThreshold) {
-                    event = onConvertIn;
-                    next  = true
-                }
-            } else if (!transition && (exited || composed < revertThreshold)) {
-                event = onConvertOut;
-                next  = false
-            }
+    /**
+     * @summary Admits finite rectangles with positive extents before composition.
+     * @param {Object|null} rect
+     * @returns {Boolean}
+     */
+    isMeasurableRect(rect) {
+        return Boolean(rect) && Number.isFinite(rect.x) && Number.isFinite(rect.y) &&
+            Number.isFinite(rect.width) && rect.width > 0 &&
+            Number.isFinite(rect.height) && rect.height > 0
+    }
 
-            let record = {composed, converted, pointerInTarget: pointer, rx, ry, sourceRect, targetRect};
+    /**
+     * @summary Clears conversion silently and invalidates pending completions.
+     */
+    reset() {
+        this.generation++;
+        this.conversionAccepted = false;
+        this.transition = null
+    }
 
-            if (transition) {
-                return {...record, transitioning: true}
-            }
+    /**
+     * @summary Selects a state without owning actuator admission or its lifecycle.
+     * A false observed exit holds through a lapsed claim; absent exit evidence keeps strict
+     * claim-loss behavior. Entry always requires a current pointer claim.
+     * @param {Object} record Measured sample and admitted state.
+     * @param {Boolean|null} pointerExitedTarget Tri-state observed departure.
+     * @returns {Boolean}
+     */
+    resolveConversion(record, pointerExitedTarget) {
+        const {composed, converted, pointerInTarget} = record;
+        if (!converted) return pointerInTarget && composed >= this.convertThreshold;
+        const exited = pointerExitedTarget === true || (pointerExitedTarget == null && !pointerInTarget);
+        return !exited && composed >= this.revertThreshold
+    }
 
-            if (!event) {
-                return record
-            }
+    /**
+     * @summary Measures a live frame and submits at most one strict proposal.
+     * Invalid geometry dominates composition. Pending admission preserves the previously admitted
+     * state; reset or destruction makes a late completion inert.
+     * @param {Object} [data={}]
+     * @param {Boolean} data.pointerInTarget Current claim on the accepting region.
+     * @param {Boolean|null} [data.pointerExitedTarget] Observed exit/still-inside evidence.
+     * @param {Object} data.sourceRect Live {x, y, width, height}.
+     * @param {Object} data.targetRect Live {x, y, width, height}.
+     * @returns {Object} Sample with rx, ry, composed, converted and optional transitioning.
+     */
+    sample({pointerExitedTarget, pointerInTarget, sourceRect, targetRect} = {}) {
+        const me         = this,
+              measurable = me.isMeasurableRect(sourceRect) && me.isMeasurableRect(targetRect),
+              rx         = measurable ? me.axisRatio(sourceRect, targetRect, 'x', 'width') : 0,
+              ry         = measurable ? me.axisRatio(sourceRect, targetRect, 'y', 'height') : 0,
+              composed   = measurable ? me.clampRatio(me.composeRatios({rx, ry})) : 0,
+              record     = {composed, converted: me.conversionAccepted,
+                  pointerInTarget: pointerInTarget === true, rx, ry, sourceRect, targetRect};
 
-            const proposed = {...record, converted: next};
+        if (me.transition) return {...record, transitioning: true};
 
-            let admission;
+        const next = me.resolveConversion(record, pointerExitedTarget);
+        if (typeof next !== 'boolean' || next === me.conversionAccepted) return record;
 
-            try {
-                admission = event(proposed)
-            } catch {
-                return record
-            }
+        const proposed = {...record, converted: next},
+              event    = next ? me.onConvertIn : me.onConvertOut;
+        let admission;
+        try {
+            admission = event.call(me, proposed)
+        } catch {
+            return record
+        }
 
-            if (admission === true) {
-                converted = next;
-                return proposed
-            }
+        if (admission === true) {
+            me.conversionAccepted = next;
+            return proposed
+        }
+        if (typeof admission?.then !== 'function') return record;
 
-            if (typeof admission?.then !== 'function') {
-                return record
-            }
+        const token = ++me.generation,
+              state = {promise: null, targetConverted: next, token};
+        me.transition = state;
+        state.promise = Promise.resolve(admission).then(value => {
+            if (me.isDestroyed || me.transition !== state || me.generation !== token) return false;
+            value === true && (me.conversionAccepted = next);
+            me.transition = null;
+            return value === true
+        }, () => {
+            if (!me.isDestroyed && me.transition === state && me.generation === token) me.transition = null;
+            return false
+        });
+        return {...record, transitioning: true}
+    }
 
-            const token = ++generation,
-                  state = {promise: null, targetConverted: next, token};
-
-            transition = state;
-            state.promise = Promise.resolve(admission).then(value => {
-                if (transition !== state || generation !== token) return false;
-
-                value === true && (converted = next);
-                transition = null;
-
-                return value === true
-            }, () => {
-                if (transition === state && generation === token) {
-                    transition = null
-                }
-
-                return false
-            });
-
-            return {...record, transitioning: true}
+    /**
+     * @summary Checks the default policy's band and required callbacks.
+     * @param {Object} config Effective class defaults plus instance overrides.
+     * @protected
+     */
+    validateConfig({composeRatios, convertThreshold, revertThreshold, onConvertIn, onConvertOut}) {
+        this.assertThreshold('convertThreshold', convertThreshold);
+        this.assertThreshold('revertThreshold', revertThreshold);
+        if (convertThreshold <= revertThreshold) {
+            throw new Error(`${this.className}: convertThreshold must sit strictly above revertThreshold`)
+        }
+        if (typeof composeRatios !== 'function') {
+            throw new Error(`${this.className}: composeRatios must be a function seam`)
+        }
+        if (typeof onConvertIn !== 'function' || typeof onConvertOut !== 'function') {
+            throw new Error(`${this.className}: onConvertIn and onConvertOut are required function seams`)
         }
     }
 }
+
+export default Neo.setupClass(VesselConversion);

--- a/test/playwright/unit/dashboard/DockTabSortZone.spec.mjs
+++ b/test/playwright/unit/dashboard/DockTabSortZone.spec.mjs
@@ -22,6 +22,24 @@ import TabHeaderSortZone from '../../../../src/draggable/tab/header/toolbar/Sort
  * walk); the rendered consequence rides the visual harness.
  */
 test.describe('Neo.dashboard.dock.interaction.TabSortZone', () => {
+    test('owns the registered sensor across resets and destroys it with the zone', async () => {
+        const zone = Neo.create(DockTabSortZone, {
+            owner: {addDomListeners() {}, cls: [], dragResortable: false,
+                items: [], on() {}, style: {}, up: () => ({fire() {}})}
+        });
+        try {
+            await zone.ready();
+            const sensor = zone.getVesselConversionSensor();
+            expect(sensor.className).toBe('Neo.dashboard.dock.window.VesselConversion');
+            zone.resetVesselConversion();
+            expect(zone.getVesselConversionSensor()).toBe(sensor);
+            zone.destroy();
+            expect(sensor.isDestroyed).toBe(true)
+        } finally {
+            zone.destroy()
+        }
+    });
+
     test('keeps dock headers parent-sized and toolbar-relative during a drag', () => {
         expect(DockTabSortZone.config.adjustItemRectsToParent).toBe(true);
         expect(DockTabSortZone.config.expandOwnerOnDrag).toBe(false);
@@ -629,8 +647,11 @@ test.describe('Neo.dashboard.dock.interaction.TabSortZone', () => {
     });
 
     test.describe('vessel conversion binding — source-owned decision and pointer stability', () => {
+        const zones      = [];
         const sourceRect = {x: 20, y: 20, width: 200, height: 120};
         const targetRect = {x: 0, y: 0, width: 800, height: 600};
+
+        test.afterEach(() => zones.splice(0).forEach(zone => zone.vesselConversionSensor?.destroy()));
 
         function createZone(overrides = {}) {
             const calls = [];
@@ -679,6 +700,7 @@ test.describe('Neo.dashboard.dock.interaction.TabSortZone', () => {
                 ...overrides
             };
 
+            zones.push(zone);
             return {calls, zone}
         }
 

--- a/test/playwright/unit/dashboard/DockVesselConversion.spec.mjs
+++ b/test/playwright/unit/dashboard/DockVesselConversion.spec.mjs
@@ -4,15 +4,15 @@ setup({
     appConfig: {
         name: 'DashboardDockVesselConversionTest'
     },
-    // The sensor is a zero-import pure module: no Main facade, no LocalStorage addon. Declaring
-    // both mocks off keeps this file runnable SOLO — the mock paths call `Neo.ns`, which only
-    // exists once a sibling spec has loaded the real core into the shared worker.
+    // The decision owner needs no Main facade or LocalStorage addon.
     mockLocalStorage: false,
     mockMain        : false
 });
 
-import {test, expect}                 from '@playwright/test';
-import {createVesselConversionSensor} from '../../../../src/dashboard/dock/window/VesselConversion.mjs';
+import {test, expect}   from '@playwright/test';
+import Neo              from '../../../../src/Neo.mjs';
+import * as core        from '../../../../src/core/_export.mjs';
+import VesselConversion from '../../../../src/dashboard/dock/window/VesselConversion.mjs';
 
 /**
  * @summary The dual-window conversion sensor, driven end-to-end through its injected seams.
@@ -25,11 +25,20 @@ import {createVesselConversionSensor} from '../../../../src/dashboard/dock/windo
  * fails CLOSED — a converted sensor fed NaN reverts instead of freezing. The seams are the
  * decision surface; the returned sample record is the geometry surface.
  */
-test.describe('Neo.dashboard.dock.window.VesselConversion — createVesselConversionSensor', () => {
+test.describe('Neo.dashboard.dock.window.VesselConversion', () => {
+    const sensors      = [];
+    const createSensor = (config, cls=VesselConversion) => {
+        const sensor = Neo.create(cls, config);
+        sensors.push(sensor);
+        return sensor
+    };
+
+    test.afterEach(() => sensors.splice(0).forEach(sensor => sensor.destroy()));
+
     const harness = (config = {}) => {
         const calls = {converted: [], reverted: []};
 
-        const sensor = createVesselConversionSensor({
+        const sensor = createSensor({
             onConvertIn: record => {
                 calls.converted.push(record);
                 return true
@@ -52,6 +61,66 @@ test.describe('Neo.dashboard.dock.window.VesselConversion — createVesselConver
         pointerInTarget,
         sourceRect: rect(bx, 0, 100, 100),
         targetRect: rect(0, 0, 100, 100)
+    });
+
+    test('a policy override changes measurement without copying transition ownership', () => {
+        const {sensor} = harness();
+        sensor.axisRatio = () => 1;
+        expect(slideSample(sensor, 99).converted).toBe(true)
+    });
+
+    test('the registered class and a subclass share lifecycle while specializing the decision', () => {
+        expect(Neo.ns('Neo.dashboard.dock.window.VesselConversion')).toBe(VesselConversion);
+        class NeverConvert extends VesselConversion {
+            static config = {className: 'Test.Unit.Dashboard.VesselConversion.NeverConvert'};
+            resolveConversion() { return false }
+        }
+        const sensor = createSensor({onConvertIn: () => true, onConvertOut: () => true}, Neo.setupClass(NeverConvert));
+        expect(sensor instanceof VesselConversion).toBe(true);
+        expect(slideSample(sensor, 0).converted).toBe(false);
+        expect(sensor.transitioning).toBe(false)
+    });
+
+    test('Neo.overwrites changes inherited policy methods and defaults before registration', () => {
+        const previous = Neo.overwrites;
+        class OverwrittenPolicy extends VesselConversion {
+            static config = {className: 'Test.Unit.Dashboard.VesselConversion.OverwrittenPolicy'}
+        }
+        try {
+            Neo.overwrites = {Test: {Unit: {Dashboard: {VesselConversion: {OverwrittenPolicy: {
+                convertThreshold: 0.9,
+                resolveConversion(record) { return record.pointerInTarget }
+            }}}}}};
+            const sensor = createSensor({onConvertIn: () => true, onConvertOut: () => true}, Neo.setupClass(OverwrittenPolicy));
+            expect(sensor.convertThreshold).toBe(0.9);
+            expect(slideSample(sensor, 99).converted).toBe(true)
+        } finally {
+            Neo.overwrites = previous
+        }
+    });
+
+    test('destruction unregisters the sensor and makes late admission inert', async () => {
+        let finish;
+        const admission = new Promise(resolve => finish = resolve),
+              {sensor}  = harness({onConvertIn: () => admission}),
+              id        = sensor.id,
+              lookup    = () => Neo.manager?.Instance?.get(id) ?? Neo.idMap?.[id];
+        expect(lookup()).toBe(sensor);
+        slideSample(sensor, 0);
+        const pending = sensor.transitionPromise;
+        sensor.destroy();
+        finish(true);
+        await expect(pending).resolves.toBe(false);
+        expect(sensor.isDestroyed).toBe(true);
+        expect(sensor.converted).toBe(false);
+        expect(sensor.transitioning).toBe(false);
+        expect(lookup()).toBeFalsy()
+    });
+
+    test('invalid policy is rejected before an instance id is registered', () => {
+        const id = 'invalid-vessel-policy-18388';
+        expect(() => createSensor({id, convertThreshold: 0})).toThrow(/finite number/);
+        expect(Neo.manager?.Instance?.get(id) ?? Neo.idMap?.[id]).toBeFalsy()
     });
 
     test('reachability: composed attains 1.0 and converts for EVERY size-pair direction — small over large, large over small, near-equal, extreme aspect', () => {
@@ -330,17 +399,17 @@ test.describe('Neo.dashboard.dock.window.VesselConversion — createVesselConver
     test('config validation fails LOUD: inverted or degenerate bands, out-of-range thresholds, missing or non-function seams', () => {
         const seams = {onConvertIn: () => {}, onConvertOut: () => {}};
 
-        expect(() => createVesselConversionSensor({...seams, convertThreshold: 0.3, revertThreshold: 0.5}))
+        expect(() => createSensor({...seams, convertThreshold: 0.3, revertThreshold: 0.5}))
             .toThrow(/strictly above/);
-        expect(() => createVesselConversionSensor({...seams, convertThreshold: 0.4, revertThreshold: 0.4}))
+        expect(() => createSensor({...seams, convertThreshold: 0.4, revertThreshold: 0.4}))
             .toThrow(/strictly above/);
-        expect(() => createVesselConversionSensor({...seams, convertThreshold: 1.2}))
+        expect(() => createSensor({...seams, convertThreshold: 1.2}))
             .toThrow(/finite number in \(0, 1\]/);
-        expect(() => createVesselConversionSensor({...seams, revertThreshold: 0}))
+        expect(() => createSensor({...seams, revertThreshold: 0}))
             .toThrow(/finite number in \(0, 1\]/);
-        expect(() => createVesselConversionSensor({onConvertIn: () => {}}))
+        expect(() => createSensor({onConvertIn: () => {}}))
             .toThrow(/required function seams/);
-        expect(() => createVesselConversionSensor({...seams, composeRatios: 'min'}))
+        expect(() => createSensor({...seams, composeRatios: 'min'}))
             .toThrow(/composeRatios must be a function seam/)
     });
 


### PR DESCRIPTION
Resolves #18388
Related: #18304

Vessel conversion is now a registered `Neo.core.Base` class. Applications can specialize geometry and conversion decisions through methods or `Neo.overwrites` without copying asynchronous admission. TabSortZone creates, reuses across resets, and destroys its sensor. The closure factory and its callers are removed.

Evidence: L2 (real Neo class creation, overwrite/subclass dispatch, generation-fenced admission and source teardown) → L2 required. Residual: none for this leaf.

## AC Evidence

| AC | Evidence |
|---|---|
| AC-1 | `DockVesselConversion.spec.mjs`: namespace identity, instance policy override, subclass decision and `Neo.overwrites` method/default controls. |
| AC-2 | Existing sensor geometry, threshold, pointer-exit, hysteresis and strict sync/async admission cases retain their assertions. |
| AC-3 | Reset and destroy controls settle held admission after invalidation and verify no restored conversion or pending transition. |
| AC-4 | Real TabSortZone owns/reuses/destroys the sensor; invalid configuration fails before registration; source/test scan finds no retired factory callers. |
| AC-5 | Sensor/source suites, full unit suite, generated class hierarchy and preflight checks pass. |

## Deltas from ticket

None substantive. `resolveConversion` isolates decision policy from admission lifecycle; validation occurs before Base allocates an instance id. No other dashboard owner is changed.

## Test Evidence

The regression was red before implementation: replacing a sensor's `axisRatio` with `() => 1` still produced `converted: false`, because the closure ignored that method. It passes through the class's method dispatch. All coverage runs in CI.

## Signal Ledger

D#18150's [terminal approval](https://github.com/neomjs/neo/discussions/18150#discussioncomment-18293826) establishes per-responsibility ownership. The [extensibility finding](https://github.com/neomjs/neo/issues/18304#issuecomment-5560546655) and [independent peer assessment](https://github.com/neomjs/neo/issues/18304#issuecomment-5560658524) require specializing a stateful decision without duplicating its lifecycle.

## Unresolved Dissent

No new decision-machine or persistence contract is proposed. The surrounding dashboard architecture remains under #18304.

## Unresolved Liveness

No deferred acceptance for this leaf.

## Post-Merge Validation

No additional post-merge-only requirements.

Authored by Euclid (GPT-6, Codex). Session 01a07609-5e09-70f0-bf2c-a27d77d1b7f2.

