### PR TITLE
test(grid): the selection arm binds rows by record, not by position (#18439)

### DIFF
--- a/test/playwright/e2e/grid/TreeBigData.spec.mjs
+++ b/test/playwright/e2e/grid/TreeBigData.spec.mjs
@@ -45,39 +45,58 @@ test.describe('TreeGrid Big Data E2E', () => {
         await expect(firstFolderRow.locator('+ .neo-grid-row')).toHaveText(siblingText);
     });
 
+    /**
+     * Every row this arm asserts on is bound by `data-record-id`, never by position — the idiom the
+     * collapse arm below already uses, applied here because this arm did not have it.
+     *
+     * `neo-selected` is applied to the row rendering the selected RECORD, while `+ .neo-grid-row`
+     * names a POSITION. `grid.Body` pools rows and recycles them in place, so an expand re-projects
+     * which record each element renders. A positional locator therefore identifies one row at click
+     * time and possibly a different one at assertion time, and the class it waits for will never
+     * appear on the second — no timeout can help, because nothing is late.
+     *
+     * That is not hypothetical. A hosted failure's call log caught it mid-assertion, one element
+     * resolving to two records:
+     *
+     *      2 x  id="neo-grid-body-1__row-1"  data-record-id="neo-record-2"   level=1
+     *     12 x  id="neo-grid-body-1__row-1"  data-record-id="neo-record-79"  level=2
+     */
     test('Selection happy path: initial render and after single expand', async ({ page }) => {
         // 1. Initial State Selection
-        // Wait for initial render
         await expect(page.locator('.neo-grid-row:visible')).not.toHaveCount(0);
 
-        // Click the first row to select it
-        const firstRow = page.locator('.neo-grid-row:visible').first();
+        const firstRowId = await page.locator('.neo-grid-row:visible').first().getAttribute('data-record-id');
+        const firstRow   = page.locator(`.neo-grid-row[data-record-id="${firstRowId}"]`);
 
         await firstRow.locator('.neo-grid-cell').nth(2).click({ force: true });
-
-        // Verify it gets the selection class
         await expect(firstRow).toHaveClass(/neo-selected/);
 
         // 2. Selection after single expand
-        const firstFolderRow = page.locator('.neo-grid-row:has(.neo-tree-toggle)').first();
-        const toggleIcon     = firstFolderRow.locator('.neo-tree-toggle');
+        const folderId   = await page.locator('.neo-grid-row:has(.neo-tree-toggle)').first().getAttribute('data-record-id');
+        const folderRow  = page.locator(`.neo-grid-row[data-record-id="${folderId}"]`);
+        const toggleIcon = folderRow.locator('.neo-tree-toggle');
         await expect(toggleIcon).toBeVisible();
 
-        // Click to expand
         await toggleIcon.click();
         await expect(toggleIcon).toHaveClass(/is-expanded/);
 
-        // Find the newly revealed child row (it will be immediately after the expanded folder)
-        const childRow = firstFolderRow.locator('+ .neo-grid-row');
-        await expect(childRow).toBeVisible();
+        // The child is FOUND by position — that is what "newly revealed below the folder" means — and
+        // then pinned to its record before anything else happens. Position is how you locate it once;
+        // identity is what every later step must use.
+        const revealed = folderRow.locator('+ .neo-grid-row');
+        await expect(revealed).toBeVisible();
 
-        // Click the child row to select it
+        const childId  = await revealed.getAttribute('data-record-id');
+        const childRow = page.locator(`.neo-grid-row[data-record-id="${childId}"]`);
+
+        expect(childId, 'the revealed child must carry a record id, or every assertion below is positional again').toBeTruthy();
+        expect(childId, 'expanding must reveal a DIFFERENT record below the folder').not.toBe(folderId);
+
         await childRow.locator('.neo-grid-cell').nth(2).click();
 
-        // Verify the child row gets the selection class
         await expect(childRow).toHaveClass(/neo-selected/);
 
-        // In single-select mode, the first row should no longer be selected
+        // In single-select mode, the first row should no longer be selected.
         await expect(firstRow).not.toHaveClass(/neo-selected/);
     });
 


### PR DESCRIPTION
Resolves #18441
Refs #18439

The TreeBigData selection test now captures `data-record-id` and rebinds every asserted row to that record. A pooled DOM row changing occupants between click and assertion can no longer redirect the selector. The revealed child must have an ID distinct from the folder. Only the existing selection test changes; no timeout is raised.

Evidence: L2 (test execution and the recorded failing attempt) → L2 required by #18441. No residual for this leaf. #18439 retains the separate ThumbDragPause failure and broader tier investigation.

## AC Evidence

| Criterion | Evidence |
|---|---|
| AC-1: asserted rows use record identity | `firstRow`, `folderRow`, and `childRow` all use `[data-record-id]`; position is used only to find the revealed row before capturing its ID. |
| AC-2: rebinding cannot be vacuous | The child ID is required and must differ from the folder ID. |
| AC-3: an absent record still fails | Author control using `neo-record-NOPE` fails at the click; receipt below. |
| AC-4: no timeout increase | The diff adds or changes no timeout option. |
| AC-5: structural claim is bounded | The selector stays with one record; local passes do not establish a new hosted failure rate. |

## Mechanism

The recorded failed attempt showed pooled element `neo-grid-body-1__row-1` rendering `neo-record-2` and later `neo-record-79` during the same positional assertion. `grid.Body` recycles rows in place. The repaired selector identifies the record, rather than whichever record later occupies that element. The collapse test in the same file already uses this record-ID idiom.

The artifact establishes that identity mismatch. It does not by itself establish the effect of tier position, runner load, or the repair's future failure rate; those questions remain with #18439.

## Deltas from ticket

None to #18441's scope. ThumbDragPause and the parent ticket's rate/position investigation remain outside this PR. The other positional assertions in this file are unchanged.

## Test Evidence

Author runs: whole spec 5 passed (10.3s); selection arm repeated eight times, 8 passed (12.3s). Author absent-record control: pointing the locator at `neo-record-NOPE` fails at `locator.click` after the test timeout.

Reviewer checks at `315b718dd080d5670c1be65f13bd3fa8da8693ae`:

- Three headed observation runs captured old sibling `neo-record-2` and revealed child `neo-record-79`, then passed (6.0s total).
- Removing only the child click failed the selection assertion for `neo-record-79` after 5s.
- Restoring the exact original file (SHA-256 `aa62abe287d808cbe69bf1ec00c8dd5d201c88899841ef628dfbb8929858f038`) passed the normal arm (2.7s).

The observation and mutation lines were removed; no reviewer source change is included. These controls verify target identity and dependence on the click, not a post-merge hosted failure rate.

## Post-Merge Validation

The broader attempt-rate follow-up and remaining ThumbDragPause investigation stay on #18439. They are not closing criteria for this selection-only leaf.

Authored by Ada (Claude Opus 5, Claude Code). Origin session 95f9ff6e-1ba5-43b6-860a-208fbf7f4442.
