### PR TITLE
fix(build): the interactive prompts use inquirer's registered select type (#18443)

### DIFF
--- a/buildScripts/build/all.mjs
+++ b/buildScripts/build/all.mjs
@@ -64,7 +64,7 @@ if (programOpts.info) {
     if (!programOpts.noquestions) {
         if (!programOpts.npminstall) {
             questions.push({
-                type   : 'list',
+                type   : 'select',
                 name   : 'npminstall',
                 message: 'Run npm install?:',
                 choices: ['yes', 'no'],
@@ -74,7 +74,7 @@ if (programOpts.info) {
 
         if (!programOpts.env) {
             questions.push({
-                type   : 'list',
+                type   : 'select',
                 name   : 'env',
                 message: 'Please choose the environment:',
                 choices: ['all', 'dev', 'esm', 'prod'],
@@ -84,7 +84,7 @@ if (programOpts.info) {
 
         if (!programOpts.npminstall) {
             questions.push({
-                type   : 'list',
+                type   : 'select',
                 name   : 'themes',
                 message: 'Build the themes?',
                 choices: ['yes', 'no'],
@@ -94,7 +94,7 @@ if (programOpts.info) {
 
         if (!programOpts.threads) {
             questions.push({
-                type   : 'list',
+                type   : 'select',
                 name   : 'threads',
                 message: 'Build the threads?',
                 choices: ['yes', 'no'],
@@ -104,7 +104,7 @@ if (programOpts.info) {
 
         if (!programOpts.parsedocs) {
             questions.push({
-                type   : 'list',
+                type   : 'select',
                 name   : 'parsedocs',
                 message: 'Trigger the docs-json parsing?',
                 choices: ['yes', 'no'],

--- a/buildScripts/build/themes.mjs
+++ b/buildScripts/build/themes.mjs
@@ -71,7 +71,7 @@ if (programOpts.info) {
     if (!programOpts.noquestions) {
         if (!programOpts.themes) {
             questions.push({
-                type   : 'list',
+                type   : 'select',
                 name   : 'themes',
                 message: 'Please choose the themes to build:',
                 choices: ['all', ...themeFolders],
@@ -81,7 +81,7 @@ if (programOpts.info) {
 
         if (!programOpts.env) {
             questions.push({
-                type   : 'list',
+                type   : 'select',
                 name   : 'env',
                 message: 'Please choose the environment:',
                 choices: ['all', 'dev', 'esm', 'prod'],

--- a/buildScripts/create/addConfig.mjs
+++ b/buildScripts/create/addConfig.mjs
@@ -257,7 +257,7 @@ if (programOpts.info) {
 
     if (!programOpts.type) {
         answer = await inquirer.prompt({
-            type   : 'list',
+            type   : 'select',
             name   : 'type',
             message: 'Please choose a type for your class config:',
             default: 'Custom',

--- a/buildScripts/create/app.mjs
+++ b/buildScripts/create/app.mjs
@@ -81,7 +81,7 @@ if (programOpts.info) {
 
     if (!programOpts.themes) {
         questions.push({
-            type   : 'list',
+            type   : 'select',
             name   : 'themes',
             message: 'Please choose a theme for your neo app:',
             choices: ['all', ...themeFolders, 'none'],
@@ -91,7 +91,7 @@ if (programOpts.info) {
 
     if (!programOpts.useSharedWorkers) {
         questions.push({
-            type   : 'list',
+            type   : 'select',
             name   : 'useSharedWorkers',
             message: 'Do you want to use SharedWorkers? Pick yes for multiple main threads (Browser Windows):',
             choices: ['yes', 'no'],

--- a/buildScripts/create/appMinimal.mjs
+++ b/buildScripts/create/appMinimal.mjs
@@ -81,7 +81,7 @@ if (programOpts.info) {
 
     if (!programOpts.themes) {
         questions.push({
-            type:     'list',
+            type:     'select',
             name:     'themes',
             message:  'Please choose a theme for your neo app:',
             choices:  ['all', ...themeFolders, 'none'],
@@ -91,7 +91,7 @@ if (programOpts.info) {
 
     if (!programOpts.useSharedWorkers) {
         questions.push({
-            type:     'list',
+            type:     'select',
             name:     'useSharedWorkers',
             message:  'Do you want to use SharedWorkers? Pick yes for multiple main threads (Browser Windows):',
             choices:  ['yes', 'no'],
@@ -101,7 +101,7 @@ if (programOpts.info) {
 
     if (!programOpts.useServiceWorker) {
         questions.push({
-            type:     'list',
+            type:     'select',
             name:     'useServiceWorker',
             message:  'Do you want to use a ServiceWorker for caching assets?',
             choices:  ['yes', 'no'],

--- a/buildScripts/create/class.mjs
+++ b/buildScripts/create/class.mjs
@@ -108,7 +108,7 @@ if (programOpts.info) {
 
     if (!programOpts.baseClass) {
         questions.push({
-            type   : 'list',
+            type   : 'select',
             name   : 'baseClass',
             message: 'Please pick the base class, which you want to extend:',
             default: guessBaseClass(programOpts.className || answers.className),
@@ -130,7 +130,7 @@ if (programOpts.info) {
 
     if (!programOpts.singleton) {
         questions.push({
-            type   : 'list',
+            type   : 'select',
             name   : 'singleton',
             message: 'Singleton?',
             default: 'no',

--- a/buildScripts/create/component.mjs
+++ b/buildScripts/create/component.mjs
@@ -83,7 +83,7 @@ if (programOpts.info) {
 
     if (!programOpts.baseClass) {
         questions.push({
-            type   : 'list',
+            type   : 'select',
             name   : 'baseClass',
             message: 'Please pick the base class, which you want to extend:',
             default: guessBaseClass(programOpts.className || answers.className),
@@ -106,7 +106,7 @@ if (programOpts.info) {
 
     if (!programOpts.singleton) {
         questions.push({
-            type   : 'list',
+            type   : 'select',
             name   : 'singleton',
             message: 'Singleton?',
             default: 'no',

--- a/buildScripts/webpack/buildThreads.mjs
+++ b/buildScripts/webpack/buildThreads.mjs
@@ -59,7 +59,7 @@ if (programOpts.info) {
     if (!programOpts.noquestions) {
         if (!programOpts.threads) {
             questions.push({
-                type   : 'list',
+                type   : 'select',
                 name   : 'threads',
                 message: 'Please choose the threads to build:',
                 choices: ['all', 'app', 'canvas', 'data', 'main', 'service', 'task', 'vdom'],
@@ -69,7 +69,7 @@ if (programOpts.info) {
 
         if (!programOpts.env) {
             questions.push({
-                type   : 'list',
+                type   : 'select',
                 name   : 'env',
                 message: 'Please choose the environment:',
                 choices: ['all', 'dev', 'prod'],


### PR DESCRIPTION
Resolves #18443

`inquirer` 14 removed the legacy `list` prompt in favour of `select`, so every questions array under `buildScripts/` threw `UnknownPromptTypeError` before it could render. Seven of the eight interactive npm scripts were dead: `build-themes`, `build-threads`, `create-app`, `create-app-minimal`, `create-class`, `create-component`, `add-config`. Only `build-all` escaped — it is the one invocation that passes `-n`, and `all.mjs:127` forwards that `-n` to the `themes` and `threads` scripts it spawns, which is why those two work through `build-all` and fail through their own scripts. `choices` and `default` carry over unchanged, so this is a rename of the type string at 19 sites and nothing else. The commit also records the executable bit on `buildScripts/create/class.mjs`, the package's single declared `bin`.

Evidence: L2 → L2 required (the defect is a runtime throw from an installed dependency, so it is only checkable by running the scripts and the registry). Residual: none.

Micro-review eligible: mechanical — 19 identical substitutions of one string literal plus one file-mode bit; the diff is 19 insertions and 19 deletions, all `type` lines.

## AC Evidence

| AC | Evidence |
|---|---|
| AC-1 | outside-CI: `grep -rn "type[[:space:]]*:[[:space:]]*'list'" buildScripts/` → 0. Control: same predicate for `'select'` → 19, `'input'` → 8, `'checkbox'` → 1, so the predicate demonstrably finds things. |
| AC-2 | outside-CI: a registry check over every file importing `inquirer` under `buildScripts/` → HEAD 28 prompt-types / **0 unregistered**; `origin/dev` 28 / **19 unregistered**. The negative control is the point — the check reds on the pre-fix revision, so a clean HEAD is a measurement rather than a tautology. |
| AC-3 | outside-CI: `node buildScripts/create/class.mjs -c MyApp.view.Thing` renders `? Please pick the base class, which you want to extend:`, and `create/component.mjs` renders its namespace prompt. Both threw `UnknownPromptTypeError` on `origin/dev`. |
| AC-4 | outside-CI: `git show --stat` → 8 files, 19 insertions, 19 deletions; every changed line is a `type` line (verified by bucketing the diff's `+`/`-` lines: 9× `type   : 'list'`→`'select'` at 16-space indent, 7× at 12-space, 3× `type:     'list'`→`'select'`). |
| AC-5 | outside-CI: `all.mjs` lines 64–107 still show all five prompts nested under `if (!programOpts.noquestions)`, and line 127's `programOpts.noquestions && cpArgs.push('-n')` is untouched by the diff. |
| AC-6 | outside-CI: `buildThreads.mjs` has exactly two invocation paths — `npm run build-threads` (`-f` only → prompts reached → was broken) and `build/all.mjs:150` `spawnSync(...concat(cpArgs))` (non-interactive when `build-all` forwards `-n`). |
| AC-7 | outside-CI: `git ls-files -s buildScripts/create/class.mjs` → `100755`; `chmod 755` on the file afterwards leaves `git status --porcelain` empty for that path. The commit's raw diff shows `:100644 100755`. |

## Deltas from ticket

The ticket's first draft undercounted the breakage at six scripts and said seven of eight files carried `list`. Both were wrong and are corrected on the ticket: it is **seven** broken npm scripts (I had missed `build-threads`, whose npm script passes `-f` but not `-n`) and **all eight** files. The correction came from tracing `buildThreads.mjs`'s invocation paths for AC-6 — the same check that produced the `-n`-forwarding finding.

## Test Evidence

No automated arm is added; the ACs are the evidence, and every one of them runs outside CI because the defect is a runtime throw from an installed dependency that no existing suite exercises.

The instrument used for AC-2 had to be repaired mid-verification before I trusted it: its first regex matched `ntype:` inside the scaffolders' *emitted template strings* (`ntype: 'fit'`, `ntype: 'component'`), reporting 6 false "unregistered" hits at HEAD. A negative lookbehind for a preceding letter fixed it, and the corrected run reds on `origin/dev` with exactly the 19 real sites.

Two ACs are deliberately narrower than what I first tried to claim. I attempted to drive all seven previously-broken entry points end-to-end; five of them EOF on a closed stdin at an earlier `input` prompt and never reach their `select`, so "no throw" there would have been a pass witnessing nothing. AC-3 therefore claims only the two entry points I actually drove to a rendered `select`, and the uniform coverage claim lives in AC-2's registry check instead.

## Post-Merge Validation

- [ ] `npm run create-app` end-to-end in a scratch directory on a real TTY, confirming the theme and SharedWorkers selects render and the app scaffolds.
- [ ] After the next `npm install` in a workspace with `neo.mjs` linked, confirm `buildScripts/create/class.mjs` no longer appears in `git status`.

## Commits

- f84b489648 — the 19 prompt-type renames plus the recorded executable bit.

Authored by Ada (Claude Opus 5, Claude Code). Session 4d40c4c0-d1d7-400f-92e1-49f52fbceeb8.
