### PR TITLE
fix(dock): prevent duplicate pane DOM after popup adoption (#18409)

### DIFF
--- a/src/dashboard/dock/projection/Reconciler.mjs
+++ b/src/dashboard/dock/projection/Reconciler.mjs
@@ -261,7 +261,8 @@ class Reconciler extends Base {
             }
         });
 
-        const commitBars = new Set();
+        const commitAncestors = new Set(),
+              commitBars      = new Set();
 
         if (reconcileItems) {
             this.reconcileTabChrome(
@@ -271,7 +272,8 @@ class Reconciler extends Base {
                 oldShell,
                 resolveItem,
                 preserveItemIds,
-                commitBars
+                commitBars,
+                commitAncestors
             )
         }
 
@@ -280,7 +282,7 @@ class Reconciler extends Base {
         });
         placeholders.clear();
 
-        return {currentTabs, commitBars, nextShell: oldShell, plans, reconciledItems: reconcileItems}
+        return {currentTabs, commitAncestors, commitBars, nextShell: oldShell, plans, reconciledItems: reconcileItems}
     }
 
     /**
@@ -348,6 +350,8 @@ class Reconciler extends Base {
      * inventing an outgoing shell. Each phase receives its own host update so renderer cleanup
      * cannot overtake a native reparent. Floating Overflow controls are reprojected only after final
      * ownership settles.
+     * Live panes imported from elsewhere in the same window commit through their common ancestor
+     * before inner rendering flights, preserving the existing DOM node across projection boundaries.
      *
      * Workspace-specific FLIP capture/play, animation timing, pane creation, and menu readiness stay
      * outside this method. `onProjectionStaged` can decorate retained chrome before the first commit.
@@ -401,6 +405,10 @@ class Reconciler extends Base {
                     oldShell,
                     plans      : stableProjection.plans
                 });
+            for (const ancestor of stableProjection.commitAncestors) {
+                ancestor.updateDepth = -1;
+                await ancestor.promiseUpdate()
+            }
             await Promise.all([...stableProjection.commitBars].map(bar => {
                 bar.sortZone?.adjustItemCls(true);
                 bar.updateDepth = -1;
@@ -479,7 +487,8 @@ class Reconciler extends Base {
             throw error
         }
 
-        const commitBars = new Set();
+        const commitAncestors = new Set(),
+              commitBars      = new Set();
 
         // With an outgoing shell, phases 2-4 are the window in which the host holds TWO shells. A
         // first projection holds one hidden shell instead, but the same awaited flights can reject
@@ -504,8 +513,14 @@ class Reconciler extends Base {
                 nextShell,
                 resolveItem,
                 preserveItemIds,
-                commitBars
+                commitBars,
+                commitAncestors
             );
+
+            for (const ancestor of commitAncestors) {
+                ancestor.updateDepth = -1;
+                await ancestor.promiseUpdate()
+            }
 
         // Existing pane/button pairs move through the host's common-ancestor transaction below.
         // A parked pane has no surviving button DOM to move, so its newly materialized pair needs
@@ -786,6 +801,9 @@ class Reconciler extends Base {
      * membership changed SILENTLY and therefore require one awaited direct-owner commit. Two kinds
      * qualify: a bar that materialized a fresh pane/button pair, and both bars of a cross-bar move —
      * the source's removal and the target's insertion are each silent, so neither publishes on its own.
+     * @param {Set<Neo.container.Base>} [commitAncestors=new Set()] Common ancestors of live panes
+     * imported from outside the projected tabs. Commit these before descendant flights so the
+     * renderer observes one move instead of inserting a duplicate beside the external DOM copy.
      * @returns {Map<String,Object>}
      * @static
      */
