### PR TITLE
feat(dock): preserve maximize across Group projections (#18471)

### DIFF
--- a/apps/workstation/view/PopupWorkspace.mjs
+++ b/apps/workstation/view/PopupWorkspace.mjs
@@ -59,9 +59,7 @@ class PopupWorkspace extends DockWorkspace {
             dispose    : () => { if (!me.isDestroyed) me.destroy() },
             getDocument: () => me.dockModel,
             setDocument: value => me.dockModel = value,
-            project    : context => me.projectDockZoneDocument(context.snapshot.participants[me.workspaceKey], context.descriptor, me, {
-                preserveItemIds: context.preserveItemIds
-            })
+            project    : context => me.projectDockCommit(context)
         });
         me.syncParticipation()
     }

--- a/apps/workstation/view/Workspace.mjs
+++ b/apps/workstation/view/Workspace.mjs
@@ -953,9 +953,7 @@ class Workspace extends DockWorkspace {
             componentId: me.id,
             getDocument: () => me.dockModel,
             setDocument: document => me.dockModel = document,
-            project    : context => me.projectDockZoneDocument(context.snapshot.participants[Workspace.MAIN_WORKSPACE_ID], context.descriptor, me, {
-                preserveItemIds: context.preserveItemIds
-            })
+            project    : context => me.projectDockCommit(context)
         });
         if (registered) {
             firstRegistration && TransactionManager.setHistoryDepth({groupId: me.topologyGroupId, depth: me.dockHistoryDepth});

--- a/buildScripts/util/file-size-baseline.json
+++ b/buildScripts/util/file-size-baseline.json
@@ -1,6 +1,6 @@
 {
-    "apps/workstation/view/Workspace.mjs": 2671,
+    "apps/workstation/view/Workspace.mjs": 2669,
     "examples/dashboard/crossWindow/DemoBWorkspace.mjs": 2612,
-    "src/dashboard/dock/Workspace.mjs": 1027,
+    "src/dashboard/dock/Workspace.mjs": 1032,
     "src/main/addon/DragDrop.mjs": 1267
 }

--- a/buildScripts/util/file-size-baseline.json
+++ b/buildScripts/util/file-size-baseline.json
@@ -1,6 +1,6 @@
 {
     "apps/workstation/view/Workspace.mjs": 2669,
     "examples/dashboard/crossWindow/DemoBWorkspace.mjs": 2612,
-    "src/dashboard/dock/Workspace.mjs": 1032,
+    "src/dashboard/dock/Workspace.mjs": 1035,
     "src/main/addon/DragDrop.mjs": 1267
 }

--- a/src/dashboard/dock/Workspace.mjs
+++ b/src/dashboard/dock/Workspace.mjs
@@ -2223,20 +2223,34 @@ class Workspace extends Container {
     }
 
     /**
+     * @summary Projects a Group participant's adopted document with its captured operation context.
+     * Presentation collaborators can distinguish ordered operations against their before-state;
+     * the context is runtime-only and does not enter the document or reconciliation options.
+     * @param {Object} context The Group participant's projection context.
+     * @returns {Promise} This projection's outcome.
+     */
+    projectDockCommit(context) {
+        return this.projectDockZoneDocument(context.snapshot.participants[context.workspaceKey], context.descriptor, this, {
+            preserveItemIds: context.preserveItemIds
+        }, context)
+    }
+
+    /**
      * @summary Projects an adopted document without admitting another semantic write.
      * @param {Object|null} document The committed document to present.
      * @param {Object|null} [descriptor=null] The operation associated with the committed document.
      * @param {Object|null} [source=null] The originating interaction surface.
      * @param {Object} [projectionOptions={}] Committed topology's pane-preservation policy.
+     * @param {Object|null} [commitContext=null] Group capture and workspace identity for collaborators.
      * @returns {Promise} This projection's outcome; later projections survive its failure.
      * @protected
      */
-    projectDockZoneDocument(document, descriptor=null, source=null, projectionOptions={}) {
+    projectDockZoneDocument(document, descriptor=null, source=null, projectionOptions={}, commitContext=null) {
         let me = this,
             commitOptions, preserved, tabInsertDescriptor, refreshOptions, tail;
 
         // Presentation owners release transient state before the outgoing shell is reconciled.
-        me.fire('beforeDockZoneDocumentChange', {descriptor, document, source});
+        me.fire('beforeDockZoneDocumentChange', {commitContext, descriptor, document, source});
 
         tabInsertDescriptor = me.getTabInsertProjectionDescriptor(document, descriptor);
         commitOptions       = me.getRefreshOptions(descriptor, source);

--- a/src/dashboard/dock/Workspace.mjs
+++ b/src/dashboard/dock/Workspace.mjs
@@ -2217,7 +2217,7 @@ class Workspace extends Container {
             pending.catch(error => Neo.logError(error));
             return pending
         }
-        const projection = me.projectDockZoneDocument(document, descriptor, source);
+        const projection = me.projectDockZoneDocument(document, descriptor, source, {previousDocument: me.dockModel});
         me.dockModel = document;
         return projection
     }
@@ -2231,8 +2231,10 @@ class Workspace extends Container {
      */
     projectDockCommit(context) {
         return this.projectDockZoneDocument(context.snapshot.participants[context.workspaceKey], context.descriptor, this, {
-            preserveItemIds: context.preserveItemIds
-        }, context)
+            preserveItemIds : context.preserveItemIds,
+            previousDocument: context.captured.value,
+            workspaceKey    : context.workspaceKey
+        })
     }
 
     /**
@@ -2240,22 +2242,23 @@ class Workspace extends Container {
      * @param {Object|null} document The committed document to present.
      * @param {Object|null} [descriptor=null] The operation associated with the committed document.
      * @param {Object|null} [source=null] The originating interaction surface.
-     * @param {Object} [projectionOptions={}] Committed topology's pane-preservation policy.
-     * @param {Object|null} [commitContext=null] Group capture and workspace identity for collaborators.
+     * @param {Object} [projectionOptions={}] Pane-preservation policy plus optional `previousDocument`
+     *     and `workspaceKey` for the collaborator event; those two fields never reach reconciliation.
      * @returns {Promise} This projection's outcome; later projections survive its failure.
      * @protected
      */
-    projectDockZoneDocument(document, descriptor=null, source=null, projectionOptions={}, commitContext=null) {
+    projectDockZoneDocument(document, descriptor=null, source=null, projectionOptions={}) {
         let me = this,
+            {previousDocument=me.dockModel, workspaceKey, ...viewOptions} = projectionOptions,
             commitOptions, preserved, tabInsertDescriptor, refreshOptions, tail;
 
         // Presentation owners release transient state before the outgoing shell is reconciled.
-        me.fire('beforeDockZoneDocumentChange', {commitContext, descriptor, document, source});
+        me.fire('beforeDockZoneDocumentChange', {descriptor, document, previousDocument, source, workspaceKey});
 
         tabInsertDescriptor = me.getTabInsertProjectionDescriptor(document, descriptor);
         commitOptions       = me.getRefreshOptions(descriptor, source);
-        preserved           = [...new Set([...commitOptions.preserveItemIds ?? [], ...projectionOptions.preserveItemIds ?? []])];
-        refreshOptions      = {...commitOptions, ...projectionOptions};
+        preserved           = [...new Set([...commitOptions.preserveItemIds ?? [], ...viewOptions.preserveItemIds ?? []])];
+        refreshOptions      = {...commitOptions, ...viewOptions};
 
         // `preserveItemIds` is the one option these two sides ADD to rather than choose between.
         // The commit's ids are panes it parked; the caller's are panes owned by sibling documents in

--- a/src/dashboard/dock/plugin/Maximize.mjs
+++ b/src/dashboard/dock/plugin/Maximize.mjs
@@ -1,4 +1,5 @@
 import MotionSignal      from '../projection/MotionSignal.mjs';
+import Operations        from '../model/Operations.mjs';
 import Plugin            from '../../../plugin/Base.mjs';
 import Reconciler        from '../projection/Reconciler.mjs';
 import WorkspaceDocument from '../model/WorkspaceDocument.mjs';
@@ -12,15 +13,15 @@ import WorkspaceDocument from '../model/WorkspaceDocument.mjs';
  * maximize state, and no re-parent happens (a pane hosting an iframe reloads its browsing context
  * on re-parent). The owner is a `Neo.dashboard.dock.Workspace`; the plugin reaches it through four
  * collaborator seams and nothing else: the `dockHeaderAction` event carries the `maximize` intent,
- * the `beforeDockZoneDocumentChange` event lets a committed operation clear the transient before it
- * applies, {@link #getDockProjectionOptions} contributes the projected toggle and its icons, and
+ * the `beforeDockZoneDocumentChange` event lets a committed operation clear the transient before
+ * reconciliation, {@link #getDockProjectionOptions} contributes the projected toggle and its icons, and
  * {@link #syncDockProjection} re-applies a surviving transient after each refresh. `Escape` binds
  * on the owner's key navigation with this plugin as scope.
  *
  * Input contract while a node is maximized: in-strip tab reordering stays live; cross-zone drag
  * sources and tear-out affordances of the maximized node are suppressed (every drop target sits
  * under the maximized plane); engaging maximize closes an in-progress reveal overlay; a committed
- * dock operation that reaches beyond the maximized node clears maximize BEFORE applying,
+ * dock operation that reaches beyond the maximized node clears maximize BEFORE reconciliation,
  * terminally; operations confined to the node itself (activating one of its tabs; closing,
  * reordering or adding an item within it) defer to the re-projection rule instead, which
  * re-applies onto the surviving node and clears when the node collapsed.
@@ -228,18 +229,19 @@ class Maximize extends Plugin {
     }
 
     /**
-     * A committed operation clears maximize BEFORE applying — and that clear is terminal: the
+     * A committed operation clears maximize BEFORE reconciliation — and that clear is terminal: the
      * re-projection continuity re-applies only a transient that survived, never one an operation
      * cleared. Operations confined to the maximized node itself are the exception: they defer to
      * that same continuity rule, which re-applies onto the surviving node — without the exception,
      * switching tabs INSIDE a maximized pane would restore it.
      * @param {Object} data
      * @param {Object|null} data.descriptor The semantic operation about to apply.
+     * @param {Object|null} [data.commitContext] Group capture and workspace identity.
      */
-    onBeforeDockZoneDocumentChange({descriptor}) {
+    onBeforeDockZoneDocumentChange({commitContext, descriptor}) {
         let me = this;
 
-        if (me.maximizedNodeId && !me.isNeutralOperation(descriptor)) {
+        if (me.maximizedNodeId && !me.isNeutralChange(descriptor, commitContext)) {
             me.motion          = 'instant';
             me.maximizedNodeId = null
         }
@@ -758,6 +760,31 @@ class Maximize extends Plugin {
     }
 
     /**
+     * @summary Classifies a scalar change or an ordered Group batch against its captured document.
+     * Replaying pure reducers advances source membership between operations; checking only the
+     * adopted result would mistake a cross-node move into the maximized pane for a local move.
+     * Missing/mismatched context and failed reductions retain the conservative clear.
+     * @param {Object|null} descriptor
+     * @param {Object|null} [context]
+     * @returns {Boolean}
+     * @protected
+     */
+    isNeutralChange(descriptor, context) {
+        if (!Array.isArray(descriptor?.operations)) return this.isNeutralOperation(descriptor);
+
+        let document = context?.captured?.value;
+        if (!document || !context.workspaceKey || descriptor.workspaceKey !== context.workspaceKey) return false;
+
+        for (const operation of descriptor.operations) {
+            if (!this.isNeutralOperation(operation, document)) return false;
+            const result = Operations.applyOperation(document, operation);
+            if (result.errors.length) return false;
+            document = result.document
+        }
+        return true
+    }
+
+    /**
      * @summary Classifies a committed operation as catalog-only or confined to the maximized node — the ops
      * that must NOT pre-clear the transient: their effect stays inside the pane the user is
      * looking at, so the continuity rule ({@link #syncDockProjection}) decides from the committed
@@ -765,13 +792,13 @@ class Maximize extends Plugin {
      * topology mutations, boundary crossings, whole-document applies (a `null` descriptor
      * included) — clears terminally before it applies.
      * @param {Object|null} descriptor
+     * @param {Object} [document=this.owner.dockModel] State before this operation.
      * @returns {Boolean}
      * @protected
      */
-    isNeutralOperation(descriptor) {
+    isNeutralOperation(descriptor, document=this.owner.dockModel) {
         let me                                            = this,
             nodeId                                        = me.maximizedNodeId,
-            document                                      = me.owner.dockModel,
             {itemId, operation, tabsNodeId, targetNodeId} = descriptor || {};
 
         if (!operation || !nodeId) {
@@ -780,7 +807,7 @@ class Maximize extends Plugin {
 
         switch (operation) {
             case 'addItem':
-                return descriptor.target === undefined || me.isNeutralOperation({...descriptor.target, itemId});
+                return descriptor.target === undefined || me.isNeutralOperation({...descriptor.target, itemId}, document);
             case 'addTab': {
                 // The addTab handler re-dispatches an already-contained item to moveItem, so a
                 // descriptor targeting the maximized node can still RELOCATE the item out of a

--- a/src/dashboard/dock/plugin/Maximize.mjs
+++ b/src/dashboard/dock/plugin/Maximize.mjs
@@ -236,12 +236,13 @@ class Maximize extends Plugin {
      * switching tabs INSIDE a maximized pane would restore it.
      * @param {Object} data
      * @param {Object|null} data.descriptor The semantic operation about to apply.
-     * @param {Object|null} [data.commitContext] Group capture and workspace identity.
+     * @param {Object|null} data.previousDocument State before the committed change.
+     * @param {String} [data.workspaceKey] Group participant identity.
      */
-    onBeforeDockZoneDocumentChange({commitContext, descriptor}) {
+    onBeforeDockZoneDocumentChange({descriptor, previousDocument, workspaceKey}) {
         let me = this;
 
-        if (me.maximizedNodeId && !me.isNeutralChange(descriptor, commitContext)) {
+        if (me.maximizedNodeId && !me.isNeutralChange(descriptor, previousDocument, workspaceKey)) {
             me.motion          = 'instant';
             me.maximizedNodeId = null
         }
@@ -765,15 +766,15 @@ class Maximize extends Plugin {
      * adopted result would mistake a cross-node move into the maximized pane for a local move.
      * Missing/mismatched context and failed reductions retain the conservative clear.
      * @param {Object|null} descriptor
-     * @param {Object|null} [context]
+     * @param {Object|null} document State before the change.
+     * @param {String} [workspaceKey] Group participant identity.
      * @returns {Boolean}
      * @protected
      */
-    isNeutralChange(descriptor, context) {
-        if (!Array.isArray(descriptor?.operations)) return this.isNeutralOperation(descriptor);
+    isNeutralChange(descriptor, document, workspaceKey) {
+        if (!Array.isArray(descriptor?.operations)) return this.isNeutralOperation(descriptor, document);
 
-        let document = context?.captured?.value;
-        if (!document || !context.workspaceKey || descriptor.workspaceKey !== context.workspaceKey) return false;
+        if (!document || !workspaceKey || descriptor.workspaceKey !== workspaceKey) return false;
 
         for (const operation of descriptor.operations) {
             if (!this.isNeutralOperation(operation, document)) return false;
@@ -792,16 +793,16 @@ class Maximize extends Plugin {
      * topology mutations, boundary crossings, whole-document applies (a `null` descriptor
      * included) — clears terminally before it applies.
      * @param {Object|null} descriptor
-     * @param {Object} [document=this.owner.dockModel] State before this operation.
+     * @param {Object} document State before this operation.
      * @returns {Boolean}
      * @protected
      */
-    isNeutralOperation(descriptor, document=this.owner.dockModel) {
+    isNeutralOperation(descriptor, document) {
         let me                                            = this,
             nodeId                                        = me.maximizedNodeId,
             {itemId, operation, tabsNodeId, targetNodeId} = descriptor || {};
 
-        if (!operation || !nodeId) {
+        if (!operation || !nodeId || !document) {
             return false
         }
 

--- a/test/playwright/component/apps/dock-maximize/app.mjs
+++ b/test/playwright/component/apps/dock-maximize/app.mjs
@@ -1,8 +1,11 @@
-import Component     from '../../../../../src/component/Base.mjs';
-import DockWorkspace from '../../../../../src/dashboard/dock/Workspace.mjs';
-import Maximize      from '../../../../../src/dashboard/dock/plugin/Maximize.mjs';
-import Persistence   from '../../../../../src/dashboard/dock/model/Persistence.mjs';
-import Viewport      from '../../../../../src/container/Viewport.mjs';
+import Component         from '../../../../../src/component/Base.mjs';
+import DockWorkspace     from '../../../../../src/dashboard/dock/Workspace.mjs';
+import Maximize          from '../../../../../src/dashboard/dock/plugin/Maximize.mjs';
+import Persistence       from '../../../../../src/dashboard/dock/model/Persistence.mjs';
+import WorkspaceDocument from '../../../../../src/dashboard/dock/model/WorkspaceDocument.mjs';
+import WorkspaceSet      from '../../../../../src/dashboard/dock/window/WorkspaceSet.mjs';
+import Transaction       from '../../../../../src/manager/Transaction.mjs';
+import Viewport          from '../../../../../src/container/Viewport.mjs';
 import '../../../../../src/tab/Container.mjs';
 
 /**
@@ -336,6 +339,12 @@ class MaximizeFixtureWorkspace extends DockWorkspace {
          */
         closeItemId_: null,
         /**
+         * Enables the real Group participant path for the continuity witness.
+         * @member {Boolean} groupBacked_=false
+         * @reactive
+         */
+        groupBacked_: false,
+        /**
          * @member {Boolean} enableDockCloseAction=true
          */
         enableDockCloseAction: true,
@@ -431,6 +440,14 @@ class MaximizeFixtureWorkspace extends DockWorkspace {
      * @member {String|null} docJson=null
      */
     docJson = null
+
+    /** @summary Original pane reference retained only for the Group identity witness. @member {Neo.component.Base|null} */
+    groupAlphaPane = null
+
+    /** @summary Whether the original live pane instance survived the Group projection. @returns {Boolean} */
+    get groupPaneRetained() {
+        return !!this.groupAlphaPane && !this.groupAlphaPane.isDestroyed && this.groupAlphaPane === Neo.get('dock-maximize-pane-alpha')
+    }
 
     /**
      * Spec-readable perspective capture, refreshed per {@link #captureCount} bump.
@@ -627,6 +644,41 @@ class MaximizeFixtureWorkspace extends DockWorkspace {
         // the reconciler replaces the shell at `dockShellIndex` rather than inserting blind.
         this.add(this.projectDockModel());
         this.onDockZoneDocumentChange(structuredClone(fixtureDocument))
+    }
+
+    /**
+     * @summary Registers this fixture as the owner of one real Group document.
+     * @param {Boolean} value
+     * @protected
+     */
+    afterSetGroupBacked(value) {
+        if (!value || this.workspaceSet) return;
+        const me = this, binding = Transaction.bind({windowId: me.windowId, workspaceKey: 'main'});
+        me.groupAlphaPane = Neo.get('dock-maximize-pane-alpha');
+        me.topologyGroupId = binding.groupId;
+        me.workspaceKey = 'main';
+        me.workspaceSet = Neo.create(WorkspaceSet, {
+            manager: Transaction, getGroupId: () => binding.groupId, documentModel: WorkspaceDocument
+        });
+        Transaction.setHistoryDepth({groupId: binding.groupId, depth: 5});
+        me.workspaceSet.register('main', {
+            getDocument: () => me.dockModel,
+            setDocument: value => { me.dockModel = value; me.docJson = JSON.stringify(value) },
+            project    : context => me.projectDockCommit(context)
+        })
+    }
+
+    /** @summary The Group's semantic write count, separate from presentation work. @returns {Number} */
+    get groupHistoryCount() {
+        return Transaction.get(this.topologyGroupId)?.history?.count ?? 0
+    }
+
+    /** @summary Retires the fixture-owned adapter and Group. @param {Object[]} args */
+    destroy(...args) {
+        const set = this.workspaceSet, groupId = set && this.topologyGroupId;
+        set?.destroy();
+        super.destroy(...args);
+        groupId && Transaction.retireGroup(groupId)
     }
 
     /**

--- a/test/playwright/component/dashboard/DockMaximize.spec.mjs
+++ b/test/playwright/component/dashboard/DockMaximize.spec.mjs
@@ -333,6 +333,54 @@ test.describe('dock maximize — presentation, never topology', () => {
         expect(docAfter).toBe(docBefore)
     });
 
+    test('Group tab activation preserves maximized presentation and identity; an outside change clears it', async ({page}) => {
+        await setWorkspace(page, {groupBacked: true});
+        await expect.poll(async () => (await readWorkspace(page, ['topologyGroupId']))[0]).toBeTruthy();
+
+        const main = tabsNodeWith(page, 'Alpha');
+        await tabButton(main, 'Alpha').click();
+        await actionButton(main, 'fa-window-maximize').click();
+        await expectMaximizedCount(page, 1);
+        await maximizedRectMatchesHost(page);
+        const countBefore = (await readWorkspace(page, ['groupHistoryCount']))[0];
+        expect(await readWorkspace(page, ['groupPaneRetained'])).toEqual([true]);
+        await main.evaluate(element => window.__groupMaximizeNode = element);
+
+        await tabButton(main, 'Beta').click();
+        await expect.poll(async () => JSON.parse((await readWorkspace(page, ['docJson']))[0]).nodes['main-tabs'].activeItemId).toBe('beta');
+        await expectMaximizedCount(page, 1);
+        await maximizedRectMatchesHost(page);
+        expect(await readPlugin(page, ['maximizedNodeId'])).toEqual(['main-tabs']);
+        expect(await main.evaluate(element => element === window.__groupMaximizeNode)).toBe(true);
+        expect(await readWorkspace(page, ['groupPaneRetained'])).toEqual([true]);
+        expect(await readWorkspace(page, ['groupHistoryCount'])).toEqual([countBefore + 1]);
+
+        await setWorkspace(page, {closeItemId: 'gamma'});
+        await expectMaximizedCount(page, 0);
+        expect(await readPlugin(page, ['maximizedNodeId'])).toEqual([null]);
+        await expect.poll(async () => (await readWorkspace(page, ['groupHistoryCount']))[0]).toBe(countBefore + 2)
+    });
+
+    test('Group in-node closes preserve maximize until the node collapses', async ({page}) => {
+        await setWorkspace(page, {groupBacked: true});
+        const main = tabsNodeWith(page, 'Alpha');
+        await tabButton(main, 'Alpha').click();
+        await actionButton(main, 'fa-window-maximize').click();
+        await expectMaximizedCount(page, 1);
+        const countBefore = (await readWorkspace(page, ['groupHistoryCount']))[0];
+
+        await setWorkspace(page, {closeItemId: 'beta'});
+        await expect(tabButton(main, 'Beta')).toHaveCount(0);
+        await expectMaximizedCount(page, 1);
+        expect(await readPlugin(page, ['maximizedNodeId'])).toEqual(['main-tabs']);
+
+        await setWorkspace(page, {closeItemId: 'alpha'});
+        await expectMaximizedCount(page, 0);
+        await expect.poll(async () => (await readPlugin(page, ['maximizedNodeId']))[0]).toBeNull();
+        expect(JSON.parse((await readWorkspace(page, ['docJson']))[0]).nodes['main-tabs']).toBeUndefined();
+        expect(await readWorkspace(page, ['groupHistoryCount'])).toEqual([countBefore + 2])
+    });
+
     test('inside-the-node operations keep maximize, outside operations clear it terminally, and continuity re-applies iff the node survives', async ({page}) => {
         const main = tabsNodeWith(page, 'Alpha');
 

--- a/test/playwright/unit/dashboard/DockMaximizePlugin.spec.mjs
+++ b/test/playwright/unit/dashboard/DockMaximizePlugin.spec.mjs
@@ -219,11 +219,11 @@ test.describe('dock maximize as a declinable plugin', () => {
 
         expect(seen, 'fired once, with the descriptor, while the outgoing document is still committed')
             .toEqual([{descriptor, stillOutgoing: true}]);
-        expect(plugin.isNeutralOperation(descriptor), 'an operation confined to the node it would own').toBe(false);
+        expect(plugin.isNeutralOperation(descriptor, workspace.dockModel), 'an operation confined to the node it would own').toBe(false);
 
         plugin.maximizedNodeId = 'main-tabs';
-        expect(plugin.isNeutralOperation(descriptor)).toBe(true);
-        expect(plugin.isNeutralOperation({operation: 'splitNode', nodeId: 'side-tabs'}), 'a topology mutation reaches beyond it').toBe(false)
+        expect(plugin.isNeutralOperation(descriptor, workspace.dockModel)).toBe(true);
+        expect(plugin.isNeutralOperation({operation: 'splitNode', nodeId: 'side-tabs'}, workspace.dockModel), 'a topology mutation reaches beyond it').toBe(false)
     });
 
     for (const [name, target, expected] of [
@@ -273,11 +273,11 @@ test.describe('dock maximize as a declinable plugin', () => {
                   set     = Neo.create(WorkspaceSet, {manager: Transaction, getGroupId: () => binding.groupId, documentModel: WorkspaceDocument}),
                   plugin  = workspace.getPlugin('dock-maximize'),
                   before  = workspace.dockModel,
-                  events  = [];
+                events    = [], refreshes = [];
             Transaction.setHistoryDepth({groupId: binding.groupId, depth: 5});
             set.register('main', {getDocument: () => workspace.dockModel, setDocument: value => workspace.dockModel = value,
                 project: context => workspace.projectDockCommit(context)});
-            workspace.refreshDockWorkspace = async () => {};
+            workspace.refreshDockWorkspace = async (descriptor, document, options) => { refreshes.push(options) };
             plugin._maximizedNodeId = 'main-tabs';
             workspace.on('beforeDockZoneDocumentChange', event => events.push(event));
             try {
@@ -285,7 +285,10 @@ test.describe('dock maximize as a declinable plugin', () => {
                 await expect.poll(() => events.length).toBe(1);
                 await workspace.refreshPromise;
                 expect(plugin.maximizedNodeId).toBe(expected);
-                expect(events[0].commitContext.captured.value).toEqual(before);
+                expect(events[0].previousDocument).toEqual(before);
+                expect(events[0].workspaceKey).toBe('main');
+                expect(refreshes[0]).not.toHaveProperty('previousDocument');
+                expect(refreshes[0]).not.toHaveProperty('workspaceKey');
                 expect(Transaction.get(binding.groupId).history.count).toBe(1);
 
                 const committed = workspace.dockModel;
@@ -308,7 +311,7 @@ test.describe('dock maximize as a declinable plugin', () => {
               descriptor = {workspaceKey: 'main', operations: [{operation: 'setActiveItem', tabsNodeId: 'main-tabs', itemId: 'beta'}]};
         plugin._maximizedNodeId = 'main-tabs';
         expect(plugin.isNeutralChange(descriptor)).toBe(false);
-        expect(plugin.isNeutralChange(descriptor, {workspaceKey: 'other', captured: {value: workspace.dockModel}})).toBe(false)
+        expect(plugin.isNeutralChange(descriptor, workspace.dockModel, 'other')).toBe(false)
     });
 
     test('the observation follows the owner across render windows, and an await retired by the hop arms nothing', async () => {

--- a/test/playwright/unit/dashboard/DockMaximizePlugin.spec.mjs
+++ b/test/playwright/unit/dashboard/DockMaximizePlugin.spec.mjs
@@ -6,13 +6,16 @@ setup({
     }
 });
 
-import {test, expect} from '@playwright/test';
-import Neo            from '../../../../src/Neo.mjs';
-import * as core      from '../../../../src/core/_export.mjs';
-import DockWorkspace  from '../../../../src/dashboard/dock/Workspace.mjs';
-import Maximize       from '../../../../src/dashboard/dock/plugin/Maximize.mjs';
-import Plugin         from '../../../../src/plugin/Base.mjs';
-import Reconciler     from '../../../../src/dashboard/dock/projection/Reconciler.mjs';
+import {test, expect}    from '@playwright/test';
+import Neo               from '../../../../src/Neo.mjs';
+import * as core         from '../../../../src/core/_export.mjs';
+import DockWorkspace     from '../../../../src/dashboard/dock/Workspace.mjs';
+import WorkspaceDocument from '../../../../src/dashboard/dock/model/WorkspaceDocument.mjs';
+import WorkspaceSet      from '../../../../src/dashboard/dock/window/WorkspaceSet.mjs';
+import Transaction       from '../../../../src/manager/Transaction.mjs';
+import Maximize          from '../../../../src/dashboard/dock/plugin/Maximize.mjs';
+import Plugin            from '../../../../src/plugin/Base.mjs';
+import Reconciler        from '../../../../src/dashboard/dock/projection/Reconciler.mjs';
 import '../../../../src/manager/Instance.mjs';
 import '../../../../src/tab/Container.mjs';
 import '../../../../src/vdom/util/DomApiVnodeCreator.mjs';
@@ -247,6 +250,66 @@ test.describe('dock maximize as a declinable plugin', () => {
             expect(plugin.maximizedNodeId).toBe(expected)
         })
     }
+
+    for (const [name, operations, expected] of [
+        ['local add and reorder', [
+            {operation: 'addItem', itemId: 'created', item: {componentRef: 'created'}},
+            {operation: 'addTab', itemId: 'created', tabsNodeId: 'main-tabs'},
+            {operation: 'moveItem', itemId: 'beta', targetNodeId: 'main-tabs', index: 0}
+        ], 'main-tabs'],
+        ['ordered creation and removal', [
+            {operation: 'addItem', itemId: 'created', item: {componentRef: 'created'}, target: {operation: 'addTab', tabsNodeId: 'main-tabs'}},
+            {operation: 'closeItem', itemId: 'created'}
+        ], 'main-tabs'],
+        ['cross-node move into the maximized pane', [{operation: 'moveItem', itemId: 'gamma', targetNodeId: 'main-tabs'}], null],
+        ['mixed local and cross-node changes', [
+            {operation: 'setActiveItem', tabsNodeId: 'main-tabs', itemId: 'beta'},
+            {operation: 'moveItem', itemId: 'gamma', targetNodeId: 'main-tabs'}
+        ], null]
+    ]) {
+        test(`Group batch ${name} uses ordered captured state for maximize`, async () => {
+            create();
+            const binding = Transaction.bind({windowId: workspace.id, workspaceKey: 'main'}),
+                  set     = Neo.create(WorkspaceSet, {manager: Transaction, getGroupId: () => binding.groupId, documentModel: WorkspaceDocument}),
+                  plugin  = workspace.getPlugin('dock-maximize'),
+                  before  = workspace.dockModel,
+                  events  = [];
+            Transaction.setHistoryDepth({groupId: binding.groupId, depth: 5});
+            set.register('main', {getDocument: () => workspace.dockModel, setDocument: value => workspace.dockModel = value,
+                project: context => workspace.projectDockCommit(context)});
+            workspace.refreshDockWorkspace = async () => {};
+            plugin._maximizedNodeId = 'main-tabs';
+            workspace.on('beforeDockZoneDocumentChange', event => events.push(event));
+            try {
+                await set.commit('main', operations);
+                await expect.poll(() => events.length).toBe(1);
+                await workspace.refreshPromise;
+                expect(plugin.maximizedNodeId).toBe(expected);
+                expect(events[0].commitContext.captured.value).toEqual(before);
+                expect(Transaction.get(binding.groupId).history.count).toBe(1);
+
+                const committed = workspace.dockModel;
+                await expect(set.commit('main', [{operation: 'setActiveItem', tabsNodeId: 'main-tabs', itemId: 'missing'}]))
+                    .rejects.toThrow('not a member');
+                expect(workspace.dockModel).toBe(committed);
+                expect(plugin.maximizedNodeId).toBe(expected);
+                expect(events).toHaveLength(1);
+                expect(Transaction.get(binding.groupId).history.count).toBe(1)
+            } finally {
+                set.destroy();
+                Transaction.retireGroup(binding.groupId)
+            }
+        })
+    }
+
+    test('a Group batch without matching capture context remains non-neutral', () => {
+        create();
+        const plugin     = workspace.getPlugin('dock-maximize'),
+              descriptor = {workspaceKey: 'main', operations: [{operation: 'setActiveItem', tabsNodeId: 'main-tabs', itemId: 'beta'}]};
+        plugin._maximizedNodeId = 'main-tabs';
+        expect(plugin.isNeutralChange(descriptor)).toBe(false);
+        expect(plugin.isNeutralChange(descriptor, {workspaceKey: 'other', captured: {value: workspace.dockModel}})).toBe(false)
+    });
 
     test('the observation follows the owner across render windows, and an await retired by the hop arms nothing', async () => {
         create({windowId: 1});

--- a/test/playwright/unit/dashboard/DockWorkspaceSetTransaction.spec.mjs
+++ b/test/playwright/unit/dashboard/DockWorkspaceSetTransaction.spec.mjs
@@ -10,6 +10,7 @@ import DockService              from '../../../../src/ai/client/DockService.mjs'
 import InstanceService          from '../../../../src/ai/client/InstanceService.mjs';
 import LegacyTransactionService from '../../../../src/ai/TransactionService.mjs';
 import WriteGuard               from '../../../../src/ai/WriteGuard.mjs';
+import DockWorkspace            from '../../../../src/dashboard/dock/Workspace.mjs';
 import {dispatchServiceMethod}  from '../../../../src/ai/client/resolveServiceMethod.mjs';
 import PopupWorkspace           from '../../../../apps/workstation/view/PopupWorkspace.mjs';
 import WorkstationWorkspace     from '../../../../apps/workstation/view/Workspace.mjs';
@@ -303,6 +304,45 @@ test.describe.serial('Dock WorkspaceSet transaction participants', () => {
             service.destroy(); legacy.destroy()
         }
     });
+
+    for (const kind of ['main', 'popup']) {
+        test(`${kind} participant preserves maximize when a Group commit activates a local tab`, async () => {
+            const key     = kind === 'main' ? WorkstationWorkspace.MAIN_WORKSPACE_ID : 'popup',
+                  initial = document(key);
+            initial.items.second = {componentRef: 'second', title: 'Second'};
+            initial.nodes.root.items.push('second');
+
+            const owner = Neo.create(kind === 'main' ? DockWorkspace : PopupWorkspace, {
+                dockModel: initial, topologyGroupId: groupId,
+                ...(kind === 'popup' ? {workspaceSet: set, workspaceKey: key,
+                    rootWorkspace: {resolvePane: () => ({ntype: 'component'})}} : {})
+            });
+            owner.refreshDockWorkspace = async () => {};
+            if (kind === 'main') {
+                owner.workspaceSet = set;
+                owner.dockHistoryDepth = 5;
+                owner.dockPlacement = {};
+                expect(WorkstationWorkspace.prototype.registerMainWorkspace.call(owner)).toBe(true)
+            }
+
+            const plugin     = owner.getPlugin('dock-maximize'),
+                  descriptor = {operation: 'setActiveItem', tabsNodeId: 'root', itemId: 'second'},
+                  events     = [];
+            plugin._maximizedNodeId = 'root';
+            owner.on('beforeDockZoneDocumentChange', event => events.push(event));
+            try {
+                const result = owner.applyDockZoneOperation(descriptor);
+                await owner.onDockZoneDocumentChange(result.document, descriptor);
+                await expect.poll(() => events.length).toBe(1);
+                await owner.refreshPromise;
+                expect(owner.dockModel.nodes.root.activeItemId).toBe('second');
+                expect(plugin.maximizedNodeId).toBe('root');
+                expect(TransactionManager.get(groupId).history.count).toBe(1)
+            } finally {
+                owner.destroy()
+            }
+        })
+    }
 
     test('a full popup Workspace commits a human tab activation to its Group document', async () => {
         const initial = document('popup');


### PR DESCRIPTION
Resolves #18471

Group tab operations now preserve a surviving maximized pane when their effects stay inside it. `Workspace.projectDockCommit(context)` carries the existing transaction capture to presentation collaborators; Workstation's main and popup registrations delegate to that entrypoint. Maximize evaluates the batch in order against captured state, advancing with the pure reducers. Cross-node changes still clear before reconciliation, and a removed node clears through existing projection continuity.

Evidence: L3 rendered Group-backed workspace plus real Transaction/WorkspaceSet integration → L3 required. No residuals.

## AC Evidence

| AC | Evidence |
|---|---|
| AC-1 — real main/popup registration | CI-covered: `DockWorkspaceSetTransaction.spec.mjs` invokes the actual main registration on a lightweight engine host and constructs the real PopupWorkspace. Both Group activation arms were red on merged dev `5be879d2be`. |
| AC-2 — confinement and ordered batches | CI-covered: `DockMaximizePlugin.spec.mjs` exercises local add/reorder, creation followed by removal, cross-node and mixed batches, rejected writes and missing/mismatched context. Existing scalar controls remain covered; component coverage verifies close preserves maximize until the node collapses. |
| AC-3 — captured-source distinction | CI-covered: cross-node/mixed Group controls assert terminal clearing and one history entry. The final-document mutation below fails both. |
| AC-4 — rendered behavior and identity | CI-covered: `DockMaximize.spec.mjs` clicks a real tab on a Group-backed fixture and checks active-item truth, host-relative maximize geometry, the same tabs DOM node and live pane instance, outside-change clearing, and exactly the expected Group write count. |

## Deltas from ticket

One reusable engine projection entrypoint replaces two copies of app-side context forwarding. Workstation loses two physical/code lines (4,478 → 4,476 total); its popup callback also loses two. Only `previousDocument` and workspace identity reach the collaborator event; both are stripped from reconciliation options. The direct path also passes its previous document explicitly. Group writes, history and persisted shapes are unchanged.

Change class: capability (`feat`) — adds the reusable Group projection entrypoint. `agent-preflight` is not hosted in this Engine checkout; local hooks and the shared PR baseline supply the available checks.

size-guard-growth: src/dashboard/dock/Workspace.mjs — eight code lines centralize the captured-document handoff and remove four duplicated consumer callback lines; no new state owner or writer.

## Test Evidence

- On dev `5be879d2be`, the main and popup positive Group tests each committed the active tab but failed with `maximizedNodeId: null` instead of `root`.
- Replacing captured before-state with the adopted document made both cross-node/mixed controls fail: expected `null`, received `main-tabs`.
- Disabling batch classification while keeping the new renderer witness made the tab activation commit but removed the maximized DOM marker (expected 1, received 0; plugin state `null`). The mutation was removed after the run.

## Post-Merge Validation

No merge-dependent validation remains.

Authored by Emmy (GPT-6 Astra, Codex). Session 153d2e0a-ebae-4087-bcd5-3c92d213132c.
