### PR TITLE
feat(dock): register the WorkspaceSet adapter (#18450)

### DIFF
--- a/apps/workstation/view/Workspace.mjs
+++ b/apps/workstation/view/Workspace.mjs
@@ -27,7 +27,7 @@ import {
     createDockVesselEmbodiment,
     createDockVesselProxyEmbodiment
 }                                                from '../../../src/dashboard/dock/window/VesselEmbodiment.mjs';
-import {createDockWorkspaceSet}                 from '../../../src/dashboard/dock/window/WorkspaceSet.mjs';
+import WorkspaceSet                             from '../../../src/dashboard/dock/window/WorkspaceSet.mjs';
 import VesselPark                               from '../../../src/dashboard/dock/window/VesselPark.mjs';
 import PreviewContract                          from '../../../src/dashboard/dock/model/PreviewContract.mjs';
 import {workstationTourScript, initialDocument} from '../tour/denseWorkstation.mjs';
@@ -436,14 +436,14 @@ class Workspace extends DockWorkspace {
         me.topologyLibrary ??= Neo.create(TopologyLibrary, {
             collection: Persistence.createTopologyCollection([], {activeLayoutId: null}).collection
         });
-        me.workspaceSet = createDockWorkspaceSet({documentModel: WorkspaceDocument, manager: TransactionManager, getGroupId: () => me.topologyGroupId});
+        me.workspaceSet = Neo.create(WorkspaceSet, {documentModel: WorkspaceDocument, manager: TransactionManager, getGroupId: () => me.topologyGroupId});
 
         for (const [workspaceId, document] of Object.entries(me.initialTopology?.workspaces ?? {})) {
             if (workspaceId === Workspace.MAIN_WORKSPACE_ID) continue;
             const host = Neo.create(PopupWorkspace, {
-                dockModel: WorkspaceDocument.clone(document), flex: 1, rootWorkspace: me,
+                dockModel      : WorkspaceDocument.clone(document), flex: 1, rootWorkspace: me,
                 topologyGroupId: me.topologyGroupId, workspaceKey: workspaceId, workspaceSet: me.workspaceSet,
-                stateProvider: {module: StateProvider, parent: me.stateProvider}
+                stateProvider  : {module: StateProvider, parent: me.stateProvider}
             });
             const state = {
                 committed   : true,
@@ -1160,7 +1160,7 @@ class Workspace extends DockWorkspace {
             },
             previewToOperation   : preview => PreviewContract.previewToOperation(preview),
             // Docking design record §2.3: every window of this root declares the root's Group as its commit authority.
-            resolveOwnershipId   : () => me.resolveTopologyGroup() ?? null,
+            resolveOwnershipId    : () => me.resolveTopologyGroup() ?? null,
             resumeNativeWindowDrag: isMain ? itemId => me.nativeVesselParkHandlers.onGestureTerminal({
                 itemId,
                 outcome: 'rejected'
@@ -1169,7 +1169,7 @@ class Workspace extends DockWorkspace {
                 itemId : draggedItem?.dockItemId,
                 outcome: 'committed'
             }) : null,
-            sortGroup          : Workspace.CROSS_WINDOW_SORT_GROUP,
+            sortGroup              : Workspace.CROSS_WINDOW_SORT_GROUP,
             suspendNativeWindowDrag: isMain ? (itemId, data) => {
                 me.vesselConversionTargetWindowId = data?.targetWindowId ?? null;
 
@@ -1290,7 +1290,7 @@ class Workspace extends DockWorkspace {
      * @returns {Object|null}
      */
     getPopupState(workspaceId) {
-        const id = TransactionManager.getParticipant(this.topologyGroupId, workspaceId)?.componentId;
+        const id    = TransactionManager.getParticipant(this.topologyGroupId, workspaceId)?.componentId;
         const owner = id && Neo.getComponent(id);
         return owner?.rootWorkspace === this ? owner.runtimeState ?? null : null
     }
@@ -1671,10 +1671,10 @@ class Workspace extends DockWorkspace {
         if (!descriptor || !me.workspaceSet.has(sourceWorkspaceId) || !me.workspaceSet.has(targetWorkspaceId)) return false;
         try {
             const committed = await me.workspaceSet.transfer(descriptor, {provenance: {origin: 'human'}});
-            const receipt = me.lastCrossWindowTransfer = {
-                applied: true, descriptor, sourceWorkspaceId, targetWorkspaceId,
+            const receipt   = me.lastCrossWindowTransfer = {
+                applied      : true, descriptor, sourceWorkspaceId, targetWorkspaceId,
                 transactionId: committed.transactionId, phases: ['documents-adopted'],
-                reconciled: false, closeRequested: false, topologyExited: false
+                reconciled   : false, closeRequested: false, topologyExited: false
             };
             const source = me.getPopupState(sourceWorkspaceId), target = me.getPopupState(targetWorkspaceId);
             await Promise.all([me.refreshPromise, source?.host?.refreshPromise, target?.host?.refreshPromise]);
@@ -1695,7 +1695,7 @@ class Workspace extends DockWorkspace {
      * @protected
      */
     async mountVesselWorkspace(workspaceId) {
-        const state = this.getPopupState(workspaceId), host = state?.host;
+        const state  = this.getPopupState(workspaceId), host = state?.host;
         const target = state?.renderTarget ?? state?.app?.mainView;
         if (!host || host.isDestroyed || !target || target.isDestroyed) return false;
         host.parent?.remove(host, false, true);
@@ -3096,15 +3096,15 @@ class Workspace extends DockWorkspace {
             return true
         }
         const workspaceId = vessel.workspaceKey ?? Workspace.vesselWorkspaceId(itemId);
-        const existing = me.getPopupState(workspaceId);
-        let state = existing;
+        const existing    = me.getPopupState(workspaceId);
+        let   state       = existing;
         try {
             if (!me.tearOutHandlers.capturePane(itemId)) throw new Error(`No live pane for ${itemId}`);
             if (!state) {
                 const host = Neo.create(PopupWorkspace, {
-                    dockModel: me.createVesselWorkspaceDocument(itemId), flex: 1,
+                    dockModel    : me.createVesselWorkspaceDocument(itemId), flex: 1,
                     rootWorkspace: me, topologyGroupId: me.topologyGroupId,
-                    workspaceKey: workspaceId, workspaceSet: me.workspaceSet,
+                    workspaceKey : workspaceId, workspaceSet: me.workspaceSet,
                     stateProvider: {module: StateProvider, parent: me.stateProvider}
                 });
                 state = {host, itemId, workspaceId, committed: false, disconnected: true,
@@ -3113,9 +3113,9 @@ class Workspace extends DockWorkspace {
                 host.runtimeState = state
             }
             await me.workspaceSet.transfer({
-                operation: 'transferItem', itemId, sourceWorkspaceId: Workspace.MAIN_WORKSPACE_ID,
+                operation        : 'transferItem', itemId, sourceWorkspaceId: Workspace.MAIN_WORKSPACE_ID,
                 targetWorkspaceId: workspaceId,
-                target: {operation: 'addTab', tabsNodeId: Workspace.vesselTabsNodeId(itemId)}
+                target           : {operation: 'addTab', tabsNodeId: Workspace.vesselTabsNodeId(itemId)}
             }, {provenance: {origin: 'human'}});
             state.committed = true;
             me.tearOutHandlers.adoptPane(itemId, vessel, me.nativeWindows?.getConnection(me.id, itemId) || null);
@@ -4837,6 +4837,7 @@ class Workspace extends DockWorkspace {
         me.tourRunner?.destroy();
         me.dockService?.destroy();
         me.perspectiveStore?.destroy();
+        me.workspaceSet?.destroy();
         me.topologyLibrary?.destroy();
         me.dragAffordances?.destroy();
         me.interactionService?.destroy();

--- a/buildScripts/util/file-size-baseline.json
+++ b/buildScripts/util/file-size-baseline.json
@@ -1,6 +1,6 @@
 {
-    "apps/workstation/view/Workspace.mjs": 2910,
-    "examples/dashboard/crossWindow/DemoBWorkspace.mjs": 2611,
+    "apps/workstation/view/Workspace.mjs": 2911,
+    "examples/dashboard/crossWindow/DemoBWorkspace.mjs": 2612,
     "src/dashboard/dock/Workspace.mjs": 1023,
     "src/main/addon/DragDrop.mjs": 1267
 }

--- a/docs/output/class-hierarchy.json
+++ b/docs/output/class-hierarchy.json
@@ -254,6 +254,7 @@
  "Neo.dashboard.dock.window.VesselConversion": "Neo.core.Base",
  "Neo.dashboard.dock.window.VesselPark": "Neo.core.Base",
  "Neo.dashboard.dock.window.VesselPlaceholder": "Neo.component.Base",
+ "Neo.dashboard.dock.window.WorkspaceSet": "Neo.core.Base",
  "Neo.data.Model": "Neo.core.Base",
  "Neo.data.Pipeline": "Neo.core.Base",
  "Neo.data.RecordFactory": "Neo.core.Base",

--- a/examples/dashboard/crossWindow/DemoBWorkspace.mjs
+++ b/examples/dashboard/crossWindow/DemoBWorkspace.mjs
@@ -20,7 +20,7 @@ import InteractionService                 from '../../../src/ai/client/Interacti
 import {createDockKeyboardCommands}       from '../../../src/dashboard/dock/interaction/KeyboardCommands.mjs';
 import {createDockTearOutHandlers}        from '../../../src/dashboard/dock/window/TearOut.mjs';
 import {createDockVesselEmbodiment}       from '../../../src/dashboard/dock/window/VesselEmbodiment.mjs';
-import {createDockWorkspaceSet}           from '../../../src/dashboard/dock/window/WorkspaceSet.mjs';
+import WorkspaceSet                       from '../../../src/dashboard/dock/window/WorkspaceSet.mjs';
 import VesselPark                         from '../../../src/dashboard/dock/window/VesselPark.mjs';
 import TourRunner                         from '../../../src/ai/client/TourRunner.mjs';
 import TransactionManager                 from '../../../src/manager/Transaction.mjs';
@@ -493,7 +493,7 @@ class DemoBWorkspace extends Container {
         // admitted at registration, and a Group the carrier already held is known before this
         // constructor runs; a first boot's minted identity arrives with its accepted binding, and
         // `onTopologyBind` registers the participants then.
-        me.workspaceSet = createDockWorkspaceSet({manager: TransactionManager, getGroupId: () => me.topologyGroupId, documentModel: WorkspaceDocument});
+        me.workspaceSet = Neo.create(WorkspaceSet, {manager: TransactionManager, getGroupId: () => me.topologyGroupId, documentModel: WorkspaceDocument});
         me.adoptTopologyGroup(TransactionManager.findByWindow(me.windowId)?.groupId ?? null);
 
         me.dockPreviewProducer = Neo.create(DockPreviewProducer);
@@ -4577,6 +4577,7 @@ class DemoBWorkspace extends Container {
         me.dockPreviewProducer?.destroy();
         me.interactionService?.destroy();
         me.perspectiveStore?.destroy();
+        me.workspaceSet?.destroy();
 
         Object.values(me.paneCache).forEach(pane => {
             pane?.isDestroyed || pane?.destroy?.()

--- a/src/dashboard/dock/window/WorkspaceSet.mjs
+++ b/src/dashboard/dock/window/WorkspaceSet.mjs
@@ -1,388 +1,389 @@
+import Base       from '../../../core/Base.mjs';
 import Operations from '../model/Operations.mjs';
 
 /**
- * @summary The dock adapter over a Group's participant membership — the `{workspaceId → document}`
- * composition of the docking design record (§2.1 workspace topology; §2.8.3 vessel lifecycle;
- * `learn/agentos/decisions/0029-docking-design.md`), resolved through `Neo.manager.Transaction`.
+ * @summary The dock adapter over a Group's participant membership and transaction entry.
  *
- * A workspace is one dock-zone document owned by one workspace container; multi-window composition
- * registers each vessel's document under a STABLE workspace id. That membership lives in the host's
- * topology Group: the manager holds the participants, this adapter phrases them as the dock's
- * registry and adds the dock's own adoption semantics — cross-window participations resolve foreign
- * documents through it, and an atomic transfer's committed pair is adopted through it, both-or-neither,
- * mirroring the executor's commit-or-neither contract at the ownership tier.
+ * The Group owns document membership; this adapter owns no registry. Its methods resolve the
+ * current Group through the host's live getGroupId seam. A missing Group refuses registration
+ * and returns empty lookups. Closing a window does not retire semantic participants.
  *
- * Boundary discipline (the §2.1 state-class table, binding):
- * - **No registry of its own.** The adapter keeps no entry map: every registration, lookup and count
- *   is the Group's. Before the host's window has bound there is no Group and so no membership —
- *   registration is refused and every lookup fails closed. A host that imports the manager is
- *   admitted at app registration, before its workspace constructs, so this is the exception path.
- * - **Worker-owned shared truth only.** Participants carry document accessors keyed by semantic
- *   workspace identity. `windowId`, screen geometry, and projection state NEVER enter the Group as
- *   membership — a window is a render target, not a state owner, and runtime window identity is
- *   never persisted workspace identity.
- * - **Membership is separate from binding.** Closing a vessel unbinds a render target; it does not
- *   delete worker documents — a participant lives while its Group does, and a Group holding
- *   participants is never empty. Whether an emptied entry is retained or retired is decided and
- *   named by the reintegration tier (§2.8.3), through {@link #unregister}.
- * - **Projection choreography stays with the owner.** The adapter answers "whose document, and what
- *   is it now" — reconcile ordering, generation guards, and render-target sync remain the workspace
- *   container's own contract. `register({project})` supplies that owner's post-commit callback;
- *   it must return the projection promise and must not admit another document write.
+ * Registration captures the manager, document model and Group identity for its callbacks.
+ * Those callbacks belong to the Group and remain usable after the creating adapter is destroyed.
+ * The creator releases this Base instance; borrowed popup references do not own its lifetime.
+ * Projection stays with the registered document owner and must not admit another semantic write.
  *
- * The manager, Group resolver and document model are injected. Synchronous adoption remains available;
- * write() enters the Group's complete transaction protocol without importing its machinery here.
+ * @class Neo.dashboard.dock.window.WorkspaceSet
+ * @extends Neo.core.Base
  */
+class WorkspaceSet extends Base {
+    static config = {
+        /** @member {String} className='Neo.dashboard.dock.window.WorkspaceSet' @protected */
+        className: 'Neo.dashboard.dock.window.WorkspaceSet',
+        /** @member {Object|null} documentModel=null Pure validate/clone surface required for writes. */
+        documentModel: null,
+        /** @member {Function|null} getGroupId=null Resolves the host's current Group identity. */
+        getGroupId: null,
+        /** @member {Neo.manager.Transaction|null} manager=null Worker-wide transaction authority. */
+        manager: null
+    }
 
-/**
- * @summary Creates the dock's view of one Group's participant membership and transaction entry.
- * @param {Object} seams
- * @param {Neo.manager.Transaction} seams.manager The worker-wide topology manager.
- * @param {Function} seams.getGroupId `() => String|null` — the host's Group, `null` while its window has not bound.
- * @param {Object} [seams.documentModel] WorkspaceDocument's pure validate/clone surface, required for writes.
- * @returns {Object} workspaceSet
- * @returns {Function} workspaceSet.adoptAll       `(workspaces)` all-or-nothing adoption of one document per registered key; Boolean.
- * @returns {Function} workspaceSet.adoptTransfer  `({sourceWorkspaceId, sourceDocument, targetWorkspaceId, targetDocument})` both-or-neither pair adoption; Boolean.
- * @returns {Function} workspaceSet.getDocument    `(workspaceId)` → the participant's current document, or `null` (fail closed).
- * @returns {Function} workspaceSet.has            `(workspaceId)` → Boolean.
- * @returns {Function} workspaceSet.ids            `()` → registered workspace ids.
- * @returns {Function} workspaceSet.register       `(workspaceId, {getDocument, setDocument, project})` registers-or-replaces a participant; Boolean.
- * @returns {Number}   workspaceSet.size           Registered participant count.
- * @returns {Function} workspaceSet.unregister     `(workspaceId)` explicit retirement; Boolean.
- * @returns {Function} workspaceSet.write          `(workspaces, options)` queued atomic adoption of keyed documents; Promise.
- */
-export function createDockWorkspaceSet({manager, getGroupId, documentModel}) {
-    const
-        groupId     = () => getGroupId?.() ?? null,
-        participant = workspaceId => {
-            const id = groupId();
+    /**
+     * @summary Resolves document-bearing participant keys without retaining an adapter instance.
+     * @param {Neo.manager.Transaction} manager
+     * @param {String|null} groupId
+     * @returns {String[]}
+     * @protected
+     */
+    static getParticipantKeys(manager, groupId) {
+        return groupId ? manager.participantKeys(groupId)
+            .filter(key => typeof manager.getParticipant(groupId, key)?.getDocument === 'function') : []
+    }
 
-            const entry = id ? manager.getParticipant(id, workspaceId) : null;
-            return typeof entry?.getDocument === 'function' ? entry : null
-        },
-        keys        = () => {
-            const id = groupId();
+    /** @member {Number} size Registered document participant count. */
+    get size() {
+        return this.ids().length
+    }
 
-            return id ? manager.participantKeys(id).filter(key => participant(key)) : []
+    /**
+     * @summary Resolves the live Group while this adapter owns its host connection.
+     * @returns {String|null}
+     * @protected
+     */
+    resolveGroupId() {
+        return this.isDestroyed ? null : this.getGroupId?.() ?? null
+    }
+
+    /**
+     * @summary Resolves a document-bearing participant through the current Group.
+     * @param {String} workspaceId
+     * @returns {Object|null}
+     * @protected
+     */
+    getParticipant(workspaceId) {
+        const id    = this.resolveGroupId(),
+              entry = id ? this.manager.getParticipant(id, workspaceId) : null;
+
+        return typeof entry?.getDocument === 'function' ? entry : null
+    }
+
+    /**
+     * @summary Adopts an atomically-committed document pair into both owning participants — or neither.
+     * Fail-closed preconditions, all checked BEFORE the first write: distinct source and
+     * target ids, both participants registered, both writable.
+     *
+     * Both-or-neither against THROWING writers holds by two-sided compensation: BOTH previous
+     * documents are captured before the first write, and either write failing compensates
+     * every writer already invoked — in reverse order, each re-invoked with its prior
+     * document under a guard. The compensation is deliberately re-invocation: a writer that
+     * BREACHES its accessor contract by mutating before it throws is restored by the same
+     * assignment landing again with the prior document (the breach's own mutation ordering
+     * is what makes the compensation stick), while a writer that throws without mutating
+     * makes the compensating call a guarded no-op. The original error always propagates —
+     * the owner's failure stays observable. Residual, stated: a writer that defeats BOTH
+     * the write and the compensating re-invocation (throwing before any mutation on both
+     * calls while still having mutated externally) has broken its accessor contract twice;
+     * its own state is its breach, and the pair's other side is still restored.
+     * @param {Object} data
+     * @param {Object} data.sourceDocument
+     * @param {String} data.sourceWorkspaceId
+     * @param {Object} data.targetDocument
+     * @param {String} data.targetWorkspaceId
+     * @returns {Boolean} true when both documents were adopted
+     */
+    adoptTransfer({sourceDocument, sourceWorkspaceId, targetDocument, targetWorkspaceId}) {
+        const
+            source = this.getParticipant(sourceWorkspaceId),
+            target = this.getParticipant(targetWorkspaceId);
+
+        if (
+            sourceWorkspaceId === targetWorkspaceId ||
+            !sourceDocument || !targetDocument      ||
+            !source?.setDocument || !target?.setDocument
+        ) {
+            return false
+        }
+
+        const
+            previousSourceDocument = source.getDocument(),
+            previousTargetDocument = target.getDocument(),
+            compensate             = (entry, document) => {
+                try {
+                    entry.setDocument(document)
+                } catch (compensationError) {
+                    // best-effort by construction: the original failure below still
+                    // propagates, and a writer failing its own compensation is the
+                    // documented double-breach residual
+                }
+            };
+
+        try {
+            source.setDocument(sourceDocument)
+        } catch (error) {
+            compensate(source, previousSourceDocument);
+            throw error
+        }
+
+        try {
+            target.setDocument(targetDocument)
+        } catch (error) {
+            compensate(target, previousTargetDocument);
+            compensate(source, previousSourceDocument);
+            throw error
+        }
+
+        return true
+    }
+
+    /**
+     * @summary Adopts one committed document per registered workspace key.
+     *
+     * All-or-nothing, like {@link #adoptTransfer} one arity up: the payload must name exactly
+     * the registered semantic keys. Object insertion order and registration order never pair a
+     * document with its owner. A missing/excess key, missing document, or read-only participant
+     * refuses before the first write; a throw mid-write compensates every earlier writer.
+     * @param {Object<String,Object>} workspaces Documents keyed by stable workspace identity.
+     * @returns {Boolean} true when every workspace adopted its keyed document
+     */
+    adoptAll(workspaces) {
+        const
+            isRecord = workspaces !== null && typeof workspaces === 'object' && !Array.isArray(workspaces) &&
+                (Object.getPrototypeOf(workspaces) === Object.prototype || Object.getPrototypeOf(workspaces) === null),
+            ids      = this.ids(),
+            entries  = ids.map(workspaceId => this.getParticipant(workspaceId)),
+            names    = isRecord ? Object.keys(workspaces) : [];
+
+        if (
+            !isRecord || names.length !== ids.length ||
+            names.some(workspaceId => !ids.includes(workspaceId) || !workspaces[workspaceId]) ||
+            entries.some((entry, index) => !Object.hasOwn(workspaces, ids[index]) || !entry?.setDocument)
+        ) {
+            return false
+        }
+
+        const written = [];
+
+        for (let index = 0; index < ids.length; index++) {
+            const entry = entries[index];
+
+            written.push([entry, entry.getDocument()]);
+
+            try {
+                entry.setDocument(workspaces[ids[index]])
+            } catch (error) {
+                written.reverse().forEach(([slot, previous]) => {
+                    try {
+                        slot.setDocument(previous)
+                    } catch (compensationError) {
+                        // best-effort by construction, exactly as `adoptTransfer` documents:
+                        // the original failure below still propagates, and a writer failing its
+                        // own compensation is the documented double-breach residual
+                    }
+                });
+
+                throw error
+            }
+        }
+
+        return true
+    }
+
+    /**
+     * @summary Reads the current document of a registered workspace.
+     * @param {String} workspaceId
+     * @returns {Object|null} the participant's current document, or null (fail closed)
+     */
+    getDocument(workspaceId) {
+        return this.getParticipant(workspaceId)?.getDocument() ?? null
+    }
+
+    /**
+     * @summary Reports whether the current Group holds this document participant.
+     * @param {String} workspaceId
+     * @returns {Boolean}
+     */
+    has(workspaceId) {
+        return this.getParticipant(workspaceId) !== null
+    }
+
+    /**
+     * @summary Lists the current Group's registered document identities.
+     * @returns {String[]}
+     */
+    ids() {
+        return this.constructor.getParticipantKeys(this.manager, this.resolveGroupId())
+    }
+
+    /**
+     * @summary Registers-or-replaces one workspace participant in the host's Group. Replacement is
+     * deliberate: a re-embodied vessel re-registers the SAME stable workspace id with fresh
+     * accessor seams, and the stale seams must not survive it. Refused while the host has no
+     * Group — there is no membership to join yet.
+     * @param {String} workspaceId Stable semantic identity — never a `windowId`.
+     * @param {Object} seams
+     * @param {Function} seams.getDocument `()` → the workspace's current committed document.
+     * @param {Function} [seams.setDocument] `(document)` adopts a committed document; a
+     *     participant without one is read-only to `adoptTransfer` (fail closed).
+     * @param {Function} [seams.getRevision] Owner-supplied revision stamp; otherwise reference changes are counted.
+     * @param {Function} [seams.project] Post-commit context includes `preserveItemIds` owned by sibling documents.
+     * @param {Function} [seams.dispose] Releases this owner when its Group explicitly retires.
+     * @param {String} [seams.bindingKey=workspaceId] Window slot whose generation fences this document.
+     * @param {String} [seams.componentId] Opaque live owner lookup; excluded from captured document truth.
+     * @returns {Boolean} true when registered
+     */
+    register(workspaceId, {getDocument, setDocument, getRevision, project, dispose, bindingKey = workspaceId, componentId} = {}) {
+        const id                       = this.resolveGroupId(),
+              {documentModel, manager} = this;
+
+        if (!id || !workspaceId || typeof workspaceId !== 'string' || typeof getDocument !== 'function' ||
+            (getRevision !== undefined && typeof getRevision !== 'function')) {
+            return false
+        }
+
+        const participantKeys = this.constructor.getParticipantKeys.bind(this.constructor, manager, id);
+        let   initialized     = false, lastDocument, revision = 0;
+
+        // Registration never reads a document: the first transaction establishes the reference.
+        const observeDocument = () => {
+            const value = getDocument();
+            if (!getRevision && initialized && value !== lastDocument) revision++;
+            initialized = true;
+            lastDocument = value;
+            return value
+        };
+        const cloneDocument = value => {
+            if (typeof documentModel?.clone !== 'function' || typeof documentModel?.validate !== 'function') {
+                throw new TypeError('WorkspaceSet transactions require an injected documentModel')
+            }
+            return documentModel.clone(value)
+        };
+        const entry = {
+            domain     : 'dock',
+            getDocument,
+            setDocument: typeof setDocument === 'function' ? setDocument : null,
+            capture    : () => ({
+                value     : observeDocument(),
+                generation: manager.getBinding(id, bindingKey)?.generation || 0,
+                revision  : getRevision ? getRevision() : revision
+            }),
+            prepare: (input, captured, context) => {
+                let candidate = input;
+                if (input.transfer) {
+                    const descriptor = input.transfer;
+                    const result     = Operations[descriptor.operation](context.valuesBefore[descriptor.sourceWorkspaceId],
+                        context.valuesBefore[descriptor.targetWorkspaceId], descriptor);
+                    if (result.errors.length) throw new TypeError(result.errors.join('; '));
+                    candidate = workspaceId === descriptor.sourceWorkspaceId ? result.sourceDocument : result.targetDocument
+                }
+                if (Array.isArray(input.operations)) {
+                    candidate = captured.value;
+                    for (const descriptor of input.operations) {
+                        const result = Operations.applyOperation(candidate, descriptor);
+                        if (result.errors.length) throw new TypeError(result.errors.join('; '));
+                        candidate = result.document
+                    }
+                }
+                candidate = cloneDocument(candidate);
+                const errors = documentModel.validate(candidate);
+                if (errors.length) throw new TypeError(`invalid dock document: ${errors.join('; ')}`);
+                return candidate
+            }
         };
 
-    return {
-        get size() {
-            return keys().length
-        },
-
-        /**
-         * Adopts an atomically-committed document pair into both owning participants — or neither.
-         * Fail-closed preconditions, all checked BEFORE the first write: distinct source and
-         * target ids, both participants registered, both writable.
-         *
-         * Both-or-neither against THROWING writers holds by two-sided compensation: BOTH previous
-         * documents are captured before the first write, and either write failing compensates
-         * every writer already invoked — in reverse order, each re-invoked with its prior
-         * document under a guard. The compensation is deliberately re-invocation: a writer that
-         * BREACHES its accessor contract by mutating before it throws is restored by the same
-         * assignment landing again with the prior document (the breach's own mutation ordering
-         * is what makes the compensation stick), while a writer that throws without mutating
-         * makes the compensating call a guarded no-op. The original error always propagates —
-         * the owner's failure stays observable. Residual, stated: a writer that defeats BOTH
-         * the write and the compensating re-invocation (throwing before any mutation on both
-         * calls while still having mutated externally) has broken its accessor contract twice;
-         * its own state is its breach, and the pair's other side is still restored.
-         * @param {Object} data
-         * @param {Object} data.sourceDocument
-         * @param {String} data.sourceWorkspaceId
-         * @param {Object} data.targetDocument
-         * @param {String} data.targetWorkspaceId
-         * @returns {Boolean} true when both documents were adopted
-         */
-        adoptTransfer({sourceDocument, sourceWorkspaceId, targetDocument, targetWorkspaceId}) {
-            const
-                source = participant(sourceWorkspaceId),
-                target = participant(targetWorkspaceId);
-
-            if (
-                sourceWorkspaceId === targetWorkspaceId ||
-                !sourceDocument || !targetDocument      ||
-                !source?.setDocument || !target?.setDocument
-            ) {
-                return false
-            }
-
-            const
-                previousSourceDocument = source.getDocument(),
-                previousTargetDocument = target.getDocument(),
-                compensate             = (entry, document) => {
-                    try {
-                        entry.setDocument(document)
-                    } catch (compensationError) {
-                        // best-effort by construction: the original failure below still
-                        // propagates, and a writer failing its own compensation is the
-                        // documented double-breach residual
-                    }
-                };
-
-            try {
-                source.setDocument(sourceDocument)
-            } catch (error) {
-                compensate(source, previousSourceDocument);
-                throw error
-            }
-
-            try {
-                target.setDocument(targetDocument)
-            } catch (error) {
-                compensate(target, previousTargetDocument);
-                compensate(source, previousSourceDocument);
-                throw error
-            }
-
-            return true
-        },
-
-        /**
-         * Adopts one committed document per registered workspace key.
-         *
-         * All-or-nothing, like {@link #adoptTransfer} one arity up: the payload must name exactly
-         * the registered semantic keys. Object insertion order and registration order never pair a
-         * document with its owner. A missing/excess key, missing document, or read-only participant
-         * refuses before the first write; a throw mid-write compensates every earlier writer.
-         * @param {Object<String,Object>} workspaces Documents keyed by stable workspace identity.
-         * @returns {Boolean} true when every workspace adopted its keyed document
-         */
-        adoptAll(workspaces) {
-            const
-                isRecord = workspaces !== null && typeof workspaces === 'object' && !Array.isArray(workspaces) &&
-                    (Object.getPrototypeOf(workspaces) === Object.prototype || Object.getPrototypeOf(workspaces) === null),
-                ids      = keys(),
-                entries  = ids.map(workspaceId => participant(workspaceId)),
-                names    = isRecord ? Object.keys(workspaces) : [];
-
-            if (
-                !isRecord || names.length !== ids.length ||
-                names.some(workspaceId => !ids.includes(workspaceId) || !workspaces[workspaceId]) ||
-                entries.some((entry, index) => !Object.hasOwn(workspaces, ids[index]) || !entry?.setDocument)
-            ) {
-                return false
-            }
-
-            const written = [];
-
-            for (let index = 0; index < ids.length; index++) {
-                const entry = entries[index];
-
-                written.push([entry, entry.getDocument()]);
-
-                try {
-                    entry.setDocument(workspaces[ids[index]])
-                } catch (error) {
-                    written.reverse().forEach(([slot, previous]) => {
-                        try {
-                            slot.setDocument(previous)
-                        } catch (compensationError) {
-                            // best-effort by construction, exactly as `adoptTransfer` documents:
-                            // the original failure below still propagates, and a writer failing its
-                            // own compensation is the documented double-breach residual
-                        }
-                    });
-
-                    throw error
-                }
-            }
-
-            return true
-        },
-
-        /**
-         * @param {String} workspaceId
-         * @returns {Object|null} the participant's current document, or null (fail closed)
-         */
-        getDocument(workspaceId) {
-            return participant(workspaceId)?.getDocument() ?? null
-        },
-
-        /**
-         * @param {String} workspaceId
-         * @returns {Boolean}
-         */
-        has(workspaceId) {
-            return participant(workspaceId) !== null
-        },
-
-        /**
-         * @returns {String[]}
-         */
-        ids() {
-            return keys()
-        },
-
-        /**
-         * @summary Registers-or-replaces one workspace participant in the host's Group. Replacement is
-         * deliberate: a re-embodied vessel re-registers the SAME stable workspace id with fresh
-         * accessor seams, and the stale seams must not survive it. Refused while the host has no
-         * Group — there is no membership to join yet.
-         * @param {String} workspaceId Stable semantic identity — never a `windowId`.
-         * @param {Object} seams
-         * @param {Function} seams.getDocument `()` → the workspace's current committed document.
-         * @param {Function} [seams.setDocument] `(document)` adopts a committed document; a
-         *     participant without one is read-only to `adoptTransfer` (fail closed).
-         * @param {Function} [seams.getRevision] Owner-supplied revision stamp; otherwise reference changes are counted.
-         * @param {Function} [seams.project] Post-commit context includes `preserveItemIds` owned by sibling documents.
-         * @param {Function} [seams.dispose] Releases this owner when its Group explicitly retires.
-         * @param {String} [seams.bindingKey=workspaceId] Window slot whose generation fences this document.
-         * @param {String} [seams.componentId] Opaque live owner lookup; excluded from captured document truth.
-         * @returns {Boolean} true when registered
-         */
-        register(workspaceId, {getDocument, setDocument, getRevision, project, dispose, bindingKey = workspaceId, componentId} = {}) {
-            const id = groupId();
-
-            if (!id || !workspaceId || typeof workspaceId !== 'string' || typeof getDocument !== 'function' ||
-                (getRevision !== undefined && typeof getRevision !== 'function')) {
-                return false
-            }
-
-            let initialized = false, lastDocument, revision = 0;
-
-            // Registration never reads a document: the first transaction establishes the reference.
-            const observeDocument = () => {
-                const value = getDocument();
-                if (!getRevision && initialized && value !== lastDocument) revision++;
+        if (entry.setDocument) {
+            entry.adopt = (candidate, context) => {
+                const result = setDocument(cloneDocument(candidate), context);
+                if (result === false || result?.then) return result;
+                observeDocument();
+                return result
+            };
+            entry.compensate = (captured, context) => {
+                const result = setDocument(cloneDocument(captured.value), context);
+                if (result === false || result?.then) return result;
+                lastDocument = getDocument();
                 initialized = true;
-                lastDocument = value;
-                return value
-            };
-            const cloneDocument = value => {
-                if (typeof documentModel?.clone !== 'function' || typeof documentModel?.validate !== 'function') {
-                    throw new TypeError('WorkspaceSet transactions require an injected documentModel')
-                }
-                return documentModel.clone(value)
-            };
-            const entry = {
-                domain     : 'dock',
-                getDocument,
-                setDocument: typeof setDocument === 'function' ? setDocument : null,
-                capture    : () => ({
-                    value     : observeDocument(),
-                    generation: manager.getBinding(id, bindingKey)?.generation || 0,
-                    revision  : getRevision ? getRevision() : revision
-                }),
-                prepare: (input, captured, context) => {
-                    let candidate = input;
-                    if (input.transfer) {
-                        const descriptor = input.transfer;
-                        const result = Operations[descriptor.operation](context.valuesBefore[descriptor.sourceWorkspaceId],
-                            context.valuesBefore[descriptor.targetWorkspaceId], descriptor);
-                        if (result.errors.length) throw new TypeError(result.errors.join('; '));
-                        candidate = workspaceId === descriptor.sourceWorkspaceId ? result.sourceDocument : result.targetDocument
-                    }
-                    if (Array.isArray(input.operations)) {
-                        candidate = captured.value;
-                        for (const descriptor of input.operations) {
-                            const result = Operations.applyOperation(candidate, descriptor);
-                            if (result.errors.length) throw new TypeError(result.errors.join('; '));
-                            candidate = result.document
-                        }
-                    }
-                    candidate = cloneDocument(candidate);
-                    const errors = documentModel.validate(candidate);
-                    if (errors.length) throw new TypeError(`invalid dock document: ${errors.join('; ')}`);
-                    return candidate
-                }
-            };
-
-            if (entry.setDocument) {
-                entry.adopt = (candidate, context) => {
-                    const result = setDocument(cloneDocument(candidate), context);
-                    if (result === false || result?.then) return result;
-                    observeDocument();
-                    return result
-                };
-                entry.compensate = (captured, context) => {
-                    const result = setDocument(cloneDocument(captured.value), context);
-                    if (result === false || result?.then) return result;
-                    lastDocument = getDocument();
-                    initialized = true;
-                    if (!getRevision) revision = captured.revision;
-                    return result
-                }
+                if (!getRevision) revision = captured.revision;
+                return result
             }
-
-            if (typeof project === 'function') entry.project = context => project({
-                ...context,
-                preserveItemIds: keys().filter(key => key !== workspaceId)
-                    .flatMap(key => Object.keys(context.snapshot.participants[key]?.items ?? {}))
-            });
-            if (componentId !== undefined) entry.componentId = componentId;
-            if (typeof dispose === 'function') entry.dispose = dispose;
-
-            return manager.registerParticipant({
-                groupId     : id,
-                participant : entry,
-                workspaceKey: workspaceId
-            })
-        },
-
-        /**
-         * @summary Queues keyed document candidates through the Group's participant protocol.
-         * @param {Object<String,Object>} workspaces The workspace keys changed by this transaction.
-         * @param {Object} options Cause, provenance, descriptor and cursorAction for the Group write.
-         * @returns {Promise<Object>} The manager's complete transaction result.
-         */
-        async write(workspaces, {cause, provenance = {}, descriptor = {}, cursorAction = 'append'} = {}) {
-            const id = groupId();
-            if (!id) throw new Error('WorkspaceSet.write requires a bound Group');
-            if (!workspaces || typeof workspaces !== 'object' || Array.isArray(workspaces) ||
-                (Object.getPrototypeOf(workspaces) !== Object.prototype && Object.getPrototypeOf(workspaces) !== null)) {
-                throw new TypeError('WorkspaceSet.write requires documents keyed by workspace')
-            }
-            return manager.write({
-                groupId: id,
-                cause,
-                provenance,
-                descriptor,
-                cursorAction,
-                changes: Object.entries(workspaces).map(([workspaceKey, input]) => ({workspaceKey, input}))
-            })
-        },
-
-        /**
-         * @summary Reduces semantic operations against the document captured at the Group queue head.
-         * @param {String} workspaceKey
-         * @param {Object[]} operations
-         * @param {Object} [options={}] Group cause and provenance.
-         * @returns {Promise<Object>} The committed Group transaction.
-         */
-        commit(workspaceKey, operations, options = {}) {
-            return this.write({[workspaceKey]: {operations}}, {
-                cause: 'dock', descriptor: {operations, workspaceKey}, ...options
-            })
-        },
-
-        /**
-         * @summary Prepares a transfer from both queue-head documents before either owner adopts.
-         * @param {Object} descriptor Source and target workspace keys plus the transfer operation.
-         * @param {Object} [options={}]
-         * @returns {Promise<Object>}
-         */
-        transfer(descriptor, options = {}) {
-            if (!['transferItem', 'transferNode'].includes(descriptor.operation) ||
-                descriptor.sourceWorkspaceId === descriptor.targetWorkspaceId) {
-                return Promise.reject(new TypeError('a transfer needs distinct workspace keys'))
-            }
-            return this.write({[descriptor.sourceWorkspaceId]: {transfer: descriptor},
-                [descriptor.targetWorkspaceId]: {transfer: descriptor}},
-                {cause: 'dock-transfer', descriptor, ...options})
-        },
-
-        /**
-         * Explicit participant retirement — never a side effect of a window's binding leaving (see
-         * the summary's vessel-lifecycle boundary).
-         * @param {String} workspaceId
-         * @returns {Boolean} true when a participant was removed
-         */
-        unregister(workspaceId) {
-            const id = groupId();
-
-            return id ? manager.unregisterParticipant({groupId: id, workspaceKey: workspaceId}) : false
         }
+
+        if (typeof project === 'function') entry.project = context => project({
+            ...context,
+            preserveItemIds: participantKeys().filter(key => key !== workspaceId)
+                .flatMap(key => Object.keys(context.snapshot.participants[key]?.items ?? {}))
+        });
+        if (componentId !== undefined) entry.componentId = componentId;
+        if (typeof dispose === 'function') entry.dispose = dispose;
+
+        return manager.registerParticipant({
+            groupId     : id,
+            participant : entry,
+            workspaceKey: workspaceId
+        })
+    }
+
+    /**
+     * @summary Queues keyed document candidates through the Group's participant protocol.
+     * @param {Object<String,Object>} workspaces The workspace keys changed by this transaction.
+     * @param {Object} options Cause, provenance, descriptor and cursorAction for the Group write.
+     * @returns {Promise<Object>} The manager's complete transaction result.
+     */
+    async write(workspaces, {cause, provenance = {}, descriptor = {}, cursorAction = 'append'} = {}) {
+        const id = this.resolveGroupId();
+        if (!id) throw new Error('WorkspaceSet.write requires a bound Group');
+        if (!workspaces || typeof workspaces !== 'object' || Array.isArray(workspaces) ||
+            (Object.getPrototypeOf(workspaces) !== Object.prototype && Object.getPrototypeOf(workspaces) !== null)) {
+            throw new TypeError('WorkspaceSet.write requires documents keyed by workspace')
+        }
+        return this.manager.write({
+            groupId: id,
+            cause,
+            provenance,
+            descriptor,
+            cursorAction,
+            changes: Object.entries(workspaces).map(([workspaceKey, input]) => ({workspaceKey, input}))
+        })
+    }
+
+    /**
+     * @summary Reduces semantic operations against the document captured at the Group queue head.
+     * @param {String} workspaceKey
+     * @param {Object[]} operations
+     * @param {Object} [options={}] Group cause and provenance.
+     * @returns {Promise<Object>} The committed Group transaction.
+     */
+    commit(workspaceKey, operations, options = {}) {
+        return this.write({[workspaceKey]: {operations}}, {
+            cause: 'dock', descriptor: {operations, workspaceKey}, ...options
+        })
+    }
+
+    /**
+     * @summary Prepares a transfer from both queue-head documents before either owner adopts.
+     * @param {Object} descriptor Source and target workspace keys plus the transfer operation.
+     * @param {Object} [options={}]
+     * @returns {Promise<Object>}
+     */
+    transfer(descriptor, options = {}) {
+        if (!['transferItem', 'transferNode'].includes(descriptor.operation) ||
+            descriptor.sourceWorkspaceId === descriptor.targetWorkspaceId) {
+            return Promise.reject(new TypeError('a transfer needs distinct workspace keys'))
+        }
+        return this.write({[descriptor.sourceWorkspaceId]: {transfer: descriptor},
+            [descriptor.targetWorkspaceId]: {transfer: descriptor}},
+            {cause: 'dock-transfer', descriptor, ...options})
+    }
+
+    /**
+     * @summary Explicitly retires a participant, independently of window binding or adapter disposal.
+     * @param {String} workspaceId
+     * @returns {Boolean} true when a participant was removed
+     */
+    unregister(workspaceId) {
+        const id = this.resolveGroupId();
+
+        return id ? this.manager.unregisterParticipant({groupId: id, workspaceKey: workspaceId}) : false
     }
 }
+
+export default Neo.setupClass(WorkspaceSet);

--- a/test/playwright/unit/apps/workstation/Workspace.spec.mjs
+++ b/test/playwright/unit/apps/workstation/Workspace.spec.mjs
@@ -24,10 +24,10 @@ import {initialDocument} from '../../../../../apps/workstation/tour/denseWorksta
 test('pointer readiness reads current popup and supplied main visual owners', () => {
     for (const isMain of [false, true]) {
         const workspaceId = isMain ? Workspace.MAIN_WORKSPACE_ID : 'workstation-vessel:metrics',
-              preview = {previewId: 'current-preview'},
-              target = {currentPreview: preview},
-              visuals = {
-                  preview: {dockPreview: preview},
+              preview     = {previewId: 'current-preview'},
+              target      = {currentPreview: preview},
+              visuals     = {
+                  preview   : {dockPreview: preview},
                   indicators: {
                       activeCandidate: {preview}, candidateSet: {itemId: 'audit', cross: [], root: {chips: []}}, cls: []
                   }
@@ -39,11 +39,11 @@ test('pointer readiness reads current popup and supplied main visual owners', ()
               },
               workspace = {
                   crossWindowParticipations: new Map(isMain ? [[workspaceId, participation]] : []),
-                  dragAffordances: visuals,
-                  getPopupState: () => ({host: {participation}})
+                  dragAffordances          : visuals,
+                  getPopupState            : () => ({host: {participation}})
               },
               sourceZone = {dragCoordinator: {
-                  activeTargetZone: target,
+                  activeTargetZone   : target,
                   pointerClaimArbiter: {claimCount: 1, resolve: () => ({stableId: workspaceId})}
               }},
               read = () => Workspace.prototype.readCrossWindowGestureSnapshot.call(workspace, {
@@ -51,7 +51,7 @@ test('pointer readiness reads current popup and supplied main visual owners', ()
               });
 
         expect(read()).toMatchObject({
-            engaged: true, ready: true, preview, rendered: preview,
+            engaged   : true, ready: true, preview, rendered: preview,
             indicators: {activePreviewId: preview.previewId, itemId: 'audit', visible: true}
         });
         visuals.preview.dockPreview = {previewId: 'stale-preview'};
@@ -1693,10 +1693,28 @@ test.describe.serial('Workstation.view.Workspace', () => {
     test('explicit root destruction retires its registered popup owner', () => {
         const workspace            = Neo.create(Workspace, {windowId: Neo.config.windowId});
         const {state, workspaceId} = stageCommittedVessel(workspace);
-        const groupId              = workspace.topologyGroupId;
+        const groupId              = workspace.topologyGroupId,
+              adapter              = workspace.workspaceSet;
+        expect(Neo.get(adapter.id)).toBe(adapter);
         workspace.destroy();
         expect(state.host.isDestroyed).toBe(true);
+        expect(adapter.isDestroyed).toBe(true);
+        expect(Neo.get(adapter.id)).toBeFalsy();
         expect(TransactionManager.getParticipant(groupId, workspaceId)).toBeNull()
+    });
+
+    test('destroying a popup does not destroy the root adapter it borrows', () => {
+        const workspace = Neo.create(Workspace, {windowId: Neo.config.windowId}),
+              {state}   = stageCommittedVessel(workspace),
+              adapter   = workspace.workspaceSet;
+        try {
+            expect(state.host.workspaceSet).toBe(adapter);
+            state.host.destroy();
+            expect(Neo.get(adapter.id)).toBe(adapter);
+            expect(adapter.has(Workspace.MAIN_WORKSPACE_ID)).toBe(true)
+        } finally {
+            workspace.destroy()
+        }
     });
 
     test('Group retirement disposes popup owners before the root is released', () => {

--- a/test/playwright/unit/dashboard/DockCrossWindowParticipation.spec.mjs
+++ b/test/playwright/unit/dashboard/DockCrossWindowParticipation.spec.mjs
@@ -342,8 +342,8 @@ test.describe('Neo.dashboard.dock.window.Participation (ADR 0029 §2.3 — works
                 getForeignDocument: () => source,
                 resolveOwnershipId: () => 'group-1',
             sortGroup         : 'dock-demo',
-                windowId          : 'window-b',
-                workspaceId       : 'B'
+                windowId   : 'window-b',
+                workspaceId: 'B'
             });
 
             const result = participation.commitDrop(operation, {dockItemId: 'terminal', dockSourceOwnershipId: 'group-1', dockSourceWorkspaceId: 'A'});
@@ -1156,10 +1156,10 @@ test.describe('Neo.dashboard.dock.window.Participation (ADR 0029 §2.3 — works
         });
 
         test('a registered native popup supplies its own document and refuses empty or multi-item single-pane drags', async () => {
-            const {default: manager}       = await import('../../../../src/manager/Transaction.mjs');
-            const {createDockWorkspaceSet} = await import('../../../../src/dashboard/dock/window/WorkspaceSet.mjs');
-            const groupId                  = manager.bind({windowId: 'native-popup-owner-root', workspaceKey: 'main'}).groupId;
-            const pane                     = {id: 'pane-terminal', isDestroyed: false,
+            const {default: manager}      = await import('../../../../src/manager/Transaction.mjs');
+            const {default: WorkspaceSet} = await import('../../../../src/dashboard/dock/window/WorkspaceSet.mjs');
+            const groupId                 = manager.bind({windowId: 'native-popup-owner-root', workspaceKey: 'main'}).groupId;
+            const pane                    = {id: 'pane-terminal', isDestroyed: false,
                 dockGroupNodeId: 'stale-stack', dockSourceNodeId: 'stale-tabs'};
             const workspace = createWorkspaceStub({
                 dockModel    : targetDoc(), topologyGroupId: groupId,
@@ -1172,7 +1172,7 @@ test.describe('Neo.dashboard.dock.window.Participation (ADR 0029 §2.3 — works
             delete popup.nodes['main-tabs'];
             delete popup.nodes.root.zones.center;
 
-            const workspaceSet = createDockWorkspaceSet({manager, getGroupId: () => groupId, documentModel: WorkspaceDocument});
+            const workspaceSet = Neo.create(WorkspaceSet, {manager, getGroupId: () => groupId, documentModel: WorkspaceDocument});
             workspaceSet.register('A', {getDocument: () => workspace.dockModel, setDocument: value => workspace.dockModel = value});
             workspaceSet.register('popup-document', {getDocument: () => popup, setDocument: value => popup = value});
             workspace.nativeWindows.registerSource(workspace.id, {
@@ -1201,6 +1201,7 @@ test.describe('Neo.dashboard.dock.window.Participation (ADR 0029 §2.3 — works
                 expect(participation.target.getNativeWindowDrag('native-popup-live'), 'an empty registered owner cannot borrow the main document').toBeNull()
             } finally {
                 participation?.destroy();
+                workspaceSet.destroy();
                 manager.retireGroup(groupId)
             }
         });

--- a/test/playwright/unit/dashboard/DockPlacement.spec.mjs
+++ b/test/playwright/unit/dashboard/DockPlacement.spec.mjs
@@ -1,15 +1,15 @@
 import {setup} from '../../setup.mjs';
 setup({appConfig: {name: 'DockPlacementTest'}});
 
-import {expect, test}           from '@playwright/test';
-import Neo                      from '../../../../src/Neo.mjs';
-import * as core                from '../../../../src/core/_export.mjs';
-import Transaction              from '../../../../src/manager/Transaction.mjs';
-import WindowManager            from '../../../../src/manager/Window.mjs';
-import DragCoordinator          from '../../../../src/manager/DragCoordinator.mjs';
-import WorkspaceDocument        from '../../../../src/dashboard/dock/model/WorkspaceDocument.mjs';
-import Placement                from '../../../../src/dashboard/dock/window/Placement.mjs';
-import {createDockWorkspaceSet} from '../../../../src/dashboard/dock/window/WorkspaceSet.mjs';
+import {expect, test}    from '@playwright/test';
+import Neo               from '../../../../src/Neo.mjs';
+import * as core         from '../../../../src/core/_export.mjs';
+import Transaction       from '../../../../src/manager/Transaction.mjs';
+import WindowManager     from '../../../../src/manager/Window.mjs';
+import DragCoordinator   from '../../../../src/manager/DragCoordinator.mjs';
+import WorkspaceDocument from '../../../../src/dashboard/dock/model/WorkspaceDocument.mjs';
+import Placement         from '../../../../src/dashboard/dock/window/Placement.mjs';
+import WorkspaceSet      from '../../../../src/dashboard/dock/window/WorkspaceSet.mjs';
 
 /** @summary Creates one item-disjoint, validated dock document. @param {String} key @returns {Object} */
 function document(key) {
@@ -37,7 +37,7 @@ test.describe.serial('Dock relative placement participant', () => {
         Transaction.setHistoryDepth({groupId, depth: 5});
         const reserved = Transaction.reserve({groupId, workspaceKey: 'popup'});
         Transaction.bind({...reserved, windowId: popupWindow});
-        workspaces = createDockWorkspaceSet({manager: Transaction, getGroupId: () => groupId, documentModel: WorkspaceDocument});
+        workspaces = Neo.create(WorkspaceSet, {manager: Transaction, getGroupId: () => groupId, documentModel: WorkspaceDocument});
         const docs = {'workstation-main': document('main'), popup: document('popup')};
         for (const key of Object.keys(docs)) {
             workspaces.register(key, {getDocument: () => docs[key], setDocument: value => docs[key] = value})
@@ -49,6 +49,7 @@ test.describe.serial('Dock relative placement participant', () => {
 
     test.afterEach(() => {
         placement?.destroy();
+        workspaces?.destroy();
         Transaction.retireGroup(groupId);
         WindowManager.unregister(mainWindow);
         WindowManager.unregister(popupWindow);

--- a/test/playwright/unit/dashboard/DockTopologySeams.spec.mjs
+++ b/test/playwright/unit/dashboard/DockTopologySeams.spec.mjs
@@ -11,12 +11,12 @@ import Neo            from '../../../../src/Neo.mjs';
 import * as core      from '../../../../src/core/_export.mjs';
 import '../../../../src/manager/Instance.mjs'; // defines Neo.get — the container child-add path resolves parents through it
 import '../../../../src/tab/Container.mjs';    // registers the `tab-container` ntype the projection emits
-import DockWorkspace            from '../../../../src/dashboard/dock/Workspace.mjs';
-import Persistence              from '../../../../src/dashboard/dock/model/Persistence.mjs';
-import TopologyReconciler       from '../../../../src/dashboard/dock/model/TopologyReconciler.mjs';
-import {createDockWorkspaceSet} from '../../../../src/dashboard/dock/window/WorkspaceSet.mjs';
-import TransactionManager       from '../../../../src/manager/Transaction.mjs';
-import WorkspaceDocument        from '../../../../src/dashboard/dock/model/WorkspaceDocument.mjs';
+import DockWorkspace      from '../../../../src/dashboard/dock/Workspace.mjs';
+import Persistence        from '../../../../src/dashboard/dock/model/Persistence.mjs';
+import TopologyReconciler from '../../../../src/dashboard/dock/model/TopologyReconciler.mjs';
+import WorkspaceSet       from '../../../../src/dashboard/dock/window/WorkspaceSet.mjs';
+import TransactionManager from '../../../../src/manager/Transaction.mjs';
+import WorkspaceDocument  from '../../../../src/dashboard/dock/model/WorkspaceDocument.mjs';
 
 /**
  * @summary The holder seam pair a multi-window perspective restore reaches an app through.
@@ -93,6 +93,7 @@ test.describe('Neo.dashboard.dock.window.TopologySeams — the multi-window rest
     const groups = [];
 
     test.afterEach(() => {
+        workspace?.workspaceSet?.destroy();
         workspace?.isDestroyed === false && workspace.destroy();
         workspace = null;
         groups.splice(0).forEach(groupId => TransactionManager.retireGroup(groupId))
@@ -108,7 +109,7 @@ test.describe('Neo.dashboard.dock.window.TopologySeams — the multi-window rest
         const
             groupId = TransactionManager.bind({windowId: `seams-host-${groups.length + 1}`, workspaceKey: 'main'}).groupId,
             vessel  = {document: vesselDoc()},
-            set     = createDockWorkspaceSet({manager: TransactionManager, getGroupId: () => groupId, documentModel: WorkspaceDocument});
+            set     = Neo.create(WorkspaceSet, {manager: TransactionManager, getGroupId: () => groupId, documentModel: WorkspaceDocument});
 
         groups.push(groupId);
 

--- a/test/playwright/unit/dashboard/DockWorkspaceSet.spec.mjs
+++ b/test/playwright/unit/dashboard/DockWorkspaceSet.spec.mjs
@@ -8,11 +8,25 @@ setup({
     mockMain        : false
 });
 
-import {test, expect}           from '@playwright/test';
-import Neo                      from '../../../../src/Neo.mjs';
-import * as core                from '../../../../src/core/_export.mjs';
-import TransactionManager       from '../../../../src/manager/Transaction.mjs';
-import {createDockWorkspaceSet} from '../../../../src/dashboard/dock/window/WorkspaceSet.mjs';
+import {test, expect}     from '@playwright/test';
+import {execFileSync}     from 'node:child_process';
+import {fileURLToPath}    from 'node:url';
+import Neo                from '../../../../src/Neo.mjs';
+import * as core          from '../../../../src/core/_export.mjs';
+import TransactionManager from '../../../../src/manager/Transaction.mjs';
+import WorkspaceSet       from '../../../../src/dashboard/dock/window/WorkspaceSet.mjs';
+
+class ObservedWorkspaceSet extends WorkspaceSet {
+    static config = {className: 'Test.Unit.DockWorkspaceSet.Observed'}
+
+    /** @summary Counts real participant resolution through inherited public methods. @param {String} id @returns {Object|null} */
+    getParticipant(id) {
+        this.resolutions = (this.resolutions || 0) + 1;
+        return super.getParticipant(id)
+    }
+}
+
+Neo.setupClass(ObservedWorkspaceSet);
 
 /**
  * @summary The dock's `{workspaceId → document}` view of a Group's participant membership (docking
@@ -29,10 +43,11 @@ test.describe('Neo.dashboard.dock.window.WorkspaceSet — the dock adapter over 
         // The host window binds into a Group the way its app registration does; the adapter reads
         // that Group back through the same seam the hosts hand it.
         groupId = TransactionManager.bind({windowId: 'workspace-set-host', workspaceKey: 'main'}).groupId;
-        set     = createDockWorkspaceSet({manager: TransactionManager, getGroupId: () => groupId})
+        set     = Neo.create(WorkspaceSet, {manager: TransactionManager, getGroupId: () => groupId})
     });
 
     test.afterEach(() => {
+        set?.destroy();
         TransactionManager.retireGroup(groupId);
         TransactionManager.reconnectLeaseMs = 20000
     });
@@ -53,8 +68,45 @@ test.describe('Neo.dashboard.dock.window.WorkspaceSet — the dock adapter over 
         return holder
     }
 
+    test('the registered adapter dispatches inherited operations through its subclass', () => {
+        const extended = Neo.create(ObservedWorkspaceSet, {manager: TransactionManager, getGroupId: () => groupId}),
+              holder   = createHolder();
+
+        try {
+            expect(Neo.ns('Neo.dashboard.dock.window.WorkspaceSet', false)).toBe(WorkspaceSet);
+            expect(Neo.get(extended.id)).toBe(extended);
+            extended.register('main', holder.seams);
+            expect(extended.has('main')).toBe(true);
+            expect(extended.getDocument('main')).toBe(holder.document);
+            expect(extended.resolutions).toBe(2);
+            expect(Object.hasOwn(extended, 'has')).toBe(false)
+        } finally {
+            extended.destroy()
+        }
+    });
+
+    test('configured overwrites reach the registered adapter before creation', () => {
+        const result = JSON.parse(execFileSync(process.execPath, ['--input-type=module', '-e', `
+            await import('./src/Neo.mjs');
+            await import('./src/core/_export.mjs');
+            Neo.overwrites = {};
+            let calls = 0;
+            Neo.ns('Neo.dashboard.dock.window.WorkspaceSet', true, Neo.overwrites).getParticipant =
+                () => { calls++; return {getDocument: () => 'overwritten'} };
+            const {default: WorkspaceSet} = await import('./src/dashboard/dock/window/WorkspaceSet.mjs');
+            const adapter = Neo.create(WorkspaceSet);
+            const document = adapter.getDocument('main');
+            adapter.destroy();
+            process.stdout.write(JSON.stringify({
+                registered: WorkspaceSet === Neo.dashboard.dock.window.WorkspaceSet, document, calls
+            }));
+        `], {cwd: fileURLToPath(new URL('../../../../', import.meta.url)), encoding: 'utf8'}));
+
+        expect(result).toEqual({registered: true, document: 'overwritten', calls: 1})
+    });
+
     test('before the host binds there is no membership: registration is refused and every lookup fails closed', () => {
-        const unbound = createDockWorkspaceSet({manager: TransactionManager, getGroupId: () => null}),
+        const unbound = Neo.create(WorkspaceSet, {manager: TransactionManager, getGroupId: () => null}),
               holder  = createHolder({rootId: 'root-early'});
 
         expect(unbound.register('main', holder.seams), 'no Group to join').toBe(false);
@@ -64,7 +116,8 @@ test.describe('Neo.dashboard.dock.window.WorkspaceSet — the dock adapter over 
         expect(unbound.size).toBe(0);
         expect(unbound.unregister('main')).toBe(false);
         expect(unbound.adoptAll({main: {rootId: 'x'}}), 'nothing to adopt into').toBe(false);
-        expect(TransactionManager.participantKeys(groupId), 'the refusal wrote nowhere').toEqual([])
+        expect(TransactionManager.participantKeys(groupId), 'the refusal wrote nowhere').toEqual([]);
+        unbound.destroy()
     });
 
     test('membership is the Group\'s, and it outlives the binding: a released and expired slot keeps the participants and the Group', async () => {
@@ -88,7 +141,7 @@ test.describe('Neo.dashboard.dock.window.WorkspaceSet — the dock adapter over 
         // The fixture's resolver is the hosts' shape: a Group remembered once, never re-derived. A
         // resolver reading the LIVE binding instead loses the membership with the window — which is
         // why the engine Workspace, the Workstation and DemoB remember their Group.
-        const liveResolver = createDockWorkspaceSet({
+        const liveResolver = Neo.create(WorkspaceSet, {
             getGroupId: () => TransactionManager.findByWindow('workspace-set-host')?.groupId ?? null,
             manager   : TransactionManager
         });
@@ -98,7 +151,8 @@ test.describe('Neo.dashboard.dock.window.WorkspaceSet — the dock adapter over 
 
         // Retirement stays the owner's explicit decision.
         expect(set.unregister('main')).toBe(true);
-        expect(set.ids()).toEqual([])
+        expect(set.ids()).toEqual([]);
+        liveResolver.destroy()
     });
 
     test('register → resolve: document truth flows through the owner seam, live', () => {

--- a/test/playwright/unit/dashboard/DockWorkspaceSetTransaction.spec.mjs
+++ b/test/playwright/unit/dashboard/DockWorkspaceSetTransaction.spec.mjs
@@ -16,7 +16,7 @@ import WorkstationWorkspace     from '../../../../apps/workstation/view/Workspac
 import WorkspaceDocument        from '../../../../src/dashboard/dock/model/WorkspaceDocument.mjs';
 import Persistence              from '../../../../src/dashboard/dock/model/Persistence.mjs';
 import PerspectiveLibrary       from '../../../../src/dashboard/dock/persistence/PerspectiveLibrary.mjs';
-import {createDockWorkspaceSet} from '../../../../src/dashboard/dock/window/WorkspaceSet.mjs';
+import WorkspaceSet             from '../../../../src/dashboard/dock/window/WorkspaceSet.mjs';
 
 /** @summary Creates a valid, item-disjoint dock document. @param {String} key @param {String} title @returns {Object} */
 function document(key, title = 'before') {
@@ -38,10 +38,13 @@ test.describe.serial('Dock WorkspaceSet transaction participants', () => {
         TransactionManager.setHistoryDepth({groupId, depth: 5});
         const popup = TransactionManager.reserve({groupId, workspaceKey: 'popup'});
         TransactionManager.bind({...popup, windowId: 'workspace-set-transaction-popup'});
-        set = createDockWorkspaceSet({manager: TransactionManager, getGroupId: () => groupId, documentModel: WorkspaceDocument})
+        set = Neo.create(WorkspaceSet, {manager: TransactionManager, getGroupId: () => groupId, documentModel: WorkspaceDocument})
     });
 
-    test.afterEach(() => TransactionManager.retireGroup(groupId));
+    test.afterEach(() => {
+        set?.destroy();
+        TransactionManager.retireGroup(groupId)
+    });
 
     /** @summary Registers a document holder without reading it during registration. @param {String} key @param {Object} options @returns {Object} */
     function holder(key, {project, fail} = {}) {
@@ -62,16 +65,58 @@ test.describe.serial('Dock WorkspaceSet transaction participants', () => {
 
     const write = (workspaces, options = {}) => set.write(workspaces, {cause: 'replace-workspaces', provenance: {origin: 'unit'}, ...options});
 
+    test('registered callbacks survive adapter disposal through queued write, compensation and undo', async () => {
+        const projected   = [],
+              main        = holder('main', {project: context => projected.push(context.preserveItemIds)}),
+              popup       = holder('popup', {fail: value => value.items.popup.title === 'refused'}),
+              participant = TransactionManager.getParticipant(groupId, 'main'),
+              prepare     = participant.prepare,
+              adapterId   = set.id;
+        let release, entered;
+        const gate      = new Promise(resolve => release = resolve),
+              preparing = new Promise(resolve => entered = resolve);
+
+        participant.prepare = async (...args) => {
+            entered();
+            await gate;
+            return prepare(...args)
+        };
+
+        expect(Neo.get(adapterId)).toBe(set);
+        const pending = write({main: document('main', 'queued')});
+        await preparing;
+        set.destroy();
+        release();
+
+        expect(Neo.get(adapterId)).toBeFalsy();
+        expect(TransactionManager.participantKeys(groupId)).toEqual(['main', 'popup']);
+        expect((await pending).snapshot.participants.main).toEqual(document('main', 'queued'));
+        expect(main.document.items.main.title).toBe('queued');
+        await expect.poll(() => projected).toEqual([['popup']]);
+
+        await expect(TransactionManager.write({groupId, cause: 'after-adapter-disposal', changes: [
+            {workspaceKey: 'main', input: document('main', 'compensate')},
+            {workspaceKey: 'popup', input: document('popup', 'refused')}
+        ]})).rejects.toThrow('second setter refused');
+
+        expect(main.document.items.main.title).toBe('queued');
+        expect(popup.document).toEqual(document('popup'));
+        await TransactionManager.undo({groupId});
+        expect(main.document).toEqual(document('main'));
+        await expect.poll(() => projected.length).toBe(2);
+        expect(projected.at(-1)).toEqual(['popup'])
+    });
+
     test('Neural Link A and human B share one Group cursor and undo newest-first', async () => {
-        const main = holder('main'), context = {agentId: 'dock-writer-a', sessionId: 'dock-session-a'};
+        const main   = holder('main'), context = {agentId: 'dock-writer-a', sessionId: 'dock-session-a'};
         const legacy = Neo.create(LegacyTransactionService);
         const client = {transactionService: legacy, writeGuard: Neo.create(WriteGuard)};
-        const dock = Neo.create(DockService, {client}), commands = Neo.create(InstanceService, {client});
+        const dock   = Neo.create(DockService, {client}), commands = Neo.create(InstanceService, {client});
         client.services = {dock, instance: commands};
         const originalGetComponent = Neo.getComponent;
-        const component = {
-            id: 'group-history-holder', topologyGroupId: groupId, workspaceKey: 'main', workspaceSet: set,
-            getDockZoneDocument: () => main.document,
+        const component            = {
+            id                      : 'group-history-holder', topologyGroupId: groupId, workspaceKey: 'main', workspaceSet: set,
+            getDockZoneDocument     : () => main.document,
             onDockZoneDocumentChange: value => main.document = value
         };
         set.register('main', {...main.seams, componentId: component.id});
@@ -117,14 +162,14 @@ test.describe.serial('Dock WorkspaceSet transaction participants', () => {
     });
 
     test('window perspective restore uses the Group cursor and refuses before moving the library pointer', async () => {
-        const main = holder('main'), original = WorkspaceDocument.clone(main.document);
+        const main  = holder('main'), original = WorkspaceDocument.clone(main.document);
         const store = Neo.create(PerspectiveLibrary), dock = Neo.create(DockService);
         for (const [layoutId, title] of [['current', 'before'], ['saved', 'restored']]) {
             const layout = Persistence.capturePerspective(document('main', title), {layoutId, title}).layout;
             expect(store.savePerspective(layout, {activate: layoutId === 'current'}).saved).toBe(true)
         }
         const component = {id: 'restore-holder', topologyGroupId: groupId, workspaceSet: set,
-            perspectiveStore: store, getDockZoneDocument: () => main.document,
+            perspectiveStore        : store, getDockZoneDocument: () => main.document,
             onDockZoneDocumentChange: value => main.document = value};
         set.register('main', {...main.seams, componentId: component.id});
         const lookup = Neo.getComponent, commit = set.commit;
@@ -154,12 +199,12 @@ test.describe.serial('Dock WorkspaceSet transaction participants', () => {
     });
 
     test('a named dock batch prepares both operations before one Group commit', async () => {
-        const main = holder('main'), context = {agentId: 'batch-writer', sessionId: 'batch-session'};
+        const main   = holder('main'), context = {agentId: 'batch-writer', sessionId: 'batch-session'};
         const legacy = Neo.create(LegacyTransactionService), client = {transactionService: legacy, writeGuard: Neo.create(WriteGuard)};
-        const dock = Neo.create(DockService, {client}), commands = Neo.create(InstanceService, {client});
+        const dock   = Neo.create(DockService, {client}), commands = Neo.create(InstanceService, {client});
         client.services = {dock, instance: commands};
         const originalGetComponent = Neo.getComponent;
-        const component = {id: 'batch-holder', topologyGroupId: groupId, workspaceSet: set,
+        const component            = {id: 'batch-holder', topologyGroupId: groupId, workspaceSet: set,
             getDockZoneDocument: () => main.document};
         set.register('main', {...main.seams, componentId: component.id});
         Neo.getComponent = id => id === component.id ? component : originalGetComponent(id);
@@ -186,7 +231,7 @@ test.describe.serial('Dock WorkspaceSet transaction participants', () => {
 
     test('mixed replay is refused before the first dock or non-dock effect', async () => {
         holder('main');
-        const calls = [], legacy = Neo.create(LegacyTransactionService);
+        const calls   = [], legacy = Neo.create(LegacyTransactionService);
         const service = Neo.create(InstanceService, {client: {transactionService: legacy,
             handleRequest: (...args) => { calls.push(args); return {applied: true} }}});
         try {
@@ -206,14 +251,14 @@ test.describe.serial('Dock WorkspaceSet transaction participants', () => {
         initial.items.second = {componentRef: 'second', title: 'Second', kind: 'panel'};
         initial.nodes.root.items.push('second');
         const popup = Neo.create(PopupWorkspace, {
-            dockModel: initial, rootWorkspace: {resolvePane: () => ({ntype: 'component'})},
+            dockModel      : initial, rootWorkspace: {resolvePane: () => ({ntype: 'component'})},
             topologyGroupId: groupId, workspaceKey: 'popup', workspaceSet: set
         });
         set.register('popup', {componentId: popup.id, getDocument: () => popup.dockModel,
             setDocument: value => popup.dockModel = value});
         try {
             const descriptor = {operation: 'setActiveItem', tabsNodeId: 'root', itemId: 'second'};
-            const result = popup.applyDockZoneOperation(descriptor);
+            const result     = popup.applyDockZoneOperation(descriptor);
             await popup.onDockZoneDocumentChange(result.document, descriptor);
             expect(set.getDocument('popup').nodes.root.activeItemId).toBe('second');
             expect(TransactionManager.get(groupId).history.count).toBe(1);
@@ -229,15 +274,15 @@ test.describe.serial('Dock WorkspaceSet transaction participants', () => {
         main.document.nodes.tabs = main.document.nodes.root;
         main.document.nodes.root = {type: 'edge-zone', zones: {center: {nodeId: 'tabs'}}};
         const initial = WorkspaceDocument.clone(main.document);
-        const root = {
+        const root    = {
             get dockModel() { return main.document },
-            workspaceSet: set, topologyGroupId: groupId,
-            getPopupState: WorkstationWorkspace.prototype.getPopupState,
-            getPopupStates: WorkstationWorkspace.prototype.getPopupStates,
-            stateProvider: TransactionManager.getProvider(groupId),
-            resolvePane: () => ({ntype: 'component'}),
+            workspaceSet                 : set, topologyGroupId: groupId,
+            getPopupState                : WorkstationWorkspace.prototype.getPopupState,
+            getPopupStates               : WorkstationWorkspace.prototype.getPopupStates,
+            stateProvider                : TransactionManager.getProvider(groupId),
+            resolvePane                  : () => ({ntype: 'component'}),
             createVesselWorkspaceDocument: WorkstationWorkspace.prototype.createVesselWorkspaceDocument,
-            tearOutHandlers: {capturePane: () => true, adoptPane() {
+            tearOutHandlers              : {capturePane: () => true, adoptPane() {
                 expect(main.document.items[itemId]).toBeUndefined();
                 expect(TransactionManager.get(groupId).history.count).toBe(1)
             }}
@@ -397,12 +442,13 @@ test.describe.serial('Dock WorkspaceSet transaction participants', () => {
 
     test('the model seam is required by queued writes without changing synchronous adoption', async () => {
         const main   = holder('main');
-        const legacy = createDockWorkspaceSet({manager: TransactionManager, getGroupId: () => groupId});
+        const legacy = Neo.create(WorkspaceSet, {manager: TransactionManager, getGroupId: () => groupId});
         legacy.register('main', main.seams);
 
         expect(legacy.adoptAll({main: document('main', 'synchronous')})).toBe(true);
         await expect(legacy.write({main: document('main', 'queued')}, {cause: 'test'})).rejects.toThrow(/injected documentModel/);
         expect(main.document.items.main.title).toBe('synchronous');
-        expect(main.writes).toHaveLength(1)
+        expect(main.writes).toHaveLength(1);
+        legacy.destroy()
     })
 });

--- a/test/playwright/unit/examples/dashboard/crossWindow/DemoBWorkspace.spec.mjs
+++ b/test/playwright/unit/examples/dashboard/crossWindow/DemoBWorkspace.spec.mjs
@@ -346,10 +346,10 @@ test.describe.serial('Neo.examples.dashboard.crossWindow.DemoBWorkspace', () => 
     };
 
     test('a human document publication enters the Group cursor and is undoable', async () => {
-        const before = WorkspaceDocument.clone(workspace.dockModel);
-        const itemId = Object.keys(before.items)[0];
+        const before     = WorkspaceDocument.clone(workspace.dockModel);
+        const itemId     = Object.keys(before.items)[0];
         const descriptor = {operation: 'setItemLocked', itemId, locked: true};
-        const changed = Operations.applyOperation(before, descriptor);
+        const changed    = Operations.applyOperation(before, descriptor);
         expect(changed.errors).toEqual([]);
         TransactionManager.setHistoryDepth({groupId: hostGroupId, depth: 5});
         await workspace.onWorkspaceDocumentChange(DemoBWorkspace.MAIN_WORKSPACE_ID, changed.document, {descriptor});
@@ -364,12 +364,12 @@ test.describe.serial('Neo.examples.dashboard.crossWindow.DemoBWorkspace', () => 
     test('history-disabled transfers retain their committed before-document receipt', async () => {
         TransactionManager.setHistoryDepth({groupId: hostGroupId, depth: 0});
         const before = WorkspaceDocument.clone(workspace.dockModel);
-        const pair = {sourceWorkspaceId: DemoBWorkspace.MAIN_WORKSPACE_ID,
+        const pair   = {sourceWorkspaceId: DemoBWorkspace.MAIN_WORKSPACE_ID,
             targetWorkspaceId: DemoBWorkspace.POPUP_WORKSPACE_ID,
-            descriptor: {operation: 'transferItem', itemId: 'workbench',
+            descriptor       : {operation: 'transferItem', itemId: 'workbench',
                 sourceWorkspaceId: DemoBWorkspace.MAIN_WORKSPACE_ID,
                 targetWorkspaceId: DemoBWorkspace.POPUP_WORKSPACE_ID,
-                target: {operation: 'addTab', tabsNodeId: 'popup-tabs'}}};
+                target           : {operation: 'addTab', tabsNodeId: 'popup-tabs'}}};
         expect(await workspace.adoptCommittedTransferPair(pair)).toBe(true);
         expect(pair.sourceBefore).toEqual(before);
         expect(workspace.popupDocument.items.workbench).toEqual(before.items.workbench);
@@ -1354,11 +1354,11 @@ test.describe.serial('Neo.examples.dashboard.crossWindow.DemoBWorkspace', () => 
 
         const commit = workspace.commitCrossWindowTransfer({
             descriptor: {
-                operation: 'transferItem',
+                operation        : 'transferItem',
                 sourceWorkspaceId: DemoBWorkspace.MAIN_WORKSPACE_ID,
                 targetWorkspaceId: DemoBWorkspace.POPUP_WORKSPACE_ID,
-                itemId: 'workbench',
-                target: {operation: 'addTab', tabsNodeId: 'popup-tabs'}
+                itemId           : 'workbench',
+                target           : {operation: 'addTab', tabsNodeId: 'popup-tabs'}
             },
             sourceDocument   : detached.sourceDocument,
             sourceWorkspaceId: 'demo-b-main',
@@ -2431,14 +2431,18 @@ test.describe.serial('Neo.examples.dashboard.crossWindow.DemoBWorkspace', () => 
     });
 
     test('destroy tears down the runner, seam, store, and every cached pane', () => {
-        const pane                                        = workspace.resolvePane('workbench', initialDocument.items.workbench);
-        const {dockService, perspectiveStore, tourRunner} = workspace;
+        const pane                                                      = workspace.resolvePane('workbench', initialDocument.items.workbench);
+        const {dockService, perspectiveStore, tourRunner, workspaceSet} = workspace;
+
+        expect(Neo.get(workspaceSet.id)).toBe(workspaceSet);
 
         workspace.destroy();
 
         expect(tourRunner.isDestroyed).toBeTruthy();
         expect(dockService.isDestroyed).toBeTruthy();
         expect(perspectiveStore.isDestroyed).toBeTruthy();
+        expect(workspaceSet.isDestroyed).toBe(true);
+        expect(Neo.get(workspaceSet.id)).toBeFalsy();
         expect(pane.isDestroyed).toBeTruthy();
 
         workspace = null


### PR DESCRIPTION
Resolves #18450

The dock WorkspaceSet is now a registered `Neo.core.Base` class with executable prototype methods. Workstation and Demo-B construct it through Neo and release their own adapter during teardown. Popups continue to borrow it. Registered Group callbacks retain their manager, document model and Group identity, so adapter disposal leaves queued writes, compensation, undo and sibling-preserving projection usable.

Related: #18304

Evidence: L2 (real Group writer, retained callbacks and consumer instances in the unit runtime; isolated overwrite process) → L2 required (AC-1 through AC-6). No residual.

size-guard-growth: apps/workstation/view/Workspace.mjs — +1 code line for creator-owned adapter destruction; membership and callback behavior remain in WorkspaceSet.
size-guard-growth: examples/dashboard/crossWindow/DemoBWorkspace.mjs — +1 code line for the same creator-owned destruction obligation.

## AC Evidence

| AC | Evidence |
|---|---|
| AC-1 | CI-covered: `DockWorkspaceSet.spec.mjs` asserts the registered namespace, inherited dispatch through a subclass, and configured overwrites in a fresh process. |
| AC-2 | CI-covered: both existing consumer suites construct the registered adapter. Source sweep across tracked `src/apps/examples/test` finds no executable `createDockWorkspaceSet` reference. |
| AC-3 | CI-covered: Workstation and Demo-B teardown assertions check adapter destruction and instance deregistration; a separate Workstation arm destroys a popup and verifies the borrowed root adapter remains registered and usable. |
| AC-4 | CI-covered: `DockWorkspaceSetTransaction.spec.mjs` suspends real preparation, destroys the adapter, resumes the queued write, then checks later compensation and undo through the retained participants, including sibling preservation during projection. |
| AC-5 | CI-covered: existing WorkspaceSet, transaction, placement, topology, participation and both consumer suites. |
| AC-6 | Generated `class-hierarchy.json` adds WorkspaceSet → Base; parser/JSDoc checks cover modified APIs. |

## Deltas from ticket

None substantive. Participant-key resolution has a stateless class helper whose registration-time binding can survive Base's field cleanup. The constructor wrapper and duplicated return-object API documentation are removed; no compatibility factory or second membership registry remains.

Consumer cutover: default-import `WorkspaceSet` from `neo.mjs/src/dashboard/dock/window/WorkspaceSet.mjs`, then use `Neo.create(WorkspaceSet, {manager, getGroupId, documentModel})`. A creating host calls `destroy()` during its own teardown; a borrowed popup does not. The class JSDoc states this lifetime contract. The executable inventory above is repository-scoped; downstream creators need the same import/construction/teardown change when adopting this revision.

The new lifetime test initially used higher-level receipt fields that the manager does not return. Its corrected oracle reads the manager's snapshot and actual restored documents.

## Test Evidence

Mutation control: replace the registration-bound participant-key resolver with `() => this.ids()`. The lifetime arm fails after disposal with `preserveItemIds: []` instead of `['popup']`. Restoring the captured registration context passes. This control detects callback dependence on cleared adapter fields; it makes no browser-rendering claim.

## Post-Merge Validation

None required for this class/instance contract. No native-window or rendered-geometry claim is added.

Authored by Emmy (GPT-6 Astra, Codex). Session 153d2e0a-ebae-4087-bcd5-3c92d213132c.
