### PR TITLE
feat(dock): compose native popup target staging (#18398)

### DIFF
--- a/apps/workstation/view/PopupWorkspace.mjs
+++ b/apps/workstation/view/PopupWorkspace.mjs
@@ -82,8 +82,9 @@ class PopupWorkspace extends DockWorkspace {
         const me = this;
         me.participation?.destroy();
         me.participation = me.windowId && me.workspaceSet ? Neo.create(Participation, {
-            sortGroup: me.rootWorkspace.constructor.CROSS_WINDOW_SORT_GROUP,
-            windowId: me.windowId, workspace: me, workspaceId: me.workspaceKey, workspaceSet: me.workspaceSet
+            dragEmbodiment: me.rootWorkspace.vesselProxyEmbodiment,
+            sortGroup     : me.rootWorkspace.constructor.CROSS_WINDOW_SORT_GROUP,
+            windowId      : me.windowId, workspace: me, workspaceId: me.workspaceKey, workspaceSet: me.workspaceSet
         }) : null
     }
 

--- a/apps/workstation/view/Workspace.mjs
+++ b/apps/workstation/view/Workspace.mjs
@@ -1134,9 +1134,11 @@ class Workspace extends DockWorkspace {
         if (me.isDestroyed) return null;
 
         return Neo.create(Participation, {
+            affordances       : isMain ? me.dragAffordances : null,
             clearPreview      : () => me.clearCrossWindowPreview(workspaceId),
             commitLocal       : operation => me.commitLocalWorkspaceOperation(workspaceId, operation),
             commitTransfer    : data => me.commitCrossWindowTransfer(data),
+            dragEmbodiment    : me.vesselProxyEmbodiment,
             getDocument       : () => me.getWorkspaceDocument(workspaceId),
             getForeignDocument: sourceWorkspaceId => me.getWorkspaceDocument(sourceWorkspaceId),
             hitTest           : (localX, localY) => me.hitTestCrossWindowTarget(workspaceId, localX, localY),
@@ -1165,16 +1167,8 @@ class Workspace extends DockWorkspace {
                 return me.renderCrossWindowPreview(workspaceId, data)
             },
             previewToOperation   : preview => PreviewContract.previewToOperation(preview),
-            promoteDragEmbodiment: data => me.vesselProxyEmbodiment.promote({
-                itemId        : data.draggedItem?.dockItemId,
-                targetWindowId: windowId
-            }),
             // Docking design record §2.3: every window of this root declares the root's Group as its commit authority.
             resolveOwnershipId   : () => me.resolveTopologyGroup() ?? null,
-            restoreDragEmbodiment: data => me.vesselProxyEmbodiment.restore({
-                itemId        : data.draggedItem?.dockItemId,
-                targetWindowId: windowId
-            }),
             resumeNativeWindowDrag: isMain ? itemId => me.nativeVesselParkHandlers.onGestureTerminal({
                 itemId,
                 outcome: 'rejected'
@@ -1184,31 +1178,6 @@ class Workspace extends DockWorkspace {
                 outcome: 'committed'
             }) : null,
             sortGroup          : Workspace.CROSS_WINDOW_SORT_GROUP,
-            stageDragEmbodiment: data => me.vesselProxyEmbodiment.move({
-                ...data,
-                sourceWindowId: me.resolveTearOutVessel(data.draggedItem?.dockItemId)?.windowId,
-                targetWindowId: windowId
-            }),
-            awaitDragEmbodiment: async data => {
-                const
-                    itemId   = data.draggedItem?.dockItemId,
-                    renderer = isMain
-                        ? me.dragAffordances?.preview
-                        : me.getPopupState(workspaceId)?.preview;
-
-                if (!renderer?.dockPreview) return false;
-
-                const [embodied] = await Promise.all([
-                    me.vesselProxyEmbodiment.whenSettled({
-                        itemId,
-                        sourceWindowId: me.resolveTearOutVessel(itemId)?.windowId,
-                        targetWindowId: windowId
-                    }),
-                    renderer.promiseUpdate?.()
-                ]);
-
-                return embodied === true && Boolean(renderer.dockPreview)
-            },
             suspendNativeWindowDrag: isMain ? (itemId, data) => {
                 me.vesselConversionTargetWindowId = data?.targetWindowId ?? null;
 

--- a/buildScripts/util/file-size-baseline.json
+++ b/buildScripts/util/file-size-baseline.json
@@ -1,5 +1,5 @@
 {
-    "apps/workstation/view/Workspace.mjs": 2970,
+    "apps/workstation/view/Workspace.mjs": 2942,
     "examples/dashboard/crossWindow/DemoBWorkspace.mjs": 2622,
     "src/dashboard/dock/Workspace.mjs": 1017,
     "src/main/addon/DragDrop.mjs": 1267

--- a/src/dashboard/dock/window/Participation.mjs
+++ b/src/dashboard/dock/window/Participation.mjs
@@ -63,6 +63,17 @@ class Participation extends Base {
          */
         ntype: 'dock-crosswindow-participation',
         /**
+         * An externally owned affordance controller; omitted, this participation composes its own.
+         * @member {Neo.dashboard.dock.interaction.DragAffordances|null} affordances=null
+         */
+        affordances: null,
+        /**
+         * Existing target-proxy owner exposing move, restore, promote and whenSettled.
+         * Its creator retains teardown ownership; explicit handler configs override these defaults.
+         * @member {Object|null} dragEmbodiment=null
+         */
+        dragEmbodiment: null,
+        /**
          * Owner seam, forwarded to the target: clears the workspace's preview overlay when a
          * remote drag leaves. Optional.
          * @member {Function|null} clearPreview=null
@@ -243,7 +254,7 @@ class Participation extends Base {
     ownedPreview = null
 
     /**
-     * Creates + registers the workspace's cross-window target with the five owner seams bound.
+     * @summary Creates and registers the workspace's cross-window target with its owner seams bound.
      * @param {Object} config
      */
     construct(config) {
@@ -258,15 +269,15 @@ class Participation extends Base {
             hitTest                : me.hitTest                 ?? me.defaultHitTest.bind(me),
             previewFor             : me.previewFor              ?? me.defaultPreviewFor.bind(me),
             previewToOperation     : me.previewToOperation      ?? (preview => PreviewContract.previewToOperation(preview)),
-            promoteDragEmbodiment  : me.promoteDragEmbodiment,
+            promoteDragEmbodiment  : me.promoteDragEmbodiment ?? me.defaultPromoteDragEmbodiment.bind(me),
             resolveNativeWindowDrag: me.resolveNativeWindowDrag ?? me.defaultResolveNativeWindowDrag.bind(me),
             resolveOwnershipId     : () => me.ownershipId,
-            restoreDragEmbodiment  : me.restoreDragEmbodiment,
+            restoreDragEmbodiment  : me.restoreDragEmbodiment ?? me.defaultRestoreDragEmbodiment.bind(me),
             resumeNativeWindowDrag : me.resumeNativeWindowDrag,
             retireNativeWindowDrag : me.retireNativeWindowDrag,
             sortGroup              : me.sortGroup ?? me.defaultSortGroup(),
-            stageDragEmbodiment    : me.stageDragEmbodiment,
-            awaitDragEmbodiment    : me.awaitDragEmbodiment,
+            stageDragEmbodiment    : me.stageDragEmbodiment ?? me.defaultStageDragEmbodiment.bind(me),
+            awaitDragEmbodiment    : me.awaitDragEmbodiment ?? me.defaultAwaitDragEmbodiment.bind(me),
             suspendNativeWindowDrag: me.suspendNativeWindowDrag,
             // the workspace id IS the §2.8.1 stable claim identity: it survives re-registration
             // and never encodes windowId or registration order
@@ -282,6 +293,8 @@ class Participation extends Base {
      * @protected
      */
     resolveAffordances() {
+        if (this.affordances) return this.affordances;
+
         let me        = this,
             workspace = me.workspace,
             host      = workspace?.getDockHost?.();
@@ -304,11 +317,67 @@ class Participation extends Base {
     }
 
     /**
-     * Engine default for {@link #clearPreview}: drops the overlay this participation owns.
+     * @summary Clears feedback through the supplied or default-owned affordance controller.
      * @protected
      */
     defaultClearPreview() {
-        this.ownedAffordances?.clear()
+        (this.affordances ?? this.ownedAffordances)?.clear()
+    }
+
+    /**
+     * @summary Identifies the exact target-local embodiment without re-deriving the native source.
+     * @param {Object} payload The licensed drag payload.
+     * @returns {Object}
+     */
+    getDragEmbodimentIdentity(payload) {
+        return {itemId: payload?.draggedItem?.dockItemId,
+            sourceWindowId: payload?.sourceWindowId, targetWindowId: this.windowId}
+    }
+
+    /**
+     * @summary Stages through the supplied embodiment owner.
+     * @param {Object} payload
+     * @returns {Boolean}
+     * @protected
+     */
+    defaultStageDragEmbodiment(payload) {
+        return this.dragEmbodiment?.move({...payload, targetWindowId: this.windowId}) === true
+    }
+
+    /**
+     * @summary Restores only the licensed target embodiment.
+     * @param {Object} payload
+     * @returns {Boolean}
+     * @protected
+     */
+    defaultRestoreDragEmbodiment(payload) {
+        return this.dragEmbodiment?.restore(this.getDragEmbodimentIdentity(payload)) === true
+    }
+
+    /**
+     * @summary Promotes the target embodiment after semantic commit.
+     * @param {Object} payload
+     * @returns {Boolean}
+     * @protected
+     */
+    defaultPromoteDragEmbodiment(payload) {
+        return this.dragEmbodiment?.promote(this.getDragEmbodimentIdentity(payload)) === true
+    }
+
+    /**
+     * @summary Waits for both the live pane and its preview before the retained native handoff.
+     * @param {Object} payload The exact payload fenced by DragTarget across this await.
+     * @returns {Promise<Boolean>}
+     */
+    async defaultAwaitDragEmbodiment(payload) {
+        const preview = this.resolveAffordances()?.preview;
+        if (!this.dragEmbodiment || !preview?.dockPreview) return false;
+
+        const [settled] = await Promise.all([
+            this.dragEmbodiment.whenSettled(this.getDragEmbodimentIdentity(payload)),
+            preview.promiseUpdate?.()
+        ]);
+        return settled === true && Boolean(preview.dockPreview)
     }
 
     /**

--- a/src/dashboard/dock/window/VesselEmbodiment.mjs
+++ b/src/dashboard/dock/window/VesselEmbodiment.mjs
@@ -325,17 +325,22 @@ export function createDockVesselProxyEmbodiment({
          * @param {Object} data.proxyRect Target-window-local `{x,y,width,height}`
          * @param {Neo.draggable.container.SortZone} data.sourceSortZone
          * @param {String|Number} [data.sourceWindowId] Exact physical source vessel identity.
-         *     Falls back to the source sort zone's window for ordinary cross-window drags.
+         *     Otherwise retains an active origin or reads the live pane's rendering window before
+         *     using the source sort zone. A parked popup can differ from its originating sort zone.
          * @param {String|Number} data.targetWindowId
          * @returns {Boolean}
          */
         move({draggedItem, proxyRect, sourceSortZone, sourceWindowId, targetWindowId} = {}) {
             const itemId = draggedItem?.dockItemId;
 
-            sourceWindowId ??= sourceSortZone?.windowId;
+            if (!itemId) return false;
+
+            sourceWindowId ??= active?.itemId === itemId
+                ? active.sourceWindowId
+                : resolvePane(itemId)?.windowId ?? sourceSortZone?.windowId;
 
             if (
-                !itemId || sourceWindowId == null || targetWindowId == null ||
+                sourceWindowId == null || targetWindowId == null ||
                 !isMeasurableProxyRect(proxyRect)
             ) {
                 return false

--- a/test/playwright/e2e/workstation/WorkstationNativePopupOverPopupNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationNativePopupOverPopupNL.spec.mjs
@@ -239,7 +239,12 @@ async function popOut({app, page, workspaceId, itemId}) {
 }
 
 test.describe('Workstation — native titlebar drag popup onto popup (#18047)', () => {
-    test('a popup moved by its OS titlebar onto another popup previews there and transfers its pane', async ({page, neuralLink}) => {
+    /**
+     * @summary Runs the native transfer against either the initial or an enlarged target window.
+     * @param {Object} fixtures
+     * @param {Boolean} [resizeTarget=false]
+     */
+    const journey = async ({page, neuralLink}, resizeTarget=false) => {
         const
             pageErrors = [],
             popups     = [];
@@ -355,6 +360,20 @@ test.describe('Workstation — native titlebar drag popup onto popup (#18047)', 
             expect((await readNativeLifecycle(app, workspaceId)).owners[TARGET_ITEM]?.windowId,
                 'placing the target vessel did not hand it to the main window').toBe(target.windowId);
 
+            if (resizeTarget) {
+                const enlarged = await setBounds(targetHandle, {
+                    width : Math.min(520, stage.availLeft + stage.availWidth - targetScreen.screenX),
+                    height: Math.min(460, stage.availTop + stage.availHeight - targetScreen.screenY)
+                });
+
+                expect(enlarged.innerWidth, 'the target is substantially wider').toBeGreaterThan(targetScreen.innerWidth * 2);
+                expect(enlarged.innerHeight, 'the target is substantially taller').toBeGreaterThan(targetScreen.innerHeight * 1.5);
+                await expect.poll(async () => {
+                    const rect = await readManagerRect(app, managerId, target.windowId, 'innerRect');
+                    return Math.max(Math.abs(rect.width - enlarged.innerWidth), Math.abs(rect.height - enlarged.innerHeight))
+                }, {message: 'manager.Window observes the enlarged viewport', timeout: 5000}).toBeLessThanOrEqual(2)
+            }
+
             const
                 // the drop anchor is the source FRAME's top-left corner plus the inset, and the claim
                 // tests the target's VIEWPORT — so the aim is frame-corner-into-viewport
@@ -381,14 +400,45 @@ test.describe('Workstation — native titlebar drag popup onto popup (#18047)', 
             // bounds move uses — so a frame placed at (left, top) puts the anchor at (left + inset,
             // top + inset), no chrome arithmetic. Aim it 24 px inside the target's viewport.
             const
-                goalLeft = Math.round(targetInner.x + 24 - inset),
-                goalTop  = Math.round(targetInner.y + 24 - inset);
+                goalLeft = Math.round(targetInner.x + (resizeTarget ? targetInner.width * .7 : 24) - inset),
+                goalTop  = Math.round(targetInner.y + (resizeTarget ? targetInner.height * .5 : 24) - inset),
+                targetParticipation = (await participations(app)).find(entry => entry.workspaceId === TARGET_WORKSPACE_ID);
+
+            if (resizeTarget) {
+                expect(goalLeft + inset, 'the drop aims outside the old target width')
+                    .toBeGreaterThan(targetInner.x + targetScreen.innerWidth)
+            }
+
+            let measuredTarget;
 
             for (const [dx, dy] of [[0, 0], [3, 2], [6, 4]]) {
                 const moved = await setBounds(sourceHandle, {left: goalLeft + dx, top: goalTop + dy});
 
                 await awaitOriginParity(app, managerId, source.windowId, moved, 'manager.Window follows the source popup through the poll alone');
-                await source.popup.waitForTimeout(120)
+                await source.popup.waitForTimeout(120);
+
+                if (resizeTarget) {
+                    const observed = await app.getComponent(targetParticipation.id, ['ownedAffordances.geometry', 'ownedIndicators.candidateSet']);
+                    if (observed['ownedIndicators.candidateSet']) measuredTarget = observed
+                }
+            }
+
+            if (resizeTarget) {
+                expect(measuredTarget, 'the real native hover populated the resized target menu').toBeTruthy();
+                const host = await target.popup.locator('.workstation-vessel-dock-host').boundingBox(),
+                      zone = await target.popup.locator('.neo-dashboard-dock-tabs').first().boundingBox(),
+                      geometry = measuredTarget['ownedAffordances.geometry'],
+                      candidates = measuredTarget['ownedIndicators.candidateSet'];
+
+                for (const key of ['x', 'y', 'width', 'height']) {
+                    expect(geometry.hostRect[key], `preview host ${key} matches the resized DOM`).toBeCloseTo(host[key], 0);
+                    expect(candidates.zone.rect[key], `drop zone ${key} matches the resized DOM`).toBeCloseTo(zone[key], 0)
+                }
+                test.info().annotations.push({type: 'resized-target-geometry', description: JSON.stringify({
+                    before: {width: targetScreen.innerWidth, height: targetScreen.innerHeight},
+                    after: host, previewHost: geometry.hostRect, dropZone: candidates.zone.rect,
+                    anchor: {x: goalLeft + inset, y: goalTop + inset}
+                })})
             }
 
             // The coordinator's own arithmetic must place the anchor inside the target — the source's
@@ -434,32 +484,31 @@ test.describe('Workstation — native titlebar drag popup onto popup (#18047)', 
 
             try {
                 await expect.poll(async () => {
-                    const [state, nativeLifecycle] = await Promise.all([
-                        app.getComponent(workspaceId, ['dockModel', 'lastCrossWindowTransfer', 'lastVesselParkReceipt']),
+                    const [state, group, nativeLifecycle] = await Promise.all([
+                        app.getComponent(workspaceId, ['lastVesselParkReceipt']),
+                        app.callMethod(workspaceId, 'controller.getTopologyState'),
                         readNativeLifecycle(app, workspaceId)
                     ]);
 
-                    receipt = {...state, nativeLifecycle};
+                    receipt = {...state, group, nativeLifecycle, dockModel: group.snapshot.participants['workstation-main']};
 
                     return {
-                        applied       : state.lastCrossWindowTransfer?.applied === true,
-                        operation     : state.lastCrossWindowTransfer?.descriptor?.operation ?? null,
                         parked        : state.lastVesselParkReceipt?.parked === true,
                         sourceClosed  : source.popup.isClosed(),
                         sourceWindowId: nativeLifecycle.owners[SOURCE_ITEM].windowId,
-                        target        : state.lastCrossWindowTransfer?.targetWorkspaceId ?? null
+                        sourceItems   : Object.keys(group.snapshot.participants[`workstation-vessel:${SOURCE_ITEM}`].items),
+                        targetItems   : Object.keys(group.snapshot.participants[TARGET_WORKSPACE_ID].items).sort()
                     }
                 }, {
                     message  : 'dwelling over the target vessel commits the transfer and retires the source vessel',
                     timeout  : 15000,
                     intervals: [50, 100, 250]
                 }).toEqual({
-                    applied       : true,
-                    operation     : 'transferItem',
                     parked        : true,
                     sourceClosed  : true,
                     sourceWindowId: null,
-                    target        : TARGET_WORKSPACE_ID
+                    sourceItems   : [],
+                    targetItems   : [SOURCE_ITEM, TARGET_ITEM].sort()
                 })
             } catch (error) {
                 // Bounded triage receipt: which phase the native terminal died in, what the target saw
@@ -474,7 +523,7 @@ test.describe('Workstation — native titlebar drag popup onto popup (#18047)', 
                     lifecycle     : await readNativeLifecycle(app, workspaceId).catch(e => String(e)),
                     park          : receipt?.lastVesselParkReceipt ?? null,
                     snapshot      : await app.callMethod(workspaceId, 'readCrossWindowGestureSnapshot', [{parkedItemId: SOURCE_ITEM, targetWorkspaceId: TARGET_WORKSPACE_ID}]).catch(e => String(e)),
-                    transfer      : receipt?.lastCrossWindowTransfer ?? null,
+                    group         : receipt?.group ?? null,
                     windows       : (await app.callMethod(managerId, 'toJSON')).windows.map(win => ({id: win.id, chrome: win.chrome, innerRect: win.innerRect, outerRect: win.outerRect}))
                 }, null, 1));
                 throw error
@@ -504,5 +553,11 @@ test.describe('Workstation — native titlebar drag popup onto popup (#18047)', 
                 popup && !popup.isClosed() && await popup.close()
             }
         }
-    })
+    };
+
+    test('a popup moved by its OS titlebar onto another popup previews there and transfers its pane',
+        ({page, neuralLink}) => journey({page, neuralLink}));
+
+    test('an enlarged popup updates its drop zones before another popup transfers into the newly exposed area',
+        ({page, neuralLink}) => journey({page, neuralLink}, true))
 });

--- a/test/playwright/unit/apps/workstation/Workspace.spec.mjs
+++ b/test/playwright/unit/apps/workstation/Workspace.spec.mjs
@@ -556,67 +556,6 @@ test.describe.serial('Workstation.view.Workspace', () => {
         }
     });
 
-    test('target-proxy staging uses the physical parked popup instead of the source sort-zone window', async () => {
-        const
-            workspace       = Neo.create(Workspace, {windowId: Neo.config.windowId}),
-            originalProxy   = workspace.vesselProxyEmbodiment,
-            settledPayloads = [],
-            stagedPayloads  = [];
-        let participation;
-
-        try {
-            workspace.nativeWindows.sources.get(workspace.id).connections.set("audit", {windowId: 'parked-audit-popup'});
-            registerPopupState(workspace, 'proxy-target-workspace', {
-                preview: {
-                    dockPreview: {itemId: 'audit'},
-                    promiseUpdate() {
-                        settledPayloads.push('preview-rendered')
-                    }
-                }
-            });
-            workspace.vesselProxyEmbodiment = {
-                move: data => {
-                    stagedPayloads.push(data);
-                    return true
-                },
-                promote: () => true,
-                restore: () => true,
-                whenSettled(data) {
-                    settledPayloads.push(data);
-                    return true
-                }
-            };
-
-            participation = await workspace.createCrossWindowParticipation({
-                windowId   : 'proxy-target-window',
-                workspaceId: 'proxy-target-workspace'
-            });
-
-            const payload = {
-                draggedItem   : {dockItemId: 'audit'},
-                proxyRect     : {height: 80, width: 160, x: 20, y: 30},
-                sourceSortZone: {windowId: workspace.windowId}
-            };
-
-            expect(participation.target.stageDragEmbodiment(payload)).toBe(true);
-            expect(stagedPayloads).toEqual([{
-                ...payload,
-                sourceWindowId: 'parked-audit-popup',
-                targetWindowId: 'proxy-target-window'
-            }]);
-            await expect(participation.target.awaitDragEmbodiment(payload)).resolves.toBe(true);
-            expect(settledPayloads).toEqual([{
-                itemId        : 'audit',
-                sourceWindowId: 'parked-audit-popup',
-                targetWindowId: 'proxy-target-window'
-            }, 'preview-rendered'])
-        } finally {
-            participation?.destroy();
-            workspace.vesselProxyEmbodiment = originalProxy;
-            workspace.destroy()
-        }
-    });
-
     test('large-over-small park uses both live extents and restores the same exact popup', async () => {
         const
             workspace          = Neo.create(Workspace, {windowId: Neo.config.windowId}),

--- a/test/playwright/unit/dashboard/DockCrossWindowParticipation.spec.mjs
+++ b/test/playwright/unit/dashboard/DockCrossWindowParticipation.spec.mjs
@@ -913,7 +913,6 @@ test.describe('Neo.dashboard.dock.window.Participation (ADR 0029 §2.3 — works
 
         test('a custom preview seam leaves overlay ownership with its caller', () => {
             const workspace     = createWorkspaceStub(),
-                  overlay       = Neo.create(Container),
                   payload       = {draggedItem: {dockItemId: 'terminal'}},
                   preview       = {custom: true},
                   participation = createParticipation({
@@ -924,11 +923,9 @@ test.describe('Neo.dashboard.dock.window.Participation (ADR 0029 §2.3 — works
             try {
                 expect(participation.target.previewFor(payload)).toBe(preview);
                 expect(participation.ownedAffordances).toBeNull();
-                participation.destroy();
-                expect(overlay.isDestroyed).toBeFalsy()
+                participation.destroy()
             } finally {
-                !participation.isDestroyed && participation.destroy();
-                overlay.destroy()
+                !participation.isDestroyed && participation.destroy()
             }
         });
 
@@ -1055,6 +1052,76 @@ test.describe('Neo.dashboard.dock.window.Participation (ADR 0029 §2.3 — works
 
             participation.destroy();
             WindowManager.unregister(WindowManager.get('cwd-default-win'))
+        });
+
+        test('supplied affordances and embodiment retain ownership while the target joins exact native pane and renderer settlement', async () => {
+            const {default: DragAffordances} = await import('../../../../src/dashboard/dock/interaction/DragAffordances.mjs');
+            const {default: Preview}         = await import('../../../../src/dashboard/dock/interaction/Preview.mjs');
+            const renderer                   = Neo.create(Preview),
+                  affordances = Neo.create(DragAffordances, {preview: renderer}),
+                  calls = [],
+                  draggedItem = {dockItemId: 'alpha', dockSourceOwnershipId: 'group-1', dockSourceWorkspaceId: 'B'},
+                  semantic = {schema: 'neo.dock.preview.v1', previewId: 'preview:alpha:main-tabs:tab-into',
+                      itemId: 'alpha', target: {nodeId: 'main-tabs'}, placement: {kind: 'tab-into'}, feedback: {state: 'accepted'}},
+                  payload = {draggedItem, embodyProxy: true, sourceWindowId: 'native-source-popup',
+                      sourceSortZone: {windowId: 'source-root-window'}, localX: 100, localY: 100},
+                  identity = {itemId: 'alpha', sourceWindowId: 'native-source-popup', targetWindowId: 'target-popup'};
+            let settlePane, settleRenderer, settled = false;
+            const paneReady      = new Promise(resolve => settlePane = resolve),
+                  rendererReady  = new Promise(resolve => settleRenderer = resolve),
+                  dragEmbodiment = {
+                      move       : data => { calls.push(['move', data]); return true },
+                      whenSettled: data => { calls.push(['settle', data]); return paneReady },
+                      promote    : data => { calls.push(['promote', data]); return true },
+                      restore    : data => { calls.push(['restore', data]); return true },
+                      destroy    : () => calls.push(['destroy'])
+                  };
+            renderer.promiseUpdate = () => { calls.push(['render']); return rendererReady };
+            const participation = createParticipation({
+                affordances, dragEmbodiment, sortGroup: 'dock-engine', windowId: 'target-popup',
+                workspace: createWorkspaceStub(), workspaceId: 'B', previewFor: () => semantic
+            });
+
+            try {
+                expect(participation.resolveAffordances()).toBe(affordances);
+                expect(participation.ownedAffordances).toBeNull();
+                expect(participation.ownedPreview).toBeNull();
+                renderer.dockPreview = semantic;
+                expect(participation.target.onRemoteDragMove(payload)).toBe(semantic);
+                expect(calls[0]).toEqual(['move', {...payload, targetWindowId: 'target-popup'}]);
+
+                const ready = participation.target.awaitRemoteDragEmbodiment(draggedItem).then(value => {
+                    settled = true;
+                    return value
+                });
+                expect(calls).toContainEqual(['settle', identity]);
+                expect(calls).toContainEqual(['render']);
+                settlePane(true);
+                await new Promise(resolve => setTimeout(resolve, 0));
+                expect(settled, 'the pane alone cannot release the readability hold').toBe(false);
+                settleRenderer();
+                expect(await ready).toBe(true);
+
+                participation.target.onRemoteDragLeave();
+                expect(calls).toContainEqual(['restore', identity]);
+                expect(renderer.dockPreview, 'default clear reaches the externally owned affordances').toBeNull();
+
+                renderer.dockPreview = semantic;
+                participation.target.onRemoteDragMove(payload);
+                expect(await participation.target.onRemoteDrop(draggedItem)).toBeTruthy();
+                expect(calls).toContainEqual(['promote', identity]);
+
+                participation.target.onRemoteDragMove(payload);
+                expect(await participation.target.awaitRemoteDragEmbodiment(draggedItem), 'an absent rendered preview cannot settle').toBe(false);
+                participation.destroy();
+                expect(affordances.isDestroyed).toBeFalsy();
+                expect(renderer.isDestroyed).toBeFalsy();
+                expect(calls.some(([kind]) => kind === 'destroy')).toBe(false)
+            } finally {
+                participation.isDestroyed || participation.destroy();
+                affordances.destroy();
+                renderer.destroy()
+            }
         });
 
         test('an unset native-window resolver maps a moving popup through its Group-owned registry', () => {

--- a/test/playwright/unit/dashboard/DockVesselEmbodiment.spec.mjs
+++ b/test/playwright/unit/dashboard/DockVesselEmbodiment.spec.mjs
@@ -23,7 +23,8 @@ test.describe('Neo.dashboard.dock.window.VesselEmbodiment (#15396)', () => {
 
     test.beforeEach(() => {
         source = Neo.create(Container, {
-            items: [
+            windowId: 'source-window',
+            items   : [
                 {module: Component, html: 'before'},
                 {module: Component, html: 'live'},
                 {module: Component, html: 'after'}
@@ -337,6 +338,33 @@ test.describe('Neo.dashboard.DockVesselProxyEmbodiment (#16090)', () => {
         expect(proxyEmbodiment.restoreByWindow('source-window')).toBe(false);
         expect(proxyEmbodiment.restoreByWindow('parked-popup-window')).toBe(true);
         expect(source.items[1]).toBe(pane)
+    });
+
+    test('an omitted source window follows the live parked pane and survives later target-local moves', async () => {
+        source.windowId = 'parked-popup-window';
+        const fixture = createFixture();
+
+        expect(pane.windowId).toBe('parked-popup-window');
+        expect(proxyEmbodiment.move(), 'a frame with no item still refuses').toBe(false);
+        expect(fixture.move()).toBe(true);
+        await expect.poll(() => proxyEmbodiment.snapshot('live')?.settled).toBe(true);
+        expect(proxyEmbodiment.snapshot('live')).toMatchObject({
+            sourceWindowId: 'parked-popup-window', targetWindowId: 'target-window'
+        });
+        expect(pane.windowId, 'the first move reparents the pane into the target renderer').toBe('target-window');
+
+        expect(fixture.move(75)).toBe(true);
+        expect(fixture.proxies, 'another frame keeps the same staged proxy').toHaveLength(1);
+        expect(proxyEmbodiment.snapshot('live').sourceWindowId).toBe('parked-popup-window');
+        await expect(proxyEmbodiment.whenSettled({
+            itemId: 'live', sourceWindowId: 'parked-popup-window', targetWindowId: 'target-window'
+        })).resolves.toBe(true);
+
+        expect(proxyEmbodiment.restoreByWindow('source-window'), 'the originating sort zone owns no parked render target').toBe(false);
+        expect(proxyEmbodiment.restoreByWindow('parked-popup-window')).toBe(true);
+        expect(source.items[1]).toBe(pane);
+        expect(pane.windowId).toBe('parked-popup-window');
+        expect(proxyEmbodiment.snapshot('live')).toBeNull()
     });
 
     test('commit promotion preserves pane identity while retiring the transient proxy exact-once', async () => {


### PR DESCRIPTION
Resolves #18398
Related: #18303
Related: #18304
Related: #18400

Native popup targets now stage, settle, restore and promote through the existing proxy owner supplied to Participation. Workstation removes its four repeated callback bodies and passes the same owner to full popups. The proxy retains the pane's physical source window across target-local reparenting.

Evidence: L3 (headed Chrome, observed native window movement, real target rendering and Group transfer) → L3 required (AC-5/6). No residual for this leaf. Native movement uses on-screen CDP window bounds, not an actual human titlebar grab; no page pointer event or injected geometry drives the terminal.

## AC Evidence

| AC | Evidence |
|---|---|
| AC-1 | CI-covered: real borrowed affordances and renderer plus supplied embodiment join the target hooks, remain alive after Participation teardown, and retain explicit callback precedence. |
| AC-2 | CI-covered: pane settlement alone cannot release the hold; renderer settlement must also complete. Missing preview refuses, and DragTarget retains its exact-payload/lifetime fences. |
| AC-3 | CI-covered: a parked pane supplies its physical source independently of its originating sort zone; repeated target-local frames retain that origin and exact-source restoration. An empty frame still refuses. |
| AC-4 | Four root Workstation wrappers deleted; root and PopupWorkspace pass the existing proxy owner. Workstation implementation count drops 2970 → 2942; baseline shrinks with it. No new registry or engine-to-app import. |
| AC-5 | Outside-CI: existing native popup-to-popup journey now completes preview → park → Group document transfer → source retirement, preserving the exact pane id in the target. The sibling popup-to-main journey passes. |
| AC-6 | Outside-CI: new permanent resized-target journey enlarges Metrics from 146×172 to 520×393 client pixels, checks preview/menu rectangles against the actual DOM, then transfers the second popup into the area beyond the former right edge. |

## Deltas from ticket

The operator requested AC-6 during implementation; it reuses the existing native journey with a resized target. The separate experiment resizing an already-hovered target reproduced stale geometry (146px cached versus 520px actual); #18400 owns that repair and it is excluded here.

Adapted Emmy's published `3a640d6d` staging work onto merged #18396, retaining the registered PreviewContract and complete default overlays. Added the early missing-item refusal after a red control caught the donor's null-active origin read. The old Workstation wrapper test moves to the shared Participation owner; existing standalone proxy tests remain. Removed the earlier disconnected-overlay assertion while adding a genuinely wired borrowed-owner control.

## Test Evidence

Headed, outside CI:

```bash
NEO_AGENTOS_RUNTIME_ROOT=<neo-agent-brain> npx playwright test -c test/playwright/playwright.config.e2e.mjs test/playwright/e2e/workstation/WorkstationNativePopupOverPopupNL.spec.mjs test/playwright/e2e/workstation/WorkstationNativeTitlebarDragNL.spec.mjs --headed --workers=1
```

**3 passed, 20.2s.** The resized case records a JSON geometry annotation: actual host, preview host and drop zone each measure 520×393. Its drop anchor is explicitly beyond the former target width.

Baseline control on unchanged `dev@d9ea7a5b44`: target preview and source park succeed, but the source remains open/bound and the transfer does not complete. The repaired test replaces the root consumer's still-live `lastCrossWindowTransfer` observer with Group snapshots, because default popup targets call WorkspaceSet directly. The original observer correctly reports the baseline failure; the replacement retains independent physical closure, native ownership and pane-identity assertions. Before production changes, both new focused unit controls failed on missing supplied-owner composition and incorrect physical source identity.

The updated Group-based observer was also run with all four changed production files restored to unchanged dev: it remains red with source items `[commits]`, target items `[metrics]`, and the source still open/bound, despite `parked: true`. Restoring the published source leaves a byte-identical clean checkout. The observer migration has not removed the failing transfer signal.

## Post-Merge Validation

None for these six ACs. #18400 tracks active-hover resize; #18303 still requires its broader source-goal reconciliation, including the separate human pointer-overlap and deployed-command evidence. This PR does not certify those journeys or repair the disclosed Feed virtual-row census.

Authored by Euclid (GPT-6, Codex), incorporating Emmy's published staging handoff. Session 01a07609-5e09-70f0-bf2c-a27d77d1b7f2.
