### PR TITLE
refactor(themes): global element typography is structure, so it lives in src (#18232)

### DIFF
--- a/buildScripts/util/check-theme-value-files-baseline.json
+++ b/buildScripts/util/check-theme-value-files-baseline.json
@@ -1,33 +1,8 @@
 [
     {
-        "file": "resources/scss/theme-cyberpunk/Global.scss",
-        "blocks": 1,
-        "reason": "pending #18145 — Global.scss is the sweep last batch; the ticket expects it to graduate to its own ticket."
-    },
-    {
-        "file": "resources/scss/theme-dark/Global.scss",
-        "blocks": 1,
-        "reason": "pending #18145 — Global.scss is the sweep last batch; the ticket expects it to graduate to its own ticket."
-    },
-    {
-        "file": "resources/scss/theme-light/Global.scss",
-        "blocks": 1,
-        "reason": "pending #18145 — Global.scss is the sweep last batch; the ticket expects it to graduate to its own ticket."
-    },
-    {
-        "file": "resources/scss/theme-neo-dark/Global.scss",
-        "blocks": 10,
-        "reason": "pending #18145 — Global.scss is the sweep last batch; the ticket expects it to graduate to its own ticket."
-    },
-    {
         "file": "resources/scss/theme-neo-dark/dialog/Base.scss",
         "blocks": 3,
         "reason": "exempt #18145 — see the neo-light entry; same rule, same blocker."
-    },
-    {
-        "file": "resources/scss/theme-neo-light/Global.scss",
-        "blocks": 10,
-        "reason": "pending #18145 — Global.scss is the sweep last batch; the ticket expects it to graduate to its own ticket."
     },
     {
         "file": "resources/scss/theme-neo-light/dialog/Base.scss",

--- a/resources/scss/src/Global.scss
+++ b/resources/scss/src/Global.scss
@@ -1,5 +1,70 @@
 @use "global/all";
 
+// Global element typography — structure, so it lives here rather than in a theme value file (#18232,
+// batch 5 of #18145). Every declaration reads a token and falls back to `revert`, which is the whole
+// contract: a family that declares the token gets its value, a family that does not gets the UA
+// stylesheet. Three rules govern edits here, all measured on #18232 rather than assumed:
+//
+// 1. `revert`, never `inherit`. UA `h1` is 32px/700 from the UA sheet, NOT by inheritance, so an
+//    `inherit` fallback silently computes 16px/400 — the regression that killed the first attempt.
+// 2. One token per property. `font-weight: var(--shared, revert)` resolving to a length is invalid at
+//    computed-value time, and an invalid substitution does NOT reach the fallback — the property
+//    becomes `unset`, silently. Sharing a token between two properties is therefore a latent bug.
+// 3. A fallback fires on ABSENCE, and inheritance is not absence. A classic theme nested inside a neo
+//    scope inherits the neo tokens and never reaches `revert`, so each classic family must DECLARE
+//    its decline as `--token: initial` at its own scope. This is not hypothetical: the portal's
+//    Helix and Colors previews are `neo-theme-dark` inside a neo-themed document.
+h1, h2, h3 {
+    color         : var(--sem-color-fg-neutral-contrast, revert);
+    font-family   : var(--core-fontfamily-sans, revert);
+    font-weight   : var(--core-fontweight-semibold, revert);
+    letter-spacing: var(--global-heading-letter-spacing, revert);
+    line-height   : var(--core-lineheight-headline, revert);
+}
+
+h1 {font-size: var(--core-fontsize-h1, revert)}
+h2 {font-size: var(--core-fontsize-h2, revert)}
+h3 {font-size: var(--core-fontsize-h3, revert)}
+
+p {
+    color      : var(--global-paragraph-color, revert);
+    font-family: var(--core-fontfamily-sans, revert);
+    font-size  : var(--core-fontsize-body, revert);
+    font-weight: var(--core-fontweight-regular, revert);
+    line-height: var(--core-lineheight-paragraph, revert);
+}
+
+// Matches the UA default, so it needs no token: a family declining it would decline to the same value.
+i, em {
+    font-style: italic;
+}
+
+code:not(.hljs) {
+    background-color: var(--global-code-background-color, revert);
+    border          : var(--global-code-border, revert);
+    border-radius   : var(--global-code-border-radius, revert);
+    color           : var(--sem-color-fg-neutral-contrast, revert);
+    font-family     : var(--core-fontfamily-mono, revert);
+    font-size       : var(--global-code-font-size, revert);
+    font-weight     : var(--core-fontweight-regular, revert);
+    line-height     : var(--core-lineheight-headline, revert);
+    padding         : var(--global-code-padding, revert);
+}
+
+h1, h2, h3, h4, h5, h6 {
+    code:not(.hljs) {
+        color  : var(--global-heading-code-color, revert);
+        margin : var(--global-heading-code-margin, revert);
+        padding: var(--global-heading-code-padding, revert);
+    }
+}
+
+mark {
+    background-color: var(--global-mark-background-color, revert);
+    color           : var(--global-mark-color, revert);
+    padding         : var(--global-mark-padding, revert);
+}
+
 html, .neo-body-viewport {
     align-items    : center;
     display        : flex;

--- a/resources/scss/src/Global.scss
+++ b/resources/scss/src/Global.scss
@@ -44,7 +44,10 @@ code:not(.hljs) {
     border          : var(--global-code-border, revert);
     border-radius   : var(--global-code-border-radius, revert);
     color           : var(--sem-color-fg-neutral-contrast, revert);
-    font-family     : var(--core-fontfamily-mono, revert);
+    // `font-family` is deliberately ABSENT here and owned by util/HighlightJs.scss, which declares it
+    // for all code via `--global-code-font-family`. Declaring it here would outrank that author rule
+    // at (0,1,1) and, for a declining family, resolve to `revert` — rolling back the author origin and
+    // erasing it rather than deferring to it.
     font-size       : var(--global-code-font-size, revert);
     font-weight     : var(--core-fontweight-regular, revert);
     line-height     : var(--core-lineheight-headline, revert);

--- a/resources/scss/src/Global.scss
+++ b/resources/scss/src/Global.scss
@@ -44,14 +44,32 @@ code:not(.hljs) {
     border          : var(--global-code-border, revert);
     border-radius   : var(--global-code-border-radius, revert);
     color           : var(--sem-color-fg-neutral-contrast, revert);
-    // `font-family` is deliberately ABSENT here and owned by util/HighlightJs.scss, which declares it
-    // for all code via `--global-code-font-family`. Declaring it here would outrank that author rule
-    // at (0,1,1) and, for a declining family, resolve to `revert` — rolling back the author origin and
-    // erasing it rather than deferring to it.
+    // `font-family` is absent HERE and declared at zero weight below — see that rule for why.
     font-size       : var(--global-code-font-size, revert);
     font-weight     : var(--core-fontweight-regular, revert);
     line-height     : var(--core-lineheight-headline, revert);
     padding         : var(--global-code-padding, revert);
+}
+
+// Inline-code font, at ZERO specificity, and the weight is the whole mechanism.
+//
+// Two sheets can supply this font and only one of them is always present:
+//   - `util/HighlightJs.scss` declares `code` at (0,0,1) reading the same token. It is the author
+//     rule that already owned the mono font, and it loads lazily.
+//   - this rule, at (0,0,0) via `:where()`, is in the always-loaded structure layer.
+//
+// Because `:where()` zeroes the selector, HighlightJs OUTRANKS this whenever it is present, so the
+// two never fight; this one speaks only when that sheet has not loaded. That is what keeps neo
+// inline code on its mono token in a document without HighlightJs — a `revert` here would hand that
+// case back to the user agent, and declaring it at (0,1,1) inside the block above would do the
+// reverse damage: outrank HighlightJs and, for a declining family, roll back the author origin and
+// erase it. Zero weight is the only position that is correct in BOTH compositions.
+//
+// Verified across the full 2×2 — {neo, classic} × {with, without HighlightJs} — against `dev`.
+// The `revert` fallback is right here precisely because no other author rule exists in the
+// uncomposed case; a family that declines and has no HighlightJs should reach the UA.
+:where(code:not(.hljs)) {
+    font-family: var(--global-code-font-family, revert);
 }
 
 h1, h2, h3, h4, h5, h6 {

--- a/resources/scss/src/util/HighlightJs.scss
+++ b/resources/scss/src/util/HighlightJs.scss
@@ -4,7 +4,22 @@ pre.hljs {
     padding: 0;
 }
 
-code,
+// This sheet owns the mono font for ALL code, highlighted or not, and it is the only author rule that
+// does. The two selectors are split rather than grouped so a theme can restyle inline `code` without
+// reaching `.hljs`: `--global-code-font-family` is the seam, and `Menlo, monospace` stays here as its
+// default rather than moving into a theme or into Global.
+//
+// The split is load-bearing for a family that DECLINES the theme's mono font. Global's structural
+// `code` rule cannot carry `font-family` for that case: it would outrank this declaration at (0,1,1)
+// and then resolve to `revert`, which rolls back the whole AUTHOR origin — discarding this rule
+// instead of deferring to it. Declining to a token default keeps the author cascade; declining to
+// `revert` destroys it. Measured on #18232 after it shipped the destructive form.
+code {
+    font-family: var(--global-code-font-family, Menlo, monospace);
+}
+
+// Grouped-out on purpose: `.hljs` (0,1,0) outranks `code` (0,0,1), so highlighted code keeps this
+// font in every theme regardless of what a theme declares for inline code.
 .hljs {
     font-family: Menlo, monospace;
 }

--- a/resources/scss/theme-cyberpunk/Global.scss
+++ b/resources/scss/theme-cyberpunk/Global.scss
@@ -33,7 +33,6 @@
     //
     // This replaces the hand-written `p { …: inherit }` reset. That block stated the same intent for
     // one element; these declarations state it for every element the structure layer now covers.
-    --core-fontfamily-mono         : initial;
     --core-fontfamily-sans         : initial;
     --core-fontsize-body           : initial;
     --core-fontsize-h1             : initial;
@@ -47,6 +46,7 @@
 
     --global-code-background-color : initial;
     --global-code-border           : initial;
+    --global-code-font-family      : initial;
     --global-code-border-radius    : initial;
     --global-code-font-size        : initial;
     --global-code-padding          : initial;

--- a/resources/scss/theme-cyberpunk/Global.scss
+++ b/resources/scss/theme-cyberpunk/Global.scss
@@ -24,11 +24,38 @@
     --cyber-border        : #30363d;
     --cyber-glow          : 0 0 10px var(--cyber-cyan);
 
-    p {
-        color      : inherit;
-        font-family: inherit;
-        font-size  : inherit;
-        font-weight: inherit;
-        line-height: inherit;
-    }
+    // Global element typography — this family DECLINES it (#18232), and `initial` is how a family
+    // says so. It is NOT the same as omitting the token: the structural rules in
+    // resources/scss/src/Global.scss reach their `revert` fallback only when a token is ABSENT, and
+    // inside a neo-themed ancestor these tokens are present by INHERITANCE. Declaring the decline is
+    // what keeps a nested classic scope — the portal's Helix and Colors previews are exactly this —
+    // rendering as the user-agent rather than as neo.
+    //
+    // This replaces the hand-written `p { …: inherit }` reset. That block stated the same intent for
+    // one element; these declarations state it for every element the structure layer now covers.
+    --core-fontfamily-mono         : initial;
+    --core-fontfamily-sans         : initial;
+    --core-fontsize-body           : initial;
+    --core-fontsize-h1             : initial;
+    --core-fontsize-h2             : initial;
+    --core-fontsize-h3             : initial;
+    --core-fontweight-regular      : initial;
+    --core-fontweight-semibold     : initial;
+    --core-lineheight-headline     : initial;
+    --core-lineheight-paragraph    : initial;
+    --sem-color-fg-neutral-contrast: initial;
+
+    --global-code-background-color : initial;
+    --global-code-border           : initial;
+    --global-code-border-radius    : initial;
+    --global-code-font-size        : initial;
+    --global-code-padding          : initial;
+    --global-heading-code-color    : initial;
+    --global-heading-code-margin   : initial;
+    --global-heading-code-padding  : initial;
+    --global-heading-letter-spacing: initial;
+    --global-mark-background-color : initial;
+    --global-mark-color            : initial;
+    --global-mark-padding          : initial;
+    --global-paragraph-color       : initial;
 }

--- a/resources/scss/theme-dark/Global.scss
+++ b/resources/scss/theme-dark/Global.scss
@@ -23,7 +23,6 @@
     //
     // This replaces the hand-written `p { …: inherit }` reset. That block stated the same intent for
     // one element; these declarations state it for every element the structure layer now covers.
-    --core-fontfamily-mono         : initial;
     --core-fontfamily-sans         : initial;
     --core-fontsize-body           : initial;
     --core-fontsize-h1             : initial;
@@ -37,6 +36,7 @@
 
     --global-code-background-color : initial;
     --global-code-border           : initial;
+    --global-code-font-family      : initial;
     --global-code-border-radius    : initial;
     --global-code-font-size        : initial;
     --global-code-padding          : initial;

--- a/resources/scss/theme-dark/Global.scss
+++ b/resources/scss/theme-dark/Global.scss
@@ -14,11 +14,38 @@
     // The product motion vocabulary (see resources/scss/_motion.scss — one authority, all themes)
     @include motion-vocabulary;
 
-    p {
-        color      : inherit;
-        font-family: inherit;
-        font-size  : inherit;
-        font-weight: inherit;
-        line-height: inherit;
-    }
+    // Global element typography — this family DECLINES it (#18232), and `initial` is how a family
+    // says so. It is NOT the same as omitting the token: the structural rules in
+    // resources/scss/src/Global.scss reach their `revert` fallback only when a token is ABSENT, and
+    // inside a neo-themed ancestor these tokens are present by INHERITANCE. Declaring the decline is
+    // what keeps a nested classic scope — the portal's Helix and Colors previews are exactly this —
+    // rendering as the user-agent rather than as neo.
+    //
+    // This replaces the hand-written `p { …: inherit }` reset. That block stated the same intent for
+    // one element; these declarations state it for every element the structure layer now covers.
+    --core-fontfamily-mono         : initial;
+    --core-fontfamily-sans         : initial;
+    --core-fontsize-body           : initial;
+    --core-fontsize-h1             : initial;
+    --core-fontsize-h2             : initial;
+    --core-fontsize-h3             : initial;
+    --core-fontweight-regular      : initial;
+    --core-fontweight-semibold     : initial;
+    --core-lineheight-headline     : initial;
+    --core-lineheight-paragraph    : initial;
+    --sem-color-fg-neutral-contrast: initial;
+
+    --global-code-background-color : initial;
+    --global-code-border           : initial;
+    --global-code-border-radius    : initial;
+    --global-code-font-size        : initial;
+    --global-code-padding          : initial;
+    --global-heading-code-color    : initial;
+    --global-heading-code-margin   : initial;
+    --global-heading-code-padding  : initial;
+    --global-heading-letter-spacing: initial;
+    --global-mark-background-color : initial;
+    --global-mark-color            : initial;
+    --global-mark-padding          : initial;
+    --global-paragraph-color       : initial;
 }

--- a/resources/scss/theme-light/Global.scss
+++ b/resources/scss/theme-light/Global.scss
@@ -23,7 +23,6 @@
     //
     // This replaces the hand-written `p { …: inherit }` reset. That block stated the same intent for
     // one element; these declarations state it for every element the structure layer now covers.
-    --core-fontfamily-mono         : initial;
     --core-fontfamily-sans         : initial;
     --core-fontsize-body           : initial;
     --core-fontsize-h1             : initial;
@@ -37,6 +36,7 @@
 
     --global-code-background-color : initial;
     --global-code-border           : initial;
+    --global-code-font-family      : initial;
     --global-code-border-radius    : initial;
     --global-code-font-size        : initial;
     --global-code-padding          : initial;

--- a/resources/scss/theme-light/Global.scss
+++ b/resources/scss/theme-light/Global.scss
@@ -14,11 +14,38 @@
     // The product motion vocabulary (see resources/scss/_motion.scss — one authority, all themes)
     @include motion-vocabulary;
 
-    p {
-        color      : inherit;
-        font-family: inherit;
-        font-size  : inherit;
-        font-weight: inherit;
-        line-height: inherit;
-    }
+    // Global element typography — this family DECLINES it (#18232), and `initial` is how a family
+    // says so. It is NOT the same as omitting the token: the structural rules in
+    // resources/scss/src/Global.scss reach their `revert` fallback only when a token is ABSENT, and
+    // inside a neo-themed ancestor these tokens are present by INHERITANCE. Declaring the decline is
+    // what keeps a nested classic scope — the portal's Helix and Colors previews are exactly this —
+    // rendering as the user-agent rather than as neo.
+    //
+    // This replaces the hand-written `p { …: inherit }` reset. That block stated the same intent for
+    // one element; these declarations state it for every element the structure layer now covers.
+    --core-fontfamily-mono         : initial;
+    --core-fontfamily-sans         : initial;
+    --core-fontsize-body           : initial;
+    --core-fontsize-h1             : initial;
+    --core-fontsize-h2             : initial;
+    --core-fontsize-h3             : initial;
+    --core-fontweight-regular      : initial;
+    --core-fontweight-semibold     : initial;
+    --core-lineheight-headline     : initial;
+    --core-lineheight-paragraph    : initial;
+    --sem-color-fg-neutral-contrast: initial;
+
+    --global-code-background-color : initial;
+    --global-code-border           : initial;
+    --global-code-border-radius    : initial;
+    --global-code-font-size        : initial;
+    --global-code-padding          : initial;
+    --global-heading-code-color    : initial;
+    --global-heading-code-margin   : initial;
+    --global-heading-code-padding  : initial;
+    --global-heading-letter-spacing: initial;
+    --global-mark-background-color : initial;
+    --global-mark-color            : initial;
+    --global-mark-padding          : initial;
+    --global-paragraph-color       : initial;
 }

--- a/resources/scss/theme-neo-dark/Global.scss
+++ b/resources/scss/theme-neo-dark/Global.scss
@@ -22,6 +22,7 @@
     --global-paragraph-color       : var(--white-off);
     --global-code-background-color : var(--sem-color-surface-primary-background);
     --global-code-border           : 1px solid var(--sem-color-border-subtle);
+    --global-code-font-family      : var(--core-fontfamily-mono);
     --global-code-border-radius    : 4px;
     --global-code-font-size        : 14px;
     --global-code-padding          : 2px 0.3em;

--- a/resources/scss/theme-neo-dark/Global.scss
+++ b/resources/scss/theme-neo-dark/Global.scss
@@ -15,70 +15,20 @@
     // The product motion vocabulary (see resources/scss/_motion.scss — one authority, all themes)
     @include motion-vocabulary;
 
-    h1 {
-        color           : var(--sem-color-fg-neutral-contrast);
-        font-family     : var(--core-fontfamily-sans);
-        font-size       : var(--core-fontsize-h1);
-        font-weight     : var(--core-fontweight-semibold);
-        letter-spacing  : -0.02em;
-        line-height     : var(--core-lineheight-headline);
-    }
-
-    h2 {
-        color           : var(--sem-color-fg-neutral-contrast);
-        font-family     : var(--core-fontfamily-sans);
-        font-size       : var(--core-fontsize-h2);
-        font-weight     : var(--core-fontweight-semibold);
-        letter-spacing  : -0.02em;
-        line-height     : var(--core-lineheight-headline);
-    }
-
-    h3 {
-        color           : var(--sem-color-fg-neutral-contrast);
-        font-family     : var(--core-fontfamily-sans);
-        font-size       : var(--core-fontsize-h3);
-        font-weight     : var(--core-fontweight-semibold);
-        letter-spacing  : -0.02em;
-        line-height     : var(--core-lineheight-headline);
-    }
-
-    p {
-        color           : var(--white-off);
-        font-family     : var(--core-fontfamily-sans);
-        font-size       : var(--core-fontsize-body);
-        font-weight     : var(--core-fontweight-regular);
-        line-height     : var(--core-lineheight-paragraph);
-    }
-
-    i, em {
-        font-style: italic;
-    }
-
-    code {
-        &:not(.hljs) {
-            background-color: var(--sem-color-surface-primary-background);
-            border          : 1px solid var(--sem-color-border-subtle);
-            border-radius   : 4px;
-            color           : var(--sem-color-fg-neutral-contrast);
-            font-family     : var(--core-fontfamily-mono);
-            font-size       : 14px;
-            font-weight     : var(--core-fontweight-regular);
-            line-height     : var(--core-lineheight-headline);
-            padding         : 2px 0.3em;
-        }
-    }
-
-    h1, h2, h3, h4, h5, h6 {
-        code:not(.hljs) {
-            color  : var(--white-off);
-            margin : 0 0.15em;
-            padding: 0 0.3em;
-        }
-    }
-
-    mark {
-        background-color: var(--green-900);
-        color           : var(--white);
-        padding         : 0.1em 0.2em;
-    }
+    // Global element typography — the VALUES for the structural rules in resources/scss/src/Global.scss
+    // (#18232). One token per property, deliberately: a shared token would compute to `unset` on the
+    // property whose type it does not match. The contract lives at the top of that file.
+    --global-heading-letter-spacing: -0.02em;
+    --global-paragraph-color       : var(--white-off);
+    --global-code-background-color : var(--sem-color-surface-primary-background);
+    --global-code-border           : 1px solid var(--sem-color-border-subtle);
+    --global-code-border-radius    : 4px;
+    --global-code-font-size        : 14px;
+    --global-code-padding          : 2px 0.3em;
+    --global-heading-code-color    : var(--white-off);
+    --global-heading-code-margin   : 0 0.15em;
+    --global-heading-code-padding  : 0 0.3em;
+    --global-mark-background-color : var(--green-900);
+    --global-mark-color            : var(--white);
+    --global-mark-padding          : 0.1em 0.2em;
 }

--- a/resources/scss/theme-neo-light/Global.scss
+++ b/resources/scss/theme-neo-light/Global.scss
@@ -15,69 +15,24 @@
     // The product motion vocabulary (see resources/scss/_motion.scss — one authority, all themes)
     @include motion-vocabulary;
 
-    h1 {
-        color           : var(--sem-color-fg-neutral-contrast);
-        font-family     : var(--core-fontfamily-sans);
-        font-size       : var(--core-fontsize-h1);
-        font-weight     : var(--core-fontweight-semibold);
-        letter-spacing  : -0.02em;
-        line-height     : var(--core-lineheight-headline);
-    }
-
-    h2 {
-        color           : var(--sem-color-fg-neutral-contrast);
-        font-family     : var(--core-fontfamily-sans);
-        font-size       : var(--core-fontsize-h2);
-        font-weight     : var(--core-fontweight-semibold);
-        letter-spacing  : -0.02em;
-        line-height     : var(--core-lineheight-headline);
-    }
-
-    h3 {
-        color           : var(--sem-color-fg-neutral-contrast);
-        font-family     : var(--core-fontfamily-sans);
-        font-size       : var(--core-fontsize-h3);
-        font-weight     : var(--core-fontweight-semibold);
-        letter-spacing  : -0.02em;
-        line-height     : var(--core-lineheight-headline);
-    }
-
-    p {
-        color           : var(--sem-color-fg-neutral-contrast);
-        font-family     : var(--core-fontfamily-sans);
-        font-size       : var(--core-fontsize-body);
-        font-weight     : var(--core-fontweight-regular);
-        line-height     : var(--core-lineheight-paragraph);
-    }
-
-    i, em {
-        font-style: italic;
-    }
-
-    code {
-        &:not(.hljs) {
-            background-color: #E6EDF7;
-            border          : 1px solid var(--sem-color-border-subtle);
-            border-radius   : 4px;
-            color           : var(--sem-color-fg-neutral-contrast);
-            font-family     : var(--core-fontfamily-mono);
-            font-size       : 14px;
-            font-weight     : var(--core-fontweight-regular);
-            line-height     : var(--core-lineheight-headline);
-            padding         : 2px 0.3em;
-        }
-    }
-
-    h1, h2, h3, h4, h5, h6 {
-        code:not(.hljs) {
-            margin : 0 0.15em;
-            padding: 0 0.3em;
-        }
-    }
-
-    mark {
-        background-color: var(--green-50);
-        color           : black;
-        padding         : 0.1em 0.2em;
-    }
+    // Global element typography — the VALUES for the structural rules in resources/scss/src/Global.scss
+    // (#18232). One token per property, deliberately: a shared token would compute to `unset` on the
+    // property whose type it does not match. The contract lives at the top of that file.
+    --global-heading-letter-spacing: -0.02em;
+    --global-paragraph-color       : var(--sem-color-fg-neutral-contrast);
+    --global-code-background-color : #E6EDF7;
+    --global-code-border           : 1px solid var(--sem-color-border-subtle);
+    --global-code-border-radius    : 4px;
+    --global-code-font-size        : 14px;
+    --global-code-padding          : 2px 0.3em;
+    // Declared, although the old block left heading-code colour to the general `code` rule: the
+    // structural `h1..h6 code` selector (0,1,2) now OUTWEIGHS `code:not(.hljs)` (0,1,1), so leaving
+    // this undeclared would `revert` heading code to the UA colour instead of inheriting the
+    // contrast token it renders with today. The old cascade is reproduced by stating it.
+    --global-heading-code-color    : var(--sem-color-fg-neutral-contrast);
+    --global-heading-code-margin   : 0 0.15em;
+    --global-heading-code-padding  : 0 0.3em;
+    --global-mark-background-color : var(--green-50);
+    --global-mark-color            : black;
+    --global-mark-padding          : 0.1em 0.2em;
 }

--- a/resources/scss/theme-neo-light/Global.scss
+++ b/resources/scss/theme-neo-light/Global.scss
@@ -22,6 +22,7 @@
     --global-paragraph-color       : var(--sem-color-fg-neutral-contrast);
     --global-code-background-color : #E6EDF7;
     --global-code-border           : 1px solid var(--sem-color-border-subtle);
+    --global-code-font-family      : var(--core-fontfamily-mono);
     --global-code-border-radius    : 4px;
     --global-code-font-size        : 14px;
     --global-code-padding          : 2px 0.3em;

--- a/test/playwright/component/apps/global-typography-nesting/app.mjs
+++ b/test/playwright/component/apps/global-typography-nesting/app.mjs
@@ -45,10 +45,10 @@ TypographySpecimen = Neo.setupClass(TypographySpecimen);
  *
  * `neo-theme-dark` is deliberate and is not a stand-in for a neo theme: the classic families are
  * the ones that DECLINE the global element typography, and declining is the half that a nested
- * scope can get wrong. This is the shape shipped on the portal home page —
- * `apps/portal/view/home/parts/Helix.mjs` and `Colors.mjs` both set `theme: 'neo-theme-dark'`
- * inside the neo-themed portal — so the fixture reproduces a real configuration rather than one
- * constructed to fail.
+ * scope can get wrong. `theme_` is a first-class per-component config, so this arrangement is
+ * reachable by any consumer; the portal ships it as `livePreviewCode` in
+ * `apps/portal/view/home/parts/Helix.mjs` and `Colors.mjs`, which mounts a classic scope inside
+ * the neo-themed page when a reader opens those previews.
  * @class Test.Playwright.Component.GlobalTypographyNesting.ClassicScope
  * @extends Neo.container.Base
  */

--- a/test/playwright/component/apps/global-typography-nesting/app.mjs
+++ b/test/playwright/component/apps/global-typography-nesting/app.mjs
@@ -1,0 +1,97 @@
+import Component from '../../../../../src/component/Base.mjs';
+import Container from '../../../../../src/container/Base.mjs';
+import Viewport  from '../../../../../src/container/Viewport.mjs';
+
+/**
+ * @summary Renders one `h1`, one `mark` and one inline `code` so a spec can read their COMPUTED
+ * styles — the only instrument that can see this contract.
+ *
+ * The emitted CSS cannot answer the question the spec asks. `resources/scss/src/Global.scss`
+ * declares `var(--token, revert)` for each of these properties, and whether that fallback fires
+ * depends on whether the token is present in the element's scope — which is a cascade fact, not a
+ * text fact. A stylesheet diff shows the same bytes in both arms.
+ * @class Test.Playwright.Component.GlobalTypographyNesting.Specimen
+ * @extends Neo.component.Base
+ */
+class TypographySpecimen extends Component {
+    static config = {
+        /**
+         * @member {String} className='Test.Playwright.Component.GlobalTypographyNesting.Specimen'
+         * @protected
+         */
+        className: 'Test.Playwright.Component.GlobalTypographyNesting.Specimen'
+    }
+
+    /**
+     * @param {Object} config
+     */
+    construct(config) {
+        super.construct(config);
+
+        const me = this;
+
+        me.vdom.cn = [
+            {tag: 'h1',   id: `${me.id}-h1`,   text: 'Heading'},
+            {tag: 'mark', id: `${me.id}-mark`, text: 'Marked'},
+            {tag: 'code', id: `${me.id}-code`, text: 'inline()'}
+        ]
+    }
+}
+
+TypographySpecimen = Neo.setupClass(TypographySpecimen);
+
+/**
+ * @summary A CLASSIC theme scope, carried as a class default so item creation hands it down.
+ *
+ * `neo-theme-dark` is deliberate and is not a stand-in for a neo theme: the classic families are
+ * the ones that DECLINE the global element typography, and declining is the half that a nested
+ * scope can get wrong. This is the shape shipped on the portal home page —
+ * `apps/portal/view/home/parts/Helix.mjs` and `Colors.mjs` both set `theme: 'neo-theme-dark'`
+ * inside the neo-themed portal — so the fixture reproduces a real configuration rather than one
+ * constructed to fail.
+ * @class Test.Playwright.Component.GlobalTypographyNesting.ClassicScope
+ * @extends Neo.container.Base
+ */
+class ClassicScope extends Container {
+    static config = {
+        /**
+         * @member {String} className='Test.Playwright.Component.GlobalTypographyNesting.ClassicScope'
+         * @protected
+         */
+        className: 'Test.Playwright.Component.GlobalTypographyNesting.ClassicScope',
+        /**
+         * @member {String} theme='neo-theme-dark'
+         */
+        theme: 'neo-theme-dark'
+    }
+}
+
+ClassicScope = Neo.setupClass(ClassicScope);
+
+/**
+ * Two specimens: one under the app's neo theme (the first `themes` entry, stamped on the body), one
+ * inside a nested classic scope. The outer arm is what makes the inner assertion non-vacuous — a
+ * fixture whose outer scope resolved nothing would let the inner arm pass for the wrong reason.
+ */
+export const onStart = () => Neo.app({
+    mainView: {
+        module: Viewport,
+        id    : 'global-typography-nesting-viewport',
+        layout: {ntype: 'vbox', align: 'start'},
+        style : {gap: '40px', padding: '40px'},
+        items : [{
+            module: TypographySpecimen,
+            id    : 'outer-neo'
+        }, {
+            module: ClassicScope,
+            id    : 'classic-scope',
+            layout: {ntype: 'vbox', align: 'start'},
+            style : {padding: '20px'},
+            items : [{
+                module: TypographySpecimen,
+                id    : 'inner-classic'
+            }]
+        }]
+    },
+    name: 'Test.Playwright.GlobalTypographyNesting'
+});

--- a/test/playwright/component/apps/global-typography-nesting/index.html
+++ b/test/playwright/component/apps/global-typography-nesting/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Neo.mjs Global Typography Nesting Fixture</title>
+</head>
+<body>
+    <script src="../../../../../src/MicroLoader.mjs" type="module"></script>
+</body>
+</html>

--- a/test/playwright/component/apps/global-typography-nesting/index.html
+++ b/test/playwright/component/apps/global-typography-nesting/index.html
@@ -5,14 +5,21 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Neo.mjs Global Typography Nesting Fixture</title>
     <!--
-        The REAL HighlightJs sheet, linked rather than retyped: it declares `code, .hljs {font-family:
-        Menlo, monospace}` at (0,1) and is the author rule the structural `code` rule competes with.
-        A fixture that omits it can only measure the UA baseline, and a UA-default control cannot show
-        whether an existing author declaration still applies — which is the gap this composition closes.
-        Load order is not load-bearing: the two rules differ in specificity, so the cascade decides
-        regardless of which sheet arrives first.
+        The REAL HighlightJs sheet, linked rather than retyped: it owns the mono font for all code and
+        is the author rule the structural `code` rule competes with. A fixture that omits it can only
+        measure the UA baseline, and a UA-default control cannot show whether an existing author
+        declaration still applies — which is the gap this composition closes. Load order is not
+        load-bearing: the two rules differ in specificity, so the cascade decides either way.
+
+        `dist/development/**` is the correct tree and the path is load-bearing. This suite's
+        `globalSetup` runs `ensureDevelopmentThemeAssets()`, i.e. `build-themes -e dev`, so this file
+        is the one output the tier GUARANTEES — and it is the same tree this fixture's own app reads,
+        since its neo-config declares `environment: development`. An earlier revision linked
+        `dist/esm/**`, which passed locally only because an unrelated `-e esm` build happened to be
+        present and was absent in CI: the link 404'd, `code` fell back to the user agent, and BOTH
+        arms went red including the neo control. A fixture must name a path its own tier produces.
     -->
-    <link rel="stylesheet" href="../../../../../dist/esm/css/src/util/HighlightJs.css">
+    <link rel="stylesheet" href="../../../../../dist/development/css/src/util/HighlightJs.css">
 </head>
 <body>
     <script src="../../../../../src/MicroLoader.mjs" type="module"></script>

--- a/test/playwright/component/apps/global-typography-nesting/index.html
+++ b/test/playwright/component/apps/global-typography-nesting/index.html
@@ -4,6 +4,15 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Neo.mjs Global Typography Nesting Fixture</title>
+    <!--
+        The REAL HighlightJs sheet, linked rather than retyped: it declares `code, .hljs {font-family:
+        Menlo, monospace}` at (0,1) and is the author rule the structural `code` rule competes with.
+        A fixture that omits it can only measure the UA baseline, and a UA-default control cannot show
+        whether an existing author declaration still applies — which is the gap this composition closes.
+        Load order is not load-bearing: the two rules differ in specificity, so the cascade decides
+        regardless of which sheet arrives first.
+    -->
+    <link rel="stylesheet" href="../../../../../dist/esm/css/src/util/HighlightJs.css">
 </head>
 <body>
     <script src="../../../../../src/MicroLoader.mjs" type="module"></script>

--- a/test/playwright/component/apps/global-typography-nesting/index.html
+++ b/test/playwright/component/apps/global-typography-nesting/index.html
@@ -5,21 +5,16 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Neo.mjs Global Typography Nesting Fixture</title>
     <!--
-        The REAL HighlightJs sheet, linked rather than retyped: it owns the mono font for all code and
-        is the author rule the structural `code` rule competes with. A fixture that omits it can only
-        measure the UA baseline, and a UA-default control cannot show whether an existing author
-        declaration still applies — which is the gap this composition closes. Load order is not
-        load-bearing: the two rules differ in specificity, so the cascade decides either way.
+        NO HighlightJs sheet here, deliberately. This document is the UNCOMPOSED arm: the structure
+        layer and the theme sheets alone, which is what a consumer gets before HighlightJs lazy-loads.
+        The spec composes the real sheet at runtime for the second arm, so both compositions are
+        measured from one fixture.
 
-        `dist/development/**` is the correct tree and the path is load-bearing. This suite's
-        `globalSetup` runs `ensureDevelopmentThemeAssets()`, i.e. `build-themes -e dev`, so this file
-        is the one output the tier GUARANTEES — and it is the same tree this fixture's own app reads,
-        since its neo-config declares `environment: development`. An earlier revision linked
-        `dist/esm/**`, which passed locally only because an unrelated `-e esm` build happened to be
-        present and was absent in CI: the link 404'd, `code` fell back to the user agent, and BOTH
-        arms went red including the neo control. A fixture must name a path its own tier produces.
+        An earlier revision linked HighlightJs here and thereby DELETED this arm instead of adding the
+        other one — every specimen became composed, and the regression that made HighlightJs a
+        precondition for neo inline typography became invisible to the very suite meant to catch it.
+        A control is not replaced by a better control; it is kept alongside it.
     -->
-    <link rel="stylesheet" href="../../../../../dist/development/css/src/util/HighlightJs.css">
 </head>
 <body>
     <script src="../../../../../src/MicroLoader.mjs" type="module"></script>

--- a/test/playwright/component/apps/global-typography-nesting/neo-config.json
+++ b/test/playwright/component/apps/global-typography-nesting/neo-config.json
@@ -1,0 +1,9 @@
+{
+    "appPath"         : "test/playwright/component/apps/global-typography-nesting/app.mjs",
+    "basePath"        : "../../../../../",
+    "environment"     : "development",
+    "mainPath"        : "./Main.mjs",
+    "mainThreadAddons": ["DragDrop", "Navigator", "Stylesheet"],
+    "themes"          : ["neo-theme-neo-dark", "neo-theme-dark"],
+    "useSharedWorkers": false
+}

--- a/test/playwright/component/component/GlobalTypographyNesting.spec.mjs
+++ b/test/playwright/component/component/GlobalTypographyNesting.spec.mjs
@@ -31,7 +31,7 @@ const
     // fallback is `revert` and not `inherit`. An `inherit` fallback computes 16px here, so this
     // constant is also what separates the two fallback keywords.
     UA_H1_SIZE    = '32px',
-    // neo-dark maps `--global-mark-background-color` to `--green-900`, which is `#000`.
+    // neo-dark maps `--global-mark-background-color` to `--green-900`, which resolves to black.
     NEO_MARK_BG   = 'rgb(0, 0, 0)',
     UA_MARK_BG    = 'rgb(255, 255, 0)',
     UA_CODE_FAMILY = 'monospace';

--- a/test/playwright/component/component/GlobalTypographyNesting.spec.mjs
+++ b/test/playwright/component/component/GlobalTypographyNesting.spec.mjs
@@ -34,7 +34,10 @@ const
     // neo-dark maps `--global-mark-background-color` to `--green-900`, which resolves to black.
     NEO_MARK_BG   = 'rgb(0, 0, 0)',
     UA_MARK_BG    = 'rgb(255, 255, 0)',
-    UA_CODE_FAMILY = 'monospace';
+    // From the composed `resources/scss/src/util/HighlightJs.scss` — an AUTHOR rule, not the UA's.
+    // The user agent's own `code` font is bare `monospace`; landing there means the author origin was
+    // discarded rather than declined.
+    AUTHOR_CODE_FAMILY = 'Menlo, monospace';
 
 const computed = (page, id, prop) =>
     page.locator(`#${id}`).evaluate((node, name) => getComputedStyle(node)[name], prop);
@@ -73,13 +76,31 @@ test.describe('Global element typography — a nested classic scope declines, an
         ).toBe(UA_MARK_BG)
     });
 
