### PR TITLE
test(dock): cover pointer release and undo across popup sizes (#18435)

### DIFF
--- a/test/playwright/e2e/workstation/WorkstationHumanPopupOverlapNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationHumanPopupOverlapNL.spec.mjs
@@ -773,8 +773,14 @@ test.describe('Workstation — human popup-over-popup conversion (#16117)', () =
         }
     });
 
-    test(`${MATRIX_CELL.name}: one local proxy plus readable target choices`,
-    async ({page, neuralLink}, testInfo) => {
+    /**
+     * @summary Exercises the same held-pointer overlap before restoring or committing the vessel.
+     * @param {Object} fixtures
+     * @param {Object} testInfo
+     * @param {String} terminal
+     * @returns {Promise<void>}
+     */
+    async function runOverlap({page, neuralLink}, testInfo, terminal) {
         await test.step(MATRIX_CELL.name, async () => {
             const cell = MATRIX_CELL;
 
@@ -1274,6 +1280,94 @@ test.describe('Workstation — human popup-over-popup conversion (#16117)', () =
                         .toBe(sourceBefore.browser.outer.width > positioned.target.browser.inner.width
                             || sourceBefore.browser.outer.height > positioned.target.browser.inner.height);
 
+                    if (terminal === 'commit') {
+                        const paneId = await app.callMethod(wsId, 'getPaneIdentity', [cell.itemId]),
+                              {groupId} = await app.callMethod(wsId, 'controller.getTopologyState'),
+                              rows = async () => (await app.callMethod(wsId, 'transactionManager.get', [groupId])).history.rows,
+                              placement = async () => {
+                                  const [main, target, pane] = await Promise.all([
+                                      app.callMethod(wsId, 'getWorkspaceDocument', ['workstation-main']),
+                                      app.callMethod(wsId, 'getWorkspaceDocument', [TARGET_WORKSPACE_ID]),
+                                      app.getComponent(paneId, ['windowId'])
+                                  ]);
+
+                                  return {
+                                      main: Object.values(main.nodes).some(node => node.items?.includes(cell.itemId)),
+                                      target: Object.values(target.nodes).some(node => node.items?.includes(cell.itemId)),
+                                      metrics: Object.values(target.nodes).some(node => node.items?.includes(TARGET_ITEM_ID)),
+                                      paneWindowId: pane.windowId
+                                  }
+                              };
+
+                        expect(await placement(), 'the held gesture has not committed early')
+                            .toMatchObject({main: true, target: false, metrics: true});
+                        expect((await rows()).filter(row => row.itemId === cell.itemId)).toHaveLength(0);
+
+                        await page.mouse.up();
+                        pointerDown = false;
+
+                        const committed = {main: false, target: true, metrics: true, paneWindowId: targetWindowId};
+
+                        await expect.poll(placement, {
+                            message  : 'ordinary pointer release adopts into the existing popup',
+                            timeout  : 10000,
+                            intervals: [25, 50, 100]
+                        }).toEqual(committed);
+                        await expect.poll(() => sourcePage.isClosed()).toBe(true);
+                        expect(targetPage.isClosed()).toBe(false);
+                        const retired = await awaitVesselRetirement(app, managerId, wsId, cell.itemId, sourceWindowId);
+                        expect(await app.callMethod(wsId, 'getPaneIdentity', [cell.itemId])).toBe(paneId);
+                        await expect(targetPage.locator(`[id="${paneId}"]`)).toHaveCount(1);
+                        await expect(targetPage.locator(`[id="${paneId}"]`)).toBeVisible();
+                        await expect(page.locator(`[id="${paneId}"]`)).toHaveCount(0);
+
+                        const afterRows = await rows(),
+                              transfers = afterRows.filter(row => row.itemId === cell.itemId);
+
+                        // Physical target staging can append placement rows while the pointer is held.
+                        // Name the pane's transaction rather than mistaking all cursor growth for a drop.
+                        expect(transfers).toHaveLength(1);
+                        expect(transfers[0]).toMatchObject({
+                            cause            : 'dock-transfer',
+                            sourceWorkspaceId: 'workstation-main',
+                            targetWorkspaceId: TARGET_WORKSPACE_ID
+                        });
+                        expect(transfers[0].participants.map(participant => participant.workspaceKey))
+                            .toEqual(['workstation-main', TARGET_WORKSPACE_ID]);
+
+                        await app.callMethod(wsId, 'transactionManager.undo', [{groupId}]);
+                        await expect.poll(async () => {
+                            const {main, target, metrics} = await placement();
+
+                            return {main, target, metrics}
+                        }).toEqual({main: true, target: false, metrics: true});
+                        expect(await app.callMethod(wsId, 'getPaneIdentity', [cell.itemId])).toBe(paneId);
+                        await expect(page.locator(`[id="${paneId}"]`)).toHaveCount(1);
+                        await expect(page.locator(`[id="${paneId}"]`)).toBeVisible();
+                        await expect(targetPage.locator(`[id="${paneId}"]`)).toHaveCount(0);
+                        expect(await rows(), 'undo preserves every retained history row').toEqual(afterRows);
+
+                        await app.callMethod(wsId, 'transactionManager.redo', [{groupId}]);
+                        await expect.poll(placement).toEqual(committed);
+                        expect(await rows(), 'redo preserves every retained history row').toEqual(afterRows);
+                        await expect(targetPage.locator(`[id="${paneId}"]`)).toHaveCount(1);
+                        await expect(targetPage.locator(`[id="${paneId}"]`)).toBeVisible();
+                        await expect(page.locator(`[id="${paneId}"]`)).toHaveCount(0);
+
+                        await testInfo.attach(`human-popup-release-${cell.name}`, {
+                            body: Buffer.from(JSON.stringify({
+                                cell: cell.name, committed, paneId, retired, sourceWindowId, targetWindowId,
+                                historyIds: afterRows.map(row => row.id),
+                                transaction: {
+                                    id: transfers[0].id, cause: transfers[0].cause,
+                                    participants: transfers[0].participants.map(participant => participant.workspaceKey)
+                                }
+                            }, null, 2)),
+                            contentType: 'application/json'
+                        });
+                        return
+                    }
+
                     const targetFar = await targetHandle.cdp.send(
                         'Browser.getWindowBounds',
                         {windowId: targetHandle.windowId}
@@ -1479,5 +1573,14 @@ test.describe('Workstation — human popup-over-popup conversion (#16117)', () =
                 if (targetPage && !targetPage.isClosed()) await targetPage.close().catch(() => {});
             }
         })
-    })
+    }
+
+    for (const terminal of ['restore', 'commit']) {
+        const name = terminal === 'restore'
+            ? 'one local proxy plus readable target choices'
+            : 'pointer release transfers one pane with undo and redo';
+
+        test(`${MATRIX_CELL.name}: ${name}`, ({page, neuralLink}, testInfo) =>
+            runOverlap({page, neuralLink}, testInfo, terminal))
+    }
 });

