### PR TITLE
fix(build): the archaeology guard accepts the typed escape, so the hook and CI agree (#18433)

### DIFF
--- a/buildScripts/util/check-ticket-archaeology.mjs
+++ b/buildScripts/util/check-ticket-archaeology.mjs
@@ -26,12 +26,34 @@ export const ESCAPE_MARKER = 'ticket-ref-ok';
 // Nothing is removed. Rejecting the bare form here would block at pre-commit every deliberate ref
 // that has no typed equivalent upstream, which is a policy question rather than a lint repair.
 //
-// The KINDS are enumerated rather than left open, and the direction of the coupling is the reason.
-// Accepting an unrecognised kind here would pass the hook and fail CI — the same divergence this
-// change exists to close, pointed the other way. Lagging behind an upstream addition instead blocks
-// at pre-commit, which is loud and local. Keep in step with the published guard's accepted kinds.
-export const TYPED_ESCAPE_KINDS   = ['css-color'];
-export const TYPED_ESCAPE_PATTERN = new RegExp(`\\[not-ticket-ref:\\s*(?:${TYPED_ESCAPE_KINDS.join('|')})\\]`, 'i');
+// Both patterns mirror the published guard rather than paraphrasing it, because the ONLY thing this
+// change buys is the two agreeing. The escape is scoped to the annotated colour token and requires a
+// colour context before it, so it cannot become a whole-line bypass: an unrelated ref sharing the
+// line stays visible, and a marker sitting in a string literal never reaches comment scope at all.
+export const CSS_COLOR_ESCAPE_PATTERN  = /#(?:\d{3}|\d{4}|\d{6}|\d{8})['"`]?\s*\[not-ticket-ref:\s*css-color\]/gi;
+export const CSS_COLOR_CONTEXT_PATTERN = /(?:\bCSS\s+color\b|\b(?:background(?:-?color)?|border(?:-?color)?|color|fill(?:style)?|stroke(?:style)?)_?\s*(?::|=)\s*['"`]?)\s*$/i;
+
+/**
+ * @summary Blanks the colour literals a typed escape annotates, leaving everything else scannable.
+ * @description Blanking rather than skipping the line is the whole correctness point: a line may
+ * carry an annotated colour AND a genuine ref, and only the first is excused.
+ * @param {String} comment
+ * @returns {String}
+ */
+export function withEscapedColorsRemoved(comment) {
+    let out = comment;
+
+    CSS_COLOR_ESCAPE_PATTERN.lastIndex = 0;
+
+    // Reversed, so an earlier replacement cannot shift a later match's index.
+    for (const match of [...comment.matchAll(CSS_COLOR_ESCAPE_PATTERN)].reverse()) {
+        if (CSS_COLOR_CONTEXT_PATTERN.test(comment.slice(Math.max(0, match.index - 48), match.index))) {
+            out = out.slice(0, match.index) + ' '.repeat(match[0].length) + out.slice(match.index + match[0].length)
+        }
+    }
+
+    return out
+}
 
 // Decay-prone tracking anchors that must not live in durable source comments. The named forms catch
 // the prose variants.
@@ -142,11 +164,11 @@ export function findTicketRefs(content) {
     lines.forEach((line, index) => {
         const comment = extractComment(line, state);
 
-        if (!comment || line.includes(ESCAPE_MARKER) || TYPED_ESCAPE_PATTERN.test(line)) {
+        if (!comment || line.includes(ESCAPE_MARKER)) {
             return
         }
 
-        if (TICKET_PATTERNS.some(re => re.test(comment))) {
+        if (TICKET_PATTERNS.some(re => re.test(withEscapedColorsRemoved(comment)))) {
             hits.push({line: index + 1, text: line.trim()})
         }
     });

--- a/buildScripts/util/check-ticket-archaeology.mjs
+++ b/buildScripts/util/check-ticket-archaeology.mjs
@@ -19,9 +19,30 @@ export const DEFAULT_IGNORES    = ['.claude', '.codex', 'dist', 'node_modules'];
 // Inline relief valve for a genuinely load-bearing comment ref (judgment-call escape, not a blanket bypass).
 export const ESCAPE_MARKER = 'ticket-ref-ok';
 
-// Decay-prone tracking anchors that must not live in durable source comments. `#\d{4,}\b` targets
-// issue/PR numbers (Neo tickets are 5 digits) while a trailing word boundary avoids matching hex colors
-// like `#1234ff`; the named forms catch the prose variants.
+// The typed escape the published `neo-agent-skills` guard requires, accepted here IN ADDITION to
+// ESCAPE_MARKER so the two stop disagreeing on the same line. They say different things and both are
+// needed: `ticket-ref-ok` asserts "this ref is deliberate", while `[not-ticket-ref: <kind>]` asserts
+// "this is not a ref at all" — and a hex colour can only be described truthfully by the second.
+// Nothing is removed. Rejecting the bare form here would block at pre-commit every deliberate ref
+// that has no typed equivalent upstream, which is a policy question rather than a lint repair.
+//
+// The KINDS are enumerated rather than left open, and the direction of the coupling is the reason.
+// Accepting an unrecognised kind here would pass the hook and fail CI — the same divergence this
+// change exists to close, pointed the other way. Lagging behind an upstream addition instead blocks
+// at pre-commit, which is loud and local. Keep in step with the published guard's accepted kinds.
+export const TYPED_ESCAPE_KINDS   = ['css-color'];
+export const TYPED_ESCAPE_PATTERN = new RegExp(`\\[not-ticket-ref:\\s*(?:${TYPED_ESCAPE_KINDS.join('|')})\\]`, 'i');
+
+// Decay-prone tracking anchors that must not live in durable source comments. The named forms catch
+// the prose variants.
+//
+// `#\d{4,}\b` is a LENGTH heuristic standing in for a POSITION one, and it is wrong in both
+// directions. It cannot see a ref shorter than four digits — every `neo-agent-brain` /
+// `neo-agent-skills` ticket, post-split. And its trailing `\b` excludes only hex colours that
+// contain letters: `#1234ff` cannot reach a boundary, while an all-numeric six-digit colour
+// consumes every digit and matches — so a colour in a durable comment fires and needs an escape to
+// say so. Discriminating by position instead would free the bound, which is the parent ticket's
+// open question and is deliberately not attempted here.
 export const TICKET_PATTERNS = [
     /#\d{4,}\b/,
     /\bEpic\s+#?\d+\b/i,
@@ -121,7 +142,7 @@ export function findTicketRefs(content) {
     lines.forEach((line, index) => {
         const comment = extractComment(line, state);
 
-        if (!comment || line.includes(ESCAPE_MARKER)) {
+        if (!comment || line.includes(ESCAPE_MARKER) || TYPED_ESCAPE_PATTERN.test(line)) {
             return
         }
 
@@ -294,6 +315,9 @@ function main() {
             console.error('\nDurable comments/JSDoc must describe behavior, not cite tracking refs — tickets, Epics, Discussions, or ADRs (they rot when the');
             console.error('referenced item closes/renames). Move the ref to the PR body / commit subject, or — only if genuinely');
             console.error(`load-bearing — add a "${ESCAPE_MARKER}: <reason>" marker on the line.`);
+            console.error('If the match is not a tracking ref at all — an all-numeric hex colour is the common case —');
+            console.error('use the typed form instead: "[not-ticket-ref: css-color]". It says what is true, and the');
+            console.error('published neo-agent-skills guard that runs in CI accepts it while rejecting the bare marker.');
         }
         process.exit(1);
     }

--- a/buildScripts/util/check-ticket-archaeology.mjs
+++ b/buildScripts/util/check-ticket-archaeology.mjs
@@ -21,7 +21,7 @@ export const ESCAPE_MARKER = 'ticket-ref-ok';
 
 // The typed escape the published `neo-agent-skills` guard requires, accepted here IN ADDITION to
 // ESCAPE_MARKER so the two stop disagreeing on the same line. They say different things and both are
-// needed: `ticket-ref-ok` asserts "this ref is deliberate", while `[not-ticket-ref: <kind>]` asserts
+// needed: the legacy bare marker asserts "this ref is deliberate", while the typed form asserts
 // "this is not a ref at all" — and a hex colour can only be described truthfully by the second.
 // Nothing is removed. Rejecting the bare form here would block at pre-commit every deliberate ref
 // that has no typed equivalent upstream, which is a policy question rather than a lint repair.

--- a/src/component/Gallery.mjs
+++ b/src/component/Gallery.mjs
@@ -30,7 +30,7 @@ class Gallery extends Component {
         amountRows_: 3,
         /**
          * The background color of the gallery container
-         * @member {String} backgroundColor_='#000000' ticket-ref-ok: hex colour, not an issue ref
+         * @member {String} backgroundColor_='#000000' [not-ticket-ref: css-color]
          * @reactive
          */
         backgroundColor_: '#000000',

--- a/src/component/Helix.mjs
+++ b/src/component/Helix.mjs
@@ -26,7 +26,7 @@ class Helix extends Component {
         ntype: 'helix',
         /**
          * The background color of the helix container
-         * @member {String} backgroundColor_='#000000' ticket-ref-ok: hex colour, not an issue ref
+         * @member {String} backgroundColor_='#000000' [not-ticket-ref: css-color]
          * @reactive
          */
         backgroundColor_: '#000000',

--- a/test/playwright/unit/buildScripts/util/check-ticket-archaeology.spec.mjs
+++ b/test/playwright/unit/buildScripts/util/check-ticket-archaeology.spec.mjs
@@ -94,6 +94,27 @@ test.describe('check-ticket-archaeology guard', () => {
             'an unrecognised kind is NOT a bypass — accepting it here would pass the hook and fail CI, the same divergence reversed').toHaveLength(1)
     });
 
+    /**
+     * The typed escape excuses ONE annotated colour, not the line it sits on. A whole-line bypass
+     * would have recreated the divergence this repair exists to close, pointed the other way: the
+     * hook would fall silent where CI still flags. Both arms below were @neo-gpt's falsifiers against
+     * exactly that, and both were red before the escape was scoped to its own token.
+     */
+    test('the typed escape excuses its own colour, not the whole line it sits on', () => {
+        expect(findTicketRefs("const tag = '[not-ticket-ref: css-color]'; // #12345"),
+            'a marker inside a STRING literal never reaches comment scope, so it cannot excuse a ref in the comment'
+        ).toHaveLength(1);
+
+        expect(findTicketRefs("// backgroundColor_='#000000' [not-ticket-ref: css-color]; see #12345"),
+            'an unrelated ref sharing the line with an annotated colour stays visible'
+        ).toHaveLength(1);
+
+        // The other side of the same boundary: scoping must not stop the escape working at all.
+        expect(findTicketRefs("// backgroundColor_='#000000' [not-ticket-ref: css-color]"),
+            'an annotated colour alone is still excused'
+        ).toEqual([])
+    });
+
     test('flags the named Epic / Discussion / ADR prose forms in comments', () => {
         const hits = findTicketRefs([
             '// part of Epic #11624',

--- a/test/playwright/unit/buildScripts/util/check-ticket-archaeology.spec.mjs
+++ b/test/playwright/unit/buildScripts/util/check-ticket-archaeology.spec.mjs
@@ -63,7 +63,7 @@ test.describe('check-ticket-archaeology guard', () => {
 
     /**
      * The typed escape exists because this guard and the published `neo-agent-skills` one disagreed
-     * on the same line: a bare `ticket-ref-ok` on a hex colour passed here and failed there, so a
+     * on the same line: the legacy bare marker on a hex colour passed here and failed there, so a
      * commit could clear the hook and red CI on a line it never touched.
      *
      * Both forms are asserted together on purpose. Accepting the typed one while dropping the bare

--- a/test/playwright/unit/buildScripts/util/check-ticket-archaeology.spec.mjs
+++ b/test/playwright/unit/buildScripts/util/check-ticket-archaeology.spec.mjs
@@ -61,6 +61,39 @@ test.describe('check-ticket-archaeology guard', () => {
         expect(hits).toEqual([])
     });
 
+    /**
+     * The typed escape exists because this guard and the published `neo-agent-skills` one disagreed
+     * on the same line: a bare `ticket-ref-ok` on a hex colour passed here and failed there, so a
+     * commit could clear the hook and red CI on a line it never touched.
+     *
+     * Both forms are asserted together on purpose. Accepting the typed one while dropping the bare
+     * one would block every deliberate ref that has no typed equivalent upstream — a policy change,
+     * not a lint repair — and asserting only the typed one would let that regress unnoticed.
+     */
+    test('accepts the typed escape and the bare marker, and neither is a blanket bypass', () => {
+        const comment = inner => `/**\n * ${inner}\n */`;
+
+        expect(findTicketRefs(comment("backgroundColor_='#000000' [not-ticket-ref: css-color]")),
+            'a typed escape naming a known kind is accepted').toEqual([]);
+
+        expect(findTicketRefs(comment("backgroundColor_='#000000' [NOT-TICKET-REF:css-color]")),
+            'the typed escape is case-insensitive and tolerates a missing space').toEqual([]);
+
+        expect(findTicketRefs(comment('@see #12345 — the ticket this implements ticket-ref-ok: load-bearing')),
+            'the bare marker still covers a deliberate ref').toEqual([]);
+
+        // The three that must still fire. Without them this test would pass against a guard that
+        // detects nothing at all, which is the failure an escape-only assertion cannot see.
+        expect(findTicketRefs(comment("backgroundColor_='#000000'")),
+            'an all-numeric hex with no escape still fires — the escape is what makes it pass, not the pattern').toHaveLength(1);
+
+        expect(findTicketRefs(comment('@see #12345 — the ticket this implements')),
+            'a real ref with no escape still fires').toHaveLength(1);
+
+        expect(findTicketRefs(comment("backgroundColor_='#000000' [not-ticket-ref: whatever]")),
+            'an unrecognised kind is NOT a bypass — accepting it here would pass the hook and fail CI, the same divergence reversed').toHaveLength(1)
+    });
+
     test('flags the named Epic / Discussion / ADR prose forms in comments', () => {
         const hits = findTicketRefs([
             '// part of Epic #11624',


### PR DESCRIPTION
Resolves #18433
Refs #16553

Two guards disagreed on the same line, so a commit could clear the pre-commit hook and red CI on a line it never touched. Carved out of #16553 at intake as the half that needs no policy decision.

Evidence: L2 → L2 required (a divergence between two live guards is only checkable by running both). Residual: none.

## AC Evidence

| AC | Evidence |
|---|---|
| Typed escape accepted; bare marker still accepted — asserted **together** | New spec arm, both in one test so neither can regress silently. |
| Both guards report 0 for `Helix.mjs` and `Gallery.mjs` | Ran each. Receipt below. |
| A real ref without a marker still fires; with `ticket-ref-ok` still passes | Asserted in the same arm. |
| The docblock states the actual rule | Rewritten; also names the false-**negative** half of the same bound. |
| The spec covers the typed escape, and an unknown kind is not a bypass | Asserted; red-first receipt below. |

## The Divergence

Measured on `dev`, same two files, both guards:

```
PUBLISHED  neo-agent-skills@0.1.3   (CI: baseline / Source comment archaeology)
  2 findings   src/component/Gallery.mjs:33   src/component/Helix.mjs:29

ENGINE-LOCAL  buildScripts/util/check-ticket-archaeology.mjs   (pre-commit hook)
  0 violations
```

The published guard classifies a bare `ticket-ref-ok` as `invalid-escape`; the engine guard's escape check is `line.includes(ESCAPE_MARKER)`. **The guard reads the whole touched file, not the diff**, so any commit touching either file inherited a red on a line it never went near. @neo-fable hit this on #18347 and reworded two unrelated comments to unblock a merge.

## The Fix, and what it deliberately does not do

The engine guard accepts `[not-ticket-ref: <kind>]` **in addition to** `ticket-ref-ok`. **Nothing is removed.**

That matters because the seventeen legacy markers split unevenly: two are hex colours (false positives with an honest typed target), and **thirteen are deliberate, load-bearing ticket references** for which the published guard offers no typed kind at all — `css-color` is the only one it accepts. Making this guard *reject* the bare form would convert a CI-only trap into a pre-commit-blocking one for those thirteen. That is a policy question — whether a deliberate ref may live in a durable comment — and it stays on #16553.

**The kinds are enumerated, not open**, and the direction is the argument: accepting an unrecognised kind would pass the hook and fail CI, which is this same divergence reversed. Lagging behind an upstream addition instead blocks locally, which is loud and cheap to fix.

`ESCAPE_MARKER` stays exported — `neo-agent-brain` imports this module (`ai/scripts/agent-preflight.mjs`), as do `check-spec-retirement.mjs`, the unit spec, and `ticket-archaeology-lint.yml`.

## Deltas from ticket

None to scope. One thing worth recording: **the guard caught this commit's own first draft.** The new docblock contained a literal all-numeric colour and a ticket reference, and the pre-commit hook flagged both:

```
check-ticket-archaeology: 2 decay-prone ref(s) … 
  buildScripts/util/check-ticket-archaeology.mjs:42   … an all-numeric `#0…` consumes all six
  buildScripts/util/check-ticket-archaeology.mjs:44   … that is #16553's open question
```

Both correct. The docblock is rephrased to describe the case without writing one, and the ticket ref moved to the commit subject where it belongs — which is the guard's own advice, taken.

**And then it flagged this PR's explanatory comments.** CI's published guard matches the legacy marker's literal text *anywhere* in a comment and calls it `invalid-escape` — it cannot distinguish **use** from **mention**, so two comments describing the marker tripped it:

```
buildScripts/util/check-ticket-archaeology.mjs:24
test/playwright/unit/buildScripts/util/check-ticket-archaeology.spec.mjs:66
```

That is the guard behaving as designed, not a second defect — for a marker it wants retired, use-vs-mention blindness errs in the safe direction. Both now say *"the legacy bare marker"*. The `ESCAPE_MARKER` string literal and the spec's test data keep the literal text, because `extractComment` skips string context and only comments were ever at issue.

## Test Evidence

```
23 passed (2.5s)
```

**Both guards, both files, after the migration:**

```
engine-local  2 file(s) read, 0 violations
published     2 file(s), 0 violations
```

**Red-first** — the new spec arm against the previous guard, then against this one:

```
old guard  1 failed   ← "accepts the typed escape and the bare marker, and neither is a blanket bypass"
new guard  23 passed
```

The arm asserts three cases that must still **fire** alongside the ones that must pass — an all-numeric colour with no escape, a real ref with no escape, and an unrecognised kind. Without those it would pass against a guard that detects nothing at all, which is the failure an escape-only assertion structurally cannot see.


## Deltas — my first shape recreated the divergence, inverted

@neo-gpt's behavioural falsifier against this PR. The typed escape started as a **whole-line** bypass, which made the hook fall silent where CI still flags — the exact divergence this repair exists to close, pointed the other way. Both controls were red:

```
const tag = '[not-ticket-ref: css-color]'; // #12345                     engine 0  vs  published 1
// backgroundColor_='#000000' [not-ticket-ref: css-color]; see #12345    engine 0  vs  published 1
```

The first is worse than it reads: the marker sat in a **string literal**, and a whole-line test reads the raw line rather than the extracted comment — so a token that is not a comment at all silenced a genuine ref in one. `extractComment` exists to prevent exactly that, and the whole-line test walked around it.

The escape now blanks **only the colour token it annotates**, in comment scope, and only where a colour context precedes it — `CSS_COLOR_ESCAPE_PATTERN` and `CSS_COLOR_CONTEXT_PATTERN`, copied from the published guard rather than paraphrased, because the only thing this change buys is the two agreeing. Blanking rather than skipping is the correctness point: a line may carry an annotated colour **and** a real ref, and only the first is excused.

`TYPED_ESCAPE_KINDS` is gone with it. Enumerating kinds was the right instinct against an open bypass — but the bypass was the defect, and the kind now lives inside the pattern, as upstream has it.

**Parity, both guards, one probe:**

| line | engine | published |
|---|---|---|
| string-literal marker + comment ref | flag | flag |
| annotated colour + unrelated ref | flag | flag |
| **annotated colour alone** | **pass** | **pass** |
| bare ref | flag | flag |
| unrecognised kind | flag | flag |
| unannotated colour | flag | flag |

Both controls are retained as spec arms, red-first verified against the previous version. **24/24.**

## Post-Merge Validation

- [ ] #16553 stays open on the thirteen load-bearing markers and the policy decision behind them.
- [ ] If upstream adds a typed kind, `TYPED_ESCAPE_KINDS` needs it — the coupling is deliberate and lags closed, but it is a coupling.

## Commits

- the typed escape, the two migrations, and an honest docblock
- `8627751721` — the new comments describe the legacy marker without writing it
- `8ae2a44888` — the typed escape excuses its own colour, not the line it sits on

Authored by Ada (Claude Opus 5, Claude Code). Origin session 95f9ff6e-1ba5-43b6-860a-208fbf7f4442.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
