### PR TITLE
feat(dock): register shared preview policy (#18389)

### DIFF
--- a/apps/workstation/view/Workspace.mjs
+++ b/apps/workstation/view/Workspace.mjs
@@ -29,7 +29,7 @@ import {
 }                                                from '../../../src/dashboard/dock/window/VesselEmbodiment.mjs';
 import {createDockWorkspaceSet}                 from '../../../src/dashboard/dock/window/WorkspaceSet.mjs';
 import {createVesselParkHandlers}               from '../../../src/dashboard/dock/window/VesselPark.mjs';
-import {previewToOperation}                     from '../../../src/dashboard/dock/model/PreviewContract.mjs';
+import PreviewContract                          from '../../../src/dashboard/dock/model/PreviewContract.mjs';
 import {workstationTourScript, initialDocument} from '../tour/denseWorkstation.mjs';
 import '../../../src/button/Base.mjs';
 import '../../../src/tab/Container.mjs';
@@ -1164,7 +1164,7 @@ class Workspace extends DockWorkspace {
 
                 return me.renderCrossWindowPreview(workspaceId, data)
             },
-            previewToOperation,
+            previewToOperation   : preview => PreviewContract.previewToOperation(preview),
             promoteDragEmbodiment: data => me.vesselProxyEmbodiment.promote({
                 itemId        : data.draggedItem?.dockItemId,
                 targetWindowId: windowId
@@ -3740,7 +3740,7 @@ class Workspace extends DockWorkspace {
                 }
             }
 
-            let descriptor     = previewToOperation(finalPreview),
+            let descriptor     = PreviewContract.previewToOperation(finalPreview),
                 expectedResult = descriptor && Operations.applyOperation(
                     WorkspaceDocument.clone(documentBefore),
                     descriptor

--- a/docs/output/class-hierarchy.json
+++ b/docs/output/class-hierarchy.json
@@ -235,6 +235,7 @@
  "Neo.dashboard.dock.interaction.TabSortZone": "Neo.draggable.tab.header.toolbar.SortZone",
  "Neo.dashboard.dock.model.Operations": "Neo.core.Base",
  "Neo.dashboard.dock.model.Persistence": "Neo.core.Base",
+ "Neo.dashboard.dock.model.PreviewContract": "Neo.core.Base",
  "Neo.dashboard.dock.model.TopologyDiff": "Neo.core.Base",
  "Neo.dashboard.dock.model.TopologyReconciler": "Neo.core.Base",
  "Neo.dashboard.dock.model.WorkspaceDocument": "Neo.core.Base",

--- a/examples/dashboard/crossWindow/DemoBCrossWindowStage.mjs
+++ b/examples/dashboard/crossWindow/DemoBCrossWindowStage.mjs
@@ -1,8 +1,8 @@
-import Container            from '../../../src/container/Base.mjs';
-import DockDropIndicators   from '../../../src/dashboard/dock/interaction/DropIndicators.mjs';
-import DockPreview          from '../../../src/dashboard/dock/interaction/Preview.mjs';
-import WorkspaceDocument    from '../../../src/dashboard/dock/model/WorkspaceDocument.mjs';
-import {previewToOperation} from '../../../src/dashboard/dock/model/PreviewContract.mjs';
+import Container          from '../../../src/container/Base.mjs';
+import DockDropIndicators from '../../../src/dashboard/dock/interaction/DropIndicators.mjs';
+import DockPreview        from '../../../src/dashboard/dock/interaction/Preview.mjs';
+import WorkspaceDocument  from '../../../src/dashboard/dock/model/WorkspaceDocument.mjs';
+import PreviewContract    from '../../../src/dashboard/dock/model/PreviewContract.mjs';
 
 /**
  * @module Neo.examples.dashboard.crossWindow.DemoBCrossWindowStage
@@ -182,7 +182,7 @@ export function createCrossWindowStage(seams) {
             getForeignDocument: sourceWorkspaceId => getWorkspaceDocument(sourceWorkspaceId),
             hitTest           : (localX, localY) => hitTestWorkspace(workspaceId, localX, localY),
             previewFor        : data => renderWorkspacePreview(workspaceId, data),
-            previewToOperation,
+            previewToOperation: preview => PreviewContract.previewToOperation(preview),
             resolveOwnershipId,
             sortGroup,
             windowId,

--- a/examples/dashboard/crossWindow/DemoBWorkspace.mjs
+++ b/examples/dashboard/crossWindow/DemoBWorkspace.mjs
@@ -1,31 +1,31 @@
-import Component                            from '../../../src/component/Base.mjs';
-import Container                            from '../../../src/container/Base.mjs';
-import CounterPane                          from './CounterPane.mjs';
-import {createCrossWindowStage}             from './DemoBCrossWindowStage.mjs';
-import DockDropIndicators                   from '../../../src/dashboard/dock/interaction/DropIndicators.mjs';
-import DockLayoutAdapter                    from '../../../src/dashboard/dock/projection/LayoutAdapter.mjs';
-import DockMotionSignal                     from '../../../src/dashboard/dock/projection/MotionSignal.mjs';
-import PerspectiveLibrary                   from '../../../src/dashboard/dock/persistence/PerspectiveLibrary.mjs';
-import Placement                            from '../../../src/dashboard/dock/window/Placement.mjs';
-import TopologySeams                        from '../../../src/dashboard/dock/window/TopologySeams.mjs';
-import DockPreview                          from '../../../src/dashboard/dock/interaction/Preview.mjs';
-import DockPreviewProducer                  from '../../../src/dashboard/dock/interaction/PreviewProducer.mjs';
-import DockProjectionReconciler             from '../../../src/dashboard/dock/projection/Reconciler.mjs';
-import DockService                          from '../../../src/ai/client/DockService.mjs';
-import DockTopologyReconciler               from '../../../src/dashboard/dock/model/TopologyReconciler.mjs';
-import WorkspaceDocument                    from '../../../src/dashboard/dock/model/WorkspaceDocument.mjs';
-import Operations                           from '../../../src/dashboard/dock/model/Operations.mjs';
-import Persistence                          from '../../../src/dashboard/dock/model/Persistence.mjs';
-import InteractionService                   from '../../../src/ai/client/InteractionService.mjs';
-import {createDockKeyboardCommands}         from '../../../src/dashboard/dock/interaction/KeyboardCommands.mjs';
-import {createDockTearOutHandlers}          from '../../../src/dashboard/dock/window/TearOut.mjs';
-import {createDockVesselEmbodiment}         from '../../../src/dashboard/dock/window/VesselEmbodiment.mjs';
-import {createDockWorkspaceSet}             from '../../../src/dashboard/dock/window/WorkspaceSet.mjs';
-import {createVesselParkHandlers}           from '../../../src/dashboard/dock/window/VesselPark.mjs';
-import TourRunner                           from '../../../src/ai/client/TourRunner.mjs';
-import TransactionManager                   from '../../../src/manager/Transaction.mjs';
-import {PREVIEW_SCHEMA, previewToOperation} from '../../../src/dashboard/dock/model/PreviewContract.mjs';
-import {demoBTourScript, initialDocument}   from './demoBPerspectives.mjs';
+import Component                          from '../../../src/component/Base.mjs';
+import Container                          from '../../../src/container/Base.mjs';
+import CounterPane                        from './CounterPane.mjs';
+import {createCrossWindowStage}           from './DemoBCrossWindowStage.mjs';
+import DockDropIndicators                 from '../../../src/dashboard/dock/interaction/DropIndicators.mjs';
+import DockLayoutAdapter                  from '../../../src/dashboard/dock/projection/LayoutAdapter.mjs';
+import DockMotionSignal                   from '../../../src/dashboard/dock/projection/MotionSignal.mjs';
+import PerspectiveLibrary                 from '../../../src/dashboard/dock/persistence/PerspectiveLibrary.mjs';
+import Placement                          from '../../../src/dashboard/dock/window/Placement.mjs';
+import TopologySeams                      from '../../../src/dashboard/dock/window/TopologySeams.mjs';
+import DockPreview                        from '../../../src/dashboard/dock/interaction/Preview.mjs';
+import DockPreviewProducer                from '../../../src/dashboard/dock/interaction/PreviewProducer.mjs';
+import DockProjectionReconciler           from '../../../src/dashboard/dock/projection/Reconciler.mjs';
+import DockService                        from '../../../src/ai/client/DockService.mjs';
+import DockTopologyReconciler             from '../../../src/dashboard/dock/model/TopologyReconciler.mjs';
+import WorkspaceDocument                  from '../../../src/dashboard/dock/model/WorkspaceDocument.mjs';
+import Operations                         from '../../../src/dashboard/dock/model/Operations.mjs';
+import Persistence                        from '../../../src/dashboard/dock/model/Persistence.mjs';
+import InteractionService                 from '../../../src/ai/client/InteractionService.mjs';
+import {createDockKeyboardCommands}       from '../../../src/dashboard/dock/interaction/KeyboardCommands.mjs';
+import {createDockTearOutHandlers}        from '../../../src/dashboard/dock/window/TearOut.mjs';
+import {createDockVesselEmbodiment}       from '../../../src/dashboard/dock/window/VesselEmbodiment.mjs';
+import {createDockWorkspaceSet}           from '../../../src/dashboard/dock/window/WorkspaceSet.mjs';
+import {createVesselParkHandlers}         from '../../../src/dashboard/dock/window/VesselPark.mjs';
+import TourRunner                         from '../../../src/ai/client/TourRunner.mjs';
+import TransactionManager                 from '../../../src/manager/Transaction.mjs';
+import PreviewContract                    from '../../../src/dashboard/dock/model/PreviewContract.mjs';
+import {demoBTourScript, initialDocument} from './demoBPerspectives.mjs';
 import '../../../src/button/Base.mjs';   // registers the `button` ntype the bars compose
 import '../../../src/tab/Container.mjs'; // registers the `tab-container` ntype the projection emits
 import '../../../src/toolbar/Base.mjs';  // registers the `toolbar` ntype the bars use
@@ -1004,7 +1004,7 @@ class DemoBWorkspace extends Container {
             feedback : {state: 'accepted'},
             itemId   : target.itemId,
             placement: {kind: 'tab-into'},
-            schema   : PREVIEW_SCHEMA,
+            schema   : PreviewContract.PREVIEW_SCHEMA,
             target   : {nodeId: target.tabsId}
         };
         renderer.applyTargetGeometry(me.localDockRect(zone.rect, geometry.hostRect))
@@ -3701,7 +3701,7 @@ class DemoBWorkspace extends Container {
     onDockCrossZoneDrop(workspaceId, data) {
         let me         = this,
             preview    = me.renderWorkspacePreview(workspaceId, data),
-            descriptor = previewToOperation(preview),
+            descriptor = PreviewContract.previewToOperation(preview),
             result     = null;
 
         me.crossWindowStats.localDropFires++;

--- a/src/dashboard/dock/Workspace.mjs
+++ b/src/dashboard/dock/Workspace.mjs
@@ -13,7 +13,7 @@ import StateProvider               from '../../state/Provider.mjs';
 import {createDockTearOutHandlers} from './window/TearOut.mjs';
 import WorkspaceDocument           from './model/WorkspaceDocument.mjs';
 import Operations                  from './model/Operations.mjs';
-import {previewToOperation}        from './model/PreviewContract.mjs';
+import PreviewContract             from './model/PreviewContract.mjs';
 import TopologySeams               from './window/TopologySeams.mjs';
 
 /**
@@ -2119,7 +2119,7 @@ class Workspace extends Container {
                 }))
                 .filter(zone => zone.rect),
             preview    = me.dockPreviewProducer?.produce({pointer: {x: clientX, y: clientY}, zones: producerZones, itemId, sourceNodeId}),
-            descriptor = preview && previewToOperation(preview);
+            descriptor = preview && PreviewContract.previewToOperation(preview);
 
         if (descriptor) {
             let result = me.applyDockZoneOperation(descriptor);

--- a/src/dashboard/dock/interaction/DragAffordances.mjs
+++ b/src/dashboard/dock/interaction/DragAffordances.mjs
@@ -1,7 +1,7 @@
-import Base                 from '../../../core/Base.mjs';
-import WorkspaceDocument    from '../model/WorkspaceDocument.mjs';
-import PreviewProducer      from './PreviewProducer.mjs';
-import {previewToOperation} from '../model/PreviewContract.mjs';
+import Base              from '../../../core/Base.mjs';
+import WorkspaceDocument from '../model/WorkspaceDocument.mjs';
+import PreviewProducer   from './PreviewProducer.mjs';
+import PreviewContract   from '../model/PreviewContract.mjs';
 
 /**
  * @class Neo.dashboard.dock.interaction.DragAffordances
@@ -335,7 +335,7 @@ class DragAffordances extends Base {
 
         me.clear();
 
-        let descriptor = previewToOperation(preview);
+        let descriptor = PreviewContract.previewToOperation(preview);
 
         if (descriptor) {
             let result = me.owner.applyDockZoneOperation(descriptor);

--- a/src/dashboard/dock/interaction/DropIndicators.mjs
+++ b/src/dashboard/dock/interaction/DropIndicators.mjs
@@ -1,7 +1,7 @@
-import Component             from '../../../component/Base.mjs';
-import Container             from '../../../container/Base.mjs';
-import NeoArray              from '../../../util/Array.mjs';
-import {isValidCandidateSet} from '../model/PreviewContract.mjs';
+import Component       from '../../../component/Base.mjs';
+import Container       from '../../../container/Base.mjs';
+import NeoArray        from '../../../util/Array.mjs';
+import PreviewContract from '../model/PreviewContract.mjs';
 
 /**
  * @summary The drag-time drop-indicator menu: renders every valid drop option simultaneously —
@@ -30,7 +30,7 @@ import {isValidCandidateSet} from '../model/PreviewContract.mjs';
  *   under the `--dock-transition-*` motion contract instead of popping. Visibility is cls-based
  *   (warm DOM), mirroring the reveal overlay.
  * - **Fail closed.** A malformed candidate set or a missing host rect hides the layer
- *   ({@link module:dockPreviewContract.isValidCandidateSet}) rather than guessing coordinates.
+ *   ({@link Neo.dashboard.dock.model.PreviewContract#isValidCandidateSet}) rather than guessing coordinates.
  *
  * @class Neo.dashboard.dock.interaction.DropIndicators
  * @extends Neo.container.Base
@@ -330,7 +330,7 @@ class DropIndicators extends Container {
             set                                                          = me.candidateSet,
             cls                                                          = me.cls || [],
             validHost                                                    = !!hostRect && [hostRect.x, hostRect.y].every(v => typeof v === 'number' && !Number.isNaN(v)),
-            visible                                                      = validHost && isValidCandidateSet(set),
+            visible                                                      = validHost && PreviewContract.isValidCandidateSet(set),
             placements                                                   = new Map();
 
         me.#indicatorRects.clear();

--- a/src/dashboard/dock/interaction/Preview.mjs
+++ b/src/dashboard/dock/interaction/Preview.mjs
@@ -1,5 +1,5 @@
-import Component                from '../../../component/Base.mjs';
-import * as dockPreviewContract from '../model/PreviewContract.mjs';
+import Component       from '../../../component/Base.mjs';
+import PreviewContract from '../model/PreviewContract.mjs';
 
 /**
  * @class Neo.dashboard.dock.interaction.Preview
@@ -22,42 +22,15 @@ import * as dockPreviewContract from '../model/PreviewContract.mjs';
  *   never written into the persisted dock-zone model. This component has no write path to a
  *   persisted model — it reads a preview and emits transient VDOM plus operation descriptors.
  * - **Fail closed.** A missing, malformed, stale or `rejected`-placement preview clears the
- *   affordance and performs no model mutation ({@link Neo.dashboard.dock.interaction.Preview.isValidPreview}).
+ *   affordance and performs no model mutation ({@link Neo.dashboard.dock.model.PreviewContract#isValidPreview}).
  * - **Semantic drop.** On an accepted drop the owning adapter converts the preview into a semantic
- *   operation (`moveItem` / `splitNode` / `addTab`); {@link Neo.dashboard.dock.interaction.Preview.previewToOperation}
+ *   operation (`moveItem` / `splitNode` / `addTab`); {@link Neo.dashboard.dock.model.PreviewContract#previewToOperation}
  *   yields that operation DESCRIPTOR — this overlay never mutates the dock tree itself.
  *
  * The producer (raw drag geometry -> `dockPreview`) and the operation executor (descriptor ->
  * persisted-tree mutation) are deliberately out of scope: they are separate docking leaves.
  */
 class Preview extends Component {
-    /**
-     * The dockPreview contract schema this renderer accepts.
-     * @member {String} PREVIEW_SCHEMA='neo.dock.preview.v1'
-     * @static
-     */
-    static PREVIEW_SCHEMA = dockPreviewContract.PREVIEW_SCHEMA
-    /**
-     * Every candidate `placement.kind` the contract defines.
-     * @member {Set<String>} VALID_PLACEMENT_KINDS
-     * @static
-     */
-    static VALID_PLACEMENT_KINDS = dockPreviewContract.VALID_PLACEMENT_KINDS
-    /**
-     * @member {Set<String>} EDGE_KINDS
-     * @static
-     */
-    static EDGE_KINDS = dockPreviewContract.EDGE_KINDS
-    /**
-     * @member {Set<String>} SPLIT_KINDS
-     * @static
-     */
-    static SPLIT_KINDS = dockPreviewContract.SPLIT_KINDS
-    /**
-     * @member {Set<String>} TAB_KINDS
-     * @static
-     */
-    static TAB_KINDS = dockPreviewContract.TAB_KINDS
 
     static config = {
         /**
@@ -128,21 +101,6 @@ class Preview extends Component {
     dragSource = null
 
     /**
-     * @summary Structural validity gate for a dockPreview object (fail-closed).
-     *
-     * Returns true only for a well-formed `neo.dock.preview.v1` payload that carries a
-     * stable `itemId`, a `target.nodeId`, a known `placement.kind`, an accept/reject
-     * `feedback.state`, and (for split placements) a valid `placement.orientation`. Anything
-     * malformed, partial or unknown returns false so the renderer clears rather than guesses.
-     * @param {Object|null} preview
-     * @returns {Boolean}
-     * @static
-     */
-    static isValidPreview(preview) {
-        return dockPreviewContract.isValidPreview(preview)
-    }
-
-    /**
      * @summary Maps a dockPreview into a renderable affordance descriptor, or null.
      *
      * Returns null for an invalid preview or a `rejected` placement (no candidate to draw).
@@ -154,7 +112,7 @@ class Preview extends Component {
      * @static
      */
     static mapPreviewToAffordance(preview) {
-        if (!this.isValidPreview(preview)) return null;
+        if (!PreviewContract.isValidPreview(preview)) return null;
 
         let {feedback, itemId, placement, target} = preview,
             {kind}                                = placement;
@@ -169,16 +127,16 @@ class Preview extends Component {
             targetNodeId: target.nodeId
         };
 
-        if (this.EDGE_KINDS.has(kind)) {
+        if (PreviewContract.EDGE_KINDS.has(kind)) {
             let edge     = kind.slice('edge-'.length),
-                position = dockPreviewContract.edgeSplitPosition(edge);
+                position = PreviewContract.edgeSplitPosition(edge);
 
             // The fraction the NEW pane commits to, resolved through the same authority
             // `previewToOperation` uses, so the region cannot paint a size the drop will not produce.
-            return {...base, group: 'edge', edge, ratio: this.newNodeFraction(placement.ratio, position)}
+            return {...base, group: 'edge', edge, ratio: PreviewContract.newNodeFraction(placement.ratio, position)}
         }
 
-        if (this.SPLIT_KINDS.has(kind)) {
+        if (PreviewContract.SPLIT_KINDS.has(kind)) {
             let position = kind.slice('split-'.length);
 
             return {
@@ -186,52 +144,13 @@ class Preview extends Component {
                 group      : 'split',
                 orientation: placement.orientation,
                 position,
-                ratio      : this.newNodeFraction(placement.ratio, position)
+                ratio      : PreviewContract.newNodeFraction(placement.ratio, position)
             }
         }
 
         return {...base, group: 'tab', index: Number.isInteger(placement.index) ? placement.index : null, position: kind.slice('tab-'.length)}
     }
 
-    /**
-     * @summary Converts an ACCEPTED drop into a semantic dock-zone operation descriptor, or null.
-     *
-     * The renderer never mutates the dock tree; it routes an accepted preview into one of the
-     * contract's semantic operations (`addTab` / `splitNode`) so the owning adapter can commit it.
-     * Invalid previews, `rejected` placements, and non-accepted feedback all yield null (no commit).
-     * Tab placements emit `addTab`; the adapter downgrades to `moveItem` when the item already
-     * lives in the tree. Edge placements route to `splitNode` (the adapter may instead realise an
-     * edge-zone insertion, then `normalizeTree`).
-     * @param {Object|null} preview
-     * @returns {Object|null}
-     * @static
-     */
-    static previewToOperation(preview) {
-        return dockPreviewContract.previewToOperation(preview)
-    }
-
-    /**
-     * @summary Normalizes an optional split ratio into a two-child, sum-to-one size pair.
-     * @param {Number} [ratio] the new node's fraction; defaults to an even split when absent/invalid
-     * @param {String} position 'before' | 'after' — which child the new node becomes
-     * @returns {Number[]} normalized [first, second] sizes summing to 1
-     * @static
-     */
-    static ratioToSizes(ratio, position) {
-        return dockPreviewContract.ratioToSizes(ratio, position)
-    }
-
-    /**
-     * @summary The fraction of the target axis the NEW pane will occupy.
-     *
-     * Reads the committed size pair rather than the raw ratio, so an absent or out-of-domain ratio
-     * lands on whatever `ratioToSizes` normalizes it to. `before` places the new node first, `after`
-     * second — the pair is indexed accordingly rather than re-deriving the ratio.
-     * @param {Number} [ratio] the new node's fraction; normalized by `ratioToSizes`
-     * @param {String} position `'before'` or `'after'`
-     * @returns {Number}
-     * @static
-     */
     /**
      * @summary The already-resolved region fraction on an affordance, or the even split.
      *
@@ -245,23 +164,6 @@ class Preview extends Component {
         let ratio = affordance?.ratio;
 
         return (typeof ratio === 'number' && ratio > 0 && ratio < 1) ? ratio : 0.5
-    }
-
-    /**
-     * @summary The fraction of the target axis the NEW pane will occupy.
-     *
-     * Reads the committed size pair rather than the raw ratio, so an absent or out-of-domain ratio
-     * lands on whatever `ratioToSizes` normalizes it to. `before` places the new node first, `after`
-     * second — the pair is indexed accordingly rather than re-deriving the ratio.
-     * @param {Number} [ratio] the new node's fraction; normalized by `ratioToSizes`
-     * @param {String} position `'before'` or `'after'`
-     * @returns {Number}
-     * @static
-     */
-    static newNodeFraction(ratio, position) {
-        let sizes = this.ratioToSizes(ratio, position);
-
-        return position === 'after' ? sizes[1] : sizes[0]
     }
 
     /**

--- a/src/dashboard/dock/interaction/PreviewProducer.mjs
+++ b/src/dashboard/dock/interaction/PreviewProducer.mjs
@@ -27,7 +27,7 @@ import Base from '../../../core/Base.mjs';
  * - **Layer-blind.** This producer must not import the renderer (`Neo.dashboard.dock.interaction.Preview`)
  *   renderer/validator. So this producer re-derives the schema's placement vocabulary locally; the
  *   producer → consumer contract is PINNED in the unit test (which may import both layers) by
- *   asserting every produced payload satisfies `Preview.isValidPreview`.
+ *   asserting every produced payload satisfies `PreviewContract.isValidPreview`.
  * - **Fail closed.** A malformed rect, a pointer outside every zone, or a missing item id yields
  *   `null` (no affordance) rather than a guess — mirroring the renderer's fail-closed clear.
  *

--- a/src/dashboard/dock/model/Operations.mjs
+++ b/src/dashboard/dock/model/Operations.mjs
@@ -313,7 +313,7 @@ class Operations extends Base {
      *
      * The leading/trailing side comes from an explicit `position` (`before` / `after`) when given;
      * otherwise it is derived from the descriptor's `edge` — `top` / `left` lead (before), `bottom` /
-     * `right` trail (after) — so a `Preview.previewToOperation()` edge descriptor places correctly.
+     * `right` trail (after) — so a `PreviewContract.previewToOperation()` edge descriptor places correctly.
      * @param {Object} document
      * @param {Object} args {itemId, targetNodeId, orientation, position, sizes, edge}
      * @returns {{document:Object, errors:String[]}}
@@ -347,7 +347,7 @@ class Operations extends Base {
             orientation,
             children: atPosition === 'before' ? [newTabsId, targetNodeId] : [targetNodeId, newTabsId],
             // `sizes` maps positionally to `children` in their final order; the caller
-            // (Preview.previewToOperation) supplies them already in that order.
+            // (PreviewContract.previewToOperation) supplies them already in that order.
             sizes   : ratio
         };
 
@@ -584,7 +584,7 @@ class Operations extends Base {
     }
 
     /**
-     * @summary Applies an operation descriptor (the shape `Preview.previewToOperation()` emits)
+     * @summary Applies an operation descriptor (the shape `PreviewContract.previewToOperation()` emits)
      * to the document, dispatching through {@link #operationHandlers} — the table whose keys ARE
      * the exported vocabulary, so dispatch and `operations` cannot diverge.
      *

--- a/src/dashboard/dock/model/PreviewContract.mjs
+++ b/src/dashboard/dock/model/PreviewContract.mjs
@@ -1,295 +1,319 @@
-/**
- * @summary The pure, layer-neutral `neo.dock.preview.v1` contract — the schema constant, the
- * placement-kind vocabulary, structural validation, the preview→operation conversion, and the
- * split-ratio normalizer.
- *
- * Extracted from the preview renderer (now `Neo.dashboard.dock.interaction.Preview`) so the three sides of the docking line share ONE source
- * of truth without a layer inversion: the producer (`Neo.dashboard.dock.interaction.PreviewProducer`, src), the
- * renderer (that app-layer view), AND the src-layer drop owners (`examples/dashboard/dock`, the FM
- * cockpit) — the src/example layers cannot import `apps/`, so the model-semantic half of the
- * contract had to move down here. Rendering + geometry stay in the view; only the pure half lives
- * here (no Neo class, no DOM, no persisted-model write).
- *
- * @see learn/agentos/DockZoneModel.md
- */
+import Base from '../../../core/Base.mjs';
 
 /**
- * The dockPreview contract schema every side of the line accepts / emits.
- * @type {String}
+ * @summary Owns validation and conversion of runtime dock previews through one Neo policy.
+ * @description Renderer and drop callers share this registered owner. Internal decisions dispatch
+ * through its methods so Neo.overwrites reaches normalization, validation and conversion together.
+ * The methods return plain data and never mutate a document or acquire rendering resources.
+ * @class Neo.dashboard.dock.model.PreviewContract
+ * @extends Neo.core.Base
+ * @singleton
  */
-export const PREVIEW_SCHEMA = 'neo.dock.preview.v1';
-
-/**
- * The drop-candidate-set schema: the runtime-only payload the producer emits for the
- * indicator-overlay menu (the full valid-placement menu for one hovered zone plus the
- * container edge chips), consumed by `Neo.dashboard.dock.interaction.DropIndicators`. Every candidate
- * wraps a complete, individually valid `neo.dock.preview.v1` payload — a drop on an
- * indicator commits through `previewToOperation` exactly like a pointer-inferred preview.
- * @type {String}
- */
-export const CANDIDATES_SCHEMA = 'neo.dock.candidates.v1';
-
-/**
- * The five cross positions of the indicator menu, in render order. `center` maps to the
- * tab-merge candidate; the four directions map to directional split candidates (which kind —
- * `edge-*` node split vs `split-before/after` sibling insert — the producer resolves from the
- * hovered zone's parent-split orientation, identical to the pointer-inference grammar).
- * @type {String[]}
- */
-export const CROSS_POSITIONS = ['center', 'top', 'right', 'bottom', 'left'];
-
-/** The four container-edge chip positions, in render order. @type {String[]} */
-export const CHIP_EDGES = ['top', 'right', 'bottom', 'left'];
-
-/** @type {Set<String>} */
-export const EDGE_KINDS = new Set(['edge-top', 'edge-right', 'edge-bottom', 'edge-left']);
-
-/** @type {Set<String>} */
-export const SPLIT_KINDS = new Set(['split-before', 'split-after']);
-
-/** @type {Set<String>} */
-export const TAB_KINDS = new Set(['tab-before', 'tab-after', 'tab-into']);
-
-/** Every candidate `placement.kind` the contract defines (+ the terminal `rejected`). @type {Set<String>} */
-export const VALID_PLACEMENT_KINDS = new Set([...EDGE_KINDS, ...SPLIT_KINDS, ...TAB_KINDS, 'rejected']);
-
-/**
- * @summary Structural validity gate for a dockPreview object (fail-closed).
- *
- * Returns true only for a well-formed `neo.dock.preview.v1` payload that carries a stable
- * `itemId`, a `target.nodeId`, a known `placement.kind`, an accept/reject `feedback.state`, and (for
- * split placements) a valid `placement.orientation`. A whole-stack gesture may additionally carry
- * a runtime-only `groupNodeId`; when present it must be a non-empty string. Anything malformed,
- * partial or unknown returns false so consumers clear/fail rather than guess.
- * @param {Object|null} preview
- * @returns {Boolean}
- */
-export function isValidPreview(preview) {
-    if (!preview || typeof preview !== 'object')               return false;
-    if (preview.schema !== PREVIEW_SCHEMA)                     return false;
-    if (typeof preview.itemId !== 'string' || !preview.itemId) return false;
-    if (preview.groupNodeId != null &&
-        (typeof preview.groupNodeId !== 'string' || !preview.groupNodeId)) return false;
-
-    let {feedback, placement, target} = preview;
-
-    if (!target || typeof target.nodeId !== 'string' || !target.nodeId) return false;
-    if (!placement || !VALID_PLACEMENT_KINDS.has(placement.kind))       return false;
-    if (!feedback || (feedback.state !== 'accepted' && feedback.state !== 'rejected')) return false;
-
-    // Split placements MUST carry an orientation (contract: required for split previews).
-    if (SPLIT_KINDS.has(placement.kind) &&
-        placement.orientation !== 'horizontal' && placement.orientation !== 'vertical') {
-        return false
+class PreviewContract extends Base {
+    static config = {
+        /**
+         * @member {String} className='Neo.dashboard.dock.model.PreviewContract'
+         * @protected
+         */
+        className: 'Neo.dashboard.dock.model.PreviewContract',
+        /**
+         * @member {Boolean} singleton=true
+         * @protected
+         */
+        singleton: true
     }
 
-    return true
-}
+    /**
+     * The dockPreview contract schema every side of the line accepts / emits.
+     * @member {String} PREVIEW_SCHEMA
+     */
+    PREVIEW_SCHEMA = 'neo.dock.preview.v1';
 
-/**
- * @summary Numeric-rect gate shared by the candidate-set validator (fail-closed).
- * @param {Object|null} rect
- * @returns {Boolean}
- */
-function isValidRect(rect) {
-    return !!rect &&
-        [rect.x, rect.y, rect.width, rect.height].every(v => typeof v === 'number' && !Number.isNaN(v)) &&
-        rect.width > 0 && rect.height > 0
-}
+    /**
+     * The drop-candidate-set schema: the runtime-only payload the producer emits for the
+     * indicator-overlay menu (the full valid-placement menu for one hovered zone plus the
+     * container edge chips), consumed by `Neo.dashboard.dock.interaction.DropIndicators`. Every candidate
+     * wraps a complete, individually valid `neo.dock.preview.v1` payload — a drop on an
+     * indicator commits through `previewToOperation` exactly like a pointer-inferred preview.
+     * @member {String} CANDIDATES_SCHEMA
+     */
+    CANDIDATES_SCHEMA = 'neo.dock.candidates.v1';
 
-/**
- * @summary One cross direction's legal placement tuple — the §06 grammar as a checkable rule.
- *
- * `center` is exactly the tab-merge. A directional indicator is either the node split for its
- * own side (`edge-<direction>`) or the along-axis sibling insert the producer's orientation
- * grammar resolves — `split-before` only from a LEADING direction (top/left), `split-after`
- * only from a TRAILING one (bottom/right), with `vertical` for top/bottom and `horizontal` for
- * left/right. Anything else is a menu lying about its operation.
- * @param {String} position a `CROSS_POSITIONS` entry
- * @param {Object} placement the candidate preview's placement descriptor
- * @returns {Boolean}
- */
-function crossPlacementMatchesPosition(position, placement) {
-    let {kind, orientation} = placement;
+    /**
+     * The five cross positions of the indicator menu, in render order. `center` maps to the
+     * tab-merge candidate; the four directions map to directional split candidates (which kind —
+     * `edge-*` node split vs `split-before/after` sibling insert — the producer resolves from the
+     * hovered zone's parent-split orientation, identical to the pointer-inference grammar).
+     * @member {String[]} CROSS_POSITIONS
+     */
+    CROSS_POSITIONS = ['center', 'top', 'right', 'bottom', 'left'];
 
-    if (position === 'center') return kind === 'tab-into';
+    /** The four container-edge chip positions, in render order. @member {String[]} CHIP_EDGES */
+    CHIP_EDGES = ['top', 'right', 'bottom', 'left'];
 
-    return kind === `edge-${position}` ||
-        (kind === 'split-before' && (
-            (position === 'top'  && orientation === 'vertical') ||
-            (position === 'left' && orientation === 'horizontal')
-        )) ||
-        (kind === 'split-after' && (
-            (position === 'bottom' && orientation === 'vertical') ||
-            (position === 'right'  && orientation === 'horizontal')
-        ))
-}
+    /** @member {Set<String>} EDGE_KINDS */
+    EDGE_KINDS = new Set(['edge-top', 'edge-right', 'edge-bottom', 'edge-left']);
 
-/**
- * @summary Structural validity gate for a dockCandidates set (fail-closed).
- *
- * Returns true only for a COMPLETE, internally coherent `neo.dock.candidates.v1` payload:
- *
- * - a stable `itemId`, and a hovered `zone` with a node id and a numeric rect;
- * - a `cross` of EXACTLY the five unique positions (`CROSS_POSITIONS`), every candidate wrapping
- *   an individually valid preview that carries the SET's `itemId`, targets the hovered zone's
- *   node, and whose placement kind matches its position per the §06 grammar
- *   ({@link crossPlacementMatchesPosition});
- * - a `root` that is either null (no distinct container target) or a node id + rect + EXACTLY
- *   the four unique edges (`CHIP_EDGES`), each chip's preview carrying the set's `itemId`,
- *   targeting the root node, with kind `edge-<edge>` exactly.
- *
- * A partial menu, a duplicated position, a candidate built for another item, or a candidate
- * whose visual position lies about its operation all return false — the indicator layer clears
- * rather than renders a menu that misrepresents the drop. Same fail-closed posture as
- * `isValidPreview`.
- * @param {Object|null} set
- * @returns {Boolean}
- */
-export function isValidCandidateSet(set) {
-    if (!set || typeof set !== 'object')               return false;
-    if (set.schema !== CANDIDATES_SCHEMA)              return false;
-    if (typeof set.itemId !== 'string' || !set.itemId) return false;
+    /** @member {Set<String>} SPLIT_KINDS */
+    SPLIT_KINDS = new Set(['split-before', 'split-after']);
 
-    let {cross, root, zone} = set;
+    /** @member {Set<String>} TAB_KINDS */
+    TAB_KINDS = new Set(['tab-before', 'tab-after', 'tab-into']);
 
-    if (!zone || typeof zone.nodeId !== 'string' || !zone.nodeId || !isValidRect(zone.rect)) return false;
+    /** Every candidate `placement.kind`, including `rejected`. @member {Set<String>} VALID_PLACEMENT_KINDS */
+    VALID_PLACEMENT_KINDS = new Set([...this.EDGE_KINDS, ...this.SPLIT_KINDS, ...this.TAB_KINDS, 'rejected']);
 
-    if (!Array.isArray(cross) || cross.length !== CROSS_POSITIONS.length) return false;
+    /**
+     * @summary Structural validity gate for a dockPreview object (fail-closed).
+     *
+     * Returns true only for a well-formed `neo.dock.preview.v1` payload that carries a stable
+     * `itemId`, a `target.nodeId`, a known `placement.kind`, an accept/reject `feedback.state`, and (for
+     * split placements) a valid `placement.orientation`. A whole-stack gesture may additionally carry
+     * a runtime-only `groupNodeId`; when present it must be a non-empty string. Anything malformed,
+     * partial or unknown returns false so consumers clear/fail rather than guess.
+     * @param {Object|null} preview
+     * @returns {Boolean}
+     */
+    isValidPreview(preview) {
+        if (!preview || typeof preview !== 'object')               return false;
+        if (preview.schema !== this.PREVIEW_SCHEMA)               return false;
+        if (typeof preview.itemId !== 'string' || !preview.itemId) return false;
+        if (preview.groupNodeId != null &&
+            (typeof preview.groupNodeId !== 'string' || !preview.groupNodeId)) return false;
 
-    let positions = new Set(cross.map(candidate => candidate?.position));
+        let {feedback, placement, target} = preview;
 
-    if (positions.size !== CROSS_POSITIONS.length || !CROSS_POSITIONS.every(position => positions.has(position))) {
-        return false
-    }
+        if (!target || typeof target.nodeId !== 'string' || !target.nodeId) return false;
+        if (!placement || !this.VALID_PLACEMENT_KINDS.has(placement.kind)) return false;
+        if (!feedback || (feedback.state !== 'accepted' && feedback.state !== 'rejected')) return false;
 
-    if (!cross.every(candidate =>
-        candidate &&
-        isValidPreview(candidate.preview) &&
-        candidate.preview.itemId === set.itemId &&
-        candidate.preview.groupNodeId === set.groupNodeId &&
-        candidate.preview.target.nodeId === zone.nodeId &&
-        crossPlacementMatchesPosition(candidate.position, candidate.preview.placement)
-    )) {
-        return false
-    }
-
-    if (root != null) {
-        if (typeof root.nodeId !== 'string' || !root.nodeId || !isValidRect(root.rect)) return false;
-
-        if (!Array.isArray(root.chips) || root.chips.length !== CHIP_EDGES.length) return false;
-
-        let edges = new Set(root.chips.map(chip => chip?.edge));
-
-        if (edges.size !== CHIP_EDGES.length || !CHIP_EDGES.every(edge => edges.has(edge))) {
+        // Split placements MUST carry an orientation (contract: required for split previews).
+        if (this.SPLIT_KINDS.has(placement.kind) &&
+            placement.orientation !== 'horizontal' && placement.orientation !== 'vertical') {
             return false
         }
 
-        if (!root.chips.every(chip =>
-            chip &&
-            isValidPreview(chip.preview) &&
-            chip.preview.itemId === set.itemId &&
-            chip.preview.groupNodeId === set.groupNodeId &&
-            chip.preview.target.nodeId === root.nodeId &&
-            chip.preview.placement.kind === `edge-${chip.edge}`
+        return true
+    }
+
+    /**
+     * @summary Numeric-rect gate shared by the candidate-set validator (fail-closed).
+     * @param {Object|null} rect
+     * @returns {Boolean}
+     */
+    isValidRect(rect) {
+        return !!rect &&
+            [rect.x, rect.y, rect.width, rect.height].every(v => typeof v === 'number' && !Number.isNaN(v)) &&
+            rect.width > 0 && rect.height > 0
+    }
+
+    /**
+     * @summary One cross direction's legal placement tuple — the §06 grammar as a checkable rule.
+     *
+     * `center` is exactly the tab-merge. A directional indicator is either the node split for its
+     * own side (`edge-<direction>`) or the along-axis sibling insert the producer's orientation
+     * grammar resolves — `split-before` only from a LEADING direction (top/left), `split-after`
+     * only from a TRAILING one (bottom/right), with `vertical` for top/bottom and `horizontal` for
+     * left/right. Anything else is a menu lying about its operation.
+     * @param {String} position a `CROSS_POSITIONS` entry
+     * @param {Object} placement the candidate preview's placement descriptor
+     * @returns {Boolean}
+     */
+    crossPlacementMatchesPosition(position, placement) {
+        let {kind, orientation} = placement;
+
+        if (position === 'center') return kind === 'tab-into';
+
+        return kind === `edge-${position}` ||
+            (kind === 'split-before' && (
+                (position === 'top'  && orientation === 'vertical') ||
+                (position === 'left' && orientation === 'horizontal')
+            )) ||
+            (kind === 'split-after' && (
+                (position === 'bottom' && orientation === 'vertical') ||
+                (position === 'right'  && orientation === 'horizontal')
+            ))
+    }
+
+    /**
+     * @summary Structural validity gate for a dockCandidates set (fail-closed).
+     *
+     * Returns true only for a COMPLETE, internally coherent `neo.dock.candidates.v1` payload:
+     *
+     * - a stable `itemId`, and a hovered `zone` with a node id and a numeric rect;
+     * - a `cross` of EXACTLY the five unique positions (`CROSS_POSITIONS`), every candidate wrapping
+     *   an individually valid preview that carries the SET's `itemId`, targets the hovered zone's
+     *   node, and whose placement kind matches its position per the §06 grammar
+     *   ({@link Neo.dashboard.dock.model.PreviewContract#crossPlacementMatchesPosition});
+     * - a `root` that is either null (no distinct container target) or a node id + rect + EXACTLY
+     *   the four unique edges (`CHIP_EDGES`), each chip's preview carrying the set's `itemId`,
+     *   targeting the root node, with kind `edge-<edge>` exactly.
+     *
+     * A partial menu, a duplicated position, a candidate built for another item, or a candidate
+     * whose visual position lies about its operation all return false — the indicator layer clears
+     * rather than renders a menu that misrepresents the drop. Same fail-closed posture as
+     * `isValidPreview`.
+     * @param {Object|null} set
+     * @returns {Boolean}
+     */
+    isValidCandidateSet(set) {
+        if (!set || typeof set !== 'object')               return false;
+        if (set.schema !== this.CANDIDATES_SCHEMA)         return false;
+        if (typeof set.itemId !== 'string' || !set.itemId) return false;
+
+        let {cross, root, zone} = set;
+
+        if (!zone || typeof zone.nodeId !== 'string' || !zone.nodeId || !this.isValidRect(zone.rect)) return false;
+
+        if (!Array.isArray(cross) || cross.length !== this.CROSS_POSITIONS.length) return false;
+
+        let positions = new Set(cross.map(candidate => candidate?.position));
+
+        if (positions.size !== this.CROSS_POSITIONS.length || !this.CROSS_POSITIONS.every(position => positions.has(position))) {
+            return false
+        }
+
+        if (!cross.every(candidate =>
+            candidate &&
+            this.isValidPreview(candidate.preview) &&
+            candidate.preview.itemId === set.itemId &&
+            candidate.preview.groupNodeId === set.groupNodeId &&
+            candidate.preview.target.nodeId === zone.nodeId &&
+            this.crossPlacementMatchesPosition(candidate.position, candidate.preview.placement)
         )) {
             return false
         }
+
+        if (root != null) {
+            if (typeof root.nodeId !== 'string' || !root.nodeId || !this.isValidRect(root.rect)) return false;
+
+            if (!Array.isArray(root.chips) || root.chips.length !== this.CHIP_EDGES.length) return false;
+
+            let edges = new Set(root.chips.map(chip => chip?.edge));
+
+            if (edges.size !== this.CHIP_EDGES.length || !this.CHIP_EDGES.every(edge => edges.has(edge))) {
+                return false
+            }
+
+            if (!root.chips.every(chip =>
+                chip &&
+                this.isValidPreview(chip.preview) &&
+                chip.preview.itemId === set.itemId &&
+                chip.preview.groupNodeId === set.groupNodeId &&
+                chip.preview.target.nodeId === root.nodeId &&
+                chip.preview.placement.kind === `edge-${chip.edge}`
+            )) {
+                return false
+            }
+        }
+
+        return true
     }
 
-    return true
-}
+    /**
+     * @summary Which side of a two-child split an edge drop lands the NEW node on.
+     *
+     * `bottom` and `right` append; `top` and `left` prepend. Shared so the operation descriptor and the
+     * rendered region cannot disagree about which half the drop will occupy.
+     * @param {String} edge
+     * @returns {String} `'before'` or `'after'`
+     */
+    edgeSplitPosition(edge) {
+        return (edge === 'bottom' || edge === 'right') ? 'after' : 'before'
+    }
 
-/**
- * @summary Normalizes an optional split ratio into a two-child, sum-to-one size pair.
- * @param {Number} [ratio] the new node's fraction; defaults to an even split when absent/invalid
- * @param {String} position 'before' | 'after' — which child the new node becomes
- * @returns {Number[]} normalized [first, second] sizes summing to 1
- */
-/**
- * @summary Which side of a two-child split an edge drop lands the NEW node on.
- *
- * `bottom` and `right` append; `top` and `left` prepend. Shared so the operation descriptor and the
- * rendered region cannot disagree about which half the drop will occupy.
- * @param {String} edge
- * @returns {String} `'before'` or `'after'`
- */
-export function edgeSplitPosition(edge) {
-    return (edge === 'bottom' || edge === 'right') ? 'after' : 'before'
-}
+    /**
+     * @summary Normalizes an optional split ratio into a two-child, sum-to-one size pair.
+     * @param {Number} [ratio] The new node's fraction; absent or invalid defaults to an even split.
+     * @param {String} position 'before' or 'after'.
+     * @returns {Number[]} Normalized sizes in child order.
+     */
+    ratioToSizes(ratio, position) {
+        let r = (typeof ratio === 'number' && ratio > 0 && ratio < 1) ? ratio : 0.5;
+        return position === 'after' ? [1 - r, r] : [r, 1 - r]
+    }
 
-export function ratioToSizes(ratio, position) {
-    let r = (typeof ratio === 'number' && ratio > 0 && ratio < 1) ? ratio : 0.5;
-    return position === 'after' ? [1 - r, r] : [r, 1 - r]
-}
+    /**
+     * @summary Converts an ACCEPTED drop preview into a semantic dock-zone operation descriptor, or null.
+     *
+     * The one authored path from a hover preview to a `model.Operations` operation. Invalid previews,
+     * `rejected` placements, and non-accepted feedback all yield null (no commit). Item previews emit
+     * `addTab` / `splitNode` as before. A preview carrying `groupNodeId` instead emits one
+     * `transferNode` descriptor whose nested target uses the same tab/split placement grammar — the
+     * preview remains the single placement authority for both item and whole-stack drops.
+     * @param {Object|null} preview
+     * @returns {Object|null}
+     */
+    previewToOperation(preview) {
+        if (!this.isValidPreview(preview)) return null;
 
-/**
- * @summary Converts an ACCEPTED drop preview into a semantic dock-zone operation descriptor, or null.
- *
- * The one authored path from a hover preview to a `model.Operations` operation. Invalid previews,
- * `rejected` placements, and non-accepted feedback all yield null (no commit). Item previews emit
- * `addTab` / `splitNode` as before. A preview carrying `groupNodeId` instead emits one
- * `transferNode` descriptor whose nested target uses the same tab/split placement grammar — the
- * preview remains the single placement authority for both item and whole-stack drops.
- * @param {Object|null} preview
- * @returns {Object|null}
- */
-export function previewToOperation(preview) {
-    if (!isValidPreview(preview)) return null;
+        let {feedback, groupNodeId, itemId, placement, target} = preview,
+            {kind}                                             = placement;
 
-    let {feedback, groupNodeId, itemId, placement, target} = preview,
-        {kind}                                             = placement;
+        if (kind === 'rejected' || feedback.state !== 'accepted') return null;
 
-    if (kind === 'rejected' || feedback.state !== 'accepted') return null;
+        let nodeId = target.nodeId;
 
-    let nodeId = target.nodeId;
+        if (groupNodeId) {
+            let nodePlacement;
 
-    if (groupNodeId) {
-        let nodePlacement;
+            if (this.TAB_KINDS.has(kind)) {
+                nodePlacement = {kind: 'tab-into'}
+            } else if (this.SPLIT_KINDS.has(kind)) {
+                let position = kind.slice('split-'.length);
 
-        if (TAB_KINDS.has(kind)) {
-            nodePlacement = {kind: 'tab-into'}
-        } else if (SPLIT_KINDS.has(kind)) {
+                nodePlacement = {
+                    orientation: placement.orientation,
+                    position,
+                    sizes      : this.ratioToSizes(placement.ratio, position)
+                }
+            } else {
+                let edge = kind.slice('edge-'.length);
+
+                nodePlacement = {
+                    edge,
+                    orientation: (edge === 'left' || edge === 'right') ? 'horizontal' : 'vertical',
+                    sizes      : this.ratioToSizes(placement.ratio, this.edgeSplitPosition(edge))
+                }
+            }
+
+            return {
+                operation: 'transferNode',
+                nodeId   : groupNodeId,
+                target   : {targetNodeId: nodeId, placement: nodePlacement}
+            }
+        }
+
+        if (this.TAB_KINDS.has(kind)) {
+            return {operation: 'addTab', itemId, tabsNodeId: nodeId, index: Number.isInteger(placement.index) ? placement.index : null}
+        }
+
+        if (this.SPLIT_KINDS.has(kind)) {
             let position = kind.slice('split-'.length);
-
-            nodePlacement = {
-                orientation: placement.orientation,
-                position,
-                sizes      : ratioToSizes(placement.ratio, position)
-            }
-        } else {
-            let edge = kind.slice('edge-'.length);
-
-            nodePlacement = {
-                edge,
-                orientation: (edge === 'left' || edge === 'right') ? 'horizontal' : 'vertical',
-                sizes      : ratioToSizes(placement.ratio, edgeSplitPosition(edge))
-            }
+            return {operation: 'splitNode', itemId, targetNodeId: nodeId, orientation: placement.orientation, position, sizes: this.ratioToSizes(placement.ratio, position)}
         }
 
+        let edge = kind.slice('edge-'.length);
         return {
-            operation: 'transferNode',
-            nodeId   : groupNodeId,
-            target   : {targetNodeId: nodeId, placement: nodePlacement}
+            operation   : 'splitNode',
+            itemId,
+            targetNodeId: nodeId,
+            edge,
+            orientation : (edge === 'left' || edge === 'right') ? 'horizontal' : 'vertical',
+            sizes       : this.ratioToSizes(placement.ratio, this.edgeSplitPosition(edge))
         }
     }
 
-    if (TAB_KINDS.has(kind)) {
-        return {operation: 'addTab', itemId, tabsNodeId: nodeId, index: Number.isInteger(placement.index) ? placement.index : null}
-    }
-
-    if (SPLIT_KINDS.has(kind)) {
-        let position = kind.slice('split-'.length);
-        return {operation: 'splitNode', itemId, targetNodeId: nodeId, orientation: placement.orientation, position, sizes: ratioToSizes(placement.ratio, position)}
-    }
-
-    let edge = kind.slice('edge-'.length);
-    return {
-        operation   : 'splitNode',
-        itemId,
-        targetNodeId: nodeId,
-        edge,
-        orientation : (edge === 'left' || edge === 'right') ? 'horizontal' : 'vertical',
-        sizes       : ratioToSizes(placement.ratio, edgeSplitPosition(edge))
+    /**
+     * @summary Resolves the rendered new-node fraction from the same normalized pair as the drop.
+     * @param {Number} [ratio]
+     * @param {String} position 'before' or 'after'.
+     * @returns {Number}
+     */
+    newNodeFraction(ratio, position) {
+        const sizes = this.ratioToSizes(ratio, position);
+        return position === 'after' ? sizes[1] : sizes[0]
     }
 }
+
+export default Neo.setupClass(PreviewContract);

--- a/src/dashboard/dock/window/Participation.mjs
+++ b/src/dashboard/dock/window/Participation.mjs
@@ -1,10 +1,10 @@
-import Base                                    from '../../../core/Base.mjs';
-import DragAffordances                         from '../interaction/DragAffordances.mjs';
-import DragTarget                              from './DragTarget.mjs';
-import WorkspaceDocument                       from '../model/WorkspaceDocument.mjs';
-import Operations                              from '../model/Operations.mjs';
-import Preview                                 from '../interaction/Preview.mjs';
-import {previewToOperation as toDockOperation} from '../model/PreviewContract.mjs';
+import Base              from '../../../core/Base.mjs';
+import DragAffordances   from '../interaction/DragAffordances.mjs';
+import DragTarget        from './DragTarget.mjs';
+import WorkspaceDocument from '../model/WorkspaceDocument.mjs';
+import Operations        from '../model/Operations.mjs';
+import Preview           from '../interaction/Preview.mjs';
+import PreviewContract   from '../model/PreviewContract.mjs';
 
 /**
  * @class Neo.dashboard.dock.window.Participation
@@ -249,7 +249,7 @@ class Participation extends Base {
             dragCoordinator        : me.dragCoordinator,
             hitTest                : me.hitTest                 ?? me.defaultHitTest.bind(me),
             previewFor             : me.previewFor              ?? me.defaultPreviewFor.bind(me),
-            previewToOperation     : me.previewToOperation      ?? toDockOperation,
+            previewToOperation     : me.previewToOperation      ?? (preview => PreviewContract.previewToOperation(preview)),
             promoteDragEmbodiment  : me.promoteDragEmbodiment,
             resolveNativeWindowDrag: me.resolveNativeWindowDrag ?? me.defaultResolveNativeWindowDrag.bind(me),
             resolveOwnershipId     : () => me.ownershipId,

--- a/test/playwright/e2e/workstation/WorkstationFiveBeatNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationFiveBeatNL.spec.mjs
@@ -3,7 +3,9 @@ import {createHash}                                                 from 'node:c
 import path                                                         from 'node:path';
 import {promisify}                                                  from 'node:util';
 import fs                                                           from 'fs-extra';
-import {previewToOperation}                                         from '../../../../src/dashboard/dock/model/PreviewContract.mjs';
+import Neo                                                          from '../../../../src/Neo.mjs';
+import * as core                                                    from '../../../../src/core/_export.mjs';
+import PreviewContract                                              from '../../../../src/dashboard/dock/model/PreviewContract.mjs';
 import {test, expect}                                               from '../../fixtures.mjs';
 import {assertPreviewZoneAlignment, readComponentRects}             from '../utils/dockGeometry.mjs';
 import {pinToCaptureDisplay, placeNativeWindow, readBrowserSurface} from '../utils/filmStage.mjs';
@@ -2258,7 +2260,7 @@ test.describe('Workstation — the five-beat multi-window journey', () => {
             'the target renderer must display the exact semantic preview').toBe(committedPreview.previewId);
 
         const
-            expectedOperation = previewToOperation(committedPreview),
+            expectedOperation = PreviewContract.previewToOperation(committedPreview),
             expectedReturn    = Operations.applyOperation(documentBeforeReturn, expectedOperation);
 
         expect(expectedOperation, 'the retained accepted preview must convert through the production contract')

--- a/test/playwright/unit/apps/workstation/Workspace.spec.mjs
+++ b/test/playwright/unit/apps/workstation/Workspace.spec.mjs
@@ -12,7 +12,6 @@ import * as core                from '../../../../../src/core/_export.mjs';
 import DockProjectionReconciler from '../../../../../src/dashboard/dock/projection/Reconciler.mjs';
 import WorkspaceDocument        from '../../../../../src/dashboard/dock/model/WorkspaceDocument.mjs';
 import Operations               from '../../../../../src/dashboard/dock/model/Operations.mjs';
-import {previewToOperation}     from '../../../../../src/dashboard/dock/model/PreviewContract.mjs';
 import '../../../../../src/manager/Instance.mjs';
 import TransactionManager from '../../../../../src/manager/Transaction.mjs';
 import FeedPane           from '../../../../../apps/workstation/view/FeedPane.mjs';

--- a/test/playwright/unit/dashboard/DockCrossWindowParticipation.spec.mjs
+++ b/test/playwright/unit/dashboard/DockCrossWindowParticipation.spec.mjs
@@ -6,9 +6,10 @@ setup({
     }
 });
 
-import {test, expect} from '@playwright/test';
-import Neo            from '../../../../src/Neo.mjs';
-import * as core      from '../../../../src/core/_export.mjs';
+import {test, expect}  from '@playwright/test';
+import Neo             from '../../../../src/Neo.mjs';
+import * as core       from '../../../../src/core/_export.mjs';
+import PreviewContract from '../../../../src/dashboard/dock/model/PreviewContract.mjs';
 
 /**
  * @summary Tests for Neo.dashboard.dock.window.Participation — the adapter-tier composition
@@ -97,6 +98,34 @@ test.describe('Neo.dashboard.dock.window.Participation (ADR 0029 §2.3 — works
         expect(calls[1]).toEqual(['unregister', zone]);
         // Base.destroy() deletes own members — the owned target reference is gone either way
         expect(participation.target ?? null).toBeNull()
+    });
+
+    test('a registered target resolves the current preview policy at drop time', () => {
+        const participation = Neo.create(DockCrossWindowParticipation, {
+            dragCoordinator: createCoordinatorStub([]),
+            getDocument    : () => targetDoc(),
+            sortGroup      : 'dock-demo',
+            windowId       : 'window-b',
+            workspaceId    : 'B'
+        });
+        const original = PreviewContract.previewToOperation;
+        const preview  = {
+            schema  : 'neo.dock.preview.v1', itemId: 'alpha',
+            target  : {nodeId: 'main-tabs'}, placement: {kind: 'tab-into'},
+            feedback: {state: 'accepted'}
+        };
+
+        try {
+            expect(participation.target.previewToOperation(preview).operation).toBe('addTab');
+            PreviewContract.previewToOperation = function(value) {
+                return this.isValidPreview(value) ? {operation: 'customDrop'} : null
+            };
+            expect(participation.target.previewToOperation(preview)).toEqual({operation: 'customDrop'});
+            expect(participation.target.previewToOperation(null)).toBeNull()
+        } finally {
+            PreviewContract.previewToOperation = original;
+            participation.destroy()
+        }
     });
 
     test('native-titlebar source seams ride the SAME stable participation registration', async () => {

--- a/test/playwright/unit/dashboard/DockDropIndicators.spec.mjs
+++ b/test/playwright/unit/dashboard/DockDropIndicators.spec.mjs
@@ -6,12 +6,12 @@ setup({
     }
 });
 
-import {test, expect}                                          from '@playwright/test';
-import Neo                                                     from '../../../../src/Neo.mjs';
-import * as core                                               from '../../../../src/core/_export.mjs';
-import DockDropIndicators                                      from '../../../../src/dashboard/dock/interaction/DropIndicators.mjs';
-import DockPreviewProducer                                     from '../../../../src/dashboard/dock/interaction/PreviewProducer.mjs';
-import {CANDIDATES_SCHEMA, PREVIEW_SCHEMA, previewToOperation} from '../../../../src/dashboard/dock/model/PreviewContract.mjs';
+import {test, expect}      from '@playwright/test';
+import Neo                 from '../../../../src/Neo.mjs';
+import * as core           from '../../../../src/core/_export.mjs';
+import DockDropIndicators  from '../../../../src/dashboard/dock/interaction/DropIndicators.mjs';
+import DockPreviewProducer from '../../../../src/dashboard/dock/interaction/PreviewProducer.mjs';
+import PreviewContract     from '../../../../src/dashboard/dock/model/PreviewContract.mjs';
 
 // Geometry fixture (viewport space): host at (100, 50); hovered zone centered at (400, 300).
 const HOST_RECT = {x: 100, y: 50, width: 800, height: 600};
@@ -19,7 +19,7 @@ const ZONE_RECT = {x: 300, y: 250, width: 200, height: 100};
 const ROOT_RECT = {x: 100, y: 50, width: 800, height: 600};
 
 const mkPreview = (nodeId, kind, itemId='terminal') => ({
-    schema   : PREVIEW_SCHEMA,
+    schema   : PreviewContract.PREVIEW_SCHEMA,
     previewId: `preview:${itemId}:${nodeId}:${kind}`,
     itemId,
     source   : {surface: 'dashboard-sort-zone', sortZoneId: 'src-tabs'},
@@ -29,7 +29,7 @@ const mkPreview = (nodeId, kind, itemId='terminal') => ({
 });
 
 const mkSet = ({root=true, zoneRect=ZONE_RECT, nodeId='main-tabs'}={}) => ({
-    schema: CANDIDATES_SCHEMA,
+    schema: PreviewContract.CANDIDATES_SCHEMA,
     itemId: 'terminal',
     zone  : {nodeId, rect: zoneRect, orientation: null},
     cross : [
@@ -238,7 +238,7 @@ test.describe('Neo.dashboard.dock.interaction.DropIndicators (§06 — the indic
 
         // …and the carried preview converts through the UNCHANGED contract path — the
         // component stayed commit-free; the descriptor is the workspace's business
-        const descriptor = previewToOperation(hit.preview);
+        const descriptor = PreviewContract.previewToOperation(hit.preview);
         expect(descriptor.operation).toBe('splitNode');
         expect(descriptor.targetNodeId).toBe('b-tabs');
         expect(descriptor.orientation).toBe('vertical');

--- a/test/playwright/unit/dashboard/DockPreview.spec.mjs
+++ b/test/playwright/unit/dashboard/DockPreview.spec.mjs
@@ -10,6 +10,7 @@ import {test, expect}  from '@playwright/test';
 import Neo             from '../../../../src/Neo.mjs';
 import * as core       from '../../../../src/core/_export.mjs';
 import DockPreview     from '../../../../src/dashboard/dock/interaction/Preview.mjs';
+import PreviewContract from '../../../../src/dashboard/dock/model/PreviewContract.mjs';
 import fs              from 'fs';
 import path            from 'path';
 import {fileURLToPath} from 'url';
@@ -147,60 +148,6 @@ test.describe('Neo.dashboard.dock.interaction.Preview', () => {
         })
     });
 
-    test.describe('isValidPreview (fail-closed)', () => {
-        test('accepts a well-formed preview', () => {
-            expect(DockPreview.isValidPreview(preview())).toBe(true)
-        });
-
-        test('rejects null, undefined and non-objects', () => {
-            expect(DockPreview.isValidPreview(null)).toBe(false);
-            expect(DockPreview.isValidPreview(undefined)).toBe(false);
-            expect(DockPreview.isValidPreview('preview')).toBe(false)
-        });
-
-        test('rejects a wrong or missing schema', () => {
-            expect(DockPreview.isValidPreview(preview({schema: 'neo.dock.preview.v2'}))).toBe(false);
-            expect(DockPreview.isValidPreview(preview({schema: undefined}))).toBe(false)
-        });
-
-        test('rejects a missing itemId', () => {
-            expect(DockPreview.isValidPreview(preview({itemId: ''}))).toBe(false);
-            expect(DockPreview.isValidPreview(preview({itemId: undefined}))).toBe(false)
-        });
-
-        test('admits only a non-empty runtime whole-stack identity', () => {
-            expect(DockPreview.isValidPreview(preview({groupNodeId: 'popup-stack'}))).toBe(true);
-            expect(DockPreview.isValidPreview(preview({groupNodeId: ''}))).toBe(false);
-            expect(DockPreview.isValidPreview(preview({groupNodeId: 42}))).toBe(false)
-        });
-
-        test('rejects a missing target.nodeId', () => {
-            expect(DockPreview.isValidPreview(preview({target: {containerId: 'workspace'}}))).toBe(false);
-            expect(DockPreview.isValidPreview(preview({target: {nodeId: ''}}))).toBe(false)
-        });
-
-        test('rejects an unknown placement.kind', () => {
-            expect(DockPreview.isValidPreview(preview({placement: {kind: 'corner-top-left'}}))).toBe(false);
-            expect(DockPreview.isValidPreview(preview({placement: {}}))).toBe(false)
-        });
-
-        test('rejects a split placement without a valid orientation', () => {
-            expect(DockPreview.isValidPreview(preview({placement: {kind: 'split-before'}}))).toBe(false);
-            expect(DockPreview.isValidPreview(preview({placement: {kind: 'split-after', orientation: 'diagonal'}}))).toBe(false);
-            expect(DockPreview.isValidPreview(preview({placement: {kind: 'split-after', orientation: 'vertical'}}))).toBe(true)
-        });
-
-        test('rejects a missing or invalid feedback.state', () => {
-            expect(DockPreview.isValidPreview(preview({feedback: {}}))).toBe(false);
-            expect(DockPreview.isValidPreview(preview({feedback: {state: 'maybe'}}))).toBe(false);
-            expect(DockPreview.isValidPreview(preview({feedback: undefined}))).toBe(false)
-        });
-
-        test('treats a rejected placement as structurally valid', () => {
-            expect(DockPreview.isValidPreview(preview({placement: {kind: 'rejected'}, feedback: {state: 'rejected'}}))).toBe(true)
-        })
-    });
-
     test.describe('mapPreviewToAffordance', () => {
         test('maps every edge kind to an edge affordance', () => {
             for (const edge of ['top', 'right', 'bottom', 'left']) {
@@ -245,98 +192,6 @@ test.describe('Neo.dashboard.dock.interaction.Preview', () => {
         test('returns null for an invalid preview', () => {
             expect(DockPreview.mapPreviewToAffordance(preview({schema: 'nope'}))).toBe(null);
             expect(DockPreview.mapPreviewToAffordance(null)).toBe(null)
-        })
-    });
-
-    test.describe('previewToOperation (semantic drop, never mutates)', () => {
-        test('tab placements route to addTab with the target tabs node and index', () => {
-            const op = DockPreview.previewToOperation(preview({placement: {kind: 'tab-after', index: 1}}));
-            expect(op.operation).toBe('addTab');
-            expect(op.tabsNodeId).toBe('main-tabs');
-            expect(op.itemId).toBe('strategy');
-            expect(op.index).toBe(1)
-        });
-
-        test('split placements route to splitNode with orientation and normalized sizes', () => {
-            const op = DockPreview.previewToOperation(preview({placement: {kind: 'split-before', orientation: 'vertical', ratio: 0.3}}));
-            expect(op.operation).toBe('splitNode');
-            expect(op.orientation).toBe('vertical');
-            expect(op.position).toBe('before');
-            expect(op.sizes).toEqual([0.3, 0.7])
-        });
-
-        test('edge placements route to splitNode with a derived orientation', () => {
-            const left = DockPreview.previewToOperation(preview({placement: {kind: 'edge-left'}}));
-            expect(left.operation).toBe('splitNode');
-            expect(left.edge).toBe('left');
-            expect(left.orientation).toBe('horizontal');
-
-            const bottom = DockPreview.previewToOperation(preview({placement: {kind: 'edge-bottom'}}));
-            expect(bottom.orientation).toBe('vertical')
-        });
-
-        test('whole-stack previews preserve the placement grammar in one transferNode descriptor', () => {
-            const groupNodeId = 'popup-stack';
-
-            expect(DockPreview.previewToOperation(preview({groupNodeId, placement: {kind: 'tab-into'}}))).toEqual({
-                operation: 'transferNode',
-                nodeId   : groupNodeId,
-                target   : {targetNodeId: 'main-tabs', placement: {kind: 'tab-into'}}
-            });
-
-            expect(DockPreview.previewToOperation(preview({
-                groupNodeId,
-                placement: {kind: 'split-before', orientation: 'vertical', ratio: 0.3}
-            }))).toEqual({
-                operation: 'transferNode',
-                nodeId   : groupNodeId,
-                target   : {
-                    targetNodeId: 'main-tabs',
-                    placement   : {orientation: 'vertical', position: 'before', sizes: [0.3, 0.7]}
-                }
-            });
-
-            expect(DockPreview.previewToOperation(preview({groupNodeId, placement: {kind: 'edge-right'}}))).toEqual({
-                operation: 'transferNode',
-                nodeId   : groupNodeId,
-                target   : {
-                    targetNodeId: 'main-tabs',
-                    placement   : {edge: 'right', orientation: 'horizontal', sizes: [0.5, 0.5]}
-                }
-            })
-        });
-
-        test('returns null for rejected feedback', () => {
-            expect(DockPreview.previewToOperation(preview({feedback: {state: 'rejected'}}))).toBe(null)
-        });
-
-        test('returns null for a rejected placement', () => {
-            expect(DockPreview.previewToOperation(preview({placement: {kind: 'rejected'}, feedback: {state: 'rejected'}}))).toBe(null)
-        });
-
-        test('returns null for an invalid preview', () => {
-            expect(DockPreview.previewToOperation(preview({itemId: ''}))).toBe(null)
-        });
-
-        test('never leaks a runtime-only field into the operation descriptor', () => {
-            const op = DockPreview.previewToOperation(preview());
-            expect(op).not.toHaveProperty('previewId');
-            expect(op).not.toHaveProperty('source');
-            expect(op).not.toHaveProperty('feedback');
-            expect(JSON.stringify(op)).not.toContain('dashboard-sort-zone')
-        })
-    });
-
-    test.describe('ratioToSizes', () => {
-        test('defaults to an even split for an absent or invalid ratio', () => {
-            expect(DockPreview.ratioToSizes(undefined, 'before')).toEqual([0.5, 0.5]);
-            expect(DockPreview.ratioToSizes(0, 'before')).toEqual([0.5, 0.5]);
-            expect(DockPreview.ratioToSizes(1.5, 'after')).toEqual([0.5, 0.5])
-        });
-
-        test('honors a valid ratio for before and after positions', () => {
-            expect(DockPreview.ratioToSizes(0.25, 'before')).toEqual([0.25, 0.75]);
-            expect(DockPreview.ratioToSizes(0.25, 'after')).toEqual([0.75, 0.25])
         })
     });
 
@@ -389,7 +244,7 @@ test.describe('Neo.dashboard.dock.interaction.Preview', () => {
             const source     = preview({placement: {kind: 'split-before', orientation: 'horizontal', ratio: 0.3}}),
                   affordance = DockPreview.mapPreviewToAffordance(source),
                   geometry   = DockPreview.affordanceGeometry(affordance, rect),
-                  operation  = DockPreview.previewToOperation(source);
+                  operation  = PreviewContract.previewToOperation(source);
 
             expect(operation.sizes[0]).toBe(0.3);
             expect(geometry.width).toBe(rect.width * operation.sizes[0])
@@ -412,9 +267,9 @@ test.describe('Neo.dashboard.dock.interaction.Preview', () => {
 
             // …and an ASYMMETRIC pair separates them: ratio 0.3 `after` commits [0.7, 0.3], so a mapper
             // reading the first child reports 0.7 and paints the wrong pane.
-            expect(DockPreview.newNodeFraction(0.3, 'after')).toBeCloseTo(0.3);
-            expect(DockPreview.newNodeFraction(0.3, 'before')).toBeCloseTo(0.3);
-            expect(DockPreview.ratioToSizes(0.3, 'after')).toEqual([0.7, 0.3])
+            expect(PreviewContract.newNodeFraction(0.3, 'after')).toBeCloseTo(0.3);
+            expect(PreviewContract.newNodeFraction(0.3, 'before')).toBeCloseTo(0.3);
+            expect(PreviewContract.ratioToSizes(0.3, 'after')).toEqual([0.7, 0.3])
         });
 
         test('MAPPED end-to-end: the painted region matches the descriptor, per direction', () => {
@@ -426,7 +281,7 @@ test.describe('Neo.dashboard.dock.interaction.Preview', () => {
             ]) {
                 const source     = preview({placement: {kind, orientation: 'horizontal', ratio: 0.3}}),
                       affordance = DockPreview.mapPreviewToAffordance(source),
-                      operation  = DockPreview.previewToOperation(source),
+                      operation  = PreviewContract.previewToOperation(source),
                       sizes      = operation.sizes ?? operation.target?.placement?.sizes;
 
                 expect(DockPreview.affordanceGeometry(affordance, rect), kind).toEqual(expected);

--- a/test/playwright/unit/dashboard/DockPreviewContract.spec.mjs
+++ b/test/playwright/unit/dashboard/DockPreviewContract.spec.mjs
@@ -1,0 +1,246 @@
+import {setup} from '../../setup.mjs';
+
+setup({appConfig: {name: 'DockPreviewContractTest'}});
+
+import {test, expect}  from '@playwright/test';
+import Neo             from '../../../../src/Neo.mjs';
+import * as core       from '../../../../src/core/_export.mjs';
+import PreviewContract from '../../../../src/dashboard/dock/model/PreviewContract.mjs';
+import {execFileSync}  from 'node:child_process';
+import {fileURLToPath} from 'node:url';
+
+/**
+ * @summary Builds one preview DTO without importing its implementation as fixture data.
+ * @param {Object} [overrides={}]
+ * @returns {Object}
+ */
+function preview(overrides = {}) {
+    return {
+        schema   : 'neo.dock.preview.v1',
+        previewId: 'preview:strategy:main-tabs:tab-after:1',
+        itemId   : 'strategy',
+        source   : {surface: 'dashboard-sort-zone', sortZoneId: 'left-workspace'},
+        target   : {containerId: 'workspace', nodeId: 'main-tabs'},
+        placement: {kind: 'tab-after', index: 1},
+        feedback : {state: 'accepted'},
+        ...overrides
+    }
+}
+test.describe('Neo.dashboard.dock.model.PreviewContract', () => {
+    test('one Neo overwrite controls the rendered region and applied split, including explicit ratios', () => {
+        const result = JSON.parse(execFileSync(process.execPath, ['--input-type=module', '-e', `
+            await import('./src/Neo.mjs');
+            await import('./src/core/_export.mjs');
+            const {setup} = await import('./test/playwright/setup.mjs');
+            setup({appConfig: {name: 'DockPreviewOverwriteTest'}});
+
+            Neo.overwrites = {};
+            Neo.ns('Neo.dashboard.dock.model.PreviewContract', true, Neo.overwrites).ratioToSizes = function(ratio, position) {
+                const r = typeof ratio === 'number' && ratio > 0 && ratio < 1 ? ratio : 0.25;
+                return position === 'after' ? [1 - r, r] : [r, 1 - r];
+            };
+
+            const {default: contract} = await import('./src/dashboard/dock/model/PreviewContract.mjs');
+            const {default: Preview} = await import('./src/dashboard/dock/interaction/Preview.mjs');
+            const {default: Operations} = await import('./src/dashboard/dock/model/Operations.mjs');
+            const document = {
+                schema: 'neo.dock.zone.v1', root: 'root',
+                items: {
+                    strategy: {componentRef: 'strategy', title: 'Strategy', kind: 'panel'},
+                    inspector: {componentRef: 'inspector', title: 'Inspector', kind: 'panel'}
+                },
+                nodes: {
+                    root: {type: 'edge-zone', zones: {center: {nodeId: 'main-tabs'}}},
+                    'main-tabs': {type: 'tabs', items: ['strategy'], activeItemId: 'strategy'}
+                }
+            };
+            const original = JSON.stringify(document);
+            const rows = [];
+            for (const kind of ['split-before', 'split-after', 'edge-left', 'edge-right']) {
+                for (const ratio of [undefined, 0.3]) {
+                    const preview = {
+                        schema: 'neo.dock.preview.v1', itemId: 'inspector',
+                        target: {nodeId: 'main-tabs'}, feedback: {state: 'accepted'},
+                        placement: {kind, orientation: 'horizontal', ratio}
+                    };
+                    const before = JSON.stringify(preview);
+                    const operation = contract.previewToOperation(preview);
+                    const applied = Operations.applyOperation(document, operation);
+                    const split = Object.values(applied.document.nodes).find(node => node.type === 'split');
+                    const newIndex = split?.children.findIndex(id => applied.document.nodes[id].items?.includes('inspector'));
+                    const affordance = Preview.mapPreviewToAffordance(preview);
+                    const geometry = Preview.affordanceGeometry(affordance, {x: 0, y: 0, width: 400, height: 200});
+                    const group = contract.previewToOperation({...preview, groupNodeId: 'other-stack'});
+                    rows.push({
+                        errors: applied.errors, fraction: geometry.width / 400,
+                        applied: split?.sizes[newIndex], operation: operation.sizes[newIndex],
+                        group: group.target.placement.sizes[newIndex],
+                        unchanged: before === JSON.stringify(preview), expected: ratio ?? 0.25
+                    });
+                }
+            }
+            process.stdout.write(JSON.stringify({
+                registered: contract === Neo.dashboard.dock.model.PreviewContract,
+                unchanged: original === JSON.stringify(document), rows
+            }));
+        `], {cwd: fileURLToPath(new URL('../../../../', import.meta.url)), encoding: 'utf8'}));
+
+        expect(result.registered).toBe(true);
+        expect(result.unchanged).toBe(true);
+        expect(result.rows).toHaveLength(8);
+        for (const row of result.rows) {
+            expect(row.errors).toEqual([]);
+            expect(row.unchanged).toBe(true);
+            expect(row.fraction).toBe(row.expected);
+            expect(row.applied).toBe(row.expected);
+            expect(row.operation).toBe(row.expected);
+            expect(row.group).toBe(row.expected)
+        }
+    });
+
+    test.describe('isValidPreview (fail-closed)', () => {
+        test('accepts a well-formed preview', () => {
+            expect(PreviewContract.isValidPreview(preview())).toBe(true)
+        });
+
+        test('rejects null, undefined and non-objects', () => {
+            expect(PreviewContract.isValidPreview(null)).toBe(false);
+            expect(PreviewContract.isValidPreview(undefined)).toBe(false);
+            expect(PreviewContract.isValidPreview('preview')).toBe(false)
+        });
+
+        test('rejects a wrong or missing schema', () => {
+            expect(PreviewContract.isValidPreview(preview({schema: 'neo.dock.preview.v2'}))).toBe(false);
+            expect(PreviewContract.isValidPreview(preview({schema: undefined}))).toBe(false)
+        });
+
+        test('rejects a missing itemId', () => {
+            expect(PreviewContract.isValidPreview(preview({itemId: ''}))).toBe(false);
+            expect(PreviewContract.isValidPreview(preview({itemId: undefined}))).toBe(false)
+        });
+
+        test('admits only a non-empty runtime whole-stack identity', () => {
+            expect(PreviewContract.isValidPreview(preview({groupNodeId: 'popup-stack'}))).toBe(true);
+            expect(PreviewContract.isValidPreview(preview({groupNodeId: ''}))).toBe(false);
+            expect(PreviewContract.isValidPreview(preview({groupNodeId: 42}))).toBe(false)
+        });
+
+        test('rejects a missing target.nodeId', () => {
+            expect(PreviewContract.isValidPreview(preview({target: {containerId: 'workspace'}}))).toBe(false);
+            expect(PreviewContract.isValidPreview(preview({target: {nodeId: ''}}))).toBe(false)
+        });
+
+        test('rejects an unknown placement.kind', () => {
+            expect(PreviewContract.isValidPreview(preview({placement: {kind: 'corner-top-left'}}))).toBe(false);
+            expect(PreviewContract.isValidPreview(preview({placement: {}}))).toBe(false)
+        });
+
+        test('rejects a split placement without a valid orientation', () => {
+            expect(PreviewContract.isValidPreview(preview({placement: {kind: 'split-before'}}))).toBe(false);
+            expect(PreviewContract.isValidPreview(preview({placement: {kind: 'split-after', orientation: 'diagonal'}}))).toBe(false);
+            expect(PreviewContract.isValidPreview(preview({placement: {kind: 'split-after', orientation: 'vertical'}}))).toBe(true)
+        });
+
+        test('rejects a missing or invalid feedback.state', () => {
+            expect(PreviewContract.isValidPreview(preview({feedback: {}}))).toBe(false);
+            expect(PreviewContract.isValidPreview(preview({feedback: {state: 'maybe'}}))).toBe(false);
+            expect(PreviewContract.isValidPreview(preview({feedback: undefined}))).toBe(false)
+        });
+
+        test('treats a rejected placement as structurally valid', () => {
+            expect(PreviewContract.isValidPreview(preview({placement: {kind: 'rejected'}, feedback: {state: 'rejected'}}))).toBe(true)
+        })
+    });
+
+    test.describe('previewToOperation (semantic drop, never mutates)', () => {
+        test('tab placements route to addTab with the target tabs node and index', () => {
+            const op = PreviewContract.previewToOperation(preview({placement: {kind: 'tab-after', index: 1}}));
+            expect(op.operation).toBe('addTab');
+            expect(op.tabsNodeId).toBe('main-tabs');
+            expect(op.itemId).toBe('strategy');
+            expect(op.index).toBe(1)
+        });
+
+        test('split placements route to splitNode with orientation and normalized sizes', () => {
+            const op = PreviewContract.previewToOperation(preview({placement: {kind: 'split-before', orientation: 'vertical', ratio: 0.3}}));
+            expect(op.operation).toBe('splitNode');
+            expect(op.orientation).toBe('vertical');
+            expect(op.position).toBe('before');
+            expect(op.sizes).toEqual([0.3, 0.7])
+        });
+
+        test('edge placements route to splitNode with a derived orientation', () => {
+            const left = PreviewContract.previewToOperation(preview({placement: {kind: 'edge-left'}}));
+            expect(left.operation).toBe('splitNode');
+            expect(left.edge).toBe('left');
+            expect(left.orientation).toBe('horizontal');
+
+            const bottom = PreviewContract.previewToOperation(preview({placement: {kind: 'edge-bottom'}}));
+            expect(bottom.orientation).toBe('vertical')
+        });
+
+        test('whole-stack previews preserve the placement grammar in one transferNode descriptor', () => {
+            const groupNodeId = 'popup-stack';
+
+            expect(PreviewContract.previewToOperation(preview({groupNodeId, placement: {kind: 'tab-into'}}))).toEqual({
+                operation: 'transferNode',
+                nodeId   : groupNodeId,
+                target   : {targetNodeId: 'main-tabs', placement: {kind: 'tab-into'}}
+            });
+
+            expect(PreviewContract.previewToOperation(preview({
+                groupNodeId,
+                placement: {kind: 'split-before', orientation: 'vertical', ratio: 0.3}
+            }))).toEqual({
+                operation: 'transferNode',
+                nodeId   : groupNodeId,
+                target   : {
+                    targetNodeId: 'main-tabs',
+                    placement   : {orientation: 'vertical', position: 'before', sizes: [0.3, 0.7]}
+                }
+            });
+
+            expect(PreviewContract.previewToOperation(preview({groupNodeId, placement: {kind: 'edge-right'}}))).toEqual({
+                operation: 'transferNode',
+                nodeId   : groupNodeId,
+                target   : {
+                    targetNodeId: 'main-tabs',
+                    placement   : {edge: 'right', orientation: 'horizontal', sizes: [0.5, 0.5]}
+                }
+            })
+        });
+
+        test('returns null for rejected feedback', () => {
+            expect(PreviewContract.previewToOperation(preview({feedback: {state: 'rejected'}}))).toBe(null)
+        });
+
+        test('returns null for a rejected placement', () => {
+            expect(PreviewContract.previewToOperation(preview({placement: {kind: 'rejected'}, feedback: {state: 'rejected'}}))).toBe(null)
+        });
+
+        test('returns null for an invalid preview', () => {
+            expect(PreviewContract.previewToOperation(preview({itemId: ''}))).toBe(null)
+        });
+
+        test('never leaks a runtime-only field into the operation descriptor', () => {
+            const op = PreviewContract.previewToOperation(preview());
+            expect(op).not.toHaveProperty('previewId');
+            expect(op).not.toHaveProperty('source');
+            expect(op).not.toHaveProperty('feedback');
+            expect(JSON.stringify(op)).not.toContain('dashboard-sort-zone')
+        })
+    });
+
+    test.describe('ratioToSizes', () => {
+        test('defaults to an even split for an absent or invalid ratio', () => {
+            expect(PreviewContract.ratioToSizes(undefined, 'before')).toEqual([0.5, 0.5]);
+            expect(PreviewContract.ratioToSizes(0, 'before')).toEqual([0.5, 0.5]);
+            expect(PreviewContract.ratioToSizes(1.5, 'after')).toEqual([0.5, 0.5])
+        });
+
+        test('honors a valid ratio for before and after positions', () => {
+            expect(PreviewContract.ratioToSizes(0.25, 'before')).toEqual([0.25, 0.75]);
+            expect(PreviewContract.ratioToSizes(0.25, 'after')).toEqual([0.75, 0.25])
+        })
+    });
+});

--- a/test/playwright/unit/dashboard/DockPreviewProducer.spec.mjs
+++ b/test/playwright/unit/dashboard/DockPreviewProducer.spec.mjs
@@ -6,18 +6,18 @@ setup({
     }
 });
 
-import {test, expect} from '@playwright/test';
-import Neo            from '../../../../src/Neo.mjs';
-import * as core      from '../../../../src/core/_export.mjs';
+import {test, expect}  from '@playwright/test';
+import Neo             from '../../../../src/Neo.mjs';
+import * as core       from '../../../../src/core/_export.mjs';
+import PreviewContract from '../../../../src/dashboard/dock/model/PreviewContract.mjs';
 
 test.describe('Neo.dashboard.dock.interaction.PreviewProducer (ADR 0029 §2.3 — the dock preview producer)', () => {
-    let DockPreviewProducer, DockPreview, producer;
+    let DockPreviewProducer, producer;
 
     const RECT = {x: 0, y: 0, width: 100, height: 100}; // default band = 0.24 * 100 = 24
 
     test.beforeAll(async () => {
         DockPreviewProducer = (await import('../../../../src/dashboard/dock/interaction/PreviewProducer.mjs')).default;
-        DockPreview         = (await import('../../../../src/dashboard/dock/interaction/Preview.mjs')).default;
         producer            = Neo.create(DockPreviewProducer)
     });
 
@@ -123,7 +123,7 @@ test.describe('Neo.dashboard.dock.interaction.PreviewProducer (ADR 0029 §2.3 �
         expect(preview.placement.kind).toBe('split-after');
         expect(preview.placement.orientation).toBe('vertical');  // contract: split placements MUST carry orientation
         expect(preview.previewId).toBe('preview:terminal:side-split-child:split-after');
-        expect(DockPreview.isValidPreview(preview)).toBe(true)   // THE PIN — incl. the split-orientation requirement
+        expect(PreviewContract.isValidPreview(preview)).toBe(true)   // THE PIN — incl. the split-orientation requirement
     });
 
     test('hitTestZone returns the innermost containing zone, or null', () => {
@@ -144,7 +144,7 @@ test.describe('Neo.dashboard.dock.interaction.PreviewProducer (ADR 0029 §2.3 �
         // on strip-scale rects the carve-out owns the top by design (see the STRIP spec).
         const zones = [{nodeId: 'main-tabs', rect: {x: 0, y: 0, width: 400, height: 300}}];
 
-        // one produce per resolvable kind — each MUST satisfy the landed DockPreview.isValidPreview (write === read)
+        // one produce per resolvable kind — each MUST satisfy PreviewContract.isValidPreview (write === read)
         for (const [x, y, kind] of [[200, 150, 'tab-into'], [200, 50, 'edge-top'], [390, 150, 'edge-right'], [10, 150, 'edge-left'], [200, 290, 'edge-bottom']]) {
             const preview = producer.produce({pointer: {x, y}, zones, itemId: 'strategy', containerId: 'workspace'});
 
@@ -152,7 +152,7 @@ test.describe('Neo.dashboard.dock.interaction.PreviewProducer (ADR 0029 §2.3 �
             expect(preview.placement.kind).toBe(kind);
             expect(preview.target.nodeId).toBe('main-tabs');
             expect(preview.feedback.state).toBe('accepted');
-            expect(DockPreview.isValidPreview(preview)).toBe(true) // THE PIN
+            expect(PreviewContract.isValidPreview(preview)).toBe(true) // THE PIN
         }
     });
 
@@ -200,9 +200,8 @@ test.describe('Neo.dashboard.dock.interaction.PreviewProducer (ADR 0029 §2.3 �
     });
 
     test('whole-stack production carries one coherent runtime group through previews and candidates', async () => {
-        const {isValidCandidateSet} = await import('../../../../src/dashboard/dock/model/PreviewContract.mjs');
-        const zones                 = [{nodeId: 'main-tabs', rect: RECT, orientation: 'vertical'}];
-        const params                = {
+        const zones  = [{nodeId: 'main-tabs', rect: RECT, orientation: 'vertical'}];
+        const params = {
             groupNodeId: 'popup-stack',
             itemId     : 'strategy',
             pointer    : {x: 50, y: 50},
@@ -213,10 +212,10 @@ test.describe('Neo.dashboard.dock.interaction.PreviewProducer (ADR 0029 §2.3 �
 
         expect(preview.groupNodeId).toBe('popup-stack');
         expect(preview.previewId).toBe('preview:group:popup-stack:main-tabs:tab-into');
-        expect(DockPreview.isValidPreview(preview)).toBe(true);
+        expect(PreviewContract.isValidPreview(preview)).toBe(true);
         expect(set.groupNodeId).toBe('popup-stack');
         expect(set.cross.every(candidate => candidate.preview.groupNodeId === 'popup-stack')).toBe(true);
-        expect(isValidCandidateSet(set)).toBe(true);
+        expect(PreviewContract.isValidCandidateSet(set)).toBe(true);
 
         expect(producer.produce({...params, groupNodeId: ''})).toBeNull();
         expect(producer.produceCandidates({...params, groupNodeId: 42})).toBeNull()
@@ -247,7 +246,7 @@ test.describe('Neo.dashboard.dock.interaction.PreviewProducer (ADR 0029 §2.3 �
         expect(preview.placement.kind).toBe('edge-left');
 
         // the middle: preview → semantic operation descriptor
-        const descriptor = DockPreview.previewToOperation(preview);
+        const descriptor = PreviewContract.previewToOperation(preview);
         expect(descriptor.operation).toBe('splitNode');
         expect(descriptor.targetNodeId).toBe('b-tabs');
 
@@ -262,8 +261,6 @@ test.describe('Neo.dashboard.dock.interaction.PreviewProducer (ADR 0029 §2.3 �
     });
 
     test('produceCandidates emits the full §06 menu — schema-pinned, every preview consumer-valid', async () => {
-        const contract = await import('../../../../src/dashboard/dock/model/PreviewContract.mjs');
-
         const TALL  = {x: 100, y: 100, width: 400, height: 300};
         const ROOT  = {x: 0, y: 0, width: 800, height: 600};
         const zones = [{nodeId: 'main-tabs', rect: TALL, orientation: 'vertical'}];
@@ -273,9 +270,9 @@ test.describe('Neo.dashboard.dock.interaction.PreviewProducer (ADR 0029 §2.3 �
             root   : {nodeId: 'root', rect: ROOT}
         });
 
-        // the schema config is pinned against the contract module (same mechanism as `schema`)
-        expect(set.schema).toBe(contract.CANDIDATES_SCHEMA);
-        expect(contract.isValidCandidateSet(set)).toBe(true);      // THE candidate-set PIN
+        // the schema config is pinned against the contract owner (same mechanism as `schema`)
+        expect(set.schema).toBe(PreviewContract.CANDIDATES_SCHEMA);
+        expect(PreviewContract.isValidCandidateSet(set)).toBe(true);      // THE candidate-set PIN
 
         // the 5-position cross, §06 grammar on a vertical-split child: along-axis directions
         // sibling-insert, perpendicular directions split the node, center tab-merges
@@ -294,9 +291,9 @@ test.describe('Neo.dashboard.dock.interaction.PreviewProducer (ADR 0029 §2.3 �
         expect(set.root.chips.map(c => c.preview.placement.kind)).toEqual(['edge-top', 'edge-right', 'edge-bottom', 'edge-left']);
         expect(set.root.chips.every(c => c.preview.target.nodeId === 'root')).toBe(true);
 
-        // EVERY candidate preview individually passes the app-layer consumer validator
+        // EVERY candidate preview individually passes the shared contract validator
         for (const candidate of [...set.cross, ...set.root.chips]) {
-            expect(DockPreview.isValidPreview(candidate.preview)).toBe(true)
+            expect(PreviewContract.isValidPreview(candidate.preview)).toBe(true)
         }
     });
 
@@ -333,8 +330,6 @@ test.describe('Neo.dashboard.dock.interaction.PreviewProducer (ADR 0029 §2.3 �
     });
 
     test('isValidCandidateSet rejects partial, duplicated, mismatched and lying menus', async () => {
-        const {isValidCandidateSet} = await import('../../../../src/dashboard/dock/model/PreviewContract.mjs');
-
         const TALL  = {x: 0, y: 0, width: 400, height: 300};
         const valid = (orientation='vertical') => producer.produceCandidates({
             pointer: {x: 200, y: 150}, zones: [{nodeId: 'main-tabs', orientation, rect: TALL}], itemId: 'terminal',
@@ -343,49 +338,49 @@ test.describe('Neo.dashboard.dock.interaction.PreviewProducer (ADR 0029 §2.3 �
 
         // Both producer grammar axes are positive controls: the stricter tuple gate must preserve
         // every real emission while rejecting only contradictory direction/orientation payloads.
-        expect(isValidCandidateSet(valid('vertical'))).toBe(true);
-        expect(isValidCandidateSet(valid('horizontal'))).toBe(true);
+        expect(PreviewContract.isValidCandidateSet(valid('vertical'))).toBe(true);
+        expect(PreviewContract.isValidCandidateSet(valid('horizontal'))).toBe(true);
 
         // a one-entry "menu" is a partial menu — rejected (completeness, not just per-entry validity)
         let set = valid();
         set.cross = [set.cross[0]];
-        expect(isValidCandidateSet(set)).toBe(false);
+        expect(PreviewContract.isValidCandidateSet(set)).toBe(false);
 
         // duplicated positions are rejected even at the right length
         set = valid();
         set.cross[1] = {...set.cross[0]};
-        expect(isValidCandidateSet(set)).toBe(false);
+        expect(PreviewContract.isValidCandidateSet(set)).toBe(false);
 
         // a candidate whose position lies about its operation is rejected
         // (the review falsifier: a `center` indicator wired to an `edge-left` split)
         set = valid();
         set.cross.find(c => c.position === 'center').preview.placement = {kind: 'edge-left'};
-        expect(isValidCandidateSet(set)).toBe(false);
+        expect(PreviewContract.isValidCandidateSet(set)).toBe(false);
 
         // a candidate built for ANOTHER item is rejected
         set = valid();
         set.cross[2].preview.itemId = 'somebody-else';
-        expect(isValidCandidateSet(set)).toBe(false);
+        expect(PreviewContract.isValidCandidateSet(set)).toBe(false);
 
         // a cross candidate targeting a node other than the hovered zone is rejected
         set = valid();
         set.cross[3].preview.target.nodeId = 'other-node';
-        expect(isValidCandidateSet(set)).toBe(false);
+        expect(PreviewContract.isValidCandidateSet(set)).toBe(false);
 
         // chips: a missing edge is rejected (4 unique required when root exists)…
         set = valid();
         set.root.chips.pop();
-        expect(isValidCandidateSet(set)).toBe(false);
+        expect(PreviewContract.isValidCandidateSet(set)).toBe(false);
 
         // …and a chip whose kind does not match its own edge is rejected
         set = valid();
         set.root.chips.find(c => c.edge === 'top').preview.placement = {kind: 'edge-bottom'};
-        expect(isValidCandidateSet(set)).toBe(false);
+        expect(PreviewContract.isValidCandidateSet(set)).toBe(false);
 
         // a split-kind on a TRAILING direction claiming `split-before` is rejected
         set = valid();
         set.cross.find(c => c.position === 'bottom').preview.placement = {kind: 'split-before', orientation: 'vertical'};
-        expect(isValidCandidateSet(set)).toBe(false);
+        expect(PreviewContract.isValidCandidateSet(set)).toBe(false);
 
         // Split direction + kind + axis form one semantic tuple. Each otherwise-valid split kind
         // is rejected when it advertises the perpendicular axis.
@@ -397,7 +392,7 @@ test.describe('Neo.dashboard.dock.interaction.PreviewProducer (ADR 0029 §2.3 �
         ]) {
             set = valid(position === 'left' || position === 'right' ? 'horizontal' : 'vertical');
             set.cross.find(candidate => candidate.position === position).preview.placement = {kind, orientation};
-            expect(isValidCandidateSet(set), `${position} ${kind} must reject ${orientation}`).toBe(false)
+            expect(PreviewContract.isValidCandidateSet(set), `${position} ${kind} must reject ${orientation}`).toBe(false)
         }
     })
 });

--- a/test/playwright/unit/examples/dashboard/crossWindow/DemoBWorkspace.spec.mjs
+++ b/test/playwright/unit/examples/dashboard/crossWindow/DemoBWorkspace.spec.mjs
@@ -14,6 +14,7 @@ import Component                                           from '../../../../../
 import Container                                           from '../../../../../../src/container/Base.mjs';
 import DemoBWorkspace, {describeCrossWindowChromeMismatch} from '../../../../../../examples/dashboard/crossWindow/DemoBWorkspace.mjs';
 import DockPreview                                         from '../../../../../../src/dashboard/dock/interaction/Preview.mjs';
+import PreviewContract                                     from '../../../../../../src/dashboard/dock/model/PreviewContract.mjs';
 import DockProjectionReconciler                            from '../../../../../../src/dashboard/dock/projection/Reconciler.mjs';
 import WorkspaceDocument                                   from '../../../../../../src/dashboard/dock/model/WorkspaceDocument.mjs';
 import Operations                                          from '../../../../../../src/dashboard/dock/model/Operations.mjs';
@@ -2194,7 +2195,7 @@ test.describe.serial('Neo.examples.dashboard.crossWindow.DemoBWorkspace', () => 
             schema   : 'neo.dock.preview.v1',
             target   : {nodeId: 'popup-tabs'}
         });
-        expect(DockPreview.isValidPreview(renderer.dockPreview)).toBe(true);
+        expect(PreviewContract.isValidPreview(renderer.dockPreview)).toBe(true);
 
         // rendered as the whole-zone band, positioned host-locally (viewport → host conversion)
         expect(affordance.cls).toEqual(expect.arrayContaining([


### PR DESCRIPTION
Resolves #18389

Related: #18304

Dock preview customization now has one registered owner, `Neo.dashboard.dock.model.PreviewContract`. It is a Base singleton whose internal decisions dispatch through instance methods. Renderer and drop consumers call it dynamically, including callbacks registered before a policy replacement. The renderer's competing policy wrappers and the module's named-function exports are removed; preview grammar and explicit ratios are preserved.

Evidence: L2 (real Neo registration/overwrite, renderer geometry, semantic operation application and existing unit consumers) → L2 required (policy ownership and dispatch). Residual: none for this ticket. No native-window behavior is changed or newly certified.

## AC Evidence

| AC | Evidence |
|---|---|
| AC-1 | CI-covered: `unit/dashboard/DockPreviewContract.spec.mjs` installs a real `Neo.overwrites` method before import and verifies the singleton's namespace identity. Internal conversion and rendered-fraction methods dispatch through `this`. |
| AC-2 | CI-covered: `DockCrossWindowParticipation.spec.mjs` replaces the converter after target registration and verifies the current method is invoked. Production import/callback migration removes captured converter aliases and competing Preview wrappers. |
| AC-3 | CI-covered: `DockPreviewContract.spec.mjs` compares geometry, descriptor and applied split under a 25% default override. Outside-CI control on merged base `3a0773c9a5` reproduces rendered `0.25` versus operation `[0.5,0.5]`. |
| AC-4 | CI-covered: moved contract tests retain validation/refusal and item/group grammar coverage. The overwrite matrix checks before/after and left/right edge placements, explicit 30% ratios, whole-stack descriptors, and unchanged input preview/document DTOs. |
| AC-5 | CI-covered: preview, producer, indicator, participation and consumer suites. JSDoc generation adds the owner as a Base child in `docs/output/class-hierarchy.json`; no generated file was hand-edited. |

## Deltas from ticket

None substantive. Pure-policy tests move from the renderer spec into `DockPreviewContract.spec.mjs`. The FiveBeat E2E module now initializes Neo core before its Node-side import of the registered contract.

## Test Evidence

Outside-CI control: loaded the unmodified Preview and PreviewContract source from git object `3a0773c9a5` in a fresh process, replaced `Preview.ratioToSizes`, then observed rendered `0.25` and operation `[0.5,0.5]` for the same omitted-ratio preview.

FiveBeat import-boundary check: with the existing `NEO_AGENTOS_RUNTIME_ROOT`, Playwright E2E `--list` collects all 11 scenarios. This is collection evidence, not execution of those journeys.

## Post-Merge Validation

None required for this bounded policy change.

Authored by Emmy (GPT-6 Astra, Codex). Session d14f2413-4744-43e9-a6c1-191166d58fe9.
