### PR TITLE
fix(dock): a recreated pane keeps its FLIP marker (#18446)

### DIFF
--- a/src/dashboard/dock/Workspace.mjs
+++ b/src/dashboard/dock/Workspace.mjs
@@ -345,8 +345,9 @@ class Workspace extends Container {
         dockShellIndex: 0,
         /**
          * Prefix of the per-item marker class the FLIP addon correlates across a re-projection.
-         * {@link #resolveProjectedPane} stamps `<prefix><encoded item id>` onto every plain pane
-         * config, so consumers never carry the marker by hand.
+         * {@link #resolveProjectedPane} and {@link #prepareRecreateCandidate} stamp
+         * `<prefix><encoded item id>` onto every plain pane config, so consumers never carry the
+         * marker by hand — including through a `resolveFreshPane` override.
          * @member {String} flipMarkerPrefix='dock-flip-item-'
          */
         flipMarkerPrefix: 'dock-flip-item-',
@@ -2707,7 +2708,13 @@ class Workspace extends Container {
         let candidate;
 
         try {
-            candidate = this.resolveFreshPane(itemId, item)
+            // Decorating what the HOOK RETURNS, rather than fixing the base `resolveFreshPane` to
+            // delegate to the decorated resolver, is deliberate: `resolveFreshPane` is the documented
+            // extension point for a cache-backed factory, and a consumer that overrides it would
+            // otherwise still answer with an undecorated candidate and re-open this gap. An instance
+            // candidate passes through untouched, so the `live-instance` refusal below still compares
+            // identities.
+            candidate = this.decorateFlipMarker(this.resolveFreshPane(itemId, item), itemId)
         } catch (error) {
             return {ok: false, candidate: null, reason: 'threw', error}
         }

--- a/test/playwright/unit/dashboard/DockRecreateCandidate.spec.mjs
+++ b/test/playwright/unit/dashboard/DockRecreateCandidate.spec.mjs
@@ -163,6 +163,12 @@ test.describe('dock recreate — Phase 1 validates a candidate before anything i
         // A config object describing the same pane IS a valid candidate; only the mounted instance
         // itself is refused. An equality-based check would reject this and make recreate impossible
         // for every config-returning consumer.
+        //
+        // This arm asserted `toBe(candidate)` until #18446. Phase 1 now decorates the hook's return
+        // with the FLIP marker, so a PLAIN CONFIG comes back as a decorated copy — the same shape
+        // `resolveProjectedPane` has always returned. The reference identity was incidental to what
+        // this arm is about; the refusal semantics below are the contract, and an instance candidate
+        // still passes through by identity (see the FLIP describe block).
         const candidate = {ntype: 'component', text: 'fresh'};
 
         workspace.resolveFreshPane = () => candidate;
@@ -170,7 +176,10 @@ test.describe('dock recreate — Phase 1 validates a candidate before anything i
         const result = workspace.prepareRecreateCandidate('editor', livePane);
 
         expect(result.ok).toBe(true);
-        expect(result.candidate).toBe(candidate);
+        expect(result.candidate, 'a config is accepted, never refused as the live instance')
+            .not.toBe(livePane);
+        expect(result.candidate, 'and it carries through what the resolver described')
+            .toMatchObject({ntype: 'component', text: 'fresh'});
         expect(result.reason).toBeNull()
     });
 
@@ -778,5 +787,113 @@ test.describe('Workstation cache adoption', () => {
         } finally {
             container.destroy()
         }
+    })
+});
+
+/**
+ * The FLIP marker is what lets the `DockFlip` addon recognise a pane as the SAME pane across a
+ * re-projection, so a pane without it is silently and permanently excluded from dock motion.
+ *
+ * Three paths produce a pane candidate and the rule between them is one line, which is exactly the
+ * shape that must not be re-derived per consumer: projection and rail-reveal decorate, recreate did
+ * not. Nothing threw and nothing logged — the pane rendered and worked, it just stopped animating
+ * while its siblings moved, and a marker-keyed locator reported it as destroyed.
+ *
+ * `flipMarkerPrefix`'s own docblock already promised this: it says the marker lands on "every plain
+ * pane config, so consumers never carry the marker by hand". These arms are that sentence made
+ * enforceable on the path where it was not true.
+ */
+test.describe('dock recreate — a rebuilt pane keeps its FLIP identity', () => {
+    const MARKER = 'dock-flip-item-editor';
+
+    let workspace, livePane;
+
+    test.beforeEach(() => {
+        workspace = buildWorkspace();
+        livePane  = Neo.create(Component, {appName: 'DashboardDockRecreateCandidateTest'})
+    });
+
+    test.afterEach(() => {
+        workspace?.destroy?.();
+        livePane?.destroy?.();
+        workspace = livePane = null
+    });
+
+    test('a recreate candidate carries the marker, like the two paths that already decorate', () => {
+        // RED-FIRST: this is the defect. `prepareRecreateCandidate` called `resolveFreshPane` raw,
+        // so the candidate reached `container.insert` undecorated and that instance never animated
+        // again. Asserting on phase 1 rather than through a mounted container keeps the witness on
+        // the exact seam that was wrong.
+        workspace.resolvePane = () => ({ntype: 'component', cls: ['app-pane']});
+
+        const result = workspace.prepareRecreateCandidate('editor', livePane);
+
+        expect(result.ok, 'phase 1 admits the candidate').toBe(true);
+        expect(result.candidate.cls, 'and the candidate carries the FLIP marker').toContain(MARKER);
+        expect(result.candidate.cls, 'without discarding what the consumer asked for')
+            .toContain('app-pane');
+
+        // Non-vacuity: the marker is not simply always present on anything this spec builds.
+        const undecorated = workspace.resolvePane('editor', null);
+
+        expect(undecorated.cls, 'the raw resolver output is genuinely unmarked').not.toContain(MARKER)
+    });
+
+    test('a consumer that OVERRIDES resolveFreshPane is decorated too', () => {
+        // This is why the fix belongs at the call site rather than inside the base
+        // `resolveFreshPane`. A cache-backed factory is the documented extension point, and fixing
+        // the base hook would have decorated only the consumers who never override it — leaving the
+        // gap open for precisely the hosts most likely to hit it.
+        workspace.resolveFreshPane = () => ({ntype: 'component', cls: ['from-consumer-factory']});
+
+        const result = workspace.prepareRecreateCandidate('editor', livePane);
+
+        expect(result.ok).toBe(true);
+        expect(result.candidate.cls, 'an overriding host still gets the engine rule').toContain(MARKER);
+        expect(result.candidate.cls).toContain('from-consumer-factory')
+    });
+
+    test('a live-component candidate is returned untouched, so the identity guard still fires', () => {
+        // `decorateFlipMarker` returns a non-plain-object candidate unchanged, and that tolerance is
+        // load-bearing HERE rather than merely defensive: phase 1's `live-instance` refusal compares
+        // `candidate === livePane`. If decoration cloned or wrapped an instance, that identity would
+        // break and the refusal that prevents silent pane loss would stop firing.
+        const decorated = workspace.decorateFlipMarker(livePane, 'editor');
+
+        expect(decorated, 'an instance survives decoration by identity').toBe(livePane);
+        expect(livePane.cls ?? [], 'and is not stamped').not.toContain(MARKER);
+
+        workspace.resolveFreshPane = () => livePane;
+
+        const result = workspace.prepareRecreateCandidate('editor', livePane);
+
+        expect(result.ok, 'so the cache-returns-the-live-instance refusal is intact').toBe(false);
+        expect(result.reason).toBe('live-instance')
+    });
+
+    test('a candidate that already carries the marker is not stamped twice', () => {
+        // The projection path may hand back a config that already went through decoration. `cls` is
+        // built through a Set, so this holds today; the arm makes it a contract rather than an
+        // implementation detail a future refactor could drop.
+        workspace.resolveFreshPane = () => ({ntype: 'component', cls: [MARKER, 'app-pane']});
+
+        const result = workspace.prepareRecreateCandidate('editor', livePane);
+
+        const occurrences = result.candidate.cls.filter(entry => entry === MARKER).length;
+
+        expect(occurrences, 'the marker appears exactly once').toBe(1)
+    });
+
+    test('the two paths that already decorated are unchanged', () => {
+        // A control on the blast radius: the fix touches one call site, so the other two producers
+        // must be observably identical. Without this, a regression that moved decoration UP into a
+        // shared helper could pass every arm above while changing what projection emits.
+        workspace.resolvePane = () => ({ntype: 'component', cls: ['app-pane']});
+
+        const projected = workspace.resolveProjectedPane('editor', null);
+
+        expect(projected.cls, 'projection still decorates').toContain(MARKER);
+        expect(workspace.resolveRevealPane('editor', null).cls, 'and reveal still delegates undecorated')
+            .not.toContain(MARKER)
     })
 });