-    test('code font-family: the neo scope resolves its mono token, the nested classic scope keeps UA monospace', async ({page}) => {
+    test('code font-family: the neo scope resolves its mono token, the classic scope keeps the composed author font', async ({page}) => {
         await expect.poll(() => computed(page, 'outer-neo-code', 'fontFamily'),
             {message: 'control: the neo scope resolves --core-fontfamily-mono'}
         ).toContain('Source Code Pro');
 
+        // NOT the UA fallback. `code, .hljs {font-family: Menlo, monospace}` is an AUTHOR rule that
+        // applies in every theme, and `revert` rolls back the whole author ORIGIN rather than only the
+        // structural rule — so a classic scope that declines must still land on the composed sheet's
+        // value, not on the user agent's. This is the assertion a UA-only fixture could not make.
         await expect.poll(() => computed(page, 'inner-classic-code', 'fontFamily'),
-            {message: 'UA monospace, the second D+S falsifier'}
-        ).toBe(UA_CODE_FAMILY)
+            {message: 'the composed HighlightJs author declaration must survive the classic decline'}
+        ).toBe(AUTHOR_CODE_FAMILY)
+    });
+
+    test('control: highlighted code is untouched in both scopes', async ({page}) => {
+        // `.hljs` (0,1,0) outranks the structural `code:not(.hljs)`, so this arm must be inert to the
+        // whole batch. It is what separates "the classic decline broke inline code" from "the batch
+        // broke code styling generally" — without it, a red above has two candidate causes.
+        for (const id of ['outer-neo-code', 'inner-classic-code']) {
+            await expect.poll(() => page.locator(`#${id}`).evaluate(node => {
+                node.classList.add('hljs');
+                const family = getComputedStyle(node).fontFamily;
+                node.classList.remove('hljs');
+                return family
+            }), {message: `${id}: .hljs keeps the composed author font`}).toBe(AUTHOR_CODE_FAMILY)
+        }
     })
 });

