### PR TITLE
fix(dock): root chips measure the boundary they commit against (#18421)

### DIFF
--- a/apps/workstation/view/PopupWorkspace.mjs
+++ b/apps/workstation/view/PopupWorkspace.mjs
@@ -118,7 +118,7 @@ class PopupWorkspace extends DockWorkspace {
 
         if (!nodeId) return super.resolveDockableRoot();
 
-        let host = me.getDockHost?.() ?? null;
+        let host = me.getDockHost();
 
         // The chip must measure the CONTENT, not the shell: the projected container for the stack
         // root is the region a drop actually lands in, and the shell's rect would over-report it.

--- a/apps/workstation/view/PopupWorkspace.mjs
+++ b/apps/workstation/view/PopupWorkspace.mjs
@@ -56,10 +56,10 @@ class PopupWorkspace extends DockWorkspace {
         const me = this;
         me.workspaceSet.register(me.workspaceKey, {
             componentId: me.id,
-            dispose: () => { if (!me.isDestroyed) me.destroy() },
+            dispose    : () => { if (!me.isDestroyed) me.destroy() },
             getDocument: () => me.dockModel,
             setDocument: value => me.dockModel = value,
-            project: context => me.projectDockZoneDocument(context.snapshot.participants[me.workspaceKey], context.descriptor, me, {
+            project    : context => me.projectDockZoneDocument(context.snapshot.participants[me.workspaceKey], context.descriptor, me, {
                 preserveItemIds: context.preserveItemIds
             })
         });
@@ -100,16 +100,18 @@ class PopupWorkspace extends DockWorkspace {
 
     /**
      * @summary A full popup presents a vessel SHELL, so its dockable boundary is the content inside
-     * that shell rather than the shell itself.
+     * that shell — see {@link Neo.dashboard.dock.Workspace#resolveDockableRoot} for why the pair
+     * travels together.
      *
      * Wrapping the shell would leave {@link Neo.dashboard.dock.model.WorkspaceDocument#resolveStackRoot}
-     * unable to resolve — it reads the root's `center` and requires the root to BE an `edge-zone` —
-     * and `window.Participation` refuses whole-stack admission unless that resolution matches the
-     * transferred `groupNodeId`. So a wrapped shell would keep docking and silently stop being
-     * transferable.
+     * unable to resolve, and `window.Participation` refuses whole-stack admission unless that
+     * resolution matches the transferred `groupNodeId` — so a wrapped shell would keep docking and
+     * silently stop being transferable.
      *
-     * Falls back to the inherited arrangement boundary when no stack root resolves, so a popup whose
-     * document is not shell-shaped still docks at its own root instead of refusing every root chip.
+     * Two ways to decline, and neither substitutes a rect from a different node. No stack root: the
+     * document is not shell-shaped, so the inherited arrangement boundary applies. A stack root with
+     * no projected container: nothing measurable represents it, so no boundary is offered at all —
+     * naming the stack while measuring the shell is the very mismatch this seam exists to end.
      * @returns {Object|null}
      */
     resolveDockableRoot() {
@@ -118,11 +120,9 @@ class PopupWorkspace extends DockWorkspace {
 
         if (!nodeId) return super.resolveDockableRoot();
 
-        let host = me.getDockHost();
+        let component = me.getDockHost().down({dockNodeId: nodeId});
 
-        // The chip must measure the CONTENT, not the shell: the projected container for the stack
-        // root is the region a drop actually lands in, and the shell's rect would over-report it.
-        return host ? {component: host.down({dockNodeId: nodeId}) ?? host, nodeId} : null
+        return component ? {component, nodeId} : null
     }
 
     /**

--- a/apps/workstation/view/PopupWorkspace.mjs
+++ b/apps/workstation/view/PopupWorkspace.mjs
@@ -1,5 +1,6 @@
-import DockWorkspace from '../../../src/dashboard/dock/Workspace.mjs';
-import Participation from '../../../src/dashboard/dock/window/Participation.mjs';
+import DockWorkspace     from '../../../src/dashboard/dock/Workspace.mjs';
+import Participation     from '../../../src/dashboard/dock/window/Participation.mjs';
+import WorkspaceDocument from '../../../src/dashboard/dock/model/WorkspaceDocument.mjs';
 
 /**
  * @summary Owns one popup document while resolving the root's existing live pane instances.
@@ -95,6 +96,33 @@ class PopupWorkspace extends DockWorkspace {
     getDockProjectionOptions() {
         return {...super.getDockProjectionOptions(), workspaceId: this.workspaceKey,
             crossWindowSortGroup: this.rootWorkspace.constructor.CROSS_WINDOW_SORT_GROUP, enableStackDrag: true}
+    }
+
+    /**
+     * @summary A full popup presents a vessel SHELL, so its dockable boundary is the content inside
+     * that shell rather than the shell itself.
+     *
+     * Wrapping the shell would leave {@link Neo.dashboard.dock.model.WorkspaceDocument#resolveStackRoot}
+     * unable to resolve — it reads the root's `center` and requires the root to BE an `edge-zone` —
+     * and `window.Participation` refuses whole-stack admission unless that resolution matches the
+     * transferred `groupNodeId`. So a wrapped shell would keep docking and silently stop being
+     * transferable.
+     *
+     * Falls back to the inherited arrangement boundary when no stack root resolves, so a popup whose
+     * document is not shell-shaped still docks at its own root instead of refusing every root chip.
+     * @returns {Object|null}
+     */
+    resolveDockableRoot() {
+        let me     = this,
+            nodeId = WorkspaceDocument.resolveStackRoot(me.dockModel);
+
+        if (!nodeId) return super.resolveDockableRoot();
+
+        let host = me.getDockHost?.() ?? null;
+
+        // The chip must measure the CONTENT, not the shell: the projected container for the stack
+        // root is the region a drop actually lands in, and the shell's rect would over-report it.
+        return host ? {component: host.down({dockNodeId: nodeId}) ?? host, nodeId} : null
     }
 
     /**

--- a/buildScripts/util/file-size-baseline.json
+++ b/buildScripts/util/file-size-baseline.json
@@ -1,6 +1,6 @@
 {
     "apps/workstation/view/Workspace.mjs": 2916,
     "examples/dashboard/crossWindow/DemoBWorkspace.mjs": 2611,
-    "src/dashboard/dock/Workspace.mjs": 1017,
+    "src/dashboard/dock/Workspace.mjs": 1023,
     "src/main/addon/DragDrop.mjs": 1267
 }

--- a/src/dashboard/dock/Workspace.mjs
+++ b/src/dashboard/dock/Workspace.mjs
@@ -797,6 +797,35 @@ class Workspace extends Container {
     }
 
     /**
+     * @summary Names the node a ROOT-EDGE drop wraps, and the component whose rect measures it.
+     *
+     * The two travel together on purpose: a root chip is PAINTED from the component's rect and
+     * COMMITTED against the nodeId, so a boundary naming one region while measuring another
+     * previews a drop it cannot perform.
+     *
+     * Resolved live on every call, never captured. A root-edge drop replaces `dockModel.root` with
+     * the wrapping split, so a node id read once names the PREVIOUS root from the second gesture
+     * onward — the same mismatch, one drop later.
+     *
+     * The default boundary is the whole arrangement: the document root, measured by the dock host.
+     * A workspace presenting a vessel SHELL — window chrome around transferable content — overrides
+     * this to name the content boundary inside that shell, so the shell is never wrapped and
+     * {@link Neo.dashboard.dock.model.WorkspaceDocument#resolveStackRoot} keeps resolving.
+     *
+     * The node TYPE cannot make that distinction, which is why this is a declaration rather than an
+     * inference: an arrangement root and a vessel shell are both `edge-zone`, and occupied side
+     * slots are a layout state rather than an identity.
+     * @returns {Object|null} `{component, nodeId}`, or null when nothing dockable resolves
+     */
+    resolveDockableRoot() {
+        let me        = this,
+            component = me.getDockHost?.() ?? null,
+            nodeId    = me.dockModel?.root ?? null;
+
+        return component && nodeId ? {component, nodeId} : null
+    }
+
+    /**
      * @summary The live component currently rendering one dock item, or null.
      *
      * The two resolver-shaped members this folds together — the tree lookup and the stand-in

--- a/src/dashboard/dock/Workspace.mjs
+++ b/src/dashboard/dock/Workspace.mjs
@@ -819,7 +819,7 @@ class Workspace extends Container {
      */
     resolveDockableRoot() {
         let me        = this,
-            component = me.getDockHost?.() ?? null,
+            component = me.getDockHost(),
             nodeId    = me.dockModel?.root ?? null;
 
         return component && nodeId ? {component, nodeId} : null

--- a/src/dashboard/dock/interaction/DragAffordances.mjs
+++ b/src/dashboard/dock/interaction/DragAffordances.mjs
@@ -1,7 +1,6 @@
-import Base              from '../../../core/Base.mjs';
-import WorkspaceDocument from '../model/WorkspaceDocument.mjs';
-import PreviewProducer   from './PreviewProducer.mjs';
-import PreviewContract   from '../model/PreviewContract.mjs';
+import Base            from '../../../core/Base.mjs';
+import PreviewProducer from './PreviewProducer.mjs';
+import PreviewContract from '../model/PreviewContract.mjs';
 
 /**
  * @class Neo.dashboard.dock.interaction.DragAffordances
@@ -120,8 +119,9 @@ class DragAffordances extends Base {
      * @summary Measures once per gesture and window size (memoized as a promise so the
      * ~60hz move stream never stacks measurements): the host rect (the overlays' coordinate
      * origin), every projected tabs-zone rect with its parent-split orientation, and the
-     * chips' root target — the edge-zone's CENTER node when the document root is an
-     * edge-zone, the root itself otherwise.
+     * chips' root target — the boundary its owner declares through
+     * {@link Neo.dashboard.dock.Workspace#resolveDockableRoot}, measured on that boundary's
+     * own component so the chip's nodeId and its rect describe the same node.
      * @returns {Promise<Object|null>} {hostRect, zones, root} or null when nothing is measurable
      * @protected
      */
@@ -145,14 +145,21 @@ class DragAffordances extends Base {
                 .filter(nodeId => nodes[nodeId].type === 'tabs')
                 .map(nodeId => ({nodeId, container: host.down({dockNodeId: nodeId})}))
                 .filter(zone => zone.container),
-            // a zone entry is an OBJECT DESCRIPTOR ({nodeId, …} — the v13.2 contract rejects the
-            // retired string shorthand) — the canonical unwrap keeps the producer's fail-closed
-            // id guard from silently dropping every root edge chip
-            rootId      = nodes[me.owner.dockModel.root]?.type === 'edge-zone'
-                ? (WorkspaceDocument.getZoneNodeId(nodes[me.owner.dockModel.root].zones?.center) ?? me.owner.dockModel.root)
-                : me.owner.dockModel.root;
+            // A root-edge drop wraps the node the OWNER declares, so the chip's nodeId and the
+            // rect it is drawn from have to name the same node. Reading the nodeId from document
+            // SHAPE while always measuring the host is what made a bottom drop preview the full
+            // width and commit a corner. Resolved LIVE every gesture: wrapping rewrites
+            // `document.root`, so a captured id is stale one drop later.
+            dockable    = me.owner.resolveDockableRoot(),
+            measureIds  = [host.id, ...zoneEntries.map(zone => zone.container.id)],
+            // measured in the SAME batch, and reusing the host's rect when the boundary IS the
+            // host — the ordinary whole-arrangement root, which is most documents
+            rootIndex   = dockable && dockable.component !== host ? measureIds.push(dockable.component.id) - 1 : 0;
 
-        const promise = host.getDomRect([host.id, ...zoneEntries.map(zone => zone.container.id)]).then(([hostRect, ...zoneRects]) => {
+        const promise = host.getDomRect(measureIds).then(rects => {
+            let hostRect  = rects[0],
+                zoneRects = rects.slice(1, zoneEntries.length + 1);
+
             if (me.dragGeometry === promise && me.geometrySignature !== me.getGeometrySignature()) {
                 me.clear();
                 return null
@@ -160,7 +167,7 @@ class DragAffordances extends Base {
 
             let geometry = hostRect?.width > 0 && hostRect?.height > 0 && {
                 hostRect,
-                root : {nodeId: rootId, rect: hostRect},
+                root : {nodeId: dockable?.nodeId ?? null, rect: rects[rootIndex]},
                 zones: zoneEntries
                     .map((zone, index) => ({
                         nodeId     : zone.nodeId,
@@ -275,7 +282,35 @@ class DragAffordances extends Base {
 
         if (candidate?.preview?.itemId === itemId) return candidate.preview;
 
-        return producer.produce({groupNodeId, itemId, pointer, root: geometry.root, sourceNodeId, zones: geometry.zones})
+        return me.guardEmptyWrap(producer.produce({groupNodeId, itemId, pointer, root: geometry.root, sourceNodeId, zones: geometry.zones}), itemId)
+    }
+
+    /**
+     * @summary Refuses a root placement that would dock the arrangement's only pane beside nothing.
+     *
+     * A root-edge drop wraps the whole arrangement, so when the dragged item IS the whole
+     * arrangement the wrap pairs the new pane with an empty half. Tabs and splits vanish in that
+     * state — `normalizeTree` deletes them — but an `edge-zone` survives losing every zone on
+     * purpose: it stays a resolvable re-attachment anchor
+     * ({@link Neo.dashboard.dock.model.WorkspaceDocument#captureNodeHome}). So an edge-zone root is
+     * the one target whose empty half would persist in the committed tree, and it is the only case
+     * this refuses — a tabs or split root still commits exactly as before.
+     *
+     * Refused at preview time, not only at commit, so the affordance never promises a drop the
+     * document would keep as a stranded half.
+     * @param {Object|null} preview
+     * @param {String} itemId
+     * @returns {Object|null} the preview, or null when it must not be offered
+     * @protected
+     */
+    guardEmptyWrap(preview, itemId) {
+        const document = this.owner?.dockModel,
+              target   = document?.nodes?.[preview?.target?.nodeId],
+              items    = document?.items;
+
+        if (target?.type !== 'edge-zone' || !items) return preview;
+
+        return Object.keys(items).length === 1 && items[itemId] ? null : preview
     }
 
     /**
@@ -380,7 +415,7 @@ class DragAffordances extends Base {
 
         me.clear();
 
-        let descriptor = PreviewContract.previewToOperation(preview);
+        let descriptor = PreviewContract.previewToOperation(me.guardEmptyWrap(preview, itemId));
 
         if (descriptor) {
             let result = me.owner.applyDockZoneOperation(descriptor);

--- a/src/dashboard/dock/interaction/DragAffordances.mjs
+++ b/src/dashboard/dock/interaction/DragAffordances.mjs
@@ -280,7 +280,9 @@ class DragAffordances extends Base {
 
         const candidate = indicators?.updatePointer(pointer);
 
-        if (candidate?.preview?.itemId === itemId) return candidate.preview;
+        // Both tiers pass the same guard: a root chip selected from the MENU would otherwise
+        // promise a wrap the release refuses, which is the mismatch this whole seam exists to end.
+        if (candidate?.preview?.itemId === itemId) return me.guardEmptyWrap(candidate.preview, itemId);
 
         return me.guardEmptyWrap(producer.produce({groupNodeId, itemId, pointer, root: geometry.root, sourceNodeId, zones: geometry.zones}), itemId)
     }

--- a/src/dashboard/dock/interaction/DragAffordances.mjs
+++ b/src/dashboard/dock/interaction/DragAffordances.mjs
@@ -126,7 +126,7 @@ class DragAffordances extends Base {
      * @protected
      */
     ensureGeometry() {
-        let me = this,
+        let me        = this,
             signature = me.getGeometrySignature();
 
         if (signature !== me.geometrySignature) {
@@ -145,11 +145,9 @@ class DragAffordances extends Base {
                 .filter(nodeId => nodes[nodeId].type === 'tabs')
                 .map(nodeId => ({nodeId, container: host.down({dockNodeId: nodeId})}))
                 .filter(zone => zone.container),
-            // A root-edge drop wraps the node the OWNER declares, so the chip's nodeId and the
-            // rect it is drawn from have to name the same node. Reading the nodeId from document
-            // SHAPE while always measuring the host is what made a bottom drop preview the full
-            // width and commit a corner. Resolved LIVE every gesture: wrapping rewrites
-            // `document.root`, so a captured id is stale one drop later.
+            // The boundary its owner declares — `Workspace#resolveDockableRoot` carries why the
+            // nodeId and its rect must name ONE node. Resolved live every gesture: wrapping
+            // rewrites `document.root`, so a captured id is stale one drop later.
             dockable    = me.owner.resolveDockableRoot(),
             measureIds  = [host.id, ...zoneEntries.map(zone => zone.container.id)],
             // measured in the SAME batch, and reusing the host's rect when the boundary IS the
@@ -208,7 +206,7 @@ class DragAffordances extends Base {
      */
     getGeometrySignature() {
         const windowId = this.host?.windowId,
-              rect = windowId != null ? Neo.manager?.Window?.get(windowId)?.innerRect : null;
+              rect     = windowId != null ? Neo.manager?.Window?.get(windowId)?.innerRect : null;
 
         return rect ? JSON.stringify([windowId, rect.width, rect.height]) : null
     }

--- a/test/playwright/e2e/workstation/WorkstationRootEdgeCornerNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationRootEdgeCornerNL.spec.mjs
@@ -1,0 +1,167 @@
+import {test, expect}       from '../../fixtures.mjs';
+import {readComponentRects} from '../utils/dockGeometry.mjs';
+
+/**
+ * Whitebox-e2e: the root edge chips aim at the arrangement they are drawn from.
+ *
+ * The defect this journey exists for: the root edge chips are painted from the dock host's rect,
+ * so the bottom chip promises the FULL window width. The resolution used to retarget an
+ * `edge-zone` root to its CENTER node, which excludes the left, right and bottom bands — so the
+ * drop landed a pane roughly three quarters of the promised width and the side zones kept the
+ * corners. Nothing caught it, because the preview payload carries NO rect: the painted extent
+ * came from `geometry.root.rect` and the commit from `target.nodeId`, two places with nothing
+ * reconciling them. That is the blind spot `utils/dockGeometry.mjs` was written for — a geometry
+ * contract that shipped through a green suite because no assertion ever read a rect.
+ *
+ * Product truth proven against the running workstation: on the dense `edge-zone`-rooted surface,
+ * the root tier resolves the WHOLE arrangement and paints it at the host's full width. Against
+ * the pre-fix source this same read returns the centre split, so the journey is defect-specific.
+ *
+ * Scope note — why the release is a CANCEL. Committing the drop is covered at the unit level
+ * (`test/playwright/unit/dashboard/DockDragAffordances.spec.mjs`, asserted on the document tree
+ * with a pre-fix control). It is not asserted here because the flagship's tear-out layer claims a
+ * release near the surface boundary before the dock's drop seam sees it: at a 1280x720 viewport
+ * the bottom chip's centre sits ~23px above the host edge, the drag proxy overdrags the tear-out
+ * boundary, and the pane leaves the document entirely (`items` loses it). That interference is a
+ * separate subsystem from the resolution under test and is reported on its own.
+ *
+ * Run: NEO_AGENTOS_RUNTIME_ROOT=<abs path to neo-agent-brain> NEO_E2E_PORT=8162 \
+ *      npx playwright test WorkstationRootEdgeCornerNL -c test/playwright/playwright.config.e2e.mjs --workers=1
+ */
+
+test.describe('Workstation root-edge boundary (Neural Link)', () => {
+    test.setTimeout(120000);
+
+    // The painted chip is measured against the host it was promised from. Splitter chrome and
+    // sub-pixel layout cost a few px; the defect costs ~25% of the width, so the two are nowhere
+    // near each other — this tolerance separates rounding from regression.
+    const EDGE_TOLERANCE = 8;
+
+    /** @param {Object|Object[]} result @returns {String|null} */
+    const readId = result => (Array.isArray(result) ? result[0] : result)?.id ?? null;
+
+    /**
+     * Boots the flagship and resolves the App-Worker Workspace plus the dock host's rect.
+     * @param {Object} page
+     * @param {Object} neuralLink
+     * @returns {Promise<Object>} {app, dockModel, hostRect, wsId}
+     */
+    async function bootFlagship(page, neuralLink) {
+        await page.goto('/apps/workstation/index.html');
+
+        await page.waitForSelector('.workstation-dock-host',               {timeout: 60000});
+        await page.waitForSelector('.neo-tab-header-button.neo-draggable', {timeout: 60000});
+        await page.evaluate(() => document.fonts.ready);
+
+        // LAYOUT readiness, not DOM presence: a drag against the collapsed frame measures
+        // zero-area zones, and this journey asserts widths — it must run on the settled surface.
+        await page.waitForFunction(() => {
+            const host = document.querySelector('.workstation-dock-host'),
+                  zone = [...document.querySelectorAll('.neo-dashboard-dock-tabs')]
+                      .find(el => el.querySelector('.neo-grid-container'));
+
+            return host && host.getBoundingClientRect().height > 300
+                && zone && zone.getBoundingClientRect().height > 100
+        }, {timeout: 60000});
+
+        const app    = await neuralLink.connectToApp('Workstation'),
+              wsId   = readId(await app.findInstances({className: 'Workstation.view.Workspace'}, ['id'])),
+              hostId = await page.evaluate(() => document.querySelector('.workstation-dock-host').id);
+
+        expect(wsId,   'the Workspace must exist in the App Worker').toBeTruthy();
+        expect(hostId, 'the dock host must expose a component id').toBeTruthy();
+
+        const {[hostId]: hostRect} = await readComponentRects(app, [hostId]),
+              {dockModel}          = await app.getComponent(wsId, ['dockModel']);
+
+        // The dense arrangement is the whole point: an edge-zone root whose left / right / bottom
+        // bands are exactly what the pre-fix commit target excluded.
+        expect(dockModel.nodes[dockModel.root].type, 'the flagship boots an edge-zone root').toBe('edge-zone');
+        expect(dockModel.nodes[dockModel.root].zones.center.nodeId, 'with a centre that is NOT the root')
+            .toBeTruthy();
+
+        return {app, dockModel, hostRect, wsId}
+    }
+
+    /**
+     * Real pointer drag of one tab header, parked at the target with the move stream settled.
+     *
+     * The micro-jiggle is not decoration: the controller's geometry self-heal is per-move-frame,
+     * and a perfectly still pointer emits no frames — the settle must not depend on exactly one
+     * measurement landing correctly.
+     * @param {Object} page
+     * @param {String} label the tab's visible text
+     * @param {{x: Number, y: Number}} target
+     */
+    async function parkDrag(page, label, target) {
+        const header = page.locator('.neo-tab-header-button', {hasText: label}).first();
+
+        await expect(header).toBeVisible();
+
+        const box = await header.boundingBox();
+
+        await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+        await page.mouse.down();
+        await page.mouse.move(box.x + box.width / 2 + 12, box.y + box.height / 2 + 12, {steps: 4});
+        await expect(page.locator('.neo-tab-header-toolbar.neo-is-dragging')).toBeVisible();
+        await page.mouse.move(target.x, target.y, {steps: 15});
+
+        for (const dx of [2, -2, 1]) {
+            await page.mouse.move(target.x + dx, target.y, {steps: 1});
+            await page.waitForTimeout(120)
+        }
+
+        await page.waitForTimeout(300)
+    }
+
+    test('the bottom root chip resolves the whole arrangement, not the edge-zone centre', async ({page, neuralLink}) => {
+        const {app, dockModel, hostRect, wsId} = await bootFlagship(page, neuralLink),
+              rootId                           = dockModel.root,
+              centerId                         = dockModel.nodes[rootId].zones.center.nodeId;
+
+        // 8px above the host's bottom edge: inside the 24px root strip, and deliberately also
+        // deep inside the dense arrangement's own bottom band — the strip must win over the zone
+        // beneath it, which is what makes this the ROOT tier rather than a band drop.
+        await parkDrag(page, 'Audit', {x: hostRect.left + hostRect.width / 2, y: hostRect.bottom - 8});
+
+        // Worker truth first. A width alone would prove nothing: the edge-zone's own bottom band
+        // ALSO spans the full width, so a band placement and a root placement paint the same
+        // number. Only the resolved target separates them.
+        const previewId     = readId(await app.findInstances({className: 'Neo.dashboard.dock.interaction.Preview'}, ['id'])),
+              {dockPreview} = await app.getComponent(previewId, ['dockPreview']);
+
+        expect(dockPreview, 'the parked hover must resolve a preview').toBeTruthy();
+        expect(dockPreview.placement.kind, 'the strip resolves a ROOT edge').toBe('edge-bottom');
+        expect(dockPreview.target.nodeId, 'aimed at the whole arrangement').toBe(rootId);
+        expect(dockPreview.target.nodeId, 'and NOT at the centre the pre-fix code retargeted to').not.toBe(centerId);
+
+        // The indicator MENU's root chip family is asserted at unit level instead
+        // (`DockDragAffordances.spec.mjs`, four edges against the same boundary, with a pre-fix
+        // control). A strip pointer is the inference tier, not the menu tier — measured here, the
+        // single live layer reports `candidateSet.root: null` at this position — and characterising
+        // when the menu populates is a different question from the boundary under test.
+
+        // Only now is the painted width meaningful: the promise belongs to the whole arrangement.
+        const promised = await page.evaluate(() => {
+            const r = document.querySelector('.neo-dock-preview-affordance')?.getBoundingClientRect();
+
+            return r && {width: r.width}
+        });
+
+        expect(promised, 'the root chip must paint a preview').toBeTruthy();
+        expect(promised.width, 'the bottom chip promises the full host width')
+            .toBeGreaterThanOrEqual(hostRect.width - EDGE_TOLERANCE);
+
+        // Cancel: this journey commits nothing, and the unchanged document is the control that
+        // the reads above came from a live gesture rather than a settled surface.
+        await page.keyboard.press('Escape');
+        await page.waitForTimeout(120);
+        await page.mouse.up();
+        await page.waitForTimeout(300);
+
+        const after = (await app.getComponent(wsId, ['dockModel'])).dockModel;
+
+        expect(after.root, 'the cancelled gesture committed nothing').toBe(rootId);
+        expect(Object.keys(after.items)).toHaveLength(Object.keys(dockModel.items).length)
+    })
+});

--- a/test/playwright/e2e/workstation/WorkstationRootEdgeCornerNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationRootEdgeCornerNL.spec.mjs
@@ -19,11 +19,13 @@ import {readComponentRects} from '../utils/dockGeometry.mjs';
  *
  * Scope note — why the release is a CANCEL. Committing the drop is covered at the unit level
  * (`test/playwright/unit/dashboard/DockDragAffordances.spec.mjs`, asserted on the document tree
- * with a pre-fix control). It is not asserted here because the flagship's tear-out layer claims a
- * release near the surface boundary before the dock's drop seam sees it: at a 1280x720 viewport
- * the bottom chip's centre sits ~23px above the host edge, the drag proxy overdrags the tear-out
- * boundary, and the pane leaves the document entirely (`items` loses it). That interference is a
- * separate subsystem from the resolution under test and is reported on its own.
+ * with a pre-fix control). It is not asserted here because a release near the surface boundary
+ * does not reach the dock's drop seam at all: measured at a 1280x720 viewport, releasing in the
+ * bottom root strip — or on the bottom chip's own centre, y=697 against a host bottom of 720 —
+ * removes the pane from the document entirely (`items` drops from 20 to 19) while the mid-gesture
+ * preview at that same pointer reads `edge-bottom` on the root. The mechanism is NOT established
+ * here; only that outcome and that disagreement were measured. Reported for the actual-pointer
+ * lane rather than diagnosed in this spec.
  *
  * Run: NEO_AGENTOS_RUNTIME_ROOT=<abs path to neo-agent-brain> NEO_E2E_PORT=8162 \
  *      npx playwright test WorkstationRootEdgeCornerNL -c test/playwright/playwright.config.e2e.mjs --workers=1

--- a/test/playwright/e2e/workstation/WorkstationRootEdgeCornerNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationRootEdgeCornerNL.spec.mjs
@@ -2,7 +2,8 @@ import {test, expect}       from '../../fixtures.mjs';
 import {readComponentRects} from '../utils/dockGeometry.mjs';
 
 /**
- * Whitebox-e2e: the root edge chips aim at the arrangement they are drawn from.
+ * Whitebox-e2e: root-edge corner weighting on the flagship — the drop lands the arrangement the
+ * chip promised, and the last drop takes the corner.
  *
  * The defect this journey exists for: the root edge chips are painted from the dock host's rect,
  * so the bottom chip promises the FULL window width. The resolution used to retarget an
@@ -13,31 +14,43 @@ import {readComponentRects} from '../utils/dockGeometry.mjs';
  * reconciling them. That is the blind spot `utils/dockGeometry.mjs` was written for — a geometry
  * contract that shipped through a green suite because no assertion ever read a rect.
  *
- * Product truth proven against the running workstation: on the dense `edge-zone`-rooted surface,
- * the root tier resolves the WHOLE arrangement and paints it at the host's full width. Against
- * the pre-fix source this same read returns the centre split, so the journey is defect-specific.
+ * Product truths proven against the running workstation, on the dense `edge-zone`-rooted surface:
+ * 1. a real pointer drop in the bottom root strip lands a pane spanning the whole arrangement, in
+ *    the document tree AND in pixels — the side bands travel INSIDE the wrapped node;
+ * 2. a later right drop takes the corner from it: the right pane runs the full height and the
+ *    bottom pane narrows — resolved LIVE against the document the first drop produced, so a
+ *    captured root id would re-wrap the inner node and leave the bottom pane outside the column.
  *
- * Scope note — why the release is a CANCEL. Committing the drop is covered at the unit level
- * (`test/playwright/unit/dashboard/DockDragAffordances.spec.mjs`, asserted on the document tree
- * with a pre-fix control). It is not asserted here because a release near the surface boundary
- * does not reach the dock's drop seam at all: measured at a 1280x720 viewport, releasing in the
- * bottom root strip — or on the bottom chip's own centre, y=697 against a host bottom of 720 —
- * removes the pane from the document entirely (`items` drops from 20 to 19) while the mid-gesture
- * preview at that same pointer reads `edge-bottom` on the root. The mechanism is NOT established
- * here; only that outcome and that disagreement were measured. Reported for the actual-pointer
- * lane rather than diagnosed in this spec.
+ * Against the pre-fix source the first read already fails (`split-main` for `root`), so the
+ * journey is defect-specific rather than a generic docking smoke test.
  *
  * Run: NEO_AGENTOS_RUNTIME_ROOT=<abs path to neo-agent-brain> NEO_E2E_PORT=8162 \
  *      npx playwright test WorkstationRootEdgeCornerNL -c test/playwright/playwright.config.e2e.mjs --workers=1
  */
 
-test.describe('Workstation root-edge boundary (Neural Link)', () => {
-    test.setTimeout(120000);
+test.describe('Workstation root-edge corner weighting (Neural Link)', () => {
+    test.setTimeout(180000);
 
-    // The painted chip is measured against the host it was promised from. Splitter chrome and
-    // sub-pixel layout cost a few px; the defect costs ~25% of the width, so the two are nowhere
-    // near each other — this tolerance separates rounding from regression.
-    const EDGE_TOLERANCE = 8;
+    /**
+     * How far inside the root edge the gesture parks.
+     *
+     * Not arbitrary, and not a magic number: the root strip is `rootEdgeBandPx` (24) wide, while
+     * the tear-out boundary fires on the drag PROXY's intersection ratio against
+     * `SortZone#detachThreshold` (0.8). The proxy is 48x32 and centred on the pointer, so parking
+     * d px inside gives 0.5 + d/48 horizontally and 0.5 + d/32 vertically — below ~15px the proxy
+     * has already crossed the detach threshold and the release becomes a tear-out instead of a
+     * dock. 20 sits inside the strip on both axes and above the threshold on both.
+     *
+     * The approach matters as much as the parking spot: `reattachThreshold` (0.6) means a crossing
+     * must be EARNED BACK, so a gesture that dips closer first stays detached even after returning.
+     * These moves therefore never go nearer than this.
+     * @type {Number}
+     */
+    const EDGE_INSET = 20;
+
+    // The rendered pane is measured against the host it was promised from. Splitter chrome costs
+    // ~24px of 1280; the defect costs ~25% of the width, so the two are nowhere near each other.
+    const FULL_SPAN_RATIO = 0.95;
 
     /** @param {Object|Object[]} result @returns {String|null} */
     const readId = result => (Array.isArray(result) ? result[0] : result)?.id ?? null;
@@ -79,23 +92,23 @@ test.describe('Workstation root-edge boundary (Neural Link)', () => {
         // The dense arrangement is the whole point: an edge-zone root whose left / right / bottom
         // bands are exactly what the pre-fix commit target excluded.
         expect(dockModel.nodes[dockModel.root].type, 'the flagship boots an edge-zone root').toBe('edge-zone');
-        expect(dockModel.nodes[dockModel.root].zones.center.nodeId, 'with a centre that is NOT the root')
-            .toBeTruthy();
 
         return {app, dockModel, hostRect, wsId}
     }
 
     /**
-     * Real pointer drag of one tab header, parked at the target with the move stream settled.
+     * Real pointer drag of one tab header to `target`, parked with the move stream settled.
      *
      * The micro-jiggle is not decoration: the controller's geometry self-heal is per-move-frame,
      * and a perfectly still pointer emits no frames — the settle must not depend on exactly one
-     * measurement landing correctly.
+     * measurement landing correctly. It jiggles ALONG the edge, never toward it, for the
+     * reattach-threshold reason in {@link EDGE_INSET}.
      * @param {Object} page
      * @param {String} label the tab's visible text
      * @param {{x: Number, y: Number}} target
+     * @param {String} axis 'x' or 'y' — the direction that runs parallel to the edge
      */
-    async function parkDrag(page, label, target) {
+    async function dragTo(page, label, target, axis) {
         const header = page.locator('.neo-tab-header-button', {hasText: label}).first();
 
         await expect(header).toBeVisible();
@@ -108,62 +121,91 @@ test.describe('Workstation root-edge boundary (Neural Link)', () => {
         await expect(page.locator('.neo-tab-header-toolbar.neo-is-dragging')).toBeVisible();
         await page.mouse.move(target.x, target.y, {steps: 15});
 
-        for (const dx of [2, -2, 1]) {
-            await page.mouse.move(target.x + dx, target.y, {steps: 1});
+        for (const delta of [2, -2, 1]) {
+            await page.mouse.move(target.x + (axis === 'x' ? delta : 0), target.y + (axis === 'y' ? delta : 0), {steps: 1});
             await page.waitForTimeout(120)
         }
 
         await page.waitForTimeout(300)
     }
 
-    test('the bottom root chip resolves the whole arrangement, not the edge-zone centre', async ({page, neuralLink}) => {
+    /**
+     * @summary The rendered rect of the projected container for one document node.
+     * @param {Object} app
+     * @param {String} nodeId
+     * @returns {Promise<Object>}
+     */
+    async function nodeRect(app, nodeId) {
+        const id = readId(await app.queryComponent({dockNodeId: nodeId}, ['id']));
+
+        expect(id, `node "${nodeId}" must project a live container`).toBeTruthy();
+
+        return (await readComponentRects(app, [id]))[id]
+    }
+
+    test('a bottom root-edge drop spans the whole arrangement, and a later right drop takes the corner', async ({page, neuralLink}) => {
         const {app, dockModel, hostRect, wsId} = await bootFlagship(page, neuralLink),
-              rootId                           = dockModel.root,
-              centerId                         = dockModel.nodes[rootId].zones.center.nodeId;
+              rootBefore                       = dockModel.root,
+              centerBefore                     = dockModel.nodes[rootBefore].zones.center.nodeId;
 
-        // 8px above the host's bottom edge: inside the 24px root strip, and deliberately also
-        // deep inside the dense arrangement's own bottom band — the strip must win over the zone
-        // beneath it, which is what makes this the ROOT tier rather than a band drop.
-        await parkDrag(page, 'Audit', {x: hostRect.left + hostRect.width / 2, y: hostRect.bottom - 8});
+        await dragTo(page, 'Audit', {x: hostRect.left + hostRect.width / 2, y: hostRect.bottom - EDGE_INSET}, 'x');
 
-        // Worker truth first. A width alone would prove nothing: the edge-zone's own bottom band
-        // ALSO spans the full width, so a band placement and a root placement paint the same
-        // number. Only the resolved target separates them.
+        // Worker truth first. A width alone would prove nothing here: the edge-zone's own bottom
+        // band ALSO spans the full width, so a band placement and a root placement paint the same
+        // number. Only the resolved target separates them — and it is the pre-fix failure point.
         const previewId     = readId(await app.findInstances({className: 'Neo.dashboard.dock.interaction.Preview'}, ['id'])),
               {dockPreview} = await app.getComponent(previewId, ['dockPreview']);
 
         expect(dockPreview, 'the parked hover must resolve a preview').toBeTruthy();
         expect(dockPreview.placement.kind, 'the strip resolves a ROOT edge').toBe('edge-bottom');
-        expect(dockPreview.target.nodeId, 'aimed at the whole arrangement').toBe(rootId);
-        expect(dockPreview.target.nodeId, 'and NOT at the centre the pre-fix code retargeted to').not.toBe(centerId);
+        expect(dockPreview.target.nodeId, 'aimed at the whole arrangement').toBe(rootBefore);
+        expect(dockPreview.target.nodeId, 'and NOT the centre the pre-fix code retargeted to').not.toBe(centerBefore);
 
-        // The indicator MENU's root chip family is asserted at unit level instead
-        // (`DockDragAffordances.spec.mjs`, four edges against the same boundary, with a pre-fix
-        // control). A strip pointer is the inference tier, not the menu tier — measured here, the
-        // single live layer reports `candidateSet.root: null` at this position — and characterising
-        // when the menu populates is a different question from the boundary under test.
-
-        // Only now is the painted width meaningful: the promise belongs to the whole arrangement.
-        const promised = await page.evaluate(() => {
-            const r = document.querySelector('.neo-dock-preview-affordance')?.getBoundingClientRect();
-
-            return r && {width: r.width}
-        });
-
-        expect(promised, 'the root chip must paint a preview').toBeTruthy();
-        expect(promised.width, 'the bottom chip promises the full host width')
-            .toBeGreaterThanOrEqual(hostRect.width - EDGE_TOLERANCE);
-
-        // Cancel: this journey commits nothing, and the unchanged document is the control that
-        // the reads above came from a live gesture rather than a settled surface.
-        await page.keyboard.press('Escape');
-        await page.waitForTimeout(120);
         await page.mouse.up();
-        await page.waitForTimeout(300);
+        await page.waitForTimeout(1200); // commit + re-projection settle
 
-        const after = (await app.getComponent(wsId, ['dockModel'])).dockModel;
+        const afterBottom = (await app.getComponent(wsId, ['dockModel'])).dockModel,
+              bottomRoot  = afterBottom.nodes[afterBottom.root],
+              droppedId   = (bottomRoot.children ?? []).find(childId => afterBottom.nodes[childId]?.items?.includes('audit'));
 
-        expect(after.root, 'the cancelled gesture committed nothing').toBe(rootId);
-        expect(Object.keys(after.items)).toHaveLength(Object.keys(dockModel.items).length)
+        expect(Object.keys(afterBottom.items), 'the pane docked rather than leaving the document')
+            .toHaveLength(Object.keys(dockModel.items).length);
+        expect(afterBottom.root, 'the drop wraps the arrangement in a NEW root').not.toBe(rootBefore);
+        expect(bottomRoot).toMatchObject({type: 'split', orientation: 'vertical'});
+        expect(droppedId, 'the dropped pane is a DIRECT child of the new root').toBeTruthy();
+        // Both halves of the corner question in one line: the edge-zone (carrying its side bands)
+        // and the dropped pane are SIBLINGS, so the pane runs the full width beneath everything.
+        expect(bottomRoot.children).toEqual([rootBefore, droppedId]);
+        expect(afterBottom.nodes[rootBefore].type, 'the bands travel inside the wrapped node').toBe('edge-zone');
+
+        // And in pixels: what the chip promised is what the surface renders. This is the arm that
+        // would have caught the original report — the tree alone cannot show a delivered width.
+        const droppedRect = await nodeRect(app, droppedId);
+
+        expect(droppedRect.width / hostRect.width, 'the delivered pane matches the promised width')
+            .toBeGreaterThanOrEqual(FULL_SPAN_RATIO);
+
+        // The operator's second gesture: the right drop takes the corner. Resolved LIVE — the
+        // boundary is now the split the bottom drop created, not the id captured before it.
+        await dragTo(page, 'Metrics', {x: hostRect.right - EDGE_INSET, y: hostRect.top + hostRect.height / 2}, 'y');
+        await page.mouse.up();
+        await page.waitForTimeout(1200);
+
+        const afterRight = (await app.getComponent(wsId, ['dockModel'])).dockModel,
+              rightRoot  = afterRight.nodes[afterRight.root],
+              rightId    = (rightRoot.children ?? []).find(childId => afterRight.nodes[childId]?.items?.includes('metrics'));
+
+        expect(rightRoot).toMatchObject({type: 'split', orientation: 'horizontal'});
+        expect(rightId, 'the right pane is a DIRECT child of the newest root').toBeTruthy();
+        expect(rightRoot.children, 'the right pane wraps everything the bottom drop produced')
+            .toEqual([afterBottom.root, rightId]);
+
+        const rightRect       = await nodeRect(app, rightId),
+              droppedNarrowed = await nodeRect(app, droppedId);
+
+        expect(rightRect.height / hostRect.height, 'the right pane runs the full height')
+            .toBeGreaterThanOrEqual(FULL_SPAN_RATIO);
+        expect(droppedNarrowed.width, 'and the bottom pane gives up the corner')
+            .toBeLessThan(droppedRect.width)
     })
 });

--- a/test/playwright/unit/apps/workstation/Workspace.spec.mjs
+++ b/test/playwright/unit/apps/workstation/Workspace.spec.mjs
@@ -1685,6 +1685,20 @@ test.describe.serial('Workstation.view.Workspace', () => {
             expect(dockable.nodeId, 'the boundary is the stack root').toBe(stackRoot);
             expect(dockable.nodeId, 'never the shell').not.toBe(state.document.root);
 
+            // And the transfer contract survives the drop itself: a root-edge placement against
+            // that boundary is the descriptor `previewToOperation` emits, so committing one must
+            // leave the shell standing and the stack still resolvable — otherwise docking would
+            // quietly cost the popup its whole-stack admission.
+            const docked = Operations.splitNode(state.document, {
+                edge : 'bottom', itemId: 'security', orientation: 'vertical',
+                sizes: [0.5, 0.5], targetNodeId: dockable.nodeId
+            });
+
+            expect(docked.errors).toEqual([]);
+            expect(docked.document.root, 'the shell is still the root').toBe(state.document.root);
+            expect(WorkspaceDocument.resolveStackRoot(docked.document), 'the stack still resolves')
+                .toBe(docked.document.nodes[state.document.root].zones.center.nodeId);
+
             // A popup whose document is NOT shell-shaped still docks — at its own root, through the
             // inherited arrangement boundary — instead of refusing every root chip.
             popup.dockModel = {

--- a/test/playwright/unit/apps/workstation/Workspace.spec.mjs
+++ b/test/playwright/unit/apps/workstation/Workspace.spec.mjs
@@ -1668,6 +1668,38 @@ test.describe.serial('Workstation.view.Workspace', () => {
         expect(workspace.isDestroyed).toBe(true)
     });
 
+    test('a vessel popup docks at its transferable stack root, never at the window shell', () => {
+        const workspace = Neo.create(Workspace, {windowId: Neo.config.windowId});
+        const {state}   = stageCommittedVessel(workspace), popup = state.host;
+
+        try {
+            const stackRoot = WorkspaceDocument.resolveStackRoot(state.document),
+                  dockable  = popup.resolveDockableRoot();
+
+            // A full popup presents a vessel SHELL, so its dockable boundary is the content inside.
+            // Wrapping the shell would keep docking and silently stop the stack being transferable:
+            // `resolveStackRoot` requires the root to BE an edge-zone, and `window.Participation`
+            // admits a whole stack only when that resolution matches the transferred `groupNodeId`.
+            expect(stackRoot).toBeTruthy();
+            expect(state.document.nodes[state.document.root].type).toBe('edge-zone');
+            expect(dockable.nodeId, 'the boundary is the stack root').toBe(stackRoot);
+            expect(dockable.nodeId, 'never the shell').not.toBe(state.document.root);
+
+            // A popup whose document is NOT shell-shaped still docks — at its own root, through the
+            // inherited arrangement boundary — instead of refusing every root chip.
+            popup.dockModel = {
+                schema: 'neo.dock.zone.v1', root: 'plain-tabs',
+                items : {solo: {componentRef: 'solo', title: 'Solo', kind: 'pane'}},
+                nodes : {'plain-tabs': {type: 'tabs', items: ['solo'], activeItemId: 'solo'}}
+            };
+
+            expect(WorkspaceDocument.resolveStackRoot(popup.dockModel), 'no shell to resolve').toBe(null);
+            expect(popup.resolveDockableRoot()).toEqual({component: popup, nodeId: 'plain-tabs'})
+        } finally {
+            workspace.destroy()
+        }
+    });
+
     test('window release retains the full Workspace document for warm rebind', async () => {
         const workspace = Neo.create(Workspace, {windowId: Neo.config.windowId});
         const {state, workspaceId} = stageCommittedVessel(workspace), owner = state.host;

--- a/test/playwright/unit/apps/workstation/Workspace.spec.mjs
+++ b/test/playwright/unit/apps/workstation/Workspace.spec.mjs
@@ -89,13 +89,13 @@ const stageCommittedVessel = (workspace, ownerItemId='alerts', incomingItemId='s
 
     const host = Neo.create(PopupWorkspace, {
         rootWorkspace: workspace, dockModel: provisional, workspaceSet: workspace.workspaceSet,
-        workspaceKey: workspaceId, topologyGroupId: workspace.topologyGroupId
+        workspaceKey : workspaceId, topologyGroupId: workspace.topologyGroupId
     });
     const state = {
-        app                 : {mainView: {isDestroyed: false}},
-        closeRequested      : false,
-        committed           : true,
-        disconnected        : false,
+        app           : {mainView: {isDestroyed: false}},
+        closeRequested: false,
+        committed     : true,
+        disconnected  : false,
         get document() { return host.dockModel },
         set document(value) { host.dockModel = value },
         host,
@@ -111,7 +111,7 @@ const stageCommittedVessel = (workspace, ownerItemId='alerts', incomingItemId='s
     host.runtimeState = state;
     workspace.workspaceSet.register(workspaceId, {
         componentId: host.id,
-        dispose: () => { if (!host.isDestroyed) host.destroy() },
+        dispose    : () => { if (!host.isDestroyed) host.destroy() },
         getDocument: () => state.document,
         setDocument: document => state.document = document
     });
@@ -171,8 +171,8 @@ const releaseVessel = async (workspace, windowId, itemId='alerts') => {
 function registerPopupState(workspace, workspaceId, state) {
     const owner = Neo.create(PopupWorkspace, {
         rootWorkspace: workspace, workspaceSet: workspace.workspaceSet,
-        workspaceKey: workspaceId, topologyGroupId: workspace.topologyGroupId,
-        dockModel: state.document ?? workspace.createVesselWorkspaceDocument(state.itemId ?? 'fixture')
+        workspaceKey : workspaceId, topologyGroupId: workspace.topologyGroupId,
+        dockModel    : state.document ?? workspace.createVesselWorkspaceDocument(state.itemId ?? 'fixture')
     });
     state.workspaceId ??= workspaceId;
     state.host ??= owner;
@@ -1593,9 +1593,9 @@ test.describe.serial('Workstation.view.Workspace', () => {
     });
 
     test('full Workspace transfer compensates refusal and settles both projections before native close', async () => {
-        const workspace = Neo.create(Workspace, {windowId: Neo.config.windowId});
+        const workspace                        = Neo.create(Workspace, {windowId: Neo.config.windowId});
         const {state, workspaceId, tabsNodeId} = stageCommittedVessel(workspace);
-        const groupId = workspace.topologyGroupId, manager = TransactionManager, order = [];
+        const groupId                          = workspace.topologyGroupId, manager = TransactionManager, order = [];
         manager.setHistoryDepth({groupId, depth: 5});
         const participant = manager.getParticipant(groupId, workspaceId), adopt = participant.adopt;
         const initialMain = WorkspaceDocument.clone(workspace.dockModel), initialPopup = WorkspaceDocument.clone(state.document);
@@ -1604,7 +1604,7 @@ test.describe.serial('Workstation.view.Workspace', () => {
         workspace.retireReturnedVessel = async () => { order.push('close-refused'); return false };
         const descriptor = {operation: 'transferItem', itemId: 'activity',
             sourceWorkspaceId: Workspace.MAIN_WORKSPACE_ID, targetWorkspaceId: workspaceId,
-            target: {operation: 'addTab', tabsNodeId}};
+            target           : {operation: 'addTab', tabsNodeId}};
         const request = {descriptor, sourceWorkspaceId: descriptor.sourceWorkspaceId, targetWorkspaceId: workspaceId};
         try {
             participant.adopt = () => { throw new Error('target refused') };
@@ -1619,7 +1619,7 @@ test.describe.serial('Workstation.view.Workspace', () => {
             expect(workspace.dockModel.items.activity).toBeUndefined();
             const returning = {operation: 'transferNode', nodeId: WorkspaceDocument.resolveStackRoot(state.document),
                 sourceWorkspaceId: workspaceId, targetWorkspaceId: Workspace.MAIN_WORKSPACE_ID,
-                target: {targetNodeId: 'heavy-tabs', placement: {kind: 'tab-into'}}};
+                target           : {targetNodeId: 'heavy-tabs', placement: {kind: 'tab-into'}}};
             order.length = 0;
             expect(await workspace.commitCrossWindowTransfer({descriptor: returning,
                 sourceWorkspaceId: workspaceId, targetWorkspaceId: Workspace.MAIN_WORKSPACE_ID})).toBe(true);
@@ -1637,7 +1637,7 @@ test.describe.serial('Workstation.view.Workspace', () => {
     });
 
     test('Group membership alone determines whether a popup document can be resolved', () => {
-        const workspace = Neo.create(Workspace, {windowId: Neo.config.windowId});
+        const workspace            = Neo.create(Workspace, {windowId: Neo.config.windowId});
         const {state, workspaceId} = stageCommittedVessel(workspace);
         try {
             expect(workspace.getWorkspaceDocument(workspaceId)).toEqual(state.document);
@@ -1651,9 +1651,9 @@ test.describe.serial('Workstation.view.Workspace', () => {
     });
 
     test('explicit root destruction retires its registered popup owner', () => {
-        const workspace = Neo.create(Workspace, {windowId: Neo.config.windowId});
+        const workspace            = Neo.create(Workspace, {windowId: Neo.config.windowId});
         const {state, workspaceId} = stageCommittedVessel(workspace);
-        const groupId = workspace.topologyGroupId;
+        const groupId              = workspace.topologyGroupId;
         workspace.destroy();
         expect(state.host.isDestroyed).toBe(true);
         expect(TransactionManager.getParticipant(groupId, workspaceId)).toBeNull()
@@ -1661,7 +1661,7 @@ test.describe.serial('Workstation.view.Workspace', () => {
 
     test('Group retirement disposes popup owners before the root is released', () => {
         const workspace = Neo.create(Workspace, {windowId: Neo.config.windowId});
-        const {state} = stageCommittedVessel(workspace);
+        const {state}   = stageCommittedVessel(workspace);
         TransactionManager.retireGroup(workspace.topologyGroupId);
         expect(() => workspace.destroy()).not.toThrow();
         expect(state.host.isDestroyed).toBe(true);
@@ -1674,7 +1674,13 @@ test.describe.serial('Workstation.view.Workspace', () => {
 
         try {
             const stackRoot = WorkspaceDocument.resolveStackRoot(state.document),
-                  dockable  = popup.resolveDockableRoot();
+                  // The projected container for the stack root, as a double: an unrendered popup
+                  // projects nothing, and the absent case below is asserted separately.
+                  content   = {id: 'stack-content'};
+
+            popup.getDockHost = () => ({down: ({dockNodeId}) => dockNodeId === stackRoot ? content : null});
+
+            const dockable = popup.resolveDockableRoot();
 
             // A full popup presents a vessel SHELL, so its dockable boundary is the content inside.
             // Wrapping the shell would keep docking and silently stop the stack being transferable:
@@ -1684,6 +1690,18 @@ test.describe.serial('Workstation.view.Workspace', () => {
             expect(state.document.nodes[state.document.root].type).toBe('edge-zone');
             expect(dockable.nodeId, 'the boundary is the stack root').toBe(stackRoot);
             expect(dockable.nodeId, 'never the shell').not.toBe(state.document.root);
+            expect(dockable.component, 'measured on the CONTENT container, not the shell').toBe(content);
+
+            // The absent-component control, and it is the one that matters: with nothing projected
+            // for the stack root there is no rect that represents it, so the boundary must be
+            // REFUSED rather than substituted with the shell's. Naming the stack while measuring
+            // the shell is the exact mismatch this whole change exists to remove — reintroducing
+            // it in the fallback would have shipped the defect inside its own fix.
+            popup.getDockHost = () => ({down: () => null});
+
+            expect(popup.resolveDockableRoot(), 'no projected container ⇒ no dockable boundary').toBe(null);
+
+            popup.getDockHost = () => ({down: ({dockNodeId}) => dockNodeId === stackRoot ? content : null});
 
             // And the transfer contract survives the drop itself: a root-edge placement against
             // that boundary is the descriptor `previewToOperation` emits, so committing one must
@@ -1707,6 +1725,9 @@ test.describe.serial('Workstation.view.Workspace', () => {
                 nodes : {'plain-tabs': {type: 'tabs', items: ['solo'], activeItemId: 'solo'}}
             };
 
+            // Restored so the inherited path measures the popup itself, as it does in production.
+            delete popup.getDockHost;
+
             expect(WorkspaceDocument.resolveStackRoot(popup.dockModel), 'no shell to resolve').toBe(null);
             expect(popup.resolveDockableRoot()).toEqual({component: popup, nodeId: 'plain-tabs'})
         } finally {
@@ -1715,9 +1736,9 @@ test.describe.serial('Workstation.view.Workspace', () => {
     });
 
     test('window release retains the full Workspace document for warm rebind', async () => {
-        const workspace = Neo.create(Workspace, {windowId: Neo.config.windowId});
+        const workspace            = Neo.create(Workspace, {windowId: Neo.config.windowId});
         const {state, workspaceId} = stageCommittedVessel(workspace), owner = state.host;
-        const mainBefore = WorkspaceDocument.clone(workspace.dockModel), popupBefore = WorkspaceDocument.clone(state.document);
+        const mainBefore           = WorkspaceDocument.clone(workspace.dockModel), popupBefore = WorkspaceDocument.clone(state.document);
         try {
             await releaseVessel(workspace, 'window-alerts');
             expect(workspace.dockModel).toEqual(mainBefore);
@@ -1734,7 +1755,7 @@ test.describe.serial('Workstation.view.Workspace', () => {
     });
 
     test('reconnect lease expiry cannot discard the headless owner or its retained cursor', async () => {
-        const workspace = Neo.create(Workspace, {windowId: Neo.config.windowId});
+        const workspace            = Neo.create(Workspace, {windowId: Neo.config.windowId});
         const {state, workspaceId} = stageCommittedVessel(workspace), groupId = workspace.topologyGroupId;
         TransactionManager.setHistoryDepth({groupId, depth: 5});
         try {
@@ -1853,10 +1874,10 @@ test.describe.serial('Workstation.view.Workspace', () => {
     });
 
     test('mounting a popup reuses the Group document owner rather than creating a second host', async () => {
-        const workspace = Neo.create(Workspace, {windowId: Neo.config.windowId});
+        const workspace            = Neo.create(Workspace, {windowId: Neo.config.windowId});
         const {state, workspaceId} = stageCommittedVessel(workspace), owner = state.host;
-        const document = owner.dockModel, calls = [];
-        const target = {isDestroyed: false, add: host => calls.push(host)};
+        const document             = owner.dockModel, calls = [];
+        const target               = {isDestroyed: false, add: host => calls.push(host)};
         owner.promiseUpdate = async () => calls.push('paint');
         state.renderTarget = target;
         try {

--- a/test/playwright/unit/dashboard/DockCrossWindowParticipation.spec.mjs
+++ b/test/playwright/unit/dashboard/DockCrossWindowParticipation.spec.mjs
@@ -10,6 +10,7 @@ import {test, expect}  from '@playwright/test';
 import Neo             from '../../../../src/Neo.mjs';
 import * as core       from '../../../../src/core/_export.mjs';
 import Container       from '../../../../src/container/Base.mjs';
+import DockWorkspace   from '../../../../src/dashboard/dock/Workspace.mjs';
 import PreviewContract from '../../../../src/dashboard/dock/model/PreviewContract.mjs';
 
 /**
@@ -843,7 +844,11 @@ test.describe('Neo.dashboard.dock.window.Participation (ADR 0029 §2.3 — works
             },
             resolvePane(itemId, item) {
                 return resolvePane?.(itemId, item) ?? null
-            }
+            },
+            // BORROWED, never reimplemented: the root chip's boundary is a dock-owner seam, so a
+            // double that answered it in its own words could agree with an assertion the shipped
+            // resolution disagrees with. With no host this correctly resolves to null.
+            resolveDockableRoot: DockWorkspace.prototype.resolveDockableRoot
         });
 
         const createParticipation = config => Neo.create(DockCrossWindowParticipation, {
@@ -860,6 +865,7 @@ test.describe('Neo.dashboard.dock.window.Participation (ADR 0029 §2.3 — works
             workspace.dockModel = targetDoc();
             workspace.getDockHost = () => workspace;
             workspace.getDockProjectionOptions = () => ({});
+            workspace.resolveDockableRoot = DockWorkspace.prototype.resolveDockableRoot;
             workspace.getDomRect = async () => [
                 {x: 100, y: 80, width: 800, height: 600},
                 {x: 100, y: 80, width: 800, height: 600}

--- a/test/playwright/unit/dashboard/DockDragAffordances.spec.mjs
+++ b/test/playwright/unit/dashboard/DockDragAffordances.spec.mjs
@@ -13,6 +13,7 @@ import '../../../../src/manager/Instance.mjs';
 import DockDragAffordances from '../../../../src/dashboard/dock/interaction/DragAffordances.mjs';
 import DockDropIndicators  from '../../../../src/dashboard/dock/interaction/DropIndicators.mjs';
 import DockPreview         from '../../../../src/dashboard/dock/interaction/Preview.mjs';
+import DockWorkspace       from '../../../../src/dashboard/dock/Workspace.mjs';
 import Operations          from '../../../../src/dashboard/dock/model/Operations.mjs';
 import WindowManager       from '../../../../src/manager/Window.mjs';
 
@@ -72,6 +73,13 @@ test.describe('Neo.dashboard.dock.interaction.DragAffordances', () => {
             preview    = Neo.create(DockPreview),
             owner      = {
                 dockModel: makeDocument(),
+                getDockHost() {
+                    return controller.host
+                },
+                // BORROWED, never reimplemented: the rig stands in for a dock owner, so the root
+                // chip's boundary has to be resolved by the production seam. A stub that computed
+                // its own answer could agree with the assertion while the shipped one disagrees.
+                resolveDockableRoot: DockWorkspace.prototype.resolveDockableRoot,
                 applyDockZoneOperation(descriptor) {
                     return Operations.applyOperation(this.dockModel, descriptor)
                 },
@@ -187,11 +195,12 @@ test.describe('Neo.dashboard.dock.interaction.DragAffordances', () => {
         destroyAll(rig)
     });
 
-    test('an edge-zone root with a descriptor-shaped center still offers the root edge chips', async () => {
-        // The regression fingerprint: `zones.center` is a DESCRIPTOR ({nodeId}) in the current
-        // schema, and passing it raw where the producer requires a node-id string trips the
-        // fail-closed guard — the candidate set arrives with root: null and every container
-        // edge chip stays off, silently, for every edge-zone-rooted workspace.
+    test('an edge-zone root offers the root edge chips against the boundary its owner declares', async () => {
+        // Two regressions share this fixture. The older one: `zones.center` is a DESCRIPTOR
+        // ({nodeId}), and passing it raw where the producer requires an id string tripped the
+        // fail-closed guard — root: null, every container edge chip silently off. The newer one is
+        // why the id is no longer read from zone shape at all: retargeting to the CENTER while the
+        // chip is still drawn from the HOST rect promises the full width and delivers a corner.
         const rig   = compose(),
               rects = {
                   host : {x: 0, y: 0, width: 800, height: 600},
@@ -221,15 +230,191 @@ test.describe('Neo.dashboard.dock.interaction.DragAffordances', () => {
 
         const geometry = await rig.controller.ensureGeometry();
 
-        // the unwrapped STRING is what the producer's id guard accepts
-        expect(geometry.root.nodeId).toBe('split-main');
+        // The pairing invariant: the chip's nodeId names the node its rect covers. The rect is the
+        // whole host, so the id must be the whole arrangement — not the center inside it.
+        expect(geometry.root).toEqual({nodeId: 'root', rect: rects.host});
 
         await rig.controller.onDragMove({clientX: 200, clientY: 300, itemId: 'gamma', sourceNodeId: 'right-tabs'});
 
         expect(rig.indicators.candidateSet?.zone?.nodeId).toBe('left-tabs');
         expect(rig.indicators.candidateSet?.root, 'the root chip family must be offered').toBeTruthy();
-        expect(rig.indicators.candidateSet.root.nodeId).toBe('split-main');
+        expect(rig.indicators.candidateSet.root.nodeId).toBe('root');
         expect(rig.indicators.candidateSet.root.chips.map(chip => chip.edge)).toEqual(['top', 'right', 'bottom', 'left']);
+
+        destroyAll(rig)
+    });
+
+    test('a bottom root-edge drop on an edge-zone root spans the whole arrangement', async () => {
+        // The operator-reported defect, at the seam that produced it: the bottom chip previewed the
+        // full window width and the drop landed a pane the width of the CENTER, because the side
+        // bands were never inside the node being wrapped. Asserted on the committed TREE — a
+        // rendered width could be reached by another route, a direct root child could not.
+        const rig   = compose(),
+              rects = {
+                  host : {x: 0, y: 0, width: 800, height: 600},
+                  left : {x: 0, y: 0, width: 400, height: 600},
+                  right: {x: 400, y: 0, width: 400, height: 600}
+              };
+
+        rig.owner.dockModel = {
+            schema: 'neo.dock.zone.v1',
+            root  : 'root',
+            items : rig.owner.dockModel.items,
+            nodes : {
+                root        : {type: 'edge-zone', zones: {center: {nodeId: 'split-main'}, bottom: {nodeId: 'left-tabs', extent: 0.25, resizable: true}}},
+                'split-main': {type: 'split', orientation: 'horizontal', children: ['left-tabs', 'right-tabs'], sizes: [0.5, 0.5]},
+                'left-tabs' : {type: 'tabs', items: ['alpha', 'beta'], activeItemId: 'alpha'},
+                'right-tabs': {type: 'tabs', items: ['gamma'], activeItemId: 'gamma'}
+            }
+        };
+
+        rig.controller.host = {
+            id: 'host-1',
+            down(selector) {
+                return {'left-tabs': {id: 'zone-left'}, 'right-tabs': {id: 'zone-right'}}[selector.dockNodeId] ?? null
+            },
+            getDomRect: async () => [rects.host, rects.left, rects.right]
+        };
+
+        // 592 sits in the 24px root strip above the host's bottom edge; the whole gesture runs the
+        // production hover and release paths, so nothing here can inject the target by hand.
+        await rig.controller.onDragMove({clientX: 400, clientY: 592, itemId: 'gamma', sourceNodeId: 'right-tabs'});
+
+        expect(rig.preview.dockPreview?.placement?.kind).toBe('edge-bottom');
+        expect(rig.preview.dockPreview?.target?.nodeId, 'the preview must aim at the whole arrangement').toBe('root');
+
+        await rig.controller.onDrop({clientX: 400, clientY: 592, itemId: 'gamma', sourceNodeId: 'right-tabs'});
+
+        expect(rig.committed).toHaveLength(1);
+
+        const doc      = rig.committed[0],
+              children = doc.nodes[doc.root]?.children ?? [],
+              dropped  = children.find(childId => doc.nodes[childId]?.items?.includes('gamma'));
+
+        expect(doc.root, 'the drop wraps the arrangement in a NEW root').not.toBe('root');
+        expect(doc.nodes[doc.root].orientation).toBe('vertical');
+        // Both halves of the corner question in one line: the edge-zone (with its side bands) and
+        // the dropped pane are SIBLINGS, so the pane runs the full width beneath everything.
+        expect(children).toEqual(['root', dropped]);
+        expect(doc.nodes.root.type, 'the bands travel inside the wrapped node').toBe('edge-zone');
+
+        destroyAll(rig)
+    });
+
+    test('two sequential root-edge drops: the last one takes the corner', async () => {
+        // The operator's stated semantics, and the reason the boundary must be resolved LIVE:
+        // the bottom drop rewrites `document.root`, so the following right drop has to wrap what
+        // that produced. A captured root id would re-wrap the inner node and leave the bottom pane
+        // OUTSIDE the new right column — the corner rule silently inverted one gesture later.
+        const rig   = compose(),
+              rects = {
+                  host : {x: 0, y: 0, width: 800, height: 600},
+                  left : {x: 0,   y: 0,   width: 400, height: 450},
+                  right: {x: 400, y: 0,   width: 400, height: 450},
+                  band : {x: 0,   y: 450, width: 800, height: 150}
+              };
+
+        // An EDGE-ZONE root with an occupied band — the flagship's shape, and the only one where
+        // this test can fail: with a plain split root both the old and new resolution agree. The
+        // third left pane keeps either drag from emptying its source, since a node the drag empties
+        // collapses away and would move the tree for a reason unrelated to corners.
+        rig.owner.dockModel = {
+            schema: 'neo.dock.zone.v1',
+            root  : 'root',
+            items : {
+                ...rig.owner.dockModel.items,
+                delta  : {componentRef: 'ref-delta',   title: 'Delta',   kind: 'pane'},
+                epsilon: {componentRef: 'ref-epsilon', title: 'Epsilon', kind: 'pane'}
+            },
+            nodes: {
+                root        : {type: 'edge-zone', zones: {center: {nodeId: 'split-main'}, bottom: {nodeId: 'band-tabs', extent: 0.25, resizable: true}}},
+                'split-main': {type: 'split', orientation: 'horizontal', children: ['left-tabs', 'right-tabs'], sizes: [0.5, 0.5]},
+                'left-tabs' : {type: 'tabs', items: ['alpha', 'beta', 'delta'], activeItemId: 'alpha'},
+                'right-tabs': {type: 'tabs', items: ['gamma'], activeItemId: 'gamma'},
+                'band-tabs' : {type: 'tabs', items: ['epsilon'], activeItemId: 'epsilon'}
+            }
+        };
+
+        rig.controller.host = {
+            id: 'host-1',
+            down(selector) {
+                return {'left-tabs': {id: 'zone-left'}, 'right-tabs': {id: 'zone-right'}, 'band-tabs': {id: 'zone-band'}}[selector.dockNodeId] ?? null
+            },
+            getDomRect: async () => [rects.host, rects.left, rects.right, rects.band]
+        };
+
+        const originalRoot = rig.owner.dockModel.root;
+
+        // 1. bottom: 592 is inside the 24px strip above the host's bottom edge
+        await rig.controller.onDragMove({clientX: 400, clientY: 592, itemId: 'alpha', sourceNodeId: 'left-tabs'});
+        await rig.controller.onDrop    ({clientX: 400, clientY: 592, itemId: 'alpha', sourceNodeId: 'left-tabs'});
+
+        const afterBottom = rig.owner.dockModel,
+              bottomPane  = afterBottom.nodes[afterBottom.root].children
+                  .find(childId => afterBottom.nodes[childId]?.items?.includes('alpha'));
+
+        expect(afterBottom.nodes[afterBottom.root]).toMatchObject({type: 'split', orientation: 'vertical'});
+        expect(afterBottom.nodes[afterBottom.root].children).toEqual([originalRoot, bottomPane]);
+
+        // 2. right: 792 is inside the strip left of the host's right edge
+        await rig.controller.onDragMove({clientX: 792, clientY: 300, itemId: 'beta', sourceNodeId: 'left-tabs'});
+        await rig.controller.onDrop    ({clientX: 792, clientY: 300, itemId: 'beta', sourceNodeId: 'left-tabs'});
+
+        const afterRight = rig.owner.dockModel,
+              rightPane  = afterRight.nodes[afterRight.root].children
+                  .find(childId => afterRight.nodes[childId]?.items?.includes('beta'));
+
+        expect(afterRight.nodes[afterRight.root]).toMatchObject({type: 'split', orientation: 'horizontal'});
+        // The right pane's sibling is the WHOLE bottom arrangement, so the right column runs the
+        // full height and the bottom pane — now one level deeper — gives up the corner.
+        expect(afterRight.nodes[afterRight.root].children).toEqual([afterBottom.root, rightPane]);
+        expect(afterRight.nodes[afterBottom.root].children).toContain(bottomPane);
+
+        destroyAll(rig)
+    });
+
+    test('a sole-pane root-edge drop is refused before it can strand an empty half', async () => {
+        // `normalizeTree` deletes emptied tabs and splits but RETAINS an emptied edge-zone on
+        // purpose — it stays a re-attachment anchor. So wrapping an edge-zone root whose only
+        // content is the item being dragged would leave an empty sibling in the committed tree
+        // forever. The refusal lands at preview time, so the affordance never promises it either.
+        const rig   = compose(),
+              rects = {
+                  host  : {x: 0, y: 0, width: 800, height: 600},
+                  center: {x: 0, y: 0, width: 800, height: 600}
+              };
+
+        rig.owner.dockModel = {
+            schema: 'neo.dock.zone.v1',
+            root  : 'shell',
+            items : {alpha: rig.owner.dockModel.items.alpha},
+            nodes : {
+                shell        : {type: 'edge-zone', zones: {center: {nodeId: 'center-tabs'}}},
+                'center-tabs': {type: 'tabs', items: ['alpha'], activeItemId: 'alpha'}
+            }
+        };
+
+        rig.controller.host = {
+            id: 'host-1',
+            down(selector) {
+                return selector.dockNodeId === 'center-tabs' ? {id: 'zone-center'} : null
+            },
+            getDomRect: async () => [rects.host, rects.center]
+        };
+
+        await rig.controller.onDragMove({clientX: 400, clientY: 592, itemId: 'alpha', sourceNodeId: 'center-tabs'});
+        await rig.controller.onDrop    ({clientX: 400, clientY: 592, itemId: 'alpha', sourceNodeId: 'center-tabs'});
+
+        const doc = rig.owner.dockModel,
+              // every node that can hold content, and whether it actually holds any
+              stranded = Object.entries(doc.nodes).filter(([, node]) =>
+                  (node.type === 'tabs' && !node.items?.length) ||
+                  (node.type === 'edge-zone' && !Object.values(node.zones || {}).length));
+
+        expect(rig.preview.dockPreview, 'the affordance never promised the drop').toBe(null);
+        expect(rig.committed, 'and nothing committed').toHaveLength(0);
+        expect(stranded, `no node may be left empty — ${JSON.stringify(doc.nodes)}`).toEqual([]);
+        expect(doc.nodes.shell.zones.center.nodeId, 'the shell keeps its content').toBe('center-tabs');
 
         destroyAll(rig)
     });

--- a/test/playwright/unit/dashboard/DockDragAffordances.spec.mjs
+++ b/test/playwright/unit/dashboard/DockDragAffordances.spec.mjs
@@ -445,6 +445,57 @@ test.describe('Neo.dashboard.dock.interaction.DragAffordances', () => {
         destroyAll(rig)
     });
 
+    test('an owner that refuses a boundary offers no root placement and commits nothing against it', async () => {
+        // The other half of the boundary contract: a `null` from the owner must mean NO root
+        // chip, never a substituted rect. `PopupWorkspace` returns null when the stack root has
+        // no projected container, so this is the consumer side of that refusal — without it the
+        // controller would be free to pair the absent boundary's id with the host's rect.
+        const rig   = compose(),
+              rects = {
+                  host : {x: 0, y: 0, width: 800, height: 600},
+                  left : {x: 0,   y: 0, width: 400, height: 600},
+                  right: {x: 400, y: 0, width: 400, height: 600}
+              };
+
+        rig.owner.dockModel = {
+            schema: 'neo.dock.zone.v1',
+            root  : 'root',
+            items : rig.owner.dockModel.items,
+            nodes : {
+                root        : {type: 'edge-zone', zones: {center: {nodeId: 'split-main'}}},
+                'split-main': {type: 'split', orientation: 'horizontal', children: ['left-tabs', 'right-tabs'], sizes: [0.5, 0.5]},
+                'left-tabs' : {type: 'tabs', items: ['alpha', 'beta'], activeItemId: 'alpha'},
+                'right-tabs': {type: 'tabs', items: ['gamma'], activeItemId: 'gamma'}
+            }
+        };
+
+        rig.owner.resolveDockableRoot = () => null;
+
+        rig.controller.host = {
+            id: 'host-1',
+            down(selector) {
+                return {'left-tabs': {id: 'zone-left'}, 'right-tabs': {id: 'zone-right'}}[selector.dockNodeId] ?? null
+            },
+            getDomRect: async () => [rects.host, rects.left, rects.right]
+        };
+
+        const geometry = await rig.controller.ensureGeometry();
+
+        expect(geometry.root.nodeId, 'a refused boundary names nothing').toBe(null);
+
+        // 592 is inside the root strip — where a root placement WOULD be offered if one existed.
+        await rig.controller.onDragMove({clientX: 400, clientY: 592, itemId: 'gamma', sourceNodeId: 'right-tabs'});
+
+        expect(rig.preview.dockPreview?.target?.nodeId, 'no placement may target the refused root').not.toBe('root');
+
+        await rig.controller.onDrop({clientX: 400, clientY: 592, itemId: 'gamma', sourceNodeId: 'right-tabs'});
+
+        expect(rig.owner.dockModel.root, 'and nothing wrapped the arrangement').toBe('root');
+        expect(rig.owner.dockModel.nodes.root.type).toBe('edge-zone');
+
+        destroyAll(rig)
+    });
+
     test('the production measurement path: measure, map, and the degenerate self-heal', async () => {
         const rig   = compose(),
               rects = {

--- a/test/playwright/unit/dashboard/DockDragAffordances.spec.mjs
+++ b/test/playwright/unit/dashboard/DockDragAffordances.spec.mjs
@@ -276,6 +276,14 @@ test.describe('Neo.dashboard.dock.interaction.DragAffordances', () => {
             getDomRect: async () => [rects.host, rects.left, rects.right]
         };
 
+        const descriptors = [],
+              reduce      = rig.owner.applyDockZoneOperation.bind(rig.owner);
+
+        rig.owner.applyDockZoneOperation = descriptor => {
+            descriptors.push(descriptor);
+            return reduce(descriptor)
+        };
+
         // 592 sits in the 24px root strip above the host's bottom edge; the whole gesture runs the
         // production hover and release paths, so nothing here can inject the target by hand.
         await rig.controller.onDragMove({clientX: 400, clientY: 592, itemId: 'gamma', sourceNodeId: 'right-tabs'});
@@ -283,9 +291,16 @@ test.describe('Neo.dashboard.dock.interaction.DragAffordances', () => {
         expect(rig.preview.dockPreview?.placement?.kind).toBe('edge-bottom');
         expect(rig.preview.dockPreview?.target?.nodeId, 'the preview must aim at the whole arrangement').toBe('root');
 
+        // The node whose RECT was measured, captured before the release clears the geometry.
+        const measured = rig.controller.geometry.root.nodeId;
+
         await rig.controller.onDrop({clientX: 400, clientY: 592, itemId: 'gamma', sourceNodeId: 'right-tabs'});
 
         expect(rig.committed).toHaveLength(1);
+        // ONE resolution, read by both halves. Asserting only that each half says 'root' would
+        // still pass if a later edit gave the preview and the commit their own resolutions — the
+        // original defect was exactly two reads that agreed on a name and not on a node.
+        expect(descriptors[0].targetNodeId, 'the commit targets the node whose rect was measured').toBe(measured);
 
         const doc      = rig.committed[0],
               children = doc.nodes[doc.root]?.children ?? [],

--- a/test/playwright/unit/dashboard/DockDragAffordances.spec.mjs
+++ b/test/playwright/unit/dashboard/DockDragAffordances.spec.mjs
@@ -496,12 +496,12 @@ test.describe('Neo.dashboard.dock.interaction.DragAffordances', () => {
     });
 
     test('a resize replaces the measurement once and a late old frame cannot overwrite it', async () => {
-        const rig = compose(), originalGet = WindowManager.get, requests = [];
-        let width = 800, height = 600;
+        const rig   = compose(), originalGet = WindowManager.get, requests = [];
+        let   width = 800, height = 600;
         WindowManager.get = () => ({innerRect: {width, height}});
         rig.controller.host = {
-            id: 'resizing-host', windowId: 'resizing-window',
-            down: ({dockNodeId}) => ({id: dockNodeId}),
+            id        : 'resizing-host', windowId: 'resizing-window',
+            down      : ({dockNodeId}) => ({id: dockNodeId}),
             getDomRect: () => new Promise(resolve => requests.push({resolve, width, height}))
         };
         const resolve = request => request.resolve([
@@ -541,12 +541,12 @@ test.describe('Neo.dashboard.dock.interaction.DragAffordances', () => {
     });
 
     test('release refuses a cached pre-resize frame and a fresh gesture still commits', async () => {
-        const rig = compose(), originalGet = WindowManager.get;
-        let width = 800;
+        const rig   = compose(), originalGet = WindowManager.get;
+        let   width = 800;
         WindowManager.get = () => ({innerRect: {width, height: 600}});
         rig.controller.host = {
-            id: 'release-resize-host', windowId: 'release-resize-window',
-            down: ({dockNodeId}) => ({id: dockNodeId}),
+            id        : 'release-resize-host', windowId: 'release-resize-window',
+            down      : ({dockNodeId}) => ({id: dockNodeId}),
             getDomRect: async () => [
                 {x: 0, y: 0, width, height: 600},
                 {x: 0, y: 0, width: width / 2, height: 600},

--- a/test/playwright/unit/dashboard/DockDragAffordances.spec.mjs
+++ b/test/playwright/unit/dashboard/DockDragAffordances.spec.mjs
@@ -413,6 +413,17 @@ test.describe('Neo.dashboard.dock.interaction.DragAffordances', () => {
 
         expect(rig.preview.dockPreview, 'the affordance never promised the drop').toBe(null);
         expect(rig.committed, 'and nothing committed').toHaveLength(0);
+
+        // The MENU tier is guarded too, not just pointer inference: an indicator hit outranks
+        // inference, so a root chip selected from the menu would otherwise light up and then be
+        // refused on release — the promise/commit mismatch this seam exists to end, in miniature.
+        rig.controller.indicators.updatePointer = () => ({
+            preview: {itemId: 'alpha', placement: {kind: 'edge-bottom'}, target: {nodeId: 'shell'}}
+        });
+
+        await rig.controller.onDragMove({clientX: 400, clientY: 300, itemId: 'alpha', sourceNodeId: 'center-tabs'});
+
+        expect(rig.preview.dockPreview, 'a menu-selected root chip is refused as well').toBe(null);
         expect(stranded, `no node may be left empty — ${JSON.stringify(doc.nodes)}`).toEqual([]);
         expect(doc.nodes.shell.zones.center.nodeId, 'the shell keeps its content').toBe('center-tabs');
 


### PR DESCRIPTION
Resolves #18421

🌿 A chip could be drawn from one node and committed against another, so "full width" was a promise the surface had no way to keep; the boundary is now declared once and both halves read it, which leaves *"the preview measured something the drop never touched"* with nothing here to describe.

Related: #18303
Related: #18304

A root-edge chip was painted from the dock host's rect while its target was read from document SHAPE — an `edge-zone` root retargeted to its `center`. Those are different nodes, so on the dense Workstation the bottom chip promised the full window width and the drop landed a pane the width of the centre, with the left and right bands keeping the corners. The owner now declares its dockable root through one `resolveDockableRoot()` seam, and `ensureGeometry` takes both the nodeId and the measured component from that single answer. `PopupWorkspace` overrides it with `resolveStackRoot`, so a vessel shell keeps the transfer contract that made the original retarget correct for vessels. No manager, no parallel state, no new orchestration layer; the interaction layer no longer imports `WorkspaceDocument` at all.

Evidence: L3 (headed Chrome against the running flagship, App-Worker document truth, plus pre-fix controls on every new assertion) → L3 required (AC-1 through AC-6). No residual: AC-3's rendered arm is pushed and green. An earlier revision of this body claimed a residual on #18303 for it; that rested on a tear-out I have since retracted, and nothing carries over to #18303.

size-guard-growth: src/dashboard/dock/Workspace.mjs — +6 lines for the `resolveDockableRoot()` seam, the one method that lets the interaction layer stop reading document shape: `DragAffordances` loses its `WorkspaceDocument` import and the `edge-zone → center` retarget it existed for. The engine grew by a declaration so a consumer could shed an inference.

## AC Evidence

| AC | Evidence |
|---|---|
| AC-1 | CI-covered: `DockDragAffordances.spec.mjs` — "an edge-zone root offers the root edge chips against the boundary its owner declares" asserts `geometry.root` as ONE object (`{nodeId: 'root', rect: hostRect}`), so a nodeId that does not name the measured node cannot pass. Outside-CI: `WorkstationRootEdgeCornerNL` reads the live flagship's `dockPreview` mid-gesture — `edge-bottom` on `root`, never on the centre. Both fail on unchanged `dev` with `Expected: "root" / Received: "split-main"`. |
| AC-2 | Outside-CI: `WorkstationRootEdgeCornerNL` runs the operator's own sequence on the live flagship — a bottom drop, then a right drop, each asserted on the committed tree and on rendered geometry. CI-covered: "two sequential root-edge drops: the last one takes the corner" drives the production hover+release twice on an `edge-zone`-rooted fixture and asserts the tree — bottom gives a vertical root `[oldRoot, newPane]`, the following right gives a horizontal root `[previousRoot, rightPane]` with the bottom pane one level deeper. It fails on unchanged `dev`. The fixture is edge-zone-rooted deliberately: with a plain split root both resolutions agree and the test could not fail. |
| AC-3 | Outside-CI: `WorkstationRootEdgeCornerNL` commits the bottom drop and asserts the delivered pane against the host it was promised from — `droppedRect.width / hostRect.width >= 0.95`, measured `1256 / 1280`. The pre-fix defect delivers ~75% of that, so the bands do not overlap. It fails pre-fix on the same first read as AC-1. |
| AC-4 | CI-covered: `apps/workstation/Workspace.spec.mjs` — "a vessel popup docks at its transferable stack root, never at the window shell" resolves a real `PopupWorkspace` boundary to `resolveStackRoot` (never the shell), then commits a root-edge split against that boundary and asserts the shell is still the document root and the stack still resolves. Without the `PopupWorkspace` override it returns `workstation-vessel-root:alerts` instead of `workstation-vessel-tabs:alerts`. The 27 `DockCrossWindowParticipation` admission tests stay green. |
| AC-5 | CI-covered: "a sole-pane root-edge drop is refused before it can strand an empty half". `guardEmptyWrap` takes the ticket's second branch (refuse earlier) rather than changing the model: emptied tabs and splits are deleted by `normalizeTree`, but an `edge-zone` survives losing every zone on purpose — it stays a re-attachment anchor for `captureNodeHome` — so only that wrap could strand a half. Pre-fix the same gesture commits a document; now nothing commits and the preview never promises it. |
| AC-6 | CI-covered: the inside-container cross is untouched — the existing zone/candidate/release-truth tests in `DockDragAffordances.spec.mjs` and `DockDropIndicators.spec.mjs` pass unchanged, and the guard cannot reach a zone placement (zone targets are always `tabs` nodes; only a root placement can target an `edge-zone`). Full unit tier: 3494 passed. |

## Deltas from ticket

**`guardEmptyWrap` is a scope addition, and it exists because my own change made the case reachable.** Before this PR an `edge-zone` root retargeted to its centre, so the shell was never wrapped and never emptied; wrapping the arrangement makes AC-5's stranding reachable for the first time.

**Two different tests, which an earlier revision of this body ran together into a contradiction.** The arm I *discovered* it with asserted "no node is left empty": it passed on unchanged `dev` and failed on my change — that is the regression signal. The arm now in the diff asserts the *refusal*: on unchanged `dev` the same gesture commits a document, and with the guard nothing commits and the preview never promises it. Both statements are true of their own arm; only the shipped one is in the AC-5 row. The refusal is scoped to an `edge-zone` target, so tabs and split roots commit exactly as before, and a vessel's boundary is a tabs node — the vessel path is untouched. It applies at **both** selection tiers: `resolvePreview` first guarded only pointer inference and returned an indicator candidate unchanged, so a root chip picked from the menu lit up and was then refused on release. That is this ticket's own mismatch in miniature, so it is guarded and covered.

**Fallback sweep, after the second one bit.** Twice in this PR a guard written to remove the mismatch reintroduced it one layer down — the indicator-menu tier, then @neo-gpt-emmy's popup fallback. So I enumerated every `??`, `||` and ternary the source diff adds and checked each for the same class. Result: clean, and the reason is structural rather than lucky — `ensureGeometry` measures the component the owner **declared**, so a declared pair cannot come apart; the only way to break it was to declare a pair that was already wrong, which is what the popup fallback did. Both live consumers (`Workstation.view.Workspace`, `DemoAWorkspace`) set `dockHostReference: 'dock-host'`, so their declared component and the controller's measured host are the same object. One line in the diff that looks like new logic — `rect = windowId != null ? … innerRect : null` in `getGeometrySignature` — is the alignment fixer re-spacing an existing assignment, not a change.

The interaction layer's `WorkspaceDocument` import is removed. **The accurate claim is narrower than an earlier revision of this body made it** (@neo-gpt-emmy's rhetorical-drift audit): what no longer comes from document shape is WHICH node is dockable. `guardEmptyWrap` still reads the target's `type` and the item count — deliberately, because "would this wrap strand an empty half?" is a document question and there is nowhere else to ask it.

Two observations recorded rather than acted on. **The preview payload carries no rect** (`placement` is `{kind, orientation?}`) — the painted extent comes from `geometry.root.rect` and the commit from `target.nodeId`, which is why a green suite never caught this.

**Edge splits are always 50/50** — `previewToOperation` emits no ratio and the producer says so in source (`An optional split ratio is not emitted yet`), so a bottom root drop takes half the window height against an arrangement whose own bottom band ships at extent `0.17`. I measured whether that is a second mismatch of this PR's family, and **it is not**: mid-gesture the affordance paints `290` of a `579` host (50.1%) and the drop delivers `275` (47.4%, the difference being splitter chrome). The preview promises half the height and the drop gives half the height, so the contract this PR is about holds on the **other** axis too, unchanged and by accident of the same geometry. Whether 50% is the right default for an edge drop is a design question with a truthful preview in front of it, not a defect — left alone, and flagged here so the first bottom drop after merge is not read as a regression.

## Test Evidence

The e2e, against the running flagship:

```bash
NEO_AGENTOS_RUNTIME_ROOT=<brain-checkout> NEO_E2E_PORT=8162 npx playwright test WorkstationRootEdgeCornerNL -c test/playwright/playwright.config.e2e.mjs --workers=1
```

**1 passed**, re-run at head `b65050519c` after the last source change rather than left standing from an earlier commit. Against unchanged source the same spec fails with `Error: aimed at the whole arrangement / Expected: "root" / Received: "split-main"` — the operator's report, caught end to end.

**Do not read the green `e2e-engine` check as covering it.** That job is the Brain-free tier and sets no `NEO_AGENTOS_RUNTIME_ROOT`, so this `neuralLink` spec is removed from SELECTION there — not skipped, so no reporter line mentions it (`test/playwright/externalBrainSelection.mjs` exists because that gap is inaudible). The run above is the only evidence for it.

Every new or changed unit assertion has a pre-fix control, run by stashing only the source file: the affordances tests report `Expected: "root" / Received: "split-main"`; the vessel test reports `workstation-vessel-root:alerts` for `workstation-vessel-tabs:alerts`; the sole-pane test commits one document instead of none. Three previously green specs needed their dock-owner doubles extended, because the owner contract gained a member — those doubles **borrow `DockWorkspace.prototype.resolveDockableRoot` rather than reimplementing it**, so a stub cannot agree with an assertion the shipped resolution disagrees with.

**Retraction.** An earlier revision of this body reported that a release near the root edge is claimed by the tear-out layer — the pane leaving the document while the preview read `edge-bottom` on `root` — and used it to justify AC-3 as a residual. **That was my gesture, not the product.** `SortZone#detachThreshold` (0.8) fires the boundary exit on the drag PROXY's intersection ratio, and the proxy is 48x32 centred on the pointer, so parking d px inside gives `0.5 + d/48` horizontally and `0.5 + d/32` vertically. My approach parked at d=8, ratio 0.75 — already across — and `reattachThreshold` (0.6) means a crossing must be earned back, so every later position stayed detached, including the chip centre I read as a second data point.

Measured on the live flagship, approaching no nearer than the parking spot: **bottom d=14 and d=20, and right d=24, all commit** (`items` 20 → 20). The usable band is roughly 15–24px on both edges — inside the 24px root strip, outside the detach zone. `EDGE_INSET` carries that arithmetic in its docblock so the next author does not rediscover it the way I did. Full detail in [this comment](https://github.com/neomjs/neo/pull/18426#issuecomment-5563896976).

**CI needed two reruns at `b65050519c`, and I would rather show that than let a green badge stand.** `e2e-engine` failed twice and passed on the third run of an unchanged head — with a **different** spec each time: `grid/ThumbDragPause.spec.mjs` (`no frame blanked`, `Expected: 0, Received: 10`), then `grid/TreeBigData.spec.mjs` (a 5000ms `toHaveClass(/neo-selected/)` timeout). A real regression fails the same test deterministically; a rotating casualty points at a shared cause, and both modes have closed tickets — #14853 for the blank frames, #14854 for the TreeGrid BigData family. **Those closures show the modes are real and previously seen; they are not evidence the arms are benign now** — @neo-opus-ada's point, and it is the sharper one: the engine tier runs these specs as roughly the 22nd–25th arm on a shared runner, a load profile that did not exist until this week, so whatever closed them was verified under conditions that no longer apply. My diff is dock-only and `git grep -l "dashboard/dock" -- examples/grid` finds no executable path into a grid demo; this branch also passed `e2e-engine` twice earlier with the dock change as the only delta since. Handed to @neo-opus-ada, whose e2e-tier lane owns it.

## Post-Merge Validation

- [ ] @tobiu repeats the original report on the dense Workstation: drop a pane at the bottom root edge and confirm it spans the full container width, then drop another at the right edge and confirm the right pane takes the full height while the bottom pane narrows. **Expect the new pane to take about half the height** — that is the unchanged 50/50 edge-split default, the preview shows it before you release, and it is not part of this change (see Deltas). Approach the edge no nearer than ~15px: closer than that the drag proxy crosses `SortZone#detachThreshold` and the gesture becomes a tear-out instead of a dock, which is what fooled my first automated attempt.

## Commits

- `75969a6db3` — the boundary seam, its two overrides, the empty-wrap guard, and the unit + e2e coverage
- `ce1615fe85` — the vessel's whole-stack admission after a root-edge drop (AC-4's second half)
- `ea43b63b17` — the re-measured size baseline for the seam's six lines
- `f367320573` — the e2e scope note states what was measured; the mechanism claim it carried was an inference I never verified
- `3ba9f3680c` — `getDockHost()` called directly; the optional call guarded nothing
- `388df1f846` — the indicator-menu tier passes the empty-wrap guard too (found on a self-review pass; the control shows the menu previewing `edge-bottom` on the shell without it)
- `669cbf80b7` — the e2e becomes the full two-gesture journey: both drops commit, rendered geometry asserted, `EDGE_INSET` documents the detach-threshold arithmetic
- `ae188ffb77` — the block alignment the previous commit skipped (I committed from a scratch worktree with a `core.hooksPath` override that pointed git at a non-executable hook)
- `b65050519c` — @neo-gpt-emmy's RA-1: a popup with no projected stack container now offers no boundary instead of substituting the shell's component, with the absent-component control and the consumer-side refusal arm

Authored by Vega (Opus 5, Claude Code). Session a9aa27b4-c253-4f8b-a287-c1ac847333c1.