--- a/test/playwright/unit/dashboard/DockRecreateCandidate.spec.mjs
+++ b/test/playwright/unit/dashboard/DockRecreateCandidate.spec.mjs
@@ -164,11 +164,11 @@ test.describe('dock recreate — Phase 1 validates a candidate before anything i
         // itself is refused. An equality-based check would reject this and make recreate impossible
         // for every config-returning consumer.
         //
-        // This arm asserted `toBe(candidate)` until #18446. Phase 1 now decorates the hook's return
-        // with the FLIP marker, so a PLAIN CONFIG comes back as a decorated copy — the same shape
-        // `resolveProjectedPane` has always returned. The reference identity was incidental to what
-        // this arm is about; the refusal semantics below are the contract, and an instance candidate
-        // still passes through by identity (see the FLIP describe block).
+        // Phase 1 decorates the hook's return with the FLIP marker, so a PLAIN CONFIG comes back as
+        // a decorated copy — the same shape `resolveProjectedPane` returns. Reference identity is
+        // therefore not what this arm asserts: the refusal rule below is the contract, and an
+        // instance candidate still passes through by identity, which is what keeps that rule able
+        // to fire (see the FLIP describe block).
         const candidate = {ntype: 'component', text: 'fresh'};
 
         workspace.resolveFreshPane = () => candidate;


### PR DESCRIPTION
Resolves #18446

`prepareRecreateCandidate` called `resolveFreshPane` raw, so a pane rebuilt by the reload action reached `container.insert` without `dock-flip-item-<itemId>` and was silently excluded from dock motion for the rest of that instance's life. One line at the call site, plus the arms that make it a contract. Decorating what the hook **returns** — rather than fixing the base `resolveFreshPane` to delegate to the decorated resolver — is what covers the documented override seam, which is the reason the ticket chose this call site.

Evidence: L2 → L2 required (the defect is a missing class on a resolved config, observable in a unit arm; no runtime or hosted surface is involved). Residual: none.

Micro-review eligible: mechanical — one call site wrapped in an existing helper, one docblock corrected, and five new arms.

## AC Evidence

| AC | Evidence |
|---|---|
| AC-1 | CI-covered: `DockRecreateCandidate.spec.mjs` › *a recreate candidate carries the marker, like the two paths that already decorate*. Asserts `dock-flip-item-editor` on the phase-1 candidate, and that the consumer's own `app-pane` class survives. |
| AC-2 | outside-CI **red-first receipt**: on `origin/dev` the two marker arms fail (`Received array: ["from-consumer-factory"]`, marker absent) while the other three pass — `2 failed, 3 passed`. After the fix, `5 passed`. The three that passed red-first are controls describing behaviour that was already correct, so the split is a measurement rather than an all-red smear. |
| AC-3 | CI-covered: › *a consumer that OVERRIDES `resolveFreshPane` is decorated too*. This is the arm that fails if anyone later "simplifies" the fix into the base hook. |
| AC-4 | CI-covered: › *a live-component candidate is returned untouched, so the identity guard still fires*. Asserts `decorateFlipMarker(livePane) === livePane` **and** that `prepareRecreateCandidate` still refuses with `reason: 'live-instance'` — the tolerance is load-bearing rather than defensive, because decoration that cloned an instance would break the refusal that prevents silent pane loss. |
| AC-5 | CI-covered by two arms: › *a candidate that already carries the marker is not stamped twice* (counts occurrences, expects exactly 1 — `cls` is built through a `Set`), and › *the two paths that already decorated are unchanged* (projection still decorates; `resolveRevealPane` still returns undecorated, since reveal decorates at its call site). |
| AC-6 | outside-CI: dock unit tier **950 passed, 2 skipped, 0 failed**; dock component tier **121 passed**; the recreate spec itself 32 passed. |

## Deltas from ticket

**One existing arm changed, and it is the part worth reviewing.** `a distinct candidate is accepted — identity, not equality` asserted `expect(result.candidate).toBe(candidate)` — that phase 1 hands back the resolver's exact object reference. Decoration returns `{...config, cls}`, so for a plain config the candidate is now a copy and that assertion fails.

I changed the arm rather than the fix, on this reasoning: the arm's name, comment and subject are entirely about the **refusal** semantics ("only the mounted instance itself is refused"), and `resolveProjectedPane` has *always* returned a decorated copy — so "phase 1 returns your exact object" was never a system-wide contract, only an incidental property of the one undecorated path. The arm now asserts its actual subject (a config is accepted, not refused as the live instance; the resolver's description carries through) and the reference-identity case it really depends on is covered explicitly in AC-4, where an instance candidate still passes through by identity.

