### PR TITLE
feat(core): share bounded predicate waits (#18406)

### DIFF
--- a/apps/workstation/view/Workspace.mjs
+++ b/apps/workstation/view/Workspace.mjs
@@ -3507,15 +3507,7 @@ class Workspace extends DockWorkspace {
                     screenX: window.innerRect.x + (point?.x ?? startX),
                     screenY: window.innerRect.y + (point?.y ?? startY)
                 }),
-                waitUntil      = async (predicate, attempts=120) => {
-                    for (let attempt = 0; attempt <= attempts && !me.isDestroyed; attempt++) {
-                        if (predicate()) return true;
-
-                        attempt < attempts && await me.timeout(16)
-                    }
-
-                    return Boolean(predicate())
-                },
+                waitUntil      = (predicate, attempts=120) => me.waitFor(predicate, {attempts, delay: 16}),
                 moveTo         = (x, y) => {
                     if (cursorDot) {
                         cursorDot.style = {...cursorDot.style, left: `${x - 8}px`, top: `${y - 8}px`}
@@ -4744,13 +4736,7 @@ class Workspace extends DockWorkspace {
         let me    = this,
             armed = () => Boolean(sortZone?.dragProxy && sortZone?.boundaryContainerRect && sortZone?.itemRects);
 
-        for (let attempt = 0; attempt <= attempts && !me.isDestroyed; attempt++) {
-            if (armed()) return true;
-
-            attempt < attempts && await me.timeout(delay)
-        }
-
-        return armed()
+        return me.waitFor(armed, {attempts, delay})
     }
 
     /**
@@ -4767,13 +4753,9 @@ class Workspace extends DockWorkspace {
     async waitForTearOutVessel(itemId, {attempts=180, delay=16}={}) {
         let me = this;
 
-        for (let attempt = 0; attempt <= attempts && !me.isDestroyed; attempt++) {
-            if (me.nativeWindows?.getConnection(me.id, itemId) || me.nativeWindows?.getOwner(me.id, itemId)) return true;
-
-            attempt < attempts && await me.timeout(delay)
-        }
-
-        return Boolean(me.nativeWindows?.getConnection(me.id, itemId) || me.nativeWindows?.getOwner(me.id, itemId))
+        return me.waitFor(() => Boolean(
+            me.nativeWindows?.getConnection(me.id, itemId) || me.nativeWindows?.getOwner(me.id, itemId)
+        ), {attempts, delay})
     }
 
     /**
@@ -4793,13 +4775,7 @@ class Workspace extends DockWorkspace {
                 !me.tearOutEmbodiment.isStaged(itemId) && !me.tearOutHandlers.activeVessel
             );
 
-        for (let attempt = 0; attempt <= attempts && !me.isDestroyed; attempt++) {
-            if (retired()) return true;
-
-            attempt < attempts && await me.timeout(delay)
-        }
-
-        return retired()
+        return me.waitFor(retired, {attempts, delay})
     }
 
     /**
@@ -4821,13 +4797,7 @@ class Workspace extends DockWorkspace {
                     && Boolean(document.items?.[itemId])
             };
 
-        for (let attempt = 0; attempt <= attempts && !me.isDestroyed; attempt++) {
-            if (detached()) return true;
-
-            attempt < attempts && await me.timeout(delay)
-        }
-
-        return detached()
+        return me.waitFor(detached, {attempts, delay})
     }
 
     /**

--- a/buildScripts/util/file-size-baseline.json
+++ b/buildScripts/util/file-size-baseline.json
@@ -1,6 +1,6 @@
 {
-    "apps/workstation/view/Workspace.mjs": 2942,
-    "examples/dashboard/crossWindow/DemoBWorkspace.mjs": 2622,
+    "apps/workstation/view/Workspace.mjs": 2922,
+    "examples/dashboard/crossWindow/DemoBWorkspace.mjs": 2610,
     "src/dashboard/dock/Workspace.mjs": 1017,
     "src/main/addon/DragDrop.mjs": 1267
 }

--- a/examples/dashboard/crossWindow/DemoBWorkspace.mjs
+++ b/examples/dashboard/crossWindow/DemoBWorkspace.mjs
@@ -2856,13 +2856,7 @@ class DemoBWorkspace extends Container {
             // container/SortZone.onDragMove needs before it reaches checkWindowBoundary (@582/@588).
             armed = () => Boolean(sortZone?.dragProxy && sortZone?.boundaryContainerRect && sortZone?.itemRects);
 
-        for (let attempt = 0; attempt <= attempts && !me.isDestroyed; attempt++) {
-            if (armed()) return true;
-
-            attempt < attempts && await me.timeout(delay)
-        }
-
-        return armed()
+        return me.waitFor(armed, {attempts, delay})
     }
 
     /**
@@ -2925,13 +2919,7 @@ class DemoBWorkspace extends Container {
     async waitForTearOutVessel(itemId, {attempts = 180, delay = 16} = {}) {
         let me = this;
 
-        for (let attempt = 0; attempt <= attempts && !me.isDestroyed; attempt++) {
-            if (me.hasTearOutVessel(itemId)) return true;
-
-            attempt < attempts && await me.timeout(delay)
-        }
-
-        return me.hasTearOutVessel(itemId)
+        return me.waitFor(() => me.hasTearOutVessel(itemId), {attempts, delay})
     }
 
     /**
@@ -2954,13 +2942,7 @@ class DemoBWorkspace extends Container {
                     && Boolean(document.items?.[itemId])
             };
 
-        for (let attempt = 0; attempt <= attempts && !me.isDestroyed; attempt++) {
-            if (detached()) return true;
-
-            attempt < attempts && await me.timeout(delay)
-        }
-
-        return detached()
+        return me.waitFor(detached, {attempts, delay})
     }
 
     /**

--- a/src/core/Base.mjs
+++ b/src/core/Base.mjs
@@ -1165,6 +1165,28 @@ class Base {
     }
 
     /**
+     * @summary Waits for a synchronous predicate using this instance's cancellable timeouts.
+     * Samples immediately and once more after the retry budget is exhausted. Predicate errors
+     * propagate; destruction during a pending timeout rejects with `Neo.isDestroyed`.
+     * @param {Function} predicate Synchronous readiness check
+     * @param {Object} [options={}]
+     * @param {Number} [options.attempts=120] Maximum number of waits
+     * @param {Number} [options.delay=16] Delay between samples in milliseconds
+     * @returns {Promise<Boolean>}
+     */
+    async waitFor(predicate, {attempts=120, delay=16}={}) {
+        let me = this;
+
+        for (let attempt = 0; attempt <= attempts && !me.isDestroyed; attempt++) {
+            if (predicate()) return true;
+
+            attempt < attempts && await me.timeout(delay)
+        }
+
+        return Boolean(predicate())
+    }
+
+    /**
      * Wraps a promise to ensure it rejects if the component is destroyed before completion.
      * @param {Promise} promise - The promise to wrap.
      * @returns {Promise}

--- a/test/playwright/unit/apps/workstation/Workspace.spec.mjs
+++ b/test/playwright/unit/apps/workstation/Workspace.spec.mjs
@@ -2473,6 +2473,7 @@ test.describe('cross-zone dwell candidate re-verification (prototype-call)', () 
                 },
                 cancelTearOutGesture   : async () => ({}),
                 retireFilmCursorDot    : async () => {},
+                waitFor                : core.Base.prototype.waitFor,
                 waitForTearOutDragArmed: async () => true
             },
             step = {

--- a/test/playwright/unit/core/BaseTimeout.spec.mjs
+++ b/test/playwright/unit/core/BaseTimeout.spec.mjs
@@ -2,6 +2,90 @@ import {test, expect} from '@playwright/test';
 import Neo            from '../../../../src/Neo.mjs';
 import * as core      from '../../../../src/core/_export.mjs';
 
+test.describe('core/Base bounded predicate waits', () => {
+    test('immediate success schedules no timeout', async () => {
+        const instance = Neo.create(core.Base);
+        let   waits    = 0;
+
+        instance.timeout = async () => { waits++ };
+
+        try {
+            await expect(instance.waitFor(() => true)).resolves.toBe(true);
+            expect(waits).toBe(0)
+        } finally {
+            instance.destroy()
+        }
+    });
+
+    test('uses the instance timeout until a predicate succeeds', async () => {
+        const instance = Neo.create(core.Base),
+              delays   = [];
+        let samples = 0;
+
+        instance.timeout = async delay => { delays.push(delay) };
+
+        try {
+            await expect(instance.waitFor(() => ++samples === 3, {attempts: 5, delay: 7})).resolves.toBe(true);
+            expect(samples).toBe(3);
+            expect(delays).toEqual([7, 7])
+        } finally {
+            instance.destroy()
+        }
+    });
+
+    for (const finalResult of [false, true]) {
+        test(`exhaustion performs the final sample: ${finalResult}`, async () => {
+            const instance = Neo.create(core.Base),
+                  delays   = [];
+            let samples = 0;
+
+            instance.timeout = async delay => { delays.push(delay) };
+
+            try {
+                await expect(instance.waitFor(() => ++samples === 4 && finalResult, {
+                    attempts: 2,
+                    delay   : 9
+                })).resolves.toBe(finalResult);
+                expect(samples).toBe(4);
+                expect(delays).toEqual([9, 9])
+            } finally {
+                instance.destroy()
+            }
+        })
+    }
+
+    test('propagates a predicate failure', async () => {
+        const instance = Neo.create(core.Base),
+              failure  = new Error('predicate failed');
+
+        try {
+            await expect(instance.waitFor(() => { throw failure })).rejects.toBe(failure)
+        } finally {
+            instance.destroy()
+        }
+    });
+
+    test('destroy rejects a pending wait without changing another instance', async () => {
+        const instance = Neo.create(core.Base),
+              other    = Neo.create(core.Base);
+        let samples = 0;
+
+        try {
+            const pending = instance.waitFor(() => { samples++; return false }, {delay: 1000});
+
+            instance.destroy();
+
+            await expect(pending).rejects.toBe(Neo.isDestroyed);
+            expect(samples).toBe(1);
+            await expect(other.waitFor(() => true)).resolves.toBe(true);
+            expect(other.isDestroyed).toBeFalsy()
+        } finally {
+            !instance.isDestroyed && instance.destroy();
+            other.destroy()
+        }
+    })
+});
+
 test.describe('core/Base Timeout Handling', () => {
     test('timeout() should resolve after the specified delay', async () => {
         class TestClass extends core.Base {


### PR DESCRIPTION
Resolves #18406

Base now owns bounded synchronous predicate polling through `waitFor()`, using its existing cancellable `timeout()` lifecycle. Eight repeated Boolean wait bodies in Workstation and DemoB delegate to it while retaining their predicates, defaults and public methods. The consumers lose 32 code lines; no new module or collaborator is introduced.

Evidence: L2 (actual Base timeout/destruction controls and consumer unit suites) → L2 required (shared polling and unchanged lifecycle contract). Residual: none.

Related: #18304

## AC Evidence

| AC | Evidence |
|---|---|
| AC-1 | `src/core/Base.mjs`: one `waitFor()` implementation calling the instance's existing `timeout()`. |
| AC-2 | Five Workstation and three DemoB loop bodies removed; seven gesture/snapshot/receipt loops remain outside this cut. |
| AC-3 | `test/playwright/unit/core/BaseTimeout.spec.mjs`: immediate and delayed success, bounded waits/final sampling, predicate failure, destruction rejection and instance isolation. |
| AC-4 | Focused consumer/core suites and full unit suite; baseline records Workstation 2942→2922 and DemoB 2622→2610 code lines. |

## Deltas from ticket

One existing Workstation prototype-call fixture now supplies the actual Base method that real consumers inherit. Its two dwell-loss controls initially failed on the incomplete test host and remain unchanged after this fixture repair.

## Test Evidence

All coverage runs in CI. The six new controls were first run against the unchanged Base and failed because the method did not exist. The implementation preserves the final predicate sample and propagates `Neo.isDestroyed` from a pending timeout.

One local full run failed the existing `VdomDestroyCancellation` sentinel. It passed in isolation alongside the new Base controls, and the unchanged full rerun passed. No VDOM implementation was changed.

## Post-Merge Validation

No merge-only validation is required for this polling contract. This PR makes no new native-window or rendered-journey claim.

Authored by Emmy (GPT-6 Astra, Codex). Session 10c286a7-65e7-4f15-be8e-8dace71af32d.
