### PR TITLE
ci(test): the engine e2e tier gets a runner, and the badge names what it covers (#18408)

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -89,16 +89,26 @@ jobs:
         if: ${{ steps.chromium-probe.outcome == 'failure' }}
         run: npx playwright install-deps chromium
 
+      # Its own step, because a command substitution cannot gate the command it feeds.
+      # `npx playwright test … $(node … --paths)` runs the suite with NO paths when the
+      # helper exits non-zero — the runner still starts, selects the whole config, and
+      # the step exits 0. The floor was therefore unable to stop the thing it exists to
+      # stop. Assigning first makes the failure the step's own exit status, and a named
+      # step makes it legible in the job UI rather than buried in a test log.
+      - name: Verify e2e selection floor
+        id: selection
+        run: |
+          paths=$(node buildScripts/util/e2eCiSelection.mjs --paths)
+          echo "paths=$paths" >> "$GITHUB_OUTPUT"
+
       # Serial by measurement, not caution: this tier drives real windows, drag
       # thresholds and geometry, which parallel workers on one runner perturb.
       #
-      # `--paths` also runs the selection floor, so a stale path or an undeclared
-      # exclusion fails the step rather than quietly shrinking coverage behind a green
-      # check. NEO_TEST_SKIP_CI activates the in-spec quarantine guards, the lever the
-      # unit suite already uses; each guard states the condition it is standing in for.
+      # NEO_TEST_SKIP_CI activates the in-spec quarantine guards, the lever the unit
+      # suite already uses; each guard states the condition it stands in for.
       - name: Run e2e (engine tier)
         timeout-minutes: 5
-        run: npx playwright test -c test/playwright/playwright.config.e2e.mjs --workers=1 $(node buildScripts/util/e2eCiSelection.mjs --paths)
+        run: npx playwright test -c test/playwright/playwright.config.e2e.mjs --workers=1 ${{ steps.selection.outputs.paths }}
         env:
           NEO_TEST_SKIP_CI: 'true'
 

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -1,0 +1,160 @@
+name: E2E (engine tier)
+
+# Why this is its own workflow rather than a third suite in `test.yml`:
+#
+# The e2e tier cannot run whole in CI, and the reasons are structural rather than
+# provisional. Two of them bound what this job may ever contain:
+#
+#   1. GPU. Specs that boot `/apps/workstation/index.html` inherit five canvas files
+#      and drive animated OffscreenCanvas work. CI runners have no GPU compute for
+#      that, so the workstation tier is out of scope here — not skipped, not flaky,
+#      out of scope. The dashboard app carries zero canvas files, which is why the
+#      dock and cross-window specs are the tier that fits.
+#   2. Time. The operator's ceiling for this pipeline is five minutes. Measured
+#      serially on an idle developer machine, the selection below runs in 3.7m and
+#      the full Brain-free set runs in 7.2m. The set is chosen to fit, and the
+#      timeout below is what stops it from silently growing past the ceiling.
+#
+# A third reason bounds the REPORTING rather than the content, and it is the one a
+# reader is most likely to be misled by. `playwright.config.e2e.mjs` uses
+# `testIgnore` for the specs that need an external `neo-agent-brain` checkout, and
+# `testIgnore` removes files from SELECTION rather than skipping them: no reporter,
+# summary line or `--list` output can mention them, and a run missing four fifths of
+# the tier still prints `Skipped: 0`. A green check here therefore certifies a
+# genuine but PARTIAL tier, and the coverage step below writes that fraction into
+# the job summary so the badge cannot imply the whole.
+#
+# Origin: neomjs/neo#17853.
+
+on:
+  pull_request:
+    branches: [dev]
+  push:
+    branches: [dev]
+
+concurrency:
+  # Matches `test.yml`: initial attempts share the ref stream so a new head supersedes
+  # old work, while reruns keep their run_id and cannot cancel a newer head (#15593).
+  group: tests-${{ github.workflow }}-${{ github.run_attempt == '1' && github.ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  e2e-engine:
+    name: e2e-engine
+    runs-on: ubuntu-latest
+    # The operator's ceiling is 5 minutes of RUN time; this bounds the whole job
+    # including provisioning, and exists to fail loudly if the selection grows rather
+    # than to let a slow run pass unnoticed.
+    timeout-minutes: 12
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: '24'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Bundle parse5
+        run: npm run bundle-parse5
+
+      - name: Resolve Playwright version
+        id: playwright
+        run: echo "version=$(node -p "require('@playwright/test/package.json').version")" >> "$GITHUB_OUTPUT"
+
+      - name: Restore Playwright Chromium
+        id: playwright-cache
+        uses: actions/cache/restore@v6
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-chromium-${{ runner.os }}-${{ steps.playwright.outputs.version }}
+
+      - name: Install Playwright Chromium
+        if: ${{ steps.playwright-cache.outputs.cache-hit != 'true' }}
+        run: npx playwright install chromium
+
+      - name: Save Playwright Chromium
+        if: ${{ steps.playwright-cache.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v6
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ steps.playwright-cache.outputs.cache-primary-key }}
+
+      - name: Verify Chromium launches
+        id: chromium-probe
+        continue-on-error: true
+        run: node -e "require('@playwright/test').chromium.launch().then(browser => browser.close())"
+
+      - name: Install Playwright system dependencies
+        if: ${{ steps.chromium-probe.outcome == 'failure' }}
+        run: npx playwright install-deps chromium
+
+      # Serial by measurement, not by caution: the tier drives real windows, drag
+      # thresholds and geometry, and parallel workers on one runner perturb exactly
+      # those arms. The 3.7m figure above is a `--workers=1` number.
+      #
+      # NEO_TEST_SKIP_CI activates the in-spec quarantine guards, the same lever the
+      # unit suite uses. Every guard it fires carries a reason and a ticket at its
+      # call site; a guard without one is a bug in the guard.
+      - name: Run e2e (engine tier)
+        run: |
+          npx playwright test -c test/playwright/playwright.config.e2e.mjs --workers=1 \
+            test/playwright/e2e/colors \
+            test/playwright/e2e/core \
+            test/playwright/e2e/dashboard \
+            test/playwright/e2e/grid \
+            test/playwright/e2e/portal \
+            test/playwright/e2e/rendering
+        env:
+          NEO_TEST_SKIP_CI: 'true'
+
+      # The honesty guard. Without it the badge reads as "e2e passed" while the tier
+      # it covers is a fraction, and the deselected remainder is invisible by
+      # construction rather than by omission.
+      # Counts what this JOB runs, not what the config selects — the two differ, and
+      # reporting the larger number would be the exact false green this step exists to
+      # prevent. Derived rather than hardcoded so it stays true as the tree moves.
+      - name: Report tier coverage
+        if: ${{ always() }}
+        run: |
+          node --input-type=module -e "
+            import {selectExternalBrainSpecs} from './test/playwright/externalBrainSelection.mjs';
+            import {readdirSync}              from 'node:fs';
+            import {join}                     from 'node:path';
+
+            const root  = join(process.cwd(), 'test/playwright/e2e'),
+                  {ignore, total} = selectExternalBrainSpecs(root),
+                  walk  = dir => readdirSync(dir, {withFileTypes: true}).flatMap(entry =>
+                      entry.isDirectory()             ? walk(join(dir, entry.name)) :
+                      entry.name.endsWith('.spec.mjs') ? [join(dir, entry.name)]    : []),
+                  // Only the Brain-FREE workstation specs are excluded by THIS job; the rest were
+                  // already deselected above. Counting all of them double-subtracts and reports a
+                  // negative coverage, which is how the first version of this step was wrong.
+                  isIgnored  = file => ignore.some(pattern => pattern.test(file)),
+                  brainFree  = total - ignore.length,
+                  gpuTier    = walk(join(root, 'workstation')).filter(file => !isIgnored(file)).length,
+                  ran        = brainFree - gpuTier;
+
+            console.log([
+              '### e2e (engine tier) coverage',
+              '',
+              \`This job ran **\${ran} of \${total}** e2e spec files.\`,
+              '',
+              \`- **\${ignore.length}** require an external \\\`neo-agent-brain\\\` checkout and are DESELECTED by \\\`testIgnore\\\` — they cannot appear as skips in any report.\`,
+              \`- **\${gpuTier}** are workstation specs, excluded here: that app inherits animated OffscreenCanvas work CI has no GPU for.\`,
+              '',
+              'A green check on this job certifies the engine tier only. It does not certify the two groups above.'
+            ].join('\n'));
+          " >> "\$GITHUB_STEP_SUMMARY"
+
+      - name: Upload test artifacts on failure
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: test-results-e2e-engine-${{ github.run_id }}
+          path: test/playwright/test-results/

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -101,6 +101,22 @@ jobs:
       # NEO_TEST_SKIP_CI activates the in-spec quarantine guards, the same lever the
       # unit suite uses. Every guard it fires carries a reason and a ticket at its
       # call site; a guard without one is a bug in the guard.
+      # Paths rather than directories, because two specs in this tier need build output
+      # this job deliberately does not produce. The job runs `npm ci` and nothing else:
+      # adding `build-all` to reach them would spend the five-minute budget on a build
+      # in order to run two specs.
+      #
+      #   rendering/LivePreviewMultiWindow — parameterised over Dev, Dist Dev and Dist
+      #       Prod; the two Dist environments need built bundles, and without them every
+      #       arm burns its full 30s timeout. This is what made the first CI attempt take
+      #       9m17s against 3.4m locally: my own checkout HAD `dist/`, so the suite passed
+      #       here and could not have passed there. A local green from local build output
+      #       is a false green, and it took a real runner to say so.
+      #   portal/LearnLinkRoutingNL — asserts rendered learn content ("Adopting in Your
+      #       App"), which is generated rather than checked in.
+      #
+      # Both belong in this tier the day the pipeline can afford a build, and neither is
+      # a product failure.
       - name: Run e2e (engine tier)
         run: |
           npx playwright test -c test/playwright/playwright.config.e2e.mjs --workers=1 \
@@ -108,8 +124,8 @@ jobs:
             test/playwright/e2e/core \
             test/playwright/e2e/dashboard \
             test/playwright/e2e/grid \
-            test/playwright/e2e/portal \
-            test/playwright/e2e/rendering
+            test/playwright/e2e/rendering/InputModalityMultiWindow.spec.mjs \
+            test/playwright/e2e/rendering/ViewTransitionReveal.spec.mjs
         env:
           NEO_TEST_SKIP_CI: 'true'
 
@@ -138,7 +154,11 @@ jobs:
                   isIgnored  = file => ignore.some(pattern => pattern.test(file)),
                   brainFree  = total - ignore.length,
                   gpuTier    = walk(join(root, 'workstation')).filter(file => !isIgnored(file)).length,
-                  ran        = brainFree - gpuTier;
+                  // Named rather than derived: 'needs build output' is a property of what a spec
+                  // asserts, not of where it sits, so the filesystem cannot answer it. Keep this
+                  // list and the run step's paths in step — they are the same decision twice.
+                  buildTier  = 2,
+                  ran        = brainFree - gpuTier - buildTier;
 
             console.log([
               '### e2e (engine tier) coverage',
@@ -147,8 +167,9 @@ jobs:
               '',
               \`- **\${ignore.length}** require an external \\\`neo-agent-brain\\\` checkout and are DESELECTED by \\\`testIgnore\\\` — they cannot appear as skips in any report.\`,
               \`- **\${gpuTier}** are workstation specs, excluded here: that app inherits animated OffscreenCanvas work CI has no GPU for.\`,
+              \`- **\${buildTier}** need build output this job does not produce (Dist environments, generated learn content).\`,
               '',
-              'A green check on this job certifies the engine tier only. It does not certify the two groups above.'
+              'A green check on this job certifies the engine tier only. It does not certify the three groups above.'
             ].join('\n'));
           " >> "\$GITHUB_STEP_SUMMARY"
 

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -1,30 +1,23 @@
 name: E2E (engine tier)
 
-# Why this is its own workflow rather than a third suite in `test.yml`:
+# Its own workflow rather than a suite in `test.yml`, because the e2e tier cannot run
+# whole in CI and the reasons are structural:
 #
-# The e2e tier cannot run whole in CI, and the reasons are structural rather than
-# provisional. Two of them bound what this job may ever contain:
+#   GPU  — specs booting the workstation app inherit animated OffscreenCanvas work no
+#          hosted runner can composite. The dashboard app carries none, which is why
+#          the dock and cross-window specs are the tier that fits.
+#   Time — the ceiling is five minutes of test time, enforced on the step below rather
+#          than on the job, so a slow suite is distinguishable from a slow `npm ci`.
 #
-#   1. GPU. Specs that boot `/apps/workstation/index.html` inherit five canvas files
-#      and drive animated OffscreenCanvas work. CI runners have no GPU compute for
-#      that, so the workstation tier is out of scope here — not skipped, not flaky,
-#      out of scope. The dashboard app carries zero canvas files, which is why the
-#      dock and cross-window specs are the tier that fits.
-#   2. Time. The operator's ceiling for this pipeline is five minutes. Measured
-#      serially on an idle developer machine, the selection below runs in 3.7m and
-#      the full Brain-free set runs in 7.2m. The set is chosen to fit, and the
-#      timeout below is what stops it from silently growing past the ceiling.
+# A third constraint bounds the REPORTING, and is the one a reader is most likely to be
+# misled by: `playwright.config.e2e.mjs` uses `testIgnore` for the Brain-dependent
+# specs, and `testIgnore` removes files from SELECTION rather than skipping them. No
+# reporter can name them, and a run missing four fifths of the tier still prints
+# `Skipped: 0`. A green check here certifies a genuine but PARTIAL tier.
 #
-# A third reason bounds the REPORTING rather than the content, and it is the one a
-# reader is most likely to be misled by. `playwright.config.e2e.mjs` uses
-# `testIgnore` for the specs that need an external `neo-agent-brain` checkout, and
-# `testIgnore` removes files from SELECTION rather than skipping them: no reporter,
-# summary line or `--list` output can mention them, and a run missing four fifths of
-# the tier still prints `Skipped: 0`. A green check here therefore certifies a
-# genuine but PARTIAL tier, and the coverage step below writes that fraction into
-# the job summary so the badge cannot imply the whole.
-#
-# Origin: neomjs/neo#17853.
+# Which specs run, why the rest do not, and the coverage this job reports all live in
+# `buildScripts/util/e2eCiSelection.mjs` — one source for the invocation and the
+# summary, so the two cannot drift into describing different populations.
 
 on:
   pull_request:
@@ -42,9 +35,8 @@ jobs:
   e2e-engine:
     name: e2e-engine
     runs-on: ubuntu-latest
-    # The operator's ceiling is 5 minutes of RUN time; this bounds the whole job
-    # including provisioning, and exists to fail loudly if the selection grows rather
-    # than to let a slow run pass unnoticed.
+    # Bounds provisioning plus tests. The test-time ceiling is the step below; this
+    # exists so a hung install cannot occupy a runner indefinitely.
     timeout-minutes: 12
 
     steps:
@@ -63,6 +55,9 @@ jobs:
       - name: Bundle parse5
         run: npm run bundle-parse5
 
+      # Browser provisioning is cached on the installed Playwright version, and the
+      # system libraries are installed only when a launch probe says they are missing —
+      # the same shape `test.yml` uses for its components suite, and for its reasons.
       - name: Resolve Playwright version
         id: playwright
         run: echo "version=$(node -p "require('@playwright/test/package.json').version")" >> "$GITHUB_OUTPUT"
@@ -94,84 +89,26 @@ jobs:
         if: ${{ steps.chromium-probe.outcome == 'failure' }}
         run: npx playwright install-deps chromium
 
-      # Serial by measurement, not by caution: the tier drives real windows, drag
-      # thresholds and geometry, and parallel workers on one runner perturb exactly
-      # those arms. The 3.7m figure above is a `--workers=1` number.
+      # Serial by measurement, not caution: this tier drives real windows, drag
+      # thresholds and geometry, which parallel workers on one runner perturb.
       #
-      # NEO_TEST_SKIP_CI activates the in-spec quarantine guards, the same lever the
-      # unit suite uses. Every guard it fires carries a reason and a ticket at its
-      # call site; a guard without one is a bug in the guard.
-      # Paths rather than directories, because two specs in this tier need build output
-      # this job deliberately does not produce. The job runs `npm ci` and nothing else:
-      # adding `build-all` to reach them would spend the five-minute budget on a build
-      # in order to run two specs.
-      #
-      #   rendering/LivePreviewMultiWindow — parameterised over Dev, Dist Dev and Dist
-      #       Prod; the two Dist environments need built bundles, and without them every
-      #       arm burns its full 30s timeout. This is what made the first CI attempt take
-      #       9m17s against 3.4m locally: my own checkout HAD `dist/`, so the suite passed
-      #       here and could not have passed there. A local green from local build output
-      #       is a false green, and it took a real runner to say so.
-      #   portal/LearnLinkRoutingNL — asserts rendered learn content ("Adopting in Your
-      #       App"), which is generated rather than checked in.
-      #
-      # Both belong in this tier the day the pipeline can afford a build, and neither is
-      # a product failure.
+      # `--paths` also runs the selection floor, so a stale path or an undeclared
+      # exclusion fails the step rather than quietly shrinking coverage behind a green
+      # check. NEO_TEST_SKIP_CI activates the in-spec quarantine guards, the lever the
+      # unit suite already uses; each guard states the condition it is standing in for.
       - name: Run e2e (engine tier)
-        run: |
-          npx playwright test -c test/playwright/playwright.config.e2e.mjs --workers=1 \
-            test/playwright/e2e/colors \
-            test/playwright/e2e/core \
-            test/playwright/e2e/dashboard \
-            test/playwright/e2e/grid \
-            test/playwright/e2e/rendering/InputModalityMultiWindow.spec.mjs \
-            test/playwright/e2e/rendering/ViewTransitionReveal.spec.mjs
+        timeout-minutes: 5
+        run: npx playwright test -c test/playwright/playwright.config.e2e.mjs --workers=1 $(node buildScripts/util/e2eCiSelection.mjs --paths)
         env:
           NEO_TEST_SKIP_CI: 'true'
 
-      # The honesty guard. Without it the badge reads as "e2e passed" while the tier
-      # it covers is a fraction, and the deselected remainder is invisible by
-      # construction rather than by omission.
-      # Counts what this JOB runs, not what the config selects — the two differ, and
-      # reporting the larger number would be the exact false green this step exists to
-      # prevent. Derived rather than hardcoded so it stays true as the tree moves.
+      # `always()`, because a failed run needs its coverage stated more than a green one
+      # does — and the destination is unescaped on purpose: an earlier inline form wrote
+      # to a file literally named `$GITHUB_STEP_SUMMARY`, so the honesty guard never
+      # reached GitHub at all.
       - name: Report tier coverage
         if: ${{ always() }}
-        run: |
-          node --input-type=module -e "
-            import {selectExternalBrainSpecs} from './test/playwright/externalBrainSelection.mjs';
-            import {readdirSync}              from 'node:fs';
-            import {join}                     from 'node:path';
-
-            const root  = join(process.cwd(), 'test/playwright/e2e'),
-                  {ignore, total} = selectExternalBrainSpecs(root),
-                  walk  = dir => readdirSync(dir, {withFileTypes: true}).flatMap(entry =>
-                      entry.isDirectory()             ? walk(join(dir, entry.name)) :
-                      entry.name.endsWith('.spec.mjs') ? [join(dir, entry.name)]    : []),
-                  // Only the Brain-FREE workstation specs are excluded by THIS job; the rest were
-                  // already deselected above. Counting all of them double-subtracts and reports a
-                  // negative coverage, which is how the first version of this step was wrong.
-                  isIgnored  = file => ignore.some(pattern => pattern.test(file)),
-                  brainFree  = total - ignore.length,
-                  gpuTier    = walk(join(root, 'workstation')).filter(file => !isIgnored(file)).length,
-                  // Named rather than derived: 'needs build output' is a property of what a spec
-                  // asserts, not of where it sits, so the filesystem cannot answer it. Keep this
-                  // list and the run step's paths in step — they are the same decision twice.
-                  buildTier  = 2,
-                  ran        = brainFree - gpuTier - buildTier;
-
-            console.log([
-              '### e2e (engine tier) coverage',
-              '',
-              \`This job ran **\${ran} of \${total}** e2e spec files.\`,
-              '',
-              \`- **\${ignore.length}** require an external \\\`neo-agent-brain\\\` checkout and are DESELECTED by \\\`testIgnore\\\` — they cannot appear as skips in any report.\`,
-              \`- **\${gpuTier}** are workstation specs, excluded here: that app inherits animated OffscreenCanvas work CI has no GPU for.\`,
-              \`- **\${buildTier}** need build output this job does not produce (Dist environments, generated learn content).\`,
-              '',
-              'A green check on this job certifies the engine tier only. It does not certify the three groups above.'
-            ].join('\n'));
-          " >> "\$GITHUB_STEP_SUMMARY"
+        run: node buildScripts/util/e2eCiSelection.mjs --summary >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload test artifacts on failure
         if: ${{ failure() }}

--- a/buildScripts/util/e2eCiSelection.mjs
+++ b/buildScripts/util/e2eCiSelection.mjs
@@ -57,6 +57,19 @@ export const EXCLUSIONS = [{
 }];
 
 /**
+ * Arms that ARE selected but skip themselves under `NEO_TEST_SKIP_CI`. Declared here as well as at
+ * their call site so the job summary can name them: a quarantine that appears only as an anonymous
+ * skip in a test log is the silent quarantine this file exists to prevent, and an owner is what
+ * separates a debt marker from an abandonment.
+ * @member {Object[]} QUARANTINES
+ */
+export const QUARANTINES = [{
+    path  : 'test/playwright/e2e/dashboard/DockSplitterProxyPaintNL.spec.mjs',
+    reason: 'crossing the drag threshold creates no splitter proxy; reproduced serially at low load and headed on a real GPU, so neither contention nor a compositor gap',
+    owner : '@neo-opus-ada — holds the repair; the guard is a debt marker, and removing it is the fix'
+}];
+
+/**
  * @summary Walks a directory for spec files.
  * @param {String} dir
  * @returns {String[]}
@@ -129,6 +142,9 @@ export function summary(root = process.cwd()) {
         `- **${gpu}** boot the workstation app, which inherits animated OffscreenCanvas work a hosted runner cannot composite.`,
         ...EXCLUSIONS.map(entry => `- \`${entry.path.replace('test/playwright/e2e/', '')}\` — ` +
             (entry.kind === 'cause' ? '' : '**cause not established.** ') + `${entry.reason}. Owner: ${entry.owner}.`),
+        '',
+        `Selected but quarantined — these run in the tier and skip themselves, so they appear as skips rather than coverage:`,
+        ...QUARANTINES.map(entry => `- \`${entry.path.replace('test/playwright/e2e/', '')}\` — ${entry.reason}. Owner: ${entry.owner}.`),
         '',
         `**Selected is not executed.** This line reports what the job SELECTED; whether those specs ran and passed is the job's own status, because a provisioning failure reaches this summary too. A green check certifies the ${executed} selected files only — quarantined arms inside them appear as skips with a reason, while the ${ignored + gpu} above appear nowhere.`
     ].join('\n')

--- a/buildScripts/util/e2eCiSelection.mjs
+++ b/buildScripts/util/e2eCiSelection.mjs
@@ -1,0 +1,149 @@
+import {readdirSync}              from 'fs';
+import {join}                     from 'path';
+import {selectExternalBrainSpecs} from '../../test/playwright/externalBrainSelection.mjs';
+
+/**
+ * @summary The one place that decides which e2e specs the CI tier runs, and the one place that
+ * reports what that decision covered.
+ *
+ * @description Both halves live here on purpose. The workflow previously carried the spec paths in
+ * its run step and re-derived the counts in a separate arithmetic reporter, so the two could drift
+ * and the summary could describe a selection nobody ran. `--paths` and `--summary` now read the same
+ * constants, and {@link assertSelectionFloor} fails the job if the executed population shrinks
+ * below what this file declares — a new exclusion has to be written down here to take effect.
+ *
+ * Three populations are excluded, and they are not the same kind of thing:
+ *
+ * - **Brain-dependent** — removed by `testIgnore` in `playwright.config.e2e.mjs`, which deselects
+ *   rather than skips: no reporter can name them, and a run missing four fifths of the tier still
+ *   prints `Skipped: 0`. That invisibility is why this file reports the fraction at all.
+ * - **GPU** — specs booting the workstation app, which inherits animated OffscreenCanvas work no
+ *   hosted runner can composite.
+ * - **Observed failures** — arms that fail for reasons NOT established here. They carry an owner
+ *   rather than a diagnosis, because naming an unverified cause is worse than admitting one is
+ *   missing.
+ */
+
+/**
+ * Spec paths the CI tier executes, relative to the repository root. Directories expand to every
+ * spec beneath them; individual files are named where a sibling in the same directory is excluded.
+ * @member {String[]} RUN_PATHS
+ */
+export const RUN_PATHS = [
+    'test/playwright/e2e/colors',
+    'test/playwright/e2e/core',
+    'test/playwright/e2e/dashboard',
+    'test/playwright/e2e/grid',
+    'test/playwright/e2e/rendering/InputModalityMultiWindow.spec.mjs',
+    'test/playwright/e2e/rendering/ViewTransitionReveal.spec.mjs'
+];
+
+/**
+ * Specs deliberately outside {@link RUN_PATHS}, each with the reason it is out and who owns getting
+ * it back. `cause` is stated only where it was verified; `observed` records a failure whose cause is
+ * NOT established, which is a different and more honest claim.
+ * @member {Object[]} EXCLUSIONS
+ */
+export const EXCLUSIONS = [{
+    path  : 'test/playwright/e2e/rendering/LivePreviewMultiWindow.spec.mjs',
+    kind  : 'cause',
+    reason: 'parameterised over Dev, Dist Dev and Dist Prod; the Dist environments need built bundles this job does not produce, so each arm burns its full 30s timeout',
+    owner : 'this tier, the day the pipeline can afford a build step'
+}, {
+    path  : 'test/playwright/e2e/portal/LearnLinkRoutingNL.spec.mjs',
+    kind  : 'observed',
+    reason: 'fails on a hosted runner asserting the destination guide heading; the guide and the learn index are BOTH tracked, so "needs generated content" was wrong and no verified cause has replaced it',
+    owner : '@neo-opus-ada — diagnose or hand over; excluded rather than diagnosed'
+}];
+
+/**
+ * @summary Walks a directory for spec files.
+ * @param {String} dir
+ * @returns {String[]}
+ */
+function walk(dir) {
+    return readdirSync(dir, {withFileTypes: true}).flatMap(entry => entry.isDirectory()
+        ? walk(join(dir, entry.name))
+        : entry.name.endsWith('.spec.mjs') ? [join(dir, entry.name)] : [])
+}
+
+/**
+ * @summary Counts every population the reader needs to tell a partial green from a whole one.
+ * @param {String} [root=process.cwd()]
+ * @returns {{brainFree: Number, executed: Number, gpu: Number, ignored: Number, total: Number}}
+ */
+export function populations(root = process.cwd()) {
+    const e2e             = join(root, 'test/playwright/e2e'),
+          {ignore, total} = selectExternalBrainSpecs(e2e),
+          isIgnored       = file => ignore.some(pattern => pattern.test(file)),
+          // Only the Brain-FREE workstation specs; the rest are already deselected, and counting
+          // them again reports a negative coverage.
+          gpu             = walk(join(e2e, 'workstation')).filter(file => !isIgnored(file)).length,
+          // Counted through the SAME ignore set Playwright applies, because a directory in
+          // RUN_PATHS names Brain-dependent specs the config will deselect. Counting what the paths
+          // name rather than what the run selects reported 52 against an expected 14 — two
+          // different notions of "selected", which is the defect this file exists to remove.
+          executed        = RUN_PATHS.flatMap(path => path.endsWith('.spec.mjs')
+              ? [join(root, path)]
+              : walk(join(root, path))).filter(file => !isIgnored(file)).length;
+
+    return {brainFree: total - ignore.length, executed, gpu, ignored: ignore.length, total}
+}
+
+/**
+ * @summary Refuses a run whose executed population is smaller than this file declares.
+ * @description Without it, a path typo or a directory rename shrinks coverage silently and the job
+ * still reports green — the failure mode a coverage line alone cannot catch, because it would
+ * faithfully report the smaller number.
+ * @param {String} [root=process.cwd()]
+ * @returns {Number} The executed spec-file count.
+ * @throws {Error} When fewer specs are selected than declared.
+ */
+export function assertSelectionFloor(root = process.cwd()) {
+    const {brainFree, executed, gpu} = populations(root),
+          expected                   = brainFree - gpu - EXCLUSIONS.length;
+
+    if (executed !== expected) {
+        throw new Error(`e2e CI selection: expected ${expected} spec files (${brainFree} Brain-free ` +
+            `− ${gpu} GPU − ${EXCLUSIONS.length} excluded) but RUN_PATHS resolves ${executed}. ` +
+            'Either a path is stale or an exclusion is undeclared; both are silent coverage loss.')
+    }
+
+    return executed
+}
+
+/**
+ * @summary Renders the job-summary markdown.
+ * @param {String} [root=process.cwd()]
+ * @returns {String}
+ */
+export function summary(root = process.cwd()) {
+    const {brainFree, executed, gpu, ignored, total} = populations(root);
+
+    return [
+        '### e2e (engine tier) coverage',
+        '',
+        `This job selected **${executed} of ${total}** e2e spec files.`,
+        '',
+        `- **${ignored}** need an external \`neo-agent-brain\` checkout. \`testIgnore\` DESELECTS them, so they cannot appear as skips in any report — a run missing them still prints \`Skipped: 0\`.`,
+        `- **${gpu}** boot the workstation app, which inherits animated OffscreenCanvas work a hosted runner cannot composite.`,
+        ...EXCLUSIONS.map(entry => `- \`${entry.path.replace('test/playwright/e2e/', '')}\` — ` +
+            (entry.kind === 'cause' ? '' : '**cause not established.** ') + `${entry.reason}. Owner: ${entry.owner}.`),
+        '',
+        `**Selected is not executed.** This line reports what the job SELECTED; whether those specs ran and passed is the job's own status, because a provisioning failure reaches this summary too. A green check certifies the ${executed} selected files only — quarantined arms inside them appear as skips with a reason, while the ${ignored + gpu} above appear nowhere.`
+    ].join('\n')
+}
+
+if (process.argv[1]?.endsWith('e2eCiSelection.mjs')) {
+    const mode = process.argv[2];
+
+    if (mode === '--paths') {
+        assertSelectionFloor();
+        process.stdout.write(RUN_PATHS.join(' '))
+    } else if (mode === '--summary') {
+        process.stdout.write(summary() + '\n')
+    } else {
+        console.error('usage: e2eCiSelection.mjs --paths | --summary');
+        process.exit(2)
+    }
+}

--- a/test/playwright/e2e/custom-reporter.js
+++ b/test/playwright/e2e/custom-reporter.js
@@ -473,7 +473,14 @@ export default class BenchmarkSystemReporter {
   }
 
   /**
-   * @summary Flushes the final receipt and prints the existing terminal benchmark summary.
+   * @summary Flushes the final receipt and prints the run duration.
+   * @description Deliberately prints no tallies. It used to print three, read off `result.stats`,
+   * which Playwright's `FullResult` does not carry — so every run, red or green, ended on
+   * `❌ Failed: 0`. A controlled `src/` mutation surfaced it: the log read `1 failed` from
+   * Playwright's own reporter and `❌ Failed: 0` from this one, four lines apart.
+   *
+   * Counting here rather than deleting would have rebuilt a tally Playwright already prints
+   * correctly and immediately above — so the fix is the removal.
    * @param {Object} result
    * @returns {void}
    */
@@ -483,8 +490,5 @@ export default class BenchmarkSystemReporter {
     this.flushReceipt();
 
     console.log(`\n Benchmark completed in ${Math.round(duration / 1000)}s`);
-    console.log(`✅ Passed: ${result.stats?.passed || 0}`);
-    console.log(`❌ Failed: ${result.stats?.failed || 0}`);
-    console.log(`⏭️  Skipped: ${result.stats?.skipped || 0}`);
   }
 }

--- a/test/playwright/e2e/dashboard/DockSplitterProxyPaintNL.spec.mjs
+++ b/test/playwright/e2e/dashboard/DockSplitterProxyPaintNL.spec.mjs
@@ -25,6 +25,17 @@ const HOSTS = [
 test.describe('Neo.dashboard.dock.interaction.DockSplitter — the drag proxy carries its paint', () => {
     test.setTimeout(90000);
 
+    // QUARANTINED, and deliberately not dressed up as an environment problem: this arm is a known
+    // failure on `dev`, dying on `crossing the drag threshold must create a splitter proxy —
+    // element(s) not found`. Reproduced serially at low load with `--workers=1`, and headed on a
+    // real GPU, so it is neither contention nor a compositor gap.
+    //
+    // The guard exists so the e2e pipeline can run the surrounding tier at all; it is a debt marker,
+    // not a verdict. Removing it is the fix — skipping it is what buys the time to make one.
+    // ticket-ref-ok: a quarantine whose skip message names no owner is the silent quarantine this
+    // guard exists to avoid; the reason string is what a CI reader sees instead of the arm.
+    test.skip(process.env.NEO_TEST_SKIP_CI === 'true', 'known failure on dev — drag proxy is never created; see #17853');
+
     for (const host of HOSTS) {
     test(`a live drag proxy resolves the splitter tokens it was cloned from — ${host.name}`, async ({page}) => {
         await page.goto(host.url);

--- a/test/playwright/e2e/dashboard/DockSplitterProxyPaintNL.spec.mjs
+++ b/test/playwright/e2e/dashboard/DockSplitterProxyPaintNL.spec.mjs
@@ -32,9 +32,7 @@ test.describe('Neo.dashboard.dock.interaction.DockSplitter — the drag proxy ca
     //
     // The guard exists so the e2e pipeline can run the surrounding tier at all; it is a debt marker,
     // not a verdict. Removing it is the fix — skipping it is what buys the time to make one.
-    // ticket-ref-ok: a quarantine whose skip message names no owner is the silent quarantine this
-    // guard exists to avoid; the reason string is what a CI reader sees instead of the arm.
-    test.skip(process.env.NEO_TEST_SKIP_CI === 'true', 'known failure on dev — drag proxy is never created; see #17853');
+    test.skip(process.env.NEO_TEST_SKIP_CI === 'true', 'known failure on dev — drag proxy is never created; see #17853'); // ticket-ref-ok: a quarantine whose skip message names no owner is the silent quarantine this guard exists to avoid
 
     for (const host of HOSTS) {
     test(`a live drag proxy resolves the splitter tokens it was cloned from — ${host.name}`, async ({page}) => {

--- a/test/playwright/e2e/dashboard/DockSplitterProxyPaintNL.spec.mjs
+++ b/test/playwright/e2e/dashboard/DockSplitterProxyPaintNL.spec.mjs
@@ -32,7 +32,7 @@ test.describe('Neo.dashboard.dock.interaction.DockSplitter — the drag proxy ca
     //
     // The guard exists so the e2e pipeline can run the surrounding tier at all; it is a debt marker,
     // not a verdict. Removing it is the fix — skipping it is what buys the time to make one.
-    test.skip(process.env.NEO_TEST_SKIP_CI === 'true', 'known failure on dev — drag proxy is never created; see #17853'); // ticket-ref-ok: a quarantine whose skip message names no owner is the silent quarantine this guard exists to avoid
+    test.skip(process.env.NEO_TEST_SKIP_CI === 'true', 'known failure on dev: crossing the drag threshold creates no splitter proxy');
 
     for (const host of HOSTS) {
     test(`a live drag proxy resolves the splitter tokens it was cloned from — ${host.name}`, async ({page}) => {

--- a/test/playwright/e2e/workstation/WorkstationTabOverflowCapNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationTabOverflowCapNL.spec.mjs
@@ -51,6 +51,12 @@ test.describe('Workstation — the active tab never runs beneath the overflow co
                       Math.min(a.bottom, b.bottom) - Math.max(a.top, b.top)),
                   control = document.querySelector('.neo-tab-overflow-control'),
                   capped  = document.querySelector('.neo-tab-overflow-capped'),
+                  // Resolved once and reported through sentinels below. A capped button that lost
+                  // its text or indicator node is a DIFFERENT failure from one whose style is
+                  // wrong, and reading them inline threw `getComputedStyle(null)` — a TypeError
+                  // that aborts the evaluate and names neither condition.
+                  cappedText      = capped?.querySelector('.neo-button-text'),
+                  cappedIndicator = capped?.querySelector('.neo-tab-button-indicator'),
                   toolbar = capped?.closest('.neo-tab-header-toolbar'),
                   pressed = [...document.querySelectorAll('.neo-tab-header-button.pressed')];
 
@@ -71,8 +77,8 @@ test.describe('Workstation — the active tab never runs beneath the overflow co
                 capped      : capped && {
                     rect         : rect(capped),
                     maxWidth     : parseFloat(capped.style.maxWidth),
-                    textOverflow : getComputedStyle(capped.querySelector('.neo-button-text')).textOverflow,
-                    indicatorRect: rect(capped.querySelector('.neo-tab-button-indicator')),
+                    textOverflow : cappedText ? getComputedStyle(cappedText).textOverflow : 'no-text-node',
+                    indicatorRect: cappedIndicator ? rect(cappedIndicator) : null,
                     controlIx    : control ? overlap(rect(capped), rect(control)) : -1
                 },
                 toolbarRect: toolbar && rect(toolbar),
@@ -108,6 +114,10 @@ test.describe('Workstation — the active tab never runs beneath the overflow co
         // where the control begins. Zero painted intersection.
         expect(facts.capped.controlIx, 'capped active button must not intersect the overflow control').toBe(0);
         expect(facts.capped.rect.right, 'capped box ends at or before the control edge').toBeLessThanOrEqual(facts.control.left + 0.5);
+        // Presence before geometry: without this, a capped button that lost its indicator fails on
+        // `Cannot read properties of null` one line down — an abort that names no condition, which
+        // is the same crash this spec used to take inside the evaluate.
+        expect(facts.capped.indicatorRect, 'the capped button carries a per-button indicator').not.toBeNull();
         expect(
             Math.abs(facts.capped.indicatorRect.width - facts.capped.rect.width),
             'the per-button indicator spans exactly the capped box'


### PR DESCRIPTION
Resolves #18408
Refs #17853

104 e2e spec files — 60 of them dock, Workstation, DemoB or multi-window — executed by **zero** workflows. `git grep -l playwright.config.e2e -- '.github/*'` returns nothing: not gated, never called. So "e2e-certified" has meant *someone ran it by hand once, on some tree*, including for the journeys #18303 and #18304 are certified on. This gives that tier a runner, and makes the resulting badge state what it does and does not cover.

**Why the close target changed.** This opened against #17853 and now resolves #18408, the leaf split out of it. @neo-opus-grace ruled on their own ticket ([here](https://github.com/neomjs/neo/issues/17853#issuecomment-5562777163)): AC-1 amended, AC-3 through AC-6 met, and **AC-2 deferred with a named home** — building a separate workflow turned the classifier path predicate from two lines inside `test.yml` into either a duplicated ~200-line predicate or a reusable-workflow extraction (`neomjs/neo-agent-skills#14`). Their words: *"#17853 stays open on AC-2. I am not closing it on the merge."* Merging with `Resolves #17853` would have closed it anyway. @neo-gpt-emmy's RA-4 is what caught the contradiction.

Evidence: L2 → L2 required. Residual: none.

## AC Evidence (#18408)

| AC | Evidence |
|---|---|
| A workflow executes e2e specs on `pull_request` and `push` to `dev` | `.github/workflows/test-e2e.yml`, job `e2e-engine`. Hosted green: [run 34066256952](https://github.com/neomjs/neo/actions/runs/34066256952). |
| Test step bounded to five minutes, separately from provisioning | `timeout-minutes: 5` on the run step, `12` on the job. Measured hosted: test step **2m23s**, whole job **2m56s**. |
| Summary states the fraction and names every excluded population with an owner | `Report tier coverage`, `if: always()`. Renders *selected **14 of 104***, then the 84 Brain-deselected, the 4 GPU, the 2 excluded and the 1 quarantined — each with an owner. |
| The floor fails the job at the invocation boundary | `Verify e2e selection floor` is its own named step; a rejection is that step's exit status. See RA-1 below. |
| A controlled `src/` mutation turns the tier red | Receipt below. |

## The gating control

A pipeline that reports without gating is worse than none, so it is measured in two halves rather than assumed:

**A spec regression follows `src/`.** Changed `src/grid/column/component/Tree.mjs:208` to write a different toggle class, ran the pipeline command on `grid/Tree`:

```
mutant   1 failed, 2 passed   exit 1   ← Tree.spec.mjs:19  toHaveClass(/is-collapsed/)
control  3 passed             exit 0   ← same command, mutation reverted
```

The failing assertion is the one that reads the class that line writes. Attributed, not merely red.

**A nonzero exit reddens the job.** Already observed, not staged: [run 34063075394](https://github.com/neomjs/neo/actions/runs/34063075394) concluded `failure` when specs failed on this workflow.

## A false green the control found

The mutant run ended:

```
  1 failed
  2 passed (10.0s)

 Benchmark completed in 10s
✅ Passed: 0
❌ Failed: 0
⏭️  Skipped: 0
```

Four lines apart, two answers. `custom-reporter.js` read `result.stats` in `onEnd`, which Playwright's `FullResult` does not carry — `status`, `startTime`, `duration` only. Those counters were hardcoded zeros on every run since they were written, and this workflow would have printed `❌ Failed: 0` into every red CI log it produces. **Removed, not repaired**: a tally in `onTestEnd` would rebuild, less well, the summary Playwright already prints correctly two lines above. Nothing keyed on them — the exit code was always right, which is why the lie sat unnoticed beside it.

## Deltas from ticket

Two constraints arrived after #17853 was written and shaped the delivery. @tobiu: *e2e cannot easily run in CI — anything with animated offscreen canvases needs GPU compute CI lacks; use `NEO_TEST_SKIP_CI`, own pipeline, ≤5m.* And @neo-opus-grace's app-level trace: every spec booting the workstation app inherits five canvas files, while the dashboard app carries zero.

So the selection is **14 files**, and `buildScripts/util/e2eCiSelection.mjs` is the single source for both the invocation and the summary — they cannot drift into describing different populations. What is out, and why:

- **84** — need an external `neo-agent-brain` checkout. `testIgnore` **deselects** rather than skips, so no reporter can name them and a run missing four fifths of the tier still prints `Skipped: 0`. That is @neo-opus-grace's finding and the reason the coverage step exists at all.
- **4** — boot the workstation app (GPU).
- **`rendering/LivePreviewMultiWindow`** — parameterised over Dist Dev and Dist Prod, which need built bundles this job does not produce. Cause verified: it is the only one of the 14 that references `dist`, and @neo-opus-grace swept the other 13 to confirm.
- **`portal/LearnLinkRoutingNL`** — fails on a hosted runner. **Cause not established.** I claimed it needed generated learn content; @neo-gpt-emmy showed the guide and `learn/tree.json` are both tracked. I did not substitute a second guess — it is recorded as an observed failure with an owner, which is a weaker and more honest claim.
- **`dashboard/DockSplitterProxyPaintNL`** — selected but quarantined behind `NEO_TEST_SKIP_CI`. A known failure on `dev`, reproduced serially at low load and headed on a real GPU, so neither contention nor a compositor gap. Owned; removing the guard is the fix.

Five further failures are real and out of scope — three `WorkstationPaletteBridgeNL` arms, `WorkstationStarvedGeometryNL:64`, `WorkstationTabOverflowCapNL:28`, all in the GPU tier. **An earlier revision of this body named `HeaderActionPolicy.mjs` from #18306 as the likely shared cause. @neo-opus-vega falsified it**: my guarded spec run against `ac93c04e3c`, the commit immediately before #18306, fails byte-identically, so `actionCount === 1` predates that move. No mechanism has replaced it, the cluster is unowned, and it is a product question rather than a CI one.

## Test Evidence

Hosted, at `6384623dcb`:

```
Running 37 tests using 1 worker
  4 skipped
  33 passed (2.4m)
```

`--workers=1` is a measurement, not caution: the tier drives drag thresholds and geometry, which parallel workers perturb. My first failure sweep and timings were taken at load 7 with twelve concurrent Playwright processes and were all invalid; @neo-opus-grace measured the contention (eleven agent seats, one machine) and @neo-opus-vega cleared a window. The serial re-measurement at load 3.94 reproduced **the same six failures at the same lines**, which is what established they are real.

## Review actions

- **RA-1** (`a24e0b6ff7`) — the floor could not gate. A command substitution cannot stop the command it feeds: `npx playwright test … $(node … --paths)` with a failing helper still starts the runner, selects the whole config, and exits 0. Reproduced with @neo-gpt-emmy's spy; the floor now runs in its own named step and passes paths through a step output.
- **RA-2** (`0b1eed112e`) — five-minute budget on the test step; summary destination unescaped, after an inline form wrote to a file literally named `$GITHUB_STEP_SUMMARY`.
- **RA-3** (`a24e0b6ff7`) — the quarantine carries a durable owner in the same record as the exclusions.
- **RA-4** (this update) — close target corrected to #18408; the `49 passes / 16 files / ticket-ref-ok marker` rows replaced with the current hosted numbers.

## Post-Merge Validation

- [ ] First `e2e-engine` run on `dev` stays inside the 5-minute test step — 2m23s leaves headroom, but the tier grows and that is this PR's own thesis.
- [ ] `LearnLinkRoutingNL`'s cause gets established or the exclusion gets handed over, rather than settling in as permanent.

## Commits

- `d333ce898d` — the overflow-cap arm reports its condition instead of aborting inside `page.evaluate`
- `94f6d5acb4` — the workflow, and a real `test.skip` for the splitter arm
- `883067babc`, `d28ea64c22`, `7200bbec01` — hosted-run corrections: the build-dependent exclusion, the quarantine reason, the summary destination and step budget
- `70d969d93d` — RA-1 and RA-3: the floor gates from its own step; the quarantine has an owner
- `24fbf52825` — the reporter stops printing a tally it never had

Rebased onto `dev` after #18407 and #18402 merged. `check-size` had failed on `apps/workstation/view/Workspace.mjs` and `examples/dashboard/crossWindow/DemoBWorkspace.mjs` — **neither in this PR's diff**, and both byte-identical between my HEAD and my merge-base. `dev` had moved them *down* (4948→4887, 4607→4589), so the base-to-HEAD ratchet read my untouched files as grown. A `size-guard-growth` annotation would have signed for growth I did not author and permanently exempted two files; the rebase resolves it with no conflict. The five files above are unchanged by it, so the hosted evidence still describes this tree.

Authored by Ada (Claude Opus 5, Claude Code). Origin session a59d553a-9454-40c8-a70b-ed810e067e3d, continued in 95f9ff6e-1ba5-43b6-860a-208fbf7f4442.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
