### PR TITLE
fix(dock): a multi-step pin commit stages the document between its steps (#18448)

### DIFF
--- a/buildScripts/util/file-size-baseline.json
+++ b/buildScripts/util/file-size-baseline.json
@@ -1,6 +1,6 @@
 {
     "apps/workstation/view/Workspace.mjs": 2911,
     "examples/dashboard/crossWindow/DemoBWorkspace.mjs": 2612,
-    "src/dashboard/dock/Workspace.mjs": 1030,
+    "src/dashboard/dock/Workspace.mjs": 1023,
     "src/main/addon/DragDrop.mjs": 1267
 }

--- a/buildScripts/util/file-size-baseline.json
+++ b/buildScripts/util/file-size-baseline.json
@@ -1,6 +1,6 @@
 {
     "apps/workstation/view/Workspace.mjs": 2911,
     "examples/dashboard/crossWindow/DemoBWorkspace.mjs": 2612,
-    "src/dashboard/dock/Workspace.mjs": 1023,
+    "src/dashboard/dock/Workspace.mjs": 1030,
     "src/main/addon/DragDrop.mjs": 1267
 }

--- a/buildScripts/util/file-size-baseline.json
+++ b/buildScripts/util/file-size-baseline.json
@@ -1,6 +1,6 @@
 {
     "apps/workstation/view/Workspace.mjs": 2911,
     "examples/dashboard/crossWindow/DemoBWorkspace.mjs": 2612,
-    "src/dashboard/dock/Workspace.mjs": 1023,
+    "src/dashboard/dock/Workspace.mjs": 1027,
     "src/main/addon/DragDrop.mjs": 1267
 }

--- a/src/dashboard/dock/Workspace.mjs
+++ b/src/dashboard/dock/Workspace.mjs
@@ -537,11 +537,8 @@ class Workspace extends Container {
     /**
      * The pure reducer of the holder contract: applies one semantic operation descriptor against
      * the live committed document and returns `model.Operations`' fail-closed `{document, errors}`
-     * result. Never mutates {@link #dockModel}: the view-sync {@link #onDockZoneDocumentChange} is
-     * its writer, called by the committing surface on success. One exception, and it is bounded —
-     * a multi-step sequence stages the field between its own steps so each reduces against the last
-     * (every implementation of this reducer reads `this.dockModel`, so staging is what reaches an
-     * override), and restores it before publishing.
+     * result. Never mutates {@link #dockModel} — the view-sync {@link #onDockZoneDocumentChange}
+     * is the only writer, called by the committing surface on success.
      * @param {Object} descriptor The semantic operation descriptor.
      * @returns {{document: Object, errors: String[]}}
      */
@@ -1779,21 +1776,27 @@ class Workspace extends Container {
     /**
      * Commits the engine-owned pin action — docking design record §2.7's collapse-to-rail sequence.
      *
-     * §2.7 specifies a two-step sequence and forbids a composite OPERATION — not a multi-operation
-     * commit: `setItemPinned(false)` when the item is pinned (the model rejects `autoHidden` on a
-     * pinned item), then `setItemAutoHidden(true)`. Each step stays an independent, individually
-     * validated reduction through {@link #applyDockZoneOperation}.
+     * §2.7 specifies a two-step sequence and forbids a composite operation: `setItemPinned(false)`
+     * when the item is pinned (the model rejects `autoHidden` on a pinned item), then
+     * `setItemAutoHidden(true)`. Each step is an INDEPENDENT commit — reduced through
+     * {@link #applyDockZoneOperation} and published through {@link #onDockZoneDocumentChange} on its
+     * own — so both steps stay visible at the class's own write seam, the one `DockService` and
+     * `DockSplitter` already reach a holder through. Folding them into a single published change
+     * would make step 2 bypass that seam, since the seam reduces against the committed `dockModel`
+     * and step 2 needs step 1's result.
      *
-     * The reduction is staged locally — `dockModel` advanced between steps — and published ONCE with
-     * the ordered descriptors. Publishing per step would not do: only the direct path assigns
-     * `dockModel` synchronously, while a topology Group returns `pending` and advances the field
-     * later, so step 2 would reduce against a document step 1 had not reached. The field is advanced
-     * rather than passed as an argument because this reducer is a consumer-overridable seam whose
-     * implementations read `this.dockModel`; an argument would reach only those that opted in. On
-     * refusal the staged field is restored, so no unpublished document is left behind.
+     * **Step 1's publish is therefore awaited, which is why this method is async.** The direct path
+     * assigns `dockModel` synchronously, but a topology Group returns a pending transaction and
+     * advances the field later inside adopt; an unawaited step 2 then reduces against a document
+     * step 1 never reached and is refused. Awaiting preserves both properties the row requires —
+     * the steps stay independently committed, and they land in the specified order.
      *
-     * An UNPINNED item — the ordinary case — is a single step and a single publish; only collapsing a
-     * pinned pane reduces twice.
+     * A step-2 rejection therefore leaves the item unpinned and still visible. That is §2.7's own
+     * intermediate state, which it calls benign, and it is the price of the independence the row
+     * requires; the alternative buys atomicity by making half the gesture unobservable.
+     *
+     * An UNPINNED item — the ordinary case — is a single step and a single refresh; only collapsing a
+     * pinned pane commits twice.
      *
      * **Eligibility is re-derived here, from the current document, and not inherited from the chrome
      * that emitted the intent.** The pin action's binding ({@link Neo.dashboard.dock.projection.HeaderActionPolicy#createActionBindings}) hides it wherever no edge owns the
@@ -1809,7 +1812,7 @@ class Workspace extends Container {
      * @returns {{document:Object,errors:String[]}|null}
      * @protected
      */
-    handleDockPinAction({dockNodeId, tabContainer}={}) {
+    async handleDockPinAction({dockNodeId, tabContainer}={}) {
         let me     = this,
             itemId = me.getActiveDockItemId(tabContainer);
 
@@ -1825,8 +1828,7 @@ class Workspace extends Container {
             return {document: me.dockModel, errors: ['Dock pin action requires an item owned by an edge zone']}
         }
 
-        let committed   = me.dockModel,
-            descriptors = [],
+        let descriptors = [],
             result      = null;
 
         me.dockModel.items?.[itemId]?.pinned === true &&
@@ -1838,18 +1840,14 @@ class Workspace extends Container {
             result = me.applyDockZoneOperation(descriptor);
 
             if (!result || result.errors?.length || !result.document) {
-                // Never leave an unpublished document staged on a refusal.
-                me.dockModel = committed;
                 return result
             }
 
-            me.dockModel = result.document
+            // Awaited: the seam reads the committed `dockModel`, and only the direct path assigns it
+            // synchronously. Under a Group the publish is a pending transaction, so an unawaited step
+            // 2 reduces against a document step 1 has not reached.
+            await me.onDockZoneDocumentChange(result.document, descriptor, tabContainer)
         }
-
-        // Load-bearing: the Group branch is entered only while `document !== me.dockModel`, so a
-        // staged field equal to the result would route the commit down the direct path.
-        me.dockModel = committed;
-        me.onDockZoneDocumentChange(result.document, descriptors, tabContainer);
 
         return result
     }
@@ -2186,33 +2184,24 @@ class Workspace extends Container {
      * in THIS closure, so they are consumed by exactly one projection.
      * @param {Object|null} document The committed dock-zone document; `null` clears the workspace
      *     toward the empty projection.
-     * @param {Object|Object[]|null} [descriptor=null] The semantic operation that produced
-     *     `document`, or the ordered operations of one multi-step sequence. An array commits as a
-     *     single transaction, which the Group reduces sequentially against its own queue head — so a
-     *     later step sees an earlier one landed, which publishing per step cannot guarantee here.
+     * @param {Object|null} [descriptor=null] The semantic operation that produced `document`.
      * @param {Object|null} [source=null] The committing surface, when it identifies itself.
      * @returns {Promise} The scheduled projection's outcome.
      */
     onDockZoneDocumentChange(document, descriptor=null, source=null) {
-        const me   = this,
-              set  = me.workspaceSet,
-              // A sequence commits as one transaction; the projection is still described by the step
-              // whose effect it presents, which is the last one.
-              descriptors = Array.isArray(descriptor) ? descriptor : descriptor ? [descriptor] : [],
-              primary     = descriptors[descriptors.length - 1] ?? null;
-
+        const me = this, set = me.workspaceSet;
         if (set && me.topologyGroupId && document !== me.dockModel) {
             const manager = Neo.manager.Transaction;
             const workspaceKey = me.workspaceKey ?? set.ids()
                 .find(key => manager.getParticipant(me.topologyGroupId, key)?.componentId === me.id);
             if (!workspaceKey) return Promise.reject(new Error('dock participant not registered'));
-            const pending = descriptors.every(entry => entry?.operation) && descriptors.length
-                ? set.commit(workspaceKey, descriptors, {provenance: {origin: 'human'}})
+            const pending = descriptor?.operation
+                ? set.commit(workspaceKey, [descriptor], {provenance: {origin: 'human'}})
                 : set.write({[workspaceKey]: document}, {cause: 'dock', provenance: {origin: 'human'}});
             pending.catch(error => Neo.logError(error));
             return pending
         }
-        const projection = me.projectDockZoneDocument(document, primary, source);
+        const projection = me.projectDockZoneDocument(document, descriptor, source);
         me.dockModel = document;
         return projection
     }

--- a/src/dashboard/dock/Workspace.mjs
+++ b/src/dashboard/dock/Workspace.mjs
@@ -1779,21 +1779,27 @@ class Workspace extends Container {
     /**
      * Commits the engine-owned pin action — docking design record §2.7's collapse-to-rail sequence.
      *
-     * §2.7 specifies a two-step sequence and forbids a composite operation: `setItemPinned(false)`
-     * when the item is pinned (the model rejects `autoHidden` on a pinned item), then
-     * `setItemAutoHidden(true)`. Each step is an INDEPENDENT commit — reduced through
-     * {@link #applyDockZoneOperation} and published through {@link #onDockZoneDocumentChange} on its
-     * own — so both steps stay visible at the class's own write seam, the one `DockService` and
-     * `DockSplitter` already reach a holder through. Folding them into a single published change
-     * would make step 2 bypass that seam, since the seam reduces against the committed `dockModel`
-     * and step 2 needs step 1's result.
+     * §2.7 specifies a two-step sequence and forbids a composite OPERATION — not a multi-operation
+     * commit: `setItemPinned(false)` when the item is pinned (the model rejects `autoHidden` on a
+     * pinned item), then `setItemAutoHidden(true)`. Each step stays an independent, individually
+     * validated reduction through {@link #applyDockZoneOperation}, so both remain visible at the
+     * class's own write seam — the one `DockService` and `DockSplitter` already reach a holder
+     * through. What `#18448` changed is only WHEN the result is published.
      *
-     * A step-2 rejection therefore leaves the item unpinned and still visible. That is §2.7's own
-     * intermediate state, which it calls benign, and it is the price of the independence the row
-     * requires; the alternative buys atomicity by making half the gesture unobservable.
+     * The sequence used to publish after every step, on the premise that publishing assigns
+     * `dockModel` synchronously so the next step could reduce against it. That is true of the direct
+     * path and FALSE under a topology Group, which returns `pending` and advances the field later
+     * inside adopt. Step 2 then reduced against a document where step 1 had not landed, and the model
+     * refused it — silently, because a refusal is a returned `errors` array nobody surfaces.
      *
-     * An UNPINNED item — the ordinary case — is a single step and a single refresh; only collapsing a
-     * pinned pane commits twice.
+     * So the reduction is staged locally — `dockModel` advanced between steps — and published ONCE
+     * with the ordered descriptors. The field is advanced rather than passed as an argument because
+     * this reducer is a consumer-overridable seam whose implementations read `this.dockModel`; an
+     * argument would reach only the implementations that opted in. On refusal the staged field is
+     * restored, so no unpublished document is ever left behind.
+     *
+     * An UNPINNED item — the ordinary case — is a single step and a single publish; only collapsing a
+     * pinned pane reduces twice.
      *
      * **Eligibility is re-derived here, from the current document, and not inherited from the chrome
      * that emitted the intent.** The pin action's binding ({@link Neo.dashboard.dock.projection.HeaderActionPolicy#createActionBindings}) hides it wherever no edge owns the

--- a/src/dashboard/dock/Workspace.mjs
+++ b/src/dashboard/dock/Workspace.mjs
@@ -1809,7 +1809,8 @@ class Workspace extends Container {
      * @param {Object} data
      * @param {String} data.dockNodeId
      * @param {Neo.tab.Container} data.tabContainer
-     * @returns {{document:Object,errors:String[]}|null}
+     * @returns {Promise<{document:Object,errors:String[]}|null>} Resolves; never rejects — a failed
+     *     commit is returned as `errors`, because the caller is a listener slot with no rejection seam.
      * @protected
      */
     async handleDockPinAction({dockNodeId, tabContainer}={}) {
@@ -1836,17 +1837,27 @@ class Workspace extends Container {
 
         descriptors.push({operation: 'setItemAutoHidden', itemId, autoHidden: true});
 
-        for (const descriptor of descriptors) {
-            result = me.applyDockZoneOperation(descriptor);
+        // The catch converts a failure into this method's own `{document, errors}` contract rather
+        // than propagating it. Awaiting introduces that obligation: the only caller is a component
+        // listener slot — `LayoutAdapter` wires `headerAction` straight to it — so there is nowhere
+        // above to attach a rejection handler, and an escaping rejection would be unhandled. It is
+        // deliberately not re-logged; the Group branch already routes to `Neo.logError`, so what
+        // changes here is the shape of the failure, never whether it is reported.
+        try {
+            for (const descriptor of descriptors) {
+                result = me.applyDockZoneOperation(descriptor);
 
-            if (!result || result.errors?.length || !result.document) {
-                return result
+                if (!result || result.errors?.length || !result.document) {
+                    return result
+                }
+
+                // Awaited: the seam reads the committed `dockModel`, and only the direct path assigns
+                // it synchronously. Under a Group the publish is a pending transaction, so an
+                // unawaited step 2 reduces against a document step 1 has not reached.
+                await me.onDockZoneDocumentChange(result.document, descriptor, tabContainer)
             }
-
-            // Awaited: the seam reads the committed `dockModel`, and only the direct path assigns it
-            // synchronously. Under a Group the publish is a pending transaction, so an unawaited step
-            // 2 reduces against a document step 1 has not reached.
-            await me.onDockZoneDocumentChange(result.document, descriptor, tabContainer)
+        } catch (error) {
+            return {document: me.dockModel, errors: [error.message]}
         }
 
         return result

--- a/src/dashboard/dock/Workspace.mjs
+++ b/src/dashboard/dock/Workspace.mjs
@@ -1512,11 +1512,12 @@ class Workspace extends Container {
      * Routing lives here and the effect lives in one handler per action, so a further engine action is
      * a new handler plus a row below rather than another branch grown into this method.
      *
-     * **`pop-out` is the one asynchronous row**, because vessel admission is: it returns the
-     * settlement as a Promise of the same `{document, errors}` envelope the synchronous rows return,
-     * never a bare Boolean. The projection wire discards this return, so the shape is a contract for
-     * a subclass or a direct caller rather than for the button — which is exactly why it must not
-     * quietly differ per action.
+     * **`pop-out` and `pin` are the asynchronous rows.** `pop-out` because vessel admission is;
+     * `pin` because its collapse sequence awaits each step's commit before reducing the next. Both
+     * return the settlement as a Promise of the same `{document, errors}` envelope the synchronous
+     * rows return, never a bare Boolean, and neither rejects. The projection wire discards this
+     * return, so the shape is a contract for a subclass or a direct caller rather than for the
+     * button — which is exactly why it must not quietly differ per action.
      * @param {Object} data
      * @param {String} data.action
      * @param {String} data.dockNodeId
@@ -1857,7 +1858,11 @@ class Workspace extends Container {
                 await me.onDockZoneDocumentChange(result.document, descriptor, tabContainer)
             }
         } catch (error) {
-            return {document: me.dockModel, errors: [error.message]}
+            // `error?.message ?? String(error)` rather than `error.message`: a rejection value is not
+            // required to be an Error. `Promise.reject(null)` would make the property read throw
+            // INSIDE this catch, and that throw escapes the method — reintroducing the exact
+            // unhandled rejection this block exists to prevent, in the one path nothing else covers.
+            return {document: me.dockModel, errors: [error?.message ?? String(error)]}
         }
 
         return result

--- a/src/dashboard/dock/Workspace.mjs
+++ b/src/dashboard/dock/Workspace.mjs
@@ -537,8 +537,11 @@ class Workspace extends Container {
     /**
      * The pure reducer of the holder contract: applies one semantic operation descriptor against
      * the live committed document and returns `model.Operations`' fail-closed `{document, errors}`
-     * result. Never mutates {@link #dockModel} — the view-sync {@link #onDockZoneDocumentChange}
-     * is the only writer, called by the committing surface on success.
+     * result. Never mutates {@link #dockModel}: the view-sync {@link #onDockZoneDocumentChange} is
+     * its writer, called by the committing surface on success. One exception, and it is bounded —
+     * a multi-step sequence stages the field between its own steps so each reduces against the last
+     * (every implementation of this reducer reads `this.dockModel`, so staging is what reaches an
+     * override), and restores it before publishing.
      * @param {Object} descriptor The semantic operation descriptor.
      * @returns {{document: Object, errors: String[]}}
      */
@@ -1822,7 +1825,8 @@ class Workspace extends Container {
             return {document: me.dockModel, errors: ['Dock pin action requires an item owned by an edge zone']}
         }
 
-        let descriptors = [],
+        let committed   = me.dockModel,
+            descriptors = [],
             result      = null;
 
         me.dockModel.items?.[itemId]?.pinned === true &&
@@ -1830,17 +1834,34 @@ class Workspace extends Container {
 
         descriptors.push({operation: 'setItemAutoHidden', itemId, autoHidden: true});
 
+        // §2.7 forbids a composite OPERATION, not a multi-operation commit: each step below stays an
+        // independent, individually validated `Operations` call. The sequence used to publish after
+        // every step, on the premise that publishing assigns `dockModel` synchronously — true of the
+        // direct path, false under a Group, which returns `pending` and advances the field later
+        // inside adopt. Step 2 then reduced against a document where step 1 had not landed and was
+        // refused, silently, because the refusal is a returned `errors` array nobody surfaces.
+        //
+        // So the reduction is staged locally and published ONCE. The field is advanced between steps
+        // rather than threaded as an argument, because the reducer is a consumer-overridable seam and
+        // every implementation of it reads `this.dockModel`; an argument would reach only the ones
+        // that opted in.
         for (const descriptor of descriptors) {
             result = me.applyDockZoneOperation(descriptor);
 
             if (!result || result.errors?.length || !result.document) {
+                // Never leave an unpublished document staged on a refusal.
+                me.dockModel = committed;
                 return result
             }
 
-            // Publishing here is what lets the NEXT step reduce against this one: the seam reads the
-            // committed `dockModel`, and this assigns it synchronously before the refresh is chained.
-            me.onDockZoneDocumentChange(result.document, descriptor, tabContainer)
+            me.dockModel = result.document
         }
+
+        // Restoring before publishing is load-bearing, not tidiness: `onDockZoneDocumentChange`
+        // enters its Group branch only while `document !== me.dockModel`, so a staged field that
+        // already equals the result would route the commit down the direct path instead.
+        me.dockModel = committed;
+        me.onDockZoneDocumentChange(result.document, descriptors, tabContainer);
 
         return result
     }
@@ -2177,24 +2198,33 @@ class Workspace extends Container {
      * in THIS closure, so they are consumed by exactly one projection.
      * @param {Object|null} document The committed dock-zone document; `null` clears the workspace
      *     toward the empty projection.
-     * @param {Object|null} [descriptor=null] The semantic operation that produced `document`.
+     * @param {Object|Object[]|null} [descriptor=null] The semantic operation that produced
+     *     `document`, or the ordered operations of one multi-step sequence. An array commits as a
+     *     single transaction, which the Group reduces sequentially against its own queue head — so a
+     *     later step sees an earlier one landed, which publishing per step cannot guarantee here.
      * @param {Object|null} [source=null] The committing surface, when it identifies itself.
      * @returns {Promise} The scheduled projection's outcome.
      */
     onDockZoneDocumentChange(document, descriptor=null, source=null) {
-        const me = this, set = me.workspaceSet;
+        const me   = this,
+              set  = me.workspaceSet,
+              // A sequence commits as one transaction; the projection is still described by the step
+              // whose effect it presents, which is the last one.
+              descriptors = Array.isArray(descriptor) ? descriptor : descriptor ? [descriptor] : [],
+              primary     = descriptors[descriptors.length - 1] ?? null;
+
         if (set && me.topologyGroupId && document !== me.dockModel) {
             const manager = Neo.manager.Transaction;
             const workspaceKey = me.workspaceKey ?? set.ids()
                 .find(key => manager.getParticipant(me.topologyGroupId, key)?.componentId === me.id);
             if (!workspaceKey) return Promise.reject(new Error('dock participant not registered'));
-            const pending = descriptor?.operation
-                ? set.commit(workspaceKey, [descriptor], {provenance: {origin: 'human'}})
+            const pending = descriptors.every(entry => entry?.operation) && descriptors.length
+                ? set.commit(workspaceKey, descriptors, {provenance: {origin: 'human'}})
                 : set.write({[workspaceKey]: document}, {cause: 'dock', provenance: {origin: 'human'}});
             pending.catch(error => Neo.logError(error));
             return pending
         }
-        const projection = me.projectDockZoneDocument(document, descriptor, source);
+        const projection = me.projectDockZoneDocument(document, primary, source);
         me.dockModel = document;
         return projection
     }

--- a/src/dashboard/dock/Workspace.mjs
+++ b/src/dashboard/dock/Workspace.mjs
@@ -1782,21 +1782,15 @@ class Workspace extends Container {
      * §2.7 specifies a two-step sequence and forbids a composite OPERATION — not a multi-operation
      * commit: `setItemPinned(false)` when the item is pinned (the model rejects `autoHidden` on a
      * pinned item), then `setItemAutoHidden(true)`. Each step stays an independent, individually
-     * validated reduction through {@link #applyDockZoneOperation}, so both remain visible at the
-     * class's own write seam — the one `DockService` and `DockSplitter` already reach a holder
-     * through. What `#18448` changed is only WHEN the result is published.
+     * validated reduction through {@link #applyDockZoneOperation}.
      *
-     * The sequence used to publish after every step, on the premise that publishing assigns
-     * `dockModel` synchronously so the next step could reduce against it. That is true of the direct
-     * path and FALSE under a topology Group, which returns `pending` and advances the field later
-     * inside adopt. Step 2 then reduced against a document where step 1 had not landed, and the model
-     * refused it — silently, because a refusal is a returned `errors` array nobody surfaces.
-     *
-     * So the reduction is staged locally — `dockModel` advanced between steps — and published ONCE
-     * with the ordered descriptors. The field is advanced rather than passed as an argument because
-     * this reducer is a consumer-overridable seam whose implementations read `this.dockModel`; an
-     * argument would reach only the implementations that opted in. On refusal the staged field is
-     * restored, so no unpublished document is ever left behind.
+     * The reduction is staged locally — `dockModel` advanced between steps — and published ONCE with
+     * the ordered descriptors. Publishing per step would not do: only the direct path assigns
+     * `dockModel` synchronously, while a topology Group returns `pending` and advances the field
+     * later, so step 2 would reduce against a document step 1 had not reached. The field is advanced
+     * rather than passed as an argument because this reducer is a consumer-overridable seam whose
+     * implementations read `this.dockModel`; an argument would reach only those that opted in. On
+     * refusal the staged field is restored, so no unpublished document is left behind.
      *
      * An UNPINNED item — the ordinary case — is a single step and a single publish; only collapsing a
      * pinned pane reduces twice.
@@ -1840,17 +1834,6 @@ class Workspace extends Container {
 
         descriptors.push({operation: 'setItemAutoHidden', itemId, autoHidden: true});
 
-        // §2.7 forbids a composite OPERATION, not a multi-operation commit: each step below stays an
-        // independent, individually validated `Operations` call. The sequence used to publish after
-        // every step, on the premise that publishing assigns `dockModel` synchronously — true of the
-        // direct path, false under a Group, which returns `pending` and advances the field later
-        // inside adopt. Step 2 then reduced against a document where step 1 had not landed and was
-        // refused, silently, because the refusal is a returned `errors` array nobody surfaces.
-        //
-        // So the reduction is staged locally and published ONCE. The field is advanced between steps
-        // rather than threaded as an argument, because the reducer is a consumer-overridable seam and
-        // every implementation of it reads `this.dockModel`; an argument would reach only the ones
-        // that opted in.
         for (const descriptor of descriptors) {
             result = me.applyDockZoneOperation(descriptor);
 
@@ -1863,9 +1846,8 @@ class Workspace extends Container {
             me.dockModel = result.document
         }
 
-        // Restoring before publishing is load-bearing, not tidiness: `onDockZoneDocumentChange`
-        // enters its Group branch only while `document !== me.dockModel`, so a staged field that
-        // already equals the result would route the commit down the direct path instead.
+        // Load-bearing: the Group branch is entered only while `document !== me.dockModel`, so a
+        // staged field equal to the result would route the commit down the direct path.
         me.dockModel = committed;
         me.onDockZoneDocumentChange(result.document, descriptors, tabContainer);
 

--- a/test/playwright/unit/dashboard/DockPinAction.spec.mjs
+++ b/test/playwright/unit/dashboard/DockPinAction.spec.mjs
@@ -20,10 +20,10 @@ import '../../../../src/tab/Container.mjs';
 /**
  * @summary A committed document whose `inspector` item is PINNED and owned by the `right` edge.
  *
- * Both properties are load-bearing for `#18448`. Edge ownership is what `handleDockPinAction`
- * requires before it will commit at all, and `pinned: true` is what makes the collapse a TWO-step
- * sequence — the model refuses `autoHidden` on a pinned item, so the action must first unpin. A
- * single-step collapse cannot reproduce the defect, because there is no second step to starve.
+ * Both properties are load-bearing. Edge ownership is what `handleDockPinAction` requires before it
+ * will commit at all, and `pinned: true` is what makes the collapse a TWO-step sequence — the model
+ * refuses `autoHidden` on a pinned item, so the action must first unpin. A single-step collapse
+ * cannot exercise the staging at all, because there is no second step to starve.
  * @returns {Object}
  */
 function createDocument() {
@@ -93,7 +93,7 @@ async function collapseInspector(workspace) {
     }
 }
 
-test.describe.serial('Dock pin action (#18448)', () => {
+test.describe.serial('Dock pin action', () => {
     let groupId, set;
 
     test.beforeEach(() => {

--- a/test/playwright/unit/dashboard/DockPinAction.spec.mjs
+++ b/test/playwright/unit/dashboard/DockPinAction.spec.mjs
@@ -66,31 +66,16 @@ PinWorkspace = Neo.setupClass(PinWorkspace);
 /**
  * @summary Resolves the projected `inspector-tabs` container and collapses it through the real action.
  *
- * `handleDockPinAction` publishes but does not RETURN the publish — under a Group that publish is a
- * pending transaction, so an assertion made straight after the call would read the document before
- * the Group has adopted it and would pass or fail on timing rather than on the fix. The pass-through
- * below captures that promise without altering what the action does.
+ * The action is async because it awaits each step's publish before reducing the next — under a Group
+ * that publish is a pending transaction. Awaiting the call is therefore sufficient; no seam has to be
+ * wrapped to observe the settled document.
  * @param {Neo.dashboard.dock.Workspace} workspace
  * @returns {Promise<{document:Object,errors:String[]}|null>}
  */
-async function collapseInspector(workspace) {
-    const tabContainer = Reconciler.collectProjectedTabs(workspace.items[0]).get('inspector-tabs'),
-          original     = workspace.onDockZoneDocumentChange;
+function collapseInspector(workspace) {
+    const tabContainer = Reconciler.collectProjectedTabs(workspace.items[0]).get('inspector-tabs');
 
-    let published = null;
-
-    workspace.onDockZoneDocumentChange = function(...args) {
-        published = original.apply(this, args);
-        return published
-    };
-
-    try {
-        const result = workspace.handleDockPinAction({dockNodeId: 'inspector-tabs', tabContainer});
-        await published;
-        return result
-    } finally {
-        delete workspace.onDockZoneDocumentChange
-    }
+    return workspace.handleDockPinAction({dockNodeId: 'inspector-tabs', tabContainer})
 }
 
 test.describe.serial('Dock pin action', () => {
@@ -192,7 +177,7 @@ test.describe.serial('Dock pin action', () => {
 
         try {
             const tabContainer = Reconciler.collectProjectedTabs(workspace.items[0]).get('center-tabs'),
-                  result       = workspace.handleDockPinAction({dockNodeId: 'center-tabs', tabContainer});
+                  result       = await workspace.handleDockPinAction({dockNodeId: 'center-tabs', tabContainer});
 
             expect(result.errors).toEqual(['Dock pin action requires an item owned by an edge zone']);
             expect(workspace.dockModel).toEqual(before)

--- a/test/playwright/unit/dashboard/DockPinAction.spec.mjs
+++ b/test/playwright/unit/dashboard/DockPinAction.spec.mjs
@@ -169,6 +169,31 @@ test.describe.serial('Dock pin action', () => {
         }
     });
 
+    test('a rejected commit comes back as errors — the handler resolves, never rejects', async () => {
+        // The await introduced this obligation: the sole caller is a component listener slot with
+        // nowhere to attach a rejection handler, so an escaping rejection would be unhandled. This
+        // arm is what makes the docblock's "never rejects" a checked property rather than a promise
+        // in prose — if the handler propagated, the `await` below would throw and fail the test.
+        const workspace = Neo.create(PinWorkspace, {
+            dockModel: createDocument(), topologyGroupId: groupId, workspaceKey: 'main', workspaceSet: set
+        });
+
+        set.register('main', {
+            componentId: workspace.id,
+            getDocument: () => workspace.dockModel,
+            setDocument: () => { throw new Error('commit refused by the holder') }
+        });
+
+        try {
+            const result = await collapseInspector(workspace);
+
+            expect(result, 'a refused commit still returns the contract shape').toBeTruthy();
+            expect(result.errors.join(' '), 'and carries the refusal').toContain('commit refused by the holder')
+        } finally {
+            workspace.destroy()
+        }
+    });
+
     test('an item no edge owns is refused, and the committed document is untouched', async () => {
         // `center` sits in the root centre, which §2.7 forbids collapsing. The guard is what keeps a
         // stale-but-still-dispatchable header action from committing, so it is worth its own arm.

--- a/test/playwright/unit/dashboard/DockPinAction.spec.mjs
+++ b/test/playwright/unit/dashboard/DockPinAction.spec.mjs
@@ -86,7 +86,12 @@ test.describe.serial('Dock pin action', () => {
         set     = Neo.create(WorkspaceSet, {manager: TransactionManager, getGroupId: () => groupId, documentModel: WorkspaceDocument})
     });
 
-    test.afterEach(() => TransactionManager.retireGroup(groupId));
+    test.afterEach(() => {
+        // The set is a registered class instance since the adapter conversion, so retiring the Group
+        // no longer disposes it — an un-destroyed participant survives into the next arm's registry.
+        set.destroy();
+        TransactionManager.retireGroup(groupId)
+    });
 
     test('the two-step collapse reaches autoHidden under a registered Group participant', async () => {
         const workspace = Neo.create(PinWorkspace, {
@@ -189,6 +194,39 @@ test.describe.serial('Dock pin action', () => {
 
             expect(result, 'a refused commit still returns the contract shape').toBeTruthy();
             expect(result.errors.join(' '), 'and carries the refusal').toContain('commit refused by the holder')
+        } finally {
+            workspace.destroy()
+        }
+    });
+
+    test('a NON-Error rejection also comes back as errors, not a crash inside the catch', async () => {
+        // The sibling arm above rejects with an Error, so it witnesses only the Error case — the
+        // property the control itself has. Reading `.message` off `null` throws INSIDE the catch,
+        // which escapes the method and reintroduces the unhandled rejection the catch exists to
+        // prevent. @neo-gpt-emmy found it against the previous head.
+        //
+        // The rejection is injected AT THE SEAM rather than through a holder, and that is the whole
+        // point of the arm: a holder that throws `null` is wrapped into an Error by the transaction
+        // machinery long before this catch sees it, so a holder-based version passes on the broken
+        // source and proves nothing. It was written that way first and measured green against the
+        // defect, which is what sent me looking for the real path.
+        const workspace = Neo.create(PinWorkspace, {
+            dockModel: createDocument(), topologyGroupId: groupId, workspaceKey: 'main', workspaceSet: set
+        });
+
+        set.register('main', {
+            componentId: workspace.id,
+            getDocument: () => workspace.dockModel,
+            setDocument: value => workspace.dockModel = value
+        });
+
+        workspace.onDockZoneDocumentChange = () => Promise.reject(null);
+
+        try {
+            const result = await collapseInspector(workspace);
+
+            expect(result, 'a null rejection still returns the contract shape').toBeTruthy();
+            expect(result.errors, 'and carries one rendered entry rather than crashing').toEqual(['null'])
         } finally {
             workspace.destroy()
         }

--- a/test/playwright/unit/dashboard/DockPinAction.spec.mjs
+++ b/test/playwright/unit/dashboard/DockPinAction.spec.mjs
@@ -6,14 +6,14 @@ setup({
     }
 });
 
-import {test, expect}           from '@playwright/test';
-import Neo                      from '../../../../src/Neo.mjs';
-import * as core                from '../../../../src/core/_export.mjs';
-import DockWorkspace            from '../../../../src/dashboard/dock/Workspace.mjs';
-import Reconciler               from '../../../../src/dashboard/dock/projection/Reconciler.mjs';
-import TransactionManager       from '../../../../src/manager/Transaction.mjs';
-import WorkspaceDocument        from '../../../../src/dashboard/dock/model/WorkspaceDocument.mjs';
-import {createDockWorkspaceSet} from '../../../../src/dashboard/dock/window/WorkspaceSet.mjs';
+import {test, expect}     from '@playwright/test';
+import Neo                from '../../../../src/Neo.mjs';
+import * as core          from '../../../../src/core/_export.mjs';
+import DockWorkspace      from '../../../../src/dashboard/dock/Workspace.mjs';
+import Reconciler         from '../../../../src/dashboard/dock/projection/Reconciler.mjs';
+import TransactionManager from '../../../../src/manager/Transaction.mjs';
+import WorkspaceDocument  from '../../../../src/dashboard/dock/model/WorkspaceDocument.mjs';
+import WorkspaceSet       from '../../../../src/dashboard/dock/window/WorkspaceSet.mjs';
 import '../../../../src/manager/Instance.mjs';
 import '../../../../src/tab/Container.mjs';
 
@@ -98,7 +98,7 @@ test.describe.serial('Dock pin action', () => {
 
     test.beforeEach(() => {
         groupId = TransactionManager.bind({windowId: 'dock-pin-action-root', workspaceKey: 'main'}).groupId;
-        set     = createDockWorkspaceSet({manager: TransactionManager, getGroupId: () => groupId, documentModel: WorkspaceDocument})
+        set     = Neo.create(WorkspaceSet, {manager: TransactionManager, getGroupId: () => groupId, documentModel: WorkspaceDocument})
     });
 
     test.afterEach(() => TransactionManager.retireGroup(groupId));

--- a/test/playwright/unit/dashboard/DockPinAction.spec.mjs
+++ b/test/playwright/unit/dashboard/DockPinAction.spec.mjs
@@ -1,0 +1,203 @@
+import {setup} from '../../setup.mjs';
+
+setup({
+    appConfig: {
+        name: 'NeoDashboardDockPinActionTest'
+    }
+});
+
+import {test, expect}           from '@playwright/test';
+import Neo                      from '../../../../src/Neo.mjs';
+import * as core                from '../../../../src/core/_export.mjs';
+import DockWorkspace            from '../../../../src/dashboard/dock/Workspace.mjs';
+import Reconciler               from '../../../../src/dashboard/dock/projection/Reconciler.mjs';
+import TransactionManager       from '../../../../src/manager/Transaction.mjs';
+import WorkspaceDocument        from '../../../../src/dashboard/dock/model/WorkspaceDocument.mjs';
+import {createDockWorkspaceSet} from '../../../../src/dashboard/dock/window/WorkspaceSet.mjs';
+import '../../../../src/manager/Instance.mjs';
+import '../../../../src/tab/Container.mjs';
+
+/**
+ * @summary A committed document whose `inspector` item is PINNED and owned by the `right` edge.
+ *
+ * Both properties are load-bearing for `#18448`. Edge ownership is what `handleDockPinAction`
+ * requires before it will commit at all, and `pinned: true` is what makes the collapse a TWO-step
+ * sequence — the model refuses `autoHidden` on a pinned item, so the action must first unpin. A
+ * single-step collapse cannot reproduce the defect, because there is no second step to starve.
+ * @returns {Object}
+ */
+function createDocument() {
+    return {
+        schema: 'neo.dock.zone.v1',
+        root  : 'root',
+        items : {
+            center   : {componentRef: 'Center',    title: 'Center',    kind: 'panel'},
+            inspector: {componentRef: 'Inspector', title: 'Inspector', kind: 'panel', pinned: true}
+        },
+        nodes: {
+            root: {
+                type : 'edge-zone',
+                zones: {
+                    center: {nodeId: 'center-tabs'},
+                    right : {nodeId: 'inspector-tabs', extent: 0.25, resizable: true}
+                }
+            },
+            'center-tabs'   : {type: 'tabs', items: ['center'],    activeItemId: 'center'},
+            'inspector-tabs': {type: 'tabs', items: ['inspector'], activeItemId: 'inspector'}
+        }
+    }
+}
+
+/** @summary Workspace fixture that mounts the real projected tab composition once. */
+class PinWorkspace extends DockWorkspace {
+    static config = {
+        className: 'Test.Unit.Dashboard.DockPinAction.Workspace',
+        layout   : {ntype: 'vbox', align: 'stretch'}
+    }
+
+    construct(config) {
+        super.construct(config);
+        this.add(this.projectDockModel())
+    }
+}
+
+PinWorkspace = Neo.setupClass(PinWorkspace);
+
+/**
+ * @summary Resolves the projected `inspector-tabs` container and collapses it through the real action.
+ *
+ * `handleDockPinAction` publishes but does not RETURN the publish — under a Group that publish is a
+ * pending transaction, so an assertion made straight after the call would read the document before
+ * the Group has adopted it and would pass or fail on timing rather than on the fix. The pass-through
+ * below captures that promise without altering what the action does.
+ * @param {Neo.dashboard.dock.Workspace} workspace
+ * @returns {Promise<{document:Object,errors:String[]}|null>}
+ */
+async function collapseInspector(workspace) {
+    const tabContainer = Reconciler.collectProjectedTabs(workspace.items[0]).get('inspector-tabs'),
+          original     = workspace.onDockZoneDocumentChange;
+
+    let published = null;
+
+    workspace.onDockZoneDocumentChange = function(...args) {
+        published = original.apply(this, args);
+        return published
+    };
+
+    try {
+        const result = workspace.handleDockPinAction({dockNodeId: 'inspector-tabs', tabContainer});
+        await published;
+        return result
+    } finally {
+        delete workspace.onDockZoneDocumentChange
+    }
+}
+
+test.describe.serial('Dock pin action (#18448)', () => {
+    let groupId, set;
+
+    test.beforeEach(() => {
+        groupId = TransactionManager.bind({windowId: 'dock-pin-action-root', workspaceKey: 'main'}).groupId;
+        set     = createDockWorkspaceSet({manager: TransactionManager, getGroupId: () => groupId, documentModel: WorkspaceDocument})
+    });
+
+    test.afterEach(() => TransactionManager.retireGroup(groupId));
+
+    test('the two-step collapse reaches autoHidden under a registered Group participant', async () => {
+        const workspace = Neo.create(PinWorkspace, {
+            dockModel: createDocument(), topologyGroupId: groupId, workspaceKey: 'main', workspaceSet: set
+        });
+
+        set.register('main', {
+            componentId: workspace.id,
+            getDocument: () => workspace.dockModel,
+            setDocument: value => workspace.dockModel = value
+        });
+
+        try {
+            await collapseInspector(workspace);
+
+            // The whole ticket, in two assertions. Step 1 unpins; step 2 auto-hides. Before the fix,
+            // step 1's publish returned `pending` without advancing `dockModel`, so step 2 reduced
+            // against a document where `inspector` was STILL pinned — and the model refuses
+            // `autoHidden` on a pinned item. `pinned` therefore landed and `autoHidden` did not,
+            // which is precisely the half-applied gesture this arm pins down.
+            const committed = set.getDocument('main');
+
+            expect(committed.items.inspector.pinned,     'step 1 must land').toBe(false);
+            expect(committed.items.inspector.autoHidden, 'step 2 must land — this is the defect').toBe(true)
+        } finally {
+            workspace.destroy()
+        }
+    });
+
+    test('pin, restore, pin again — the SECOND collapse also reaches autoHidden', async () => {
+        const workspace = Neo.create(PinWorkspace, {
+            dockModel: createDocument(), topologyGroupId: groupId, workspaceKey: 'main', workspaceSet: set
+        });
+
+        set.register('main', {
+            componentId: workspace.id,
+            getDocument: () => workspace.dockModel,
+            setDocument: value => workspace.dockModel = value
+        });
+
+        try {
+            await collapseInspector(workspace);
+            expect(set.getDocument('main').items.inspector.autoHidden, 'first collapse').toBe(true);
+
+            // Restore to the pinned, visible state so the next collapse is a two-step sequence again
+            // rather than the single-step path an already-unpinned item would take.
+            const restored = workspace.applyDockZoneOperation({operation: 'setItemAutoHidden', itemId: 'inspector', autoHidden: false});
+            expect(restored.errors).toEqual([]);
+            await workspace.onDockZoneDocumentChange(restored.document, {operation: 'setItemAutoHidden', itemId: 'inspector', autoHidden: false});
+
+            const repinned = workspace.applyDockZoneOperation({operation: 'setItemPinned', itemId: 'inspector', pinned: true});
+            expect(repinned.errors).toEqual([]);
+            await workspace.onDockZoneDocumentChange(repinned.document, {operation: 'setItemPinned', itemId: 'inspector', pinned: true});
+            expect(set.getDocument('main').items.inspector.pinned, 'restore must re-pin').toBe(true);
+
+            await collapseInspector(workspace);
+
+            const committed = set.getDocument('main');
+
+            expect(committed.items.inspector.pinned,     'second collapse, step 1').toBe(false);
+            expect(committed.items.inspector.autoHidden, 'second collapse, step 2').toBe(true)
+        } finally {
+            workspace.destroy()
+        }
+    });
+
+    test('the direct path — no Group participant — is unchanged', async () => {
+        // The fix must not trade one path for the other. This workspace has neither `workspaceSet`
+        // nor `topologyGroupId`, so `onDockZoneDocumentChange` takes its synchronous branch and
+        // `dockModel` is assigned directly. It passed before the fix and must keep passing.
+        const workspace = Neo.create(PinWorkspace, {dockModel: createDocument()});
+
+        try {
+            await collapseInspector(workspace);
+
+            expect(workspace.dockModel.items.inspector.pinned,     'step 1 on the direct path').toBe(false);
+            expect(workspace.dockModel.items.inspector.autoHidden, 'step 2 on the direct path').toBe(true)
+        } finally {
+            workspace.destroy()
+        }
+    });
+
+    test('an item no edge owns is refused, and the committed document is untouched', async () => {
+        // `center` sits in the root centre, which §2.7 forbids collapsing. The guard is what keeps a
+        // stale-but-still-dispatchable header action from committing, so it is worth its own arm.
+        const workspace = Neo.create(PinWorkspace, {dockModel: createDocument()}),
+              before    = WorkspaceDocument.clone(workspace.dockModel);
+
+        try {
+            const tabContainer = Reconciler.collectProjectedTabs(workspace.items[0]).get('center-tabs'),
+                  result       = workspace.handleDockPinAction({dockNodeId: 'center-tabs', tabContainer});
+
+            expect(result.errors).toEqual(['Dock pin action requires an item owned by an edge zone']);
+            expect(workspace.dockModel).toEqual(before)
+        } finally {
+            workspace.destroy()
+        }
+    });
+});

--- a/test/playwright/unit/dashboard/DockWorkspace.spec.mjs
+++ b/test/playwright/unit/dashboard/DockWorkspace.spec.mjs
@@ -2340,7 +2340,7 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
 
         // And the refusal holds if the intent is dispatched anyway — the model is the authority, not
         // the hidden flag, which a host could always bypass.
-        const refused = workspace.onDockHeaderAction({
+        const refused = await workspace.onDockHeaderAction({
             action: 'pin', dockNodeId: 'inspector-tabs', tabContainer: inspector
         });
 
@@ -2460,7 +2460,7 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
             .toEqual({...before.dockZone, items: null})
     });
 
-    test('the pin action reports its own missing preconditions, and stays inert while its opt-in is off', () => {
+    test('the pin action reports its own missing preconditions, and stays inert while its opt-in is off', async () => {
         workspace = Neo.create(PlainWorkspace, {
             dockModel          : createEdgeDocument(),
             enableDockPinAction: true
@@ -2470,13 +2470,13 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
 
         workspace.dockModel = null;
 
-        expect(workspace.onDockHeaderAction({
+        expect((await workspace.onDockHeaderAction({
             action: 'pin', dockNodeId: 'inspector-tabs', tabContainer: inspector
-        }).errors).toEqual(['Dock pin action requires a committed document']);
+        })).errors).toEqual(['Dock pin action requires a committed document']);
 
         workspace.dockModel = createEdgeDocument();
 
-        expect(workspace.onDockHeaderAction({action: 'pin', dockNodeId: 'inspector-tabs'}).errors)
+        expect((await workspace.onDockHeaderAction({action: 'pin', dockNodeId: 'inspector-tabs'})).errors)
             .toEqual(['Dock pin action requires an active item']);
 
         // With the opt-in off the name belongs to the host again: the intent is re-emitted, not acted
@@ -2581,7 +2581,7 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
             .toBe(null);
         expect(pinAction.hidden, 'the retained action refuses at the commit boundary').toBe(true);
 
-        const refused = workspace.onDockHeaderAction({
+        const refused = await workspace.onDockHeaderAction({
             action: 'pin', dockNodeId: 'inspector-tabs', tabContainer: inspector
         });
 


### PR DESCRIPTION
Resolves #18448

The pin sequence now **awaits each step's publish** before reducing the next. Only the direct path assigns `dockModel` synchronously; a topology Group returns a pending transaction and advances the field later inside adopt, so step 2 was reducing against a document step 1 had not reached, and the model refused it.

size-guard-growth: src/dashboard/dock/Workspace.mjs — +4 code lines, all of them the try/catch that keeps the newly-async handler from ever rejecting. Awaiting created that obligation and this PR discharges it rather than deferring it; no consumer lines come out because this repairs an existing path.

Evidence: L2 (six unit arms, each measured per-arm in isolation against `origin/dev`) → L2 required by AC-1, AC-2, AC-3. AC-5 and AC-6 carry independent reviewer evidence, cited below. Residual: none.

## Decision Record impact

**`aligned-with` ADR 0029** — `learn/agentos/decisions/0029-docking-design.md:414`, the collapse row.

Stated rather than assumed, because an earlier revision of this branch got it wrong. That revision **staged the reduction and published once with an ordered pair**, contradicting the row's *"Each step commits independently"* clause while carrying no Decision Record declaration at all. @neo-gpt-emmy caught it as an authority correction; @neo-opus-vega independently retracted the same prescription, which was his. Awaiting preserves **both** properties the row requires — independent commits, specified order — so no amendment is needed.

## AC Evidence
| AC-1 | `DockPinAction.spec.mjs` — pin → restore → pin under a registered Group participant, asserting the second collapse reaches `autoHidden`. **Fails on `origin/dev`** |
| AC-2 | the two-step collapse reaches `autoHidden` under a participant. On dev, `pinned` lands and `autoHidden` returns `undefined` — step 1 applied, step 2 refused |
| AC-3 | the direct path with no participant, **passing on dev and after**; the non-edge-owned refusal guard on the same terms |
| AC-4 | **RETIRED upstream by @neo-opus-vega** — the AC named its own mechanism (*"under candidate 2 this is structural — the transaction `throw`s"*) and excluded the alternative (*"not that instrumentation was added"*), so it was a rider on the withdrawn candidate: unmeetable as written, not unmet. **Its successor #18455 was then retracted too**, and closed not-planned on an operator premise challenge — a projection is a render target whose only input is the committed document, so it learns a refusal by the document *not changing*; wiring it to consume returns would give the view a second way to disagree with the document. **No residual owner, because there is nothing left to own** |
| AC-5 | **behavioural proof by @neo-gpt-emmy** ([IC_kwDODSospM8AAAABTKqD7Q](https://github.com/neomjs/neo/issues/18448#issuecomment-5581210605)) — the real `apps/workstation/view/Workspace.mjs` instantiated with its actual WorkspaceSet registration, reducers and publication seam, edge-owned `feed` primed pinned/visible. Base `01f65aaff6`: **1 publication**, error *item "feed" is pinned and cannot be autoHidden*, final `pinned:false / autoHidden:false`. Reviewed `f6a64fa9df`: **2 publications**, no error, `pinned:false / autoHidden:true`. Projection and active-item selection stubbed — semantic/Group evidence, explicitly not a paint receipt |
| AC-6 | **superseded by a parser, also @neo-gpt-emmy's** — Acorn over tracked `src/`, `apps/` and `examples/`, predicate a direct member-call expression including optional calls, then **actual loop ancestry** and the containing callback/method. **21 calls: 15 engine, 6 consumers.** The pin call is the positive control and **the only lexically loop-enclosed publisher**, awaited at this head. `DockService`'s registered-participant branch awaits `WorkspaceSet.commit`, so TourRunner's awaited operation loop never reaches the fallback |

## Deltas from ticket

**The ticket's candidate 2 (stage locally, publish once) is withdrawn, not implemented.** The delivered fix is `async` + `await` plus the try/catch below.

**And one thing this PR fixes that the ticket did not ask for, because the change itself introduced it.** Awaiting means a rejected commit propagates — and `handleDockPinAction`'s only caller is a component listener slot (`LayoutAdapter.mjs:1344`), so there is nowhere above it to attach a rejection handler. Left alone that would have shipped a new unhandled rejection. @neo-opus-vega refused it as a residual and was right; his #18455 retraction confirms the containment belongs in the handler, because the handler owns its failure when nothing above it structurally can. The handler converts a failure into its own `{document, errors}` contract and is deliberately **not** re-logged: the Group branch already routes to `Neo.logError` (`:2201`), so what changes is the shape of the failure, never whether it is reported.

## Test Evidence

**Red-first, per arm, in isolation** — `describe.serial` skips after the first failure, so a plain run hides later statuses. Measured against `origin/dev` after the rework rather than carried over from the withdrawn candidate:

| arm | against `origin/dev` |
|---|---|
| two-step collapse under a Group participant | **failed** |
| pin → restore → pin, second collapse | **failed** |
| a rejected commit comes back as errors | **failed** |
| a NON-Error rejection comes back as errors | **failed** *(vs the previous head, `fb3fc12ebb`)* |
| direct path, no participant | passed — control |
| non-edge-owned item refused | passed — control |

**Six arms, four red, two controls.** The two passes are the point of the four failures: a change that broke everything would have turned all six red.

**The non-Error arm is the one to read, because its first version was green over a live defect.** @neo-gpt-emmy found that `errors: [error.message]` assumes the rejection value is an Error — `Promise.reject(null)` makes that read throw *inside* the catch, and that throw escapes, reintroducing the unhandled rejection the catch exists to prevent. My first arm for it used a holder that throws `null`, and it **passed against the broken source**: the transaction machinery wraps a holder throw into an Error long before the catch sees it. The rejection is now injected at the seam, which is her actual repro, and it reds. An arm witnesses only the property its own control has.

**AC-6's earlier proximity result is withdrawn, and the correction is worth stating.** I reported 14 call sites, swept with a predicate that looked for a loop keyword within the 18 preceding lines. @neo-gpt-emmy's parse found **21** — the grep undercounted by seven, because it matched nearby text rather than parsing member-call expressions, missed optional calls, and could not read loop *ancestry* at all. My version reached the same conclusion about the pin site, which is exactly why the miss is worth recording: a heuristic that happens to agree is still not the measurement.

`DockWorkspace.spec.mjs` — **104 passed** with the four call sites that read the pin return now awaiting it.

**Blast radius, enumerated rather than discovered in review.** `handleDockPinAction` becoming async changes what `onDockHeaderAction` returns for one of its rows. Its only production consumer, `LayoutAdapter.mjs:1344`, discards the return; `Maximize.mjs:226` handles `maximize` only. Four test sites read the pin return synchronously and now await it, and one enclosing test becomes `async`. Two further sites (`:874`, `:2497`) are untouched **because the opt-in is off there**, so the action never runs.

## Post-Merge Validation

- [ ] Re-confirm the six arms on `dev` once merged — the red-first receipt is measured against `origin/dev` at review time, and it is the arms, not the fix, that carry #18448's evidence forward.

## Commits
- `d66369361e` — withdraw the staged candidate; await each step instead
- `fb3fc12ebb` — convert a rejected commit into the handler's contract, with the arm that witnesses it
- `f6a64fa9df` — a non-Error rejection no longer crashes inside that catch; the router names both async rows; `afterEach` destroys the registered set

Related: #18450 / #18452 · #18446 · #18303 · #18455 (filed and retracted)

Authored by Ada (Claude Opus 5, Claude Code). Session 69ff8d6f-0e9e-4c44-aff9-e8007f4d7090.
