### PR TITLE
feat(dock): compose complete default target affordances (#18395)

### DIFF
--- a/src/dashboard/dock/interaction/DragAffordances.mjs
+++ b/src/dashboard/dock/interaction/DragAffordances.mjs
@@ -28,9 +28,10 @@ import PreviewContract   from '../model/PreviewContract.mjs';
  * **The consumer duck-type (`owner`):** a workspace container providing `dockModel` (the
  * committed document), `applyDockZoneOperation(descriptor)` (the reducer), and
  * `onDockZoneDocumentChange(document)` (the view-sync) — the normative reducer-container
- * ownership pattern every docking workspace implements. The overlay instances (`preview`,
- * `indicators`) and the dock `host` container are direct instance refs the consumer assigns
- * after composing them — no reference-name coupling, no app imports in this tier.
+ * ownership pattern every docking workspace implements. The composition owner supplies the
+ * `preview`, `indicators` and `host` instances: an app can compose them, while
+ * {@link Neo.dashboard.dock.window.Participation} owns the complete default remote-target tier.
+ * This controller borrows those views; their composer destroys them. No app imports in this tier.
  */
 class DragAffordances extends Base {
     static config = {
@@ -50,9 +51,8 @@ class DragAffordances extends Base {
 
     /**
      * The settled geometry of the live gesture — the synchronous mirror of {@link #dragGeometry},
-     * null until that promise resolves and again after {@link #invalidateGeometry}. A remote frame
-     * (the cross-window participation path) must resolve its preview on the frame it arrives and
-     * writes the renderer itself, so it reads this instead of awaiting.
+     * null until that promise resolves and again after {@link #invalidateGeometry}. Remote frames
+     * use this mirror to select and publish feedback synchronously.
      * @member {Object|null} geometry=null
      */
     geometry = null
@@ -97,7 +97,7 @@ class DragAffordances extends Base {
     }
 
     /**
-     * Ends a drag affordance session: geometry cache dropped (invalidating every in-flight
+     * @summary Ends a drag affordance session: geometry cache dropped (invalidating every in-flight
      * await's generation token), indicator menu and preview cleared. Called on drop, cancel,
      * teardown, and by every consumer re-projection.
      */
@@ -106,7 +106,7 @@ class DragAffordances extends Base {
 
         me.invalidateGeometry();
         me.indicators?.clear();
-        me.preview && (me.preview.dockPreview = null)
+        me.renderPreview(null)
     }
 
     /**
@@ -215,11 +215,9 @@ class DragAffordances extends Base {
     }
 
     /**
-     * Resolves the preview one pointer selects from the SETTLED geometry, in the §06 tier order — a
-     * hovered indicator's candidate first, pointer inference over every zone second — without
-     * touching the renderer. {@link #onDragMove} is the async, renderer-writing form of the same
-     * decision; the cross-window participation path calls this synchronously per remote frame
-     * because it owns the renderer write, and supplies its own fallback for a null.
+     * @summary Updates the candidate menu and resolves its selection from settled geometry.
+     * Indicator selection precedes pointer inference. Both local moves and remote frames use this
+     * decision, then publish through {@link #renderPreview} or a caller-owned renderer.
      * @param {Object} data
      * @param {String} data.itemId
      * @param {Object} data.pointer {x, y} in the host window's client space
@@ -228,15 +226,46 @@ class DragAffordances extends Base {
      * @returns {Object|null} the dockPreview, or null before the geometry settles or when nothing is under the pointer
      */
     resolvePreview({groupNodeId = null, itemId, pointer, sourceNodeId}) {
-        let me         = this,
-            {geometry} = me,
-            candidate  = geometry ? me.indicators?.hitTest(pointer) : null;
+        let me                               = this,
+            {geometry, indicators, producer} = me;
 
         if (!geometry) return null;
 
+        const zone = producer.hitTestZone(geometry.zones, pointer),
+              set  = indicators?.candidateSet;
+
+        if (indicators && ((zone?.nodeId ?? null) !== (set?.zone?.nodeId ?? null) || zone?.rect !== set?.zone?.rect ||
+            set?.itemId !== itemId || (set?.groupNodeId ?? null) !== groupNodeId)) {
+            indicators.candidateSet = zone
+                ? producer.produceCandidates({pointer, zones: geometry.zones, itemId, groupNodeId, sourceNodeId, root: geometry.root})
+                : null
+        }
+
+        const candidate = indicators?.updatePointer(pointer);
+
         if (candidate?.preview?.itemId === itemId) return candidate.preview;
 
-        return me.producer.produce({groupNodeId, itemId, pointer, root: geometry.root, sourceNodeId, zones: geometry.zones})
+        return producer.produce({groupNodeId, itemId, pointer, root: geometry.root, sourceNodeId, zones: geometry.zones})
+    }
+
+    /**
+     * @summary Publishes the semantic preview and native dwell using the same host-local geometry.
+     * @param {Object|null} dockPreview The exact preview the drop path consumes.
+     * @param {Object|null} [dwell=null] The native coordinator's hold clock.
+     * @returns {Object|null} The published preview.
+     */
+    renderPreview(dockPreview, dwell=null) {
+        const me = this, {preview} = me;
+
+        if (preview) {
+            preview.dwell = dwell;
+            preview.dockPreview = dockPreview;
+
+            const targetRect = me.previewTargetRect(dockPreview);
+            targetRect && preview.applyTargetGeometry(me.localRect(targetRect, me.geometry.hostRect))
+        }
+
+        return dockPreview
     }
 
     /**
@@ -249,7 +278,7 @@ class DragAffordances extends Base {
     }
 
     /**
-     * The per-frame drag consumer (§06 primary tier): the indicator menu follows the hovered
+     * @summary The per-frame drag consumer: the indicator menu follows the hovered
      * zone (candidate set swaps on zone change only — object permanence lets the cross
      * GLIDE); the pointer selects an indicator geometrically; the selected candidate's
      * preview — or the pointer-inference FALLBACK tier when no indicator is hovered — feeds
@@ -272,29 +301,11 @@ class DragAffordances extends Base {
         // geometry mid-await — a late measurement can never resurrect its overlays.
         if (!geometry || me.dragGeometry !== geometryPromise || me.isDestroyed) return;
 
-        let pointer                         = {x: clientX, y: clientY},
-            {indicators, preview, producer} = me,
-            zone                            = producer.hitTestZone(geometry.zones, pointer);
+        const dockPreview = me.resolvePreview({
+            groupNodeId, itemId, pointer: {x: clientX, y: clientY}, sourceNodeId
+        });
 
-        if (indicators) {
-            if ((zone?.nodeId ?? null) !== (indicators.candidateSet?.zone?.nodeId ?? null)) {
-                indicators.candidateSet = zone
-                    ? producer.produceCandidates({pointer, zones: geometry.zones, itemId, groupNodeId, sourceNodeId, root: geometry.root})
-                    : null
-            }
-        }
-
-        let candidate   = indicators?.updatePointer(pointer) ?? null,
-            dockPreview = candidate?.preview
-                ?? producer.produce({pointer, zones: geometry.zones, itemId, groupNodeId, root: geometry.root, sourceNodeId});
-
-        if (preview && writeRenderer) {
-            preview.dockPreview = dockPreview;
-
-            let targetRect = me.previewTargetRect(dockPreview);
-
-            targetRect && preview.applyTargetGeometry(me.localRect(targetRect, geometry.hostRect))
-        }
+        writeRenderer && me.renderPreview(dockPreview)
     }
 
     /**

--- a/src/dashboard/dock/window/Participation.mjs
+++ b/src/dashboard/dock/window/Participation.mjs
@@ -1,6 +1,7 @@
 import Base              from '../../../core/Base.mjs';
 import DragAffordances   from '../interaction/DragAffordances.mjs';
 import DragTarget        from './DragTarget.mjs';
+import DropIndicators    from '../interaction/DropIndicators.mjs';
 import WorkspaceDocument from '../model/WorkspaceDocument.mjs';
 import Operations        from '../model/Operations.mjs';
 import Preview           from '../interaction/Preview.mjs';
@@ -32,8 +33,8 @@ import PreviewContract   from '../model/PreviewContract.mjs';
  *   transaction instead of extending a `dockZone.v1` item record.
  *
  * Layer discipline (the target's established layer note, unchanged): `src/dashboard/` imports no app module —
- * every seam below arrives from the app-side workspace composition, which keeps authoring the
- * preview visuals. The {@link Neo.manager.DragCoordinator} stays dock-blind: all dock semantics
+ * hosts can override the seams below; the default preview tier composes the shared engine visuals.
+ * The {@link Neo.manager.DragCoordinator} stays dock-blind: all dock semantics
  * live here and in the seams, never in the coordinator (§2.3 binding invariant).
  *
  * The cross-window drag payload contract (stamped by {@link Neo.dashboard.dock.interaction.TabSortZone} at
@@ -228,6 +229,13 @@ class Participation extends Base {
     ownedAffordances = null
 
     /**
+     * The default target's indicator menu, created and destroyed with its preview tier.
+     * @member {Neo.dashboard.dock.interaction.DropIndicators|null} ownedIndicators=null
+     * @protected
+     */
+    ownedIndicators = null
+
+    /**
      * The preview overlay composed by {@link #resolveAffordances}. Owned here, destroyed here.
      * @member {Neo.dashboard.dock.interaction.Preview|null} ownedPreview=null
      * @protected
@@ -268,14 +276,8 @@ class Participation extends Base {
     }
 
     /**
-     * @summary Composes the engine's own affordance tier on first use.
-     *
-     * {@link Neo.dashboard.dock.interaction.Preview} and
-     * {@link Neo.dashboard.dock.interaction.DragAffordances} both document themselves as the
-     * app-neutral pieces every docking workspace composes, and no engine workspace composes either —
-     * so a host that supplies no preview seam has nothing to paint into, resolves no preview for a
-     * remote hover, and can never convert a drop into an operation. Composing them here keeps that
-     * assembly out of the workspace class while making the seam answerable.
+     * @summary Composes the shared preview renderer, indicator menu and gesture controller on first use.
+     * Default targets own this complete tier; hosts supplying a preview seam retain their own visuals.
      * @returns {Neo.dashboard.dock.interaction.DragAffordances|null}
      * @protected
      */
@@ -284,16 +286,18 @@ class Participation extends Base {
             workspace = me.workspace,
             host      = workspace?.getDockHost?.();
 
-        if (me.ownedAffordances || !workspace || !host || workspace.isDestroyed) {
+        if (me.isDestroyed || me.ownedAffordances || !workspace || !host || workspace.isDestroyed) {
             return me.ownedAffordances
         }
 
         me.ownedPreview = workspace.add({module: Preview});
+        me.ownedIndicators = workspace.add({module: DropIndicators});
 
         me.ownedAffordances = Neo.create(DragAffordances, {
             host,
-            owner  : workspace,
-            preview: me.ownedPreview
+            indicators: me.ownedIndicators,
+            owner     : workspace,
+            preview   : me.ownedPreview
         });
 
         return me.ownedAffordances
@@ -390,7 +394,8 @@ class Participation extends Base {
     }
 
     /**
-     * Engine default for {@link #previewFor}: resolves the remote hover frame against the gesture
+     * @summary Resolves and renders the remote hover frame through the gesture owner.
+     * The engine default for {@link #previewFor} uses the gesture
      * controller's synchronous geometry mirror. The warm-up is deliberately not awaited — the seam
      * must answer on the frame it arrives, and the first frames of a gesture resolving to `null`
      * while geometry settles is the documented behaviour of that mirror.
@@ -408,12 +413,12 @@ class Participation extends Base {
 
         affordances.ensureGeometry();
 
-        return affordances.resolvePreview({
+        return affordances.renderPreview(affordances.resolvePreview({
             groupNodeId : draggedItem.dockGroupNodeId ?? null,
             itemId      : draggedItem.dockItemId,
             pointer     : {x: payload.localX, y: payload.localY},
             sourceNodeId: draggedItem.dockSourceNodeId ?? payload.sourceNodeId ?? null
-        }) ?? null
+        }) ?? null, payload.dwell ?? null)
     }
 
     /**
@@ -617,7 +622,7 @@ class Participation extends Base {
     }
 
     /**
-     * Unregisters + destroys the owned target before instance teardown — the unmount half of the
+     * @summary Unregisters and destroys the owned target before instance teardown — the unmount half of the
      * registration lifecycle.
      */
     destroy() {
@@ -633,6 +638,9 @@ class Participation extends Base {
 
         me.ownedPreview?.destroy();
         me.ownedPreview = null;
+
+        me.ownedIndicators?.destroy();
+        me.ownedIndicators = null;
 
         super.destroy()
     }

--- a/test/playwright/e2e/workstation/WorkstationPopOutPaneIdentityNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationPopOutPaneIdentityNL.spec.mjs
@@ -63,9 +63,69 @@ const readIdentity = async (app, paneId) => {
     }
 };
 
-test.describe('Workstation pop-out — a nested pane subtree keeps its identities across the hop and back', () => {
+test.describe('Workstation pop-out — default affordances and retained pane identities', () => {
     test.setTimeout(120000);
     test.use({viewport: {height: 900, width: 1600}});
+
+    test('a full popup paints default target affordances through Neural Link hover dispatch', async ({page, context, neuralLink}, testInfo) => {
+        await page.goto('/apps/workstation/index.html');
+        const header = page.locator(HEADER).filter({has: page.locator(TAB, {hasText: 'Metrics'})}).first();
+        await expect(header).toBeVisible({timeout: 60000});
+        await header.locator(TAB, {hasText: 'Metrics'}).click();
+
+        const app          = await neuralLink.connectToApp('Workstation'),
+              popupPromise = context.waitForEvent('page', {timeout: 45000});
+        await header.locator(`${ACTION}:has(span[class*="${POP_OUT}"])`).first().click();
+        const vessel = await popupPromise;
+
+        try {
+            await expect(vessel.locator(TAB, {hasText: 'Metrics'})).toBeVisible({timeout: 45000});
+
+            const popups = await app.findInstances({className: 'Workstation.view.PopupWorkspace'}, ['id', 'windowId', 'dockModel']);
+            expect(popups).toHaveLength(1);
+            const popup        = await app.getComponent(popups[0].id, ['id', 'windowId', 'dockModel']),
+                  participants = await app.findInstances({ntype: 'dock-crosswindow-participation', windowId: popup.windowId}, ['id']);
+            expect(participants).toHaveLength(1);
+
+            const participationId = participants[0].id,
+                  hostRect        = await vessel.locator(`#${popup.id}`).boundingBox(),
+                  payload         = {
+                      draggedItem: {dockItemId: 'audit'},
+                      localX     : hostRect.x + hostRect.width / 2,
+                      localY     : hostRect.y + hostRect.height / 2
+                  };
+
+            await expect.poll(async () => (await app.callMethod(participationId, 'defaultPreviewFor', [payload]))?.feedback?.state,
+                {message: 'the default target accepts a hover after real geometry settles', timeout: 15000}).toBe('accepted');
+
+            const owned  = await app.getComponent(participationId, ['ownedPreview.id', 'ownedIndicators.id']),
+                  menu   = vessel.locator(`#${owned['ownedIndicators.id']}`),
+                  region = vessel.locator(`#${owned['ownedPreview.id']} .neo-dock-preview-affordance`);
+
+            await expect(menu.locator('.neo-dashboard-dock-drop-indicator:not(.neo-dashboard-dock-drop-indicator-off)')).toHaveCount(5);
+            await expect(menu).toBeVisible();
+            await expect(region, 'an accepted preview is painted, not only returned').toBeVisible();
+
+            const top      = await menu.locator('.neo-dashboard-dock-drop-indicator-top').boundingBox(),
+                  selected = await app.callMethod(participationId, 'defaultPreviewFor', [{
+                      ...payload, localX: top.x + top.width / 2, localY: top.y + top.height / 2
+                  }]);
+            expect(selected.placement.kind).toBe('edge-top');
+            await expect(region).toHaveClass(/neo-dock-preview-edge-top/);
+            expect((await app.getComponent(popup.id, ['dockModel'])).dockModel).toEqual(popup.dockModel);
+
+            await testInfo.attach('popup-default-affordances', {body: await vessel.screenshot(), contentType: 'image/png'});
+            await app.callMethod(participationId, 'defaultClearPreview');
+            await expect(region).toHaveCount(0);
+            await expect(menu).toBeHidden();
+            testInfo.annotations.push({
+                type       : 'evidence-boundary',
+                description: 'Real header pop-out and painted popup; default hover dispatched through Neural Link. No full human drag or transfer claim.'
+            })
+        } finally {
+            !vessel.isClosed() && await vessel.close()
+        }
+    });
 
     test('component, provider, store and descendant identities survive pop-out AND return', async ({page, context, neuralLink}, testInfo) => {
         const pageErrors = [];

--- a/test/playwright/unit/apps/workstation/Workspace.spec.mjs
+++ b/test/playwright/unit/apps/workstation/Workspace.spec.mjs
@@ -1135,8 +1135,13 @@ test.describe.serial('Workstation.view.Workspace', () => {
                 expect(offZone.placement.kind).toBe('tab-into');
                 expect(paintedRects.at(-1)).toEqual(local(farRect));
 
-                // …while a pointed zone still wins over the stored home.
+                // The menu owns its bottom indicator; off-menu inference still selects
+                // the pointed zone rather than the stored home.
                 expect(render({x: 290, y: 300}, Workspace.MAIN_WORKSPACE_ID)).toMatchObject({
+                    placement: {kind: 'edge-bottom'},
+                    target   : {nodeId: 'left-tabs'}
+                });
+                expect(render({x: 290, y: 330}, Workspace.MAIN_WORKSPACE_ID)).toMatchObject({
                     placement: {kind: 'tab-into'},
                     target   : {nodeId: 'left-tabs'}
                 });

--- a/test/playwright/unit/dashboard/DockCrossWindowParticipation.spec.mjs
+++ b/test/playwright/unit/dashboard/DockCrossWindowParticipation.spec.mjs
@@ -9,6 +9,7 @@ setup({
 import {test, expect}  from '@playwright/test';
 import Neo             from '../../../../src/Neo.mjs';
 import * as core       from '../../../../src/core/_export.mjs';
+import Container       from '../../../../src/container/Base.mjs';
 import PreviewContract from '../../../../src/dashboard/dock/model/PreviewContract.mjs';
 
 /**
@@ -850,6 +851,85 @@ test.describe('Neo.dashboard.dock.window.Participation (ADR 0029 §2.3 — works
             windowId       : 'window-b',
             workspaceId    : 'B',
             ...config
+        });
+
+        test('default remote hover owns, selects and paints reusable overlays without changing the document', async () => {
+            const workspace = Neo.create(Container, {
+                items: [{module: Container, dockNodeId: 'main-tabs'}]
+            });
+            workspace.dockModel = targetDoc();
+            workspace.getDockHost = () => workspace;
+            workspace.getDockProjectionOptions = () => ({});
+            workspace.getDomRect = async () => [
+                {x: 100, y: 80, width: 800, height: 600},
+                {x: 100, y: 80, width: 800, height: 600}
+            ];
+
+            const participation = createParticipation({sortGroup: 'dock-engine', workspace}),
+                  document      = JSON.stringify(workspace.dockModel),
+                  payload       = {
+                      draggedItem: {dockItemId: 'terminal'}, localX: 500, localY: 380,
+                      dwell      : {armedAt: Date.now(), durationMs: 800}
+                  };
+
+            try {
+                expect(participation.defaultPreviewFor(payload)).toBeNull();
+                await participation.ownedAffordances.ensureGeometry();
+
+                const resolved                         = participation.defaultPreviewFor(payload),
+                      {ownedAffordances, ownedPreview} = participation,
+                      indicators                       = ownedAffordances.indicators;
+
+                expect(resolved?.feedback.state).toBe('accepted');
+                expect(ownedPreview.dockPreview, 'accepted preview reaches its renderer').toEqual(resolved);
+                expect(ownedPreview.dwell).toEqual(payload.dwell);
+                expect(ownedPreview.vdom.cn[0].style).toMatchObject({left: '0px', top: '0px', width: '800px', height: '600px'});
+                expect(indicators?.candidateSet?.zone.nodeId, 'default target paints the menu').toBe('main-tabs');
+                expect(indicators.activeCandidate?.position).toBe('center');
+                expect(workspace.items.length, 'one host child and two owned overlays').toBe(3);
+
+                const split = participation.defaultPreviewFor({...payload, localY: 342});
+                expect(indicators.activeCandidate?.position).toBe('top');
+                expect(split.placement.kind).toBe('edge-top');
+                expect(ownedPreview.dockPreview).toEqual(split);
+                expect(participation.resolveAffordances()).toBe(ownedAffordances);
+                expect(JSON.stringify(workspace.dockModel)).toBe(document);
+
+                participation.defaultClearPreview();
+                expect(ownedPreview.dockPreview).toBeNull();
+                expect(ownedPreview.dwell).toBeNull();
+                expect(indicators.candidateSet).toBeNull();
+                expect(ownedAffordances.geometry).toBeNull();
+
+                participation.destroy();
+                expect(ownedPreview.isDestroyed).toBe(true);
+                expect(indicators.isDestroyed).toBe(true);
+                expect(ownedAffordances.isDestroyed).toBe(true)
+            } finally {
+                !participation.isDestroyed && participation.destroy();
+                workspace.destroy()
+            }
+        });
+
+        test('a custom preview seam leaves overlay ownership with its caller', () => {
+            const workspace     = createWorkspaceStub(),
+                  overlay       = Neo.create(Container),
+                  payload       = {draggedItem: {dockItemId: 'terminal'}},
+                  preview       = {custom: true},
+                  participation = createParticipation({
+                      sortGroup : 'dock-engine', workspace,
+                      previewFor: value => value === payload ? preview : null
+                  });
+
+            try {
+                expect(participation.target.previewFor(payload)).toBe(preview);
+                expect(participation.ownedAffordances).toBeNull();
+                participation.destroy();
+                expect(overlay.isDestroyed).toBeFalsy()
+            } finally {
+                !participation.isDestroyed && participation.destroy();
+                overlay.destroy()
+            }
         });
 
         test('a workspace publishing a cross-window sort group registers a target with no sortGroup seam', () => {

--- a/test/playwright/unit/dashboard/DockDragAffordances.spec.mjs
+++ b/test/playwright/unit/dashboard/DockDragAffordances.spec.mjs
@@ -94,7 +94,7 @@ test.describe('Neo.dashboard.dock.interaction.DragAffordances', () => {
         const rig                            = compose(),
               {controller, committed, owner} = rig;
 
-        controller.dragGeometry = Promise.resolve(GEOMETRY());
+        controller.dragGeometry = Promise.resolve(controller.geometry = GEOMETRY());
         rig.indicators.hostRect = GEOMETRY().hostRect;
 
         // hover the LEFT zone center: candidate set + preview build for left-tabs
@@ -108,7 +108,7 @@ test.describe('Neo.dashboard.dock.interaction.DragAffordances', () => {
 
         const rig2 = compose();
 
-        rig2.controller.dragGeometry = Promise.resolve(GEOMETRY());
+        rig2.controller.dragGeometry = Promise.resolve(rig2.controller.geometry = GEOMETRY());
         rig2.indicators.hostRect = GEOMETRY().hostRect;
 
         // hover LEFT (build the left candidate set), then release over RIGHT for item alpha
@@ -134,7 +134,7 @@ test.describe('Neo.dashboard.dock.interaction.DragAffordances', () => {
         const rig    = compose(),
               before = JSON.stringify(rig.owner.dockModel);
 
-        rig.controller.dragGeometry = Promise.resolve(GEOMETRY());
+        rig.controller.dragGeometry = Promise.resolve(rig.controller.geometry = GEOMETRY());
         rig.indicators.hostRect = GEOMETRY().hostRect;
 
         await rig.controller.onDragMove({clientX: 200, clientY: 300, itemId: 'gamma', sourceNodeId: 'right-tabs'});
@@ -301,6 +301,41 @@ test.describe('Neo.dashboard.dock.interaction.DragAffordances', () => {
         rig.preview.destroy()
     });
 
+    test('synchronous remote selection and local moves share current-item menu candidates', async () => {
+        const rig                               = compose(),
+              {controller, indicators, preview} = rig;
+
+        controller.dragGeometry = Promise.resolve(controller.geometry = GEOMETRY());
+        indicators.hostRect = controller.geometry.hostRect;
+
+        try {
+            const data   = {itemId: 'gamma', pointer: {x: 200, y: 262}, sourceNodeId: 'right-tabs'},
+                  remote = controller.resolvePreview(data);
+
+            expect(indicators.activeCandidate?.position).toBe('top');
+            expect(remote.placement.kind, 'the central indicator wins over tab inference').toBe('edge-top');
+            expect(preview.dockPreview, 'resolution leaves publication to the caller').toBeNull();
+
+            await controller.onDragMove({clientX: 200, clientY: 262, itemId: 'gamma', sourceNodeId: 'right-tabs'});
+            expect(preview.dockPreview).toEqual(remote);
+
+            const next = controller.resolvePreview({...data, itemId: 'beta', groupNodeId: 'another-stack'});
+            expect(next.itemId).toBe('beta');
+            expect(next.groupNodeId).toBe('another-stack');
+            expect(indicators.candidateSet.itemId).toBe('beta');
+
+            controller.geometry = GEOMETRY();
+            controller.geometry.zones[0].rect.x = 50;
+            controller.resolvePreview({...data, itemId: 'beta', groupNodeId: 'another-stack'});
+            expect(indicators.candidateSet.zone.rect.x, 'a new measurement moves the same zone menu').toBe(50);
+
+            controller.resolvePreview({...data, pointer: {x: 900, y: 900}});
+            expect(indicators.candidateSet).toBeNull()
+        } finally {
+            destroyAll(rig)
+        }
+    });
+
     /**
      * The root-edge border strip, driven through the production gesture rather than the producer.
      *
@@ -331,7 +366,7 @@ test.describe('Neo.dashboard.dock.interaction.DragAffordances', () => {
         test('hover inside the strip previews the ROOT edge, not the zone beneath it', async () => {
             const rig = compose();
 
-            rig.controller.dragGeometry = Promise.resolve(GEOMETRY());
+            rig.controller.dragGeometry = Promise.resolve(rig.controller.geometry = GEOMETRY());
             rig.indicators.hostRect     = GEOMETRY().hostRect;
 
             await rig.controller.onDragMove({clientX: 200, clientY: 10, itemId: 'gamma', sourceNodeId: 'right-tabs'});
@@ -353,7 +388,7 @@ test.describe('Neo.dashboard.dock.interaction.DragAffordances', () => {
             const rig         = compose(),
                   descriptors = withDescriptorCapture(rig);
 
-            rig.controller.dragGeometry = Promise.resolve(GEOMETRY());
+            rig.controller.dragGeometry = Promise.resolve(rig.controller.geometry = GEOMETRY());
             rig.indicators.hostRect     = GEOMETRY().hostRect;
 
             await rig.controller.onDragMove({clientX: 200, clientY: 10, itemId: 'gamma', sourceNodeId: 'right-tabs'});


### PR DESCRIPTION
Resolves #18395
Related: #18304
Related: #18303

Default remote dock targets now compose the existing Preview and DropIndicators through their Participation. Local and remote hover share DragAffordances candidate selection and preview publication, including host-local geometry and native dwell. Clear and teardown retire the default-owned feedback; caller-supplied preview seams retain ownership.

Evidence: L3 (headed Chrome popup, real DOM geometry and painted feedback; hover dispatched through Neural Link) → L3 required (AC-5). No remaining acceptance for this leaf. This does not claim a full human cross-window drag or native transfer.

## AC Evidence

| AC | Evidence |
|---|---|
| AC-1 | CI-covered: DockCrossWindowParticipation owns, reuses and destroys the real overlay instances; a custom preview callback creates no default tier. |
| AC-2 | CI-covered: DockDragAffordances exercises shared local/remote indicator precedence, changed items/groups, remeasured geometry and explicit renderer publication. Outside-CI: the popup's five live choices and selected top region paint. |
| AC-3 | CI-covered: existing move/drop generation controls remain; default composition clears preview, dwell, menu and geometry and destroys its overlays. Outside-CI: popup clear removes the painted region and hides the menu. |
| AC-4 | Existing local drag, Workstation remote fallback, explicit callback, policy and geometry coverage passes. The new default-path unit failed on original source with accepted preview versus null renderer; the headed baseline control finds zero menu choices. |
| AC-5 | Outside-CI: WorkstationPopOutPaneIdentityNL's new arm opens Metrics using its actual header action, drives default hover through Neural Link using measured client coordinates, selects a rendered indicator, verifies the unchanged document and clears feedback. |

## Deltas from ticket

No substantive scope expansion. The existing Workstation remote-preview test now distinguishes the populated indicator at its original coordinates from pointer fallback off the menu. Injected geometry fixtures populate the documented synchronous mirror as well as the promise. No existing test is removed.

The composition contract documentation now names both app and default Participation ownership. The local/remote candidate loop and renderer writes are shared; Workstation's customized root composition and the separate native-embodiment change remain outside this repair. Selected renderer-publication code comes from Emmy's `b947033b`, adapted to the merged PreviewContract owner.

## Test Evidence

Headed native Chrome, outside CI:

```bash
NEO_AGENTOS_RUNTIME_ROOT=<neo-agent-brain> npx playwright test -c test/playwright/playwright.config.e2e.mjs test/playwright/e2e/workstation/WorkstationPopOutPaneIdentityNL.spec.mjs --grep 'full popup paints' --headed --workers=1
```

The new arm passes, including the screenshot attachment of the five-choice menu and top preview region. With both production files restored to unchanged `dev@88e8e78e`, the same arm still receives an accepted preview but fails on **0 menu choices instead of 5**. The repaired source was restored byte-for-byte after the control.

The complete two-arm file is **1 pass / 1 existing failure**: its older Feed identity arm gains 25 virtual grid-row descendant IDs after pop-out. It fails identically with unchanged dev source; component, Provider and Store comparisons pass before that assertion. The old arm is retained unchanged and is not claimed green or repaired here. The initial sandbox launch failed before a browser object existed; the reported rendering evidence used the approved native execution boundary.

## Post-Merge Validation

None for this leaf. #18303 remains open for the broader native/deployed-command acceptance and source-goal reconciliation. The base-relative Feed descendant-census failure above remains disclosed there; it does not expand this patch.

Authored by Euclid (GPT-6, Codex), incorporating Emmy's renderer-publication handoff. Session 01a07609-5e09-70f0-bf2c-a27d77d1b7f2.
