### PR TITLE
feat(dock): register the per-Rail reveal owner (#18393)

### DIFF
--- a/docs/output/class-hierarchy.json
+++ b/docs/output/class-hierarchy.json
@@ -229,7 +229,7 @@
  "Neo.dashboard.dock.interaction.PreviewProducer": "Neo.core.Base",
  "Neo.dashboard.dock.interaction.Rail": "Neo.container.Base",
  "Neo.dashboard.dock.interaction.RevealOverlay": "Neo.container.Base",
- "Neo.dashboard.dock.interaction.RevealStateMachine": null,
+ "Neo.dashboard.dock.interaction.RevealStateMachine": "Neo.core.Base",
  "Neo.dashboard.dock.interaction.TabContainer": "Neo.tab.Container",
  "Neo.dashboard.dock.interaction.TabEnterButton": "Neo.tab.header.Button",
  "Neo.dashboard.dock.interaction.TabSortZone": "Neo.draggable.tab.header.toolbar.SortZone",

--- a/src/dashboard/dock/interaction/Rail.mjs
+++ b/src/dashboard/dock/interaction/Rail.mjs
@@ -35,7 +35,7 @@ import NeoArray           from '../../../util/Array.mjs';
  * reachable through reveal — anything else is item loss. The policy projection (`restorable`)
  * therefore gates the overlay's pin control, never the tab.
  *
- * The reveal/dismiss timing brain lives in {@link RevealStateMachine} (documented state table);
+ * The reveal/dismiss policy lives in {@link Neo.dashboard.dock.interaction.RevealStateMachine};
  * this component owns composition, overlay binding and the executor commit path.
  *
  * @class Neo.dashboard.dock.interaction.Rail
@@ -181,8 +181,8 @@ class Rail extends Container {
      */
     revealPaneReleases = {}
     /**
-     * The reveal/dismiss timing brain. Runtime-only; created per instance, torn down in `destroy()`.
-     * @member {RevealStateMachine|null} revealMachine=null
+     * The owned reveal policy. Runtime-only; created per Rail, torn down in `destroy()`.
+     * @member {Neo.dashboard.dock.interaction.RevealStateMachine|null} revealMachine=null
      * @protected
      */
     revealMachine = null
@@ -231,7 +231,19 @@ class Rail extends Container {
 
         let me = this;
 
-        me.revealMachine = new RevealStateMachine({
+        me.revealMachine = me.createRevealMachine()
+    }
+
+    /**
+     * @summary Creates the Rail-owned reveal policy with its current timing and hover preferences.
+     * Override this factory to supply a specialized owner; Rail retains destruction responsibility.
+     * @returns {Neo.dashboard.dock.interaction.RevealStateMachine}
+     * @protected
+     */
+    createRevealMachine() {
+        const me = this;
+
+        return Neo.create(RevealStateMachine, {
             dwellMs      : Number.isFinite(me.revealDwellMs)        ? me.revealDwellMs        : undefined,
             graceMs      : Number.isFinite(me.revealDismissGraceMs) ? me.revealDismissGraceMs : undefined,
             onChange     : me.onRevealStateChange.bind(me),

--- a/src/dashboard/dock/interaction/RevealStateMachine.mjs
+++ b/src/dashboard/dock/interaction/RevealStateMachine.mjs
@@ -1,12 +1,12 @@
+import Base from '../../../core/Base.mjs';
+
 /**
- * @summary Pure reveal/dismiss state machine for auto-hidden dock items — runtime-only by
- * construction, timer-injectable for deterministic specs.
+ * @summary Owns one Rail's transient reveal state, policy and dwell/dismiss timers.
  *
- * This module is deliberately NOT a Neo class: it holds per-window runtime interaction state
- * (which item is transiently revealed, and why) that must never touch the persisted dock-zone
- * document. It has no write path to any document — its only outputs are `onChange`
- * notifications the owning affordance (`Neo.dashboard.dock.interaction.Rail`) maps to overlay updates and,
- * for the pin escape, to an executor-routed operation OUTSIDE this machine.
+ * Methods and policy defaults support Neo.overwrites and subclassing. Each Rail creates and destroys
+ * its own instance; registration does not persist interaction state. The only output is `onChange`,
+ * which the Rail maps to overlay updates. Pinning remains an executor-routed operation outside this
+ * machine. Timer functions remain injectable for deterministic tests.
  *
  * ## States
  *
@@ -46,8 +46,10 @@
  *
  * Dwell + grace are interaction timings owned here; reveal/dismiss slide durations are animation
  * timings and live in CSS, not in this machine.
+ * @class Neo.dashboard.dock.interaction.RevealStateMachine
+ * @extends Neo.core.Base
  */
-class RevealStateMachine {
+class RevealStateMachine extends Base {
     /**
      * Hover intent dwell before a reveal fires (opt-in hover mode only).
      * @member {Number} DWELL_MS=150
@@ -61,7 +63,34 @@ class RevealStateMachine {
      */
     static DISMISS_GRACE_MS = 300
 
+    static config = {
+        /** @member {String} className='Neo.dashboard.dock.interaction.RevealStateMachine' @protected */
+        className: 'Neo.dashboard.dock.interaction.RevealStateMachine',
+        /** @member {Function} clearTimeoutFn Cancels a timer owned by this instance. */
+        clearTimeoutFn: id => globalThis.clearTimeout(id),
+        /** @member {Number} dwellMs=150 Hover dwell before revealing without focus. */
+        dwellMs: RevealStateMachine.DWELL_MS,
+        /** @member {Number} graceMs=300 Pointer-leave grace before dismissal. */
+        graceMs: RevealStateMachine.DISMISS_GRACE_MS,
+        /** @member {Function|null} onChange=null Receives next and previous reveal snapshots. */
+        onChange: null,
+        /** @member {Boolean} revealOnHover=false Hover reveal is explicitly opt-in. */
+        revealOnHover: false,
+        /** @member {Function} setTimeoutFn Schedules this instance's dwell/grace callback. */
+        setTimeoutFn: (fn, ms) => globalThis.setTimeout(fn, ms)
+    }
+
+    /** @member {String|null} pendingItemId=null @protected */
+    pendingItemId = null
+    /** @member {String|null} revealedItemId=null */
+    revealedItemId = null
+    /** @member {String} state='idle' */
+    state = 'idle'
+    /** @member {Number|Object|null} timerId=null @protected */
+    timerId = null
+
     /**
+     * @summary Applies effective policy while retaining the established optional-config defaults.
      * @param {Object} config
      * @param {Function} [config.clearTimeoutFn=globalThis.clearTimeout] Injectable for fake-timer specs.
      * @param {Number} [config.dwellMs=RevealStateMachine.DWELL_MS]
@@ -70,17 +99,19 @@ class RevealStateMachine {
      * @param {Boolean} [config.revealOnHover=false] Workspace-level opt-in; hover inputs are ignored without it.
      * @param {Function} [config.setTimeoutFn=globalThis.setTimeout] Injectable for fake-timer specs.
      */
-    constructor({clearTimeoutFn, dwellMs, graceMs, onChange, revealOnHover, setTimeoutFn} = {}) {
-        this.clearTimeoutFn = clearTimeoutFn || globalThis.clearTimeout.bind(globalThis);
-        this.dwellMs        = Number.isFinite(dwellMs) ? dwellMs : RevealStateMachine.DWELL_MS;
-        this.graceMs        = Number.isFinite(graceMs) ? graceMs : RevealStateMachine.DISMISS_GRACE_MS;
-        this.onChange       = typeof onChange === 'function' ? onChange : null;
-        this.pendingItemId  = null;
-        this.revealOnHover  = revealOnHover === true;
-        this.revealedItemId = null;
-        this.setTimeoutFn   = setTimeoutFn || globalThis.setTimeout.bind(globalThis);
-        this.state          = 'idle';
-        this.timerId        = null
+    construct(config={}) {
+        config = {...config};
+
+        for (const key of ['dwellMs', 'graceMs']) {
+            if (!Number.isFinite(config[key])) delete config[key]
+        }
+
+        if (!config.clearTimeoutFn) delete config.clearTimeoutFn;
+        if (!config.setTimeoutFn) delete config.setTimeoutFn;
+        if (Object.hasOwn(config, 'onChange') && typeof config.onChange !== 'function') config.onChange = null;
+        if (Object.hasOwn(config, 'revealOnHover')) config.revealOnHover = config.revealOnHover === true;
+
+        super.construct(config)
     }
 
     /**
@@ -95,11 +126,13 @@ class RevealStateMachine {
     }
 
     /**
-     * Tears the machine down: clears timers and detaches the change listener.
+     * @summary Clears owned timers and the change listener before Base teardown.
+     * @param {...*} args
      */
-    destroy() {
+    destroy(...args) {
         this.clearTimer();
-        this.onChange = null
+        this.onChange = null;
+        super.destroy(...args)
     }
 
     /**
@@ -261,4 +294,4 @@ class RevealStateMachine {
     }
 }
 
-export default RevealStateMachine;
+export default Neo.setupClass(RevealStateMachine);

--- a/test/playwright/unit/dashboard/DockRail.spec.mjs
+++ b/test/playwright/unit/dashboard/DockRail.spec.mjs
@@ -10,10 +10,11 @@ import {test, expect}    from '@playwright/test';
 import Neo               from '../../../../src/Neo.mjs';
 import * as core         from '../../../../src/core/_export.mjs';
 import '../../../../src/manager/Instance.mjs'; // defines Neo.get — the registry the release witness reads
-import Button            from '../../../../src/button/Base.mjs';
-import DockLayoutAdapter from '../../../../src/dashboard/dock/projection/LayoutAdapter.mjs';
-import DockRail          from '../../../../src/dashboard/dock/interaction/Rail.mjs';
-import Panel             from '../../../../src/dashboard/Panel.mjs';
+import Button             from '../../../../src/button/Base.mjs';
+import DockLayoutAdapter  from '../../../../src/dashboard/dock/projection/LayoutAdapter.mjs';
+import DockRail           from '../../../../src/dashboard/dock/interaction/Rail.mjs';
+import RevealStateMachine from '../../../../src/dashboard/dock/interaction/RevealStateMachine.mjs';
+import Panel              from '../../../../src/dashboard/Panel.mjs';
 
 const createDocument = () => ({
     schema: 'neo.dock.zone.v1',
@@ -62,6 +63,79 @@ test.describe('Neo.dashboard.dock.interaction.Rail', () => {
     test.afterEach(() => {
         rail?.destroy();
         rail = null
+    });
+
+    test('a specialized reveal owner uses the existing Rail input and destruction paths', () => {
+        class UnfocusedReveal extends RevealStateMachine {
+            static config = {className: 'Test.Unit.Dashboard.Rail.UnfocusedReveal'}
+
+            /** @summary Specializes click policy while retaining the inherited transition lifecycle. */
+            tabClick(itemId) {
+                this.transition('revealed', itemId)
+            }
+        }
+        Neo.setupClass(UnfocusedReveal);
+
+        rail = Neo.create(DockRail, {
+            edge: 'right', railItems: createRailItems(),
+            createRevealMachine() {
+                return Neo.create(UnfocusedReveal, {onChange: this.onRevealStateChange.bind(this)})
+            }
+        });
+        const machine = rail.revealMachine;
+
+        expect(rail.onTabClick({component: rail.items[0]})).toEqual({revealedItemId: 'terminal', state: 'revealed'});
+        expect(machine).toBeInstanceOf(UnfocusedReveal);
+        rail.destroy();
+        expect(machine.isDestroyed).toBe(true)
+    });
+
+    test('each Rail owns independent reveal state and cancels only its own pending timer', () => {
+        const pending    = new Map();
+        let   nextId     = 0;
+        const createRail = () => Neo.create(DockRail, {
+            edge: 'right', railItems: createRailItems(),
+            createRevealMachine() {
+                return Neo.create(RevealStateMachine, {
+                    onChange     : this.onRevealStateChange.bind(this),
+                    revealOnHover: true,
+                    setTimeoutFn(fn) {
+                        const id = ++nextId;
+                        pending.set(id, fn);
+                        return id
+                    },
+                    clearTimeoutFn: id => pending.delete(id)
+                })
+            }
+        });
+
+        rail = createRail();
+        const other      = createRail();
+        const firstOwner = rail.revealMachine;
+
+        try {
+            expect(firstOwner).not.toBe(other.revealMachine);
+            firstOwner.tabHoverIn('terminal');
+            expect(other.revealMachine.state).toBe('idle');
+            other.revealMachine.tabHoverIn('terminal');
+            expect(pending.size).toBe(2);
+
+            rail.destroy();
+            expect(firstOwner.isDestroyed).toBe(true);
+            expect(other.revealMachine.isDestroyed).not.toBe(true);
+            expect(pending.size).toBe(1);
+            const callback = [...pending.values()][0];
+            pending.clear();
+            callback();
+            expect(other.revealMachine.state).toBe('revealed');
+
+            other.revealMachine.overlayPointerLeave();
+            expect(pending.size).toBe(1);
+            other.destroy();
+            expect(pending.size).toBe(0)
+        } finally {
+            other.destroy()
+        }
     });
 
     test('renders railItems as real button children and reconciles in place (object permanence)', () => {

--- a/test/playwright/unit/dashboard/DockRevealStateMachine.spec.mjs
+++ b/test/playwright/unit/dashboard/DockRevealStateMachine.spec.mjs
@@ -1,5 +1,13 @@
+import {setup} from '../../setup.mjs';
+
+setup({appConfig: {name: 'DockRevealStateMachineTest'}});
+
 import {test, expect}         from '@playwright/test';
+import Neo                    from '../../../../src/Neo.mjs';
+import * as core              from '../../../../src/core/_export.mjs';
 import DockRevealStateMachine from '../../../../src/dashboard/dock/interaction/RevealStateMachine.mjs';
+import {execFileSync}         from 'node:child_process';
+import {fileURLToPath}        from 'node:url';
 
 const createFakeTimers = () => {
     let nextId = 1,
@@ -33,20 +41,82 @@ const createFakeTimers = () => {
     }
 };
 
+const machines = new Set();
+
 const createMachine = (config={}) => {
     let changes = [],
         timers  = createFakeTimers(),
-        machine = new DockRevealStateMachine({
+        machine = Neo.create(DockRevealStateMachine, {
             clearTimeoutFn: timers.clearTimeoutFn.bind(timers),
             onChange      : (next, previous) => changes.push({next, previous}),
             setTimeoutFn  : timers.setTimeoutFn.bind(timers),
             ...config
         });
 
+    machines.add(machine);
     return {changes, machine, timers}
 };
 
 test.describe('DockRevealStateMachine', () => {
+    test.afterEach(() => {
+        machines.forEach(machine => machine.destroy());
+        machines.clear()
+    });
+
+    test('a pre-import Neo overwrite reaches a real Rail input and its owned lifecycle', () => {
+        const result = JSON.parse(execFileSync(process.execPath, ['--input-type=module', '-e', `
+            await import('./src/Neo.mjs');
+            await import('./src/core/_export.mjs');
+            const {setup} = await import('./test/playwright/setup.mjs');
+            setup({appConfig: {name: 'DockRevealOverwriteTest'}});
+            Neo.overwrites = {};
+            const policy = Neo.ns('Neo.dashboard.dock.interaction.RevealStateMachine', true, Neo.overwrites);
+            policy.dwellMs = 75;
+            policy.tabClick = function(itemId) {
+                this.transition('revealed', itemId);
+            };
+            const {default: Rail} = await import('./src/dashboard/dock/interaction/Rail.mjs');
+            const {default: Machine} = await import('./src/dashboard/dock/interaction/RevealStateMachine.mjs');
+            const rail = Neo.create(Rail, {edge: 'right', railItems: [{dockItemId: 'terminal', title: 'Terminal', restorable: true}]});
+            const machine = rail.revealMachine;
+            const dwellMs = machine.dwellMs;
+            const snapshot = rail.onTabClick({component: {dockItemId: 'terminal'}});
+            rail.destroy();
+            process.stdout.write(JSON.stringify({
+                registered: Machine === Neo.dashboard.dock.interaction.RevealStateMachine,
+                snapshot, dwellMs, destroyed: machine.isDestroyed === true
+            }));
+        `], {cwd: fileURLToPath(new URL('../../../../', import.meta.url)), encoding: 'utf8'}));
+
+        expect(result.registered).toBe(true);
+        expect(result.snapshot).toEqual({revealedItemId: 'terminal', state: 'revealed'});
+        expect(result.dwellMs).toBe(75);
+        expect(result.destroyed).toBe(true)
+    });
+
+    test('explicit dwell and grace durations govern their respective transitions', () => {
+        const {machine, timers} = createMachine({dwellMs: 12, graceMs: 23, revealOnHover: true});
+
+        machine.tabHoverIn('terminal');
+        timers.advance(11);
+        expect(machine.state).toBe('dwell-pending');
+        timers.advance(1);
+        expect(machine.state).toBe('revealed');
+        machine.overlayPointerLeave();
+        timers.advance(22);
+        expect(machine.state).toBe('dismiss-pending');
+        timers.advance(1);
+        expect(machine.state).toBe('idle')
+    });
+
+    test('invalid optional timings retain defaults and hover requires true', () => {
+        const {machine} = createMachine({dwellMs: NaN, graceMs: Infinity, revealOnHover: 'true'});
+
+        expect(machine.dwellMs).toBe(150);
+        expect(machine.graceMs).toBe(300);
+        expect(machine.revealOnHover).toBe(false)
+    });
+
     test('click-reveal is the default: click focuses, re-click dismisses', () => {
         let {changes, machine} = createMachine();
 


### PR DESCRIPTION
Resolves #18393

Related: #18304

Each Rail now owns a registered `Neo.dashboard.dock.interaction.RevealStateMachine`. Applications can override its methods and defaults through `Neo.overwrites`, or supply a subclass through `Rail.createRevealMachine()`, while Rail retains input wiring and teardown. The raw constructor path is removed. The existing transition table, timing defaults, hover opt-in and document boundary remain intact.

For a Rail-created machine, `Rail.autoHideRevealOnHover` explicitly supplies the hover flag and takes precedence over the machine default. Configure hover on the Rail/workspace; machine timing defaults apply when Rail supplies no finite override.

Evidence: L2 (real Rail input, Neo registration/overwrite and independently owned timer lifecycle) → L2 required (customization and lifecycle contract). Residual: none for this ticket.

## AC Evidence

| AC | Evidence |
|---|---|
| AC-1 | CI-covered: `DockRevealStateMachine.spec.mjs` verifies the registered namespace and a default override installed before import. Transient state remains on individual Base instances. |
| AC-2 | CI-covered: the fresh-process override changes a real Rail click to `revealed`; `DockRail.spec.mjs` supplies a specialized subclass through the factory and uses the existing input/destruction paths. |
| AC-3 | CI-covered: the existing transition tests plus explicit 12ms/23ms timing and invalid-default controls. The two-Rail test verifies independent state, two pending timers, cancellation of only the destroyed owner's timer, and the surviving Rail's transition. |
| AC-4 | CI-covered: Rail uses `Neo.create` and destroys its one owner. Existing Rail tests continue to assert reveal does not emit a document operation. |
| AC-5 | CI-covered: reveal, Rail, overlay and full unit coverage. JSDoc generation updates the existing class-hierarchy entry from no base to `Neo.core.Base`. |

## Deltas from ticket

None substantive. Only the existing owner, Rail, their two unit specs, and generated class hierarchy change. The machine retains the established timing constants; effective policy lives in its instance configs.

## Test Evidence

Red control on merged base `8d6c4216ca`: a pre-import `Neo.overwrites` entry requests an unfocused click reveal, but a real Rail returns `revealed-focused` and the namespace is absent. The new permanent arm failed before the conversion and passes after it.

All permanent coverage runs in CI. No native-window or visual-motion behavior is newly claimed.

## Post-Merge Validation

None required for this bounded owner conversion.

Authored by Emmy (GPT-6 Astra, Codex). Session d14f2413-4744-43e9-a6c1-191166d58fe9.
