### PR TITLE
fix(examples): the Demo-B stage unwraps the zone descriptor the way the engine does (#18429)

### DIFF
--- a/examples/dashboard/crossWindow/DemoBCrossWindowStage.mjs
+++ b/examples/dashboard/crossWindow/DemoBCrossWindowStage.mjs
@@ -622,8 +622,13 @@ export function createCrossWindowStage(seams) {
                 .filter(nodeId => nodes[nodeId].type === 'tabs')
                 .map(nodeId => ({nodeId, container: host.down({dockNodeId: nodeId})}))
                 .filter(zone => zone.container),
+            // A zone entry is an OBJECT DESCRIPTOR ({nodeId, …}; the v13.2 contract retired the
+            // string shorthand), so reading `zones.center` directly yields an object where an id
+            // belongs. `PreviewProducer.resolveRootEdge` then fails its `typeof nodeId === 'string'`
+            // guard and returns null, dropping every root edge chip with no error. The canonical
+            // unwrap is the one the module already imports.
             rootId      = nodes[document.root]?.type === 'edge-zone'
-                ? (nodes[document.root].zones?.center ?? document.root)
+                ? (WorkspaceDocument.getZoneNodeId(nodes[document.root].zones?.center) ?? document.root)
                 : document.root,
             [hostRect, ...zoneRects] = await host.getDomRect(
                 [host.id, ...zoneEntries.map(zone => zone.container.id)],

--- a/test/playwright/unit/examples/dashboard/crossWindow/DemoBWorkspace.spec.mjs
+++ b/test/playwright/unit/examples/dashboard/crossWindow/DemoBWorkspace.spec.mjs
@@ -22,6 +22,7 @@ import Persistence                                         from '../../../../../
 import TransactionManager                                  from '../../../../../../src/manager/Transaction.mjs';
 
 import {demoBTourScript, initialDocument} from '../../../../../../examples/dashboard/crossWindow/demoBPerspectives.mjs';
+import {createCrossWindowStage}           from '../../../../../../examples/dashboard/crossWindow/DemoBCrossWindowStage.mjs';
 
 /**
  * @summary Installs deterministic popup-vessel seams for the worker-side workspace specs.
@@ -2533,5 +2534,52 @@ test.describe('describeCrossWindowChromeMismatch', () => {
         // same assertion against the un-normalized shape finds `actual` missing on all four rows.
         expect(roundTripped.dockNodeId.actual).toBeNull();
         expect(roundTripped.barItemCount.actual).toBeNull()
+    })
+});
+
+test.describe('DemoB cross-window stage — root edge geometry', () => {
+    /**
+     * @summary Builds the stage with only the seams `measureGeometry` reaches, plus a host double
+     * whose `getDomRect` returns measurable rects.
+     * @param {Object} document
+     * @returns {Object}
+     */
+    function stageForDocument(document) {
+        const
+            host = {
+                id         : 'demo-b-host',
+                isDestroyed: false,
+                windowId   : 'demo-b-window',
+                down       : ({dockNodeId}) => ({id: `container-${dockNodeId}`}),
+                getDomRect : ids => Promise.resolve(ids.map(() => ({height: 600, width: 800, x: 0, y: 0})))
+            },
+            registries = {geometry: new Map(), hosts: new Map([['demo-b', host]]), participations: new Map()};
+
+        return createCrossWindowStage({
+            registries,
+            getWorkspaceDocument: () => document
+        })
+    }
+
+    // The v13.2 contract makes a zone entry an OBJECT DESCRIPTOR, so reading `zones.center`
+    // directly hands `PreviewProducer.resolveRootEdge` an object where its `typeof nodeId ===
+    // 'string'` guard expects an id. The producer then returns null and every root edge chip is
+    // dropped with no error, which is why this asserts the TYPE rather than only the value.
+    test('the root nodeId published for an edge-zone root is an id, not the zone descriptor', async () => {
+        const geometry = await stageForDocument(initialDocument).measureGeometry('demo-b');
+
+        expect(geometry, 'the doubles are sufficient for a measurable geometry').toBeTruthy();
+
+        expect(typeof geometry.root.nodeId, 'the producer id guard only accepts a string').toBe('string');
+        expect(geometry.root.nodeId).toBe('workbench-tabs')
+    });
+
+    // Non-vacuity: the arm above is only evidence if the fixture actually carries the descriptor
+    // shape. A perspective that shipped a bare string would satisfy it without exercising anything.
+    test('the fixture this is measured against really does ship the descriptor shape', () => {
+        const {nodes} = initialDocument;
+
+        expect(nodes.root.type).toBe('edge-zone');
+        expect(nodes.root.zones.center).toEqual({nodeId: 'workbench-tabs'})
     })
 });


### PR DESCRIPTION
Resolves #18429

Demo-B's root edge chips are off, silently, for every user of the shipped perspective. Found by @neo-opus-vega while fixing #18421, handed over rather than folded into her lane; every link re-verified here before acting.

## The mechanism

`DemoBCrossWindowStage.measureGeometry` carries a hand-copied root unwrap:

```js
rootId = nodes[document.root]?.type === 'edge-zone'
    ? (nodes[document.root].zones?.center ?? document.root)
    : document.root,
```

Under the v13.2 contract a zone entry is an **object descriptor**, not an id. `demoBPerspectives.mjs:37` ships exactly that:

```js
root: {type: 'edge-zone', zones: {center: {nodeId: 'workbench-tabs'}, right: {nodeId: 'side-tabs'}}}
```

So `rootId` becomes `{nodeId: 'workbench-tabs'}`, published as `root: {nodeId: rootId, …}`. `PreviewProducer.resolveRootEdge:175` then fails closed on it:

```js
if (!(band > 0) || typeof root?.nodeId !== 'string' || !root.nodeId || !rect || !pointer) return null;
```

This rejects pointer-inferred root edges. The separate string-ID guard in `produceCandidates()` also omits root chips for the descriptor-valued ID; neither path throws. `DemoBWorkspace.mjs:4524` carries a `popup-root` shell of the same shape, so it is not a single-perspective accident.

**The engine fixed this and the copy never heard.** `DragAffordances.mjs:150` carries both the repair and a comment naming this exact regression — *"the canonical unwrap keeps the producer's fail-closed id guard from silently dropping every root edge chip"*.

| file | `getZoneNodeId` uses, before this PR |
|---|---:|
| `src/dashboard/dock/interaction/DragAffordances.mjs` | **1** |
| `examples/dashboard/crossWindow/DemoBCrossWindowStage.mjs` | **0** |

This is the cost of re-derivation as a defect rather than a line count: one file got the repair, its duplicate kept the bug, and nothing in the tree could tell them apart. `DemoBWorkspace` extends `Container`, not the dock `Workspace`, so no inheritance edge could have carried it.

## Deltas

- **Changed** `examples/dashboard/crossWindow/DemoBCrossWindowStage.mjs`: **+6 / −1**. The unwrap routes through `WorkspaceDocument.getZoneNodeId` — a static, so it needs no inheritance — plus the comment explaining why a direct read is wrong. **The module already imported `WorkspaceDocument` at line 4**: the owner of the decision was in scope and unused.
- **Changed** `test/playwright/unit/examples/dashboard/crossWindow/DemoBWorkspace.spec.mjs`: **+48**. Two arms.

## AC Evidence

Evidence: L2 (unit arms against the shipped fixture, with a mutation control on the source change) → L2 sufficient: the defect is a value-type error at a documented contract boundary, and the guard it trips is pure.

| AC | result |
|---|---|
| 1 — the file resolves the root zone through `getZoneNodeId` | census now **1**, was `0` |
| 2 — `rootId` is a string for the shipped edge-zone root, red-first | both arms below |
| 3 — a root edge chip is produced where none is today | Reviewer-executed L2 producer witness: four root chips with the repaired ID; `root: null` with the original descriptor — see below |
| 4 — the rect names the same boundary as the id | **withdrawn from this ticket** — see below |

**AC-3 has a producer-level witness, not a headed rendering claim.** At `8efadea86c`, the reviewer ran the real `createCrossWindowStage(...).measureGeometry()` with the shipped `initialDocument` and a deterministic measurable host. Passing that geometry and a valid edge pointer to `PreviewProducer.produceCandidates()` returns root `workbench-tabs` with chips `[top, right, bottom, left]`. Replacing only `root.nodeId` with the original zone descriptor returns `root: null`. The separate `resolveRootEdge()` path returns `bottom` for that edge pointer and `null` at the center, confirming that a string ID alone is insufficient. This direct L2 result replaces the earlier inference from the ID guard. No rendered-chip or post-drop boundary claim is made; boundary alignment remains on #18304 after #18426.

**AC-4 was written against a reference that does not exist yet, and I corrected it on the ticket rather than implementing it.** `DragAffordances` publishes `root: {nodeId: rootId, rect: hostRect}` on this base too, so the engine does not satisfy that invariant either. @neo-opus-vega's PR #18426 introduces the owner seam that does. Implementing it here would have changed the copy into something the engine is not. The refuting datum was already in her hand-off — *"the engine's copy **now** resolves its boundary through an owner seam"* — and I read a landed present tense into a pending PR.

## Test Evidence

```
npm run test-unit -- DemoBWorkspace.spec.mjs -g "root edge geometry"    2 passed
npm run test-unit -- DemoBWorkspace.spec.mjs                           69 passed
node buildScripts/util/check-file-sizes.mjs                    1309 paths, 0 violations
```

**Mutation control, scoped to the source change** — the unwrap reverted to `origin/dev`'s form, the arms untouched:

```
getZoneNodeId census after revert   0    (asserted, not assumed)
  ✗ the root nodeId … is an id, not the zone descriptor      FAILS
  ✓ the fixture … really does ship the descriptor shape      still passes
getZoneNodeId census after restore  1    (asserted)
  ✓ both                                                     PASS
```

The second arm is the non-vacuity guard and it is load-bearing: it asserts `nodes.root.zones.center` equals `{nodeId: 'workbench-tabs'}`, so a perspective that ever shipped a bare string would fail it instead of quietly making the first arm pass for free. It stays green in **both** states, which is what proves the first arm's red comes from the source change rather than from the fixture.

## Post-Merge Validation

**What this does not fix, deliberately.** The duplication. `DemoBCrossWindowStage` still hand-copies `ensureGeometry`, `DemoBWorkspace` still re-implements twelve dock-specific methods without extending the dock `Workspace`, and the engine's newer boundary seam still cannot reach either. That disposition belongs to #18304, which now carries this as sub 15 and whose [seam account](https://github.com/neomjs/neo/issues/18304#issuecomment-5563564532) names the pattern.

Repairing the symptom is worth doing on its own: the defect is live, user-visible, and the fix removes the divergence at the one point where the two copies disagreed. It is not worth pretending it addresses the cause — the next engine repair to that block will diverge exactly the same way.

Worth watching after merge: whether any other consumer of `zones.center` reads it without the helper. This PR does not sweep for that.

Authored by @neo-opus-grace (Claude Opus 5), origin session `70502f9a-5b14-4dcf-bcdf-4a29b546df77`. Defect found and handed over by @neo-opus-vega.
