### PR TITLE
test(workstation): the palette bridge waits for a painted header, not a collapsed reveal (#18412)

### DIFF
--- a/test/playwright/e2e/workstation/WorkstationPaletteBridgeNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationPaletteBridgeNL.spec.mjs
@@ -74,7 +74,13 @@ async function bootWorkstation(page) {
     await page.goto('/apps/workstation/index.html');
     await page.waitForSelector('.workstation-workspace',   {timeout: 60000});
     await page.waitForSelector('.neo-grid-cell',           {timeout: 60000});
-    await page.waitForSelector('.neo-tab-header-button',   {timeout: 60000});
+    // Scoped past the dock reveals, because `waitForSelector` waits on the FIRST match in document
+    // order and a collapsed reveal comes first. Its title carries `neo-tab-header-button` while
+    // measuring zero width, so it can never become visible and the six painted headers behind it
+    // are never consulted — three arms here expired at 60s each on exactly that.
+    // `state: 'attached'` would also stop the timeout, but this wait means "a real tab header is
+    // painted", and that is worth keeping rather than weakening.
+    await page.waitForSelector('.neo-tab-header-toolbar:not(.neo-dashboard-dock-reveal-header) .neo-tab-header-button', {timeout: 60000});
     // `attached`, not the default `visible`: the engine set is focus-gated, so `pin` and `maximize`
     // rest at `visibility: hidden` with their geometry preserved. They still consume the bridged
     // tokens, and a colour that resolves to the theme is just as wrong while the action is quiet.


### PR DESCRIPTION
Resolves #18412

Three of `WorkstationPaletteBridgeNL`'s four arms have been red on `dev`, each burning a full 60s on the same line of shared setup. One selector fixes all three, and every assertion in them was already correct.

Evidence: L2 → L2 required (a DOM-visibility claim about a running app is only checkable against one). Residual: none.

## AC Evidence

| AC | Evidence |
|---|---|
| The three timing-out arms pass; the pop-out arm still passes | `4 passed (5.5s)`. Receipt below. |
| The wait cannot resolve to a reveal descendant | Selector is `.neo-tab-header-toolbar:not(.neo-dashboard-dock-reveal-header) .neo-tab-header-button`. |
| The readiness signal stays visibility-based | Default `state` retained; `attached` deliberately not used. |
| Runtime drops to the sub-second range the passing arm demonstrated | 3.1m → 5.5s. |

## The Mechanism

```
TimeoutError: page.waitForSelector: Timeout 60000ms exceeded.
  - waiting for locator('.neo-tab-header-button') to be visible
```

`waitForSelector` waits on the **first** match in document order. Measured in the running app, the first `.neo-tab-header-toolbar` is a collapsed dock reveal at `clientWidth: 0`, and its title carries the class:

```
neo-dashboard-dock-reveal-title neo-tab-overflow-capped neo-tab-header-button neo-button no-text icon-left pressed
```

Zero width is never visible, so the wait could only expire — while the six real headers, carrying tab buttons 55px to 149px wide, stayed painted throughout and were never consulted. The query never reached them.

**Nothing was broken.** The spec's assertions were right, the app was right; the readiness signal was blind. That is why the arms go green with no change to a single assertion.

Same defect class as #18410, one selector along — a document-order query resolving to a collapsed reveal instead of a real header. Between the two, five of the six red workstation e2e arms come back to that one mechanism.

## Deltas from ticket

None. The ticket's fix and ACs are what shipped.

Worth noting the near miss the ticket records: the spec's author had already met this hazard **one line below**, and solved it there —

```js
// `attached`, not the default `visible`: the engine set is focus-gated, so `pin` and `maximize`
// rest at `visibility: hidden` with their geometry preserved.
await page.waitForSelector('.neo-toolbar-action', {state: 'attached', timeout: 60000})
```

A reveal is a *second* way for a first match to be unpaintable, and the wait above it never got the same treatment. The lesson generalises past this file: **a fix applied to one selector is evidence about its neighbours.**

## Test Evidence

```
before   3 failed, 1 passed (3.1m)     ← three 60s expiries
after    4 passed (5.5s)
```

```
✓ every bridged token resolves to the instrument palette in both skins (1.3s)
✓ the bridge, not the theme, is what holds those values (1.1s)
✓ the pop-out vessel keeps the bridge it has no workspace to inherit it from (300ms)
✓ the grid header button block keeps winning on the element it declares on (553ms)
```

The pop-out arm was the one that already passed — it boots a different host and never hits the reveal — so it doubles as the control: it was unaffected before and after.

## Post-Merge Validation

- [ ] `WorkstationStarvedGeometryNL:64` is the sixth red and is **not** claimed by this mechanism. Unprobed, unowned, and deliberately not folded into this story.
- [ ] These arms sit in the GPU tier excluded from CI by #18408, so their green is local until that tier has a runner.

## Commits

- `84cc7c2cd1` — the wait scopes past the reveals

Authored by Ada (Claude Opus 5, Claude Code). Origin session 95f9ff6e-1ba5-43b6-860a-208fbf7f4442.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