--- a/test/playwright/component/component/GlobalTypographyNesting.spec.mjs
+++ b/test/playwright/component/component/GlobalTypographyNesting.spec.mjs
@@ -12,8 +12,11 @@ import {test, expect} from '@playwright/test';
  * and lets `var()` fall through. Omitting the token and declaring it `initial` produce byte-identical
  * source in the structure layer and opposite renderings here.
  *
- * The shape is shipped, not hypothetical: `apps/portal/view/home/parts/Helix.mjs:39` and
- * `Colors.mjs:38` put `theme: 'neo-theme-dark'` — a classic theme — inside the neo-themed portal.
+ * The shape is reachable, not hypothetical, and the precise reach is worth stating. `theme_` is a
+ * first-class per-component config (`src/component/Base.mjs`), so any consumer can open a scope
+ * anywhere. In this repository the classic-inside-neo case ships as `livePreviewCode` in
+ * `apps/portal/view/home/parts/Helix.mjs` and `Colors.mjs` — source the portal compiles and mounts
+ * when a reader opens the preview, rather than a scope present in the default page render.
  *
  * **The outer assertion is the non-vacuity control and runs first by construction.** If the neo arm
  * resolved nothing, every inner expectation would still pass — for the wrong reason — because "no

--- a/test/playwright/component/component/GlobalTypographyNesting.spec.mjs
+++ b/test/playwright/component/component/GlobalTypographyNesting.spec.mjs
@@ -1,0 +1,82 @@
+import {test, expect} from '@playwright/test';
+
+/**
+ * Global element typography lives in `resources/scss/src/Global.scss` as `var(--token, revert)` per
+ * property. A family that declares the token gets its value; a family that declares nothing gets the
+ * user-agent stylesheet.
+ *
+ * That contract has one failure mode no stylesheet diff can see. **A `var()` fallback fires on
+ * ABSENCE, and inheritance is not absence.** Inside a neo scope the tokens are present on every
+ * descendant by inheritance, so a nested classic scope never reaches `revert` unless it DECLARES its
+ * decline — `--token: initial` at its own scope, which makes the custom property guaranteed-invalid
+ * and lets `var()` fall through. Omitting the token and declaring it `initial` produce byte-identical
+ * source in the structure layer and opposite renderings here.
+ *
+ * The shape is shipped, not hypothetical: `apps/portal/view/home/parts/Helix.mjs:39` and
+ * `Colors.mjs:38` put `theme: 'neo-theme-dark'` — a classic theme — inside the neo-themed portal.
+ *
+ * **The outer assertion is the non-vacuity control and runs first by construction.** If the neo arm
+ * resolved nothing, every inner expectation would still pass — for the wrong reason — because "no
+ * neo value here" is exactly what the inner arm claims. Each test therefore pins the outer scope to
+ * a real neo value before reading the inner one.
+ */
+
+const
+    // 2.5rem against the 16px root, from `--core-fontsize-h1` in both neo themes.
+    NEO_H1_SIZE   = '40px',
+    // The UA `h1` is 2em — and it comes from the UA sheet, NOT by inheritance, which is why the
+    // fallback is `revert` and not `inherit`. An `inherit` fallback computes 16px here, so this
+    // constant is also what separates the two fallback keywords.
+    UA_H1_SIZE    = '32px',
+    // neo-dark maps `--global-mark-background-color` to `--green-900`, which is `#000`.
+    NEO_MARK_BG   = 'rgb(0, 0, 0)',
+    UA_MARK_BG    = 'rgb(255, 255, 0)',
+    UA_CODE_FAMILY = 'monospace';
+
+const computed = (page, id, prop) =>
+    page.locator(`#${id}`).evaluate((node, name) => getComputedStyle(node)[name], prop);
+
+test.beforeEach(async ({page}) => {
+    await page.goto('test/playwright/component/apps/global-typography-nesting/index.html');
+    await page.waitForSelector('#global-typography-nesting-viewport', {state: 'attached'});
+    await expect(page.locator('#outer-neo-h1')).toBeVisible();
+    await expect(page.locator('#inner-classic-h1')).toBeVisible();
+
+    // The scope renders its own theme class; the specimen inside carries none and inherits — the
+    // arrangement under test. A specimen that carried its own class would make this a specificity
+    // question instead of an inheritance one.
+    await expect(page.locator('#classic-scope')).toHaveClass(/neo-theme-dark/);
+    await expect(page.locator('#inner-classic')).not.toHaveClass(/neo-theme-/)
+});
+
+test.describe('Global element typography — a nested classic scope declines, and says so', () => {
+    test('h1 font-size: the neo scope resolves its token, the nested classic scope reverts to the UA', async ({page}) => {
+        await expect.poll(() => computed(page, 'outer-neo-h1', 'fontSize'),
+            {message: 'control: the neo scope resolves --core-fontsize-h1, so the inner arm can mean something'}
+        ).toBe(NEO_H1_SIZE);
+
+        await expect.poll(() => computed(page, 'inner-classic-h1', 'fontSize'),
+            {message: 'the classic scope declared the token `initial`, so var() reached `revert`'}
+        ).toBe(UA_H1_SIZE)
+    });
+
+    test('mark background: the neo scope paints its token, the nested classic scope stays UA yellow', async ({page}) => {
+        await expect.poll(() => computed(page, 'outer-neo-mark', 'backgroundColor'),
+            {message: 'control: the neo scope paints --global-mark-background-color'}
+        ).toBe(NEO_MARK_BG);
+
+        await expect.poll(() => computed(page, 'inner-classic-mark', 'backgroundColor'),
+            {message: 'UA yellow — one of the three falsifiers the Drop+Supersede named'}
+        ).toBe(UA_MARK_BG)
+    });
+
+    test('code font-family: the neo scope resolves its mono token, the nested classic scope keeps UA monospace', async ({page}) => {
+        await expect.poll(() => computed(page, 'outer-neo-code', 'fontFamily'),
+            {message: 'control: the neo scope resolves --core-fontfamily-mono'}
+        ).toContain('Source Code Pro');
+
+        await expect.poll(() => computed(page, 'inner-classic-code', 'fontFamily'),
+            {message: 'UA monospace, the second D+S falsifier'}
+        ).toBe(UA_CODE_FAMILY)
+    })
+});

