### PR TITLE
ci(test): an e2e exclusion can say its cause is real but incomplete (#18425)

### DIFF
--- a/buildScripts/util/e2eCiSelection.mjs
+++ b/buildScripts/util/e2eCiSelection.mjs
@@ -54,7 +54,7 @@ export const RUN_PATHS = [
 export const EXCLUSIONS = [{
     path  : 'test/playwright/e2e/rendering/LivePreviewMultiWindow.spec.mjs',
     kind  : 'partial',
-    reason: 'parameterised over Dev, Dist Dev and Dist Prod. The 8 Dist arms need built bundles this job does not produce, and that is verified. It does NOT cover everything: 3 of the 4 DEV arms, which need no build, also failed hosted while all 4 pass locally — so a build step alone would not return this file to the tier',
+    reason: 'parameterised over Dev, Dist Dev and Dist Prod. The 8 Dist arms need built bundles this job does not produce, and that is verified. It does NOT cover everything: 3 of the 4 DEV arms, which need no build, also failed hosted while all 4 pass locally — so a build step alone would not return this file to the tier. Those 3 die on `.neo-code-live-preview` never becoming visible, and all 3 are the arms that visit `#/learn/benefits/body/FormsEngine`; the one Dev arm that never leaves the home route passes',
     owner : 'this tier for the Dist half; @neo-opus-ada for the 3 unexplained Dev arms'
 }, {
     path  : 'test/playwright/e2e/portal/LearnLinkRoutingNL.spec.mjs',

--- a/buildScripts/util/e2eCiSelection.mjs
+++ b/buildScripts/util/e2eCiSelection.mjs
@@ -34,7 +34,6 @@ export const RUN_PATHS = [
     'test/playwright/e2e/core',
     'test/playwright/e2e/dashboard',
     'test/playwright/e2e/grid',
-    'test/playwright/e2e/portal/LearnLinkRoutingNL.spec.mjs',
     'test/playwright/e2e/rendering/InputModalityMultiWindow.spec.mjs',
     'test/playwright/e2e/rendering/ViewTransitionReveal.spec.mjs'
 ];
@@ -50,6 +49,11 @@ export const EXCLUSIONS = [{
     kind  : 'cause',
     reason: 'parameterised over Dev, Dist Dev and Dist Prod; the Dist environments need built bundles this job does not produce, so each arm burns its full 30s timeout',
     owner : 'this tier, the day the pipeline can afford a build step'
+}, {
+    path  : 'test/playwright/e2e/portal/LearnLinkRoutingNL.spec.mjs',
+    kind  : 'cause',
+    reason: 'on a hosted runner the click routes and the content never follows — the trace shows the hash at the destination and the source `h1` still in place 5s later, with no console error and no failed request. Measured at a 30s assertion window too, so it is not a timing budget; the sibling sidebar arm passes on the same runner',
+    owner : '@neo-opus-ada — #18422 holds the measurement; the arm is correct and the divergence is not'
 }];
 
 /**

--- a/buildScripts/util/e2eCiSelection.mjs
+++ b/buildScripts/util/e2eCiSelection.mjs
@@ -62,7 +62,7 @@ export const EXCLUSIONS = [{
     // this `cause` would repeat, on the entry being diagnosed, the exact overclaim `partial` was
     // added to stop on the entry beside it.
     kind  : 'observed',
-    reason: 'on a hosted runner the click routes and the content never follows — the trace shows the hash at the destination and the source `h1` still in place 5s later, with no console error and no failed request. Measured at a 30s assertion window too, so it is not a timing budget; the sibling sidebar arm passes on the same runner',
+    reason: 'on a hosted runner the click routes and the content has not followed within 30s — the trace shows the hash at the destination and the source `h1` still in place, with no console error and no failed request. Bounded deliberately: 30s is the longest window measured, so a slower-still arrival is not excluded, only a budget in the range anyone would wait; the sibling sidebar arm passes on the same runner',
     owner : '@neo-opus-ada — #18422 holds the measurement; the arm is correct and the divergence is not'
 }];
 

--- a/buildScripts/util/e2eCiSelection.mjs
+++ b/buildScripts/util/e2eCiSelection.mjs
@@ -34,6 +34,7 @@ export const RUN_PATHS = [
     'test/playwright/e2e/core',
     'test/playwright/e2e/dashboard',
     'test/playwright/e2e/grid',
+    'test/playwright/e2e/portal/LearnLinkRoutingNL.spec.mjs',
     'test/playwright/e2e/rendering/InputModalityMultiWindow.spec.mjs',
     'test/playwright/e2e/rendering/ViewTransitionReveal.spec.mjs'
 ];
@@ -49,11 +50,6 @@ export const EXCLUSIONS = [{
     kind  : 'cause',
     reason: 'parameterised over Dev, Dist Dev and Dist Prod; the Dist environments need built bundles this job does not produce, so each arm burns its full 30s timeout',
     owner : 'this tier, the day the pipeline can afford a build step'
-}, {
-    path  : 'test/playwright/e2e/portal/LearnLinkRoutingNL.spec.mjs',
-    kind  : 'observed',
-    reason: 'fails on a hosted runner asserting the destination guide heading; the guide and the learn index are BOTH tracked, so "needs generated content" was wrong and no verified cause has replaced it',
-    owner : '@neo-opus-ada — diagnose or hand over; excluded rather than diagnosed'
 }];
 
 /**

--- a/buildScripts/util/e2eCiSelection.mjs
+++ b/buildScripts/util/e2eCiSelection.mjs
@@ -58,7 +58,10 @@ export const EXCLUSIONS = [{
     owner : 'this tier for the Dist half; @neo-opus-ada for the 3 unexplained Dev arms'
 }, {
     path  : 'test/playwright/e2e/portal/LearnLinkRoutingNL.spec.mjs',
-    kind  : 'cause',
+    // `observed`, not `cause`: what is established is the BEHAVIOUR, not why it happens. Marking
+    // this `cause` would repeat, on the entry being diagnosed, the exact overclaim `partial` was
+    // added to stop on the entry beside it.
+    kind  : 'observed',
     reason: 'on a hosted runner the click routes and the content never follows — the trace shows the hash at the destination and the source `h1` still in place 5s later, with no console error and no failed request. Measured at a 30s assertion window too, so it is not a timing budget; the sibling sidebar arm passes on the same runner',
     owner : '@neo-opus-ada — #18422 holds the measurement; the arm is correct and the divergence is not'
 }];

--- a/buildScripts/util/e2eCiSelection.mjs
+++ b/buildScripts/util/e2eCiSelection.mjs
@@ -22,6 +22,13 @@ import {selectExternalBrainSpecs} from '../../test/playwright/externalBrainSelec
  * - **Observed failures** — arms that fail for reasons NOT established here. They carry an owner
  *   rather than a diagnosis, because naming an unverified cause is worse than admitting one is
  *   missing.
+ *
+ * An exclusion's `kind` is about the CAUSE, and it has three values because two were not enough.
+ * `cause` and `observed` split "we know why" from "we do not", and both were honest — but an entry
+ * marked `cause` was quietly claiming its reason covered EVERY failing arm in that file, and one of
+ * them did not: it explained 8 of 11, while 3 arms needing nothing it mentioned failed anyway.
+ * `partial` exists so a real-but-incomplete diagnosis cannot present itself as a complete one,
+ * which is the same false reassurance as an undeclared exclusion wearing better clothes.
  */
 
 /**
@@ -46,9 +53,9 @@ export const RUN_PATHS = [
  */
 export const EXCLUSIONS = [{
     path  : 'test/playwright/e2e/rendering/LivePreviewMultiWindow.spec.mjs',
-    kind  : 'cause',
-    reason: 'parameterised over Dev, Dist Dev and Dist Prod; the Dist environments need built bundles this job does not produce, so each arm burns its full 30s timeout',
-    owner : 'this tier, the day the pipeline can afford a build step'
+    kind  : 'partial',
+    reason: 'parameterised over Dev, Dist Dev and Dist Prod. The 8 Dist arms need built bundles this job does not produce, and that is verified. It does NOT cover everything: 3 of the 4 DEV arms, which need no build, also failed hosted while all 4 pass locally — so a build step alone would not return this file to the tier',
+    owner : 'this tier for the Dist half; @neo-opus-ada for the 3 unexplained Dev arms'
 }, {
     path  : 'test/playwright/e2e/portal/LearnLinkRoutingNL.spec.mjs',
     kind  : 'cause',
@@ -141,7 +148,8 @@ export function summary(root = process.cwd()) {
         `- **${ignored}** need an external \`neo-agent-brain\` checkout. \`testIgnore\` DESELECTS them, so they cannot appear as skips in any report — a run missing them still prints \`Skipped: 0\`.`,
         `- **${gpu}** boot the workstation app, which inherits animated OffscreenCanvas work a hosted runner cannot composite.`,
         ...EXCLUSIONS.map(entry => `- \`${entry.path.replace('test/playwright/e2e/', '')}\` — ` +
-            (entry.kind === 'cause' ? '' : '**cause not established.** ') + `${entry.reason}. Owner: ${entry.owner}.`),
+            ({cause: '', observed: '**cause not established.** ', partial: '**cause covers only part of the failures.** '}[entry.kind]) +
+            `${entry.reason}. Owner: ${entry.owner}.`),
         '',
         `Selected but quarantined — these run in the tier and skip themselves, so they appear as skips rather than coverage:`,
         ...QUARANTINES.map(entry => `- \`${entry.path.replace('test/playwright/e2e/', '')}\` — ${entry.reason}. Owner: ${entry.owner}.`),

--- a/test/playwright/e2e/portal/LearnLinkRoutingNL.spec.mjs
+++ b/test/playwright/e2e/portal/LearnLinkRoutingNL.spec.mjs
@@ -86,15 +86,17 @@ test.describe('learn link routing', () => {
         // subtitle is the discriminator — 'Dock Layouts:' alone would pass without navigating.
         //
         // This arm passes locally in ~800ms and fails on a hosted Ubuntu runner, and the difference
-        // is NOT a timing budget — that was tested rather than assumed. The hosted trace shows the
-        // click resolving its anchor, `navigations have finished`, the hash arriving at the
-        // destination, and the source `h1` still in place afterwards, with no console error and no
-        // failed request. Widening this assertion to 30s and running it hosted changed nothing: the
-        // arm still failed, at 32.4s.
+        // is not a timing budget in any range worth waiting — that was tested rather than assumed.
+        // The hosted trace shows the click resolving its anchor, `navigations have finished`, the
+        // hash arriving at the destination, and the source `h1` still in place afterwards, with no
+        // console error and no failed request. Widening this assertion to 30s and running it hosted
+        // changed nothing: the arm still failed, at 32.4s.
         //
-        // So the route changes and the content never follows, while the sibling sidebar arm passes
-        // on the same runner. The default window stays, because a longer one buys a slower failure
-        // and nothing else.
+        // So the route changes and the content has not followed within 30s, while the sibling sidebar
+        // arm passes on the same runner. Bounded on purpose: 30s is the longest window measured, so
+        // this does not exclude a slower-still arrival — only one inside any window a person would
+        // wait through. The default stays, because a longer one buys a slower failure and no more
+        // information.
         await expect(content.locator('h1')).toContainText('Adopting in Your App')
     });
 

--- a/test/playwright/e2e/portal/LearnLinkRoutingNL.spec.mjs
+++ b/test/playwright/e2e/portal/LearnLinkRoutingNL.spec.mjs
@@ -85,16 +85,17 @@ test.describe('learn link routing', () => {
         // The source page is 'Dock Layouts: One Application, Many Windows', so the destination's own
         // subtitle is the discriminator — 'Dock Layouts:' alone would pass without navigating.
         //
-        // The explicit timeout is a measurement, not padding. On a hosted runner this arm failed at
-        // the default 5s with the URL ALREADY at the destination: the trace's frame snapshots show
-        // the hash change at t+0 and the source `h1` still in place 5s later, with no console error
-        // and no failed request. Locally the same click lands in ~800ms, so the hosted path needs
-        // more than six times the local budget — a margin no local run can discover.
+        // This arm passes locally in ~800ms and fails on a hosted Ubuntu runner, and the difference
+        // is NOT a timing budget — that was tested rather than assumed. The hosted trace shows the
+        // click resolving its anchor, `navigations have finished`, the hash arriving at the
+        // destination, and the source `h1` still in place afterwards, with no console error and no
+        // failed request. Widening this assertion to 30s and running it hosted changed nothing: the
+        // arm still failed, at 32.4s.
         //
-        // 30s is chosen to distinguish "slower than the default window" from "never arrives". If
-        // this arm ever fails at 30s, the content genuinely does not follow the route and the
-        // timeout is no longer the story.
-        await expect(content.locator('h1')).toContainText('Adopting in Your App', {timeout: 30000})
+        // So the route changes and the content never follows, while the sibling sidebar arm passes
+        // on the same runner. The default window stays, because a longer one buys a slower failure
+        // and nothing else.
+        await expect(content.locator('h1')).toContainText('Adopting in Your App')
     });
 
 });

--- a/test/playwright/e2e/portal/LearnLinkRoutingNL.spec.mjs
+++ b/test/playwright/e2e/portal/LearnLinkRoutingNL.spec.mjs
@@ -84,7 +84,17 @@ test.describe('learn link routing', () => {
 
         // The source page is 'Dock Layouts: One Application, Many Windows', so the destination's own
         // subtitle is the discriminator — 'Dock Layouts:' alone would pass without navigating.
-        await expect(content.locator('h1')).toContainText('Adopting in Your App')
+        //
+        // The explicit timeout is a measurement, not padding. On a hosted runner this arm failed at
+        // the default 5s with the URL ALREADY at the destination: the trace's frame snapshots show
+        // the hash change at t+0 and the source `h1` still in place 5s later, with no console error
+        // and no failed request. Locally the same click lands in ~800ms, so the hosted path needs
+        // more than six times the local budget — a margin no local run can discover.
+        //
+        // 30s is chosen to distinguish "slower than the default window" from "never arrives". If
+        // this arm ever fails at 30s, the content genuinely does not follow the route and the
+        // timeout is no longer the story.
+        await expect(content.locator('h1')).toContainText('Adopting in Your App', {timeout: 30000})
     });
 
 });


### PR DESCRIPTION
Resolves #18425
Refs #18422

The last exclusion I owned in the e2e tier carried an admission that nobody knew why. This replaces it with a measurement — **and the measurement came out the other way from my hypothesis.**

Evidence: L2 → L2 required (a hosted-only failure is only visible to a hosted runner). Residual: the divergence's root cause is not established, deliberately — see **Deltas**.

## AC Evidence

| AC | Evidence |
|---|---|
| A hosted run executes the arm and its result is recorded **either way** | [Run 34069793273](https://github.com/neomjs/neo/actions/runs/34069793273): red at 32.4s. Recorded below, as promised in advance. |
| The exclusion states what was measured | The trace and the 30s result, classified `observed` — a behaviour is established, not a cause. |
| The other exclusion's cause is honest too | Found overstated while verifying the claim above; `kind: 'partial'` added. See **Deltas**. |
| The floor still passes | `FLOOR_OK`, `executed: 14`. |
| The arm still fails if the rewrite is removed | Deleted the production `rewriteLinks` invocation. Receipt below. |

## What The Local Instrument Could Not See

The arm passes locally — in isolation (`4 passed, 6.3s`) **and** at the same serial position inside the full tier (test 30 of 37, 807ms). Not serial position, not state accumulation, not resource pressure. Those were ruled out before reaching for the hosted artifact.

## What The Hosted Trace Establishes

From [run 34063075394](https://github.com/neomjs/neo/actions/runs/34063075394)'s uploaded artifact. The click is not the problem and neither is the anchor: the selector resolved, Playwright logged `waiting for scheduled navigations to finish` → `navigations have finished`, and **the trace holds no console error and no failed request.**

```
140971.2  …index.html#/learn/guides/uibuildingblocks/DockLayouts
141020.8  …index.html#/learn/guides/uibuildingblocks/DockLayoutsAdoption   ← the click routed
146050.4  …index.html#/learn/guides/uibuildingblocks/DockLayoutsAdoption   ← 5s later
```

**The route changed. The content had not followed when the window closed.** `12 × locator resolved to <h1 …>Dock Layouts: One Application, Many Windows</h1>`, with the URL already at the destination. The sibling sidebar arm passed on the same runner.

## Deltas from ticket — my hypothesis was wrong, and that is the deliverable

This PR opened claiming the likely cause was a **tight assertion**: locally the update lands in ~800ms, so a hosted runner needing more than the default 5s seemed plausible. I widened it to 30s, returned the spec to the tier, and stated in advance that the PR's own hosted run was the discriminator and that a red would be the result rather than a setback.

**It came back red at 32.4s.**

```
✓  27 … a relative guide link is rendered as a route, not a file path (1.4s)
✓  28 … a fragment-bearing link keeps its anchor on the route (1.4s)
✓  29 … control: the harness can click the app's own navigation (3.3s)
✘  30 … clicking a rewritten link arrives at its destination (32.4s)
       Expected substring: "Adopting in Your App"
       Received string:    "Dock Layouts: One Application, Many Windows"
```

So the content had **not followed within 30s** — the longest window measured — and the timeout is reverted: a longer one buys a slower failure and no more information. Bounded on purpose: that does not exclude a slower-still arrival, only one inside any budget a person would wait through.

The spec stays excluded — it is correct, and the divergence is not its fault — but its entry now carries that measurement in full. It stays classified `observed`: what is established is the **behaviour**, not why a hosted Ubuntu runner diverges from a local macOS one, and marking it `cause` would repeat on this entry the exact overclaim found on the one beside it. The list now states what was measured for both — and while verifying that claim I found the other one was overstated. See below.

Two things this deliberately does **not** claim: why a hosted Ubuntu runner diverges from a local macOS one, and whether any user-facing path is affected. Neither is established. #18422 stays open holding that, exactly as pre-registered.

## Deltas — I checked my own claim and it was overstated

Writing *"the exclusion list carries no unexplained entry"* prompted me to verify it, and the other entry did not hold up.

`LivePreviewMultiWindow`'s reason reads *"the Dist environments need built bundles this job does not produce"*. True — and it covers **8 of 11** failing arms. The other 3 are the **Dev** environment, which needs no build at all:

```
PASS  32  Environment: Dev - Popout LivePreview from Home Route (Helix)     8.4s
FAIL  33  Environment: Dev - Popout LivePreview from Learn Route           30.6s
FAIL  34  Environment: Dev - Sequential Route: Home -> Learn -> Popout     41.7s
FAIL  35  Environment: Dev - Sequential Route: Learn -> Home -> Popout     30.7s
FAIL  36-43  Dist Dev / Dist Prod                                      all 30.3s
```

All four Dev arms pass locally in 40.2s. **So a build step — the remedy that entry's owner field promised — would not have returned the file to the tier**, and a reader would have believed it would.

`kind` gains a third value. `cause` and `observed` split *we know why* from *we do not*, and both were honest; neither could express a reason that is **real and incomplete**. An entry marked `cause` was quietly asserting its explanation covered every failing arm in that file. The summary now says so out loud when it does not, and the owner field splits with it: this tier holds the Dist half, I hold the 3 Dev arms.

**The coincidence was checked, and it does not hold.** All 3 failing Dev arms die on `.neo-code-live-preview` never becoming visible, and all 3 are the arms visiting `#/learn/benefits/body/FormsEngine`; the one Dev arm that never leaves the home route passes on the same run. That looked like kinship with this PR's own exclusion — same app, same hosted-only shape, both touching learn routes.

**RETRACTED — see below.** I wrote here that the two are different surfaces, on the strength of the failing page's table of contents rendering. Parsing the trace's DOM snapshot afterwards showed that reading was wrong: the article element `neo-app-content-component` is present and **has zero children**, against 67 in a passing arm's snapshot. The guide was parsed — hence the ToC — and its body never reached the article. **Both failures are the same surface**: `.neo-app-content-component` not receiving the guide it was asked for, silently, with a healthy network. One keeps the source guide's content after a route change; the other is empty on a direct load. A ToC proves parsing, not rendering, and I published the stronger claim.

## Test Evidence

Local, after the revert: `4 passed (6.2s)`.

**Rewrite-removal control** — deleted `html = me.rewriteLinks(html)` from `src/component/Markdown.mjs`:

```
✘ a relative guide link is rendered as a route, not a file path
✘ a fragment-bearing link keeps its anchor on the route
✓ control: the harness can click the app's own navigation      ← owes nothing to the rewrite
✘ clicking a rewritten link arrives at its destination
```

Exactly the split the spec's docblock predicts, which is what keeps this arm a witness rather than a formality.

## Post-Merge Validation

- [ ] #18422 stays open on the unexplained divergence, and this PR no longer closes it. The next step is a hosted probe of the route handler, not another timeout.
- [ ] The 3 unexplained `LivePreview` Dev arms are recorded under my ownership in the standing exclusion, not in a ticket. If that proves too quiet a home, they need their own.

## Commits

- the arm returns to the tier with a widened timeout — the experiment
- the experiment's result: exclusion restored with a measured cause
- `db34036b49` — an exclusion can say its cause is only partial

Authored by Ada (Claude Opus 5, Claude Code). Origin session 95f9ff6e-1ba5-43b6-860a-208fbf7f4442.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
