### PR TITLE
fix(dock): reject native binding while retirement is pending (#18437)

### DIFF
--- a/apps/workstation/view/Workspace.mjs
+++ b/apps/workstation/view/Workspace.mjs
@@ -3213,23 +3213,6 @@ class Workspace extends DockWorkspace {
     }
 
     /**
-     * Retirement authority is established before any awaited close: a vessel that binds while its
-     * retirement is in flight is cleanup-only, and no content is ever staged into a closing realm.
-     * The Group's native retirement holds the fence; this host only reads it.
-     * @param {Object} context
-     * @param {String} context.itemId
-     * @returns {Boolean}
-     * @protected
-     */
-    admitTearOutConnection({itemId}) {
-        for (const vessel of (this.nativeWindows?.pendingRetirements(this.id) || [])) {
-            if (vessel.itemId === itemId) return false
-        }
-
-        return true
-    }
-
-    /**
      * A vessel bound its reserved slot: the engine recorded the connection (pre-terminal) or moved the
      * committed pane into it (terminal-first). Pre-terminal, the SAME live pane embodies into the
      * vessel right away while a hidden exact-slot placeholder keeps the source tab/card indices

--- a/buildScripts/util/file-size-baseline.json
+++ b/buildScripts/util/file-size-baseline.json
@@ -1,5 +1,5 @@
 {
-    "apps/workstation/view/Workspace.mjs": 2916,
+    "apps/workstation/view/Workspace.mjs": 2910,
     "examples/dashboard/crossWindow/DemoBWorkspace.mjs": 2611,
     "src/dashboard/dock/Workspace.mjs": 1017,
     "src/main/addon/DragDrop.mjs": 1267

--- a/src/manager/transaction/NativeLifecycle.mjs
+++ b/src/manager/transaction/NativeLifecycle.mjs
@@ -262,6 +262,7 @@ class NativeLifecycle extends Base {
 
     /**
      * @summary Admits only a source's reserved slot after its asynchronous platform preparation.
+     * Pending retirement rejects admission on both sides of preparation while retaining close authority.
      * @param {Object} data The Group manager's accepted generation binding.
      * @returns {Promise<void>}
      */
@@ -270,8 +271,9 @@ class NativeLifecycle extends Base {
         for (const [sourceId, source] of this.sources) {
             const match = [...source.admissions].find(([, entry]) => entry.workspaceKey === data.workspaceKey);
             if (!source.active || !match) continue;
-            const [itemId, admission] = match, effects = source.effects;
-            if (admission.connected || admission.connectingWindowId && admission.connectingWindowId !== data.windowId) continue;
+            const [itemId, admission] = match, effects = source.effects,
+                  retiring = () => this.pendingRetirements(sourceId).some(vessel => vessel.itemId === itemId);
+            if (admission.connected || admission.connectingWindowId && admission.connectingWindowId !== data.windowId || retiring()) continue;
             admission.connectingWindowId = data.windowId;
             const context = {...effects.context?.(data), admission, data, itemId, ...data};
             let accepted;
@@ -280,7 +282,7 @@ class NativeLifecycle extends Base {
                 throw error
             }
             if (!source.active || source.admissions.get(itemId) !== admission || admission.connectingWindowId !== data.windowId) continue;
-            if (accepted === false) { admission.connectingWindowId = null; continue }
+            if (accepted === false || retiring()) { admission.connectingWindowId = null; continue }
             const connection = {generation: data.generation, generationToken: admission.generationToken,
                 gestureToken: admission.gestureToken, windowId: data.windowId, workspaceKey: data.workspaceKey,
                 windowName  : context.activeVessel?.windowName || source.owners.get(itemId)?.windowName || admission.windowName};

--- a/test/playwright/unit/manager/transaction/NativeLifecycle.spec.mjs
+++ b/test/playwright/unit/manager/transaction/NativeLifecycle.spec.mjs
@@ -121,6 +121,71 @@ test.describe.serial('Group native lifecycle (#18314)', () => {
         expect(windows.getConnection('view', 'one')).toBeNull()
     });
 
+    for (const duringPrepare of [false, true]) {
+        test(`pending retirement fences binding ${duringPrepare ? 'during preparation' : 'before preparation'}`, async () => {
+            const windows = owner('root'), closing = deferred(), grant = deferred(), bound = [];
+            let acknowledged = false, prepared = 0;
+
+            windows.registerSource('view', effects({
+                close: () => acknowledged ? true : closing.promise,
+                prepare: () => {
+                    prepared++;
+                    return duringPrepare ? grant.promise : true
+                },
+                bound: data => bound.push(data)
+            }));
+            const vessel = await windows.acquire('view', {itemId: 'one'}),
+                  data   = {...vessel, windowId: 'closing-popup', generation: 1};
+            let binding, retirement;
+
+            if (duringPrepare) {
+                binding = windows.onBind(data);
+                retirement = windows.retire('view', vessel);
+                grant.resolve(true)
+            } else {
+                retirement = windows.retire('view', vessel);
+                binding = windows.onBind(data)
+            }
+
+            await binding;
+            expect(bound, 'a closing generation must never reach the publication callback').toEqual([]);
+            expect(windows.getConnection('view', 'one')).toBeNull();
+            expect(prepared).toBe(duringPrepare ? 1 : 0);
+            expect(windows.pendingRetirements('view')).toEqual([vessel]);
+
+            closing.resolve(false);
+            expect(await retirement, 'refusal retains exact cleanup authority').toBe(false);
+            expect(windows.pendingRetirements('view')).toEqual([vessel]);
+            acknowledged = true;
+            expect(await windows.retryRetirements('view', 'one')).toBe(true);
+            expect(windows.pendingRetirements('view')).toEqual([]);
+            expect(windows.getAdmission('view', 'one')).toBeNull()
+        })
+    }
+
+    test('pending retirement does not block another resource or source', async () => {
+        const windows = owner('root'), closing = deferred(), bound = [];
+
+        for (const sourceId of ['first', 'second']) {
+            windows.registerSource(sourceId, effects({
+                keyFor: itemId => `${sourceId}:${itemId}`,
+                close : () => closing.promise,
+                bound : ({itemId}) => bound.push(`${sourceId}:${itemId}`)
+            }))
+        }
+        const vessel = await windows.acquire('first', {itemId: 'one'}),
+              retirement = windows.retire('first', vessel);
+
+        for (const [sourceId, itemId] of [['first', 'two'], ['second', 'one']]) {
+            const next = await windows.acquire(sourceId, {itemId});
+            await windows.onBind({...next, windowId: `${sourceId}-${itemId}`, generation: 1});
+            expect(windows.getConnection(sourceId, itemId)?.windowId).toBe(`${sourceId}-${itemId}`)
+        }
+        expect(bound).toEqual(['first:two', 'second:one']);
+        closing.resolve(true);
+        expect(await retirement).toBe(true)
+    });
+
     test('view teardown may withdraw its source after the Group owner was destroyed', () => {
         const windows = owner('root');
         windows.registerSource('view', effects());


### PR DESCRIPTION
Resolves #18437

A native resource whose close is pending can no longer publish a new connection. `NativeLifecycle.onBind()` checks its source-local retirement records before preparation and again after the awaited callback. Workstation inherits that protection and deletes its generic admission override; its implementation count drops from 2916 to 2910.

Evidence: L2 (real Group owner with deferred platform effects) → L2 required (AC-1 through AC-4). No evidence residual. This is an admission/publication guarantee, not a headed rendering claim.

## AC Evidence

| Criterion | Evidence |
|---|---|
| AC-1 | CI-covered: `NativeLifecycle.spec.mjs`, pending retirement before preparation; no prepare, bound callback or connection. |
| AC-2 | CI-covered: retirement during deferred preparation; publication is refused, a failed close remains retryable, and acknowledged retry releases the exact admission. |
| AC-3 | CI-covered: normal binding and other source/resource controls; outside-CI original-source mutation receipts below. |
| AC-4 | CI-covered: owner and Workstation/DockWorkspace suites; standalone Workstation override deleted and generated baseline updated. |

## Deltas from ticket

None. No new lifecycle API, class or wire field. The predicate reads live retirement state through the existing owner method on both sides of the await, using the registered `sourceId`.

Demo-B's checks around its private geometry/staging/restore steps remain. They protect side effects inside `prepare`; the shared publication guard cannot undo work a consumer already performed there. The base's optional product admission hook remains available.

The fence ends at connection publication. Retirement beginning during the later `bound` callback follows existing cleanup behavior. Close authority stays in the retirement record and its captured effect; clearing `connectingWindowId` releases only the in-flight admission claim.

## Test Evidence

Before the source change, the new before-preparation and during-preparation cases each failed independently: `bound` received the retiring item and a connection was published. The unrelated-resource/source control passed on that same original source. With the repair, all three pass.

A separate direct Node owner probe confirms the boundary:

| Timing | Original prepared / bound / pending | Repaired prepared / bound / pending |
|---|---|---|
| No retirement | 1 / 1 / 0 | 1 / 1 / 0 |
| Retirement before bind | 1 / 1 / 1 | 0 / 0 / 1 |
| Retirement during prepare | 1 / 1 / 1 | 1 / 0 / 1 |

The probe invokes the real Transaction manager and `NativeLifecycle.acquire`, `retire`, and `onBind` with controlled close/preparation promises. Pending close authority is deliberately retained; the unit cases then refuse and successfully retry the close. No browser or external daemon is involved.

## Post-Merge Validation

No post-merge-only requirement for this owner-state contract. Existing native-window acceptance remains on #18303; this PR does not expand that journey.

Related: #18304 · #18303

Authored by Euclid (GPT-6, Codex) consuming Grace's seam-account handoff — session A 70502f9a-5b14-4dcf-bcdf-4a29b546df77, session B 01a07609-5e09-70f0-bf2c-a27d77d1b7f2.