@@ -796,7 +814,8 @@ class Reconciler extends Base {
         nextShell,
         resolveItem,
         preserveItemIds=[],
-        commitBars=new Set()
+        commitBars=new Set(),
+        commitAncestors=new Set()
     ) {
         const
             nextTabs       = this.collectProjectedTabs(nextShell),
@@ -895,6 +914,14 @@ class Reconciler extends Base {
                 const state = findItemState(pane);
 
                 if (!state) {
+                    if (pane.parent && pane.parent.windowId === targetBody.windowId) {
+                        const sourceParents = [pane.parent, ...pane.parent.getParents()],
+                              ancestor = [targetBody, ...targetBody.getParents()]
+                                  .find(parent => sourceParents.includes(parent));
+
+                        ancestor && commitAncestors.add(ancestor)
+                    }
+
                     const
                         inserted     = targetBody.insert(targetIndex, pane, true),
                         buttonConfig = targetTab.getTabButtonConfig(inserted.header, targetIndex);

--- a/test/playwright/e2e/workstation/WorkstationHumanPopupOverlapNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationHumanPopupOverlapNL.spec.mjs
@@ -610,6 +610,73 @@ test.describe('Workstation — human popup-over-popup conversion (#16117)', () =
     test.setTimeout(240000);
     test.use({colorScheme: 'dark', viewport: null});
 
+    test('pointer tear-out commits the same pane into its full PopupWorkspace (#18409)',
+    async ({page, neuralLink}) => {
+        await page.goto('/apps/workstation/index.html');
+        await page.waitForSelector('.workstation-dock-host', {timeout: 60000});
+
+        const
+            app       = await neuralLink.connectToApp('Workstation'),
+            workspace = await findOne(app, {className: 'Workstation.view.Workspace'}, ['id']),
+            paneId    = await app.callMethod(workspace.id, 'getPaneIdentity', [TARGET_ITEM_ID]);
+
+        await expect(page.locator(`#${paneId}`)).toBeVisible();
+
+        let popup;
+        try {
+            ({popup} = await beginActualTearOut({label: 'Metrics', page}));
+            const windowId = await awaitVesselWindowId(app, workspace.id, TARGET_ITEM_ID, false);
+
+            const liveElement = await popup.locator(`[id="${paneId}"]`).elementHandle();
+            expect(liveElement).toBeTruthy();
+            await page.mouse.up();
+            expect(await awaitVesselWindowId(app, workspace.id, TARGET_ITEM_ID, true)).toBe(windowId);
+            await awaitPointerSessionIdle(page);
+
+            const
+                target = await findOne(app, {
+                    className   : 'Workstation.view.PopupWorkspace',
+                    workspaceKey: TARGET_WORKSPACE_ID
+                }, ['id', 'windowId']),
+                tabs = await findOne(app, {
+                    className      : 'Neo.dashboard.dock.interaction.TabContainer',
+                    dockWorkspaceId: target.id
+                }, ['id']),
+                body = await app.callMethod(tabs.id, 'getCardContainer');
+
+            expect(body.id, 'the committed popup owns a live card body').toBeTruthy();
+            expect(target.properties.windowId).toBe(windowId);
+            expect(await app.callMethod(workspace.id, 'getPaneIdentity', [TARGET_ITEM_ID])).toBe(paneId);
+
+            await expect.poll(async () => {
+                const state = await app.getComponent(paneId, ['parent.id', 'windowId']),
+                      dom   = await popup.evaluate(({paneId, bodyId}) => {
+                          const pane = document.getElementById(paneId),
+                                body = document.getElementById(bodyId),
+                                rect = pane?.getBoundingClientRect(),
+                                area = body?.getBoundingClientRect();
+
+                          return {
+                              domParents: [...document.querySelectorAll(`[id="${paneId}"]`)]
+                                  .map(element => element.parentElement?.id),
+                              fillsBody: Boolean(rect && area && rect.width > 20 && rect.height > 20 &&
+                                  Math.abs(rect.x - area.x) <= 1 && Math.abs(rect.y - area.y) <= 1 &&
+                                  Math.abs(rect.width - area.width) <= 1 && Math.abs(rect.height - area.height) <= 1)
+                          }
+                      }, {paneId, bodyId: body.id});
+
+                return {...dom, windowId: state.windowId, workerParent: state['parent.id']}
+            }, {message: 'the committed pane belongs to its full popup card body', timeout: 10000}).toEqual({
+                domParents: [body.id], fillsBody: true, windowId, workerParent: body.id
+            });
+            expect(await liveElement.evaluate(element => element.isConnected &&
+                element === document.getElementById(element.id)), 'the same DOM node moves with its pane').toBe(true);
+        } finally {
+            await page.mouse.up().catch(() => {});
+            await popup?.close().catch(() => {});
+        }
+    });
+
     test(`${MATRIX_CELL.name}: one local proxy plus readable target choices`,
     async ({page, neuralLink}, testInfo) => {
         await test.step(MATRIX_CELL.name, async () => {

--- a/test/playwright/unit/dashboard/DockProjectionReconciler.spec.mjs
+++ b/test/playwright/unit/dashboard/DockProjectionReconciler.spec.mjs
@@ -127,6 +127,66 @@ const reconcileModel = async (model, mutate, {geometryOnly=false, preserveItemId
 };
 
 test.describe('Neo.dashboard.dock.projection.Reconciler', () => {
+    for (const retainTopology of [false, true]) {
+        test(`external pane move settles its ancestor before descendant commits (retain=${retainTopology})`, async () => {
+            const model = createRootTabsModel(),
+                  empty = structuredClone(model),
+                  pane = Neo.create(Component, {header: {text: 'Alpha'}});
+
+            empty.items = {};
+            empty.nodes['root-tabs'].items = [];
+            empty.nodes['root-tabs'].activeItemId = null;
+
+            const host = Neo.create(Container, {items: retainTopology ? [DockLayoutAdapter.project(empty)] : []}),
+                  viewport = Neo.create(Container, {items: [pane, host]}),
+                  placeholders = new Map(),
+                  nextConfig = DockLayoutAdapter.project(model, {
+                      resolveComponentRef() {
+                          const placeholder = Neo.create(Component, {header: {text: 'Alpha'}, hidden: true});
+                          placeholders.set('alpha', placeholder);
+                          return placeholder
+                      }
+                  }),
+                  originalUpdate = viewport.promiseUpdate.bind(viewport),
+                  events = [];
+
+            let release, projection;
+            const gate = new Promise(resolve => release = resolve);
+            viewport.promiseUpdate = async () => {
+                if (pane.parent === viewport) return originalUpdate();
+                events.push('ancestor started');
+                await gate;
+                await originalUpdate();
+                events.push('ancestor settled')
+            };
+
+            try {
+                projection = DockProjectionReconciler.reconcileProjection({
+                    host, nextConfig, placeholders, retainTopology, resolveItem: () => pane,
+                    onProjectionStaged({nextShell}) {
+                        const bar = nextShell.getTabBar(), update = bar.promiseUpdate.bind(bar);
+                        bar.promiseUpdate = () => {
+                            events.push('descendant');
+                            return update()
+                        }
+                    }
+                });
+                await expect.poll(() => events[0], {timeout: 1000}).toBe('ancestor started');
+                await new Promise(resolve => setTimeout(resolve, 0));
+                expect(events).toEqual(['ancestor started']);
+                release();
+                await projection;
+                expect(events.indexOf('descendant')).toBeGreaterThan(events.indexOf('ancestor settled'));
+                expect(host.items[0].getCardContainer().items).toEqual([pane]);
+                expect(viewport.items).toEqual([host])
+            } finally {
+                release();
+                await projection?.catch(() => {});
+                viewport.destroy()
+            }
+        })
+    }
+
     test('keys retained tab chrome and reserves only its projected destination', () => {
         const
             retainedTab = {dockNodeId: 'primary-tabs', dockNodeType: 'tabs'},


### PR DESCRIPTION
Resolves #18409
Related: #18303
Related: #18304

After a pointer tear-out creates destination-window DOM from the retained component/VDOM, committing the pane into PopupWorkspace no longer leaves a duplicate DOM copy in that popup's provisional viewport. The regression's DOM-node identity assertion covers this subsequent move within the popup; it does not claim that one DOM node survives the cross-window move. The reconciler collects the common ancestors of panes imported from outside its tab tree and awaits those moves before descendant commits. This prevents a destination `insertNode` from creating a second copy while the provisional viewport still owns the original DOM node. The change covers initial and retained-topology projection; no Workstation production code is added.

Evidence: L3 (actual-pointer headed Chrome, exact DOM-node identity and census, worker parent and native owner) → L3 required (AC-1/2). No residual for this leaf; the remaining popup-overlap journey stays on #18303.

## AC Evidence

| AC | Evidence |
|---|---|
| AC-1 | Outside-CI: the new focused `WorkstationHumanPopupOverlapNL` test uses a real Metrics pointer tear-out and release, then requires one pane DOM node in its exact card body, usable geometry, unchanged live element/component identity and matching worker/native ownership. |
| AC-2 | CI-covered: deferred ancestor settlement blocks descendant publication for both initial and retained-topology projection. Both guards fail on the original source. Outside-CI: the final browser regression fails against unchanged dev and passes with the repair. |
| AC-3 | Outside-CI: normal native popup transfer, resize-before-hover, active-hover resize and popup-to-main retain their transfer/retirement and pane-identity assertions. |

## Deltas from ticket

The defect is duplicate DOM rendering: worker adoption was already correct. The repair belongs in the existing registered Reconciler, before its inner rendering commits. It adds no popup-specific repair callback, class or native-window authority. The original full overlap matrix is unchanged.

## Test Evidence

The final native command runs the new first-terminal test and the four existing native journeys:

```bash
NEO_AGENTOS_RUNTIME_ROOT=<tooling-checkout> npx playwright test -c test/playwright/playwright.config.e2e.mjs test/playwright/e2e/workstation/WorkstationHumanPopupOverlapNL.spec.mjs test/playwright/e2e/workstation/WorkstationNativePopupOverPopupNL.spec.mjs test/playwright/e2e/workstation/WorkstationNativeTitlebarDragNL.spec.mjs --grep-invert 'one local proxy plus readable target choices' --headed --workers=1
```

**5 passed, 27.0s**, on merged `d0f3b380` plus this change. The exact final pointer regression against unchanged `d0f3b380` fails in 12.6s: the DOM census contains both viewport and card-body copies while worker ownership is already correct. The repaired source was restored before the passing batch.

The diagnostic delta log on pre-fix source showed an `insertNode` into the card body with the existing pane id and no corresponding move/removal of its viewport copy. Diagnostic logging and corrective controls are absent from the permanent test.

The old full overlap matrix remains outside this narrow run: its pre-hover bare-popup observation still needs migration. This PR claims the first pointer terminal, not complete epic acceptance. Native titlebar journeys use on-screen CDP movement, not an actual OS titlebar grab.

## Post-Merge Validation

None for this leaf. Continue the remaining actual-pointer overlap and deployed-command acceptance on #18303.

Authored by Euclid (GPT-6, Codex). Session 01a07609-5e09-70f0-bf2c-a27d77d1b7f2.