**A Contract Ledger row the ticket did not name.** `prepareRecreateCandidate`'s observable return changes for config candidates: same object → decorated copy. The ticket's ledger has rows for the marker class and for `resolveFreshPane`, but not for this. It is a behaviour change on a `@protected` surface, it is now consistent with the projection path rather than divergent from it, and no in-repo consumer depends on the reference — but it is a real delta and a reviewer should see it named rather than discover it in the test diff.

**One extra file touched.** `flipMarkerPrefix`'s docblock stated the marker lands on "every plain pane config, so consumers never carry the marker by hand" while naming only `resolveProjectedPane` as the stamper. That sentence was a guarantee the code did not keep. It now names both stampers and the override case.

## Test Evidence

All coverage runs in CI, with one exception that cannot: the **red-first receipt** above is a property of `origin/dev`, not of this branch, so no arm here can witness it. Recorded in AC-2 with the exact split.

The blast-radius runs (950 dock unit, 121 dock component) are outside-CI only in the sense that I ran them locally before handoff; CI re-runs both tiers.

## Post-Merge Validation

- [ ] On a real consumer with `Neo.config.useSharedWorkers`, click a focused pane's reload action and confirm the flip-marked pane count holds (Vega measured `3 → 2` before the fix, with the widget count steady at 3).
- [ ] Confirm a recreated pane animates on the next layout change rather than snapping while siblings move.

## Commits

- 6627b01a21 — the call-site decoration, the docblock correction, and five arms.

Authored by Ada (Claude Opus 5, Claude Code) consuming Vega's handoff — session fffad262-5537-4e4a-869d-69bce1c81b6b, session fae29740-f756-4642-b8d1-0c7725cbbb49.