--- a/test/playwright/e2e/workstation/WorkstationHumanPopupOverlapNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationHumanPopupOverlapNL.spec.mjs
@@ -1244,17 +1244,19 @@ test.describe('Workstation — human popup-over-popup conversion (#16117)', () =
                         intervals: [25, 50]
                     }).toBe(true);
 
-                    const
+                    let proxyRectB;
+
+                    await expect.poll(async () => {
                         proxyRectB = await proxy.evaluate(element => {
                             const rect = element.getBoundingClientRect();
 
                             return {height: rect.height, width: rect.width, x: rect.x, y: rect.y}
                         });
 
-                    expect(
-                        Math.abs(proxyRectB.x - proxyRectA.x) + Math.abs(proxyRectB.y - proxyRectA.y),
-                        `${cell.name}: target-local proxy follows the still-held pointer`
-                    ).toBeGreaterThan(2);
+                        return Math.abs(proxyRectB.x - proxyRectA.x) + Math.abs(proxyRectB.y - proxyRectA.y)
+                    }, {
+                        message: `${cell.name}: target-local proxy follows the still-held pointer`
+                    }).toBeGreaterThan(2);
 
                     expect(sourcePage.isClosed(), `${cell.name}: source popup remains the same live Page`).toBe(false);
                     expect(targetPage.isClosed(), `${cell.name}: target popup remains live`).toBe(false);


### PR DESCRIPTION
Resolves #18435

The popup-size matrix now has a normal pointer-release terminal alongside its existing restore terminal. Release must transfer the same pane from main into the already-open target popup, retire the provisional source, and produce exactly one two-participant history row. Undo and redo preserve every retained history row and render one pane in its owning window, with none in the window it left.