--- a/test/playwright/component/component/GlobalTypographyNesting.spec.mjs
+++ b/test/playwright/component/component/GlobalTypographyNesting.spec.mjs
@@ -37,10 +37,38 @@ const
     // From the composed `resources/scss/src/util/HighlightJs.scss` — an AUTHOR rule, not the UA's.
     // The user agent's own `code` font is bare `monospace`; landing there means the author origin was
     // discarded rather than declined.
-    AUTHOR_CODE_FAMILY = 'Menlo, monospace';
+    AUTHOR_CODE_FAMILY = 'Menlo, monospace',
+    // The user agent's own `code` font, i.e. what a declining family reaches when NO author rule
+    // supplies one. Distinct from AUTHOR_CODE_FAMILY: landing here with HighlightJs composed would
+    // mean the author origin was discarded rather than deferred to.
+    UA_CODE_FAMILY     = 'monospace';
 
 const computed = (page, id, prop) =>
     page.locator(`#${id}`).evaluate((node, name) => getComputedStyle(node)[name], prop);
+
+/**
+ * @summary Composes the REAL HighlightJs sheet into the running page, mid-test.
+ *
+ * Injected rather than linked in the fixture so one document can serve both compositions — linking it
+ * makes every specimen composed and silently retires the uncomposed arm. Injected by PATH rather than
+ * retyped, because a hand-copied `Menlo, monospace` would test this file's reconstruction of the sheet
+ * instead of the sheet. `dist/development/**` is the tree this suite's `globalSetup` guarantees
+ * (`build-themes -e dev`) and the one the fixture's own app reads, per its `environment` config.
+ * @param {import('@playwright/test').Page} page
+ * @returns {Promise<void>}
+ */
+const composeHighlightJs = async page => {
+    await page.addStyleTag({path: 'dist/development/css/src/util/HighlightJs.css'});
+    // The sheet must actually take effect before anything is read from it; asserting the highlighted
+    // control here means a failed injection surfaces as itself rather than as a confusing red on the
+    // property under test.
+    await expect.poll(() => page.locator('#outer-neo-code').evaluate(node => {
+        node.classList.add('hljs');
+        const family = getComputedStyle(node).fontFamily;
+        node.classList.remove('hljs');
+        return family
+    }), {message: 'HighlightJs composed and in effect'}).toBe(AUTHOR_CODE_FAMILY)
+};
 
 test.beforeEach(async ({page}) => {
     await page.goto('test/playwright/component/apps/global-typography-nesting/index.html');
@@ -76,31 +104,55 @@ test.describe('Global element typography — a nested classic scope declines, an
         ).toBe(UA_MARK_BG)
     });
 
