### PR TITLE
feat(dock): create items through semantic operations (#18467)

### DIFF
--- a/learn/agentos/DockZoneModel.md
+++ b/learn/agentos/DockZoneModel.md
@@ -228,6 +228,7 @@ Every mutation goes through `Neo.dashboard.dock.model.Operations`; `applyOperati
 | `splitNode` | `targetNodeId`, `orientation`, `beforeNodeId`, `afterNodeId`, `sizes` | Replaces a node with a split containing the old and new nodes. |
 | `resizeSplit` | `splitNodeId`, `sizes` | Updates an existing split node's normalized child sizes after a splitter affordance. |
 | `resizeEdgeZone` | `edgeZoneId`, `edge`, `extent` | Commits one normalized extent when that nested edge descriptor explicitly has `resizable: true`. |
+| `addItem` | `itemId`, `item`, optional `target` | Creates a JSON catalog record; an `addTab` or `splitNode` target places it atomically. Duplicate/reserved ids, invalid records and failed placement return the original document with errors. |
 | `addTab` | `itemId`, `tabsNodeId`, `index` | Inserts an item into a tab slot and may set `activeItemId`. |
 | `detachItem` | `itemId` | Removes an item from the dock tree while preserving its item record for popup/window ownership. |
 | `closeItem` | `itemId` | Removes an item from both tree and catalog when policy permits. |
@@ -239,6 +240,21 @@ Every mutation goes through `Neo.dashboard.dock.model.Operations`; `applyOperati
 | `selectSavedLayout` | collection, `layoutId` | Selects an existing saved layout id as active. |
 | `removeSavedLayout` | collection, `layoutId`, `replacementLayoutId` | Removes a named saved layout; active removals require an explicit replacement. |
 | `restoreActiveSavedLayout` | collection | Restores the active saved layout through `restoreSavedLayout()`. |
+
+For runtime creation, carry the item record in the operation so a Group participant can re-apply it
+against its current document. Seeding `document.items` outside the operation loses that input on
+the Group path; `addTab` correctly refuses unknown ids. `applyDocument` remains a whole-document
+replacement, including changes made since its candidate was prepared.
+
+```javascript
+{operation: 'addItem', itemId: 'inspector', item: {componentRef: 'inspector', title: 'Inspector'},
+ target: {operation: 'addTab', tabsNodeId: 'main-tabs'}}
+```
+
+Omit `target` to create an unplaced catalog record. The outer `itemId` controls placement; a nested
+target cannot substitute another id. `item` uses the existing JSON-only item schema, including
+optional `metadata` and `blueprint`; consumers resolve `componentRef` and construct components.
+Module factories and live component instances do not belong in the record.
 
 Every operation must maintain:
 

--- a/src/dashboard/dock/model/Operations.mjs
+++ b/src/dashboard/dock/model/Operations.mjs
@@ -37,7 +37,8 @@ class Operations extends Base {
      * @static
      */
     static operationHandlers = Object.freeze({
-        addTab: (document, descriptor) =>
+        addItem: (document, descriptor) => Operations.addItem(document, descriptor),
+        addTab : (document, descriptor) =>
             WorkspaceDocument.findContainingTabsId(document, descriptor.itemId)
                 ? Operations.moveItem(document, {itemId: descriptor.itemId, targetNodeId: descriptor.tabsNodeId, index: descriptor.index})
                 : Operations.addTab(document, descriptor),
@@ -82,17 +83,18 @@ class Operations extends Base {
      * @static
      */
     static operationChangeClass = Object.freeze({
-        addTab           : 'topology',
-        applyDocument    : 'topology',
-        setActiveItem    : 'topology',
-        moveItem         : 'topology',
-        splitNode        : 'topology',
-        moveNode         : 'topology',
-        resizeSplit      : 'geometry',
-        resizeEdgeZone   : 'geometry',
-        detachItem       : 'topology',
-        closeItem        : 'topology',
-        setItemLocked    : 'itemFlags',
+        addItem       : 'topology',
+        addTab        : 'topology',
+        applyDocument : 'topology',
+        setActiveItem : 'topology',
+        moveItem      : 'topology',
+        splitNode     : 'topology',
+        moveNode      : 'topology',
+        resizeSplit   : 'geometry',
+        resizeEdgeZone: 'geometry',
+        detachItem    : 'topology',
+        closeItem     : 'topology',
+        setItemLocked : 'itemFlags',
         // Pinned and auto-hidden write one item field each, exactly like `setItemLocked` — but they
         // are the two operations that MOVE a pane between the shell and an edge rail, and the rail
         // is projected outside the shell. They are placement changes wearing an item flag, so they
@@ -150,6 +152,43 @@ class Operations extends Base {
         return descriptor.document
             ? WorkspaceDocument.commit(document, descriptor.document)
             : {document, errors: ['applyDocument requires a candidate document']}
+    }
+
+    /**
+     * @summary Creates a JSON item record, optionally placing it through `addTab` or `splitNode`.
+     * Omitted placement leaves a catalog-only item. The descriptor carries the record so queued
+     * Group writes can reduce against current committed state without replacing unrelated changes.
+     * Validation or placement failure returns the original document without the staged record.
+     * @param {Object} document
+     * @param {Object} args {itemId, item, target?} — existing item schema and placement descriptor
+     * @returns {{document:Object, errors:String[]}}
+     * @static
+     */
+    static addItem(document, {itemId, item, target} = {}) {
+        const fail = errors => ({document, errors});
+
+        if (typeof itemId !== 'string' || !itemId) return fail(['addItem requires a non-empty itemId']);
+        if (Object.hasOwn(document.items || {}, itemId) || Object.hasOwn(Object.prototype, itemId)) {
+            return fail([`item "${itemId}" already exists or is reserved`])
+        }
+        if (!WorkspaceDocument.isJsonRecord(item)) return fail(['addItem item must be a JSON record']);
+
+        const invalid = WorkspaceDocument.findNonJsonValue(item, 'item') ||
+            WorkspaceDocument.findUnexpectedKey(item, WorkspaceDocument.dockZoneItemKeys, 'item');
+        if (invalid) return fail([`${invalid.path}: ${invalid.reason}`]);
+        if (target !== undefined && (!WorkspaceDocument.isJsonRecord(target) || !['addTab', 'splitNode'].includes(target.operation))) {
+            return fail(['addItem target must be an addTab or splitNode descriptor'])
+        }
+
+        const working = WorkspaceDocument.clone(document);
+        working.items ||= {};
+        working.items[itemId] = WorkspaceDocument.clone(item);
+
+        const result = target === undefined
+            ? WorkspaceDocument.commit(document, working)
+            : Operations.applyOperation(working, {...target, itemId});
+
+        return result.errors.length ? fail(result.errors) : result
     }
 
     /**

--- a/src/dashboard/dock/plugin/Maximize.mjs
+++ b/src/dashboard/dock/plugin/Maximize.mjs
@@ -758,7 +758,7 @@ class Maximize extends Plugin {
     }
 
     /**
-     * Classifies a committed operation descriptor as confined to the maximized node — the ops
+     * @summary Classifies a committed operation as catalog-only or confined to the maximized node — the ops
      * that must NOT pre-clear the transient: their effect stays inside the pane the user is
      * looking at, so the continuity rule ({@link #syncDockProjection}) decides from the committed
      * outcome instead (node survived ⇒ re-apply; collapsed away ⇒ clear). Everything else —
@@ -779,6 +779,8 @@ class Maximize extends Plugin {
         }
 
         switch (operation) {
+            case 'addItem':
+                return descriptor.target === undefined || me.isNeutralOperation({...descriptor.target, itemId});
             case 'addTab': {
                 // The addTab handler re-dispatches an already-contained item to moveItem, so a
                 // descriptor targeting the maximized node can still RELOCATE the item out of a

--- a/test/playwright/unit/dashboard/DockMaximizePlugin.spec.mjs
+++ b/test/playwright/unit/dashboard/DockMaximizePlugin.spec.mjs
@@ -223,6 +223,31 @@ test.describe('dock maximize as a declinable plugin', () => {
         expect(plugin.isNeutralOperation({operation: 'splitNode', nodeId: 'side-tabs'}), 'a topology mutation reaches beyond it').toBe(false)
     });
 
+    for (const [name, target, expected] of [
+        ['catalog-only', undefined, 'main-tabs'],
+        ['inside the maximized pane', {operation: 'addTab', tabsNodeId: 'main-tabs', itemId: 'gamma'}, 'main-tabs'],
+        ['inside another pane', {operation: 'addTab', tabsNodeId: 'side-tabs'}, null],
+        ['splitting the maximized pane', {operation: 'splitNode', targetNodeId: 'main-tabs', orientation: 'horizontal'}, null]
+    ]) {
+        test(`addItem ${name} preserves only neutral maximize state through the commit hook`, async () => {
+            create();
+
+            const plugin     = workspace.getPlugin('dock-maximize'),
+                  descriptor = {operation: 'addItem', itemId: 'created', item: {componentRef: 'created'},
+                      ...(target === undefined ? {} : {target})},
+                  result = workspace.applyDockZoneOperation(descriptor);
+
+            expect(result.errors).toEqual([]);
+            // Isolate the pre-projection state decision from DOM measurement and animation.
+            plugin._maximizedNodeId = 'main-tabs';
+            workspace.refreshDockView = async () => {};
+            await workspace.onDockZoneDocumentChange(result.document, descriptor, workspace);
+
+            expect(workspace.dockModel.items.created).toEqual(descriptor.item);
+            expect(plugin.maximizedNodeId).toBe(expected)
+        })
+    }
+
     test('the observation follows the owner across render windows, and an await retired by the hop arms nothing', async () => {
         create({windowId: 1});
 

--- a/test/playwright/unit/dashboard/DockWorkspaceSetTransaction.spec.mjs
+++ b/test/playwright/unit/dashboard/DockWorkspaceSetTransaction.spec.mjs
@@ -13,8 +13,9 @@ import WriteGuard               from '../../../../src/ai/WriteGuard.mjs';
 import {dispatchServiceMethod}  from '../../../../src/ai/client/resolveServiceMethod.mjs';
 import PopupWorkspace           from '../../../../apps/workstation/view/PopupWorkspace.mjs';
 import WorkstationWorkspace     from '../../../../apps/workstation/view/Workspace.mjs';
-import WorkspaceDocument        from '../../../../src/dashboard/dock/model/WorkspaceDocument.mjs';
+import Operations               from '../../../../src/dashboard/dock/model/Operations.mjs';
 import Persistence              from '../../../../src/dashboard/dock/model/Persistence.mjs';
+import WorkspaceDocument        from '../../../../src/dashboard/dock/model/WorkspaceDocument.mjs';
 import PerspectiveLibrary       from '../../../../src/dashboard/dock/persistence/PerspectiveLibrary.mjs';
 import WorkspaceSet             from '../../../../src/dashboard/dock/window/WorkspaceSet.mjs';
 
@@ -64,6 +65,63 @@ test.describe.serial('Dock WorkspaceSet transaction participants', () => {
     }
 
     const write = (workspaces, options = {}) => set.write(workspaces, {cause: 'replace-workspaces', provenance: {origin: 'unit'}, ...options});
+
+    test('addItem creates and places through a registered Group, preserving a queued lock and history', async () => {
+        const main       = holder('main'),
+              descriptor = {operation: 'addItem', itemId: 'created', item: {componentRef: 'created', title: 'Created'},
+                  target: {operation: 'addTab', tabsNodeId: 'root'}},
+              direct     = Operations.applyOperation(main.document, descriptor);
+
+        const lock = set.commit('main', [{operation: 'setItemLocked', itemId: 'main', locked: true}]),
+              add  = set.commit('main', [descriptor]);
+        await Promise.all([lock, add]);
+
+        expect(direct.errors).toEqual([]);
+        expect(main.document.items.created).toEqual(descriptor.item);
+        expect(main.document.nodes.root.items).toEqual(['main', 'created']);
+        expect(main.document.nodes).toEqual(direct.document.nodes);
+        expect(main.document.items.main.locked).toBe(true);
+        expect(TransactionManager.get(groupId).history.count).toBe(2);
+
+        await TransactionManager.undo({groupId});
+        expect(main.document.items.created).toBeUndefined();
+        expect(main.document.nodes.root.items).toEqual(['main']);
+        expect(main.document.items.main.locked).toBe(true);
+        await TransactionManager.redo({groupId});
+        expect(main.document.items.created).toEqual(descriptor.item);
+        expect(main.document.nodes.root.activeItemId).toBe('created');
+        expect(main.document.items.main.locked).toBe(true)
+    });
+
+    test('addItem creates an unplaced record and refuses a queued duplicate without another history entry', async () => {
+        const main  = holder('main'),
+              first = {operation: 'addItem', itemId: 'created', item: {componentRef: 'created', title: 'First'}};
+        const results = await Promise.allSettled([
+            set.commit('main', [first]),
+            set.commit('main', [{...first, item: {...first.item, title: 'Duplicate'}}])
+        ]);
+
+        expect(results[0].status).toBe('fulfilled');
+        expect(results[1].status).toBe('rejected');
+        expect(results[1].reason.message).toContain('already exists');
+        expect(main.document.items.created).toEqual(first.item);
+        expect(main.document.nodes).toEqual(document('main').nodes);
+        expect(TransactionManager.get(groupId).history.count).toBe(1)
+    });
+
+    test('addItem invalid placement and the old out-of-band seed path leave Group truth untouched', async () => {
+        const main   = holder('main'), original = main.document,
+              seeded = WorkspaceDocument.clone(original);
+        seeded.items.created = {componentRef: 'created'};
+        const placement = {operation: 'addTab', itemId: 'created', tabsNodeId: 'root'};
+        expect(Operations.applyOperation(seeded, placement).errors).toEqual([]);
+        await expect(set.commit('main', [placement])).rejects.toThrow('unknown item "created"');
+        await expect(set.commit('main', [{operation: 'addItem', itemId: 'created', item: seeded.items.created,
+            target: {operation: 'addTab', tabsNodeId: 'missing'}}])).rejects.toThrow('not a tabs node');
+        expect(main.document).toBe(original);
+        expect(main.writes).toEqual([]);
+        expect(TransactionManager.get(groupId).history).toBeNull()
+    });
 
     test('registered callbacks survive adapter disposal through queued write, compensation and undo', async () => {
         const projected   = [],

--- a/test/playwright/unit/dashboard/DockZoneModel.spec.mjs
+++ b/test/playwright/unit/dashboard/DockZoneModel.spec.mjs
@@ -1305,6 +1305,71 @@ test.describe('Neo.dashboard.dock.model.WorkspaceDocument', () => {
         });
     });
 
+    test.describe('addItem', () => {
+        test('creates a JSON catalog record without placement or caller-owned aliases', () => {
+            const input = doc(), before = structuredClone(input),
+                  item  = {componentRef: 'created', title: 'Created', metadata: {source: 'menu'},
+                      blueprint: {ntype: 'panel'}, closable: false},
+                  result = Operations.applyOperation(input, {operation: 'addItem', itemId: 'created', item});
+
+            expect(result.errors).toEqual([]);
+            expect(result.document.items.created).toEqual(item);
+            expect(result.document.nodes).toEqual(input.nodes);
+            expect(input).toEqual(before);
+            item.metadata.source = 'changed';
+            expect(result.document.items.created.metadata.source).toBe('menu');
+            expect(Operations.changeClassFor('addItem')).toBe('topology')
+        });
+
+        test('creates and places using addTab or splitNode with the outer item id', () => {
+            for (const target of [
+                {operation: 'addTab', tabsNodeId: 'main-tabs', index: 1, itemId: 'strategy'},
+                {operation: 'splitNode', targetNodeId: 'main-tabs', orientation: 'vertical', edge: 'top', sizes: [0.3, 0.7]}
+            ]) {
+                const input  = doc(), before = structuredClone(input),
+                      result = Operations.applyOperation(input, {operation: 'addItem', itemId: 'created',
+                          item: {componentRef: 'created'}, target}),
+                      containing = WorkspaceDocument.findContainingTabsId(result.document, 'created');
+
+                expect(result.errors).toEqual([]);
+                expect(result.document.items.created).toEqual({componentRef: 'created'});
+                expect(result.document.nodes[containing].activeItemId).toBe('created');
+                expect(WorkspaceDocument.validate(result.document)).toEqual([]);
+                expect(input).toEqual(before);
+                if (target.operation === 'addTab') {
+                    expect(result.document.nodes['main-tabs'].items).toEqual(['strategy', 'created', 'swarm'])
+                } else {
+                    const split = result.document.nodes[result.document.nodes.root.zones.center.nodeId];
+                    expect(split).toMatchObject({orientation: 'vertical', children: [containing, 'main-tabs'], sizes: [0.3, 0.7]})
+                }
+            }
+        });
+
+        test('refuses duplicate ids, non-JSON records, invalid policy and placement without leaking the record', () => {
+            const cyclic = {};
+            cyclic.self = cyclic;
+            const cases = [
+                ...['strategy', 'inspector', '__proto__', 'constructor', '', null, 42].map(itemId => ({itemId})),
+                ...[null, [], new Date(), {module: 'wrong-schema'}, {locked: 'yes'},
+                    {pinned: true, autoHidden: true}, {metadata: {callback: () => {}}},
+                    {metadata: cyclic}, {blueprint: {value: Infinity}}, {metadata: {[Symbol('key')]: 1}}
+                ].map(item => ({item})),
+                ...[null, {}, {operation: 'closeItem'}, {operation: 'restoreTab'},
+                    {operation: 'addTab', tabsNodeId: 'missing'},
+                    {operation: 'splitNode', targetNodeId: 'main-tabs', orientation: 'diagonal'}
+                ].map(target => ({target}))
+            ];
+            for (const overrides of cases) {
+                const input  = doc(), before = structuredClone(input),
+                      result = Operations.applyOperation(input, {operation: 'addItem', itemId: 'created',
+                          item: {componentRef: 'created'}, ...overrides});
+                expect(result.errors.length, JSON.stringify(overrides, (key, value) => value === cyclic ? '[cycle]' : value)).toBeGreaterThan(0);
+                expect(result.document).toBe(input);
+                expect(input).toEqual(before)
+            }
+        })
+    });
+
     test.describe('addTab', () => {
         test('inserts a catalog-only item at index and makes it active', () => {
             const {document, errors} = Operations.addTab(doc(), {itemId: 'inspector', tabsNodeId: 'main-tabs', index: 1});


### PR DESCRIPTION
Resolves #18467

Adds `addItem` to the dock operation vocabulary. Its descriptor carries a JSON item record and optional `addTab`/`splitNode` placement, so Group replay can create a pane against current document truth without overwriting unrelated queued changes. Catalog-only creation is supported; invalid records, duplicate/reserved ids and failed placement leave the original document intact. Component construction remains in the consumer.

Evidence: real reducer and Transaction/WorkspaceSet integration exercised in the CI unit tier; no unreachable host effect is required by this Engine contract. No downstream deployment or browser-rendering claim.

## AC Evidence

| AC | Evidence |
|---|---|
| AC-1 — positive Group creation and old-path control | CI-covered: `DockWorkspaceSetTransaction.spec.mjs` creates the record and tab, preserves a queued lock, and keeps the out-of-band-seed refusal unchanged. Red-first receipt below. |
| AC-2 — decided contract | The ticket's **Contract ACCEPTED** section records the peer decision and optional-target amendment before implementation. |
| AC-3 — runtime creation with a registered participant | CI-covered: real `WorkspaceSet.commit`/Transaction queue, catalog-only creation, duplicate refusal, unchanged truth on failed placement, undo/redo. |
| AC-4 — direct path unchanged (retired guard AC excluded from numbering) | CI-covered: `DockZoneModel.spec.mjs` direct creation/placement, shared placement rules, input non-mutation and JSON validation; Group test compares direct and committed placement. Existing addTab controls remain green. |

## Deltas from ticket

Implements the final accepted contract. Prototype-reserved ids are refused before catalog assignment. The maximize plugin classifies catalog-only creation as neutral and delegates supplied placement to its existing target rule; `DockMaximizePlugin.spec.mjs` covers the direct commit hook and both neutral/non-neutral targets. No consumer lines are removed here: consumers that create items from menus live downstream, and their refactor is explicitly outside this ticket. The declarative configuration sandbox and `removeItem` remain separate.

Existing Group-batch maximize continuity is out of scope and tracked separately in #18471; the review response below records its `setActiveItem` control.

Change class: capability (`feat`). `agent-preflight` is not hosted here (npm returned Missing script); local pre-commit checks passed. The shared PR baseline provides the remaining repository checks.

## Test Evidence

Before the reducer was added, `npm run test-unit -- test/playwright/unit/dashboard/DockWorkspaceSetTransaction.spec.mjs --grep 'addItem creates and places' --reporter=line` failed at dev `a57ffbe717` inside `WorkspaceSet.prepare` with `TypeError: unknown operation "addItem"`. The same positive test passes with this implementation.

The maximize hook regression was red at `5978f63473`: catalog-only and same-pane creation cleared `maximizedNodeId` to `null`; sibling/split controls passed. All four pass after the classifier repair. The fixture exercises the real reducer and workspace commit hook while isolating DOM measurement/animation; it is not browser evidence.

## Post-Merge Validation

No merge-dependent validation remains for this Engine contract.

Authored by Emmy (GPT-6 Astra, Codex) consuming Vega's ticket — session A 3581aef4-0bb5-4cb4-b428-856e9e60c9b3, session B 153d2e0a-ebae-4087-bcd5-3c92d213132c.