Only `WorkstationHumanPopupOverlapNL.spec.mjs` changes (+113/−8). The merged first-terminal and placeholder siblings remain. The shared motion check polls rendered displacement instead of treating worker readiness as a paint fence.

Evidence: L3 (author-run headed Chrome, real pointer/window actions and Neural Link state) → L3 required for the release-coverage leaf. The existing restore-journey failure remains separately recorded under #18303; these receipts do not certify the whole legacy matrix or hosted coverage.

## AC Evidence

| AC | Evidence |
|---|---|
| AC-1 | First-terminal, placeholder and all four restore registrations retained with their behavioral thresholds. The common displacement observation waits for rendering. Both earlier siblings passed; the inherited restore failure and clean-dev control are disclosed below. |
| AC-2 | Four release cases pass headed. While held: pane in main, absent from target, no incoming transfer row. After release: both panes in target, identical incoming pane, one visible DOM element, none in main, provisional source retired. |
| AC-3 | One incoming `dock-transfer` row spans main and target. Undo/redo preserve the full retained-row array and pane identity; DOM ownership is checked in both windows. |
| AC-4 | Four release-size cases pass at `adaf4fe1d19951a62ea8430359816d06cd52a97c`. Escape-before-release fails the transfer assertion; exact file restoration is verified. |

## Deltas from ticket

Rebased after #18430, #18418 and #18438 merged, then over registered WorkspaceSet #18452. The placeholder sibling at the conflicting insertion point is preserved.

Two evidence gaps were tightened: absence in the vacated window and full history equality rather than row count. The shared DOM-motion observation now waits for the effect after an immediate read observed zero displacement. Production behavior, root-edge policy and test selection are unchanged. An experimental staging-width change was evaluated and reverted.

## Test Evidence

At `adaf4fe1d19951a62ea8430359816d06cd52a97c`, fresh headed processes with one worker:

| Size cell | Release/undo/redo | Existing restore | Process |
|---|---|---|---|
| large-over-small | PASS | PASS | 14.3s |
| small-over-large | PASS | PASS | 14.2s |
| near-equal | PASS | PASS | 15.3s |
| post-resize-asymmetric | PASS | source popup closed during follow | 18.0s |

```sh
NEO_E2E_RUN_ID=pointer-release-large-over-small NEO_POPUP_CELL=large-over-small \
npx playwright test -c test/playwright/playwright.config.e2e.mjs \
  test/playwright/e2e/workstation/WorkstationHumanPopupOverlapNL.spec.mjs \
  --headed --workers=1 --grep 'one local proxy|pointer release transfers'
```

Set `NEO_AGENTOS_RUNTIME_ROOT` to the external Brain tooling checkout; repeat with the other three named cells.

The default-cell restore failure also reproduced on **clean dev `476f23aacd36ce2719036e58cc98b50a78daa045`**: two earlier siblings passed, then restore tried to read its closed source Page. In the failing diagnostic sequence, closure preceded Escape/mouse-up cleanup; source boundary coverage reached `0.621875` against a `0.6` re-entry threshold and native close was acknowledged. The original stage also placed a 760px source at x=1183 on a display ending at x=1728. These inherited restoration/staging observations remain under #18303; this PR does not claim to fix them.

Cancellation control: add `page.keyboard.press('Escape')` immediately before the commit terminal's `mouse.up()`. The transfer assertion fails with main retaining the pane and target lacking it. Final unmutated file SHA-256: `566a5112cf60e6ed9073b754af9532663a573a011c054daeff1609e8c1d679ad`.

## Post-Merge Validation

The broader restore/staging diagnosis continues under #18303. The new release coverage has no post-merge-only requirement. Its source is provisional: main → existing popup, not native titlebar transfer between two committed popup workspaces.

## Commits

- `d056669b` — recovered release terminal, preserved siblings, DOM ownership and history controls.
- `adaf4fe1` — wait for rendered pointer-follow evidence.

Related: #18303 · #18428

Authored by Euclid (GPT-6, Codex Desktop). Session b8d6e6c8-9f0c-475f-92ce-c77cfeebf909. Continues session 01a07609-5e09-70f0-bf2c-a27d77d1b7f2.