-    test('code font-family: the neo scope resolves its mono token, the classic scope keeps the composed author font', async ({page}) => {
+    // Both compositions are asserted, and keeping BOTH is the point. HighlightJs lazy-loads, so a
+    // document without it is an ordinary state rather than an edge case — and a revision of this file
+    // that composed the sheet into every specimen deleted the uncomposed arm and made a real
+    // regression (HighlightJs becoming a precondition for neo inline typography) invisible here.
+    test('code font-family, UNCOMPOSED: neo resolves its mono token with no HighlightJs present', async ({page}) => {
         await expect.poll(() => computed(page, 'outer-neo-code', 'fontFamily'),
-            {message: 'control: the neo scope resolves --core-fontfamily-mono'}
+            {message: 'the always-loaded structure layer must carry this on its own'}
         ).toContain('Source Code Pro');
 
-        // NOT the UA fallback. `code, .hljs {font-family: Menlo, monospace}` is an AUTHOR rule that
-        // applies in every theme, and `revert` rolls back the whole author ORIGIN rather than only the
-        // structural rule — so a classic scope that declines must still land on the composed sheet's
-        // value, not on the user agent's. This is the assertion a UA-only fixture could not make.
+        // Nothing else declares a mono font in this composition, so a declining family reaches the UA.
         await expect.poll(() => computed(page, 'inner-classic-code', 'fontFamily'),
-            {message: 'the composed HighlightJs author declaration must survive the classic decline'}
+            {message: 'classic declines and there is no author rule left to defer to'}
+        ).toBe(UA_CODE_FAMILY)
+    });
+
+    test('code font-family, COMPOSED: the classic decline defers to HighlightJs instead of erasing it', async ({page}) => {
+        await composeHighlightJs(page);
+
+        await expect.poll(() => computed(page, 'outer-neo-code', 'fontFamily'),
+            {message: 'control: neo still resolves its token once the author sheet is present'}
+        ).toContain('Source Code Pro');
+
+        // The assertion a UA-only fixture cannot make. `revert` rolls back the whole author ORIGIN,
+        // so a structural rule that outranked this sheet and then reverted would DELETE it. Landing
+        // on the author value is what proves the decline deferred rather than destroyed.
+        await expect.poll(() => computed(page, 'inner-classic-code', 'fontFamily'),
+            {message: 'the composed HighlightJs declaration must survive the classic decline'}
         ).toBe(AUTHOR_CODE_FAMILY)
     });
 
-    test('control: highlighted code is untouched in both scopes', async ({page}) => {
-        // `.hljs` (0,1,0) outranks the structural `code:not(.hljs)`, so this arm must be inert to the
-        // whole batch. It is what separates "the classic decline broke inline code" from "the batch
-        // broke code styling generally" — without it, a red above has two candidate causes.
+    test('control: highlighted code is inert to the batch in both compositions', async ({page}) => {
+        // `.hljs` outranks the inline-code rules in both sheets, so it must not move. This is what
+        // separates "the decline erased an author rule" from "the batch broke code styling generally"
+        // — without it, a red above has two candidate causes.
+        const read = id => page.locator(`#${id}`).evaluate(node => {
+            node.classList.add('hljs');
+            const family = getComputedStyle(node).fontFamily;
+            node.classList.remove('hljs');
+            return family
+        });
+
         for (const id of ['outer-neo-code', 'inner-classic-code']) {
-            await expect.poll(() => page.locator(`#${id}`).evaluate(node => {
-                node.classList.add('hljs');
-                const family = getComputedStyle(node).fontFamily;
-                node.classList.remove('hljs');
-                return family
-            }), {message: `${id}: .hljs keeps the composed author font`}).toBe(AUTHOR_CODE_FAMILY)
+            await expect.poll(() => read(id), {message: `${id}: UA, uncomposed`}).toBe(UA_CODE_FAMILY)
+        }
+
+        await composeHighlightJs(page);
+
+        for (const id of ['outer-neo-code', 'inner-classic-code']) {
+            await expect.poll(() => read(id), {message: `${id}: the author font, composed`}).toBe(AUTHOR_CODE_FAMILY)
         }
     })
 });


### PR DESCRIPTION
Resolves #18232

Batch 5 of #18145. The ten neo `Global.scss` element blocks move to `resources/scss/src/Global.scss`; the five theme value files become variable declarations only, and the guard's baseline drops to the two `dialog/Base.scss` entries still exempt.

This is the second attempt. PR #18288 was Drop+Superseded on an `inherit` fallback, and the premise that replaced it was measured, not reasoned.

Evidence: L3 (emitted CSS diffed per theme against a baseline built from the parent commit in place; red-first component witness with a mutation control; every named token checked against the built output) → L3 required (all ACs). Residual: none.

## AC Evidence

| AC | Evidence |
|---|---|
| AC-1 | `check-theme-value-files.mjs` exits 0 — **0 pending**, 2 exempt. The five `Global.scss` files carry zero nested selector blocks |
| AC-2 | **24 declarations per classic theme** (14 `--global-*` + 10 retained `--core`/`--sem`), read back out of the **built** CSS, not the source |
| AC-3 | `GlobalTypographyNesting.spec.mjs`, **5/5** — both compositions (with and without HighlightJs). Three red-first controls below |
| AC-4 | premise falsified; **no repaint occurs**. See below |
| AC-5 | the tie is **removed**, not dispositioned. See below |
| AC-6 | before/after built with `-f -n -e esm -t all` from the parent commit in place; **exactly 7 CSS files differ** — the 5 theme `Global.css`, `src/Global.css`, and `src/util/HighlightJs.css`, nothing else. 623 files written, asserted by **mtime** (this script exits 0 without emitting when it cannot prompt, and did exactly that on my first run) |
| AC-7 | baseline shrunk in the same commit as the sweep |

## The three rules the structure layer now carries

1. **`revert`, never `inherit`.** UA `h1` is 32px/700 from the UA stylesheet, *not* by inheritance, so `var(--token, inherit)` computes 16px/400 for a family that declares nothing — the exact regression that superseded the first attempt.
2. **One token per property.** A shared token computing to the wrong type is invalid at computed-value time, and an invalid substitution does **not** reach the fallback: the property silently becomes `unset`.
3. **A fallback fires on absence, and inheritance is not absence.** A classic theme nested inside a neo scope inherits the neo tokens and never reaches `revert`, so each classic family must **declare** its decline as `--token: initial`.

Rule 3 is why this diff is larger than the ticket sized it: **14 new tokens, not 5** — five for the neo-theme divergences the ticket identified, eight for declarations that were literals and would otherwise reach the classic families with no way to decline them, and one from the repair below.

**4. A token's fallback must be the value the next author rule would supply — `revert` only where there is none.** `revert` rolls back the entire author *origin*, so a structural rule that outranks an existing author declaration and then reverts **destroys** it rather than deferring to it. This is the rule the first head got wrong.

## R2 repair — the fix had to survive BOTH compositions

@neo-gpt-emmy's round 2: the first repair fixed composed-classic and **broke uncomposed-neo**. Moving `font-family` entirely into HighlightJs made that sheet's lazy load a precondition for neo inline typography — both neo themes went `Source Code Pro` → `monospace` with HighlightJs absent.

**It is a weight problem, and both earlier attempts sat at the wrong end of it:**

| position | composed classic | uncomposed neo |
|---|---|---|
| `(0,1,1)` in Global | ✗ outranks HighlightJs, then `revert` **erases** it | ✓ |
| absent from Global | ✓ | ✗ nothing declares the font |
| **`(0,0,0)` via `:where()`** | ✓ HighlightJs outranks it when present | ✓ speaks when it is absent |

So Global declares `:where(code:not(.hljs)) {font-family: var(--global-code-font-family, revert)}` and HighlightJs keeps its `(0,0,1)` rule reading the same token. Neither fights the other, `Menlo, monospace` stays in HighlightJs as its default, and `revert` is correct at zero weight precisely because the uncomposed case has no author rule to defer to.

**Measured across all 5 themes × {with, without HighlightJs}:** classic reads `Menlo, monospace`/16px composed and UA `monospace`/13px uncomposed — matching `dev` in both; both neo themes read `Source Code Pro`/14px in **either** composition; `.hljs` inert throughout.

**Her methodological point was the more important half.** Linking HighlightJs into the fixture composed *every* specimen and deleted the uncomposed arm — I replaced a control instead of adding one, which is exactly why the suite could not see the regression it existed to catch. The sheet is now injected per test by path, so one fixture measures both compositions and keeps both arms.

## The R1 repair (@neo-gpt-emmy's RA-1)

Reproduced in this repo's own fixture before touching anything: classic inline `code` read `monospace` where `dev` reads `Menlo, monospace`.

**The ticket's sweep had it backwards, and the arithmetic was never the problem.** #18232 cleared `util/HighlightJs.scss` because `code, .hljs` at (0,0,1) *"stays outranked by a moved `code:not(.hljs)` at (0,1,1)"*. Correct — and **being outranked was treated as being irrelevant**. It is the opposite: the structural rule wins, and in a declining family it wins *in order to* resolve `revert`, discarding HighlightJs's declaration. A winning declaration that resolves to `revert` is more destructive than one that supplies a value.

**Fix:** `font-family` leaves Global's `code` rule and stays with the sheet that owns it. HighlightJs splits into `code {font-family: var(--global-code-font-family, Menlo, monospace)}` and `.hljs` keeping the literal. A theme now declines to that author default instead of to the user agent; `.hljs` (0,1,0) still outranks `code` (0,0,1), so highlighted code is inert to the batch; and `Menlo, monospace` never leaves HighlightJs. `--core-fontfamily-mono` is no longer read by the structure layer, so its classic un-declaration is retired rather than left as dead ballast.

**The coverage gap was the real defect.** My fixture measured a UA baseline and never composed the author sheet it competed with, so a correct UA-default control certified a narrower contract than it appeared to. It now **links the real HighlightJs sheet rather than a retyped copy**, and adds an `.hljs` control so a red discriminates *"the decline erased an author rule"* from *"the batch broke code styling"*.

## Mutation control (AC-3)

Strip **only** the 24 `: initial;` declarations from `theme-dark`, rebuild, re-run:

**Control A — strip the 24 `: initial;` declarations from `theme-dark`:**

| assertion | expected (UA) | received under mutation |
|---|---|---|
| `h1` font-size | `32px` | **`40px`** — `--core-fontsize-h1`, inherited |
| `mark` background | `rgb(255, 255, 0)` | **`rgb(0, 0, 0)`** — `--green-900` |
| `code` font-family | `monospace` | **`"Source Code Pro"`** |

All three failed on the **inner** assertion only; every outer control stayed green. Each test pins the outer neo scope to a real token value *before* reading the nested one, so it cannot pass vacuously — "no neo value here" is precisely what the inner arm claims.

**Control B — the RA-1 repair, red-first at the previous head:**

| assertion | expected | received before repair |
|---|---|---|
| classic `code` font-family | `Menlo, monospace` (composed author rule) | **`monospace`** — the UA, i.e. the author origin discarded |

The `.hljs` arm stayed green through that red, which is what makes it a discriminating control rather than a second symptom.

## Test Evidence

`npm run test-components -- component/GlobalTypographyNesting.spec.mjs` → **5 passed** at `b261233c52`, covering both compositions (with and without HighlightJs). Fixture app under `test/playwright/component/apps/global-typography-nesting/`; the HighlightJs sheet is injected per test by path rather than linked, so one document serves both arms.

*Superseded receipts, labelled rather than deleted so the sequence stays readable:* **3 passed** at `97f5bc852c` (nested-scope arms only, before the composed case existed) and **4/4** at `e78b8a1eb9` (composed case added, uncomposed arm accidentally removed with it). Neither describes this head.

`node buildScripts/util/check-theme-value-files.mjs` → exit 0, *"0 file(s) pending sweep, 2 exempt"*.

`node ./buildScripts/build/themes.mjs -f -n -e esm -t all` → 623 CSS files written. **The exit code is not the receipt here:** my first run wrapped the command in `timeout`, which does not exist on macOS, and `| tail` reported tail's status — the pipeline said `exit=0` having built nothing. The mtime assertion (`find dist -name '*.css' -mmin -10`) returned 0 files and caught it. Every build claim in this PR is mtime-asserted.

Three of the greps I wrote while verifying my own diff returned false negatives — a character class without digits, an anchored pattern against minified CSS, and an alternation `ugrep` rejected outright while still printing `0`. The numbers above come from the built output and file sizes, which disagreed with those greps and are why I re-checked.

## AC-4 — the ticket's premise is wrong, in our favour

The ticket predicts a realworld2 heading repaint: `MainContainer.scss:28` at (0,1,1) loses to the theme's (0,2,1) today and would start winning against the structural (0,0,1).

`apps/realworld2/neo-config.json` declares `themes: ["neo-theme-dark", "neo-theme-light"]` — **both classic**, and classic themes have never carried heading blocks. No theme heading rule has ever matched realworld2, so `.rw2-main-container h1` already won and still outranks (0,0,1); every token it would read is declared `initial` by its own themes and reverts to the UA as before. **Nothing changes.**

## AC-5 — the tie is gone

`.portal-home-parts-aitoolchain .agent-os-faq h2` (0,2,1) tied `:root .neo-theme-neo-* h2` (0,2,1), resolved by source order under lazily-loaded theme sheets. This batch deletes the theme-side rule, leaving (0,2,1) against (0,0,1). Deterministic.

## Deltas from ticket

- **Token count 5 → 14**: five neo-theme divergences, eight declarations that were literals (rule 3 above), and `--global-code-font-family` from the HighlightJs repair.
- **`neo-light` gains `--global-heading-code-color`.** Its old block left heading-code colour to the general `code` rule, but the structural `h1..h6 code` selector (0,1,2) now outweighs `code:not(.hljs)` (0,1,1), so leaving it undeclared would revert heading code to the UA colour. The previous cascade is preserved by stating it.
- **AC-4 resolves as "no change" rather than as an accepted regression.**

## A claim of mine that did not survive

I published that the classic-inside-neo shape was "live, on a public surface" and did not verify it rendered. Measured: the portal home page has **4 LivePreview nodes and 0 mounted classic scopes**; those previews compile on demand. Repo-wide there are **zero** non-string `theme: 'neo-theme-<classic>'` configs — the only two instances are `livePreviewCode` strings in `Helix.mjs` and `Colors.mjs`, real when a reader opens the preview and absent otherwise.

The design is unchanged and rule 3 still governs: `theme_` is a first-class per-component config, and the previews do mount a classic scope for anyone who opens them. The overstatement was reporting a *reachable* configuration as an *observed* one. Corrected in the durable comments by `615a6c8`.

## Observed, not claimed

**realworld2 does not boot** — `Base.on is not a function` on load, against a dev server where the portal mounts fine on this branch. This diff touches no `src/` or realworld2 `.mjs`. No open issue names it, and #5896 (hide the RealWorld2 example, closed) suggests the app is already deprioritised. Recorded for whoever owns it; not filed, not blocking.

## Sequencing

**#18107 must re-measure after this lands.** Verified before starting: it is open, unassigned, has no PR, and is untouched since 2026-09-03. It changes the *weight* a theme sheet declares at; this changes *where the selector lives*, and a paint regression could not be attributed with both in flight.

## Post-Merge Validation

- [ ] The two portal live previews (Helix, Colors) render UA typography when opened, not neo typography. Requires a reader to open a preview; the component witness covers the same cascade deterministically.

---

Authored by Grace (Claude Opus 5, Claude Code). Session 7f0f8990-80ed-42a0-a11b-8477dd3e405e.




