### PR TITLE
fix(dashboard): the cross-window pane placeholder becomes a themable component (#18414)

### DIFF
--- a/docs/output/class-hierarchy.json
+++ b/docs/output/class-hierarchy.json
@@ -253,6 +253,7 @@
  "Neo.dashboard.dock.window.TopologySeams": "Neo.core.Base",
  "Neo.dashboard.dock.window.VesselConversion": "Neo.core.Base",
  "Neo.dashboard.dock.window.VesselPark": "Neo.core.Base",
+ "Neo.dashboard.dock.window.VesselPlaceholder": "Neo.component.Base",
  "Neo.data.Model": "Neo.core.Base",
  "Neo.data.Pipeline": "Neo.core.Base",
  "Neo.data.RecordFactory": "Neo.core.Base",

--- a/resources/scss/src/dashboard/dock/window/VesselPlaceholder.scss
+++ b/resources/scss/src/dashboard/dock/window/VesselPlaceholder.scss
@@ -1,0 +1,23 @@
+// The cross-window pane placeholder — structure only; `theme-*/dashboard/dock/window/VesselPlaceholder.scss`
+// owns the values, the two-layer split every themed sibling package honours.
+//
+// Exactly two properties, and both are load-bearing rather than decorative. The visible surface is
+// the framework load mask (`src/component/Base.scss`), which paints
+//
+//     .neo-load-mask       { background-color: inherit }
+//     .neo-loading-message { color: inherit }
+//
+// by design: the mask takes its ground and ink from whatever hosts it, so one host declaration
+// themes the panel, the message and the spinner together. Before this sheet existed the host was an
+// inline component with no stylesheet at all, so both inherit chains fell through to the user-agent
+// default and the slot rendered black-on-white under every theme while the surrounding dock was
+// dark-green. Setting these two here is the whole fix; the mask needs no change and must not get
+// one, since it is shared by every masked component in the framework.
+//
+// The fallbacks are last-resort literals for a host that loads the structure layer with no values
+// sheet — deliberately neutral rather than a copy of any one theme, so an unthemed host reads as
+// plainly unstyled instead of impersonating a skin it is not running.
+.neo-dashboard-dock-vessel-placeholder {
+    background-color: var(--dock-vessel-placeholder-ground, #1a212c);
+    color           : var(--dock-vessel-placeholder-ink,    #d6dce6);
+}

--- a/resources/scss/src/dashboard/dock/window/VesselPlaceholder.scss
+++ b/resources/scss/src/dashboard/dock/window/VesselPlaceholder.scss
@@ -2,21 +2,19 @@
 // owns the values, the two-layer split every themed sibling package honours.
 //
 // Exactly two properties, and both are load-bearing rather than decorative. The visible surface is
-// the framework load mask (`src/component/Base.scss`), which paints
+// the framework load mask (`src/component/Base.scss`), which paints `background-color: inherit` and
+// `color: inherit` by design, so one host declaration themes the panel, the message and the spinner
+// together. Before this class existed the host was an inline `Neo.create({module: Component})`,
+// which resolves `Neo.component.Base` and therefore that base's stylesheet — a sheet that declares
+// no ground or ink. Lacking a class of its own, it had no stylesheet address where per-theme values
+// could be declared, both inherit chains fell through to the user-agent default, and the slot
+// rendered black-on-white under every theme. Setting these two here is the whole fix; the mask
+// needs no change and must not get one, since every masked component in the framework shares it.
 //
-//     .neo-load-mask       { background-color: inherit }
-//     .neo-loading-message { color: inherit }
-//
-// by design: the mask takes its ground and ink from whatever hosts it, so one host declaration
-// themes the panel, the message and the spinner together. Before this sheet existed the host was an
-// inline component with no stylesheet at all, so both inherit chains fell through to the user-agent
-// default and the slot rendered black-on-white under every theme while the surrounding dock was
-// dark-green. Setting these two here is the whole fix; the mask needs no change and must not get
-// one, since it is shared by every masked component in the framework.
-//
-// The fallbacks are last-resort literals for a host that loads the structure layer with no values
-// sheet — deliberately neutral rather than a copy of any one theme, so an unthemed host reads as
-// plainly unstyled instead of impersonating a skin it is not running.
+// The fallbacks are `theme-neo-dark`'s own values, not neutral literals. A host that loads this
+// structure layer with no values sheet is unthemed, and the dock's default presentation is dark, so
+// landing on the dock's own default reads better than a white flash — but it is a copy of one
+// theme, and a future theme must add its values sheet rather than rely on these.
 .neo-dashboard-dock-vessel-placeholder {
     background-color: var(--dock-vessel-placeholder-ground, #1a212c);
     color           : var(--dock-vessel-placeholder-ink,    #d6dce6);

--- a/resources/scss/theme-cyberpunk/dashboard/dock/window/VesselPlaceholder.scss
+++ b/resources/scss/theme-cyberpunk/dashboard/dock/window/VesselPlaceholder.scss
@@ -1,0 +1,14 @@
+// The cross-window pane placeholder VALUES layer (cyberpunk). Structure owns the paint
+// (`src/dashboard/dock/window/VesselPlaceholder.scss`); this file owns the values.
+//
+// `:where()` contributes ZERO specificity, so these engine defaults lose to every application
+// projection regardless of stylesheet load order — an engine default must never win that race
+// against an app skin. A host with no projection resolves exactly these values.
+//
+// The ground is the opaque form of this theme's `--dock-preview-ground`: a placeholder occupies a
+// real slot rather than floating over one, so it takes the surface colour without the overlay's
+// alpha. The load mask inherits both properties, which is what themes the spinner and the message.
+:where(.neo-theme-cyberpunk) {
+    --dock-vessel-placeholder-ground: #0d1117;
+    --dock-vessel-placeholder-ink   : #c9d1d9;
+}

--- a/resources/scss/theme-cyberpunk/dashboard/dock/window/VesselPlaceholder.scss
+++ b/resources/scss/theme-cyberpunk/dashboard/dock/window/VesselPlaceholder.scss
@@ -1,13 +1,6 @@
-// The cross-window pane placeholder VALUES layer (cyberpunk). Structure owns the paint
-// (`src/dashboard/dock/window/VesselPlaceholder.scss`); this file owns the values.
-//
-// `:where()` contributes ZERO specificity, so these engine defaults lose to every application
-// projection regardless of stylesheet load order — an engine default must never win that race
-// against an app skin. A host with no projection resolves exactly these values.
-//
-// The ground is the opaque form of this theme's `--dock-preview-ground`: a placeholder occupies a
-// real slot rather than floating over one, so it takes the surface colour without the overlay's
-// alpha. The load mask inherits both properties, which is what themes the spinner and the message.
+// Values for the cross-window pane placeholder; the paint and the rationale live in
+// `src/dashboard/dock/window/VesselPlaceholder.scss`. `:where()` contributes zero specificity, so
+// an application projection always wins. Ground is this theme's `--dock-preview-ground` made opaque.
 :where(.neo-theme-cyberpunk) {
     --dock-vessel-placeholder-ground: #0d1117;
     --dock-vessel-placeholder-ink   : #c9d1d9;

--- a/resources/scss/theme-dark/dashboard/dock/window/VesselPlaceholder.scss
+++ b/resources/scss/theme-dark/dashboard/dock/window/VesselPlaceholder.scss
@@ -1,13 +1,6 @@
-// The cross-window pane placeholder VALUES layer (dark). Structure owns the paint
-// (`src/dashboard/dock/window/VesselPlaceholder.scss`); this file owns the values.
-//
-// `:where()` contributes ZERO specificity, so these engine defaults lose to every application
-// projection regardless of stylesheet load order — an engine default must never win that race
-// against an app skin. A host with no projection resolves exactly these values.
-//
-// The ground is the opaque form of this theme's `--dock-preview-ground`: a placeholder occupies a
-// real slot rather than floating over one, so it takes the surface colour without the overlay's
-// alpha. The load mask inherits both properties, which is what themes the spinner and the message.
+// Values for the cross-window pane placeholder; the paint and the rationale live in
+// `src/dashboard/dock/window/VesselPlaceholder.scss`. `:where()` contributes zero specificity, so
+// an application projection always wins. Ground is this theme's `--dock-preview-ground` made opaque.
 :where(.neo-theme-dark) {
     --dock-vessel-placeholder-ground: #3c3f41;
     --dock-vessel-placeholder-ink   : #e0e0e0;

--- a/resources/scss/theme-dark/dashboard/dock/window/VesselPlaceholder.scss
+++ b/resources/scss/theme-dark/dashboard/dock/window/VesselPlaceholder.scss
@@ -1,0 +1,14 @@
+// The cross-window pane placeholder VALUES layer (dark). Structure owns the paint
+// (`src/dashboard/dock/window/VesselPlaceholder.scss`); this file owns the values.
+//
+// `:where()` contributes ZERO specificity, so these engine defaults lose to every application
+// projection regardless of stylesheet load order — an engine default must never win that race
+// against an app skin. A host with no projection resolves exactly these values.
+//
+// The ground is the opaque form of this theme's `--dock-preview-ground`: a placeholder occupies a
+// real slot rather than floating over one, so it takes the surface colour without the overlay's
+// alpha. The load mask inherits both properties, which is what themes the spinner and the message.
+:where(.neo-theme-dark) {
+    --dock-vessel-placeholder-ground: #3c3f41;
+    --dock-vessel-placeholder-ink   : #e0e0e0;
+}

--- a/resources/scss/theme-light/dashboard/dock/window/VesselPlaceholder.scss
+++ b/resources/scss/theme-light/dashboard/dock/window/VesselPlaceholder.scss
@@ -1,13 +1,6 @@
-// The cross-window pane placeholder VALUES layer (light). Structure owns the paint
-// (`src/dashboard/dock/window/VesselPlaceholder.scss`); this file owns the values.
-//
-// `:where()` contributes ZERO specificity, so these engine defaults lose to every application
-// projection regardless of stylesheet load order — an engine default must never win that race
-// against an app skin. A host with no projection resolves exactly these values.
-//
-// The ground is the opaque form of this theme's `--dock-preview-ground`: a placeholder occupies a
-// real slot rather than floating over one, so it takes the surface colour without the overlay's
-// alpha. The load mask inherits both properties, which is what themes the spinner and the message.
+// Values for the cross-window pane placeholder; the paint and the rationale live in
+// `src/dashboard/dock/window/VesselPlaceholder.scss`. `:where()` contributes zero specificity, so
+// an application projection always wins. Ground is this theme's `--dock-preview-ground` made opaque.
 :where(.neo-theme-light) {
     --dock-vessel-placeholder-ground: #fafafa;
     --dock-vessel-placeholder-ink   : #24292f;

--- a/resources/scss/theme-light/dashboard/dock/window/VesselPlaceholder.scss
+++ b/resources/scss/theme-light/dashboard/dock/window/VesselPlaceholder.scss
@@ -1,0 +1,14 @@
+// The cross-window pane placeholder VALUES layer (light). Structure owns the paint
+// (`src/dashboard/dock/window/VesselPlaceholder.scss`); this file owns the values.
+//
+// `:where()` contributes ZERO specificity, so these engine defaults lose to every application
+// projection regardless of stylesheet load order — an engine default must never win that race
+// against an app skin. A host with no projection resolves exactly these values.
+//
+// The ground is the opaque form of this theme's `--dock-preview-ground`: a placeholder occupies a
+// real slot rather than floating over one, so it takes the surface colour without the overlay's
+// alpha. The load mask inherits both properties, which is what themes the spinner and the message.
+:where(.neo-theme-light) {
+    --dock-vessel-placeholder-ground: #fafafa;
+    --dock-vessel-placeholder-ink   : #24292f;
+}

--- a/resources/scss/theme-neo-dark/dashboard/dock/window/VesselPlaceholder.scss
+++ b/resources/scss/theme-neo-dark/dashboard/dock/window/VesselPlaceholder.scss
@@ -1,13 +1,6 @@
-// The cross-window pane placeholder VALUES layer (neo-dark). Structure owns the paint
-// (`src/dashboard/dock/window/VesselPlaceholder.scss`); this file owns the values.
-//
-// `:where()` contributes ZERO specificity, so these engine defaults lose to every application
-// projection regardless of stylesheet load order — an engine default must never win that race
-// against an app skin. A host with no projection resolves exactly these values.
-//
-// The ground is the opaque form of this theme's `--dock-preview-ground`: a placeholder occupies a
-// real slot rather than floating over one, so it takes the surface colour without the overlay's
-// alpha. The load mask inherits both properties, which is what themes the spinner and the message.
+// Values for the cross-window pane placeholder; the paint and the rationale live in
+// `src/dashboard/dock/window/VesselPlaceholder.scss`. `:where()` contributes zero specificity, so
+// an application projection always wins. Ground is this theme's `--dock-preview-ground` made opaque — a placeholder occupies a slot rather than floating over one.
 :where(.neo-theme-neo-dark) {
     --dock-vessel-placeholder-ground: #1a212c;
     --dock-vessel-placeholder-ink   : #d6dce6;

--- a/resources/scss/theme-neo-dark/dashboard/dock/window/VesselPlaceholder.scss
+++ b/resources/scss/theme-neo-dark/dashboard/dock/window/VesselPlaceholder.scss
@@ -1,0 +1,14 @@
+// The cross-window pane placeholder VALUES layer (neo-dark). Structure owns the paint
+// (`src/dashboard/dock/window/VesselPlaceholder.scss`); this file owns the values.
+//
+// `:where()` contributes ZERO specificity, so these engine defaults lose to every application
+// projection regardless of stylesheet load order — an engine default must never win that race
+// against an app skin. A host with no projection resolves exactly these values.
+//
+// The ground is the opaque form of this theme's `--dock-preview-ground`: a placeholder occupies a
+// real slot rather than floating over one, so it takes the surface colour without the overlay's
+// alpha. The load mask inherits both properties, which is what themes the spinner and the message.
+:where(.neo-theme-neo-dark) {
+    --dock-vessel-placeholder-ground: #1a212c;
+    --dock-vessel-placeholder-ink   : #d6dce6;
+}

--- a/resources/scss/theme-neo-light/dashboard/dock/window/VesselPlaceholder.scss
+++ b/resources/scss/theme-neo-light/dashboard/dock/window/VesselPlaceholder.scss
@@ -1,0 +1,14 @@
+// The cross-window pane placeholder VALUES layer (neo-light). Structure owns the paint
+// (`src/dashboard/dock/window/VesselPlaceholder.scss`); this file owns the values.
+//
+// `:where()` contributes ZERO specificity, so these engine defaults lose to every application
+// projection regardless of stylesheet load order — an engine default must never win that race
+// against an app skin. A host with no projection resolves exactly these values.
+//
+// The ground is the opaque form of this theme's `--dock-preview-ground`: a placeholder occupies a
+// real slot rather than floating over one, so it takes the surface colour without the overlay's
+// alpha. The load mask inherits both properties, which is what themes the spinner and the message.
+:where(.neo-theme-neo-light) {
+    --dock-vessel-placeholder-ground: #f7f9fc;
+    --dock-vessel-placeholder-ink   : #1f2733;
+}

--- a/resources/scss/theme-neo-light/dashboard/dock/window/VesselPlaceholder.scss
+++ b/resources/scss/theme-neo-light/dashboard/dock/window/VesselPlaceholder.scss
@@ -1,13 +1,6 @@
-// The cross-window pane placeholder VALUES layer (neo-light). Structure owns the paint
-// (`src/dashboard/dock/window/VesselPlaceholder.scss`); this file owns the values.
-//
-// `:where()` contributes ZERO specificity, so these engine defaults lose to every application
-// projection regardless of stylesheet load order — an engine default must never win that race
-// against an app skin. A host with no projection resolves exactly these values.
-//
-// The ground is the opaque form of this theme's `--dock-preview-ground`: a placeholder occupies a
-// real slot rather than floating over one, so it takes the surface colour without the overlay's
-// alpha. The load mask inherits both properties, which is what themes the spinner and the message.
+// Values for the cross-window pane placeholder; the paint and the rationale live in
+// `src/dashboard/dock/window/VesselPlaceholder.scss`. `:where()` contributes zero specificity, so
+// an application projection always wins. Ground is this theme's `--dock-preview-ground` made opaque.
 :where(.neo-theme-neo-light) {
     --dock-vessel-placeholder-ground: #f7f9fc;
     --dock-vessel-placeholder-ink   : #1f2733;

--- a/src/dashboard/dock/window/VesselEmbodiment.mjs
+++ b/src/dashboard/dock/window/VesselEmbodiment.mjs
@@ -1,5 +1,5 @@
-import Component          from '../../../component/Base.mjs';
 import DragProxyContainer from '../../../draggable/DragProxyContainer.mjs';
+import VesselPlaceholder  from './VesselPlaceholder.mjs';
 
 /**
  * @module Neo.dashboard.dock.window.VesselEmbodiment
@@ -51,12 +51,7 @@ export function createDockVesselEmbodiment({resolvePane, resolveTarget} = {}) {
             return false
         }
 
-        const placeholder = Neo.create({
-            module   : Component,
-            cls      : ['neo-dashboard-dock-vessel-placeholder'],
-            isLoading: 'Moving pane to another window…',
-            role     : 'status'
-        });
+        const placeholder = Neo.create(VesselPlaceholder);
 
         let record = {pane, placeholder, settlement: null, sourceParent, windowId};
 

--- a/src/dashboard/dock/window/VesselPlaceholder.mjs
+++ b/src/dashboard/dock/window/VesselPlaceholder.mjs
@@ -12,12 +12,14 @@ import Component from '../../../component/Base.mjs';
  *
  * The visible surface is the framework load mask, driven by {@link Neo.component.Base#isLoading}.
  * That mask paints `background-color: inherit` and `color: inherit` **by design** — it takes its
- * ground and ink from whatever hosts it. This class exists to BE that host: an inline
- * `Neo.create({module: Component, cls: [...]})` has no `className`, and therefore no path a theme
- * sheet can be discovered at, so the mask had nothing to inherit and resolved to the user-agent
- * default — a black panel with white text under every theme. Registering the class gives the
- * surface a themable home; `VesselPlaceholder.scss` and its per-theme values supply the two
- * properties the mask reads.
+ * ground and ink from whatever hosts it. This class exists to BE that host. The previous filler was
+ * an inline `Neo.create({module: Component, cls: [...]})`, which resolves `Neo.component.Base` and
+ * therefore that base's stylesheet — a sheet that declares neither property. Since stylesheet paths
+ * are derived from `className`, an instance with no class of its own has no address at which
+ * per-theme values could be declared: the `cls` entry was applied but no sheet in the repository
+ * defined it, so both inherit chains fell through to the user-agent default and the slot rendered
+ * black-on-white under every theme. Registering the class supplies that address;
+ * `VesselPlaceholder.scss` and its per-theme values supply the two properties the mask reads.
  */
 class VesselPlaceholder extends Component {
     static config = {

--- a/src/dashboard/dock/window/VesselPlaceholder.mjs
+++ b/src/dashboard/dock/window/VesselPlaceholder.mjs
@@ -1,0 +1,57 @@
+import Component from '../../../component/Base.mjs';
+
+/**
+ * @class Neo.dashboard.dock.window.VesselPlaceholder
+ * @extends Neo.component.Base
+ *
+ * @summary Holds a pane's slot while that pane moves to another window.
+ *
+ * {@link Neo.dashboard.dock.window.VesselEmbodiment} removes the live pane from its source parent
+ * and inserts this component at the same index, so the surrounding layout keeps its shape for the
+ * duration of the cross-window settlement instead of collapsing and re-expanding.
+ *
+ * The visible surface is the framework load mask, driven by {@link Neo.component.Base#isLoading}.
+ * That mask paints `background-color: inherit` and `color: inherit` **by design** — it takes its
+ * ground and ink from whatever hosts it. This class exists to BE that host: an inline
+ * `Neo.create({module: Component, cls: [...]})` has no `className`, and therefore no path a theme
+ * sheet can be discovered at, so the mask had nothing to inherit and resolved to the user-agent
+ * default — a black panel with white text under every theme. Registering the class gives the
+ * surface a themable home; `VesselPlaceholder.scss` and its per-theme values supply the two
+ * properties the mask reads.
+ */
+class VesselPlaceholder extends Component {
+    static config = {
+        /**
+         * @member {String} className='Neo.dashboard.dock.window.VesselPlaceholder'
+         * @protected
+         */
+        className: 'Neo.dashboard.dock.window.VesselPlaceholder',
+        /**
+         * @member {String} ntype='dock-vessel-placeholder'
+         * @protected
+         */
+        ntype: 'dock-vessel-placeholder',
+        /**
+         * @member {String[]} baseCls=['neo-dashboard-dock-vessel-placeholder']
+         * @protected
+         */
+        baseCls: ['neo-dashboard-dock-vessel-placeholder'],
+        /**
+         * The status text the load mask renders while the pane settles in its target window.
+         * A config rather than a literal so a consumer can localise or re-word the wait without
+         * subclassing. Declared WITHOUT the trailing underscore: `isLoading` is already reactive on
+         * {@link Neo.component.Base}, so this overrides the inherited default rather than
+         * redefining the config — the framework rejects the underscored form outright.
+         * @member {Boolean|String} isLoading='Moving pane to another window…'
+         */
+        isLoading: 'Moving pane to another window…',
+        /**
+         * Announced to assistive tech: the slot is reporting a transient state, not offering a
+         * control. Preserved from the inline component this class replaces.
+         * @member {String} role='status'
+         */
+        role: 'status'
+    }
+}
+
+export default Neo.setupClass(VesselPlaceholder);

--- a/test/playwright/e2e/workstation/WorkstationHumanPopupOverlapNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationHumanPopupOverlapNL.spec.mjs
@@ -677,6 +677,65 @@ test.describe('Workstation — human popup-over-popup conversion (#16117)', () =
         }
     });
 
+    // The vacated slot is the only frame in which a user meets the placeholder, and it exists ONLY
+    // while the vessel is open and the pointer is still held: `stage()` inserts it at the source
+    // index and the next commit retires it. So the read has to happen between `beginActualTearOut`
+    // returning and `mouse.up()`. A manually constructed instance cannot stand in — that proves the
+    // class resolves theme values, not that the slot the engine actually builds resolves them.
+    test('the vacated source slot is themed while its pane is torn out (#18424)',
+    async ({page}, testInfo) => {
+        await page.goto('/apps/workstation/index.html');
+        await page.waitForSelector('.workstation-dock-host', {timeout: 60000});
+        await page.waitForSelector('.neo-tab-header-button.neo-draggable', {timeout: 60000});
+
+        let popup;
+        try {
+            ({popup} = await beginActualTearOut({label: 'Metrics', page}));
+
+            const slot = page.locator('.neo-dashboard-dock-vessel-placeholder').first();
+
+            await expect(slot, 'the engine builds a registered placeholder into the vacated slot')
+                .toBeVisible({timeout: 10000});
+
+            const paint = await slot.evaluate(element => {
+                const
+                    style = getComputedStyle(element),
+                    mask  = element.querySelector('.neo-load-mask'),
+                    text  = element.querySelector('.neo-loading-message');
+
+                return {
+                    ground : style.getPropertyValue('--dock-vessel-placeholder-ground').trim(),
+                    ink    : style.getPropertyValue('--dock-vessel-placeholder-ink').trim(),
+                    hostBg : style.backgroundColor,
+                    hostInk: style.color,
+                    maskBg : mask && getComputedStyle(mask).backgroundColor,
+                    textInk: text && getComputedStyle(text).color
+                }
+            });
+
+            // Attached rather than only asserted: the assertions below prove the relationships,
+            // and a reviewer asking "what did the user actually see" wants the values.
+            await testInfo.attach('vacated-slot-paint', {
+                body: JSON.stringify(paint, null, 4), contentType: 'application/json'
+            });
+
+            // The defect this witnesses was a transparent host: the mask paints `inherit`, so with
+            // no host declaration both chains reached the user-agent default and the slot rendered
+            // black-on-white under every theme. Asserting "not transparent" rather than a literal
+            // colour keeps the arm true for whichever theme the app boots.
+            expect(paint.ground, 'the slot resolves a theme ground token').toBeTruthy();
+            expect(paint.ink,    'the slot resolves a theme ink token').toBeTruthy();
+            expect(paint.hostBg, 'the slot paints an opaque ground rather than falling through')
+                .not.toBe('rgba(0, 0, 0, 0)');
+            expect(paint.maskBg, 'the load mask inherits the slot ground it sits on')
+                .toBe(paint.hostBg);
+            expect(paint.textInk, 'the status message inherits the slot ink').toBe(paint.hostInk);
+        } finally {
+            await page.mouse.up().catch(() => {});
+            await popup?.close().catch(() => {});
+        }
+    });
+
     test(`${MATRIX_CELL.name}: one local proxy plus readable target choices`,
     async ({page, neuralLink}, testInfo) => {
         await test.step(MATRIX_CELL.name, async () => {


### PR DESCRIPTION
Resolves #18414

Dragging a tab outside the dock layout left the source slot rendering as a pitch-black panel with white text and a white spinner, under every theme — reported by @tobiu against `apps/workstation`'s dark/light green skin.

## The mechanism

`VesselEmbodiment` fills the vacated slot while the pane settles in its target window. That filler was an inline component:

```js
Neo.create({module: Component, cls: ['neo-dashboard-dock-vessel-placeholder'], isLoading: '…', role: 'status'})
```

The visible surface is the framework load mask, `resources/scss/src/component/Base.scss:31`:

```scss
.neo-load-mask       { background-color: inherit }
.neo-loading-message { color: inherit }
```

The mask takes its ground and ink **from whatever hosts it** — by design, so one host declaration themes the panel, the message and the spinner together.

That inline component resolves `Neo.component.Base`, so it carries **that base's** `className` and `ntype` and loads **that base's** stylesheet — which declares neither property. What it lacked was a class **of its own**: stylesheet paths are derived from `className`, so an instance adding no class has no address at which per-theme values could be declared. The `cls` entry was applied and no sheet in the repository defined it (`0` SCSS files repo-wide, against `2` for `dock-edge-rail` and `1` for `dock-dragproxy`). Both inherit chains fell through to the user-agent default and the mask had nothing to inherit.

> **Corrected after review.** The first version of this body, the ticket and the class docs all said the inline component had *"no `className`, no `ntype`"*. @neo-gpt-emmy falsified that by instantiating the inline configuration and reading both off it. The conclusion was unaffected; the stated mechanism was wrong, and it is wrong in a way that would have sent the next reader looking in the wrong place. Corrected in all three.

**The mask is not the bug and is untouched.** It is shared by every masked component in the framework and was already correct.

## Deltas

- **New** `src/dashboard/dock/window/VesselPlaceholder.mjs` — a registered `Neo.component.Base` subclass. Sibling-matched directory: `VesselPark`, `VesselConversion`, `VesselEmbodiment` and `Placement` already live there.
- **New** `resources/scss/src/dashboard/dock/window/VesselPlaceholder.scss` — structure declares the two properties the mask reads.
- **New** five per-theme value sheets (`theme-light`, `theme-dark`, `theme-cyberpunk`, `theme-neo-dark`, `theme-neo-light`), each `:where()`-scoped for zero specificity so an app projection always wins.
- **Changed** `src/dashboard/dock/window/VesselEmbodiment.mjs`: **+2 / −7**. The inline `Neo.create` block collapses to `Neo.create(VesselPlaceholder)`, and the now-unused `Component` import is replaced rather than added to.
- **Changed** `docs/output/class-hierarchy.json`: **+1**. Registering a class without regenerating it reds `check-freshness`.
- **Changed** `test/playwright/e2e/workstation/WorkstationHumanPopupOverlapNL.spec.mjs`: **+59**. The in-situ witness, as a sibling test.

Post-review: the five values sheets carried an identical ten-line header for four code lines each — 50 comment lines for 20 of code. The rationale now lives once, in the structure layer; each values sheet keeps only what is local to it (**15** comment lines across the five). The structure sheet's fallback description was also false — it called `#1a212c` / `#d6dce6` *"deliberately neutral"* when they are `theme-neo-dark`'s own values. It now says so, and says a new theme must add its own sheet rather than lean on them.

## AC Evidence

Evidence: L3 (computed styles read from a real headed browser — for AC-3, during an actual pointer tear-out) → L3 sufficient for every AC. Residual: **none**; #18424 exists only as the record of how AC-3 was reached and closes with this PR.

| AC | result |
|---|---|
| 1 — registered class replaces the inline `Neo.create` | `grep "module *: *Component"` in `VesselEmbodiment.mjs` → no match |
| 2 — non-default ground and ink in **every** theme, asserted per theme | **five of five**, table below |
| 3 — computed ground during a live cross-window move, captured not inferred | **MET** — headed red/green witness, below |
| 4 — status text is a config | `isLoading`, default `'Moving pane to another window…'` |
| 5 — `role: 'status'` preserved | carried on the class |

### AC-2 — computed in all five themes

Workstation ships only `neo-dark` and `neo-light`, so the other three built sheets were loaded into the live document and measured in a correctly-classed scope.

| theme | ground | ink | host bg / color | mask bg (inherited) | message |
|---|---|---|---|---|---|
| `neo-dark` | `#1a212c` | `#d6dce6` | `rgb(26,33,44)` / `rgb(214,220,230)` | `rgb(26,33,44)` | `rgb(214,220,230)` |
| `neo-light` | `#f7f9fc` | `#1f2733` | `rgb(247,249,252)` / `rgb(31,39,51)` | `rgb(247,249,252)` | `rgb(31,39,51)` |
| `dark` | `#3c3f41` | `#e0e0e0` | `rgb(60,63,65)` / `rgb(224,224,224)` | `rgb(60,63,65)` | `rgb(224,224,224)` |
| `light` | `#fafafa` | `#24292f` | `rgb(250,250,250)` / `rgb(36,41,47)` | `rgb(250,250,250)` | `rgb(36,41,47)` |
| `cyberpunk` | `#0d1117` | `#c9d1d9` | `rgb(13,17,23)` / `rgb(201,209,217)` | `rgb(13,17,23)` | `rgb(201,209,217)` |

**Control — the same markup without the placeholder class.** The token still *reads* `#1a212c`, because `:where(.neo-theme-neo-dark)` declares it on the theme scope and it inherits everywhere. But the element's background is `rgba(0,0,0,0)` and its colour falls back to the ambient `rgb(240,242,240)`. Only the element carrying the placeholder class applies the paint — a declared token is not an applied one, and that transparent background is the pre-fix symptom exactly.

**A first pass at this table was wrong.** All five themes reported `mask: rgba(0,0,0,0)`. The fixture omitted `neo-masked`, and `component/Base.scss` scopes the rule as `.neo-masked .neo-load-mask` — it measured a rule that never applied. Reported because a fixture that silently fails to exercise the rule reads exactly like a rule that does not work.

## Test Evidence

```
npm run test-unit -- DockVesselEmbodiment.spec.mjs   15 passed
npm run test-unit -- unit/dashboard                 943 passed, 2 skipped
node buildScripts/util/check-file-sizes.mjs          1310 paths, 0 violations
```

Theme build asserted by mtime rather than exit code — `build-themes` exits `0` even when it writes nothing — and all ten values re-read out of `dist/` after the rebuild.

## Post-Merge Validation

### How AC-3 stopped being a residual

@neo-gpt-emmy's first review was right that `Resolves #18414` plus `Residual-Owner: #18414` is incoherent — merging would close the ticket at the exact moment its AC-3 became the only thing left. I split AC-3 to #18424, then witnessed it instead of deferring it, so **#18424 is closed as completed** with the headed receipt below rather than surviving this merge. It stands as the record of how AC-3 was reached.

(An earlier repair — demoting the leaf to `Refs #18414` and leaving the ticket open, creating no artifact for one observation — was refused by `check-pr-body`, which requires `Resolves #N` on its own line. Recorded because the leaner shape is not available, not because I did not try it.)

### AC-3 is witnessed, and the route came from a peer refusing my claim

I twice said this could not be witnessed here — first blaming viewport geometry (wrong), then the browser pane's `window.open` denial (true of **that surface**). @neo-gpt corrected the second one: his headed Engine fixture opens real popups through `beginActualTearOut`. **One instrument generalised to every surface, in a ticket title.** I reproduced his claim on my own seat before acting on it — the spec selects here with `NEO_AGENTOS_RUNTIME_ROOT` set, and is in `testIgnore` without it, which is exactly how a capability that exists reads as one that is absent.

The witness is a sibling test in his fixture, reading the vacated slot **between `beginActualTearOut` returning and `mouse.up()`** — the only frame in which the placeholder exists, since `stage()` inserts it at the source index and the next commit retires it.

**Red arm — `dev@a4dc6c9441`, without this fix:**

```
✓ the slot IS built     .neo-dashboard-dock-vessel-placeholder visible mid-gesture
✗ ground → ""           the defect, in situ
```

The red half is the more informative one: `toBeVisible` passing there proves the engine really does build that slot during a live tear-out, so the frame a user meets is observable rather than inferred.

**Green arm — this head, same spec, 2.1s:**

```json
{
    "ground" : "#1a212c",
    "ink"    : "#d6dce6",
    "hostBg" : "rgb(26, 33, 44)",
    "hostInk": "rgb(214, 220, 230)",
    "maskBg" : "rgb(26, 33, 44)",
    "textInk": "rgb(214, 220, 230)"
}
```

Values are attached to the run rather than only asserted, so every future run records what the user saw. The assertions are relational — mask equals host ground, message equals host ink, host is not transparent — so the arm stays true whichever theme the app boots.

**What this PR still does not claim:** that the slot's *geometry* is right. Colour is now witnessed in situ; size is not, and nothing here measured it.

### The witness does not run in CI, and that is a property of the tier rather than of this arm

Stated plainly so a green check is not read as covering it. `buildScripts/util/e2eCiSelection.mjs --summary` selects **14 of 104** e2e spec files, and `WorkstationHumanPopupOverlapNL.spec.mjs` is excluded twice over: it needs an external `neo-agent-brain` checkout (`testIgnore` deselects 84 files, which therefore cannot even appear as skips), and it boots the workstation app, whose animated `OffscreenCanvas` work a hosted runner cannot composite (4 more).

So this arm is exactly as wired as the three sibling tests it sits beside — run headed, by hand or by a seat with the runtime root, which is how @neo-gpt exercised the same file tonight. It is not new dead weight, and it is not CI coverage. Both halves matter: an arm nothing runs would be theatre, and a claim of CI coverage would be false.

Command, so the next person does not have to reconstruct it:

```
NEO_AGENTOS_RUNTIME_ROOT=<your neo-agent-brain checkout> \
npm run test-e2e -- test/playwright/e2e/workstation/WorkstationHumanPopupOverlapNL.spec.mjs \
  -g "vacated source slot is themed"
```

### The two CI reds on this head are not from this change

`e2e-engine` fails on `grid/TreeBigData.spec.mjs` (TreeGrid selection) and `components` on `dashboard/DockMaximize.spec.mjs` (a 5s poll with `refreshSettledWithin2s=false`). Neither is touched by this diff, and per the selection above this PR's own new arm never executed in either job. Both jobs are green on other open PRs at the same time and were green at this branch's previous head, so I re-ran the failed jobs at the same SHA rather than asserting "flake" from a single observation.

Authored by @neo-opus-grace (Claude Opus 5), origin session `70502f9a-5b14-4dcf-bcdf-4a29b546df77`.
