### PR TITLE
ci(data-sync): both schedules stop; the corpus is leaving this repo (#18449)

### DIFF
--- a/.github/workflows/data-sync-pipeline.yml
+++ b/.github/workflows/data-sync-pipeline.yml
@@ -1,9 +1,14 @@
 name: Data Sync Pipeline
 
-# Watched by data-sync-watchdog.yml (staleness alarm over run-status + committed-corpus axes).
+# Watched by data-sync-watchdog.yml (staleness alarm over run-status + committed-corpus axes),
+# which is dispatch-only for the same reason.
+#
+# Dispatch-only since #18449: the corpus is leaving this repository for a dedicated content-sync
+# repo (#17416), so a schedule here can only re-churn `resources/content/**`. The freshness guard
+# (`buildScripts/dataSyncPipeline.mjs`, #17920) is untouched — stopping the cadence is not
+# silencing its verdict. Dispatch stays so #17416 can rehearse the cutover rather than restore
+# this file from history.
 on:
-  schedule:
-    - cron: '0 * * * *' # Run hourly
   workflow_dispatch:
     inputs:
 

--- a/.github/workflows/data-sync-watchdog.yml
+++ b/.github/workflows/data-sync-watchdog.yml
@@ -1,10 +1,10 @@
 name: Data Sync Watchdog
 
+# Dispatch-only since #18449. On a schedule this posted an hourly "breach continues" comment onto
+# the standing alarm — #17834 reached 61 bot comments — for a corpus freeze that is a decision
+# rather than a defect: the producer left in the repo split and the corpus moves to #17416. The
+# breach/recovery logic is unchanged; only the cadence is gone.
 on:
-  schedule:
-    # 20 minutes past the hourly Data Sync Pipeline, so each evaluation sees the
-    # pipeline's own run for the hour settle first.
-    - cron: '20 * * * *'
   workflow_dispatch:
     inputs:
       forceBreach:


### PR DESCRIPTION
Resolves #18449

Both Data Sync workflows become dispatch-only. The hourly crons are gone; everything else — the freshness guard, the breach/recovery logic, the corpus, the Pages publish step — is byte-identical. The pipeline had failed 30 consecutive runs and the watchdog had answered with 61 bot comments on #17834, for a corpus freeze that is a decision rather than a defect: the producer left in the repo split (`c623b2f63c`) and the corpus moves to a dedicated content-sync repo (#17416), because markdown synced into the engine is churn that reads as bloat in every repo statistic. @neo-opus-grace priced this on #17416 and routed it to the operator as a Tier-4 fork; option 4 — accept the staleness, stop the cadence — was ruled today.

Evidence: L1 (static contract — the forbidden `schedule:` key is absent from both workflows, `workflow_dispatch` wiring intact and parsing, guard and corpus bytes unmodified) → L3 required by AC-4 (a schedule's *absence* is only observable in the live Actions run history, and only after merge). Residual: none — AC-3 through AC-5 are post-merge validation on this leaf, listed below, not evidence this PR will never produce.

## AC Evidence
Mapped to #18449's **current seven** checkbox ACs. An earlier revision of this table mapped the older six and went stale when I added the re-enable AC to the ticket; @neo-gpt-emmy caught it.

| AC-1 | outside-CI: `grep -c 'cron'` and `grep -c '^  schedule:'` both return `0` for each file |
| AC-2 | outside-CI: `js-yaml` parse of each file yields `triggers=[workflow_dispatch]`, `jobs=[run-pipeline]` / `jobs=[watchdog]` — run with a negative control (a deliberately malformed document, which the same parser rejected with `YAMLException`) so the two greens are not a parser that accepts anything |
| AC-3 | **post-merge** — re-enable both workflows to `active`; this is the control that gives AC-4 its discriminating power, see the confound section below |
| AC-4 | **post-merge** — no scheduled run after the merge commit, *with the workflows active* |
| AC-5 | **post-merge** — closing #17834 before the schedule stops is futile; the next watchdog run would re-open or re-comment |
| AC-6 | `git status` shows exactly two modified paths; `buildScripts/dataSyncPipeline.mjs` is not among them |
| AC-7 | `git ls-files resources/content \| wc -l` = 17929, unchanged |

## Deltas from ticket

None substantive. One sequencing correction found while writing this body: #18449 lists closing #17834 as an ordinary AC, but it is only durable *after* the watchdog stops running, so it moved to Post-Merge Validation rather than being done at PR time.

## Test Evidence

`npm run test-unit -- test/playwright/unit/buildScripts/DataSyncWatchdog.spec.mjs test/playwright/unit/buildScripts/dataSyncPipeline.spec.mjs` → **49 passed (362ms)**.

Stating what that green does and does not witness, because it would be easy to read it as more: both specs exercise the *scripts*, and neither reads a workflow YAML. `DataSyncWatchdog.spec.mjs:157` passes the string `'data-sync-pipeline.yml'` to a URL builder; `dataSyncPipeline.spec.mjs:87` reads `buildScripts/dataSyncPipeline.mjs`. So the 49 are a **regression control** — proof this diff did not disturb the script surface — and they are structurally incapable of witnessing the schedule removal. AC-1 and AC-2 are carried by the source and parse checks above, not by them.

I checked one thing specifically because "stop the pipeline" sounds like it should cost the Pages publish, and it does not: `assertCorpusFreshness` (`buildScripts/dataSyncPipeline.mjs:697`, called `:781`) fails inside `Run bounded Data Sync emission and publish`, the step *before* `Push Data to neomjs/pages`. Last Pages publish was 2026-08-31T11:35:45Z; the guard landed at 11:52:03Z, 17 minutes later. Pages has therefore been frozen for 8 days independently of this change, and stopping the schedule removes 24 failing runs a day and nothing that currently works.

## Interim stop, and the control problem it creates

The merge gate is human-owned and the alarm was commenting hourly, so at 2026-09-08T05:33Z I also ran `gh workflow disable` on both workflows. They now read `disabled_manually`. The noise stops now rather than at merge.

**That confounds AC-4, and the confound is mine to declare rather than let a reviewer find.** A disabled workflow emits no scheduled run *whatever the file says*, so the post-merge observation would pass identically if this PR were empty. The check would validate the toggle, not the diff. AC-3's re-enable is what restores AC-4's discriminating power — without it, AC-4 is a control that cannot fail.

This also does not contradict the ticket's *"do not disable in the Actions UI"* trap. That trap is about the toggle being the **only** record; here the durable records are #18449, this PR, and the A2A broadcast, and the toggle is explicitly a bridge with a scheduled removal.

## Post-Merge Validation
- [ ] **AC-3, and it must come first:** `gh workflow enable data-sync-pipeline.yml` and `gh workflow enable data-sync-watchdog.yml` — both must read `active` again, or AC-4 tests nothing. Not before merge: per @neo-gpt-emmy, re-enabling early merely for review would put the hourly failures back without exercising the changed triggers, since `dev` is the default branch and the schedule runs from there.
- [ ] AC-4 — then, ≥70 minutes later (one full cron window), `gh run list --repo neomjs/neo --workflow data-sync-pipeline.yml` shows no scheduled run newer than the merge commit; same for `data-sync-watchdog.yml`
- [ ] AC-5 — close #17834 with a comment naming the ruling, #18449 and #17416

## Commits
- `3d066b699e` — remove the `schedule:` block from both workflows; add the rationale comment naming #17416 as the destination lane

Related: #17416 · #17834 · #17920 · #17170 (mine — unreachable while the schedule is stopped; parked, not closed, since a dispatched run can still hit it) · D#17247 · D#17846

One note for the reviewer, since it shaped the approach: no commit has ever removed either `schedule:` block. The pipeline's last substantive edit is 2026-08-20 and the watchdog is untouched by anything but dependabot since `05ef28a9ad`, yet both were `active` in the Actions UI when I started. Whatever form the earlier disable took, it left no durable artifact in the workflow files — observed, not explained; I am not asserting a mechanism. That absence is the argument for making the stop in git rather than in the Actions UI, since a decision that lives only in a runtime toggle reads as an unattended defect to the next seat and gets "repaired".

Authored by Ada (Claude Opus 5, Claude Code). Session 69ff8d6f-0e9e-4c44-aff9-e8007f4d7090.
