### PR TITLE
test(dock): the splitter witness covers both presentations, and leaves quarantine (#18419)

### DIFF
--- a/buildScripts/util/e2eCiSelection.mjs
+++ b/buildScripts/util/e2eCiSelection.mjs
@@ -63,11 +63,7 @@ export const EXCLUSIONS = [{
  * separates a debt marker from an abandonment.
  * @member {Object[]} QUARANTINES
  */
-export const QUARANTINES = [{
-    path  : 'test/playwright/e2e/dashboard/DockSplitterProxyPaintNL.spec.mjs',
-    reason: 'crossing the drag threshold creates no splitter proxy; reproduced serially at low load and headed on a real GPU, so neither contention nor a compositor gap',
-    owner : '@neo-opus-ada — holds the repair; the guard is a debt marker, and removing it is the fix'
-}];
+export const QUARANTINES = [];
 
 /**
  * @summary Walks a directory for spec files.
@@ -143,10 +139,14 @@ export function summary(root = process.cwd()) {
         ...EXCLUSIONS.map(entry => `- \`${entry.path.replace('test/playwright/e2e/', '')}\` — ` +
             (entry.kind === 'cause' ? '' : '**cause not established.** ') + `${entry.reason}. Owner: ${entry.owner}.`),
         '',
-        `Selected but quarantined — these run in the tier and skip themselves, so they appear as skips rather than coverage:`,
-        ...QUARANTINES.map(entry => `- \`${entry.path.replace('test/playwright/e2e/', '')}\` — ${entry.reason}. Owner: ${entry.owner}.`),
-        '',
-        `**Selected is not executed.** This line reports what the job SELECTED; whether those specs ran and passed is the job's own status, because a provisioning failure reaches this summary too. A green check certifies the ${executed} selected files only — quarantined arms inside them appear as skips with a reason, while the ${ignored + gpu} above appear nowhere.`
+        // Rendered only when the list has entries. An empty heading reads as "nothing to declare
+        // here", which is the same reassurance an undeclared quarantine would give.
+        ...(QUARANTINES.length ? [
+            'Selected but quarantined — these run in the tier and skip themselves, so they appear as skips rather than coverage:',
+            ...QUARANTINES.map(entry => `- \`${entry.path.replace('test/playwright/e2e/', '')}\` — ${entry.reason}. Owner: ${entry.owner}.`),
+            ''
+        ] : ['No arm in this tier is quarantined. Skips still in the log come from `test.fixme` contracts — rows declared but not yet written — which are a spec\'s own debt rather than a failure this job suppressed.', '']),
+        `**Selected is not executed.** This line reports what the job SELECTED; whether those specs ran and passed is the job's own status, because a provisioning failure reaches this summary too. A green check certifies the ${executed} selected files only — any skip inside them is accounted for above, while the ${ignored + gpu} excluded files appear nowhere in the run at all.`
     ].join('\n')
 }
 

--- a/test/playwright/e2e/dashboard/DockSplitterProxyPaintNL.spec.mjs
+++ b/test/playwright/e2e/dashboard/DockSplitterProxyPaintNL.spec.mjs
@@ -1,84 +1,83 @@
 import {test, expect} from '../../fixtures.mjs';
 
 /**
- * Whitebox-e2e: the splitter's DRAG PROXY renders its affordance while the gesture is live.
+ * Whitebox-e2e: the splitter's drag affordance stays painted while the gesture is live — in BOTH
+ * presentations the component supports.
  *
  * The defect this pins shipped because every existing arm stopped at `mouse.down()`. A splitter is
- * painted correctly at rest and the proxy is a different element entirely — a clone mounted at
- * `document.body`, outside the cascade that painted the source. Detached from it, the engine's
- * `--dock-splitter-*` defaults (declared on `.neo-dashboard`) and each consumer's values (declared
- * as descendant rules under an app root) all resolve empty, and the affordance disappears at the
- * one moment it exists to say "you are moving something".
+ * painted correctly at rest, so a resting assertion re-certifies the surface that was never broken,
+ * which is precisely how the defect passed review. Every arm below therefore CROSSES the drag
+ * threshold and inspects while the gesture is still held.
  *
- * So this witness is only meaningful if it CROSSES the drag threshold and inspects while the
- * gesture is still held. A resting assertion here would re-certify the surface that was never
- * broken — which is precisely how the defect passed review.
+ * **Two presentations, because the default moved underneath this spec.** `Neo.component.Splitter`
+ * ships `liveResize: false` — the proxy-and-commit path, where a clone mounts at `document.body`,
+ * outside the cascade that painted its source, and the `--dock-splitter-*` defaults resolve empty.
+ * `Neo.dashboard.dock.interaction.DockSplitter` overrides it to `true`, so `useProxy` is false and
+ * a dock drag creates **no proxy at all**. This spec used to assert the proxy unconditionally, and
+ * could therefore only fail on a dock splitter — a guard pinned to a branch the consumer had
+ * stopped taking, red for a reason that looked like a paint regression and was not.
+ *
+ * What survives the default flip is the VALUE, not the mechanism: the affordance must not vanish
+ * mid-gesture. Under live resize the source element carries it; under proxy-and-commit the clone
+ * does. Parameterising is what keeps a future default flip from silently retiring the coverage
+ * again — each arm states which presentation it measured.
  *
  * The Engine-owned example host proves the default paint and handle metrics travel together.
  *
- * Run: NEO_E2E_PORT=49241 NEO_TEST_SKIP_CI=true npx playwright test dashboard/DockSplitterProxyPaintNL -c test/playwright/playwright.config.e2e.mjs --workers=1
+ * Run: NEO_E2E_PORT=49241 npx playwright test dashboard/DockSplitterProxyPaintNL -c test/playwright/playwright.config.e2e.mjs --workers=1
  */
-const HOSTS = [
-    {name: 'the example (engine floor, no app dock CSS)', url: '/examples/dashboard/dock/', ready: '.neo-dashboard-dock-splitter', handleDiscriminates: true}
-];
+const HOST = {name: 'the example (engine floor, no app dock CSS)', ready: '.neo-dashboard-dock-splitter', url: '/examples/dashboard/dock/'};
 
-test.describe('Neo.dashboard.dock.interaction.DockSplitter — the drag proxy carries its paint', () => {
+/**
+ * The two presentations the component supports, each with the element that must carry the paint
+ * while the gesture is held.
+ * @type {Object[]}
+ */
+const PRESENTATIONS = [{
+    // Measured: the source darkens from `0 0 0 / 0.09` to `/ 0.26` while held — the active state
+    // doing its job. Pinning the background to its resting value would red on any legitimate
+    // active-state token, so the token-scope proof rides the HANDLE identity instead, which the
+    // gesture has no reason to change. That is the stronger half anyway: a 0px handle still renders
+    // a band, so a background-only assertion passes an affordance whose grip has vanished.
+    background: 'painted',
+    liveResize: true,
+    name      : 'live resize (the dock default)',
+    // No clone exists, so the source itself is the affordance for the whole gesture.
+    subject   : 'source'
+}, {
+    // A clone must match its source exactly: it is the same element, re-parented, so ANY divergence
+    // is the cascade loss this spec was written for.
+    background: 'identical',
+    liveResize: false,
+    name      : 'proxy-and-commit (liveResize: false)',
+    subject   : 'proxy'
+}];
+
+test.describe('Neo.dashboard.dock.interaction.DockSplitter — the drag affordance survives its gesture', () => {
     test.setTimeout(90000);
 
-    // QUARANTINED, and deliberately not dressed up as an environment problem: this arm is a known
-    // failure on `dev`, dying on `crossing the drag threshold must create a splitter proxy —
-    // element(s) not found`. Reproduced serially at low load with `--workers=1`, and headed on a
-    // real GPU, so it is neither contention nor a compositor gap.
-    //
-    // The guard exists so the e2e pipeline can run the surrounding tier at all; it is a debt marker,
-    // not a verdict. Removing it is the fix — skipping it is what buys the time to make one.
-    test.skip(process.env.NEO_TEST_SKIP_CI === 'true', 'known failure on dev: crossing the drag threshold creates no splitter proxy');
+    for (const presentation of PRESENTATIONS) {
+        test(`the held gesture keeps the splitter's resolved paint — ${presentation.name}, ${HOST.name}`, async ({neo, page}) => {
+            await page.goto(HOST.url);
+            page.on('pageerror', error => console.error('BROWSER JS ERROR:', error.message));
 
-    for (const host of HOSTS) {
-    test(`a live drag proxy resolves the splitter tokens it was cloned from — ${host.name}`, async ({page}) => {
-        await page.goto(host.url);
-        page.on('pageerror', error => console.error('BROWSER JS ERROR:', error.message));
+            const splitter = page.locator(HOST.ready).first();
+            await expect(splitter, 'the host must render a splitter to drag').toBeVisible({timeout: 60000});
 
-        const splitter = page.locator(host.ready).first();
-        await expect(splitter, 'the host must render a splitter to drag').toBeVisible({timeout: 60000});
+            const splitterId = await splitter.evaluate(el => el.id);
 
-        // The source's own resolved paint, read BEFORE the gesture. This is the comparison target:
-        // the proxy is correct when it matches what the cascade gave the element it cloned, which
-        // is a stronger statement than "not transparent" and holds for any consumer.
-        const source = await splitter.evaluate(el => {
-            const style = getComputedStyle(el);
-            return {
-                background: style.backgroundColor,
-                handleSize: style.getPropertyValue('--dock-splitter-handle-size').trim()
-            }
-        });
+            expect(splitterId, 'the splitter must expose a component id to configure through').toBeTruthy();
 
-        expect(source.background, 'the resting splitter must itself be painted, or the comparison is vacuous')
-            .not.toBe('rgba(0, 0, 0, 0)');
+            // Both arms set it explicitly. Riding the dock's default would leave the live-resize arm
+            // silently re-parameterised by any future flip — the exact failure this spec is being
+            // repaired for.
+            await neo.setConfig(splitterId, {liveResize: presentation.liveResize});
 
-        // Guards the flag above rather than trusting it: if a consumer's handle opt-out changed,
-        // this fails instead of silently turning a real assertion into `0 === 0` or the reverse.
-        host.handleDiscriminates
-            ? expect(source.handleSize, `${host.name} is declared to cover the handle axis, so its source handle must be non-zero`).not.toBe('0')
-            : expect(source.handleSize, `${host.name} is declared to opt out of the handle, so its source handle must be zero`).toBe('0');
-
-        const box = await splitter.boundingBox();
-        const sx  = box.x + box.width  / 2,
-              sy  = box.y + box.height / 2;
-
-        await page.mouse.move(sx, sy);
-        await page.mouse.down();
-        // Two moves: the first crosses the drag threshold that creates the proxy, the second is a
-        // real displacement so the proxy is genuinely in flight rather than mid-initialisation.
-        await page.mouse.move(sx + 12, sy, {steps: 4});
-        await page.mouse.move(sx + 60, sy, {steps: 15});
-
-        const proxy = page.locator('body > .neo-dragproxy.neo-dashboard-dock-splitter').first();
-
-        try {
-            await expect(proxy, 'crossing the drag threshold must create a splitter proxy').toBeVisible({timeout: 10000});
-
-            const measured = await proxy.evaluate(el => {
+            // The source's own resolved paint, read BEFORE the gesture. This is the comparison
+            // target: the affordance is correct when it matches what the cascade gave the element
+            // it belongs to, which is a stronger statement than "not transparent" and holds for any
+            // consumer.
+            const source = await splitter.evaluate(el => {
                 const style = getComputedStyle(el);
                 return {
                     background: style.backgroundColor,
@@ -86,28 +85,60 @@ test.describe('Neo.dashboard.dock.interaction.DockSplitter — the drag proxy ca
                 }
             });
 
-            // The regression state, named explicitly so a failure reads as the defect rather than
-            // as a generic mismatch: an unscoped proxy computes a transparent background.
-            expect(measured.background,
-                `the proxy must not fall back to transparent — measured ${measured.background}, source ${source.background}`
-            ).not.toBe('rgba(0, 0, 0, 0)');
+            expect(source.background, 'the resting splitter must itself be painted, or the comparison is vacuous')
+                .not.toBe('rgba(0, 0, 0, 0)');
+            expect(source.handleSize, 'the engine host must give the splitter a non-zero handle, or the handle axis is untested')
+                .not.toBe('0');
 
-            expect(measured.background,
-                'the proxy resolves the same background the cascade gave its source'
-            ).toBe(source.background);
+            const box = await splitter.boundingBox(),
+                  sx  = box.x + box.width  / 2,
+                  sy  = box.y + box.height / 2;
 
-            // The handle is the half that fails silently: a 0px handle still renders a band, so a
-            // background-only assertion would pass a proxy whose grip had vanished.
-            // Asserted on both hosts, but only DISCRIMINATING where the source handle is non-zero —
-            // see `handleDiscriminates`. On a zero-handle consumer this is a consistency check, not
-            // evidence that the metric travelled.
-            expect(measured.handleSize,
-                `the proxy resolves the handle metric too — measured '${measured.handleSize}', source '${source.handleSize}'`
-            ).toBe(source.handleSize);
-        } finally {
-            // Always release: a held button leaks into every later test in the worker.
-            await page.mouse.up()
-        }
-    })
+            await page.mouse.move(sx, sy);
+            await page.mouse.down();
+            // Two moves: the first crosses the drag threshold, the second is a real displacement so
+            // the gesture is genuinely in flight rather than mid-initialisation.
+            await page.mouse.move(sx + 12, sy, {steps: 4});
+            await page.mouse.move(sx + 60, sy, {steps: 15});
+
+            const proxy = page.locator('body > .neo-dragproxy.neo-dashboard-dock-splitter').first();
+
+            try {
+                // The presentation itself is asserted before its paint. Without this the proxy arm
+                // could pass by measuring the source, and the live arm could pass while a proxy it
+                // never inspected carried the regression.
+                presentation.subject === 'proxy'
+                    ? await expect(proxy, 'proxy-and-commit must create a body-mounted proxy').toBeVisible({timeout: 10000})
+                    : await expect(proxy, 'live resize must create NO proxy — a proxy here means the presentation did not take').toHaveCount(0);
+
+                const subject  = presentation.subject === 'proxy' ? proxy : splitter,
+                      measured = await subject.evaluate(el => {
+                          const style = getComputedStyle(el);
+                          return {
+                              background: style.backgroundColor,
+                              handleSize: style.getPropertyValue('--dock-splitter-handle-size').trim()
+                          }
+                      });
+
+                // The regression state, named explicitly so a failure reads as the defect rather
+                // than as a generic mismatch: an unscoped affordance computes transparent.
+                expect(measured.background,
+                    `${presentation.name}: the held affordance must not fall back to transparent — measured ${measured.background}, source ${source.background}`
+                ).not.toBe('rgba(0, 0, 0, 0)');
+
+                presentation.background === 'identical' && expect(measured.background,
+                    `${presentation.name}: a body-mounted clone resolves the same background the cascade gave its source`
+                ).toBe(source.background);
+
+                // The handle is the half that fails silently: a 0px handle still renders a band, so
+                // a background-only assertion would pass an affordance whose grip had vanished.
+                expect(measured.handleSize,
+                    `${presentation.name}: the handle metric travels too — measured '${measured.handleSize}', source '${source.handleSize}'`
+                ).toBe(source.handleSize)
+            } finally {
+                // Always release: a held button leaks into every later test in the worker.
+                await page.mouse.up()
+            }
+        })
     }
 });

--- a/test/playwright/e2e/dashboard/DockSplitterProxyPaintNL.spec.mjs
+++ b/test/playwright/e2e/dashboard/DockSplitterProxyPaintNL.spec.mjs
@@ -104,6 +104,19 @@ test.describe('Neo.dashboard.dock.interaction.DockSplitter — the drag affordan
             const proxy = page.locator('body > .neo-dragproxy.neo-dashboard-dock-splitter').first();
 
             try {
+                // Positive drag entry, read BEFORE any paint. @neo-gpt's catch, and it is the
+                // difference between a witness and a formality: on the live-resize arm every
+                // assertion below also holds AT REST — no proxy exists when nothing is dragging
+                // either, and an untouched source is trivially still painted. A gesture that never
+                // entered would have passed silently.
+                //
+                // `DragZone#dragStart` stamps `neo-is-dragging` on its owner, so this is the
+                // production seam that says the drag actually began rather than a marker the spec
+                // invented for itself.
+                await expect(splitter,
+                    `${presentation.name}: the gesture must enter production drag — without it every assertion below also holds at rest`
+                ).toHaveClass(/neo-is-dragging/, {timeout: 10000});
+
                 // The presentation itself is asserted before its paint. Without this the proxy arm
                 // could pass by measuring the source, and the live arm could pass while a proxy it
                 // never inspected carried the regression.


### PR DESCRIPTION
Resolves #18419

The last of the six red arms, and the one I quarantined in #18404 so the e2e tier could ship. @neo-gpt-emmy's ledger correction made that debt visible; this discharges it and returns the arm to CI.

Like the other five, it is a spec defect — and this one is the clearest: the spec asserts a mechanism a later ticket deliberately replaced.

Evidence: L2 → L2 required. Residual: none.

## AC Evidence

| AC | Evidence |
|---|---|
| Both presentations exercised, each naming which it measured | Two arms; every message is prefixed with the presentation name. `2 passed (3.6s)`. |
| The proxy arm still fails on a token-scope loss — **verified, not inspected** | Emptied the projection; only that arm reds, with the original signature. Receipt below. |
| The live arm asserts on a held gesture | Both arms cross the drag threshold, displace, and read inside `try` before `mouse.up()`. |
| Production drag entry is positively observed | `neo-is-dragging` asserted before any paint read, after @neo-gpt's review. Receipt in **Deltas**. |
| The quarantine is deleted, not weakened | `test.skip` gone from the spec; `QUARANTINES` is now empty. |
| The selection floor still passes | `FLOOR_OK`, 14 of 104 unchanged. |

## The Cause

```js
// src/component/Splitter.mjs
liveResize_: false,              // base default
useProxy   : !me.liveResize,     // :149 and :267

// src/dashboard/dock/interaction/DockSplitter.mjs
liveResize: true,                // the dock overrides to proxy-FREE
```

#17819 introduced proxy-free live sibling resizing and the dock opted in as its default — its own docblock says so: *"Dock affordances default to the proxy-free main-thread preview … `false` restores the deferred proxy-and-commit presentation."* The spec kept waiting for `body > .neo-dragproxy.neo-dashboard-dock-splitter`, so it could only fail.

**A guard pinned to a branch its consumer stopped taking.** It went red for a reason that read like a paint regression, which is why it survived quarantine rather than diagnosis.

## The Repair

What survives the default flip is the value, not the mechanism: the affordance must not vanish mid-gesture. So both presentations run, and each sets `liveResize` **explicitly** — riding the dock default would leave the live arm silently re-parameterised by the next flip, which is precisely what happened here.

The proxy path is not retired. #17616's hazard — a clone mounted at `document.body`, outside the cascade that painted its source, resolving `--dock-splitter-*` empty — is unchanged for any consumer running `liveResize: false`, and that arm now actually executes for the first time.

## Deltas from ticket

One expectation changed rather than the product. Under live resize the source darkens from `color(srgb 0 0 0 / 0.09)` to `/ 0.26` while held — the active state doing its job. My first draft asserted background identity for both arms and red on it.

Pinning the background to its resting value would red on any legitimate active token, so the token-scope proof rides the **handle identity** on the live arm, which the gesture has no reason to change. That is the stronger half regardless: a 0px handle still renders a band, so a background-only assertion passes an affordance whose grip has vanished. Background identity stays on the proxy arm, where it belongs — a clone is the same element re-parented, so any divergence *is* the cascade loss.

## Test Evidence

```
✓ the held gesture keeps the splitter's resolved paint — live resize (the dock default)
✓ the held gesture keeps the splitter's resolved paint — proxy-and-commit (liveResize: false)
  2 passed (3.6s)
```

**Discrimination control** — emptied `DockSplitter.proxyProjectedTokens` at its call site:

```
✓ live resize (the dock default)                     ← unaffected: never reads the projection
✘ proxy-and-commit (liveResize: false)
    the held affordance must not fall back to transparent —
    measured rgba(0, 0, 0, 0), source color(srgb 0 0 0 / 0.09)
```

Exactly one arm reds, with the original regression signature. The arms measure different mechanisms, and that is demonstrated rather than asserted.

**The tier, run as CI runs it:**

```
before   33 passed, 4 skipped
after    35 passed, 3 skipped
```

## Deltas from ticket — the honesty line nearly lied

With `QUARANTINES` emptied, my first summary read *"No selected spec is quarantined: every file this job selects is expected to execute."* The log still showed **3 skipped**.

They are `test.fixme` contracts in `colors/tearOutMatrix` — rows 4, 6 and 7, declared with empty bodies. Not quarantines, but a reader comparing summary to log would have found the summary wrong. (`PreviewLanguageDragPairNL` does carry a `NEO_TEST_SKIP_CI` guard, but it is Brain-ignored and not in this tier — checked rather than assumed.)

The line now explains those skips instead of asserting their absence. **A false reassurance in the file that exists to prevent false reassurance** would have been the worst possible place for one.

## Deltas from ticket — the drag-entry guard @neo-gpt required

The live-resize arm passed **at rest**. No proxy exists when nothing is dragging either, and an untouched source is trivially still painted — so a gesture that never entered production drag would have passed silently, certifying live resize without exercising it.

`DragZone#dragStart` stamps `neo-is-dragging` on its owner, so the guard reads a production seam rather than a marker the spec invented. Asserted before any paint, on both arms. Verified by removing the gesture:

```
✘ live resize (the dock default): the gesture must enter production drag —
  without it every assertion below also holds at rest
✘ proxy-and-commit (liveResize: false): the gesture must enter production drag — …
```

Second control on this spec that convicts a shape rather than a value, and the second a reviewer had to ask for. **An absence-shaped assertion is satisfied by absence of the whole scenario**, and the only repair is to positively observe the thing the scenario was meant to start.

## Post-Merge Validation

- [ ] This arm is in the CI tier, so the next `e2e-engine` run on `dev` exercises both presentations on a hosted runner for the first time.
- [ ] Those three `test.fixme` rows remain unwritten coverage debt, now visible in every job summary rather than only in a skip count.

## Commits

- both presentations, and the quarantine released
- `0d7985de20` — the arms observe production drag entry (@neo-gpt review)

Authored by Ada (Claude Opus 5, Claude Code). Origin session 95f9ff6e-1ba5-43b6-860a-208fbf7f4442.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
