### PR TITLE
feat(dock): register the vessel park owner (#18399)

### DIFF
--- a/apps/workstation/view/Workspace.mjs
+++ b/apps/workstation/view/Workspace.mjs
@@ -28,7 +28,7 @@ import {
     createDockVesselProxyEmbodiment
 }                                                from '../../../src/dashboard/dock/window/VesselEmbodiment.mjs';
 import {createDockWorkspaceSet}                 from '../../../src/dashboard/dock/window/WorkspaceSet.mjs';
-import {createVesselParkHandlers}               from '../../../src/dashboard/dock/window/VesselPark.mjs';
+import VesselPark                               from '../../../src/dashboard/dock/window/VesselPark.mjs';
 import PreviewContract                          from '../../../src/dashboard/dock/model/PreviewContract.mjs';
 import {workstationTourScript, initialDocument} from '../tour/denseWorkstation.mjs';
 import '../../../src/button/Base.mjs';
@@ -292,14 +292,14 @@ class Workspace extends DockWorkspace {
     vesselConversionTargetWindowId = null
     /**
      * The in-gesture vessel lifecycle authority (park / re-show / dispose-on-commit).
-     * @member {Object|null} vesselParkHandlers=null
+     * @member {Neo.dashboard.dock.window.VesselPark|null} vesselParkHandlers=null
      * @protected
      */
     vesselParkHandlers = null
     /**
      * Post-terminal native-titlebar park/restore authority. Separate from pointer conversion:
      * the generic DragDrop addon has no active pointer-follow session after a dropped popup.
-     * @member {Object|null} nativeVesselParkHandlers=null
+     * @member {Neo.dashboard.dock.window.VesselPark|null} nativeVesselParkHandlers=null
      * @protected
      */
     nativeVesselParkHandlers = null
@@ -554,12 +554,12 @@ class Workspace extends DockWorkspace {
         // acquisition consumes transient activation and reads as unsolicited), so conversion
         // PARKS the real vessel behind its target, out-conversion re-shows the SAME generation,
         // and only a commit disposes — every other outcome restores.
-        me.vesselParkHandlers = createVesselParkHandlers({
+        me.vesselParkHandlers = Neo.create(VesselPark, {
             disposeVessel: vessel => me.disposeParkedTearOutVessel(vessel),
             parkVessel   : vessel => me.parkTearOutVessel(vessel),
             reshowVessel : vessel => me.reshowTearOutVessel(vessel)
         });
-        me.nativeVesselParkHandlers = createVesselParkHandlers({
+        me.nativeVesselParkHandlers = Neo.create(VesselPark, {
             disposeVessel: ({itemId}) => me.retireReturnedVessel(Workspace.vesselWorkspaceId(itemId)),
             parkVessel   : vessel => me.parkTearOutVessel({...vessel, nativeTitlebar: true}),
             reshowVessel : vessel => me.reshowTearOutVessel(vessel)
@@ -4855,6 +4855,8 @@ class Workspace extends DockWorkspace {
         me.topologyLibrary?.destroy();
         me.dragAffordances?.destroy();
         me.interactionService?.destroy();
+        me.vesselParkHandlers?.destroy();
+        me.nativeVesselParkHandlers?.destroy();
         me.vesselProxyEmbodiment?.destroy();
         me.tearOutEmbodiment?.destroy();
         me.cueSettlements.clear();

--- a/buildScripts/util/file-size-baseline.json
+++ b/buildScripts/util/file-size-baseline.json
@@ -1,6 +1,6 @@
 {
-    "apps/workstation/view/Workspace.mjs": 2914,
-    "examples/dashboard/crossWindow/DemoBWorkspace.mjs": 2610,
+    "apps/workstation/view/Workspace.mjs": 2916,
+    "examples/dashboard/crossWindow/DemoBWorkspace.mjs": 2611,
     "src/dashboard/dock/Workspace.mjs": 1017,
     "src/main/addon/DragDrop.mjs": 1267
 }

--- a/docs/output/class-hierarchy.json
+++ b/docs/output/class-hierarchy.json
@@ -252,6 +252,7 @@
  "Neo.dashboard.dock.window.Placement": "Neo.core.Base",
  "Neo.dashboard.dock.window.TopologySeams": "Neo.core.Base",
  "Neo.dashboard.dock.window.VesselConversion": "Neo.core.Base",
+ "Neo.dashboard.dock.window.VesselPark": "Neo.core.Base",
  "Neo.data.Model": "Neo.core.Base",
  "Neo.data.Pipeline": "Neo.core.Base",
  "Neo.data.RecordFactory": "Neo.core.Base",

--- a/examples/dashboard/crossWindow/DemoBWorkspace.mjs
+++ b/examples/dashboard/crossWindow/DemoBWorkspace.mjs
@@ -21,7 +21,7 @@ import {createDockKeyboardCommands}       from '../../../src/dashboard/dock/inte
 import {createDockTearOutHandlers}        from '../../../src/dashboard/dock/window/TearOut.mjs';
 import {createDockVesselEmbodiment}       from '../../../src/dashboard/dock/window/VesselEmbodiment.mjs';
 import {createDockWorkspaceSet}           from '../../../src/dashboard/dock/window/WorkspaceSet.mjs';
-import {createVesselParkHandlers}         from '../../../src/dashboard/dock/window/VesselPark.mjs';
+import VesselPark                         from '../../../src/dashboard/dock/window/VesselPark.mjs';
 import TourRunner                         from '../../../src/ai/client/TourRunner.mjs';
 import TransactionManager                 from '../../../src/manager/Transaction.mjs';
 import PreviewContract                    from '../../../src/dashboard/dock/model/PreviewContract.mjs';
@@ -636,7 +636,7 @@ class DemoBWorkspace extends Container {
 
         // Conversion never reacquires a popup. The source-owned admission machines retain the
         // existing tear-out vessel while this host binds their effects to its exact native route.
-        me.vesselParkHandlers = createVesselParkHandlers({
+        me.vesselParkHandlers = Neo.create(VesselPark, {
             disposeVessel: vessel => me.disposeParkedTearOutVessel(vessel),
             parkVessel   : vessel => me.parkTearOutVessel(vessel),
             reshowVessel : vessel => me.reshowTearOutVessel(vessel)
@@ -4560,6 +4560,7 @@ class DemoBWorkspace extends Container {
             scope       : me
         });
         me.vesselReservations.clear();
+        me.vesselParkHandlers?.destroy();
         me.tearOutEmbodiment?.destroy();
         me.tearOutEmbodiment = null;
         me.crossWindowStagePromise   = null;

--- a/src/dashboard/dock/window/VesselPark.mjs
+++ b/src/dashboard/dock/window/VesselPark.mjs
@@ -1,5 +1,8 @@
+import Base from '../../../core/Base.mjs';
+
 /**
- * @module Neo.dashboard.dock.window.VesselPark
+ * @class Neo.dashboard.dock.window.VesselPark
+ * @extends Neo.core.Base
  * @summary The in-gesture vessel lifecycle authority — the pure choreography deciding what happens
  * to a dragged popup's REAL OS window between conversion and the gesture terminal: park it, never
  * close it; re-show the SAME window; dispose exactly once, on commit only.
@@ -34,45 +37,62 @@
  *   terminal with no slot, and terminals for a different `itemId` all return silently — the
  *   exact-once/idempotent cleanup bar every gesture surface owes its terminals.
  */
-
-/**
- * Creates the in-gesture park handlers a dock composition binds to the conversion sensor's
- * actuation seams, closed over one single-gesture park slot. One handler set serves one workspace
- * composition — a pointer drives at most one drag per window (the tear-out choreography's
- * single-slot reasoning), so the slot never needs a map.
- * @param {Object} seams
- * @param {Function} seams.disposeVessel Host retirement seam:
- *     `({itemId, windowName}) => Boolean|Promise<Boolean>` — the ONE close path for a committed
- *     tear-in, routed to the host's reintegration close policy. Only strict `true` clears cleanup
- *     authority; refusal retains the slot for an exact retry.
- * @param {Function} seams.parkVessel Host park seam: `({itemId, windowName}) => Boolean|Promise<Boolean>` —
- *     the platform mechanic (hide, offscreen move, minimize — matrix-selected, the host's
- *     business). Only strict `true` publishes parked ownership; dispatch is never admission.
- * @param {Function} seams.reshowVessel Host re-show seam:
- *     `({itemId, rect, terminal, windowName}) => Boolean|Promise<Boolean>` — re-presents the SAME
- *     parked window at `rect`. `terminal` distinguishes a final restore from live pointer-follow
- *     resumption. A refusal retains the slot for retry; zero re-acquisition by construction.
- * @returns {Object} `{onConversionIn, onConversionOut, onGestureTerminal, onVesselRetired,
- *     parkedVessel, transition}` — sensor handlers, terminal/external-retirement routers,
- *     admitted slot, and in-flight phase
- */
-export function createVesselParkHandlers({disposeVessel, parkVessel, reshowVessel} = {}) {
-    if (typeof disposeVessel !== 'function' || typeof parkVessel !== 'function' || typeof reshowVessel !== 'function') {
-        throw new Error(
-            'createVesselParkHandlers: disposeVessel, parkVessel and reshowVessel are required function seams — ' +
-            'the machine owns ordering, the host owns every platform effect'
-        )
+class VesselPark extends Base {
+    static config = {
+        /** @member {String} className='Neo.dashboard.dock.window.VesselPark' @protected */
+        className: 'Neo.dashboard.dock.window.VesselPark',
+        /**
+         * Receives `{itemId, windowName}`. Only strict success releases committed cleanup authority.
+         * @member {Function|null} disposeVessel=null
+         */
+        disposeVessel: null,
+        /**
+         * Receives `{itemId, windowName}`. Only strict success admits parking the existing window.
+         * @member {Function|null} parkVessel=null
+         */
+        parkVessel: null,
+        /**
+         * Receives `{itemId, rect, terminal, windowName}`. Only strict success releases the park slot.
+         * @member {Function|null} reshowVessel=null
+         */
+        reshowVessel: null
     }
 
-    // Admitted ownership and generation-scoped effects stay separate: a Promise dispatch can
-    // never publish parked/restored truth, and duplicate terminals share one settlement.
-    let generation        = 0,
-        parked            = null,
-        parking           = null,
-        pendingOut        = null,
-        pendingRetirement = null,
-        pendingTerminal   = null,
-        reshowing         = null;
+    /**
+     * @summary Validates required host effects before allocating the registered owner.
+     * @param {Object} [config={}]
+     */
+    construct(config={}) {
+        const effective = {...this.constructor.config, ...config};
+        if (['disposeVessel', 'parkVessel', 'reshowVessel'].some(key => typeof effective[key] !== 'function')) {
+            throw new Error('VesselPark: disposeVessel, parkVessel and reshowVessel are required function seams')
+        }
+        super.construct(config)
+    }
+
+    /**
+     * @summary Invalidates pending gesture work without actuating Group-owned native windows.
+     * @param {...*} args
+     */
+    destroy(...args) {
+        this.clearState();
+        super.destroy(...args)
+    }
+
+    /** @member {Number} generation=0 @protected */
+    generation = 0
+    /** @member {Object|null} parked=null @protected */
+    parked = null
+    /** @member {Object|null} parking=null @protected */
+    parking = null
+    /** @member {Object|null} pendingOut=null @protected */
+    pendingOut = null
+    /** @member {Object|null} pendingRetirement=null @protected */
+    pendingRetirement = null
+    /** @member {Object|null} pendingTerminal=null @protected */
+    pendingTerminal = null
+    /** @member {Object|null} reshowing=null @protected */
+    reshowing = null
 
     /**
      * @summary Normalizes a synchronous host throw into strict refusal.
@@ -80,22 +100,24 @@ export function createVesselParkHandlers({disposeVessel, parkVessel, reshowVesse
      * @param {Object} data
      * @returns {*}
      */
-    const callEffect = (fn, data) => {
+    callEffect(fn, data) {
         try {
             return fn(data)
         } catch {
             return false
         }
-    };
+    }
 
     /**
      * @summary Converts sync or async host results into strict Boolean admission.
      * @param {*} value
      * @returns {Boolean|Promise<Boolean>}
      */
-    const settleEffect = value => typeof value?.then === 'function'
-        ? Promise.resolve(value).then(result => result === true, () => false)
-        : value === true;
+    settleEffect(value) {
+        return typeof value?.then === 'function'
+            ? Promise.resolve(value).then(result => result === true, () => false)
+            : value === true
+    }
 
     /**
      * @summary Re-shows one admitted vessel without clearing ownership before strict success.
@@ -104,35 +126,37 @@ export function createVesselParkHandlers({disposeVessel, parkVessel, reshowVesse
      * @param {Boolean} [terminal=false]
      * @returns {Boolean|Promise<Boolean>}
      */
-    const restore = (vessel, rect, terminal=false) => {
-        if (reshowing) return reshowing.promise;
+    restore(vessel, rect, terminal=false) {
+        if (this.reshowing) return this.reshowing.promise;
 
-        const result = settleEffect(callEffect(reshowVessel, {
+        const result = this.settleEffect(this.callEffect(this.reshowVessel, {
             itemId    : vessel.itemId,
             rect      : rect ?? vessel.preConversionRect,
             terminal,
             windowName: vessel.windowName
         }));
 
+        if (this.isDestroyed) return false;
+
         if (typeof result?.then !== 'function') {
-            result && parked === vessel && (parked = null);
+            result && this.parked === vessel && (this.parked = null);
             return result
         }
 
         const state = {generation: vessel.generation, phase: 'reshowing', promise: null, vessel};
 
-        reshowing = state;
+        this.reshowing = state;
         state.promise = result.then(admitted => {
-            if (reshowing !== state || state.generation !== vessel.generation) return false;
+            if (this.reshowing !== state || state.generation !== vessel.generation) return false;
 
-            admitted && parked === vessel && (parked = null);
-            reshowing = null;
+            admitted && this.parked === vessel && (this.parked = null);
+            this.reshowing = null;
 
             return admitted
         });
 
         return state.promise
-    };
+    }
 
     /**
      * @summary Applies one admitted vessel's exact-once committed or restorative disposition.
@@ -141,251 +165,266 @@ export function createVesselParkHandlers({disposeVessel, parkVessel, reshowVesse
      * @param {Boolean} [compensate=false] Restore even when async invalidation withheld admission
      * @returns {Boolean|Promise<Boolean>}
      */
-    const finishTerminal = (vessel, data, compensate=false) => {
+    finishTerminal(vessel, data, compensate=false) {
         if (data.outcome === 'committed') {
-            const disposed = settleEffect(callEffect(disposeVessel, {
+            const disposed = this.settleEffect(this.callEffect(this.disposeVessel, {
                 itemId: vessel.itemId, windowName: vessel.windowName
             }));
 
+            if (this.isDestroyed) return false;
+
             if (typeof disposed?.then !== 'function') {
-                disposed && parked === vessel && (parked = null);
+                disposed && this.parked === vessel && (this.parked = null);
                 return disposed
             }
 
             return disposed.then(admitted => {
-                admitted && parked === vessel && (parked = null);
+                admitted && this.parked === vessel && (this.parked = null);
                 return admitted
             })
         }
 
-        return parked === vessel || compensate
-            ? restore(vessel, vessel.preConversionRect, true)
+        return this.parked === vessel || compensate
+            ? this.restore(vessel, vessel.preConversionRect, true)
             : true
-    };
+    }
 
-    return {
-        /**
-         * The sensor converted the dragged vessel into a proxy: PARK the OS window — never close
-         * it (the one-way activation door this module exists to remove). Records the vessel's
-         * pre-conversion rect as the restore anchor. A convert-in while a slot is live is a stale
-         * re-fire: ignored.
-         * @param {Object} data
-         * @param {String} data.itemId
-         * @param {Object} [data.sourceRect] The vessel's live rect at the conversion moment —
-         *     recorded as the restore/origin anchor
-         * @param {String} data.windowName
-         */
-        onConversionIn(data) {
-            if (parked || parking || reshowing || pendingRetirement || pendingTerminal) return false;
+    /**
+     * @summary Parks the existing window when the conversion sensor admits a proxy transition.
+     * The sensor converted the dragged vessel into a proxy: PARK the OS window — never close
+     * it (the one-way activation door this module exists to remove). Records the vessel's
+     * pre-conversion rect as the restore anchor. A convert-in while a slot is live is a stale
+     * re-fire: ignored.
+     * @param {Object} data
+     * @param {String} data.itemId
+     * @param {Object} [data.sourceRect] The vessel's live rect at the conversion moment —
+     *     recorded as the restore/origin anchor
+     * @param {String} data.windowName
+     * @returns {Boolean|Promise<Boolean>}
+     */
+    onConversionIn(data) {
+        if (this.isDestroyed) return false;
+        if (this.parked || this.parking || this.reshowing || this.pendingRetirement || this.pendingTerminal) return false;
 
-            let {itemId, sourceRect, windowName} = data,
-                vessel                           = {itemId, preConversionRect: sourceRect ?? null, windowName},
-                result                           = settleEffect(callEffect(parkVessel, {itemId, windowName}));
+        let {itemId, sourceRect, windowName} = data,
+            vessel                           = {itemId, preConversionRect: sourceRect ?? null, windowName},
+            result                           = this.settleEffect(this.callEffect(this.parkVessel, {itemId, windowName}));
 
-            Object.defineProperty(vessel, 'generation', {value: ++generation});
+        if (this.isDestroyed) return false;
 
-            if (typeof result?.then !== 'function') {
-                result && (parked = vessel);
-                return result
-            }
+        Object.defineProperty(vessel, 'generation', {value: ++this.generation});
 
-            const state = {generation: vessel.generation, phase: 'parking', promise: null, vessel};
+        if (typeof result?.then !== 'function') {
+            result && (this.parked = vessel);
+            return result
+        }
 
-            parking = state;
-            state.promise = result.then(admitted => {
-                if (parking !== state || state.generation !== vessel.generation) return false;
+        const state = {generation: vessel.generation, phase: 'parking', promise: null, vessel};
 
-                parking = null;
-                admitted && (parked = vessel);
+        this.parking = state;
+        state.promise = result.then(admitted => {
+            if (this.parking !== state || state.generation !== vessel.generation) return false;
 
-                return admitted
+            this.parking = null;
+            admitted && (this.parked = vessel);
+
+            return admitted
+        });
+
+        return state.promise
+    }
+
+    /**
+     * @summary Re-shows the same parked window after conversion reverses.
+     * The sensor reverted the conversion: RE-SHOW the same parked window. At the supplied live
+     * rect when the out-event carries one (the popup resumes under the pointer); at the
+     * recorded pre-conversion rect otherwise (origin semantics). No slot = stale event = no-op.
+     * @param {Object} [data]
+     * @param {Object} [data.rect] The live rect to resume at (the sensor's out-record
+     *     `sourceRect` is the natural feed)
+     * @returns {Boolean|Promise<Boolean>}
+     */
+    onConversionOut(data) {
+        if (this.isDestroyed) return false;
+        if (this.pendingRetirement) return this.pendingRetirement.promise;
+        if (this.pendingTerminal) return false;
+        if (this.pendingOut) return this.pendingOut.promise;
+        if (this.reshowing) return this.reshowing.promise;
+
+        if (this.parking) {
+            const state = {generation: this.parking.generation, phase: 'queued-out', promise: null, vessel: this.parking.vessel};
+
+            this.pendingOut = state;
+            state.promise = this.parking.promise.then(admitted => {
+                if (this.isDestroyed) return false;
+                return admitted && !this.pendingRetirement ? this.restore(state.vessel, data?.rect) : !admitted
+            }).then(restored => {
+                this.pendingOut === state && (this.pendingOut = null);
+                return restored
             });
 
             return state.promise
-        },
+        }
 
-        /**
-         * The sensor reverted the conversion: RE-SHOW the same parked window. At the supplied live
-         * rect when the out-event carries one (the popup resumes under the pointer); at the
-         * recorded pre-conversion rect otherwise (origin semantics). No slot = stale event = no-op.
-         * @param {Object} [data]
-         * @param {Object} [data.rect] The live rect to resume at (the sensor's out-record
-         *     `sourceRect` is the natural feed)
-         */
-        onConversionOut(data) {
-            if (pendingRetirement) return pendingRetirement.promise;
-            if (pendingTerminal) return false;
-            if (pendingOut) return pendingOut.promise;
-            if (reshowing) return reshowing.promise;
+        return this.parked ? this.restore(this.parked, data?.rect) : false
+    }
 
-            if (parking) {
-                const state = {generation: parking.generation, phase: 'queued-out', promise: null, vessel: parking.vessel};
+    /**
+     * @summary Disposes on committed transfer and restores on every other terminal outcome.
+     * The gesture resolved while the vessel is parked — the outcome machine's terminal routed
+     * here decides the parked window's fate:
+     * - `committed`: the target owns the item now — the ONE `disposeVessel` call fires (the
+     *   host's close policy takes it from there). Duplicate terminals coalesce while close is
+     *   pending; strict refusal retains the slot, and strict success clears it.
+     * - anything else (cancel, reject, host-routed disconnect): RESTORE — re-show at the
+     *   pre-conversion rect with zero disposition. The machine fails toward never losing the
+     *   user's window.
+     * A terminal for a different `itemId` than the parked one is stale: no-op.
+     * @param {Object} data
+     * @param {String} data.itemId
+     * @param {String} data.outcome `'committed'` disposes; every other value restores
+     * @returns {Boolean|Promise<Boolean>}
+     */
+    onGestureTerminal(data) {
+        if (this.isDestroyed) return false;
+        if (this.pendingRetirement) {
+            return this.pendingRetirement.vessel.itemId === data.itemId
+                ? this.pendingRetirement.promise
+                : false
+        }
+        if (this.pendingTerminal) {
+            return this.pendingTerminal.vessel.itemId === data.itemId
+                ? this.pendingTerminal.promise
+                : false
+        }
 
-                pendingOut = state;
-                state.promise = parking.promise.then(admitted => admitted && !pendingRetirement
-                    ? restore(state.vessel, data?.rect)
-                    : !admitted
-                ).then(restored => {
-                    pendingOut === state && (pendingOut = null);
-                    return restored
-                });
+        let vessel = this.parked ?? this.parking?.vessel ?? this.reshowing?.vessel;
 
-                return state.promise
-            }
+        if (!vessel || vessel.itemId !== data.itemId) return false;
 
-            return parked ? restore(parked, data?.rect) : false
-        },
+        if (this.parking || this.reshowing) {
+            const prerequisite = this.parking?.promise ?? this.reshowing.promise,
+                  state        = {generation: vessel.generation, phase: 'terminal', promise: null, vessel};
 
-        /**
-         * The gesture resolved while the vessel is parked — the outcome machine's terminal routed
-         * here decides the parked window's fate:
-         * - `committed`: the target owns the item now — the ONE `disposeVessel` call fires (the
-         *   host's close policy takes it from there). Duplicate terminals coalesce while close is
-         *   pending; strict refusal retains the slot, and strict success clears it.
-         * - anything else (cancel, reject, host-routed disconnect): RESTORE — re-show at the
-         *   pre-conversion rect with zero disposition. The machine fails toward never losing the
-         *   user's window.
-         * A terminal for a different `itemId` than the parked one is stale: no-op.
-         * @param {Object} data
-         * @param {String} data.itemId
-         * @param {String} data.outcome `'committed'` disposes; every other value restores
-         */
-        onGestureTerminal(data) {
-            if (pendingRetirement) {
-                return pendingRetirement.vessel.itemId === data.itemId
-                    ? pendingRetirement.promise
-                    : false
-            }
-            if (pendingTerminal) {
-                return pendingTerminal.vessel.itemId === data.itemId
-                    ? pendingTerminal.promise
-                    : false
-            }
+            this.pendingTerminal = state;
+            state.promise = prerequisite.then(() => {
+                if (
+                    this.pendingTerminal !== state || this.pendingRetirement ||
+                    state.generation !== vessel.generation
+                ) return false;
 
-            let vessel = parked ?? parking?.vessel ?? reshowing?.vessel;
-
-            if (!vessel || vessel.itemId !== data.itemId) return false;
-
-            if (parking || reshowing) {
-                const prerequisite = parking?.promise ?? reshowing.promise,
-                      state        = {generation: vessel.generation, phase: 'terminal', promise: null, vessel};
-
-                pendingTerminal = state;
-                state.promise = prerequisite.then(() => {
-                    if (
-                        pendingTerminal !== state || pendingRetirement ||
-                        state.generation !== vessel.generation
-                    ) return false;
-
-                    // False-after-reset does not prove the native park move never happened: Main
-                    // can observe the move, then invalidate pointer-follow before the worker sees
-                    // its terminal. Always run the compensating disposition for this generation.
-                    return finishTerminal(vessel, data, true)
-                }).then(result => {
-                    pendingTerminal === state && (pendingTerminal = null);
-                    return result
-                });
-
-                return state.promise
-            }
-
-            const state = {generation: vessel.generation, phase: 'terminal', promise: null, vessel};
-
-            pendingTerminal = state;
-
-            const result = finishTerminal(vessel, data);
-
-            if (typeof result?.then !== 'function') {
-                pendingTerminal = null;
+                // False-after-reset does not prove the native park move never happened: Main
+                // can observe the move, then invalidate pointer-follow before the worker sees
+                // its terminal. Always run the compensating disposition for this generation.
+                return this.finishTerminal(vessel, data, true)
+            }).then(result => {
+                this.pendingTerminal === state && (this.pendingTerminal = null);
                 return result
-            }
+            });
 
-            state.promise = Promise.resolve(result).then(admitted => {
-                if (pendingTerminal !== state || state.generation !== vessel.generation) return false;
+            return state.promise
+        }
 
-                pendingTerminal = null;
-                return admitted
+        const state = {generation: vessel.generation, phase: 'terminal', promise: null, vessel};
+
+        this.pendingTerminal = state;
+
+        const result = this.finishTerminal(vessel, data);
+
+        if (this.isDestroyed) return false;
+
+        if (typeof result?.then !== 'function') {
+            this.pendingTerminal = null;
+            return result
+        }
+
+        state.promise = Promise.resolve(result).then(admitted => {
+            if (this.pendingTerminal !== state || state.generation !== vessel.generation) return false;
+
+            this.pendingTerminal = null;
+            return admitted
+        }, () => {
+            this.pendingTerminal === state && (this.pendingTerminal = null);
+            return false
+        });
+
+        return state.promise
+    }
+
+    /**
+     * @summary Forgets a vessel another owning lifecycle has already retired.
+     *
+     * A detached cancel is owned by the tear-out machine: it consumes and closes the same
+     * empty source vessel. This clear-only seam invalidates every pending effect generation
+     * so no late park/re-show completion can resurrect ownership after that external close.
+     * @param {Object} data
+     * @param {String} data.itemId
+     * @param {Boolean|Promise<Boolean>} [data.retirement=true] Strict outer-lifecycle close
+     * @returns {Boolean|Promise<Boolean>}
+     */
+    onVesselRetired({itemId, retirement=true} = {}) {
+        if (this.isDestroyed) return false;
+        if (this.pendingRetirement) {
+            return this.pendingRetirement.vessel.itemId === itemId
+                ? this.pendingRetirement.promise
+                : false
+        }
+
+        const vessel = this.pendingTerminal?.vessel ?? this.pendingOut?.vessel ?? this.reshowing?.vessel
+            ?? this.parking?.vessel ?? this.parked;
+
+        if (!vessel || vessel.itemId !== itemId) return false;
+
+        if (typeof retirement?.then === 'function') {
+            const state = {
+                generation: vessel.generation,
+                phase     : 'retiring',
+                promise   : null,
+                vessel
+            };
+
+            this.pendingRetirement = state;
+            state.promise = Promise.resolve(retirement).then(retired => {
+                if (this.pendingRetirement !== state || state.generation !== vessel.generation) return false;
+
+                this.pendingRetirement = null;
+
+                return retired === true ? this.clearState() : false
             }, () => {
-                pendingTerminal === state && (pendingTerminal = null);
+                this.pendingRetirement === state && (this.pendingRetirement = null);
                 return false
             });
 
             return state.promise
-        },
-
-        /**
-         * @summary Forgets a vessel another owning lifecycle has already retired.
-         *
-         * A detached cancel is owned by the tear-out machine: it consumes and closes the same
-         * empty source vessel. This clear-only seam invalidates every pending effect generation
-         * so no late park/re-show completion can resurrect ownership after that external close.
-         * @param {Object} data
-         * @param {String} data.itemId
-         * @param {Boolean|Promise<Boolean>} [data.retirement=true] Strict outer-lifecycle close
-         * @returns {Boolean|Promise<Boolean>}
-         */
-        onVesselRetired({itemId, retirement=true} = {}) {
-            if (pendingRetirement) {
-                return pendingRetirement.vessel.itemId === itemId
-                    ? pendingRetirement.promise
-                    : false
-            }
-
-            const vessel = pendingTerminal?.vessel ?? pendingOut?.vessel ?? reshowing?.vessel
-                ?? parking?.vessel ?? parked;
-
-            if (!vessel || vessel.itemId !== itemId) return false;
-
-            const clear = () => {
-                generation++;
-                parked          = null;
-                parking         = null;
-                pendingOut      = null;
-                pendingRetirement = null;
-                pendingTerminal = null;
-                reshowing       = null;
-
-                return true
-            };
-
-            if (typeof retirement?.then === 'function') {
-                const state = {
-                    generation: vessel.generation,
-                    phase     : 'retiring',
-                    promise   : null,
-                    vessel
-                };
-
-                pendingRetirement = state;
-                state.promise = Promise.resolve(retirement).then(retired => {
-                    if (pendingRetirement !== state || state.generation !== vessel.generation) return false;
-
-                    pendingRetirement = null;
-
-                    return retired === true ? clear() : false
-                }, () => {
-                    pendingRetirement === state && (pendingRetirement = null);
-                    return false
-                });
-
-                return state.promise
-            }
-
-            return retirement === true ? clear() : false
-        },
-
-        /**
-         * @member {Object|null} parkedVessel
-         */
-        get parkedVessel() {
-            return parked
-        },
-
-        /**
-         * @member {Object|null} transition
-         */
-        get transition() {
-            return pendingRetirement ?? pendingTerminal ?? pendingOut ?? reshowing ?? parking
         }
+
+        return retirement === true ? this.clearState() : false
+    }
+
+    /**
+     * @summary Invalidates all pending gesture generations without calling a platform effect.
+     * @returns {Boolean}
+     * @protected
+     */
+    clearState() {
+        this.generation++;
+        this.parked = this.parking = this.pendingOut = this.pendingRetirement = this.pendingTerminal = this.reshowing = null;
+        return true
+    }
+
+    /**
+     * @member {Object|null} parkedVessel
+     */
+    get parkedVessel() {
+        return this.parked ?? null
+    }
+
+    /**
+     * @member {Object|null} transition
+     */
+    get transition() {
+        return this.pendingRetirement ?? this.pendingTerminal ?? this.pendingOut ?? this.reshowing ?? this.parking ?? null
     }
 }
+
+export default Neo.setupClass(VesselPark);

--- a/test/playwright/unit/apps/workstation/Workspace.spec.mjs
+++ b/test/playwright/unit/apps/workstation/Workspace.spec.mjs
@@ -196,6 +196,22 @@ test.describe.serial('Workstation.view.Workspace', () => {
         }
     });
 
+    test('the Workspace owns and destroys distinct pointer and native park owners', () => {
+        const workspace = Neo.create(Workspace, {windowId: Neo.config.windowId});
+        const pointer   = workspace.vesselParkHandlers, native = workspace.nativeVesselParkHandlers;
+
+        try {
+            expect(pointer.className).toBe('Neo.dashboard.dock.window.VesselPark');
+            expect(native.className).toBe('Neo.dashboard.dock.window.VesselPark');
+            expect(pointer).not.toBe(native)
+        } finally {
+            workspace.destroy()
+        }
+
+        expect(pointer.isDestroyed).toBe(true);
+        expect(native.isDestroyed).toBe(true)
+    });
+
     test('renderer-rich scale columns carry unique pooling keys', () => {
         const
             dataFields     = ScalePane.config.columns.map(column => column.dataField),

--- a/test/playwright/unit/dashboard/DockVesselPark.spec.mjs
+++ b/test/playwright/unit/dashboard/DockVesselPark.spec.mjs
@@ -4,15 +4,28 @@ setup({
     appConfig: {
         name: 'DashboardDockVesselParkTest'
     },
-    // The machine is a zero-import pure module: no Main facade, no LocalStorage addon. Declaring
-    // both mocks off keeps this file runnable SOLO (the mock paths call `Neo.ns`, which only
-    // exists once a sibling spec loads the real core into the shared worker).
     mockLocalStorage: false,
     mockMain        : false
 });
 
-import {test, expect}             from '@playwright/test';
-import {createVesselParkHandlers} from '../../../../src/dashboard/dock/window/VesselPark.mjs';
+import {test, expect}  from '@playwright/test';
+import Neo             from "../../../../src/Neo.mjs";
+import * as core       from "../../../../src/core/_export.mjs";
+import VesselPark      from '../../../../src/dashboard/dock/window/VesselPark.mjs';
+import {execFileSync}  from 'node:child_process';
+import {fileURLToPath} from 'node:url';
+
+const owners      = new Set();
+const createOwner = (config={}) => {
+    const owner = Neo.create(VesselPark, {...config});
+    owners.add(owner);
+    return owner
+};
+
+test.afterEach(() => {
+    owners.forEach(owner => owner.destroy());
+    owners.clear()
+});
 
 /**
  * @summary The in-gesture vessel park machine, driven end-to-end through its injected seams.
@@ -24,11 +37,133 @@ import {createVesselParkHandlers} from '../../../../src/dashboard/dock/window/Ve
  * every other outcome failing toward restore, and stale events (duplicate convert-in, slotless
  * out/terminal, mismatched itemId) are silent no-ops. The seams are the assertion surface.
  */
-test.describe('Neo.dashboard.dock.window.VesselPark — createVesselParkHandlers', () => {
+test.describe('Neo.dashboard.dock.window.VesselPark — createOwner', () => {
+    test('a pre-import Neo overwrite controls the internal restore path', () => {
+        const result = JSON.parse(execFileSync(process.execPath, ['--input-type=module', '-e', `
+            await import('./src/Neo.mjs');
+            await import('./src/core/_export.mjs');
+            const {setup} = await import('./test/playwright/setup.mjs');
+            setup({appConfig: {name: 'VesselParkOverwriteTest'}});
+            Neo.overwrites = {};
+            Neo.ns('Neo.dashboard.dock.window.VesselPark', true, Neo.overwrites).restore = () => false;
+            const {default: VesselPark} = await import('./src/dashboard/dock/window/VesselPark.mjs');
+            let calls = 0;
+            const owner = Neo.create(VesselPark, {
+                parkVessel: () => true, disposeVessel: () => true,
+                reshowVessel: () => { calls++; return true; }
+            });
+            owner.onConversionIn({itemId: 'pane', windowName: 'window'});
+            const restored = owner.onConversionOut();
+            const retained = owner.parkedVessel?.windowName;
+            owner.destroy();
+            process.stdout.write(JSON.stringify({
+                registered: VesselPark === Neo.dashboard.dock.window.VesselPark,
+                restored, retained, calls
+            }));
+        `], {cwd: fileURLToPath(new URL('../../../../', import.meta.url)), encoding: 'utf8'}));
+
+        expect(result).toEqual({registered: true, restored: false, retained: 'window', calls: 0})
+    });
+
+    test('a subclass can specialize live restore while retaining cancel recovery', () => {
+        class CancelOnlyPark extends VesselPark {
+            static config = {className: 'Test.Unit.Dashboard.VesselPark.CancelOnlyPark'}
+
+            /** @summary Refuses live re-show while keeping inherited terminal recovery. */
+            restore(vessel, rect, terminal=false) {
+                return terminal ? super.restore(vessel, rect, terminal) : false
+            }
+        }
+        Neo.setupClass(CancelOnlyPark);
+        const reshown = [];
+        const owner   = Neo.create(CancelOnlyPark, {
+            parkVessel  : () => true, disposeVessel: () => true,
+            reshowVessel: data => { reshown.push(data); return true }
+        });
+        owners.add(owner);
+
+        owner.onConversionIn({itemId: 'pane', windowName: 'window'});
+        expect(owner.onConversionOut()).toBe(false);
+        expect(owner.parkedVessel.windowName).toBe('window');
+        expect(owner.onGestureTerminal({itemId: 'pane', outcome: 'cancel'})).toBe(true);
+        expect(reshown).toEqual([{itemId: 'pane', windowName: 'window', rect: null, terminal: true}]);
+        expect(owner.parkedVessel).toBeNull()
+    });
+
+    test('owners keep independent gesture state and destruction actuates no window', () => {
+        let   effects = 0;
+        const config  = {parkVessel: () => true, reshowVessel: () => { effects++; return true }, disposeVessel: () => { effects++; return true }};
+        const a       = createOwner(config), b = createOwner(config);
+
+        a.onConversionIn({itemId: 'a', windowName: 'a-window'});
+        expect(b.parkedVessel).toBeNull();
+        b.onConversionIn({itemId: 'b', windowName: 'b-window'});
+        a.destroy();
+        expect(a.parkedVessel).toBeNull();
+        expect(b.parkedVessel.windowName).toBe('b-window');
+        expect(effects).toBe(0)
+    });
+
+    for (const terminal of ['out', 'cancel', 'committed']) {
+        test(`destroy during park fences a queued ${terminal} and late admission`, async () => {
+            let resolvePark, effects = 0;
+            const owner = createOwner({
+                parkVessel   : () => new Promise(resolve => resolvePark = resolve),
+                reshowVessel : () => { effects++; return true },
+                disposeVessel: () => { effects++; return true }
+            });
+            const admission = owner.onConversionIn({itemId: 'pane', windowName: 'window'});
+            const queued    = terminal === 'out' ? owner.onConversionOut() : owner.onGestureTerminal({itemId: 'pane', outcome: terminal});
+
+            owner.destroy();
+            resolvePark(true);
+            expect(await admission).toBe(false);
+            expect(await queued).toBe(false);
+            expect(owner.parkedVessel).toBeNull();
+            expect(owner.transition).toBeNull();
+            expect(effects).toBe(0)
+        })
+    }
+
+    for (const phase of ['park', 'restore', 'dispose']) {
+        test(`a synchronous ${phase} effect cannot resurrect the owner it destroys`, () => {
+            let owner;
+            const effect = current => {
+                if (phase === current) owner.destroy();
+                return true
+            };
+            owner = createOwner({parkVessel: () => effect('park'), reshowVessel: () => effect('restore'), disposeVessel: () => effect('dispose')});
+            const admitted = owner.onConversionIn({itemId: 'pane', windowName: 'window'});
+            const result   = phase === 'park' ? admitted : phase === 'restore'
+                ? owner.onConversionOut() : owner.onGestureTerminal({itemId: 'pane', outcome: 'committed'});
+
+            expect(result).toBe(false);
+            expect(owner.isDestroyed).toBe(true);
+            expect(owner.parkedVessel).toBeNull();
+            expect(owner.transition).toBeNull()
+        })
+    }
+
+    for (const phase of ['restore', 'dispose']) {
+        test(`destroy fences an in-flight ${phase} completion`, async () => {
+            let resolveEffect;
+            const pending = () => new Promise(resolve => resolveEffect = resolve);
+            const owner   = createOwner({parkVessel: () => true, reshowVessel: phase === 'restore' ? pending : () => true, disposeVessel: phase === 'dispose' ? pending : () => true});
+            owner.onConversionIn({itemId: 'pane', windowName: 'window'});
+            const result = phase === 'restore' ? owner.onConversionOut() : owner.onGestureTerminal({itemId: 'pane', outcome: 'committed'});
+
+            owner.destroy();
+            resolveEffect(true);
+            expect(await result).toBe(false);
+            expect(owner.parkedVessel).toBeNull();
+            expect(owner.transition).toBeNull()
+        })
+    }
+
     const harness = () => {
         const calls = {disposed: [], parked: [], reshown: []};
 
-        const handlers = createVesselParkHandlers({
+        const handlers = createOwner({
             disposeVessel: vessel => {
                 calls.disposed.push(vessel);
                 return true
@@ -135,7 +270,7 @@ test.describe('Neo.dashboard.dock.window.VesselPark — createVesselParkHandlers
 
         const pending  = new Promise(resolve => resolveClose = resolve),
               calls    = [],
-              handlers = createVesselParkHandlers({
+              handlers = createOwner({
                   disposeVessel: vessel => {
                       calls.push(vessel);
                       return ++attempt === 1 ? pending : true
@@ -216,7 +351,7 @@ test.describe('Neo.dashboard.dock.window.VesselPark — createVesselParkHandlers
 
         const pending  = new Promise(resolve => resolvePark = resolve),
               calls    = [],
-              handlers = createVesselParkHandlers({
+              handlers = createOwner({
                   disposeVessel: () => true,
                   parkVessel   : vessel => {
                       calls.push(vessel);
@@ -241,7 +376,7 @@ test.describe('Neo.dashboard.dock.window.VesselPark — createVesselParkHandlers
         let allowRestore = false;
 
         const calls    = [],
-              handlers = createVesselParkHandlers({
+              handlers = createOwner({
                   disposeVessel: () => true,
                   parkVessel   : () => true,
                   reshowVessel : async vessel => {
@@ -264,7 +399,7 @@ test.describe('Neo.dashboard.dock.window.VesselPark — createVesselParkHandlers
     });
 
     test('synchronous platform throws normalize to refusal and preserve recoverable ownership', () => {
-        const parkThrows = createVesselParkHandlers({
+        const parkThrows = createOwner({
             disposeVessel: () => true,
             parkVessel   : () => { throw new Error('park failed') },
             reshowVessel : () => true
@@ -273,7 +408,7 @@ test.describe('Neo.dashboard.dock.window.VesselPark — createVesselParkHandlers
         expect(() => parkThrows.onConversionIn(inData())).not.toThrow();
         expect(parkThrows.parkedVessel).toBeNull();
 
-        const restoreThrows = createVesselParkHandlers({
+        const restoreThrows = createOwner({
             disposeVessel: () => true,
             parkVessel   : () => true,
             reshowVessel : () => { throw new Error('move failed') }
@@ -289,7 +424,7 @@ test.describe('Neo.dashboard.dock.window.VesselPark — createVesselParkHandlers
 
         const pending  = new Promise(resolve => resolvePark = resolve),
               disposed = [],
-              handlers = createVesselParkHandlers({
+              handlers = createOwner({
                   disposeVessel: vessel => {
                       disposed.push(vessel);
                       return true
@@ -319,7 +454,7 @@ test.describe('Neo.dashboard.dock.window.VesselPark — createVesselParkHandlers
 
             const pending  = new Promise(resolve => resolvePark = resolve),
                   calls    = {disposed: [], reshown: []},
-                  handlers = createVesselParkHandlers({
+                  handlers = createOwner({
                       disposeVessel: vessel => {
                           calls.disposed.push(vessel);
                           return true
@@ -359,7 +494,7 @@ test.describe('Neo.dashboard.dock.window.VesselPark — createVesselParkHandlers
         let resolvePark;
 
         const pending  = new Promise(resolve => resolvePark = resolve),
-              handlers = createVesselParkHandlers({
+              handlers = createOwner({
                   disposeVessel: () => true,
                   parkVessel   : () => pending,
                   reshowVessel : () => true
@@ -382,7 +517,7 @@ test.describe('Neo.dashboard.dock.window.VesselPark — createVesselParkHandlers
 
         const pending  = new Promise(resolve => resolvePark = resolve),
               disposed = [],
-              handlers = createVesselParkHandlers({
+              handlers = createOwner({
                   disposeVessel: vessel => {
                       disposed.push(vessel);
                       return true
@@ -406,7 +541,7 @@ test.describe('Neo.dashboard.dock.window.VesselPark — createVesselParkHandlers
         let resolveRetirement;
 
         const retirement = new Promise(resolve => resolveRetirement = resolve),
-              handlers   = createVesselParkHandlers({
+              handlers   = createOwner({
                   disposeVessel: () => true,
                   parkVessel   : () => true,
                   reshowVessel : () => true
@@ -436,9 +571,9 @@ test.describe('Neo.dashboard.dock.window.VesselPark — createVesselParkHandlers
             reshowVessel : () => {}
         };
 
-        expect(() => createVesselParkHandlers()).toThrow(/required function seams/);
-        expect(() => createVesselParkHandlers({...seams, parkVessel: undefined})).toThrow(/required function seams/);
-        expect(() => createVesselParkHandlers({...seams, reshowVessel: 'hide'})).toThrow(/required function seams/);
-        expect(() => createVesselParkHandlers({...seams, disposeVessel: null})).toThrow(/required function seams/)
+        expect(() => createOwner()).toThrow(/required function seams/);
+        expect(() => createOwner({...seams, parkVessel: undefined})).toThrow(/required function seams/);
+        expect(() => createOwner({...seams, reshowVessel: 'hide'})).toThrow(/required function seams/);
+        expect(() => createOwner({...seams, disposeVessel: null})).toThrow(/required function seams/)
     })
 });

--- a/test/playwright/unit/examples/dashboard/crossWindow/DemoBWorkspace.spec.mjs
+++ b/test/playwright/unit/examples/dashboard/crossWindow/DemoBWorkspace.spec.mjs
@@ -296,6 +296,14 @@ test.describe.serial('Neo.examples.dashboard.crossWindow.DemoBWorkspace', () => 
           seedConnection = (itemId, connection) =>
               workspace.nativeWindows.sources.get(workspace.vesselSourceId).connections.set(itemId, connection);
 
+    test('the DemoB host destroys its composed park owner', () => {
+        const owner = workspace.vesselParkHandlers;
+
+        expect(owner.className).toBe('Neo.dashboard.dock.window.VesselPark');
+        workspace.destroy();
+        expect(owner.isDestroyed).toBe(true)
+    });
+
     test.beforeEach(() => {
         // The host window binds into a Group the way its app registration does — before the workspace
         // constructs, as in production, so its participants register into that Group; every slot the
@@ -1538,67 +1546,72 @@ test.describe.serial('Neo.examples.dashboard.crossWindow.DemoBWorkspace', () => 
         };
 
         seedConnection('timeline', {windowId: 'tear-child'});
-        workspace.vesselParkHandlers = {
-            onConversionIn(data) {
-                calls.push(['in', data]);
-                return true
-            },
-            onConversionOut(data) {
-                calls.push(['out', data]);
-                return true
-            },
-            onGestureTerminal(data) {
-                calls.push(['terminal', data]);
-                return Promise.resolve(true)
-            },
-            onVesselRetired(data) {
-                calls.push(['retired', data]);
-                return true
-            }
-        };
+        const previousPark = workspace.vesselParkHandlers;
+        try {
+            workspace.vesselParkHandlers = {
+                onConversionIn(data) {
+                    calls.push(['in', data]);
+                    return true
+                },
+                onConversionOut(data) {
+                    calls.push(['out', data]);
+                    return true
+                },
+                onGestureTerminal(data) {
+                    calls.push(['terminal', data]);
+                    return Promise.resolve(true)
+                },
+                onVesselRetired(data) {
+                    calls.push(['retired', data]);
+                    return true
+                }
+            };
 
-        const mainTabs  = findTabs(workspace.projectDockModel(), 'side-tabs'),
-              popupTabs = findTabs(workspace.projectDockModel(
-                  null,
-                  DemoBWorkspace.POPUP_WORKSPACE_ID,
-                  DemoBWorkspace.createPopupDocument()
-              ), 'popup-tabs');
+            const mainTabs  = findTabs(workspace.projectDockModel(), 'side-tabs'),
+                  popupTabs = findTabs(workspace.projectDockModel(
+                      null,
+                      DemoBWorkspace.POPUP_WORKSPACE_ID,
+                      DemoBWorkspace.createPopupDocument()
+                  ), 'popup-tabs');
 
-        expect(mainTabs.headerToolbar.sortZoneConfig.enableVesselConversion).toBe(true);
-        expect(popupTabs.headerToolbar.sortZoneConfig.enableVesselConversion).toBe(false);
+            expect(mainTabs.headerToolbar.sortZoneConfig.enableVesselConversion).toBe(true);
+            expect(popupTabs.headerToolbar.sortZoneConfig.enableVesselConversion).toBe(false);
 
-        const converted = {
-                  admission: false,
-                  itemId   : 'timeline',
-                  record   : {sourceRect: {height: 320, width: 480, x: 40, y: 60}}
-              },
-              reverted = {
-                  admission  : false,
-                  itemId     : 'timeline',
-                  logicalRect: {height: 320, width: 480, x: 420, y: 240}
-              },
-              terminal = {itemId: 'timeline', outcome: 'committed', settlement: false},
-              retired  = {itemId: 'timeline', retirement: Promise.resolve(true), settlement: false};
+            const converted = {
+                      admission: false,
+                      itemId   : 'timeline',
+                      record   : {sourceRect: {height: 320, width: 480, x: 40, y: 60}}
+                  },
+                  reverted = {
+                      admission  : false,
+                      itemId     : 'timeline',
+                      logicalRect: {height: 320, width: 480, x: 420, y: 240}
+                  },
+                  terminal = {itemId: 'timeline', outcome: 'committed', settlement: false},
+                  retired  = {itemId: 'timeline', retirement: Promise.resolve(true), settlement: false};
 
-        mainTabs.listeners.dockVesselConversionIn(converted);
-        mainTabs.listeners.dockVesselConversionOut(reverted);
-        mainTabs.listeners.dockVesselConversionTerminal(terminal);
-        mainTabs.listeners.dockVesselConversionRetired(retired);
+            mainTabs.listeners.dockVesselConversionIn(converted);
+            mainTabs.listeners.dockVesselConversionOut(reverted);
+            mainTabs.listeners.dockVesselConversionTerminal(terminal);
+            mainTabs.listeners.dockVesselConversionRetired(retired);
 
-        expect(converted.admission).toBe(true);
-        expect(reverted.admission).toBe(true);
-        expect(terminal.settlement).toBeInstanceOf(Promise);
-        expect(retired.settlement).toBe(true);
-        expect(calls).toEqual([
-            ['in', {
-                itemId    : 'timeline',
-                sourceRect: {height: 320, width: 480, x: 40, y: 60},
-                windowName: 'tearout-timeline'
-            }],
-            ['out', {rect: {height: 320, width: 480, x: 420, y: 240}}],
-            ['terminal', terminal],
-            ['retired', retired]
-        ])
+            expect(converted.admission).toBe(true);
+            expect(reverted.admission).toBe(true);
+            expect(terminal.settlement).toBeInstanceOf(Promise);
+            expect(retired.settlement).toBe(true);
+            expect(calls).toEqual([
+                ['in', {
+                    itemId    : 'timeline',
+                    sourceRect: {height: 320, width: 480, x: 40, y: 60},
+                    windowName: 'tearout-timeline'
+                }],
+                ['out', {rect: {height: 320, width: 480, x: 420, y: 240}}],
+                ['terminal', terminal],
+                ['retired', retired]
+            ])
+        } finally {
+            workspace.vesselParkHandlers = previousPark
+        }
     });
 
     test('popup projection alone owns the stack grip and routes one terminal to the optional park machine', () => {
@@ -1620,28 +1633,33 @@ test.describe.serial('Neo.examples.dashboard.crossWindow.DemoBWorkspace', () => 
         popup.nodes['popup-tabs'].items = ['workbench'];
         popup.nodes['popup-tabs'].activeItemId = 'workbench';
         workspace.popupDocument = popup;
-        workspace.vesselParkHandlers = {onGestureTerminal: data => terminals.push(data)};
+        const previousPark = workspace.vesselParkHandlers;
+        try {
+            workspace.vesselParkHandlers = {onGestureTerminal: data => terminals.push(data)};
 
-        const popupTabs = findTabs(workspace.projectDockModel(
-            null,
-            DemoBWorkspace.POPUP_WORKSPACE_ID,
-            popup
-        ), 'popup-tabs');
+            const popupTabs = findTabs(workspace.projectDockModel(
+                null,
+                DemoBWorkspace.POPUP_WORKSPACE_ID,
+                popup
+            ), 'popup-tabs');
 
-        expect(popupTabs.headerToolbar.sortZoneConfig.dockGroupNodeId).toBe('popup-tabs');
-        expect(popupTabs.items[0].header.text[1].cls).toEqual(['neo-dock-stack-handle']);
+            expect(popupTabs.headerToolbar.sortZoneConfig.dockGroupNodeId).toBe('popup-tabs');
+            expect(popupTabs.items[0].header.text[1].cls).toEqual(['neo-dock-stack-handle']);
 
-        // The same live pane then projects home item-only: this second projection must restore
-        // its source header before the popup config can leak an affordance into main.
-        const mainTabs = findTabs(workspace.projectDockModel(), 'workbench-tabs');
+            // The same live pane then projects home item-only: this second projection must restore
+            // its source header before the popup config can leak an affordance into main.
+            const mainTabs = findTabs(workspace.projectDockModel(), 'workbench-tabs');
 
-        expect(mainTabs.headerToolbar.sortZoneConfig.dockGroupNodeId).toBeNull();
-        expect(mainTabs.items[0].header).toBeUndefined();
+            expect(mainTabs.headerToolbar.sortZoneConfig.dockGroupNodeId).toBeNull();
+            expect(mainTabs.items[0].header).toBeUndefined();
 
-        popupTabs.listeners.dockStackDragTerminal({
-            itemId: 'workbench', outcome: 'committed', groupNodeId: 'popup-tabs'
-        });
-        expect(terminals).toEqual([{itemId: 'workbench', outcome: 'committed'}])
+            popupTabs.listeners.dockStackDragTerminal({
+                itemId: 'workbench', outcome: 'committed', groupNodeId: 'popup-tabs'
+            });
+            expect(terminals).toEqual([{itemId: 'workbench', outcome: 'committed'}])
+        } finally {
+            workspace.vesselParkHandlers = previousPark
+        }
     });
 
     test('cross-window execution drains a cue projection before it opens the popup stage', async () => {


### PR DESCRIPTION
Resolves #18399

Related: #18304

Vessel park choreography now has a registered, per-instance `Neo.dashboard.dock.window.VesselPark` owner. Internal effect and restore calls dispatch through methods, so Neo overwrites and subclasses can specialize the existing path. Workstation's two owners and DemoB's one owner are created with `Neo.create` and destroyed with their consumer. The factory export is removed; handler names, strict Boolean admission, native identity/rect payloads and cancel/commit semantics are preserved.

Destroy invalidates pending work without invoking a native effect. The conversion also checks for destruction inside a synchronous host callback before publishing admission or state.

Evidence: L2 (real Neo instances, original sync/async choreography controls, override/subclass dispatch, pending and re-entrant destruction, real consumer teardown) → L2 required (owner/customization/lifetime contract). Residual: none for this ticket. This does not certify the separate native target-staging journey in #18398.

## AC Evidence

| AC | Evidence |
|---|---|
| AC-1 | CI-covered: `DockVesselPark.spec.mjs` installs a real pre-import `Neo.overwrites.restore` refusal and verifies the internal path honors it without re-showing. A subclass refuses live restore but inherits cancel recovery. |
| AC-2 | CI-covered: all 19 existing park/out/terminal/retirement controls remain, including strict sync/async admission and retry/coalescing behavior. |
| AC-3 | CI-covered: independent-owner state; destruction during pending park with queued out/cancel/commit; pending restore/dispose; synchronous effects that destroy their own owner before returning. |
| AC-4 | CI-covered: Workstation and DemoB unit suites verify construction and teardown of all three registered owners. Two DemoB fixtures now restore their temporary test doubles in `finally`. |
| AC-5 | CI-covered: owner and consumer suites plus the full unit suite. JSDoc generation adds the Base owner to the class hierarchy. |

## Deltas from ticket

None substantive. Re-entrant callback destruction was caught while validating the new lifetime contract and repaired before handoff. No native platform park/restore body, Group authority, target-staging implementation or other factory changed.

## Test Evidence

Outside-CI baseline probe before the conversion: a pre-import `Neo.overwrites.VesselPark.restore = () => false` is ignored by the old factory; conversion-out returns `true`, calls re-show once, and the namespace is absent. The permanent fresh-process control now verifies refusal and zero re-show calls.

Three re-entrant destruction controls failed on the initial conversion because park/restore/dispose returned `true` after the callback destroyed the owner. They pass after the liveness fences. Permanent coverage runs in CI; no rendered/native-window receipt is newly claimed here.

size-guard-growth: apps/workstation/view/Workspace.mjs — two teardown calls for the newly registered owned park instances; no choreography is added to the consumer
size-guard-growth: examples/dashboard/crossWindow/DemoBWorkspace.mjs — one teardown call for its newly registered park owner

## Post-Merge Validation

None required for this bounded conversion.

Authored by Emmy (GPT-6 Astra, Codex). Session 10c286a7-65e7-4f15-be8e-8dace71af32d.
