### PR TITLE
chore(workstation): use engine-owned dock previews (#18459)

### DIFF
--- a/apps/workstation/view/Workspace.mjs
+++ b/apps/workstation/view/Workspace.mjs
@@ -29,7 +29,6 @@ import {
 }                                                from '../../../src/dashboard/dock/window/VesselEmbodiment.mjs';
 import WorkspaceSet                             from '../../../src/dashboard/dock/window/WorkspaceSet.mjs';
 import VesselPark                               from '../../../src/dashboard/dock/window/VesselPark.mjs';
-import PreviewContract                          from '../../../src/dashboard/dock/model/PreviewContract.mjs';
 import {workstationTourScript, initialDocument} from '../tour/denseWorkstation.mjs';
 import '../../../src/button/Base.mjs';
 import '../../../src/tab/Container.mjs';
@@ -325,14 +324,6 @@ class Workspace extends DockWorkspace {
      * @protected
      */
     crossWindowParticipationPromise = null
-    /**
-     * Transient exact-node measurements for active cross-window preview targets. Each entry is
-     * generation-checked by component identity plus the live manager.Window inner rectangle;
-     * projection, leave, resize, or teardown retires it. Geometry never enters dock documents.
-     * @member {Map<String,Object>} crossWindowPreviewGeometries
-     * @protected
-     */
-    crossWindowPreviewGeometries = new Map()
 
     /**
      * Most recent cross-window transfer receipt for the film/spec boundary.
@@ -544,7 +535,7 @@ class Workspace extends DockWorkspace {
         // through `afterSetTopologyGroupId`, which registers the main participant then. The Group is
         // kept for the instance's lifetime: releasing the window's slot never loses the documents.
         // Vessel workspaces register lazily on first dock-INTO (Edit 2).
-        me.crossWindowParticipationPromise = me.refreshCrossWindowParticipation(Workspace.MAIN_WORKSPACE_ID)
+        me.crossWindowParticipationPromise = me.refreshCrossWindowParticipation()
             .catch(error => {
                 me.lastCrossWindowTransfer = {applied: false, errors: [error.message]};
                 return null
@@ -1109,68 +1100,36 @@ class Workspace extends DockWorkspace {
     }
 
     /**
-     * Creates one target-side adapter over a stable workspace identity. manager.Window remains the
-     * topology/hit-test authority; the app measures exact target-node geometry transiently for the
-     * preview renderer and never persists it.
+     * @summary Creates the main target using engine affordances and Workstation's saved-home policy.
+     * Popup workspaces own their default Participation through their native window lifecycle.
      * @param {Object} data
      * @param {String|Number} data.windowId
-     * @param {String} data.workspaceId
-     * @returns {Promise<Neo.dashboard.dock.window.Participation|null>}
+     * @returns {Promise<Workstation.window.Participation|null>}
      * @protected
      */
-    async createCrossWindowParticipation({windowId, workspaceId}) {
-        let me            = this,
-            isMain        = workspaceId === Workspace.MAIN_WORKSPACE_ID,
-            Participation = (await import('../../../src/dashboard/dock/window/Participation.mjs')).default;
+    async createCrossWindowParticipation({windowId}) {
+        const me            = this,
+              Participation = (await import('../window/Participation.mjs')).default,
+              workspaceId   = Workspace.MAIN_WORKSPACE_ID;
 
         if (me.isDestroyed) return null;
 
         return Neo.create(Participation, {
-            affordances       : isMain ? me.dragAffordances : null,
-            clearPreview      : () => me.clearCrossWindowPreview(workspaceId),
-            commitLocal       : operation => me.commitLocalWorkspaceOperation(workspaceId, operation),
-            commitTransfer    : data => me.commitCrossWindowTransfer(data),
-            dragEmbodiment    : me.vesselProxyEmbodiment,
-            getDocument       : () => me.getWorkspaceDocument(workspaceId),
-            getForeignDocument: sourceWorkspaceId => me.getWorkspaceDocument(sourceWorkspaceId),
-            hitTest           : (localX, localY) => me.hitTestCrossWindowTarget(workspaceId, localX, localY),
-            previewFor        : data => {
-                // Feed the local affordance tier from the remote hover frame: the indicator
-                // menu's only population path is this pipeline (its zone hit-test and the
-                // activeCandidate the gesture-ready contract reads), and the sort-zone event
-                // chain only fires for same-window drags. The promise is deliberately
-                // fire-and-forget (caught) — the readiness poll tolerates the async warm-up
-                // and a rejected measurement must never stall the gesture it annotates.
-                if (isMain) {
-                    // writeRenderer: false — the semantic path (renderCrossWindowPreview)
-                    // owns this renderer for cross-window gestures and paints it
-                    // synchronously (incl. the stored-home fallback); this feed exists to
-                    // populate the indicator tier, and an async write here would race it.
-                    Promise.resolve(me.dragAffordances?.onDragMove({
-                        clientX      : data?.localX,
-                        clientY      : data?.localY,
-                        groupNodeId  : data?.draggedItem?.dockGroupNodeId ?? null,
-                        itemId       : data?.draggedItem?.dockItemId,
-                        sourceNodeId : data?.draggedItem?.dockSourceNodeId ?? data?.sourceNodeId,
-                        writeRenderer: false
-                    })).catch(() => {});
-                }
-
-                return me.renderCrossWindowPreview(workspaceId, data)
-            },
-            previewToOperation   : preview => PreviewContract.previewToOperation(preview),
-            // Docking design record §2.3: every window of this root declares the root's Group as its commit authority.
+            affordances           : me.dragAffordances,
+            commitLocal           : operation => me.commitLocalWorkspaceOperation(workspaceId, operation),
+            commitTransfer        : data => me.commitCrossWindowTransfer(data),
+            dragEmbodiment        : me.vesselProxyEmbodiment,
             resolveOwnershipId    : () => me.resolveTopologyGroup() ?? null,
-            resumeNativeWindowDrag: isMain ? itemId => me.nativeVesselParkHandlers.onGestureTerminal({
+            resumeNativeWindowDrag: itemId => me.nativeVesselParkHandlers.onGestureTerminal({
                 itemId,
                 outcome: 'rejected'
-            }) : null,
-            retireNativeWindowDrag: isMain ? draggedItem => me.nativeVesselParkHandlers.onGestureTerminal({
+            }),
+            retireNativeWindowDrag: draggedItem => me.nativeVesselParkHandlers.onGestureTerminal({
                 itemId : draggedItem?.dockItemId,
                 outcome: 'committed'
-            }) : null,
+            }),
             sortGroup              : Workspace.CROSS_WINDOW_SORT_GROUP,
-            suspendNativeWindowDrag: isMain ? (itemId, data) => {
+            suspendNativeWindowDrag: (itemId, data) => {
                 me.vesselConversionTargetWindowId = data?.targetWindowId ?? null;
 
                 return me.nativeVesselParkHandlers.onConversionIn({
@@ -1178,52 +1137,35 @@ class Workspace extends DockWorkspace {
                     sourceRect: me.resolveVesselConversionSourceRect({itemId}),
                     windowName: me.resolveTearOutVessel(itemId)?.windowName
                 })
-            } : null,
+            },
             windowId,
-            workspace   : isMain ? me : null,
+            workspace   : me,
             workspaceId,
             workspaceSet: me.workspaceSet
         })
     }
 
     /**
-     * Re-registers one stable participation after its render projection. Dock tab zones and the
-     * stable workspace target share a per-window coordinator slot, so the stable target must win
-     * the final registration write after every projection.
-     * @param {String} workspaceId
-     * @returns {Promise<Neo.dashboard.dock.window.Participation|null>}
+     * @summary Re-registers the main target after projection without taking ownership of its visuals.
+     * The stable target shares its coordinator slot with projected tab zones and registers last.
+     * @returns {Promise<Workstation.window.Participation|null>}
      * @protected
      */
-    async refreshCrossWindowParticipation(workspaceId) {
-        let me       = this,
-            isMain   = workspaceId === Workspace.MAIN_WORKSPACE_ID,
-            state    = isMain ? null : me.getPopupState(workspaceId),
-            windowId = isMain ? me.windowId : state?.windowId;
-
-        if (windowId == null || (!isMain && !state)) return null;
+    async refreshCrossWindowParticipation() {
+        const me = this, windowId = me.windowId, workspaceId = Workspace.MAIN_WORKSPACE_ID;
+        if (windowId == null) return null;
 
         me.crossWindowParticipations.get(workspaceId)?.destroy();
         me.crossWindowParticipations.delete(workspaceId);
-        me.crossWindowPreviewGeometries.delete(workspaceId);
-        state && (state.participation = null);
 
-        const participation = await me.createCrossWindowParticipation({windowId, workspaceId});
+        const participation = await me.createCrossWindowParticipation({windowId});
 
-        if (
-            !participation ||
-            me.isDestroyed ||
-            (!isMain && (
-                me.getPopupState(workspaceId) !== state ||
-                state.app?.mainView?.isDestroyed
-            ))
-        ) {
+        if (!participation || me.isDestroyed || me.windowId !== windowId) {
             participation?.destroy();
             return null
         }
 
         me.crossWindowParticipations.set(workspaceId, participation);
-        state && (state.participation = participation);
-
         return participation
     }
 
@@ -1264,7 +1206,6 @@ class Workspace extends DockWorkspace {
 
         state.participation?.destroy();
         me.crossWindowParticipations.delete(workspaceId);
-        me.crossWindowPreviewGeometries.delete(workspaceId);
         state.host?.parent?.remove(state.host, false, true);
         if (state.host) state.host.windowId = null;
         state.windowId = state.app = state.renderTarget = null;
@@ -1323,326 +1264,6 @@ class Workspace extends DockWorkspace {
                 [`workstation-vessel-root:${itemId}`]: {type: 'edge-zone', zones: {center: {nodeId: tabsNodeId}}},
                 [tabsNodeId]                         : {type: 'tabs', items: [], activeItemId: null}
             }
-        }
-    }
-
-    /**
-     * D-013 hit-test: accepts only points inside the live manager.Window inner rect. Exact node
-     * measurement belongs exclusively to the render path below and never participates in target
-     * arbitration.
-     * @param {String} workspaceId
-     * @param {Number} localX
-     * @param {Number} localY
-     * @returns {Boolean}
-     * @protected
-     */
-    hitTestCrossWindowTarget(workspaceId, localX, localY) {
-        let me       = this,
-            isMain   = workspaceId === Workspace.MAIN_WORKSPACE_ID,
-            state    = isMain ? null : me.getPopupState(workspaceId),
-            windowId = isMain ? me.windowId : state?.windowId,
-            inner    = windowId != null ? Neo.manager?.Window?.get(windowId)?.innerRect : null;
-
-        return Boolean(
-            inner && Number.isFinite(localX) && Number.isFinite(localY) &&
-            localX >= 0 && localY >= 0 && localX <= inner.width && localY <= inner.height &&
-            (isMain || (
-                state && !state.committed && !state.closeRequested &&
-                me.nativeWindows?.getOwner(me.id, state.itemId)
-            ))
-        )
-    }
-
-    /**
-     * Resolves the render host, exact semantic target component, and preview renderer for one
-     * VESSEL workspace. A bare vessel has no projected tabs component yet, so its main view is the
-     * exact landing surface; a projected vessel node resolves by `dockNodeId`. The main workspace
-     * does not come through here — it rides the affordance controller's own geometry
-     * ({@link #renderMainCrossWindowPreview}).
-     * @summary Keeps semantic node identity paired with its actual rendered component.
-     * @param {String} workspaceId
-     * @param {String} targetNodeId
-     * @returns {{host: Neo.component.Base, renderer: Neo.dashboard.dock.interaction.Preview,
-     *     target: Neo.component.Base, windowId: (String|Number)}|null}
-     * @protected
-     */
-    resolveCrossWindowPreviewSurface(workspaceId, targetNodeId) {
-        let me       = this,
-            state    = me.getPopupState(workspaceId),
-            windowId = state?.windowId,
-            host     = state?.host ?? state?.app?.mainView,
-            target   = state && !state.host ? host : host?.down({dockNodeId: targetNodeId}),
-            renderer = state?.preview;
-
-        return windowId != null && host && target && renderer &&
-            typeof host.getDomRect === 'function' && !host.isDestroyed && !target.isDestroyed
-            ? {host, renderer, target, windowId}
-            : null
-    }
-
-    /**
-     * Measures one exact target component and translates it once into its preview overlay host.
-     * The promise itself is memoized so a move stream cannot stack DOM reads; entry identity makes
-     * late results inert after leave, projection, resize, target replacement, or teardown.
-     * @summary Warms a fail-closed, runtime-only exact-node geometry generation.
-     * @param {String} workspaceId
-     * @param {String} targetNodeId
-     * @returns {Promise<Object|null>}
-     * @protected
-     */
-    ensureCrossWindowPreviewGeometry(workspaceId, targetNodeId) {
-        let me      = this,
-            surface = me.resolveCrossWindowPreviewSurface(workspaceId, targetNodeId),
-            inner   = surface && Neo.manager?.Window?.get(surface.windowId)?.innerRect;
-
-        if (!surface || !inner) {
-            me.crossWindowPreviewGeometries.delete(workspaceId);
-            return Promise.resolve(null)
-        }
-
-        const
-            signature = [inner.x ?? 0, inner.y ?? 0, inner.width, inner.height].join(':'),
-            current   = me.crossWindowPreviewGeometries.get(workspaceId);
-
-        if (
-            current?.host === surface.host &&
-            current?.target === surface.target &&
-            current?.targetNodeId === targetNodeId &&
-            current?.windowSignature === signature
-        ) {
-            return current.promise
-        }
-
-        const entry = {
-            geometry       : null,
-            host           : surface.host,
-            promise        : null,
-            target         : surface.target,
-            targetNodeId,
-            windowSignature: signature
-        };
-
-        entry.promise = surface.host
-            .getDomRect([surface.host.id, surface.target.id], surface.windowId)
-            .then(([hostRect, targetRect]) => {
-                if (
-                    me.isDestroyed ||
-                    me.crossWindowPreviewGeometries.get(workspaceId) !== entry ||
-                    surface.host.isDestroyed ||
-                    surface.target.isDestroyed
-                ) {
-                    return null
-                }
-
-                if (
-                    !hostRect || !targetRect ||
-                    hostRect.width <= 0 || hostRect.height <= 0 ||
-                    targetRect.width <= 0 || targetRect.height <= 0
-                ) {
-                    me.crossWindowPreviewGeometries.delete(workspaceId);
-                    return null
-                }
-
-                return entry.geometry = {
-                    ...surface,
-                    hostRect,
-                    localTargetRect: me.dragAffordances.localRect(targetRect, hostRect),
-                    targetNodeId,
-                    targetRect
-                }
-            })
-            .catch(() => {
-                me.crossWindowPreviewGeometries.get(workspaceId) === entry &&
-                    me.crossWindowPreviewGeometries.delete(workspaceId);
-
-                return null
-            });
-
-        me.crossWindowPreviewGeometries.set(workspaceId, entry);
-
-        return entry.promise
-    }
-
-    /**
-     * Computes and renders one remote preview. The main workspace resolves it the way an in-window
-     * gesture does ({@link #renderMainCrossWindowPreview}); a vessel uses its stable lazy landing
-     * surface from an exact live measurement. A missing or in-flight measurement hides the preview
-     * for that frame.
-     * @param {String} workspaceId
-     * @param {Object} data
-     * @returns {Object|null}
-     * @protected
-     */
-    renderCrossWindowPreview(workspaceId, data) {
-        let me              = this,
-            isMain          = workspaceId === Workspace.MAIN_WORKSPACE_ID,
-            state           = isMain ? null : me.getPopupState(workspaceId),
-            draggedItem     = data?.draggedItem,
-            itemId          = draggedItem?.dockItemId,
-            groupNodeId     = draggedItem?.dockGroupNodeId ?? null,
-            sourceWorkspace = draggedItem?.dockSourceWorkspaceId,
-            sourceState     = me.getPopupState(sourceWorkspace),
-            sourceItemId    = sourceWorkspace === Workspace.MAIN_WORKSPACE_ID
-                ? itemId
-                : sourceState?.itemId,
-            storedHome      = sourceItemId && me.tearOutHandlers?.peekPlacement?.(sourceItemId)?.tabsNodeId,
-            targetNodeId    = isMain
-                ? (me.dockModel.nodes?.[storedHome]?.type === 'tabs'
-                    ? storedHome
-                    : Object.entries(me.dockModel.nodes || {}).find(([, node]) => node.type === 'tabs')?.[0])
-                : Workspace.vesselTabsNodeId(state?.itemId),
-            pointer         = {x: data?.localX, y: data?.localY},
-            renderer        = isMain ? me.dragAffordances?.preview : state?.preview,
-            indicators      = state?.indicators,
-            producer        = me.dragAffordances.producer,
-            sourceNodeId    = data?.sourceNodeId,
-            preview;
-
-        // A native-titlebar hover carries the coordinator's dwell clock; the renderer paints the hold
-        // from it. Set before any preview write below, so the affordance is built with it.
-        renderer && (renderer.dwell = data?.dwell ?? null);
-
-        if (
-            !itemId || !targetNodeId || state?.committed || state?.closeRequested ||
-            !me.hitTestCrossWindowTarget(workspaceId, pointer.x, pointer.y)
-        ) {
-            renderer && (renderer.dockPreview = null);
-            indicators?.clear();
-            return null
-        }
-
-        if (isMain) {
-            return me.renderMainCrossWindowPreview({groupNodeId, itemId, pointer, renderer, sourceNodeId, targetNodeId})
-        }
-
-        me.ensureCrossWindowPreviewGeometry(workspaceId, targetNodeId);
-
-        const geometry = me.crossWindowPreviewGeometries.get(workspaceId)?.geometry;
-
-        if (!geometry) {
-            renderer && (renderer.dockPreview = null);
-            indicators?.clear();
-
-            return null
-        }
-
-        const zone = {nodeId: targetNodeId, rect: geometry.targetRect};
-
-        if (indicators) {
-            indicators.hostRect = geometry.hostRect;
-            indicators.candidateSet = producer.produceCandidates({
-                containerId: geometry.host.id,
-                groupNodeId,
-                itemId,
-                pointer,
-                root       : zone,
-                sourceNodeId,
-                zones      : [zone]
-            });
-            preview = indicators.updatePointer(pointer)?.preview ?? null
-        }
-
-        // A vessel has one landing surface — the pane joins its stack — so the pointer-inference
-        // preview binds the zone's centre (the whole-zone tab-into) wherever inside the vessel the
-        // pointer is; only a hovered indicator chip above selects anything else.
-        preview ??= producer.produce({
-            containerId: geometry.host.id,
-            groupNodeId,
-            itemId,
-            pointer    : {
-                x: geometry.targetRect.x + geometry.targetRect.width  / 2,
-                y: geometry.targetRect.y + geometry.targetRect.height / 2
-            },
-            sourceNodeId,
-            zones      : [zone]
-        });
-
-        if (geometry.renderer) {
-            geometry.renderer.dwell       = data?.dwell ?? null;
-            geometry.renderer.dockPreview = preview;
-            preview && geometry.renderer.applyTargetGeometry(geometry.localTargetRect)
-        }
-
-        return preview
-    }
-
-    /**
-     * @summary Resolves the main workspace's remote frame through the shared geometry and tier order the
-     * in-window gesture uses ({@link Neo.dashboard.dock.interaction.DragAffordances#resolvePreview} —
-     * every projected tabs zone, an indicator candidate first, pointer inference second), so a
-     * popup or remote pointer reads the full placement grammar wherever it points and the drop
-     * lands there. The measurement is warmed here and read synchronously — a frame before it
-     * settles hides the preview rather than guessing — and re-measured when the main window's
-     * rect changes mid-gesture, which a remote gesture can outlive and a pointer drag cannot.
-     * @param {Object} data
-     * @param {String|null} data.groupNodeId
-     * @param {String} data.itemId
-     * @param {Object} data.pointer {x, y} in main-window client space
-     * @param {Neo.dashboard.dock.interaction.Preview|null} data.renderer
-     * @param {String} [data.sourceNodeId]
-     * @param {String} data.targetNodeId the stored-home tabs node — the off-zone fallback target
-     * @returns {Object|null}
-     * @protected
-     */
-    renderMainCrossWindowPreview({groupNodeId, itemId, pointer, renderer, sourceNodeId, targetNodeId}) {
-        let me          = this,
-            affordances = me.dragAffordances,
-            preview, targetRect;
-
-        affordances.ensureGeometry();
-
-        const {geometry} = affordances;
-
-        if (!geometry) {
-            renderer && (renderer.dockPreview = null);
-            return null
-        }
-
-        preview = affordances.resolvePreview({groupNodeId, itemId, pointer, sourceNodeId});
-
-        // Stored-home acquisition fallback: the window hit-test already admitted the gesture, so a
-        // pointer inside the window but outside every zone still acquires the stored-home target —
-        // the preview (and its painting) binds that exact node rect, never the pointer's empty
-        // position. On-zone positions keep the full placement grammar resolved above.
-        if (!preview) {
-            const home = geometry.zones.find(zone => zone.nodeId === targetNodeId);
-
-            preview = home ? affordances.producer.produce({
-                groupNodeId,
-                itemId,
-                pointer: {x: home.rect.x + home.rect.width / 2, y: home.rect.y + home.rect.height / 2},
-                sourceNodeId,
-                zones  : [home]
-            }) : null
-        }
-
-        targetRect = affordances.previewTargetRect(preview);
-
-        if (renderer) {
-            renderer.dockPreview = preview;
-            preview && targetRect && renderer.applyTargetGeometry(affordances.localRect(targetRect, geometry.hostRect))
-        }
-
-        return preview
-    }
-
-    /**
-     * @summary Clears one target's transient preview without touching committed workspace state.
-     * @param {String} workspaceId
-     * @protected
-     */
-    clearCrossWindowPreview(workspaceId) {
-        this.crossWindowPreviewGeometries.delete(workspaceId);
-
-        if (workspaceId === Workspace.MAIN_WORKSPACE_ID) {
-            this.dragAffordances?.clear()
-        } else {
-            let state   = this.getPopupState(workspaceId),
-                preview = state?.preview;
-
-            preview && (preview.dockPreview = null);
-            state?.indicators?.clear();
-            state && !state.committed && (state.document = null)
         }
     }
 
@@ -1837,7 +1458,6 @@ class Workspace extends DockWorkspace {
     beforeRefreshDockWorkspace(document, refreshOptions) {
         let me = this;
 
-        me.crossWindowPreviewGeometries.delete(Workspace.MAIN_WORKSPACE_ID);
         me.dragAffordances?.clear()
     }
 
@@ -1940,7 +1560,7 @@ class Workspace extends DockWorkspace {
         host.updateDepth = -1;
         host.update();
         await host.promiseUpdate();
-        await me.refreshCrossWindowParticipation(Workspace.MAIN_WORKSPACE_ID)
+        await me.refreshCrossWindowParticipation()
     }
 
     /**
@@ -4832,7 +4452,6 @@ class Workspace extends DockWorkspace {
 
         me.crossWindowParticipations.forEach(participation => participation?.destroy());
         me.crossWindowParticipations.clear();
-        me.crossWindowPreviewGeometries.clear();
         me.getPopupStates().forEach(state => state.host?.destroy());
         me.tourRunner?.destroy();
         me.dockService?.destroy();

--- a/apps/workstation/window/Participation.mjs
+++ b/apps/workstation/window/Participation.mjs
@@ -1,0 +1,60 @@
+import DockParticipation from '../../../src/dashboard/dock/window/Participation.mjs';
+
+/**
+ * @summary Keeps Workstation's saved-home drop policy while the engine owns preview and geometry.
+ * @description The main workspace borrows its existing affordances. A window-admitted pointer
+ * outside every measured zone may return a pane to its surviving saved home; on-zone gestures
+ * use the engine's complete placement grammar. The inherited lifetime owns the target and
+ * releases only the visuals it created, leaving the workspace's borrowed controller intact.
+ * @class Workstation.window.Participation
+ * @extends Neo.dashboard.dock.window.Participation
+ */
+class Participation extends DockParticipation {
+    static config = {
+        /** @member {String} className='Workstation.window.Participation' */
+        className: 'Workstation.window.Participation'
+    }
+
+    /**
+     * @summary Uses the engine preview first, then the saved-home tab target for an off-zone pointer.
+     * @param {Object} payload The target-local remote drag frame.
+     * @returns {Object|null} The exact preview consumed by the drop path.
+     * @protected
+     */
+    defaultPreviewFor(payload) {
+        const me = this;
+
+        if (!me.defaultHitTest(payload?.localX, payload?.localY)) {
+            me.defaultClearPreview();
+            return null
+        }
+
+        const preview = super.defaultPreviewFor(payload);
+        if (preview) return preview;
+
+        const workspace    = me.workspace,
+              affordances  = me.resolveAffordances(),
+              geometry     = affordances?.geometry,
+              draggedItem  = payload?.draggedItem,
+              itemId       = draggedItem?.dockItemId,
+              sourceId     = draggedItem?.dockSourceWorkspaceId,
+              sourceItemId = sourceId === me.workspaceId ? itemId : workspace.getPopupState(sourceId)?.itemId,
+              storedHome   = sourceItemId && workspace.tearOutHandlers?.peekPlacement(sourceItemId)?.tabsNodeId,
+              nodes        = workspace.dockModel?.nodes ?? {},
+              homeId       = nodes[storedHome]?.type === 'tabs' ? storedHome
+                  : Object.keys(nodes).find(id => nodes[id].type === 'tabs'),
+              home          = geometry?.zones.find(zone => zone.nodeId === homeId);
+
+        if (!home || !itemId) return null;
+
+        return affordances.renderPreview(affordances.producer.produce({
+            groupNodeId : draggedItem.dockGroupNodeId ?? null,
+            itemId,
+            pointer     : {x: home.rect.x + home.rect.width / 2, y: home.rect.y + home.rect.height / 2},
+            sourceNodeId: draggedItem.dockSourceNodeId ?? payload.sourceNodeId,
+            zones       : [home]
+        }), payload.dwell ?? null)
+    }
+}
+
+export default Neo.setupClass(Participation);

--- a/apps/workstation/window/Participation.mjs
+++ b/apps/workstation/window/Participation.mjs
@@ -25,7 +25,7 @@ class Participation extends DockParticipation {
         const me = this;
 
         if (!me.defaultHitTest(payload?.localX, payload?.localY)) {
-            me.defaultClearPreview();
+            me.resolveAffordances()?.renderPreview(null, payload?.dwell ?? null);
             return null
         }
 

--- a/buildScripts/util/file-size-baseline.json
+++ b/buildScripts/util/file-size-baseline.json
@@ -1,5 +1,5 @@
 {
-    "apps/workstation/view/Workspace.mjs": 2911,
+    "apps/workstation/view/Workspace.mjs": 2671,
     "examples/dashboard/crossWindow/DemoBWorkspace.mjs": 2612,
     "src/dashboard/dock/Workspace.mjs": 1027,
     "src/main/addon/DragDrop.mjs": 1267

--- a/test/playwright/e2e/workstation/WorkstationDockPreviewSymmetryNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationDockPreviewSymmetryNL.spec.mjs
@@ -11,13 +11,14 @@ const
  * One stable `left-tabs` target is exercised through both landed routes:
  *
  * - in-window: a real Audit-tab pointer gesture drives `DockDragAffordances`;
- * - popup→main: a real Activity tear-out supplies the source window, then the registered
+ * - popup→main: a real Activity header pop-out supplies the source window, then the registered
  *   `CrossWindowDragTarget` drives the main target's remote-preview callback.
  *
  * Each route runs in both Workstation themes. The retained matrix binds the semantic node id,
  * exact target/host/window rectangles, preview rectangle, DPR, zoom, and same-scale crop for
- * top/right/bottom/left. The test compares the four thicknesses directly; independent maxima
- * or source-code symmetry are deliberately insufficient.
+ * top/right/bottom/left. The default result-region presentation must occupy the exact half of
+ * that target for each direction. Equal pixel thickness across unequal axes would describe the
+ * optional legacy bands, not the region the current default promises.
  *
  * Run:
  * NEO_E2E_PORT=8096 npx playwright test WorkstationDockPreviewSymmetryNL \
@@ -101,6 +102,8 @@ test.describe('Workstation dock-preview four-axis symmetry (Neural Link)', () =>
         expect(hostId, 'the preview containing block must resolve by reference').toBeTruthy();
         expect(targetId, 'left-tabs must resolve to one exact component id').toBeTruthy();
         expect(previewId, 'the main preview renderer must resolve by reference').toBeTruthy();
+        expect((await app.getComponent(previewId, ['resultRegionPreviews'])).resultRegionPreviews,
+            'this journey covers the default result-region presentation').toBe(true);
 
         return {app, hostId, previewId, targetId, wsId}
     }
@@ -357,10 +360,10 @@ test.describe('Workstation dock-preview four-axis symmetry (Neural Link)', () =>
     }
 
     /**
-     * Enforces exact target reuse, edge containment, and four-way CSS/physical thickness equality.
+     * Enforces exact target reuse, edge containment, and the half-target result region on every axis.
      * @param {Object[]} frames
      */
-    function assertSymmetry(frames) {
+    function assertResultRegions(frames) {
         expect(frames.map(frame => frame.edge)).toEqual(EDGES);
 
         const
@@ -373,6 +376,8 @@ test.describe('Workstation dock-preview four-axis symmetry (Neural Link)', () =>
             const
                 target     = frame.targetRect,
                 affordance = frame.affordanceRect;
+
+            expect(frame.affordanceClass).toContain('neo-dock-preview-region');
 
             for (const key of ['left', 'top', 'width', 'height']) {
                 expect(Math.abs(target[key] - reference[key]),
@@ -403,15 +408,17 @@ test.describe('Workstation dock-preview four-axis symmetry (Neural Link)', () =>
             physicalThickness[frame.edge] = cssThickness[frame.edge] * frame.devicePixelRatio
         });
 
-        const
-            cssValues      = Object.values(cssThickness),
-            physicalValues = Object.values(physicalThickness);
+        frames.forEach(frame => {
+            const expected = (frame.edge === 'top' || frame.edge === 'bottom'
+                ? frame.targetRect.height : frame.targetRect.width) / 2;
 
-        expect(Math.max(...cssValues) - Math.min(...cssValues),
-            `four-axis CSS thicknesses: ${JSON.stringify(cssThickness)}`).toBeLessThanOrEqual(1);
-        expect(Math.max(...physicalValues) - Math.min(...physicalValues),
-            `four-axis rendered thicknesses: ${JSON.stringify(physicalThickness)}`)
-            .toBeLessThanOrEqual(frames[0].devicePixelRatio)
+            expect(Math.abs(cssThickness[frame.edge] - expected),
+                `${frame.route}/${frame.theme}/${frame.edge} must fill half its target axis`)
+                .toBeLessThanOrEqual(tolerance);
+            expect(Math.abs(physicalThickness[frame.edge] - expected * frame.devicePixelRatio),
+                `${frame.route}/${frame.theme}/${frame.edge} must preserve the region at device scale`)
+                .toBeLessThanOrEqual(tolerance * frame.devicePixelRatio)
+        })
     }
 
     /**
@@ -450,7 +457,7 @@ test.describe('Workstation dock-preview four-axis symmetry (Neural Link)', () =>
             await cancelPhysicalDrag(page)
         }
 
-        assertSymmetry(frames);
+        assertResultRegions(frames);
 
         return frames
     }
@@ -554,12 +561,12 @@ test.describe('Workstation dock-preview four-axis symmetry (Neural Link)', () =>
             await app.callMethod(remoteTargetId, 'onRemoteDragLeave')
         }
 
-        assertSymmetry(frames);
+        assertResultRegions(frames);
 
         return frames
     }
 
-    test('one exact target stays symmetric across four edges, two routes, and both themes', async ({
+    test('one exact target paints its result regions across four edges, two routes, and both themes', async ({
         page,
         neuralLink
     }, testInfo) => {
@@ -583,18 +590,27 @@ test.describe('Workstation dock-preview four-axis symmetry (Neural Link)', () =>
 
             await setTheme(app, page, wsId, THEMES[0]);
 
-            const
-                popupPromise  = page.waitForEvent('popup', {timeout: 90000}),
-                tearOutResult = await app.callMethod(wsId, 'executeTearOutStep', [
-                    {itemId: 'activity', sourceNodeId: 'left-tabs'},
-                    {birthAttempts: 240, moveDelay: 16, moveSteps: 5}
-                ]);
+            const chrome = await app.callMethod(wsId, 'getTabChromeIdentity', ['left-tabs']);
+            expect(chrome?.buttons?.activity, 'Activity has live tab chrome').toBeTruthy();
+            await page.locator(`#${chrome.buttons.activity}`).click();
+
+            const action = await app.callMethod(chrome.containerId, 'getAction', ['pop-out']);
+            expect(action?.id, 'the engine exposes the native pop-out action').toBeTruthy();
+            await expect(page.locator(`#${action.id}`)).toBeVisible();
+
+            const popupPromise = page.waitForEvent('popup', {timeout: 30000});
+            await page.locator(`#${action.id}`).click();
 
             popup = await popupPromise;
             await popup.waitForLoadState('domcontentloaded');
 
-            expect(tearOutResult.errors).toEqual([]);
-            expect(tearOutResult.applied, 'Activity must be owned by one real popup source').toBe(true);
+            await expect.poll(async () => {
+                const source = await app.callMethod(wsId, 'getWorkspaceDocument', ['workstation-main']),
+                      target = await app.callMethod(wsId, 'getWorkspaceDocument', ['workstation-vessel:activity']);
+
+                return !source.items.activity &&
+                    target?.nodes?.['workstation-vessel-tabs:activity']?.items?.includes('activity') === true
+            }, {message: 'the Group must transfer Activity into its popup document'}).toBe(true);
             await expect(popup.locator('.workstation-viewport')).toBeVisible();
             await page.waitForTimeout(900);
 

--- a/test/playwright/e2e/workstation/WorkstationFiveBeatNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationFiveBeatNL.spec.mjs
@@ -2006,11 +2006,15 @@ test.describe('Workstation — the five-beat multi-window journey', () => {
             y: targetBox.y + targetBox.height / 2
         };
 
-        expect(await app.callMethod(wsId, 'hitTestCrossWindowTarget', [
-            'workstation-main',
+        const participationId = readId(await app.findInstances({
+            className: 'Workstation.window.Participation', workspaceId: 'workstation-main'
+        }, ['id']));
+
+        expect(participationId, 'the main window owns its interaction participant').toBeTruthy();
+        expect(await app.callMethod(participationId, 'defaultHitTest', [
             candidateLocalPoint.x,
             candidateLocalPoint.y
-        ]), 'the exact physical target point must pass the lower-layer workspace hit test').toBe(true);
+        ]), 'the exact physical target point must pass the participant hit test').toBe(true);
 
         const
             mainChromeHeight  = mainPlacement.browser.outer.height - mainPlacement.browser.inner.height,

--- a/test/playwright/e2e/workstation/WorkstationNativeTitlebarDragNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationNativeTitlebarDragNL.spec.mjs
@@ -87,7 +87,7 @@ async function moveNative(handle, left, top) {
  */
 async function readMainParticipationId(app) {
     const participations = asArray(await app.findInstances(
-        {className: 'Neo.dashboard.dock.window.Participation'}, ['id', 'workspaceId']
+        {className: 'Workstation.window.Participation'}, ['id', 'workspaceId']
     ));
 
     return participations.find(entry => entry.properties?.workspaceId === 'workstation-main')?.id ?? null

--- a/test/playwright/unit/apps/workstation/Workspace.spec.mjs
+++ b/test/playwright/unit/apps/workstation/Workspace.spec.mjs
@@ -12,6 +12,7 @@ import * as core                from '../../../../../src/core/_export.mjs';
 import DockProjectionReconciler from '../../../../../src/dashboard/dock/projection/Reconciler.mjs';
 import WorkspaceDocument        from '../../../../../src/dashboard/dock/model/WorkspaceDocument.mjs';
 import Operations               from '../../../../../src/dashboard/dock/model/Operations.mjs';
+import DockParticipation        from '../../../../../src/dashboard/dock/window/Participation.mjs';
 import '../../../../../src/manager/Instance.mjs';
 import TransactionManager from '../../../../../src/manager/Transaction.mjs';
 import FeedPane           from '../../../../../apps/workstation/view/FeedPane.mjs';
@@ -1031,6 +1032,83 @@ test.describe.serial('Workstation.view.Workspace', () => {
         }
     });
 
+    test('main participation executes the engine preview and preserves borrowed visuals across refresh', async () => {
+        const workspace       = Neo.create(Workspace, {windowId: Neo.config.windowId}),
+              originalPreview = DockParticipation.prototype.defaultPreviewFor,
+              WindowManager   = Neo.manager.Window,
+              originalGet     = WindowManager.get;
+        let defaultCalls = 0;
+
+        try {
+            await workspace.crossWindowParticipationPromise;
+            const first       = workspace.crossWindowParticipations.get(Workspace.MAIN_WORKSPACE_ID),
+                  affordances = workspace.dragAffordances;
+
+            WindowManager.get = () => ({innerRect: {x: 0, y: 0, width: 1280, height: 720}});
+            DockParticipation.prototype.defaultPreviewFor = function(payload) {
+                ++defaultCalls;
+                return originalPreview.call(this, payload)
+            };
+
+            expect(first.previewFor).toBeNull();
+            expect(first.clearPreview).toBeNull();
+            expect(first.affordances).toBe(affordances);
+            first.target.previewFor({draggedItem: {dockItemId: 'queues'}, localX: 50, localY: 50});
+            expect(defaultCalls).toBe(1);
+            await affordances.ensureGeometry();
+
+            const replacement = await workspace.refreshCrossWindowParticipation();
+            expect(first.isDestroyed).toBe(true);
+            expect(replacement).not.toBe(first);
+            expect(replacement.affordances).toBe(affordances);
+            expect(replacement.ownedAffordances).toBeNull();
+            expect(affordances.isDestroyed).not.toBe(true);
+            expect(affordances.preview.isDestroyed).not.toBe(true);
+            replacement.target.onRemoteDragLeave();
+            expect(affordances.preview.dockPreview).toBeNull()
+        } finally {
+            DockParticipation.prototype.defaultPreviewFor = originalPreview;
+            WindowManager.get = originalGet;
+            workspace.destroy()
+        }
+    });
+
+    test('popup participation alone owns and retires its default overlays when rebound', async () => {
+        const workspace = Neo.create(Workspace, {windowId: Neo.config.windowId});
+
+        try {
+            await workspace.crossWindowParticipationPromise;
+            const {state, workspaceId} = stageCommittedVessel(workspace),
+                  host                 = state.host;
+
+            host.windowId = 'popup-preview-owner';
+            const first       = host.participation,
+                  affordances = first.resolveAffordances(),
+                  preview     = first.ownedPreview,
+                  indicators  = first.ownedIndicators;
+
+            expect(first.constructor).toBe(DockParticipation);
+            expect(first.previewFor).toBeNull();
+            expect(first.clearPreview).toBeNull();
+            expect(workspace.crossWindowParticipations.has(workspaceId)).toBe(false);
+
+            host.syncParticipation();
+            expect(first.isDestroyed).toBe(true);
+            expect(affordances.isDestroyed).toBe(true);
+            expect(preview.isDestroyed).toBe(true);
+            expect(indicators.isDestroyed).toBe(true);
+            expect(host.participation).not.toBe(first);
+            expect(host.participation.ownedAffordances).toBeNull();
+
+            const replacement = host.participation;
+            host.windowId = null;
+            expect(replacement.isDestroyed).toBe(true);
+            expect(host.participation).toBeNull()
+        } finally {
+            workspace.destroy()
+        }
+    });
+
     test('remote main previews resolve through the affordance geometry: the full grammar on the pointed zone, the stored-home tab-into off-zone', async () => {
         const
             workspace         = Neo.create(Workspace, {windowId: Neo.config.windowId}),
@@ -1055,8 +1133,8 @@ test.describe.serial('Workstation.view.Workspace', () => {
                     .map(([nodeId]) => zoneId(nodeId)),
                 rects                   = {[host.id]: hostRect, [zoneId('left-tabs')]: leftRect, [zoneId('heavy-tabs')]: heavyRect},
                 local                   = rect => ({x: rect.x - hostRect.x, y: rect.y - hostRect.y, width: rect.width, height: rect.height}),
-                render                  = (point, sourceWorkspace = sourceWorkspaceId) => workspace.renderCrossWindowPreview(
-                    Workspace.MAIN_WORKSPACE_ID,
+                render                  = (point, sourceWorkspace = sourceWorkspaceId) => workspace.crossWindowParticipations
+                    .get(Workspace.MAIN_WORKSPACE_ID).target.previewFor(
                     {
                         draggedItem : {dockItemId: 'queues', dockSourceWorkspaceId: sourceWorkspace},
                         localX      : point.x,
@@ -1081,6 +1159,7 @@ test.describe.serial('Workstation.view.Workspace', () => {
                     return ids.map(id => rects[id] ?? farRect)
                 };
                 renderer.applyTargetGeometry = rect => paintedRects.push(rect);
+                await workspace.refreshCrossWindowParticipation();
 
                 // The first frame warms the SAME once-per-gesture measurement the indicator tier
                 // uses — the host plus EVERY projected tabs zone — and hides until it settles.
@@ -1189,7 +1268,7 @@ test.describe.serial('Workstation.view.Workspace', () => {
 
             // The construct-time participation resolves before windowId exists in this
             // harness — refresh it now that the window identity is set.
-            const participation = await workspace.refreshCrossWindowParticipation(Workspace.MAIN_WORKSPACE_ID);
+            const participation = await workspace.refreshCrossWindowParticipation();
 
             const
                 host               = workspace.getReference('dock-host'),
@@ -1957,10 +2036,11 @@ test.describe.serial('Workstation.view.Workspace', () => {
         try {
             await workspace.crossWindowParticipationPromise;
             workspace.nativeWindows.recordOwner(workspace.id, "alerts", {windowId: 'window-alerts'});
-            registerPopupState(workspace, workspaceId, {
+            const state = registerPopupState(workspace, workspaceId, {
                 itemId  : 'alerts',
                 windowId: 'window-alerts'
             });
+            state.host.windowId = state.windowId;
 
             const
                 WindowManager = Neo.manager.Window,
@@ -1970,19 +2050,11 @@ test.describe.serial('Workstation.view.Workspace', () => {
             try {
                 WindowManager.get = () => ({innerRect});
 
-                expect(workspace.hitTestCrossWindowTarget(
-                    workspaceId,
-                    300,
-                    200
-                )).toBe(true);
+                expect(state.host.participation.target.hitTest(300, 200)).toBe(true);
 
                 innerRect = {width: 240, height: 160};
 
-                expect(workspace.hitTestCrossWindowTarget(
-                    workspaceId,
-                    300,
-                    200
-                )).toBe(false)
+                expect(state.host.participation.target.hitTest(300, 200)).toBe(false)
             } finally {
                 WindowManager.get = originalGet
             }

--- a/test/playwright/unit/apps/workstation/Workspace.spec.mjs
+++ b/test/playwright/unit/apps/workstation/Workspace.spec.mjs
@@ -1198,6 +1198,12 @@ test.describe.serial('Workstation.view.Workspace', () => {
                 expect(paintedRects.at(-1)).toEqual(local(heavyRect));
                 expect(renderer.dockPreview?.previewId).toBe(split.previewId);
 
+                const settledGeometry = affordances.geometry;
+                expect(render({x: -1, y: -1})).toBeNull();
+                expect(renderer.dockPreview).toBeNull();
+                expect(affordances.geometry, 'a refused frame must not end the shared geometry session')
+                    .toBe(settledGeometry);
+
                 // Off every zone but inside the window: the stored home acquires the drop as a
                 // tab-into, painted on the home's exact rect — never on the pointer's empty position.
                 workspace.tearOutHandlers.recordPlacement('queues', {index: 1, tabsNodeId: 'right-top-tabs'});


### PR DESCRIPTION
Resolves #18459

Workstation now uses the engine Participation preview, geometry and clear paths. Its main target borrows the existing affordances; a 60-line registered app subclass adds only the tested saved-home fallback for an off-zone pointer. PopupWorkspace already owns its default Participation, so the root's parallel popup preview code and geometry cache are deleted.

Workspace falls from **4,859 to 4,478 total physical lines** (381 removed); the new policy is **60 lines**, for **321 fewer app-source lines overall**. Code lines fall from 2,911 to 2,671 in the root; the new policy has 36. The shrinking baseline is updated. This is an intermediate leaf of #18456, not its final 1,000-line entrypoint delivery.

Evidence: L3 (rendered headless matrix plus a separate headed native-titlebar journey; runtime owner and mutation controls) → L3 required (AC-3 and AC-5). Residual: none within this leaf.

## AC Evidence
| AC-1 | Six root preview/hit-test helpers, their geometry map and asynchronous indicator feed are removed. The surviving app policy calls the engine default first and uses the existing producer/renderer only for saved-home fallback. |
| AC-2 | Counts above; no copied geometry/controller pipeline moved into another app helper. |
| AC-3 | Four edges × two routes × two themes in WorkstationDockPreviewSymmetryNL; direct Group ownership checks after a real header pop-out. Headed WorkstationNativeTitlebarDragNL covers physical window movement, dwell, reintegration and cleanup. |
| AC-4 | CI-covered: Workspace.spec.mjs verifies main borrowed visuals survive refresh, popup-owned overlays retire on rebind, and refused frames preserve the shared geometry session. |
| AC-5 | Same matrix/native receipts; the unit default-path control fails when super.defaultPreviewFor is bypassed (expected one invocation, received zero). Native/FiveBeat call sites resolve the actual registered app Participation. |
| AC-6 | No engine source or API changes; no engine prerequisite introduced. |

## Deltas from ticket
PopupWorkspace.syncParticipation already owns the popup path; the old root's popup renderer was obsolete, so it is deleted rather than relocated.

The matrix still asserted the old constant-thickness presentation. Untouched base 9ce8ca7060 and the cut both returned 187px/90px for the current half-target regions. The witness now checks the exact half-region on each axis, retaining semantic target identity, containment, device-scale checks and pixel captures. Popup setup uses the engine header action and direct committed ownership, without requiring the optional tour driver.

New declarative configuration design stays in the separately scoped Discussion #18468. This PR adopts existing APIs.

Change class: zero-delta ownership refactoring. agent-preflight: not hosted here; local lint-staged, parse/JSDoc, file-size and published PR-body checks ran. The reusable PR baseline remains the CI gate.

## Test Evidence
- WorkstationDockPreviewSymmetryNL: **1 passed**, headless, all **16 frames** (four edges, in-window/popup-to-main, dark/light) with the external Brain runtime configured.
- WorkstationNativeTitlebarDragNL: **1 passed headed**, using actual browser-window bounds and the production movement-poll/dwell path.
- Default-path mutation: skipping the inherited preview method makes its invocation control fail; restoring it passes.
- Refused-frame control: the initial cut discarded shared geometry; the repaired guard hides the preview while retaining the same geometry object.
- Live Neural Link discovery confirmed Workstation.window.Participation, workspaceId workstation-main, bound to the actual main window.

Out of scope, noted in #17844: the existing optional tear-out driver's committed-state gate and the headed multi-edge matrix's early drag termination. Their [baseline evidence and scope](https://github.com/neomjs/neo/issues/17844#issuecomment-5582215885) remain visible. The headless matrix does not certify that headed variant or the whole film.

## Post-Merge Validation
- [ ] Reconfirm the selected preview and native journeys on dev after merge.

## Commits
- a5e17a287c — adopt existing preview ownership and move callers to their real owner.
- 6e80b78e56 — preserve refused-frame geometry and validate the current result-region contract.

Related: #18456 · #18460 · #17844

Authored by Emmy (GPT-6 Astra, Codex). Session 153d2e0a-ebae-4087-bcd5-3c92d213132c.
