### PR TITLE
ci(baseline): adopt the published skills release this repo's pin predates (#18465)

### DIFF
--- a/.github/workflows/pr-baseline.yml
+++ b/.github/workflows/pr-baseline.yml
@@ -70,6 +70,6 @@ permissions:
 
 jobs:
   baseline:
-    uses: neomjs/neo-agent-skills/.github/workflows/reusable-pr-baseline.yml@e409dea5dcbc9f6f97d6eb86ecbef4caa7a269b8
+    uses: neomjs/neo-agent-skills/.github/workflows/reusable-pr-baseline.yml@f5fcb7f126b41f7ce361684a75983c0c8582b7af
     with:
       required_base: dev


### PR DESCRIPTION
Resolves #18465

This repository's baseline pin predated the `neo-agent-skills@0.1.4` release, so every PR here has been running its baseline guards from `0.1.3` — the version that release exists to retire.

Evidence: L3 (both revisions read out of git at their exact SHAs; registry precondition re-checked immediately before the edit; job set diffed across the bump) → L3 required (all ACs). Residual: none.

## AC Evidence

| AC | Evidence |
|---|---|
| AC-1 | `npm view neo-agent-skills@0.1.4 version` → `0.1.4`, exit 0, re-run immediately before the edit rather than taken from the ticket body |
| AC-2 | pin now `f5fcb7f126b41f7ce361684a75983c0c8582b7af` (skills `dev`). `git show f5fcb7f:…/reusable-pr-baseline.yml \| grep -c "SKILLS_VERSION: '0.1.4'"` → **3**, matching the three install sites |
| AC-3 | job sets compared at both SHAs and **identical**: `pr-base pr-body skills-materialized source-comment-archaeology substrate-size` — md5-equal, not eyeballed |
| AC-4 | this PR's own baseline run — see below |

## The measurement

| revision | `SKILLS_VERSION` at 3 install sites |
|---|---|
| old pin `e409dea5dc` (skills #45 merge) | **`0.1.3`** |
| new pin `f5fcb7f126` (skills `dev`) | **`0.1.4`** |

Nothing was broken before this: `0.1.3` is still on the registry, so the jobs passed. The cost was silent staleness — **a green baseline was not evidence that the guards were current**, and that is the reading this change removes.

## Why the ordering mattered

neomjs/neo-agent-skills#27 records the live failure mode: a baseline naming a `SKILLS_VERSION` the registry lacks. Its trigger is a caller **reaching** such a baseline — not a merge. Bumping this pin *is* that reach, which is why it is safe now and would not have been before publication.

I had earlier pushed for publish-before-merge on the release PRs citing that same ticket. That was over-cautious: I read #27's trigger as the merge rather than the adoption, and one grep over consumer references would have settled it. Across `neo`, `neo-agent-brain`, `neo-agent-institution` and `devindex` there is **exactly one** reference to the reusable workflow — this line — and **zero** mutable `@dev`/`@main` refs, so no merge could redirect anyone. The immutable pin is what made the release window a non-event, and re-pinning is the price of that property.

## Test Evidence

No unit or component suite covers a workflow `uses:` pin; the honest verification is the emitted job behaviour, which is AC-4 and runs on this PR.

Read the **job output**, not the check name — this PR's `source-comment-archaeology` job log must show the `0.1.4` install. Those are two separate claims, and the check name has been green throughout the stale period.

## Deltas from ticket

None.

## Post-Merge Validation

- [ ] The next PR opened against `dev` shows `0.1.4` in its baseline install step, confirming adoption is repository-wide rather than branch-local.

## Out of scope

- **Automating this hop** — neomjs/neo-agent-skills#56 owns coupling merged substrate to a published version. Doing it by hand does not discharge it.
- **Other repositories** — `neo-agent-brain`, `neo-agent-institution` and `devindex` call the baseline zero times. neomjs/neo-agent-skills#40 covers the Brain's non-adoption, which is a different problem: no caller at all, versus a stale caller.
- **A branch ref instead of a SHA.** `@dev` would make every merge in another repository an unreviewed change to this repository's CI, and would have turned the release window into a live break. The re-pin cost is that safety property working as designed.

---

Authored by Grace (Claude Opus 5, Claude Code). Session 7f0f8990-80ed-42a0-a11b-8477dd3e405e.
