### PR TITLE
test(workstation): the overflow-cap witness stages its own case instead of finding one (#18410)

### DIFF
--- a/test/playwright/e2e/workstation/WorkstationTabOverflowCapNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationTabOverflowCapNL.spec.mjs
@@ -113,11 +113,16 @@ test.describe('Workstation — the active tab never runs beneath the overflow co
         // Read back BY ID. The defect this spec now guards against was a document-order query
         // resolving to a different header's button, so waiting on the class alone would reinstate
         // exactly the substitution the stage exists to prevent.
-        await page.waitForFunction(
-            id => document.getElementById(id)?.classList.contains('neo-tab-overflow-capped'),
-            stage.activeId,
-            {timeout: 30000}
-        );
+        // `expect.poll` rather than `waitForFunction`, purely for what the timeout SAYS. A bare
+        // `waitForFunction` expiry reads "Timeout 30000ms exceeded" and names neither the header
+        // nor the stage, which is the failure this spec was rewritten to stop producing.
+        await expect.poll(
+            () => page.evaluate(id => document.getElementById(id)?.classList.contains('neo-tab-overflow-capped') ?? false, stage.activeId),
+            {
+                message: `${stage.activeId} in ${stage.toolbarId} must be capped after the stage — its label was widened and the toolbar narrowed. No cap means the projection never ran on the surface this spec staged.`,
+                timeout: 30000
+            }
+        ).toBe(true);
 
         const facts = await page.evaluate(({activeId, toolbarId}) => {
             const rect = el => {
@@ -171,7 +176,19 @@ test.describe('Workstation — the active tab never runs beneath the overflow co
                 toolbarRect: rect(toolbar),
                 // Ordinary case: every pressed button OUTSIDE the staged header is uncapped and its
                 // absolute indicator spans its full box.
-                ordinary: pressed.filter(button => button.closest('.neo-tab-header-toolbar') !== toolbar)
+                ordinary: pressed.filter(button => {
+                    const owner = button.closest('.neo-tab-header-toolbar');
+
+                    // Excluding the reveals is not tidying: a collapsed reveal's title is `pressed`
+                    // and carries a STATIC cap class while measuring zero width, so it entered this
+                    // control as an empty-text, zero-box row that no assertion below can fail. A
+                    // control padded with unpaintable entries reports coverage it does not have —
+                    // the same substitution this spec exists to remove, one level along, inside my
+                    // own control.
+                    return owner && owner !== toolbar &&
+                        !owner.classList.contains('neo-dashboard-dock-reveal-header') &&
+                        rect(button).width > 0
+                })
                     .map(button => {
                         const indicator = button.querySelector('.neo-tab-button-indicator');
                         return {

--- a/test/playwright/e2e/workstation/WorkstationTabOverflowCapNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationTabOverflowCapNL.spec.mjs
@@ -6,15 +6,26 @@ import {test, expect} from '../../fixtures.mjs';
  * The overflow packing keeps the active tab visible even when it alone is wider than the usable
  * strip (active-never-hidden). Unbounded, that box — and every geometry derived from it: the
  * persistent per-button indicator, the strip's crossfade indicator, the label glyphs — runs
- * beneath the floating overflow control. The workstation heavy header stages this degenerate
- * case at default boot (twelve canonical titles in a narrow pane), so the assertions run against
- * the real composition: the capped box must end where the control begins, the reservation the cap
- * used must equal the RENDERED trailing action cluster (one value, render-grounded, never a second
- * derivation), and headers without an overflow control must keep their full natural width.
+ * beneath the floating overflow control. So the assertions run against a real composition: the
+ * capped box must end where the control begins, the reservation the cap used must equal the
+ * RENDERED trailing action cluster (one value, render-grounded, never a second derivation), and
+ * headers without an overflow control must keep their full natural width.
  *
  * The reserve is the cluster and not the control alone because the header's trailing partition is
  * variable — an engine action set opts in per consumer, and gated actions keep their box — so a
  * cap measured against one control would let the active tab run under the rest of them.
+ *
+ * **This spec stages the degenerate case itself.** It used to inherit it from the app's boot
+ * composition and read it back with `document.querySelector('.neo-tab-overflow-capped')`. When that
+ * composition drifted and no header overflowed any more, the query did not come back empty — it
+ * returned the title of a collapsed, zero-width dock reveal, whose trailing partition is a single
+ * pin by design. Every downstream measurement then described the reveal's strip, and the staging
+ * guard reported `Expected: > 1, Received: 1` about a surface the spec never meant to touch. Two
+ * peers spent a bisect and a mechanism hunt on a product regression that did not exist.
+ *
+ * Hence the shape below: the header is chosen by PREDICATE, the over-wide active is manufactured by
+ * widening a real tab's label, and the capped button is read back BY ID. A missing stage now fails
+ * as a missing stage.
  *
  * Run: NEO_E2E_PORT=8156 npx playwright test workstation/WorkstationTabOverflowCapNL -c test/playwright/playwright.config.e2e.mjs --workers=1
  */
@@ -25,7 +36,14 @@ test.describe('Workstation — the active tab never runs beneath the overflow co
         viewport      : {height: 840, width: 1180}
     });
 
-    test('the degenerate over-wide active is capped at the control edge; ordinary headers stay full width', async ({page}) => {
+    /**
+     * Long enough that the active label alone cannot fit the usable strip at any sane glyph width,
+     * and distinctive so a failure message names the button the spec staged rather than one it
+     * happened to find.
+     */
+    const OVER_WIDE = 'Priority Alert Observatory — staged over-wide active label for the overflow cap witness';
+
+    test('the degenerate over-wide active is capped at the control edge; ordinary headers stay full width', async ({neo, page}) => {
         const pageErrors = [];
 
         page.on('pageerror', error => {
@@ -36,12 +54,72 @@ test.describe('Workstation — the active tab never runs beneath the overflow co
         await page.goto('/apps/workstation/index.html');
         await page.waitForSelector('.workstation-dock-host', {timeout: 60000});
         await page.waitForSelector('.neo-tab-overflow-control', {timeout: 60000});
-        // The cap rides the same projection pass that syncs the control; the settle keeps this spec
-        // anchored on the control (which exists in every variant) so a cap-less build fails on the
-        // painted-intersection assertions below instead of a selector timeout.
-        await page.waitForTimeout(1200);
 
-        const facts = await page.evaluate(() => {
+        // Chosen by predicate, never by document order. The requirement is a header that owns an
+        // overflow control AND a multi-action trailing partition — the two things the assertions
+        // below measure against. A dock reveal satisfies neither, and excluding it explicitly
+        // costs one clause and removes the whole substitution class.
+        const stage = await page.evaluate(() => {
+            const toolbar = [...document.querySelectorAll('.neo-tab-header-toolbar')].find(candidate =>
+                !candidate.classList.contains('neo-dashboard-dock-reveal-header') &&
+                candidate.clientWidth > 0 &&
+                !!candidate.querySelector('.neo-tab-overflow-control') &&
+                candidate.querySelectorAll(':scope > .neo-toolbar-action').length > 1);
+
+            if (!toolbar) {
+                // The rejected candidates travel with the failure, because "no header qualified" is
+                // unactionable while "six headers, none with a control" names the drift.
+                return {
+                    rejected: [...document.querySelectorAll('.neo-tab-header-toolbar')].map(candidate => ({
+                        actions: candidate.querySelectorAll(':scope > .neo-toolbar-action').length,
+                        control: !!candidate.querySelector('.neo-tab-overflow-control'),
+                        reveal : candidate.classList.contains('neo-dashboard-dock-reveal-header'),
+                        width  : Math.round(candidate.clientWidth)
+                    })),
+                    toolbarId: null
+                }
+            }
+
+            const active = toolbar.querySelector('.neo-tab-header-button.pressed');
+
+            return {activeId: active?.id ?? null, rejected: null, toolbarId: toolbar.id}
+        });
+
+        expect(stage.toolbarId,
+            `no header stages the overflow branch — the app must boot one non-reveal header owning an overflow control and a multi-action trailing partition. Candidates: ${JSON.stringify(stage.rejected)}`
+        ).toBeTruthy();
+
+        expect(stage.activeId, `${stage.toolbarId} must carry a pressed tab to widen`).toBeTruthy();
+
+        // The stage has two halves, and BOTH are load-bearing.
+        //
+        // The label makes the active tab degenerate on purpose: widened through the component's own
+        // config, so the box the plugin later measures is a genuinely rendered over-wide label
+        // rather than anything simulated in the DOM.
+        await neo.setConfig(stage.activeId, {text: OVER_WIDE});
+
+        // The narrowing is what schedules the cap pass, and assuming otherwise cost an hour.
+        // Measured: after the label alone, the active box rendered 474px inside a 276px strip with
+        // `scrollWidth` 522 — a genuinely overflowing header — and NO cap appeared. A viewport nudge
+        // did not help either, and the numbers say why: the toolbar stayed 276px through it, so a
+        // geometry-keyed pass had nothing to react to. That control proved its branch ran and
+        // proved nothing about the payload.
+        //
+        // A real width change (276 → 108) caps immediately. The cap is driven by toolbar geometry,
+        // not by label content, so a spec that widens a label and waits is asserting against a pass
+        // that was never scheduled.
+        await page.setViewportSize({height: 840, width: 760});
+
+        // Read back BY ID. The defect this spec now guards against was a document-order query
+        // resolving to a different header's button, so waiting on the class alone would reinstate
+        // exactly the substitution the stage exists to prevent.
+        await page.waitForFunction(
+            id => document.getElementById(id)?.classList.contains('neo-tab-overflow-capped'),
+            stage.activeId,
+            {timeout: 30000}
+        );
+
+        const facts = await page.evaluate(({activeId, toolbarId}) => {
             const rect = el => {
                       const {left, right, top, bottom, width} = el.getBoundingClientRect();
                       return {left, right, top, bottom, width}
@@ -49,66 +127,70 @@ test.describe('Workstation — the active tab never runs beneath the overflow co
                   overlap = (a, b) => Math.max(0,
                       Math.min(a.right, b.right) - Math.max(a.left, b.left)) * Math.max(0,
                       Math.min(a.bottom, b.bottom) - Math.max(a.top, b.top)),
-                  control = document.querySelector('.neo-tab-overflow-control'),
-                  capped  = document.querySelector('.neo-tab-overflow-capped'),
+                  toolbar = document.getElementById(toolbarId),
+                  capped  = document.getElementById(activeId),
+                  // Scoped to the staged header. A document-wide control query would pick whichever
+                  // control comes first, which is the same defect one level along.
+                  control = toolbar.querySelector('.neo-tab-overflow-control'),
                   // Resolved once and reported through sentinels below. A capped button that lost
                   // its text or indicator node is a DIFFERENT failure from one whose style is
                   // wrong, and reading them inline threw `getComputedStyle(null)` — a TypeError
                   // that aborts the evaluate and names neither condition.
-                  cappedText      = capped?.querySelector('.neo-button-text'),
-                  cappedIndicator = capped?.querySelector('.neo-tab-button-indicator'),
-                  toolbar = capped?.closest('.neo-tab-header-toolbar'),
-                  pressed = [...document.querySelectorAll('.neo-tab-header-button.pressed')];
+                  cappedText      = capped.querySelector('.neo-button-text'),
+                  cappedIndicator = capped.querySelector('.neo-tab-button-indicator'),
+                  pressed         = [...document.querySelectorAll('.neo-tab-header-button.pressed')];
 
             // The reserve is the WHOLE trailing action partition, not the overflow control alone.
             // Gated actions count: the focus-gating carrier hides them with `visibility`, which
             // preserves their box, so a tab allowed to run under a quiet action would still be
             // covered the moment its pane takes focus. Measured from the DOM rather than a count
             // times an assumed size — the partition is per-consumer and per-opt-in flag.
-            const actions = toolbar ? [...toolbar.querySelectorAll(':scope > .neo-toolbar-action')] : [],
-                  cluster = actions.length && toolbar
+            const actions = [...toolbar.querySelectorAll(':scope > .neo-toolbar-action')],
+                  cluster = actions.length
                       ? rect(toolbar).right - Math.min(...actions.map(action => rect(action).left))
                       : 0;
 
             return {
-                control     : control && rect(control),
-                actionCount : actions.length,
-                clusterWidth: cluster,
-                capped      : capped && {
+                actionCount: actions.length,
+                capped     : {
                     rect         : rect(capped),
                     maxWidth     : parseFloat(capped.style.maxWidth),
                     textOverflow : cappedText ? getComputedStyle(cappedText).textOverflow : 'no-text-node',
                     indicatorRect: cappedIndicator ? rect(cappedIndicator) : null,
                     controlIx    : control ? overlap(rect(capped), rect(control)) : -1
                 },
-                toolbarRect: toolbar && rect(toolbar),
-                pressedIx  : pressed.map(button => ({
-                    text: button.textContent.trim(),
-                    ix  : control ? overlap(rect(button), rect(control)) : -1
-                })),
-                // Ordinary case: every pressed button OUTSIDE the overflowing header is uncapped and its
+                clusterWidth: cluster,
+                control     : control && rect(control),
+                // Every pressed button in the staged header, control-relative. Scoped, because a
+                // pressed button in a header that owns no control cannot intersect one.
+                pressedIx: pressed.filter(button => button.closest('.neo-tab-header-toolbar') === toolbar)
+                    .map(button => ({
+                        ix  : control ? overlap(rect(button), rect(control)) : -1,
+                        text: button.textContent.trim()
+                    })),
+                toolbarRect: rect(toolbar),
+                // Ordinary case: every pressed button OUTSIDE the staged header is uncapped and its
                 // absolute indicator spans its full box.
-                ordinary: pressed.filter(button => !button.classList.contains('neo-tab-overflow-capped'))
+                ordinary: pressed.filter(button => button.closest('.neo-tab-header-toolbar') !== toolbar)
                     .map(button => {
                         const indicator = button.querySelector('.neo-tab-button-indicator');
                         return {
-                            text       : button.textContent.trim(),
                             hasCapStyle: !!button.style.maxWidth,
+                            text       : button.textContent.trim(),
                             widthDelta : indicator ? Math.abs(rect(indicator).width - rect(button).width) : null
                         }
                     })
             }
-        });
+        }, stage);
 
-        expect(facts.control, 'precondition: the heavy header must render its overflow control at default boot').toBeTruthy();
+        expect(facts.control, `the staged header ${stage.toolbarId} must render its overflow control`).toBeTruthy();
 
-        // The symptom, first: no pressed button anywhere paints beneath the control. This is the
-        // assertion that convicts an uncapped build directly with the measured overlap in the message.
+        // The symptom, first: no pressed button in the staged header paints beneath the control.
+        // This is the assertion that convicts an uncapped build directly with the measured overlap
+        // in the message.
         facts.pressedIx.forEach(entry => {
             expect(entry.ix, `${entry.text}: pressed button must not intersect the overflow control`).toBe(0)
         });
-
-        expect(facts.capped, 'the degenerate over-wide active must be capped — if no cap exists, the stage no longer exercises this branch and the spec must fail loudly').toBeTruthy();
 
         // The core geometry: the capped active box — and the per-button indicator spanning it — ends
         // where the control begins. Zero painted intersection.
@@ -123,10 +205,11 @@ test.describe('Workstation — the active tab never runs beneath the overflow co
             'the per-button indicator spans exactly the capped box'
         ).toBeLessThanOrEqual(1);
 
-        // The staging guard: this identity is only meaningful while the header carries a real action
-        // partition. If the app ever collapses back to a lone overflow control, the assertion below
-        // degenerates into the single-operand form it replaced and stops testing the cluster at all.
-        expect(facts.actionCount, 'the heavy header must stage a multi-action trailing partition')
+        // Guards the predicate that selected this header, against the header itself: the cluster
+        // identity below is only meaningful while the trailing partition is real. If the staged
+        // header ever collapses to a lone overflow control, this fails instead of degenerating into
+        // the single-operand form it replaced.
+        expect(facts.actionCount, `${stage.toolbarId} must still carry the multi-action trailing partition it was selected for`)
             .toBeGreaterThan(1);
 
         // Reservation truth (single value, render-grounded): the cap the plugin applied equals the


### PR DESCRIPTION
Resolves #18410

`WorkstationTabOverflowCapNL` has been failing on `dev` at its staging guard. Two mechanisms were proposed tonight and both are dead: @neo-opus-vega bisected `HeaderActionPolicy`/#18306 out, then hypothesised that actions had been nested one level deeper. Neither is it.

The spec was measuring a different surface than the one it documents.

Evidence: L2 → L2 required (a DOM-geometry claim about a running app is only checkable against a running app). Residual: none.

## AC Evidence

| AC | Evidence |
|---|---|
| Stages the over-wide active itself rather than inheriting it from boot defaults | Header selected by predicate, active label widened via `neo.setConfig`, toolbar narrowed to schedule the pass. |
| Selection cannot resolve to a reveal or a zero-width element | The predicate excludes `.neo-dashboard-dock-reveal-header` and `clientWidth === 0`, and requires both an overflow control and a multi-action partition. |
| A missing STAGE fails naming it — **verified, not inspected** | Removed the staging step and read the message. Receipt below. |
| A missing qualifying HEADER fails naming it | Separate control, predicate broken to `> 99`. Receipt below. |
| The ordinary control excludes unpaintable rows | Reveal headers and zero-width buttons filtered out, after @neo-gpt's review. See **Deltas**. |
| The guard measures the surface the assertions use | Everything downstream reads `document.getElementById(stage.activeId)` and the staged toolbar; the `> 1` guard now names the header it measured. |
| Re-running against `ac93c04e3c` no longer reproduces | Passes on pre-#18306 source in a worktree. Receipt below. |

## The Substitution

Probed all eight `.neo-tab-header-toolbar` elements in the running app at the spec's own viewport:

| kind | actions | capped | ctrl | clientW | scrollW | activeW |
|---|---|---|---|---|---|---|
| **reveal** | 1 | **1** | – | **0** | 0 | 0 |
| **reveal** | 1 | **1** | – | **0** | 0 | 0 |
| header | 1 | 0 | – | 180 | 180 | 58 |
| header | 1 | 0 | – | 413 | 413 | 78 |
| header | 2 | 0 | ✔ | 276 | 276 | 149 |
| header | 1 | 0 | – | 220 | 220 | 55 |
| header | 1 | 0 | – | 220 | 220 | 63 |
| header | 1 | 0 | – | 1156 | 1156 | 114 |

No header overflows — `scrollWidth === clientWidth` on all six real ones. None carries a cap. The only two `.neo-tab-overflow-capped` elements in the document are the titles of collapsed, zero-width dock reveals, and their class is set **statically** in `RevealOverlay.mjs:204`, not by the plugin. A reveal's trailing partition is one pin by design.

`document.querySelector('.neo-tab-overflow-capped')` takes the first match in document order, so it returned a reveal title, and `toolbar` / `actions` / `clusterWidth` / the cap identity all then described the reveal's strip. `Received: 1` was the correct answer to the wrong question — which is exactly why no source change explained it, and why it reproduces identically before #18306.

**The part worth carrying elsewhere:** the spec already had a loud-failure guard for this — *"if no cap exists, the stage no longer exercises this branch and the spec must fail loudly"*. It could not fire, because a cap **did** exist. A selector that silently substitutes a different surface defeats a guard written against absence.

## Deltas from ticket

One correction to my own ticket. `#18410` implies the cap may not fire on a real over-wide active; **it does, and I nearly published otherwise.** Widening the label alone renders 474px inside a 276px strip with `scrollWidth` 522 — genuinely overflowing — and caps nothing. A viewport nudge did not help. Both readings pointed at a product regression, and both were wrong: the toolbar stayed **276px** through the nudge, so a geometry-keyed pass had nothing to react to. **That control proved its branch ran and proved nothing about the payload.**

A real width change (276 → 108) caps immediately, at `maxWidth: 59px`, on the staged button. So the plugin is correct and the cap is driven by toolbar geometry rather than label content. The stage needs both halves, and the comment in the spec says so with the numbers.

Not filed as a defect: whether a label arriving via config *should* re-cap without a resize is a separate design question, and inflating a measurement into a ticket is how the last false lead started.

## Test Evidence

```
✓ WorkstationTabOverflowCapNL … capped at the control edge (1.1s)
  1 passed (3.0s)
```

Was a 31s timeout before. Two controls, both run rather than reasoned:

**Missing STAGE fails loudly** — removed the narrowing that schedules the cap, label still widened:

```
Error: neo-tab-header-button-4 in neo-tab-header-toolbar-4 must be capped after the stage —
its label was widened and the toolbar narrowed. No cap means the projection never ran on the
surface this spec staged.
  Expected: true    Received: false
```

The wait was a bare `waitForFunction` whose expiry read only `Timeout 30000ms exceeded`, naming neither header nor stage. It is an `expect.poll` now, purely for that message.

**Missing qualifying HEADER fails loudly** — a different control for a different failure, predicate broken to `> 99`:

```
Error: no header stages the overflow branch — the app must boot one non-reveal header
owning an overflow control and a multi-action trailing partition. Candidates:
[{"actions":1,"control":false,"reveal":true,"width":0}, … {"actions":2,"control":true,"reveal":false,"width":276}, …]
```

Every rejected toolbar travels with the failure, so the two zero-width reveals are visible at a glance.

**Vega's bisect closed** — repaired spec against `ac93c04e3c`, the commit immediately before #18306, in a detached worktree:

```
[WebServer] Content not from webpack is served from '…/wt-ac93'
✓ … (1.1s)
1 passed (4.5s)
```

The server line is included because a worktree run that silently served the main checkout would have proved nothing.

## Deltas from ticket — two review repairs

**The ordinary-headers control was padded.** It filtered on *"not the staged toolbar"*, which let the two collapsed dock reveals in: their titles are `pressed` and carry a **static** cap class from `RevealOverlay` while measuring **zero width**, so they entered as empty-text, zero-box rows that no assertion below can fail. @neo-gpt found two of them in the retained trace.

That is this spec's own defect, one level along, inside the control written to remove it. **The substitution was never only about `querySelector`** — any filter selecting by what something is *not* inherits whatever else satisfies the class. Reveal headers and zero-width buttons are now excluded explicitly.

**The two controls prove different things.** `> 99` proves no header *qualifies*; the criterion asked whether a missing *stage* fails informatively. Both are kept, because I had been treating them as one.

## Post-Merge Validation

- [ ] `WorkstationPaletteBridgeNL`'s three timeouts wait for a **visible** `.neo-tab-header-button` while the capped candidates here measure zero width. One probe decides it. Stated as the next thing to check, not a finding.
- [ ] This spec stays in the GPU tier excluded from CI by #18408, so its green is a local one until that tier has a runner.

## Commits

- `3636c0c2a0` — the witness stages its own case

Authored by Ada (Claude Opus 5, Claude Code). Origin session 95f9ff6e-1ba5-43b6-860a-208fbf7f4442.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
