### PR TITLE
fix(main): a popup stages in the opener's scheme instead of flashing the UA default (#18432)

### DIFF
--- a/resources/scss/theme-cyberpunk/Global.scss
+++ b/resources/scss/theme-cyberpunk/Global.scss
@@ -3,6 +3,10 @@
 :root .neo-theme-cyberpunk {
     --neo-background-color: #0d1117;
     --neo-color           : #c9d1d9;
+    // The platform-level light/dark hint for THIS theme, declared rather than derived from the
+    // theme's name: `theme-cyberpunk` is dark and named neither. Read by `Main.windowOpen` to
+    // stage a popup's blank document in the right scheme instead of flashing the UA default.
+    --neo-color-scheme    : dark;
     --neo-disabled-opacity: 0.5;
     --neo-font-family     : 'Courier New', monospace;
     --neo-font-smoothing  : antialiased;

--- a/resources/scss/theme-dark/Global.scss
+++ b/resources/scss/theme-dark/Global.scss
@@ -3,6 +3,10 @@
 :root .neo-theme-dark {
     --neo-background-color: #323232;
     --neo-color           : #bbb;
+    // The platform-level light/dark hint for THIS theme, declared rather than derived from the
+    // theme's name: `theme-cyberpunk` is dark and named neither. Read by `Main.windowOpen` to
+    // stage a popup's blank document in the right scheme instead of flashing the UA default.
+    --neo-color-scheme    : dark;
     --neo-disabled-opacity: 0.5;
     --neo-font-family     : "Helvetica Neue", "Helvetica", "Arial", "Lucida Grande", sans-serif;
     --neo-font-smoothing  : antialiased;

--- a/resources/scss/theme-light/Global.scss
+++ b/resources/scss/theme-light/Global.scss
@@ -3,6 +3,10 @@
 :root .neo-theme-light {
     --neo-background-color: #fafafa;
     --neo-color           : #000;
+    // The platform-level light/dark hint for THIS theme, declared rather than derived from the
+    // theme's name: `theme-cyberpunk` is dark and named neither. Read by `Main.windowOpen` to
+    // stage a popup's blank document in the right scheme instead of flashing the UA default.
+    --neo-color-scheme    : light;
     --neo-disabled-opacity: 0.5;
     --neo-font-family     : "Helvetica Neue", "Helvetica", "Arial", "Lucida Grande", sans-serif;
     --neo-font-smoothing  : antialiased;

--- a/resources/scss/theme-neo-dark/Global.scss
+++ b/resources/scss/theme-neo-dark/Global.scss
@@ -4,6 +4,10 @@
 :root .neo-theme-neo-dark {
     --neo-background-color: var(--sem-color-bg-neutral-default);
     --neo-color           : var(--sem-color-text-neutral-default);
+    // The platform-level light/dark hint for THIS theme, declared rather than derived from the
+    // theme's name: `theme-cyberpunk` is dark and named neither. Read by `Main.windowOpen` to
+    // stage a popup's blank document in the right scheme instead of flashing the UA default.
+    --neo-color-scheme    : dark;
     --neo-disabled-opacity: 0.5;
     --neo-font-family     : 'Source Sans 3', sans-serif;
     --neo-font-smoothing  : antialiased;

--- a/resources/scss/theme-neo-light/Global.scss
+++ b/resources/scss/theme-neo-light/Global.scss
@@ -4,6 +4,10 @@
 :root .neo-theme-neo-light {
     --neo-background-color: #fafafa;
     --neo-color           : #000;
+    // The platform-level light/dark hint for THIS theme, declared rather than derived from the
+    // theme's name: `theme-cyberpunk` is dark and named neither. Read by `Main.windowOpen` to
+    // stage a popup's blank document in the right scheme instead of flashing the UA default.
+    --neo-color-scheme    : light;
     --neo-disabled-opacity: 0.5;
     --neo-font-family     : 'Source Sans 3', sans-serif;
     --neo-font-smoothing  : antialiased;

--- a/src/Main.mjs
+++ b/src/Main.mjs
@@ -1162,10 +1162,32 @@ class Main extends core.Base {
     }
 
     /**
+     * @summary Reads the light/dark hint the active theme declares, or `undefined` when none does.
+     *
+     * Every theme states its own scheme as `--neo-color-scheme` in its `Global.scss`, because the
+     * name cannot be trusted to carry it: `theme-cyberpunk` is dark and is named neither. The token
+     * is declared on the element holding the `neo-theme-*` class rather than on the document root,
+     * so the read has to find that element; custom properties inherit downward only.
+     *
+     * An undeclared theme returns `undefined` on purpose. The caller then omits the parameter and
+     * keeps the platform default, which is preferable to staging a guessed colour.
+     * @returns {'dark'|'light'|undefined}
+     * @protected
+     */
+    resolveThemeColorScheme() {
+        const
+            themed = document.querySelector('[class*="neo-theme-"]'),
+            value  = themed && getComputedStyle(themed).getPropertyValue('--neo-color-scheme').trim();
+
+        return value === 'dark' || value === 'light' ? value : undefined
+    }
+
+    /**
      * @summary Opens a popup and stages any same-origin canvas before its route-bearing navigation.
      * @param {Object}  data
      * @param {Object}  [data.nativeCapabilities] Owner-granted generic physical capabilities.
      * @param {'dark'|'light'} [data.stagedColorScheme] Admitted scheme for the temporary same-origin document.
+     * Omitted callers inherit the opener's own theme through {@link Neo.Main#resolveThemeColorScheme}.
      * @param {String}  data.url
      * @param {Boolean} [data.useTotalHeight=true] Using this flag will set outerHeight to innerHeight, ignoring header tools
      * @param {String}  data.windowFeatures
@@ -1176,6 +1198,11 @@ class Main extends core.Base {
         let existingWin = this.openWindows[windowName],
             stagedUrl   = null,
             targetName;
+
+        // A caller that names a scheme keeps it; one that does not inherits the opener's. The
+        // staging document paints before the child app exists, so without this the popup flashes
+        // the user-agent default no matter what theme the opener is showing.
+        stagedColorScheme ??= this.resolveThemeColorScheme();
 
         try {
             const resolved = typeof url === 'string' && new URL(url, window.location.href);

--- a/test/playwright/component/dashboard/ThemeColorSchemeStaging.spec.mjs
+++ b/test/playwright/component/dashboard/ThemeColorSchemeStaging.spec.mjs
@@ -1,0 +1,93 @@
+import {test, expect} from '@playwright/test';
+
+/**
+ * A popup opened through `Neo.Main#windowOpen` paints a blank same-origin staging document before
+ * the child app exists, so its colour is whatever the platform defaults to — a flash of the
+ * user-agent scheme regardless of the opener's theme. The parameter that prevents it,
+ * `stagedColorScheme`, has existed for a while and had exactly one caller.
+ *
+ * `Main#resolveThemeColorScheme` supplies it from the theme itself rather than from the caller.
+ * Every theme declares `--neo-color-scheme` in its `Global.scss`, because the theme's NAME cannot
+ * carry the fact: `theme-cyberpunk` declares `dark` and is named neither. These arms exist to keep
+ * that a declaration and never a derivation.
+ *
+ * Component tier rather than unit: the value is a computed custom property on a live document, and
+ * the read has to find the element carrying the `neo-theme-*` class — custom properties inherit
+ * downward only, so the document root does not resolve it.
+ */
+
+/** Runs the main-thread resolver against whatever theme class the document currently carries. */
+const readScheme = page => page.evaluate(() => Neo.Main.resolveThemeColorScheme());
+
+/**
+ * Captures the themed elements and their original classes ONCE, so a later swap that REMOVES the
+ * theme class cannot lose them: `[class*="neo-theme-"]` matches nothing after a strip, and a
+ * restore captured per-swap would only ever undo the previous swap.
+ */
+const captureThemes = page => page.evaluate(() => {
+    const nodes = [...document.querySelectorAll('[class*="neo-theme-"]')];
+
+    globalThis.__schemeProbe = {nodes, original: nodes.map(node => node.className)};
+
+    return nodes.length
+});
+
+/** Swaps every captured element's `neo-theme-*` class; `''` strips it entirely. */
+const withTheme = (page, themeClass) => page.evaluate(cls => {
+    const {nodes, original} = globalThis.__schemeProbe;
+
+    nodes.forEach((node, index) => {
+        node.className = original[index].replace(/neo-theme-[a-z-]+/, cls).trim()
+    })
+}, themeClass);
+
+/** Returns every captured element to the class list it was found with. */
+const restoreTheme = page => page.evaluate(() => {
+    const {nodes, original} = globalThis.__schemeProbe;
+
+    nodes.forEach((node, index) => {
+        node.className = original[index]
+    })
+});
+
+test.beforeEach(async ({page}) => {
+    await page.goto('test/playwright/component/apps/dock-maximize/index.html');
+    await page.waitForSelector('#dock-maximize-workspace', {state: 'attached'});
+    await page.waitForSelector('.neo-tab-header-button',   {state: 'visible'})
+});
+
+test.describe('theme colour scheme — declared, never derived from the name', () => {
+    test('the active theme supplies the staging scheme, and an undeclared one supplies nothing', async ({page}) => {
+        // Non-vacuity: the fixture must actually carry a theme class, or every arm below passes on
+        // an empty document without exercising the resolver at all.
+        const themedNodes = await captureThemes(page);
+
+        expect(themedNodes, 'the fixture must carry a theme class for any of this to mean anything')
+            .toBeGreaterThan(0);
+
+        expect(await readScheme(page), 'the shipped theme declares a scheme').toMatch(/^(dark|light)$/);
+
+        await withTheme(page, 'neo-theme-neo-dark');
+        expect(await readScheme(page), 'a dark theme resolves dark').toBe('dark');
+
+        await withTheme(page, 'neo-theme-neo-light');
+        expect(await readScheme(page), 'a light theme resolves light').toBe('light');
+
+        // `cyberpunk` — dark, and named neither — is the reason this is a declaration rather than a
+        // derivation, but it cannot be asserted here: this fixture ships only the two neo themes
+        // (`neo-config.json`), and a theme class whose sheet is absent resolves nothing at all. That
+        // is the same shape as the arm below, so testing it here would prove the fixture's theme
+        // list rather than cyberpunk's value. Its declaration lives in `theme-cyberpunk/Global.scss`.
+
+        // A theme with no declaration must yield undefined, so `windowOpen` omits the parameter and
+        // keeps the platform default rather than staging a guessed colour.
+        await withTheme(page, 'neo-theme-undeclared-probe');
+        expect(await readScheme(page), 'an undeclared theme must not leak a guess').toBeUndefined();
+
+        await withTheme(page, '');
+        expect(await readScheme(page), 'no theme class at all resolves nothing').toBeUndefined();
+
+        await restoreTheme(page);
+        expect(await readScheme(page), 'the document is left as it was found').toMatch(/^(dark|light)$/)
+    })
+});


### PR DESCRIPTION
Resolves #18432

A popup opened through `Main.windowOpen` flashes the user-agent default before the child app exists. The parameter that prevents it has existed for a while and had exactly one caller.

## The mechanism

`windowOpen` opens a **blank same-origin staging document** first, so the child can connect to the shared worker while the opener is warm. That realm paints before any app is there. `Main.mjs:1206-1211` writes `stagedColorScheme` onto it as a `color-scheme` meta — and only `apps/workstation/view/Workspace.mjs:2507` was passing one. So an engine-driven tear-out flashed while the identical gesture inside that app did not.

## Deltas

- **Changed** `src/Main.mjs`: **+30 / −1**. A `resolveThemeColorScheme()` reader, and one `??=` in `windowOpen` so a caller that names a scheme keeps it and one that does not inherits the opener's.
- **Changed** five `resources/scss/theme-*/Global.scss`: **+4 each**. One `--neo-color-scheme` declaration per theme, beside the existing `--neo-*` tokens.
- **New** `test/playwright/component/dashboard/ThemeColorSchemeStaging.spec.mjs`: **+82**.

The engine's `openTearOutVessel` is **not** changed. The layer that owns the document resolves the fact, instead of a layer that cannot see it forwarding a fact it had to be told.

## AC Evidence

Evidence: L3 (the resolver run against live documents in a real browser, both in the component fixture and in the running workstation) → L3 sufficient for AC-1 and AC-2; AC-3 and AC-4 are structural and read from source. Residual: none.

| AC | result |
|---|---|
| 1 — `windowOpen` defaults the scheme from the live document's declared theme | `dark` under `neo-theme-neo-dark`, `light` under `neo-theme-neo-light` |
| 2 — an undeclared theme supplies nothing | `undefined` for an unknown theme **and** for no theme class at all |
| 3 — no theme-name parsing anywhere | the resolver reads a declared token; `theme-cyberpunk` declares `dark` |
| 4 — Workstation's explicit path still wins | `stagedColorScheme ??= …` — a supplied value is never overwritten; `:2507` untouched |

**The declaration is measured, not invented.** Before naming the token I checked what the themes already say through their component-level `color-scheme` declarations:

| theme | already declares | across |
|---|---|---:|
| `neo-dark` | dark | 4 declarations |
| `neo-light` | light | 4 |
| `dark` | dark | 3 |
| `light` | light | 3 |
| `cyberpunk` | **dark** | 2 |

Sixteen declarations, five themes, **zero disagreement**. The new token names a fact the substrate already held without a single place to read it from.

It also settles the ticket's central constraint empirically rather than rhetorically: **`theme-cyberpunk` is dark and is named neither**, so a name-derived scheme is already wrong for one of the five themes we ship — not hypothetically, today.

**Where the token lives, verified rather than assumed.** It is declared on the element carrying the `neo-theme-*` class, and custom properties inherit downward only. In the running workstation: `documentElement` has no classes and resolves `(EMPTY)`; `body` carries `neo-theme-neo-dark` and resolves `dark`. That is why the resolver queries for the themed element instead of reading the document root, and the JSDoc says so.

## Test Evidence

```
npm run test-components -- ThemeColorSchemeStaging.spec.mjs    1 passed
node buildScripts/util/check-file-sizes.mjs           1309 paths, 0 violations
```

Theme build asserted by reading the emitted CSS rather than the exit code — `build-themes` exits `0` even when it writes nothing:

```
dist/development/css/theme-neo-dark/Global.css    --neo-color-scheme: dark
dist/development/css/theme-neo-light/Global.css   --neo-color-scheme: light
dist/development/css/theme-dark/Global.css        --neo-color-scheme: dark
dist/development/css/theme-light/Global.css       --neo-color-scheme: light
dist/development/css/theme-cyberpunk/Global.css   --neo-color-scheme: dark
```

**Two red controls, because the change has two halves and either could be dead weight:**

```
resolver reverted, tokens kept   → "Neo.Main.resolveThemeColorScheme is not a function"   RED
tokens stripped, resolver kept   → "Received has value: undefined"                        RED
both restored                                                                             PASS
```

Both were run against the **committed** tree and restored with `git checkout HEAD --`. An earlier attempt at the second control discarded two uncommitted edits outright; committing first is what made the mutation reversible.

**One arm is deliberately absent and the spec says why.** `theme-cyberpunk` is the whole reason this is a declaration, but the `dock-maximize` fixture ships only the two neo themes, and a theme class whose sheet is absent resolves nothing — identical output to the undeclared-theme arm. Asserting it there would have proved the fixture's theme list rather than cyberpunk's value.

## Post-Merge Validation

**No guard enforces the token, on purpose.** A future theme that forgets to declare one resolves `undefined`, the parameter is omitted, and the popup stages exactly as it does today. The failure mode of a missing declaration is the *old* behaviour, never a wrong colour — so a lint would police something that cannot break.

**Noticed and declined:** the sixteen component-level `color-scheme` declarations could now default to this token, which is a real consolidation and a genuine net reduction. It is a themes-wide refactor and this is a tear-out defect; recorded on #18432 so the next reader sees it was declined rather than missed.

**Not claimed:** that a torn-out vessel *runs* in the opener's theme. It does not — the theme is not in the vessel's URL, so a pane torn out of a re-themed host still boots the app's configured default. This fixes the staging flash only. That larger question is theme identity across a window boundary and stays with #18304.

Authored by @neo-opus-grace (Claude Opus 5), origin session `70502f9a-5b14-4dcf-bcdf-4a29b546df77`.
