### PR TITLE
fix(dock): refresh active target geometry on resize (#18400)

### DIFF
--- a/apps/workstation/view/Workspace.mjs
+++ b/apps/workstation/view/Workspace.mjs
@@ -335,14 +335,6 @@ class Workspace extends DockWorkspace {
     crossWindowPreviewGeometries = new Map()
 
     /**
-     * The main window's inner-rect signature at the last remote frame. A change mid-gesture means
-     * the main window was resized under a hovering popup, so the affordance geometry is re-measured
-     * (see {@link #renderMainCrossWindowPreview}). Reset when the main preview clears.
-     * @member {String|null} mainPreviewWindowSignature=null
-     * @protected
-     */
-    mainPreviewWindowSignature = null
-    /**
      * Most recent cross-window transfer receipt for the film/spec boundary.
      * @member {Object|null} lastCrossWindowTransfer=null
      */
@@ -1575,7 +1567,7 @@ class Workspace extends DockWorkspace {
     }
 
     /**
-     * The main workspace's remote frame: the SAME once-per-gesture geometry and tier order the
+     * @summary Resolves the main workspace's remote frame through the shared geometry and tier order the
      * in-window gesture uses ({@link Neo.dashboard.dock.interaction.DragAffordances#resolvePreview} —
      * every projected tabs zone, an indicator candidate first, pointer inference second), so a
      * popup or remote pointer reads the full placement grammar wherever it points and the drop
@@ -1595,15 +1587,8 @@ class Workspace extends DockWorkspace {
     renderMainCrossWindowPreview({groupNodeId, itemId, pointer, renderer, sourceNodeId, targetNodeId}) {
         let me          = this,
             affordances = me.dragAffordances,
-            inner       = Neo.manager?.Window?.get(me.windowId)?.innerRect,
-            signature   = inner ? [inner.x ?? 0, inner.y ?? 0, inner.width, inner.height].join(':') : null,
             preview, targetRect;
 
-        if (me.mainPreviewWindowSignature && me.mainPreviewWindowSignature !== signature) {
-            affordances.invalidateGeometry()
-        }
-
-        me.mainPreviewWindowSignature = signature;
         affordances.ensureGeometry();
 
         const {geometry} = affordances;
@@ -1642,7 +1627,7 @@ class Workspace extends DockWorkspace {
     }
 
     /**
-     * Clears one target's transient preview without touching committed workspace state.
+     * @summary Clears one target's transient preview without touching committed workspace state.
      * @param {String} workspaceId
      * @protected
      */
@@ -1650,7 +1635,6 @@ class Workspace extends DockWorkspace {
         this.crossWindowPreviewGeometries.delete(workspaceId);
 
         if (workspaceId === Workspace.MAIN_WORKSPACE_ID) {
-            this.mainPreviewWindowSignature = null;
             this.dragAffordances?.clear()
         } else {
             let state   = this.getPopupState(workspaceId),

--- a/buildScripts/util/file-size-baseline.json
+++ b/buildScripts/util/file-size-baseline.json
@@ -1,5 +1,5 @@
 {
-    "apps/workstation/view/Workspace.mjs": 2922,
+    "apps/workstation/view/Workspace.mjs": 2914,
     "examples/dashboard/crossWindow/DemoBWorkspace.mjs": 2610,
     "src/dashboard/dock/Workspace.mjs": 1017,
     "src/main/addon/DragDrop.mjs": 1267

--- a/src/dashboard/dock/interaction/DragAffordances.mjs
+++ b/src/dashboard/dock/interaction/DragAffordances.mjs
@@ -58,6 +58,13 @@ class DragAffordances extends Base {
     geometry = null
 
     /**
+     * Window generation and viewport size associated with the current measurement.
+     * @member {String|null} geometrySignature=null
+     * @protected
+     */
+    geometrySignature = null
+
+    /**
      * The dock host container (the overlays' coordinate origin and the zone-measure root).
      * Assigned by the consumer after composition.
      * @member {Neo.container.Base|null} host=null
@@ -110,7 +117,7 @@ class DragAffordances extends Base {
     }
 
     /**
-     * Measures the drag-session geometry once per gesture (memoized as a promise so the
+     * @summary Measures once per gesture and window size (memoized as a promise so the
      * ~60hz move stream never stacks measurements): the host rect (the overlays' coordinate
      * origin), every projected tabs-zone rect with its parent-split orientation, and the
      * chips' root target — the edge-zone's CENTER node when the document root is an
@@ -119,7 +126,13 @@ class DragAffordances extends Base {
      * @protected
      */
     ensureGeometry() {
-        let me = this;
+        let me = this,
+            signature = me.getGeometrySignature();
+
+        if (signature !== me.geometrySignature) {
+            me.clear();
+            me.geometrySignature = signature
+        }
 
         if (me.dragGeometry) return me.dragGeometry;
 
@@ -140,6 +153,11 @@ class DragAffordances extends Base {
                 : me.owner.dockModel.root;
 
         const promise = host.getDomRect([host.id, ...zoneEntries.map(zone => zone.container.id)]).then(([hostRect, ...zoneRects]) => {
+            if (me.dragGeometry === promise && me.geometrySignature !== me.getGeometrySignature()) {
+                me.clear();
+                return null
+            }
+
             let geometry = hostRect?.width > 0 && hostRect?.height > 0 && {
                 hostRect,
                 root : {nodeId: rootId, rect: hostRect},
@@ -176,10 +194,22 @@ class DragAffordances extends Base {
     }
 
     /**
+     * @summary Keys client-space measurements by their window generation and observed viewport size.
+     * Moving a native window changes screen coordinates, not the client-space rectangles cached here.
+     * @returns {String|null} Null for a host without a registered native window.
+     * @protected
+     */
+    getGeometrySignature() {
+        const windowId = this.host?.windowId,
+              rect = windowId != null ? Neo.manager?.Window?.get(windowId)?.innerRect : null;
+
+        return rect ? JSON.stringify([windowId, rect.width, rect.height]) : null
+    }
+
+    /**
      * Drops the memoized geometry without ending the session: the next frame re-measures while the
-     * indicator menu and the renderer keep their current paint until it lands. A pointer drag cannot
-     * outlive a resize of its own window, but a remote (cross-window) gesture can — its consumer
-     * calls this when the host window's rect changes mid-gesture.
+     * indicator menu and renderer keep their current paint until it lands. Window-size changes are
+     * detected by {@link #ensureGeometry} and clear obsolete feedback before re-measurement.
      */
     invalidateGeometry() {
         this.dragGeometry = this.geometry = null
@@ -279,8 +309,8 @@ class DragAffordances extends Base {
 
     /**
      * @summary The per-frame drag consumer: the indicator menu follows the hovered
-     * zone (candidate set swaps on zone change only — object permanence lets the cross
-     * GLIDE); the pointer selects an indicator geometrically; the selected candidate's
+     * zone. {@link #resolvePreview} refreshes candidates when the zone, geometry or dragged subject
+     * changes, preserving the menu's child instances. The selected candidate's
      * preview — or the pointer-inference FALLBACK tier when no indicator is hovered — feeds
      * the renderer with its exact target region.
      * @param {Object} data {clientX, clientY, itemId, groupNodeId, sourceNodeId, writeRenderer} —
@@ -309,16 +339,15 @@ class DragAffordances extends Base {
     }
 
     /**
-     * The drop half: the indicator is re-hit-tested at the RELEASE coordinates — release
-     * truth, never cached hover truth — and a candidate only counts when it was built for
-     * the item THIS gesture drags. A release-point indicator wins over pointer inference
+     * @summary Selects the release-point preview only while its measured window geometry is current.
+     * A candidate must belong to this gesture's item. An indicator hit wins over pointer inference
      * (the §06 tier order); both commit through `previewToOperation` unchanged. Same-zone
      * pointer drops stay excluded from the fallback (the within-toolbar reorder already
      * handled them); indicator drops keep self-targets (splitting your own zone is real).
      *
      * Generation guard (the supersede review's falsified defect, closed): the geometry
      * await is re-checked against the live session — a gesture cancelled or re-projected
-     * mid-await commits NOTHING.
+     * mid-await commits nothing, as does a release whose window changed without another hover.
      * @param {Object} data {clientX, clientY, itemId, sourceNodeId}
      */
     async onDrop({clientX, clientY, itemId, sourceNodeId}) {
@@ -327,6 +356,11 @@ class DragAffordances extends Base {
             geometry        = geometryPromise ? await geometryPromise : null;
 
         if (me.isDestroyed || (geometryPromise && me.dragGeometry !== geometryPromise)) return;
+
+        if (geometryPromise && me.geometrySignature !== me.getGeometrySignature()) {
+            me.clear();
+            return
+        }
 
         let pointer   = {x: clientX, y: clientY},
             preview   = null,

--- a/test/playwright/e2e/workstation/WorkstationNativePopupOverPopupNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationNativePopupOverPopupNL.spec.mjs
@@ -242,9 +242,11 @@ test.describe('Workstation — native titlebar drag popup onto popup (#18047)', 
     /**
      * @summary Runs the native transfer against either the initial or an enlarged target window.
      * @param {Object} fixtures
-     * @param {Boolean} [resizeTarget=false]
+     * @param {Object} [options={}]
+     * @param {Boolean} [options.resizeTarget=false]
+     * @param {Boolean} [options.activeHover=false]
      */
-    const journey = async ({page, neuralLink}, resizeTarget=false) => {
+    const journey = async ({page, neuralLink}, {resizeTarget=false, activeHover=false}={}) => {
         const
             pageErrors = [],
             popups     = [];
@@ -360,6 +362,22 @@ test.describe('Workstation — native titlebar drag popup onto popup (#18047)', 
             expect((await readNativeLifecycle(app, workspaceId)).owners[TARGET_ITEM]?.windowId,
                 'placing the target vessel did not hand it to the main window').toBe(target.windowId);
 
+            if (activeHover) {
+                const oldRect = await readManagerRect(app, managerId, target.windowId, 'innerRect'),
+                      {nativeWindowDropAnchorInset: inset} = await app.getComponent(coordId, ['nativeWindowDropAnchorInset']);
+
+                for (const delta of [0, 3]) {
+                    await setBounds(sourceHandle, {left: oldRect.x + 24 + delta - inset, top: oldRect.y + 24 - inset});
+                    await source.popup.waitForTimeout(120)
+                }
+
+                const participant = (await participations(app)).find(entry => entry.workspaceId === TARGET_WORKSPACE_ID),
+                      cached = await app.getComponent(participant.id, ['ownedAffordances.geometry']);
+
+                expect(cached['ownedAffordances.geometry']?.hostRect.width, 'native hover warms the old size before resizing')
+                    .toBe(targetScreen.innerWidth)
+            }
+
             if (resizeTarget) {
                 const enlarged = await setBounds(targetHandle, {
                     width : Math.min(520, stage.availLeft + stage.availWidth - targetScreen.screenX),
@@ -400,11 +418,11 @@ test.describe('Workstation — native titlebar drag popup onto popup (#18047)', 
             // bounds move uses — so a frame placed at (left, top) puts the anchor at (left + inset,
             // top + inset), no chrome arithmetic. Aim it 24 px inside the target's viewport.
             const
-                goalLeft = Math.round(targetInner.x + (resizeTarget ? targetInner.width * .7 : 24) - inset),
-                goalTop  = Math.round(targetInner.y + (resizeTarget ? targetInner.height * .5 : 24) - inset),
+                goalLeft = Math.round(targetInner.x + (resizeTarget && !activeHover ? targetInner.width * .7 : 24) - inset),
+                goalTop  = Math.round(targetInner.y + (resizeTarget && !activeHover ? targetInner.height * .5 : 24) - inset),
                 targetParticipation = (await participations(app)).find(entry => entry.workspaceId === TARGET_WORKSPACE_ID);
 
-            if (resizeTarget) {
+            if (resizeTarget && !activeHover) {
                 expect(goalLeft + inset, 'the drop aims outside the old target width')
                     .toBeGreaterThan(targetInner.x + targetScreen.innerWidth)
             }
@@ -559,5 +577,8 @@ test.describe('Workstation — native titlebar drag popup onto popup (#18047)', 
         ({page, neuralLink}) => journey({page, neuralLink}));
 
     test('an enlarged popup updates its drop zones before another popup transfers into the newly exposed area',
-        ({page, neuralLink}) => journey({page, neuralLink}, true))
+        ({page, neuralLink}) => journey({page, neuralLink}, {resizeTarget: true}));
+
+    test('resizing an already-hovered popup refreshes its drop zones without leaving the target',
+        ({page, neuralLink}) => journey({page, neuralLink}, {resizeTarget: true, activeHover: true}))
 });

--- a/test/playwright/unit/dashboard/DockDragAffordances.spec.mjs
+++ b/test/playwright/unit/dashboard/DockDragAffordances.spec.mjs
@@ -14,6 +14,7 @@ import DockDragAffordances from '../../../../src/dashboard/dock/interaction/Drag
 import DockDropIndicators  from '../../../../src/dashboard/dock/interaction/DropIndicators.mjs';
 import DockPreview         from '../../../../src/dashboard/dock/interaction/Preview.mjs';
 import Operations          from '../../../../src/dashboard/dock/model/Operations.mjs';
+import WindowManager       from '../../../../src/manager/Window.mjs';
 
 /**
  * @summary The shared gesture controller's discrimination and generation witnesses.
@@ -281,6 +282,82 @@ test.describe('Neo.dashboard.dock.interaction.DragAffordances', () => {
         expect(await rig.controller.ensureGeometry(), 'zero-area zones = degenerate').toBe(null);
         expect(rig.controller.dragGeometry, 'zero-area frame uncaches — the session self-heals once layout lands').toBe(null);
         destroyAll(rig)
+    });
+
+    test('a resize replaces the measurement once and a late old frame cannot overwrite it', async () => {
+        const rig = compose(), originalGet = WindowManager.get, requests = [];
+        let width = 800, height = 600;
+        WindowManager.get = () => ({innerRect: {width, height}});
+        rig.controller.host = {
+            id: 'resizing-host', windowId: 'resizing-window',
+            down: ({dockNodeId}) => ({id: dockNodeId}),
+            getDomRect: () => new Promise(resolve => requests.push({resolve, width, height}))
+        };
+        const resolve = request => request.resolve([
+            {x: 0, y: 0, width: request.width, height: request.height},
+            {x: 0, y: 0, width: request.width / 2, height: request.height},
+            {x: request.width / 2, y: 0, width: request.width / 2, height: request.height}
+        ]);
+
+        try {
+            const old = rig.controller.ensureGeometry();
+            expect(rig.controller.ensureGeometry()).toBe(old);
+            expect(requests).toHaveLength(1);
+
+            width = 1200;
+            const current = rig.controller.ensureGeometry();
+            expect(current, 'a resized window needs a new generation').not.toBe(old);
+            expect(rig.controller.ensureGeometry()).toBe(current);
+            expect(requests).toHaveLength(2);
+
+            resolve(requests[1]);
+            await current;
+            resolve(requests[0]);
+            await old;
+            expect(rig.controller.geometry.hostRect.width).toBe(1200);
+            expect(rig.indicators.hostRect.width).toBe(1200);
+
+            rig.controller.clear();
+            const pending = rig.controller.ensureGeometry();
+            height = 800;
+            resolve(requests[2]);
+            expect(await pending, 'a resize during measurement cannot publish the old frame').toBeNull();
+            expect(rig.controller.geometry).toBeNull()
+        } finally {
+            WindowManager.get = originalGet;
+            destroyAll(rig)
+        }
+    });
+
+    test('release refuses a cached pre-resize frame and a fresh gesture still commits', async () => {
+        const rig = compose(), originalGet = WindowManager.get;
+        let width = 800;
+        WindowManager.get = () => ({innerRect: {width, height: 600}});
+        rig.controller.host = {
+            id: 'release-resize-host', windowId: 'release-resize-window',
+            down: ({dockNodeId}) => ({id: dockNodeId}),
+            getDomRect: async () => [
+                {x: 0, y: 0, width, height: 600},
+                {x: 0, y: 0, width: width / 2, height: 600},
+                {x: width / 2, y: 0, width: width / 2, height: 600}
+            ]
+        };
+
+        try {
+            await rig.controller.onDragMove({clientX: 600, clientY: 300, itemId: 'alpha', sourceNodeId: 'left-tabs'});
+            width = 1200;
+            await rig.controller.onDrop({clientX: 600, clientY: 300, itemId: 'alpha', sourceNodeId: 'left-tabs'});
+            expect(rig.committed, 'release must not consume old indicator bounds').toHaveLength(0);
+            expect(rig.preview.dockPreview).toBeNull();
+
+            await rig.controller.onDragMove({clientX: 900, clientY: 300, itemId: 'alpha', sourceNodeId: 'left-tabs'});
+            await rig.controller.onDrop({clientX: 900, clientY: 300, itemId: 'alpha', sourceNodeId: 'left-tabs'});
+            expect(rig.committed).toHaveLength(1);
+            expect(rig.owner.dockModel.nodes['right-tabs'].items).toContain('alpha')
+        } finally {
+            WindowManager.get = originalGet;
+            destroyAll(rig)
+        }
     });
 
     test('ownership: the producer lives and dies with the controller', () => {


### PR DESCRIPTION
Resolves #18400
Related: #18303
Related: #18304

An already-hovered popup now refreshes its preview and drop-zone geometry after resize. DragAffordances keys its measurement by window generation and observed viewport size, clears obsolete feedback, and rejects late measurements or releases from an outdated frame. Workstation deletes its private signature/invalidation block and uses the same controller.

Evidence: L3 (headed Chrome, native window resizing and movement, actual DOM/menu/preview bounds and completed transfer) → L3 required (AC-1/4). No remaining acceptance for this leaf. Native movement uses on-screen CDP bounds; this is not a human OS titlebar-grab receipt.

## AC Evidence

| AC | Evidence |
|---|---|
| AC-1 | Outside-CI: the permanent active-hover journey first proves a warm 146px measurement, enlarges the target to 520px, keeps the source within its former bounds, checks refreshed menu/preview rectangles against actual DOM, then completes the transfer. |
| AC-2 | CI-covered: a newer measurement wins over a late older one; a height-only resize during measurement discards the old result. Release with cached pre-resize indicator bounds commits nothing; a fresh gesture still commits. |
| AC-3 | CI-covered: unchanged window size reuses the same promise and issues one measurement. Outside-CI: the existing resize-before-hover positive remains green. |
| AC-4 | Outside-CI: four native journeys pass, and the exact new active-hover arm fails with the two production files restored to unchanged merged source. |

## Deltas from ticket

Rebased onto merged `3ac48bb1` after #18407. The source merged cleanly; only generated baseline counts changed in `git range-diff` against the approved commit.

The fix moves the existing Workstation main-window invalidation into the shared controller, rather than adding a popup-only path. Workstation's `mainPreviewWindowSignature`, update block and reset are deleted; its implementation count drops 2922 → 2914. Client-space geometry is keyed by window identity and size, so moving a native window without resizing does not cause redundant measurement.

The existing journey helper gains an active-hover option and retains its original and resize-before-hover cases. The controller's old zone-change-only documentation is corrected to match the shared candidate selector.

## Test Evidence

Headed, outside CI:

```bash
NEO_AGENTOS_RUNTIME_ROOT=<neo-agent-brain> npx playwright test -c test/playwright/playwright.config.e2e.mjs test/playwright/e2e/workstation/WorkstationNativePopupOverPopupNL.spec.mjs test/playwright/e2e/workstation/WorkstationNativeTitlebarDragNL.spec.mjs --headed --workers=1
```

**4 passed, 24.1s at rebased head `4348fc8b`:** normal popup transfer, resize-before-hover, resize-during-active-hover, and popup-to-main. The resized cases compare measured host and candidate-zone rectangles with actual DOM geometry and retain source retirement and same-pane ownership assertions.

**Pre-fix control:** restore both changed production files to merged `2bbcd5e26b`, keeping the new test. The active-hover case fails in 4.8s: cached preview host width **146**, actual resized DOM width **520**. The repaired production files were restored afterward.

Both new unit controls also failed before the source change: resize reused the same measurement promise, and release committed using the stale indicator bounds. Their repaired positives include unchanged-size reuse and successful fresh-gesture commit.

These are scoped runs on the shared host, not independent-environment samples. The native specs' separate headless limitations remain recorded on #18402.

## Post-Merge Validation

None for this leaf. Broader epic closeout, headless-CI selection and unrelated E2E failures remain outside this PR.

Authored by Euclid (GPT-6, Codex). Session 01a07609-5e09-70f0-bf2c-a27d77d1b7f2.


