### PR TITLE
test(workstation): the starved-geometry pool claim is proportional, like its own premise (#18415)

### DIFF
--- a/test/playwright/e2e/workstation/WorkstationStarvedGeometryNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationStarvedGeometryNL.spec.mjs
@@ -57,7 +57,10 @@ test.describe('Workstation rendering starvation: grid geometry still converges (
             gridWidth     : rect ? rect.width : -1,
             mountedColumns: new Set(cells.map(cell => cell.getAttribute('aria-colindex')).filter(Boolean)).size,
             renderedCells : cells.filter(cell => cell.textContent.trim().length > 0).length,
-            rows          : grid ? grid.querySelectorAll('[role="row"]').length : -1
+            // Measured, never assumed: the pool claim below divides freed height by this, and a
+            // literal row height is the same rot the trigger premise already warns about.
+            rowHeight: cells[0] ? cells[0].getBoundingClientRect().height : -1,
+            rows     : grid ? grid.querySelectorAll('[role="row"]').length : -1
         }
     }, gridId);
 
@@ -161,10 +164,31 @@ test.describe('Workstation rendering starvation: grid geometry still converges (
         expect(domHeightAfterFlex - bootState.gridHeight, 'the zone mutation grew the grid layout box (trigger premise)')
             .toBeGreaterThan(freedBandHeight * 0.6);
 
+        // The pool claim is proportional for the same reason the trigger premise above it is, and
+        // for a reason the absolute form hid: the freed band is not a whole number of rows.
+        // Measured under this rig — 80px of new box at a 50px row is 1.60 rows, and the pool grew
+        // by ONE. The engine floors. `bootRows + 1` demanded a ceiling, so the arm convicted the
+        // carrier of starvation whenever the freed height landed between one and two rows, which
+        // is a rounding boundary rather than a regression.
+        const grownBox  = domHeightAfterFlex - bootState.gridHeight,
+              justified = Math.floor(grownBox / bootState.rowHeight);
+
+        expect(bootState.rowHeight, 'a row must have a measurable height, or the pool arithmetic below is meaningless')
+            .toBeGreaterThan(0);
+
+        // Without this the claim below degenerates into "the pool did not shrink", which a dead
+        // carrier satisfies just as well as a live one.
+        expect(justified,
+            `the rig must free at least one row of height — ${Math.round(grownBox)}px at a ${bootState.rowHeight}px row justifies none`
+        ).toBeGreaterThanOrEqual(1);
+
         await expect.poll(
             async () => (await readMatrixState(page, GRID_ID)).rows,
-            { message: 'the taller box grows the row pool without frames', timeout: 15000 }
-        ).toBeGreaterThan(bootRows + 1);
+            {
+                message: `the taller box grows the row pool without frames — ${Math.round(grownBox)}px of new box justifies ${justified} more row(s) at ${bootState.rowHeight}px`,
+                timeout: 15000
+            }
+        ).toBeGreaterThanOrEqual(bootRows + justified);
 
         // FEED CONTROL: ingestion kept painting fresh rows while the geometry carrier worked.
         await expect.poll(

--- a/test/playwright/e2e/workstation/WorkstationStarvedGeometryNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationStarvedGeometryNL.spec.mjs
@@ -166,10 +166,17 @@ test.describe('Workstation rendering starvation: grid geometry still converges (
 
         // The pool claim is proportional for the same reason the trigger premise above it is, and
         // for a reason the absolute form hid: the freed band is not a whole number of rows.
-        // Measured under this rig — 80px of new box at a 50px row is 1.60 rows, and the pool grew
-        // by ONE. The engine floors. `bootRows + 1` demanded a ceiling, so the arm convicted the
-        // carrier of starvation whenever the freed height landed between one and two rows, which
-        // is a rounding boundary rather than a regression.
+        // Measured under this rig — 80px of new box at a 50px row is 1.60 rows, the pool grew by
+        // ONE, and `bootRows + 1` demanded two. So the arm convicted the carrier of starvation on
+        // a rounding boundary rather than on a regression.
+        //
+        // The division below is a conservative LOWER BOUND on that growth, and deliberately not a
+        // model of the engine's rounding: `grid.Body` derives `availableRows` as
+        // `ceil(availableHeight / rowHeight) - 1` and pools that plus a fixed buffer, against an
+        // `availableHeight` the worker was handed rather than the container box measured here.
+        // A bound is the right instrument — this arm must convict a carrier that delivered
+        // NOTHING, and re-deriving a count the engine already owns would only couple the witness
+        // to the implementation it is meant to observe from outside.
         const grownBox  = domHeightAfterFlex - bootState.gridHeight,
               justified = Math.floor(grownBox / bootState.rowHeight);
 


### PR DESCRIPTION
Resolves #18415

The sixth and last of tonight's red workstation e2e arms, and the only one **not** explained by the reveal substitution behind #18410 and #18412. It is a different defect, held back from that story until it was probed rather than folded in because it fit.

Nothing is starved. The arm demands two rows of pool growth from 1.6 rows of freed height — a rounding boundary, not a regression.

Evidence: L2 → L2 required (a layout-arithmetic claim about a running app is only checkable against one). Residual: none.

## AC Evidence

| AC | Evidence |
|---|---|
| The arm passes on `dev` | `1 passed (3.0s)`, from `1 failed (16.2s)`. |
| The expectation derives from freed height and a **measured** row height | `Math.floor(grownBox / bootState.rowHeight)`; `rowHeight` read off a live gridcell in `readMatrixState`. |
| A freed height justifying zero rows fails as a vacuous rig | Forced that state and read the message. Receipt below. |
| The bound does not claim to be the engine's rounding rule | Corrected in `0eae8805b9` after @neo-gpt's review; see **Deltas**. |
| The failure message carries the pixels and the rows they justify | `… 80px of new box justifies 1 more row(s) at 50px`. |
| The starvation claim is untouched | No change to the rig, the boot leg, the feed control or the closing frame assertion. |

## The Arithmetic

Measured under the spec's own rig:

```
boot        grid 338px    pool 27 rows
after       grid 418px    pool 28 rows
freed band  80px          all 80px arrived at the grid
row height  50px
```

80px of new viewport at a 50px row is **1.60 rows**. The pool grew by **one**; the assertion demanded `> bootRows + 1`, i.e. two. So the arm convicted the carrier on a rounding boundary.

`floor(grownBox / rowHeight)` is a conservative **lower bound** on that growth, and deliberately not a model of the engine's rounding — a correction I owe @neo-gpt, who read the source: `grid.Body` derives `availableRows` as `ceil(availableHeight / rowHeight) - 1` and pools that plus a fixed buffer, against an `availableHeight` the worker was handed rather than the container box measured here. `ceil - 1` is not `floor`. The arithmetic never depended on the claim, but the prose asserted a rounding rule this spec has not measured, and a bound is the right instrument anyway: the arm must convict a carrier that delivered **nothing**, and re-deriving a count the engine owns would couple the witness to what it observes from outside.

**The product is correct at both measurements.** The pool tracks the box consistently — 27 = 6.8 visible + 20.2 buffer, 28 = 8.4 + 19.6 — and it is not store-capped: the body scrolls 5,000,050px, a 100k-row store. So neither end of the comparison is degenerate.

## Deltas from ticket

None. What the ticket specified is what shipped.

The arm already made its **trigger** premise proportional, and its own comment states the principle it then failed to apply to the **pool** claim one assertion later:

> *"a fixed literal here calibrates to one theme era's band chrome and rots when extents or floors change; the layout-chain integrity claim is proportional"*

`bootRows + 1` is exactly such a literal, and it holds only while the freed band clears two whole rows. **Deliberately not established:** which change moved the delta below 2.0. The assertion is wrong independently of that history, and two hypotheses died tonight from supplying a cause that felt right.

## Test Evidence

```
before   1 failed  (16.2s)   the taller box grows the row pool without frames
                             Expected: > 28   Received: 28
after    1 passed  (3.0s)
```

**Vacuity control** — the guard exists because `>= bootRows + 0` reads "the pool did not shrink", which a dead carrier satisfies as comfortably as a live one. Forced `justified` to zero:

```
Error: the rig must free at least one row of height — 80px at a 50px row justifies none
  Expected: >= 1
  Received:    0
```

It fails, and it names the arithmetic that made it vacuous rather than reporting starvation.

## Post-Merge Validation

- [ ] This arm sits in the GPU tier, which #18408's workflow excludes, so its green is local until that tier has a runner. All six workstation reds share that gap.

## Commits

- the pool claim becomes proportional
- `0eae8805b9` — the bound stops claiming to model the engine rounding

Authored by Ada (Claude Opus 5, Claude Code). Origin session 95f9ff6e-1ba5-43b6-860a-208fbf7f4442.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
