### PR TITLE
refactor(workstation): Move Workstation vessel policy into a lifecycle-owning controller (#18460)

### DIFF
--- a/apps/workstation/view/VesselController.mjs
+++ b/apps/workstation/view/VesselController.mjs
@@ -90,16 +90,44 @@ class VesselController extends Controller {
     lastTearOutClose = null
 
     /**
-     * @summary Releases only what this controller owns.
+     * @summary True from the first line of `destroy()` until `super.destroy()` returns, so an effect
+     * that has not yet dispatched a platform call refuses to start one while an already-dispatched
+     * effect still settles and honours its obligations.
      *
-     * The park geometries and retry counters are physical-recovery state for gestures that are over
-     * by the time a workspace tears down. The borrowed owners above are deliberately untouched:
-     * retiring a Group participant or a tear-out handler from here would destroy something this
-     * controller never created.
+     * It covers only that window on purpose: `core.Base#destroy` deletes every writable own
+     * property, so this flag is gone afterwards and `isDestroyed` — which that same method sets —
+     * carries the signal from there. The guards test both, and the pair is total.
+     * @member {Boolean} isTearingDown=false
+     * @protected
+     */
+    isTearingDown = false
+
+    /**
+     * @summary Releases only what this controller owns, without stranding an effect still in flight.
+     *
+     * Teardown is **not** quiescent — a gesture can be mid-dispatch when the workspace goes away —
+     * so the contract has two halves:
+     *
+     * - **Cancellation before dispatch.** Every effect entry point refuses while `isTearingDown` or
+     *   `isDestroyed` holds, in its own return shape, so no NEW platform call is started.
+     * - **Settlement after dispatch.** An already-dispatched effect runs to completion and keeps its
+     *   platform obligations. It can, because its receipt is a local object rather than a field read
+     *   back off the instance, and because park-geometry release goes through
+     *   {@link #releaseParkGeometry}. Both matter: `core.Base#destroy` DELETES own properties, so a
+     *   settling effect touching them directly throws into a surrounding catch — reporting a
+     *   successful platform call as a refusal.
+     *
+     * Nothing is written back onto a torn-down controller, and each platform effect still happens
+     * exactly once. The borrowed owners are deliberately untouched: retiring a Group participant or
+     * a tear-out handler from here would destroy something this controller never created.
      * @param {...*} args
      */
     destroy(...args) {
         const me = this;
+
+        // Set before anything is cleared: an in-flight effect reads this at its next dispatch
+        // boundary, so nothing new starts while the fields are going away.
+        me.isTearingDown = true;
 
         me.tearOutParkGeometries = {};
         me.tearOutParkAttempts   = {};
@@ -174,6 +202,22 @@ class VesselController extends Controller {
     }
 
     /**
+     * @summary Drops one item's park geometry, tolerating a teardown that landed mid-effect.
+     *
+     * Clearing the map is bookkeeping this controller owns; the platform obligations around it are
+     * not. `core.Base#destroy` DELETES own properties, so an effect still settling would throw on
+     * `delete undefined[itemId]` — and the surrounding catch swallowed that throw, turning a
+     * successful platform call into a reported refusal. One seam, because a guard added to the site
+     * someone happens to be reading leaves the other five unguarded.
+     * @param {String} itemId
+     * @protected
+     */
+    releaseParkGeometry(itemId) {
+        this.tearOutParkGeometries && delete this.tearOutParkGeometries[itemId]
+    }
+
+    /**
+     * @summary Retires a parked vessel outright — the disposal half of the park lifecycle.
      * Consumes the tear-out machine's active slot, then closes its exact parked vessel — the ONE
      * settle path for a committed conversion; a refusal retains exact retry authority.
      * @param {Object} vessel
@@ -183,6 +227,8 @@ class VesselController extends Controller {
      * @protected
      */
     async disposeParkedTearOutVessel({itemId, windowName}) {
+        if (this.isTearingDown || this.isDestroyed) return false;
+
         let me    = this,
             entry = me.resolveTearOutVessel(itemId),
             route = entry?.nativeRoute;
@@ -190,7 +236,7 @@ class VesselController extends Controller {
         const disposed = await me.component.tearOutHandlers.retireActiveVessel({itemId, windowName});
 
         if (disposed) {
-            delete me.tearOutParkGeometries[itemId];
+            me.releaseParkGeometry(itemId);
             delete me.tearOutParkAttempts[itemId];
 
             route?.nativeHandleKey && await Neo.main.addon.DragDrop.retireWindowDragOrphanRecovery({
@@ -224,6 +270,8 @@ class VesselController extends Controller {
      * @protected
      */
     async openTearOutVessel({itemId, proxyRect, topologyIdentity}) {
+        if (this.isTearingDown || this.isDestroyed) return null;
+
         let me         = this,
             {windowId} = me.component,
             windowName = `tearout-${itemId}`;
@@ -274,6 +322,7 @@ class VesselController extends Controller {
     }
 
     /**
+     * @summary Consumes the tear-out slot, then closes that exact vessel; a refusal keeps retry authority.
      * The tear-out retirement seam: closes a vessel the gesture no longer needs (re-entry, cancel,
      * or a refused model commit). Identity is the slot's lineage token — a successor admission for
      * the same item shares the window name, never the token — so a retirement presenting a superseded
@@ -289,6 +338,8 @@ class VesselController extends Controller {
      * @protected
      */
     async closeTearOutVessel({generationToken, itemId, nativeRoute, windowName}) {
+        if (this.isTearingDown || this.isDestroyed) return false;
+
         let me               = this,
             entry            = me.resolveTearOutVessel(itemId),
             admission        = me.component.nativeWindows?.getAdmission(me.component.id, itemId),
@@ -389,13 +440,14 @@ class VesselController extends Controller {
             return false
         }
 
-        delete me.tearOutParkGeometries[itemId];
+        me.releaseParkGeometry(itemId);
         closeReceipt.stage = 'acknowledged';
 
         return true
     }
 
     /**
+     * @summary Moves a live vessel off-screen for the duration of a gesture, recording why if the platform refuses.
      * Parks one converted vessel behind its conversion target — the cover geometry that keeps
      * the REAL OS window alive while the proxy embodies over the target. Close-and-reopen is a
      * one-way door (mid-gesture popup acquisition reads as unsolicited), so conversion parks
@@ -415,13 +467,16 @@ class VesselController extends Controller {
      * @protected
      */
     async parkTearOutVessel({itemId, nativeTitlebar=false, windowName}) {
+        if (this.isTearingDown || this.isDestroyed) return false;
+
         let me           = this,
+            windowId     = me.component.windowId,
             entry        = me.resolveTearOutVessel(itemId),
             route        = entry?.nativeRoute,
             sourceWindow = Neo.manager?.Window?.get(entry?.windowId),
             targetWindow = Neo.manager?.Window?.get(me.vesselConversionTargetWindowId),
             targetRoute  = targetWindow?.nativeRoute,
-            targetIsMain = me.vesselConversionTargetWindowId === me.component.windowId,
+            targetIsMain = me.vesselConversionTargetWindowId === windowId,
             // The size check and the authority check speak published inner-window geometry (a child
             // omitting outerRect never rejects an authorized live vessel); the park POSITION is a
             // frame: `moveTo` places the source frame on the target's frame origin, so the parked
@@ -448,17 +503,17 @@ class VesselController extends Controller {
                 restore: restoreRect
             } : null;
 
-        me.lastVesselParkReceipt = {
+        const parkReceipt = me.lastVesselParkReceipt = {
             authority: {
                 entryNameMatches     : entry?.windowName === windowName,
                 sourceHasHandle      : Boolean(route?.nativeHandleKey),
-                sourceOwnerMatches   : route?.ownerWindowId === me.component.windowId,
+                sourceOwnerMatches   : route?.ownerWindowId === windowId,
                 sourcePositionCapable: route?.capabilities?.position === true,
                 sourceResizeCapable  : route?.capabilities?.resize === true,
                 sourceTargetMatches  : route?.targetWindowId === entry?.windowId,
                 targetFocusCapable   : targetRoute?.capabilities?.focus === true,
                 targetHasHandle      : Boolean(targetRoute?.nativeHandleKey),
-                targetOwnerMatches   : targetRoute?.ownerWindowId === me.component.windowId,
+                targetOwnerMatches   : targetRoute?.ownerWindowId === windowId,
                 targetTargetMatches  : targetRoute?.targetWindowId === me.vesselConversionTargetWindowId
             },
             needsResize,
@@ -478,14 +533,14 @@ class VesselController extends Controller {
         };
         me.lastVesselRestoreReceipt = null;
 
-        me.lastVesselParkReceipt.parkAttempts = me.tearOutParkAttempts[itemId] = (me.tearOutParkAttempts[itemId] ?? 0) + 1;
+        parkReceipt.parkAttempts = me.tearOutParkAttempts[itemId] = (me.tearOutParkAttempts[itemId] ?? 0) + 1;
 
         if (
-            !route?.nativeHandleKey || route.ownerWindowId !== me.component.windowId ||
+            !route?.nativeHandleKey || route.ownerWindowId !== windowId ||
             route.targetWindowId !== entry.windowId || route.capabilities?.position !== true ||
             (needsResize && route.capabilities?.resize !== true) ||
             (!targetIsMain && (
-                !targetRoute?.nativeHandleKey || targetRoute.ownerWindowId !== me.component.windowId ||
+                !targetRoute?.nativeHandleKey || targetRoute.ownerWindowId !== windowId ||
                 targetRoute.targetWindowId !== me.vesselConversionTargetWindowId ||
                 targetRoute.capabilities?.focus !== true
             )) ||
@@ -494,7 +549,7 @@ class VesselController extends Controller {
                 sourceRect.width > targetRect.width || sourceRect.height > targetRect.height
             ))
         ) {
-            me.lastVesselParkReceipt.reason = 'native route or live cover geometry refused';
+            parkReceipt.reason = 'native route or live cover geometry refused';
             return false
         }
 
@@ -508,9 +563,9 @@ class VesselController extends Controller {
         // targets keep the physical park below.
         if (nativeTitlebar && targetIsMain) {
             delete me.tearOutParkAttempts[itemId];
-            me.lastVesselParkReceipt.parked   = true;
-            me.lastVesselParkReceipt.physical = false;
-            me.lastVesselParkReceipt.reason   = 'main-window target: nothing to park, the popup retires after the commit';
+            parkReceipt.parked   = true;
+            parkReceipt.physical = false;
+            parkReceipt.reason   = 'main-window target: nothing to park, the popup retires after the commit';
             return true
         }
 
@@ -527,25 +582,25 @@ class VesselController extends Controller {
             : Neo.Main.windowNativeFocus({
                 nativeHandleKey: targetRoute.nativeHandleKey,
                 targetWindowId : targetRoute.targetWindowId,
-                windowId       : me.component.windowId
+                windowId       : windowId
             });
 
         try {
             let focused = await focusTarget() === true;
 
-            me.lastVesselParkReceipt.focused = focused;
+            parkReceipt.focused = focused;
 
             if (!focused) {
                 // A popup target: the owner focuses a window it opened, which the platform grants
                 // once the OS releases the dragged source. The coordinator retries the park.
-                me.lastVesselParkReceipt.refusedAt = 'focus';
+                parkReceipt.refusedAt = 'focus';
                 return false
             }
 
             const moveData = {
                 nativeHandleKey: route.nativeHandleKey,
                 targetWindowId : route.targetWindowId,
-                windowId       : me.component.windowId,
+                windowId,
                 windowName,
                 x              : targetOuter.x,
                 y              : targetOuter.y
@@ -560,10 +615,10 @@ class VesselController extends Controller {
                 ? Neo.Main.windowNativeMoveTo(moveData)
                 : Neo.main.addon.DragDrop.parkWindowDrag(moveData)) === true;
 
-            me.lastVesselParkReceipt.moved = moved;
+            parkReceipt.moved = moved;
 
             if (!moved) {
-                me.lastVesselParkReceipt.refusedAt = 'move';
+                parkReceipt.refusedAt = 'move';
                 return false
             }
 
@@ -571,13 +626,13 @@ class VesselController extends Controller {
 
             let refocused = await focusTarget() === true;
 
-            me.lastVesselParkReceipt.refocused = refocused;
+            parkReceipt.refocused = refocused;
 
             if (!refocused) {
                 const restoreData = {
                     nativeHandleKey: route.nativeHandleKey,
                     targetWindowId : route.targetWindowId,
-                    windowId       : me.component.windowId,
+                    windowId,
                     windowName,
                     x              : sourceOuter.x,
                     y              : sourceOuter.y
@@ -586,10 +641,10 @@ class VesselController extends Controller {
                     ? Neo.Main.windowNativeMoveTo(restoreData)
                     : Neo.main.addon.DragDrop.resumeWindowDrag(restoreData)) === true;
 
-                me.lastVesselParkReceipt.compensated = compensated;
-                me.lastVesselParkReceipt.parked      = !compensated;
-                me.lastVesselParkReceipt.refusedAt   = 'refocus';
-                compensated && delete me.tearOutParkGeometries[itemId];
+                parkReceipt.compensated = compensated;
+                parkReceipt.parked      = !compensated;
+                parkReceipt.refusedAt   = 'refocus';
+                compensated && me.releaseParkGeometry(itemId);
 
                 // Recovery ownership and visual admission are separate: if target refocus failed,
                 // the real source may still cover the target. Never publish conversion-ready on
@@ -598,17 +653,18 @@ class VesselController extends Controller {
             }
 
             delete me.tearOutParkAttempts[itemId];
-            me.lastVesselParkReceipt.parked = true;
+            parkReceipt.parked = true;
 
             return true
         } catch (error) {
-            me.lastVesselParkReceipt.error  = String(error?.message || error);
-            me.lastVesselParkReceipt.reason = 'platform effect threw';
+            parkReceipt.error  = String(error?.message || error);
+            parkReceipt.reason = 'platform effect threw';
             return false
         }
     }
 
     /**
+     * @summary Returns a parked vessel to its recorded geometry and acknowledges the recovery obligation.
      * Re-shows the same exact parked generation at the logical pointer-owned origin. During a
      * live gesture the DragDrop addon also resumes physical pointer-follow; at a native drag
      * terminal that addon has already reset its session, so a strict refusal falls through to
@@ -622,7 +678,10 @@ class VesselController extends Controller {
      * @protected
      */
     async reshowTearOutVessel({itemId, rect, terminal=false, windowName}) {
+        if (this.isTearingDown || this.isDestroyed) return false;
+
         let me       = this,
+            windowId = me.component.windowId,
             entry    = me.resolveTearOutVessel(itemId),
             route    = entry?.nativeRoute,
             geometry = me.tearOutParkGeometries[itemId] ?? null,
@@ -636,7 +695,7 @@ class VesselController extends Controller {
                 y: rect.y - (chrome?.top  ?? 0)
             } : null;
 
-        me.lastVesselRestoreReceipt = {
+        const restoreReceipt = me.lastVesselRestoreReceipt = {
             frame,
             geometry,
             rect: rect && {height: rect.height, width: rect.width, x: rect.x, y: rect.y},
@@ -644,20 +703,20 @@ class VesselController extends Controller {
         };
 
         if (
-            !route?.nativeHandleKey || route.ownerWindowId !== me.component.windowId ||
+            !route?.nativeHandleKey || route.ownerWindowId !== windowId ||
             route.targetWindowId !== entry.windowId || route.capabilities?.position !== true ||
             (geometry && route.capabilities?.resize !== true) ||
             entry.windowName !== windowName ||
             !Number.isFinite(rect?.x) || !Number.isFinite(rect?.y)
         ) {
-            me.lastVesselRestoreReceipt.reason = 'native route or restore geometry refused';
+            restoreReceipt.reason = 'native route or restore geometry refused';
             return false
         }
 
         let data = {
             nativeHandleKey: route.nativeHandleKey,
             targetWindowId : route.targetWindowId,
-            windowId       : me.component.windowId,
+            windowId,
             windowName,
             x              : frame.x,
             y              : frame.y
@@ -667,26 +726,26 @@ class VesselController extends Controller {
             if (!terminal) {
                 const admitted = await Neo.main.addon.DragDrop.resumeWindowDrag(data) === true;
 
-                me.lastVesselRestoreReceipt.admitted = admitted;
-                admitted && delete me.tearOutParkGeometries[itemId];
+                restoreReceipt.admitted = admitted;
+                admitted && me.releaseParkGeometry(itemId);
 
                 return admitted
             }
 
             const addonRestored = await Neo.main.addon.DragDrop.resumeWindowDrag(data) === true;
 
-            me.lastVesselRestoreReceipt.addonRestored = addonRestored;
+            restoreReceipt.addonRestored = addonRestored;
 
             if (addonRestored) {
-                delete me.tearOutParkGeometries[itemId];
-                me.lastVesselRestoreReceipt.admitted = true;
+                me.releaseParkGeometry(itemId);
+                restoreReceipt.admitted = true;
 
                 return true
             }
 
             const recoveryPending = await Neo.main.addon.DragDrop.hasWindowDragOrphanRecovery(data) === true;
 
-            me.lastVesselRestoreReceipt.recoveryPending = recoveryPending;
+            restoreReceipt.recoveryPending = recoveryPending;
 
             // A matching predecessor effect still owns exact recovery. Never race it with a second
             // direct route mutation or degrade a required extent restore into position-only success.
@@ -696,17 +755,17 @@ class VesselController extends Controller {
                 const resized = await Neo.Main.windowNativeResizeTo({
                     nativeHandleKey: route.nativeHandleKey,
                     targetWindowId : route.targetWindowId,
-                    windowId       : me.component.windowId,
+                    windowId,
                     ...geometry.restore
                 }) === true;
 
-                me.lastVesselRestoreReceipt.resized = resized;
+                restoreReceipt.resized = resized;
 
                 if (!resized) {
                     await Neo.Main.windowNativeResizeTo({
                         nativeHandleKey: route.nativeHandleKey,
                         targetWindowId : route.targetWindowId,
-                        windowId       : me.component.windowId,
+                        windowId,
                         ...geometry.park
                     });
                     return false
@@ -716,30 +775,30 @@ class VesselController extends Controller {
             const moved = await Neo.Main.windowNativeMoveTo({
                 nativeHandleKey: route.nativeHandleKey,
                 targetWindowId : route.targetWindowId,
-                windowId       : me.component.windowId,
+                windowId,
                 x              : rect.x,
                 y              : rect.y
             }) === true;
 
-            me.lastVesselRestoreReceipt.moved = moved;
+            restoreReceipt.moved = moved;
 
             if (!moved) {
                 if (geometry) {
                     const compensationResized = await Neo.Main.windowNativeResizeTo({
                         nativeHandleKey: route.nativeHandleKey,
                         targetWindowId : route.targetWindowId,
-                        windowId       : me.component.windowId,
+                        windowId,
                         ...geometry.park
                     }) === true;
 
-                    me.lastVesselRestoreReceipt.compensationResized = compensationResized;
+                    restoreReceipt.compensationResized = compensationResized;
 
                     if (compensationResized) {
-                        me.lastVesselRestoreReceipt.compensationMoved =
+                        restoreReceipt.compensationMoved =
                             await Neo.Main.windowNativeMoveTo({
                                 nativeHandleKey: route.nativeHandleKey,
                                 targetWindowId : route.targetWindowId,
-                                windowId       : me.component.windowId,
+                                windowId,
                                 x              : geometry.park.x,
                                 y              : geometry.park.y
                             }) === true
@@ -749,13 +808,16 @@ class VesselController extends Controller {
                 return false
             }
 
-            me.lastVesselRestoreReceipt.admitted = true;
-            delete me.tearOutParkGeometries[itemId];
+            restoreReceipt.admitted = true;
+            // The map is gone if a teardown landed mid-flight. Clearing it is bookkeeping this
+            // controller owns; the acknowledgement below is an obligation to the platform, and it
+            // must not be skipped because our own bookkeeping no longer has anywhere to write.
+            me.releaseParkGeometry(itemId);
             await Neo.main.addon.DragDrop.acknowledgeWindowDragOrphanRecovery(data);
 
             return true
         } catch (error) {
-            me.lastVesselRestoreReceipt.error = String(error?.message || error);
+            restoreReceipt.error = String(error?.message || error);
             return false
         }
     }

--- a/apps/workstation/view/VesselController.mjs
+++ b/apps/workstation/view/VesselController.mjs
@@ -1,4 +1,5 @@
-import Controller from '../../../src/controller/Component.mjs';
+import Controller        from '../../../src/controller/Component.mjs';
+import WorkspaceDocument from '../../../src/dashboard/dock/model/WorkspaceDocument.mjs';
 
 /**
  * @summary Workstation's native vessel policy: which OS window a torn pane converts onto, the

--- a/apps/workstation/view/VesselController.mjs
+++ b/apps/workstation/view/VesselController.mjs
@@ -1,0 +1,763 @@
+import Controller from '../../../src/controller/Component.mjs';
+
+/**
+ * @summary Workstation's native vessel policy: which OS window a torn pane converts onto, the
+ * platform effects that park and re-show it, and the receipts that make a refusal legible.
+ *
+ * The engine already owns the DECISIONS. `Neo.dashboard.dock.window.VesselPark` is the in-gesture
+ * authority — park it, never close it; re-show the same window; dispose exactly once on commit —
+ * and it reaches a host through `callEffect`. What lives here is the other side of that seam: the
+ * effects themselves, and the product policy choosing their target.
+ *
+ * Those effects are intricate rather than clever. Popup acquisition consumes transient user
+ * activation and `windowOpen` reports failure by boolean, so a mid-gesture reopen cannot be relied
+ * on; conversion therefore parks the real window behind its target and re-shows the same
+ * generation. A source whose outer frame cannot fit shrinks first through its exact native route,
+ * and a refocus refusal compensates back to the original extent.
+ *
+ * **Borrowed, never owned.** `tearOutHandlers`, `vesselParkHandlers`, `nativeWindows` and the
+ * embodiments belong to the workspace and are reached through {@link #component}. This controller
+ * owns only the park geometry, the retry counters, the conversion target and its own receipts —
+ * so destroying it releases those and disturbs no lifecycle the engine or the workspace is running.
+ *
+ * @class Workstation.view.VesselController
+ * @extends Neo.controller.Component
+ */
+class VesselController extends Controller {
+    static config = {
+        /**
+         * @member {String} className='Workstation.view.VesselController'
+         * @protected
+         */
+        className: 'Workstation.view.VesselController'
+    }
+
+    /**
+     * Exact pre-conversion and target-cover outer geometry for parked tear-out vessels.
+     * Runtime-only physical recovery authority; never persisted workspace state.
+     * @member {Object} tearOutParkGeometries={}
+     * @protected
+     */
+    tearOutParkGeometries = {}
+    /**
+     * Park attempts per vessel item id since that vessel last parked. The coordinator retries a
+     * refused park; a stalled retry reads live as a rising count with the same `refusedAt`.
+     * @member {Object} tearOutParkAttempts={}
+     * @protected
+     */
+    tearOutParkAttempts = {}
+    /**
+     * The runtime window id of the vessel an in-flight conversion is hovering over — stashed by the
+     * conversion-in seam so the park's cover geometry resolves the exact target. Never persisted
+     * workspace state: a window is a render target.
+     * @member {String|Number|null} vesselConversionTargetWindowId=null
+     * @protected
+     */
+    vesselConversionTargetWindowId = null
+    /**
+     * Most recent exact-handle park admission receipt.
+     *
+     * `parked` and `physical` are separate answers, and the pair is the point: `parked: true` says
+     * the park was SATISFIED, `physical: false` that it performed no platform effect. A main-window
+     * target under a native titlebar is exactly that case — there is nothing to move, so the park
+     * succeeds having done nothing. A reader taking `parked` as proof of a platform call would go
+     * looking for a move that never happened.
+     * @member {Object|null} lastVesselParkReceipt=null
+     * @protected
+     */
+    lastVesselParkReceipt = null
+    /**
+     * Most recent exact-handle restore admission receipt.
+     * @member {Object|null} lastVesselRestoreReceipt=null
+     * @protected
+     */
+    lastVesselRestoreReceipt = null
+    /**
+     * Most recent vessel-open receipt. Declared here rather than assigned ad hoc, which is what it
+     * was on the workspace — an undeclared field a reader could only find by grepping its writes.
+     * @member {Object|null} lastVesselOpen=null
+     * @protected
+     */
+    lastVesselOpen = null
+    /**
+     * Most recent exact vessel-close attempt for bounded headed-failure diagnosis. Native handle
+     * authority is represented only by presence/match booleans; its secret key never enters this
+     * worker-visible receipt.
+     * @member {Object|null} lastTearOutClose=null
+     * @protected
+     */
+    lastTearOutClose = null
+
+    /**
+     * @summary Releases only what this controller owns.
+     *
+     * The park geometries and retry counters are physical-recovery state for gestures that are over
+     * by the time a workspace tears down. The borrowed owners above are deliberately untouched:
+     * retiring a Group participant or a tear-out handler from here would destroy something this
+     * controller never created.
+     * @param {...*} args
+     */
+    destroy(...args) {
+        const me = this;
+
+        me.tearOutParkGeometries = {};
+        me.tearOutParkAttempts   = {};
+
+        me.vesselConversionTargetWindowId = null;
+        me.lastVesselParkReceipt          = null;
+        me.lastVesselRestoreReceipt       = null;
+        me.lastVesselOpen                 = null;
+        me.lastTearOutClose               = null;
+
+        super.destroy(...args)
+    }
+
+    /**
+     * @summary Uses the document's semantic key for native admission too.
+     * @param {String} itemId
+     * @returns {String}
+     */
+    tearOutWorkspaceKey(itemId) {
+        return this.component.constructor.vesselWorkspaceId(itemId)
+    }
+
+    /**
+     * @summary Retries an exact retained vessel retirement before admitting a successor tear-out.
+     *
+     * A strict close refusal keeps both lifecycle owners so recovery remains possible. The next
+     * boundary exit must retire that generation and clear its park owner before opening another
+     * popup; a second refusal ends the newly armed window drag instead of leaving it wedged.
+     * @param {Object} data
+     * @returns {Promise<Boolean>}
+     * @protected
+     */
+    async onDockTearOutExit(data) {
+        let me     = this,
+            active = me.component.tearOutHandlers.activeVessel;
+
+        if (active) {
+            const retired = await me.component.tearOutHandlers.retireActiveVessel(active);
+
+            if (!retired) {
+                data.sortZone?.endWindowDrag();
+                return false
+            }
+
+            me.component.vesselParkHandlers.onVesselRetired({itemId: active.itemId, retirement: true})
+        }
+
+        await me.component.tearOutHandlers.onDockTearOutExit(data);
+
+        return true
+    }
+
+    /**
+     * @summary Resolves the exact live vessel identity for one torn item, connect- or commit-side.
+     * @param {String} itemId
+     * @returns {Object|null}
+     * @protected
+     */
+    resolveTearOutVessel(itemId) {
+        let {component}     = this,
+            {nativeWindows} = component,
+            entry           = nativeWindows?.getConnection(component.id, itemId) ?? nativeWindows?.getOwner(component.id, itemId);
+
+        if (!entry?.windowId) return null;
+
+        return {
+            ...entry,
+            itemId,
+            nativeRoute: entry.nativeRoute ?? Neo.manager?.Window?.get(entry.windowId)?.nativeRoute ?? null,
+            windowName : entry.windowName ?? `tearout-${itemId}`
+        }
+    }
+
+    /**
+     * Consumes the tear-out machine's active slot, then closes its exact parked vessel — the ONE
+     * settle path for a committed conversion; a refusal retains exact retry authority.
+     * @param {Object} vessel
+     * @param {String} vessel.itemId
+     * @param {String} vessel.windowName
+     * @returns {Promise<Boolean>}
+     * @protected
+     */
+    async disposeParkedTearOutVessel({itemId, windowName}) {
+        let me    = this,
+            entry = me.resolveTearOutVessel(itemId),
+            route = entry?.nativeRoute;
+
+        const disposed = await me.component.tearOutHandlers.retireActiveVessel({itemId, windowName});
+
+        if (disposed) {
+            delete me.tearOutParkGeometries[itemId];
+            delete me.tearOutParkAttempts[itemId];
+
+            route?.nativeHandleKey && await Neo.main.addon.DragDrop.retireWindowDragOrphanRecovery({
+                nativeHandleKey: route.nativeHandleKey,
+                targetWindowId : route.targetWindowId,
+                windowId       : me.component.windowId,
+                windowName
+            })
+        }
+
+        return disposed
+    }
+
+    /**
+     * @summary Opens one theme-correct vessel window for a mid-gesture boundary exit.
+     *
+     * Reuses the workstation viewport's `?popout=` pure-pane-host mode. The vessel carries the slot the
+     * engine reserved in this workspace's Group through `Main.windowOpen`; which pane it shows is
+     * content and stays in the URL, whom it belongs to is identity and never does. The bound child
+     * immediately carries the same live pane through {@link Neo.dashboard.dock.window.VesselEmbodiment};
+     * it owns no workspace document. Fail-closed per the admission contract: `windowOpen` returns
+     * a BOOLEAN (a blocked popup never throws), and any falsy/throwing acquisition returns `null`
+     * so the gesture degrades to its in-window fallback. The theme bootstrap is part of that
+     * acquisition rather than optional presentation: an unavailable authority reaches the outer
+     * diagnostic boundary and prevents an unthemed child from opening.
+     * @param {Object} request
+     * @param {String} request.itemId
+     * @param {Object} request.proxyRect
+     * @param {Object} request.topologyIdentity The reserved slot, written into the vessel's carrier.
+     * @returns {Promise<{popupHeight: Number, popupWidth: Number, windowName: String}|null>}
+     * @protected
+     */
+    async openTearOutVessel({itemId, proxyRect, topologyIdentity}) {
+        let me         = this,
+            {windowId} = me.component,
+            windowName = `tearout-${itemId}`;
+
+        // Diagnostic trail for the birth gate: absence has three distinct layers (admission
+        // refused / platform refused the window / window granted but never bound), and the
+        // failure diag must name which one this gesture died in.
+        me.lastVesselOpen = {itemId, stage: 'invoked'};
+
+        try {
+            let [winData, bootstrap] = await Promise.all([
+                    Neo.Main.getWindowData({windowId}),
+                    Neo.Main.getByPath({path: 'WorkstationBootstrap', windowId})
+                ]),
+                schemes       = bootstrap?.schemes || {},
+                selectedTheme = Object.hasOwn(schemes, me.component.theme)
+                    ? me.component.theme
+                    : bootstrap?.defaultTheme || me.component.theme,
+                width  = Math.max(Math.round(proxyRect?.width  || 480), 320),
+                height = Math.max(Math.round(proxyRect?.height || 360), 240),
+                left   = Math.round((proxyRect?.x ?? 120) + winData.screenLeft),
+                top    = Math.round((proxyRect?.y ?? 120) + (winData.outerHeight - winData.innerHeight) + winData.screenTop);
+
+            let opened = await Neo.Main.windowOpen({
+                nativeCapabilities: {close: true, position: true, resize: true},
+                stagedColorScheme : schemes[selectedTheme],
+                topologyIdentity,
+                url               : `./index.html?popout=${itemId}&theme=${encodeURIComponent(selectedTheme)}`,
+                windowFeatures    : `height=${height},left=${left},top=${top},width=${width}`,
+                windowId,
+                windowName
+            });
+
+            me.lastVesselOpen.stage = opened === false ? 'windowOpen-false' : 'granted';
+
+            if (opened === false) {
+                return null
+            }
+
+            me.component.tearOutVesselDims = {height, width};
+
+            return {popupHeight: height, popupWidth: width, windowName}
+        } catch (error) {
+            me.lastVesselOpen.stage = 'threw';
+            me.lastVesselOpen.error = String(error?.message || error);
+            return null
+        }
+    }
+
+    /**
+     * The tear-out retirement seam: closes a vessel the gesture no longer needs (re-entry, cancel,
+     * or a refused model commit). Identity is the slot's lineage token — a successor admission for
+     * the same item shares the window name, never the token — so a retirement presenting a superseded
+     * token is refused and the live vessel survives it. The Group's native retirement holds the
+     * retirement fence and clears the ownership records around this call; the platform close and its
+     * receipt are this host's, and an explicit refusal retains exact retry authority.
+     * @param {Object} vessel
+     * @param {String} [vessel.generationToken] The reservation's lineage token.
+     * @param {String} vessel.itemId
+     * @param {Object} [vessel.nativeRoute] Exact opener-minted physical route when available.
+     * @param {String} vessel.windowName
+     * @returns {Promise<Boolean>}
+     * @protected
+     */
+    async closeTearOutVessel({generationToken, itemId, nativeRoute, windowName}) {
+        let me               = this,
+            entry            = me.resolveTearOutVessel(itemId),
+            admission        = me.component.nativeWindows?.getAdmission(me.component.id, itemId),
+            expected         = `tearout-${itemId}`,
+            exactToken       = entry?.generationToken ?? admission?.generationToken ?? null,
+            embodiedWindowId = entry?.windowId ?? admission?.windowId ?? me.component.tearOutEmbodiment.getWindowId(itemId),
+            closed           = false;
+
+        const closeReceipt = me.lastTearOutClose = {
+            identity: {
+                entryNameMatches : !entry || entry.windowName === windowName,
+                hasEntry         : Boolean(entry),
+                hasItemId        : Boolean(itemId),
+                lineageMatches   : !generationToken || !exactToken || generationToken === exactToken,
+                windowNameMatches: windowName === expected
+            },
+            itemId: itemId ?? null,
+            stage : 'validating-identity'
+        };
+
+        if (
+            !itemId || windowName !== expected || (entry && entry.windowName !== windowName) ||
+            (generationToken && exactToken && generationToken !== exactToken)
+        ) {
+            closeReceipt.stage = 'identity-refused';
+            return false
+        }
+
+        nativeRoute ??= entry?.nativeRoute ?? (
+            admission?.windowId && Neo.manager?.Window?.get(admission.windowId)?.nativeRoute
+        );
+
+        const exactWindowId = entry?.windowId ?? admission?.windowId;
+
+        closeReceipt.route = {
+            closeCapable      : !nativeRoute || nativeRoute.capabilities?.close === true,
+            exactTargetMatches: !nativeRoute || !exactWindowId || nativeRoute.targetWindowId === exactWindowId,
+            exactWindowId     : exactWindowId ?? null,
+            hasHandle         : !nativeRoute || Boolean(nativeRoute.nativeHandleKey),
+            ownerMatches      : !nativeRoute || nativeRoute.ownerWindowId === me.component.windowId,
+            ownerWindowId     : nativeRoute?.ownerWindowId ?? null,
+            present           : Boolean(nativeRoute),
+            targetPresent     : !nativeRoute || Boolean(nativeRoute.targetWindowId),
+            targetWindowId    : nativeRoute?.targetWindowId ?? null
+        };
+
+        if (nativeRoute && (
+            !nativeRoute.nativeHandleKey || nativeRoute.ownerWindowId !== me.component.windowId ||
+            !nativeRoute.targetWindowId || nativeRoute.capabilities?.close !== true ||
+            (exactWindowId && nativeRoute.targetWindowId !== exactWindowId)
+        )) {
+            closeReceipt.stage = 'route-refused';
+            return false
+        }
+
+        // The engine established retirement before this call; a refused close retains the exact
+        // route + tear-out machine slot for retry, but the content goes safely home first.
+        if (embodiedWindowId && me.component.tearOutEmbodiment.isStaged(itemId)) {
+            const sourceOwns = Boolean(WorkspaceDocument.findContainingTabsId(me.component.dockModel, itemId)),
+                  settled    = me.component.tearOutEmbodiment[sourceOwns ? 'restore' : 'promote']({
+                      itemId, windowId: embodiedWindowId
+                  });
+
+            closeReceipt.embodiment = {settled, sourceOwns, staged: true};
+
+            if (!settled) {
+                closeReceipt.stage = 'embodiment-refused';
+                return false
+            }
+        }
+
+        try {
+            if (nativeRoute) {
+                closeReceipt.stage = 'native-dispatched';
+                closed = await Neo.Main.windowNativeClose({
+                    nativeHandleKey: nativeRoute.nativeHandleKey,
+                    targetWindowId : nativeRoute.targetWindowId,
+                    windowId       : me.component.windowId
+                }) === true
+            } else {
+                closeReceipt.stage = 'semantic-dispatched';
+                // Before connect there is no exact route to correlate yet; the active tear-out
+                // slot's unguessable semantic name is the only available authority. Once a route
+                // exists, ANY invalidity above fails closed — never downgrade to same-name close.
+                await Neo.Main.windowClose({names: [windowName], windowId: me.component.windowId});
+                closed = true
+            }
+        } catch (error) {
+            closeReceipt.error = String(error?.message || error);
+            closeReceipt.stage = 'threw';
+            return false
+        }
+
+        closeReceipt.closed = closed;
+
+        if (!closed) {
+            closeReceipt.stage = 'platform-refused';
+            return false
+        }
+
+        delete me.tearOutParkGeometries[itemId];
+        closeReceipt.stage = 'acknowledged';
+
+        return true
+    }
+
+    /**
+     * Parks one converted vessel behind its conversion target — the cover geometry that keeps
+     * the REAL OS window alive while the proxy embodies over the target. Close-and-reopen is a
+     * one-way door (mid-gesture popup acquisition reads as unsolicited), so conversion parks
+     * instead: the same exact generation re-shows on out-conversion or restore. The focus /
+     * resize / move / refocus chain is the platform-law choreography (z-order hides the parked
+     * vessel). A source whose outer frame cannot fit behind the target first shrinks through its
+     * exact native route; a refocus refusal compensates to the original extent and source rect.
+     * On the native-titlebar path to the MAIN window nothing is parked at all — the hold is the
+     * gesture: the transfer lands when the dwell completes and the popup retires right after, so the
+     * park answers satisfied with no platform effect (the platform never grants a popup an opener
+     * focus without a user activation, and an OS titlebar drag carries none).
+     * @param {Object} vessel
+     * @param {String} vessel.itemId
+     * @param {Boolean} [vessel.nativeTitlebar=false] The park follows an OS titlebar drag terminal
+     * @param {String} vessel.windowName
+     * @returns {Promise<Boolean>}
+     * @protected
+     */
+    async parkTearOutVessel({itemId, nativeTitlebar=false, windowName}) {
+        let me           = this,
+            entry        = me.resolveTearOutVessel(itemId),
+            route        = entry?.nativeRoute,
+            sourceWindow = Neo.manager?.Window?.get(entry?.windowId),
+            targetWindow = Neo.manager?.Window?.get(me.vesselConversionTargetWindowId),
+            targetRoute  = targetWindow?.nativeRoute,
+            targetIsMain = me.vesselConversionTargetWindowId === me.component.windowId,
+            // The size check and the authority check speak published inner-window geometry (a child
+            // omitting outerRect never rejects an authorized live vessel); the park POSITION is a
+            // frame: `moveTo` places the source frame on the target's frame origin, so the parked
+            // window lies behind the target's chrome and content alike.
+            sourceRect   = sourceWindow?.innerRect,
+            sourceOuter  = sourceWindow?.outerRect ?? sourceRect,
+            targetRect   = targetWindow?.innerRect,
+            targetOuter  = targetWindow?.outerRect ?? targetRect,
+            needsResize  = !nativeTitlebar && Boolean(sourceOuter && targetRect && (
+                sourceOuter.width > targetRect.width || sourceOuter.height > targetRect.height
+            )),
+            parkSize      = needsResize ? {
+                height: Math.min(sourceOuter.height, targetRect.height),
+                width : Math.min(sourceOuter.width, targetRect.width)
+            } : null,
+            restoreRect   = sourceOuter ? {
+                height: sourceOuter.height,
+                width : sourceOuter.width,
+                x     : sourceOuter.x,
+                y     : sourceOuter.y
+            } : null,
+            parkGeometry  = needsResize ? {
+                park   : {...parkSize, x: targetOuter?.x, y: targetOuter?.y},
+                restore: restoreRect
+            } : null;
+
+        me.lastVesselParkReceipt = {
+            authority: {
+                entryNameMatches     : entry?.windowName === windowName,
+                sourceHasHandle      : Boolean(route?.nativeHandleKey),
+                sourceOwnerMatches   : route?.ownerWindowId === me.component.windowId,
+                sourcePositionCapable: route?.capabilities?.position === true,
+                sourceResizeCapable  : route?.capabilities?.resize === true,
+                sourceTargetMatches  : route?.targetWindowId === entry?.windowId,
+                targetFocusCapable   : targetRoute?.capabilities?.focus === true,
+                targetHasHandle      : Boolean(targetRoute?.nativeHandleKey),
+                targetOwnerMatches   : targetRoute?.ownerWindowId === me.component.windowId,
+                targetTargetMatches  : targetRoute?.targetWindowId === me.vesselConversionTargetWindowId
+            },
+            needsResize,
+            parkSize,
+            sourceInner: sourceRect && {
+                height: sourceRect.height, width: sourceRect.width, x: sourceRect.x, y: sourceRect.y
+            },
+            sourceOuter: sourceOuter && {
+                height: sourceOuter.height, width: sourceOuter.width, x: sourceOuter.x, y: sourceOuter.y
+            },
+            targetInner: targetRect && {
+                height: targetRect.height, width: targetRect.width, x: targetRect.x, y: targetRect.y
+            },
+            targetOuter: targetOuter && {
+                height: targetOuter.height, width: targetOuter.width, x: targetOuter.x, y: targetOuter.y
+            }
+        };
+        me.lastVesselRestoreReceipt = null;
+
+        me.lastVesselParkReceipt.parkAttempts = me.tearOutParkAttempts[itemId] = (me.tearOutParkAttempts[itemId] ?? 0) + 1;
+
+        if (
+            !route?.nativeHandleKey || route.ownerWindowId !== me.component.windowId ||
+            route.targetWindowId !== entry.windowId || route.capabilities?.position !== true ||
+            (needsResize && route.capabilities?.resize !== true) ||
+            (!targetIsMain && (
+                !targetRoute?.nativeHandleKey || targetRoute.ownerWindowId !== me.component.windowId ||
+                targetRoute.targetWindowId !== me.vesselConversionTargetWindowId ||
+                targetRoute.capabilities?.focus !== true
+            )) ||
+            entry.windowName !== windowName || !sourceRect || !sourceOuter || !targetRect ||
+            (nativeTitlebar && (
+                sourceRect.width > targetRect.width || sourceRect.height > targetRect.height
+            ))
+        ) {
+            me.lastVesselParkReceipt.reason = 'native route or live cover geometry refused';
+            return false
+        }
+
+        // The hold is the gesture for a native-titlebar drop INTO this main window: the transfer lands
+        // when the dwell completes and the popup is retired right after, so there is nothing to park —
+        // and the park's focus step could never be granted on this path anyway (no user activation
+        // reaches a popup during an OS titlebar drag, so a popup asking its opener to take focus is
+        // declined for as long as the user holds, and after). The strict park is answered as satisfied
+        // with no physical effect; the receipt says so, the attempt counter resets as after a park, and
+        // the conversion bookkeeping around this call runs exactly as for a parked vessel. Popup
+        // targets keep the physical park below.
+        if (nativeTitlebar && targetIsMain) {
+            delete me.tearOutParkAttempts[itemId];
+            me.lastVesselParkReceipt.parked   = true;
+            me.lastVesselParkReceipt.physical = false;
+            me.lastVesselParkReceipt.reason   = 'main-window target: nothing to park, the popup retires after the commit';
+            return true
+        }
+
+        // The root window has no opener-minted nativeRoute, so a main target is focused through the
+        // popup's own Main actor (`opener.focus()`, granted under the user activation a keyboard
+        // command carries — the pointer conversion path); a popup target is focused by its owner
+        // through the handle it minted.
+        //
+        // A main-window target under a native titlebar never arrives here: it returns satisfied
+        // above, having nothing to park. So the main branch below serves the pointer conversion
+        // path alone — there is no native-titlebar main case to find.
+        const focusTarget = () => targetIsMain
+            ? Neo.Main.windowFocus({windowId: entry.windowId})
+            : Neo.Main.windowNativeFocus({
+                nativeHandleKey: targetRoute.nativeHandleKey,
+                targetWindowId : targetRoute.targetWindowId,
+                windowId       : me.component.windowId
+            });
+
+        try {
+            let focused = await focusTarget() === true;
+
+            me.lastVesselParkReceipt.focused = focused;
+
+            if (!focused) {
+                // A popup target: the owner focuses a window it opened, which the platform grants
+                // once the OS releases the dragged source. The coordinator retries the park.
+                me.lastVesselParkReceipt.refusedAt = 'focus';
+                return false
+            }
+
+            const moveData = {
+                nativeHandleKey: route.nativeHandleKey,
+                targetWindowId : route.targetWindowId,
+                windowId       : me.component.windowId,
+                windowName,
+                x              : targetOuter.x,
+                y              : targetOuter.y
+            };
+
+            if (!nativeTitlebar) {
+                moveData.parkSize    = parkSize;
+                moveData.restoreRect = restoreRect
+            }
+
+            let moved = await (nativeTitlebar
+                ? Neo.Main.windowNativeMoveTo(moveData)
+                : Neo.main.addon.DragDrop.parkWindowDrag(moveData)) === true;
+
+            me.lastVesselParkReceipt.moved = moved;
+
+            if (!moved) {
+                me.lastVesselParkReceipt.refusedAt = 'move';
+                return false
+            }
+
+            parkGeometry && (me.tearOutParkGeometries[itemId] = parkGeometry);
+
+            let refocused = await focusTarget() === true;
+
+            me.lastVesselParkReceipt.refocused = refocused;
+
+            if (!refocused) {
+                const restoreData = {
+                    nativeHandleKey: route.nativeHandleKey,
+                    targetWindowId : route.targetWindowId,
+                    windowId       : me.component.windowId,
+                    windowName,
+                    x              : sourceOuter.x,
+                    y              : sourceOuter.y
+                };
+                let compensated = await (nativeTitlebar
+                    ? Neo.Main.windowNativeMoveTo(restoreData)
+                    : Neo.main.addon.DragDrop.resumeWindowDrag(restoreData)) === true;
+
+                me.lastVesselParkReceipt.compensated = compensated;
+                me.lastVesselParkReceipt.parked      = !compensated;
+                me.lastVesselParkReceipt.refusedAt   = 'refocus';
+                compensated && delete me.tearOutParkGeometries[itemId];
+
+                // Recovery ownership and visual admission are separate: if target refocus failed,
+                // the real source may still cover the target. Never publish conversion-ready on
+                // that frame, even when exact source restoration also needs a later retry.
+                return false
+            }
+
+            delete me.tearOutParkAttempts[itemId];
+            me.lastVesselParkReceipt.parked = true;
+
+            return true
+        } catch (error) {
+            me.lastVesselParkReceipt.error  = String(error?.message || error);
+            me.lastVesselParkReceipt.reason = 'platform effect threw';
+            return false
+        }
+    }
+
+    /**
+     * Re-shows the same exact parked generation at the logical pointer-owned origin. During a
+     * live gesture the DragDrop addon also resumes physical pointer-follow; at a native drag
+     * terminal that addon has already reset its session, so a strict refusal falls through to
+     * the same exact Main route for the final restore; semantic-name routing is never used.
+     * @param {Object} vessel
+     * @param {String} vessel.itemId
+     * @param {Object} vessel.rect
+     * @param {Boolean} [vessel.terminal=false]
+     * @param {String} vessel.windowName
+     * @returns {Promise<Boolean>}
+     * @protected
+     */
+    async reshowTearOutVessel({itemId, rect, terminal=false, windowName}) {
+        let me       = this,
+            entry    = me.resolveTearOutVessel(itemId),
+            route    = entry?.nativeRoute,
+            geometry = me.tearOutParkGeometries[itemId] ?? null,
+            // `rect` is where the pane's CONTENT re-shows — the proxy's logical rect, or the
+            // viewport rect captured at conversion-in. `moveTo` places the FRAME, so the window's
+            // own chrome comes off the content origin; a window that never published chrome
+            // re-shows content-on-frame, the pre-chrome behaviour.
+            chrome   = Neo.manager?.Window?.get(entry?.windowId)?.chrome,
+            frame    = Number.isFinite(rect?.x) && Number.isFinite(rect?.y) ? {
+                x: rect.x - (chrome?.left ?? 0),
+                y: rect.y - (chrome?.top  ?? 0)
+            } : null;
+
+        me.lastVesselRestoreReceipt = {
+            frame,
+            geometry,
+            rect: rect && {height: rect.height, width: rect.width, x: rect.x, y: rect.y},
+            terminal
+        };
+
+        if (
+            !route?.nativeHandleKey || route.ownerWindowId !== me.component.windowId ||
+            route.targetWindowId !== entry.windowId || route.capabilities?.position !== true ||
+            (geometry && route.capabilities?.resize !== true) ||
+            entry.windowName !== windowName ||
+            !Number.isFinite(rect?.x) || !Number.isFinite(rect?.y)
+        ) {
+            me.lastVesselRestoreReceipt.reason = 'native route or restore geometry refused';
+            return false
+        }
+
+        let data = {
+            nativeHandleKey: route.nativeHandleKey,
+            targetWindowId : route.targetWindowId,
+            windowId       : me.component.windowId,
+            windowName,
+            x              : frame.x,
+            y              : frame.y
+        };
+
+        try {
+            if (!terminal) {
+                const admitted = await Neo.main.addon.DragDrop.resumeWindowDrag(data) === true;
+
+                me.lastVesselRestoreReceipt.admitted = admitted;
+                admitted && delete me.tearOutParkGeometries[itemId];
+
+                return admitted
+            }
+
+            const addonRestored = await Neo.main.addon.DragDrop.resumeWindowDrag(data) === true;
+
+            me.lastVesselRestoreReceipt.addonRestored = addonRestored;
+
+            if (addonRestored) {
+                delete me.tearOutParkGeometries[itemId];
+                me.lastVesselRestoreReceipt.admitted = true;
+
+                return true
+            }
+
+            const recoveryPending = await Neo.main.addon.DragDrop.hasWindowDragOrphanRecovery(data) === true;
+
+            me.lastVesselRestoreReceipt.recoveryPending = recoveryPending;
+
+            // A matching predecessor effect still owns exact recovery. Never race it with a second
+            // direct route mutation or degrade a required extent restore into position-only success.
+            if (recoveryPending) return false;
+
+            if (geometry) {
+                const resized = await Neo.Main.windowNativeResizeTo({
+                    nativeHandleKey: route.nativeHandleKey,
+                    targetWindowId : route.targetWindowId,
+                    windowId       : me.component.windowId,
+                    ...geometry.restore
+                }) === true;
+
+                me.lastVesselRestoreReceipt.resized = resized;
+
+                if (!resized) {
+                    await Neo.Main.windowNativeResizeTo({
+                        nativeHandleKey: route.nativeHandleKey,
+                        targetWindowId : route.targetWindowId,
+                        windowId       : me.component.windowId,
+                        ...geometry.park
+                    });
+                    return false
+                }
+            }
+
+            const moved = await Neo.Main.windowNativeMoveTo({
+                nativeHandleKey: route.nativeHandleKey,
+                targetWindowId : route.targetWindowId,
+                windowId       : me.component.windowId,
+                x              : rect.x,
+                y              : rect.y
+            }) === true;
+
+            me.lastVesselRestoreReceipt.moved = moved;
+
+            if (!moved) {
+                if (geometry) {
+                    const compensationResized = await Neo.Main.windowNativeResizeTo({
+                        nativeHandleKey: route.nativeHandleKey,
+                        targetWindowId : route.targetWindowId,
+                        windowId       : me.component.windowId,
+                        ...geometry.park
+                    }) === true;
+
+                    me.lastVesselRestoreReceipt.compensationResized = compensationResized;
+
+                    if (compensationResized) {
+                        me.lastVesselRestoreReceipt.compensationMoved =
+                            await Neo.Main.windowNativeMoveTo({
+                                nativeHandleKey: route.nativeHandleKey,
+                                targetWindowId : route.targetWindowId,
+                                windowId       : me.component.windowId,
+                                x              : geometry.park.x,
+                                y              : geometry.park.y
+                            }) === true
+                    }
+                }
+
+                return false
+            }
+
+            me.lastVesselRestoreReceipt.admitted = true;
+            delete me.tearOutParkGeometries[itemId];
+            await Neo.main.addon.DragDrop.acknowledgeWindowDragOrphanRecovery(data);
+
+            return true
+        } catch (error) {
+            me.lastVesselRestoreReceipt.error = String(error?.message || error);
+            return false
+        }
+    }
+}
+
+export default Neo.setupClass(VesselController);

--- a/apps/workstation/view/VesselController.mjs
+++ b/apps/workstation/view/VesselController.mjs
@@ -161,21 +161,22 @@ class VesselController extends Controller {
      * @protected
      */
     async onDockTearOutExit(data) {
-        let me     = this,
-            active = me.component.tearOutHandlers.activeVessel;
+        let me        = this,
+            component = me.component,
+            active    = component.tearOutHandlers.activeVessel;
 
         if (active) {
-            const retired = await me.component.tearOutHandlers.retireActiveVessel(active);
+            const retired = await component.tearOutHandlers.retireActiveVessel(active);
 
             if (!retired) {
                 data.sortZone?.endWindowDrag();
                 return false
             }
 
-            me.component.vesselParkHandlers.onVesselRetired({itemId: active.itemId, retirement: true})
+            component.vesselParkHandlers.onVesselRetired({itemId: active.itemId, retirement: true})
         }
 
-        await me.component.tearOutHandlers.onDockTearOutExit(data);
+        await component.tearOutHandlers.onDockTearOutExit(data);
 
         return true
     }
@@ -217,6 +218,42 @@ class VesselController extends Controller {
     }
 
     /**
+     * @summary Records one item's park geometry, tolerating a teardown that landed mid-effect.
+     * @param {String} itemId
+     * @param {Object} geometry
+     * @protected
+     */
+    storeParkGeometry(itemId, geometry) {
+        this.tearOutParkGeometries && (this.tearOutParkGeometries[itemId] = geometry)
+    }
+
+    /**
+     * @summary Counts one park attempt and returns the new count; 1 when the map is already gone.
+     *
+     * The counter is retry authority, so an effect settling after teardown still needs an answer —
+     * it just has nowhere durable to keep it, and the workspace it would have served is going away.
+     * @param {String} itemId
+     * @returns {Number}
+     * @protected
+     */
+    bumpParkAttempts(itemId) {
+        const me = this;
+
+        if (!me.tearOutParkAttempts) return 1;
+
+        return me.tearOutParkAttempts[itemId] = (me.tearOutParkAttempts[itemId] ?? 0) + 1
+    }
+
+    /**
+     * @summary Clears one item's retry count, tolerating a teardown that landed mid-effect.
+     * @param {String} itemId
+     * @protected
+     */
+    releaseParkAttempts(itemId) {
+        this.tearOutParkAttempts && delete this.tearOutParkAttempts[itemId]
+    }
+
+    /**
      * @summary Retires a parked vessel outright — the disposal half of the park lifecycle.
      * Consumes the tear-out machine's active slot, then closes its exact parked vessel — the ONE
      * settle path for a committed conversion; a refusal retains exact retry authority.
@@ -230,19 +267,21 @@ class VesselController extends Controller {
         if (this.isTearingDown || this.isDestroyed) return false;
 
         let me    = this,
+
+            component = me.component,
             entry = me.resolveTearOutVessel(itemId),
             route = entry?.nativeRoute;
 
-        const disposed = await me.component.tearOutHandlers.retireActiveVessel({itemId, windowName});
+        const disposed = await component.tearOutHandlers.retireActiveVessel({itemId, windowName});
 
         if (disposed) {
             me.releaseParkGeometry(itemId);
-            delete me.tearOutParkAttempts[itemId];
+            me.releaseParkAttempts(itemId);
 
             route?.nativeHandleKey && await Neo.main.addon.DragDrop.retireWindowDragOrphanRecovery({
                 nativeHandleKey: route.nativeHandleKey,
                 targetWindowId : route.targetWindowId,
-                windowId       : me.component.windowId,
+                windowId       : component.windowId,
                 windowName
             })
         }
@@ -273,13 +312,14 @@ class VesselController extends Controller {
         if (this.isTearingDown || this.isDestroyed) return null;
 
         let me         = this,
-            {windowId} = me.component,
+            component  = me.component,
+            {windowId} = component,
             windowName = `tearout-${itemId}`;
 
         // Diagnostic trail for the birth gate: absence has three distinct layers (admission
         // refused / platform refused the window / window granted but never bound), and the
         // failure diag must name which one this gesture died in.
-        me.lastVesselOpen = {itemId, stage: 'invoked'};
+        const openReceipt = me.lastVesselOpen = {itemId, stage: 'invoked'};
 
         try {
             let [winData, bootstrap] = await Promise.all([
@@ -287,9 +327,9 @@ class VesselController extends Controller {
                     Neo.Main.getByPath({path: 'WorkstationBootstrap', windowId})
                 ]),
                 schemes       = bootstrap?.schemes || {},
-                selectedTheme = Object.hasOwn(schemes, me.component.theme)
-                    ? me.component.theme
-                    : bootstrap?.defaultTheme || me.component.theme,
+                selectedTheme = Object.hasOwn(schemes, component.theme)
+                    ? component.theme
+                    : bootstrap?.defaultTheme || component.theme,
                 width  = Math.max(Math.round(proxyRect?.width  || 480), 320),
                 height = Math.max(Math.round(proxyRect?.height || 360), 240),
                 left   = Math.round((proxyRect?.x ?? 120) + winData.screenLeft),
@@ -305,18 +345,18 @@ class VesselController extends Controller {
                 windowName
             });
 
-            me.lastVesselOpen.stage = opened === false ? 'windowOpen-false' : 'granted';
+            openReceipt.stage = opened === false ? 'windowOpen-false' : 'granted';
 
             if (opened === false) {
                 return null
             }
 
-            me.component.tearOutVesselDims = {height, width};
+            component.tearOutVesselDims = {height, width};
 
             return {popupHeight: height, popupWidth: width, windowName}
         } catch (error) {
-            me.lastVesselOpen.stage = 'threw';
-            me.lastVesselOpen.error = String(error?.message || error);
+            openReceipt.stage = 'threw';
+            openReceipt.error = String(error?.message || error);
             return null
         }
     }
@@ -341,11 +381,13 @@ class VesselController extends Controller {
         if (this.isTearingDown || this.isDestroyed) return false;
 
         let me               = this,
+
+            component = me.component,
             entry            = me.resolveTearOutVessel(itemId),
-            admission        = me.component.nativeWindows?.getAdmission(me.component.id, itemId),
+            admission        = component.nativeWindows?.getAdmission(component.id, itemId),
             expected         = `tearout-${itemId}`,
             exactToken       = entry?.generationToken ?? admission?.generationToken ?? null,
-            embodiedWindowId = entry?.windowId ?? admission?.windowId ?? me.component.tearOutEmbodiment.getWindowId(itemId),
+            embodiedWindowId = entry?.windowId ?? admission?.windowId ?? component.tearOutEmbodiment.getWindowId(itemId),
             closed           = false;
 
         const closeReceipt = me.lastTearOutClose = {
@@ -379,7 +421,7 @@ class VesselController extends Controller {
             exactTargetMatches: !nativeRoute || !exactWindowId || nativeRoute.targetWindowId === exactWindowId,
             exactWindowId     : exactWindowId ?? null,
             hasHandle         : !nativeRoute || Boolean(nativeRoute.nativeHandleKey),
-            ownerMatches      : !nativeRoute || nativeRoute.ownerWindowId === me.component.windowId,
+            ownerMatches      : !nativeRoute || nativeRoute.ownerWindowId === component.windowId,
             ownerWindowId     : nativeRoute?.ownerWindowId ?? null,
             present           : Boolean(nativeRoute),
             targetPresent     : !nativeRoute || Boolean(nativeRoute.targetWindowId),
@@ -387,7 +429,7 @@ class VesselController extends Controller {
         };
 
         if (nativeRoute && (
-            !nativeRoute.nativeHandleKey || nativeRoute.ownerWindowId !== me.component.windowId ||
+            !nativeRoute.nativeHandleKey || nativeRoute.ownerWindowId !== component.windowId ||
             !nativeRoute.targetWindowId || nativeRoute.capabilities?.close !== true ||
             (exactWindowId && nativeRoute.targetWindowId !== exactWindowId)
         )) {
@@ -397,9 +439,9 @@ class VesselController extends Controller {
 
         // The engine established retirement before this call; a refused close retains the exact
         // route + tear-out machine slot for retry, but the content goes safely home first.
-        if (embodiedWindowId && me.component.tearOutEmbodiment.isStaged(itemId)) {
-            const sourceOwns = Boolean(WorkspaceDocument.findContainingTabsId(me.component.dockModel, itemId)),
-                  settled    = me.component.tearOutEmbodiment[sourceOwns ? 'restore' : 'promote']({
+        if (embodiedWindowId && component.tearOutEmbodiment.isStaged(itemId)) {
+            const sourceOwns = Boolean(WorkspaceDocument.findContainingTabsId(component.dockModel, itemId)),
+                  settled    = component.tearOutEmbodiment[sourceOwns ? 'restore' : 'promote']({
                       itemId, windowId: embodiedWindowId
                   });
 
@@ -417,14 +459,14 @@ class VesselController extends Controller {
                 closed = await Neo.Main.windowNativeClose({
                     nativeHandleKey: nativeRoute.nativeHandleKey,
                     targetWindowId : nativeRoute.targetWindowId,
-                    windowId       : me.component.windowId
+                    windowId       : component.windowId
                 }) === true
             } else {
                 closeReceipt.stage = 'semantic-dispatched';
                 // Before connect there is no exact route to correlate yet; the active tear-out
                 // slot's unguessable semantic name is the only available authority. Once a route
                 // exists, ANY invalidity above fails closed — never downgrade to same-name close.
-                await Neo.Main.windowClose({names: [windowName], windowId: me.component.windowId});
+                await Neo.Main.windowClose({names: [windowName], windowId: component.windowId});
                 closed = true
             }
         } catch (error) {
@@ -470,7 +512,9 @@ class VesselController extends Controller {
         if (this.isTearingDown || this.isDestroyed) return false;
 
         let me           = this,
-            windowId     = me.component.windowId,
+
+            component = me.component,
+            windowId     = component.windowId,
             entry        = me.resolveTearOutVessel(itemId),
             route        = entry?.nativeRoute,
             sourceWindow = Neo.manager?.Window?.get(entry?.windowId),
@@ -533,7 +577,7 @@ class VesselController extends Controller {
         };
         me.lastVesselRestoreReceipt = null;
 
-        parkReceipt.parkAttempts = me.tearOutParkAttempts[itemId] = (me.tearOutParkAttempts[itemId] ?? 0) + 1;
+        parkReceipt.parkAttempts = me.bumpParkAttempts(itemId);
 
         if (
             !route?.nativeHandleKey || route.ownerWindowId !== windowId ||
@@ -562,7 +606,7 @@ class VesselController extends Controller {
         // the conversion bookkeeping around this call runs exactly as for a parked vessel. Popup
         // targets keep the physical park below.
         if (nativeTitlebar && targetIsMain) {
-            delete me.tearOutParkAttempts[itemId];
+            me.releaseParkAttempts(itemId);
             parkReceipt.parked   = true;
             parkReceipt.physical = false;
             parkReceipt.reason   = 'main-window target: nothing to park, the popup retires after the commit';
@@ -622,7 +666,7 @@ class VesselController extends Controller {
                 return false
             }
 
-            parkGeometry && (me.tearOutParkGeometries[itemId] = parkGeometry);
+            parkGeometry && me.storeParkGeometry(itemId, parkGeometry);
 
             let refocused = await focusTarget() === true;
 
@@ -652,7 +696,7 @@ class VesselController extends Controller {
                 return false
             }
 
-            delete me.tearOutParkAttempts[itemId];
+            me.releaseParkAttempts(itemId);
             parkReceipt.parked = true;
 
             return true
@@ -681,10 +725,12 @@ class VesselController extends Controller {
         if (this.isTearingDown || this.isDestroyed) return false;
 
         let me       = this,
-            windowId = me.component.windowId,
+
+            component = me.component,
+            windowId = component.windowId,
             entry    = me.resolveTearOutVessel(itemId),
             route    = entry?.nativeRoute,
-            geometry = me.tearOutParkGeometries[itemId] ?? null,
+            geometry = me.tearOutParkGeometries?.[itemId] ?? null,
             // `rect` is where the pane's CONTENT re-shows — the proxy's logical rect, or the
             // viewport rect captured at conversion-in. `moveTo` places the FRAME, so the window's
             // own chrome comes off the content origin; a window that never published chrome

--- a/apps/workstation/view/Workspace.mjs
+++ b/apps/workstation/view/Workspace.mjs
@@ -16,6 +16,7 @@ import DockPreview              from '../../../src/dashboard/dock/interaction/Pr
 import DockProjectionReconciler from '../../../src/dashboard/dock/projection/Reconciler.mjs';
 import DockService              from '../../../src/ai/client/DockService.mjs';
 import WorkspaceDocument        from '../../../src/dashboard/dock/model/WorkspaceDocument.mjs';
+import VesselController         from './VesselController.mjs';
 import WorkspaceController      from './WorkspaceController.mjs';
 import Operations               from '../../../src/dashboard/dock/model/Operations.mjs';
 import Persistence              from '../../../src/dashboard/dock/model/Persistence.mjs';
@@ -115,12 +116,67 @@ class Workspace extends DockWorkspace {
     }
 
     /**
-     * @summary Uses the document's semantic key for native admission too.
+     * @summary Read-only observation surface for the vessel receipts, preserved because the Neural
+     * Link reads them by name off the COMPONENT — `app.getComponent(wsId, ['lastVesselParkReceipt'])`.
+     *
+     * Not forwarding for moved members: `DemoBWorkspace` publishes the same names off ITS workspace,
+     * so this is a cross-consumer observation convention rather than a workstation detail, and the
+     * receipts exist precisely so a refused park stays legible from outside. Relocating ownership to
+     * the controller must not move the surface. Writes belong to the controller; these only read.
+     * @member {Object|null} lastVesselParkReceipt
+     * @protected
+     */
+    get lastVesselParkReceipt() {
+        return this.vesselController?.lastVesselParkReceipt ?? null
+    }
+
+    /**
+     * @member {Object|null} lastVesselRestoreReceipt
+     * @protected
+     */
+    get lastVesselRestoreReceipt() {
+        return this.vesselController?.lastVesselRestoreReceipt ?? null
+    }
+
+    /**
+     * @member {Object|null} lastTearOutClose
+     * @protected
+     */
+    get lastTearOutClose() {
+        return this.vesselController?.lastTearOutClose ?? null
+    }
+
+    /**
+     * @member {Object} tearOutParkGeometries
+     * @protected
+     */
+    get tearOutParkGeometries() {
+        return this.vesselController?.tearOutParkGeometries ?? {}
+    }
+
+    /**
+     * @member {String|Number|null} vesselConversionTargetWindowId
+     * @protected
+     */
+    get vesselConversionTargetWindowId() {
+        return this.vesselController?.vesselConversionTargetWindowId ?? null
+    }
+
+    /**
+     * @member {Object|null} lastVesselOpen
+     * @protected
+     */
+    get lastVesselOpen() {
+        return this.vesselController?.lastVesselOpen ?? null
+    }
+
+    /**
+     * @summary Engine hook: the native lifecycle binds this as `keyFor`. Policy lives in the controller.
      * @param {String} itemId
      * @returns {String}
      */
     tearOutWorkspaceKey(itemId) {
-        return Workspace.vesselWorkspaceId(itemId)
+        return this.vesselController.tearOutWorkspaceKey(itemId)
     }
 
     /**
@@ -235,6 +291,14 @@ class Workspace extends DockWorkspace {
      */
     initialTopology = null
     /**
+     * Native vessel policy and its physical effects — park geometry, retry counters, the conversion
+     * target and the park/restore receipts. Created here, destroyed here; it borrows the tear-out
+     * and park owners rather than owning them.
+     * @member {Workstation.view.VesselController|null} vesselController=null
+     * @protected
+     */
+    vesselController = null
+    /**
      * @member {Neo.ai.client.TourRunner|null} tourRunner=null
      */
     tourRunner = null
@@ -267,28 +331,6 @@ class Workspace extends DockWorkspace {
      * @member {Object|null} vesselProxyEmbodiment=null
      */
     vesselProxyEmbodiment = null
-    /**
-     * Exact pre-conversion and target-cover outer geometry for parked tear-out vessels.
-     * Runtime-only physical recovery authority; never persisted workspace state.
-     * @member {Object} tearOutParkGeometries={}
-     * @protected
-     */
-    tearOutParkGeometries = {}
-    /**
-     * Park attempts per vessel item id since that vessel last parked. The coordinator retries a
-     * refused park; a stalled retry reads live as a rising count with the same `refusedAt`.
-     * @member {Object} tearOutParkAttempts={}
-     * @protected
-     */
-    tearOutParkAttempts = {}
-    /**
-     * The runtime window id of the vessel an in-flight conversion is hovering over — stashed by
-     * the conversion-in seam so the park's cover geometry resolves the exact target. Never
-     * persisted workspace state: a window is a render target.
-     * @member {String|Number|null} vesselConversionTargetWindowId=null
-     * @protected
-     */
-    vesselConversionTargetWindowId = null
     /**
      * The in-gesture vessel lifecycle authority (park / re-show / dispose-on-commit).
      * @member {Neo.dashboard.dock.window.VesselPark|null} vesselParkHandlers=null
@@ -330,13 +372,6 @@ class Workspace extends DockWorkspace {
      * @member {Object|null} lastCrossWindowTransfer=null
      */
     lastCrossWindowTransfer = null
-    /**
-     * Most recent exact vessel-close attempt for bounded headed-failure diagnosis. Native handle
-     * authority is represented only by presence/match booleans; its secret key never enters this
-     * worker-visible receipt.
-     * @member {Object|null} lastTearOutClose=null
-     */
-    lastTearOutClose = null
     /**
      * Number of coalesced producer batches appended over this workspace lifetime.
      * @member {Number} feedBatchCount=0
@@ -387,24 +422,6 @@ class Workspace extends DockWorkspace {
      * @member {Object|null} lastTourReceipt=null
      */
     lastTourReceipt = null
-    /**
-     * Most recent exact-handle park admission receipt.
-     *
-     * `parked` and `physical` are separate answers, and the pair is the point: `parked: true` says
-     * the park was SATISFIED, `physical: false` that it performed no platform effect. A main-window
-     * target under a native titlebar is exactly that case — there is nothing to move, so the park
-     * succeeds having done nothing. A reader taking `parked` as proof of a platform call would go
-     * looking for a move that never happened.
-     * @member {Object|null} lastVesselParkReceipt=null
-     * @protected
-     */
-    lastVesselParkReceipt = null
-    /**
-     * Most recent exact-handle restore admission receipt.
-     * @member {Object|null} lastVesselRestoreReceipt=null
-     * @protected
-     */
-    lastVesselRestoreReceipt = null
     /**
      * Five records every 500ms = an honest 10 records/sec.
      * @member {Number|null} #feedIntervalId=null
@@ -545,15 +562,18 @@ class Workspace extends DockWorkspace {
         // acquisition consumes transient activation and reads as unsolicited), so conversion
         // PARKS the real vessel behind its target, out-conversion re-shows the SAME generation,
         // and only a commit disposes — every other outcome restores.
+        // Created before the park owners: their closures call straight into it.
+        me.vesselController = Neo.create(VesselController, {component: me});
+
         me.vesselParkHandlers = Neo.create(VesselPark, {
-            disposeVessel: vessel => me.disposeParkedTearOutVessel(vessel),
-            parkVessel   : vessel => me.parkTearOutVessel(vessel),
-            reshowVessel : vessel => me.reshowTearOutVessel(vessel)
+            disposeVessel: vessel => me.vesselController.disposeParkedTearOutVessel(vessel),
+            parkVessel   : vessel => me.vesselController.parkTearOutVessel(vessel),
+            reshowVessel : vessel => me.vesselController.reshowTearOutVessel(vessel)
         });
         me.nativeVesselParkHandlers = Neo.create(VesselPark, {
             disposeVessel: ({itemId}) => me.retireReturnedVessel(Workspace.vesselWorkspaceId(itemId)),
-            parkVessel   : vessel => me.parkTearOutVessel({...vessel, nativeTitlebar: true}),
-            reshowVessel : vessel => me.reshowTearOutVessel(vessel)
+            parkVessel   : vessel => me.vesselController.parkTearOutVessel({...vessel, nativeTitlebar: true}),
+            reshowVessel : vessel => me.vesselController.reshowTearOutVessel(vessel)
         });
 
         // The reactive afterSet fires before the dock host exists during construction —
@@ -895,33 +915,13 @@ class Workspace extends DockWorkspace {
     }
 
     /**
-     * @summary Retries an exact retained vessel retirement before admitting a successor tear-out.
-     *
-     * A strict close refusal keeps both lifecycle owners so recovery remains possible. The next
-     * boundary exit must retire that generation and clear its park owner before opening another
-     * popup; a second refusal ends the newly armed window drag instead of leaving it wedged.
+     * @summary Engine hook: referenced by `Workspace`, `LayoutAdapter` and `window/TearOut`.
      * @param {Object} data
      * @returns {Promise<Boolean>}
      * @protected
      */
-    async onDockTearOutExit(data) {
-        let me     = this,
-            active = me.tearOutHandlers.activeVessel;
-
-        if (active) {
-            const retired = await me.tearOutHandlers.retireActiveVessel(active);
-
-            if (!retired) {
-                data.sortZone?.endWindowDrag();
-                return false
-            }
-
-            me.vesselParkHandlers.onVesselRetired({itemId: active.itemId, retirement: true})
-        }
-
-        await me.tearOutHandlers.onDockTearOutExit(data);
-
-        return true
+    onDockTearOutExit(data) {
+        return this.vesselController.onDockTearOutExit(data)
     }
 
     /**
@@ -1065,14 +1065,14 @@ class Workspace extends DockWorkspace {
                 // The coordinator speaks stable claim identity. Platform effects speak runtime
                 // window identity. Resolve the former through the app-owned workspace registry;
                 // never reinterpret `workstation-vessel:<item>` as a manager.Window id.
-                me.vesselConversionTargetWindowId = targetWorkspaceId === Workspace.MAIN_WORKSPACE_ID
+                me.vesselController.vesselConversionTargetWindowId = targetWorkspaceId === Workspace.MAIN_WORKSPACE_ID
                     ? me.windowId
                     : targetState?.windowId ?? null;
 
                 return me.vesselParkHandlers.onConversionIn({
                     itemId    : data.itemId,
                     sourceRect: data.record?.sourceRect ?? null,
-                    windowName: me.resolveTearOutVessel(data.itemId)?.windowName
+                    windowName: me.vesselController.resolveTearOutVessel(data.itemId)?.windowName
                 })
             },
             onDockVesselConversionOut: data => {
@@ -1128,12 +1128,12 @@ class Workspace extends DockWorkspace {
             }),
             sortGroup              : Workspace.CROSS_WINDOW_SORT_GROUP,
             suspendNativeWindowDrag: (itemId, data) => {
-                me.vesselConversionTargetWindowId = data?.targetWindowId ?? null;
+                me.vesselController.vesselConversionTargetWindowId = data?.targetWindowId ?? null;
 
                 return me.nativeVesselParkHandlers.onConversionIn({
                     itemId,
                     sourceRect: me.resolveVesselConversionSourceRect({itemId}),
-                    windowName: me.resolveTearOutVessel(itemId)?.windowName
+                    windowName: me.vesselController.resolveTearOutVessel(itemId)?.windowName
                 })
             },
             windowId,
@@ -1333,7 +1333,7 @@ class Workspace extends DockWorkspace {
     async retireReturnedVessel(workspaceId) {
         let me      = this,
             state   = me.getPopupState(workspaceId),
-            vessel  = state && me.resolveTearOutVessel(state.itemId),
+            vessel  = state && me.vesselController.resolveTearOutVessel(state.itemId),
             receipt = me.lastCrossWindowTransfer;
 
         if (!state || Object.keys(state.document?.items || {}).length || !vessel) return false;
@@ -2078,610 +2078,30 @@ class Workspace extends DockWorkspace {
     }
 
     /**
-     * @summary Opens one theme-correct vessel window for a mid-gesture boundary exit.
-     *
-     * Reuses the workstation viewport's `?popout=` pure-pane-host mode. The vessel carries the slot the
-     * engine reserved in this workspace's Group through `Main.windowOpen`; which pane it shows is
-     * content and stays in the URL, whom it belongs to is identity and never does. The bound child
-     * immediately carries the same live pane through {@link Neo.dashboard.dock.window.VesselEmbodiment};
-     * it owns no workspace document. Fail-closed per the admission contract: `windowOpen` returns
-     * a BOOLEAN (a blocked popup never throws), and any falsy/throwing acquisition returns `null`
-     * so the gesture degrades to its in-window fallback. The theme bootstrap is part of that
-     * acquisition rather than optional presentation: an unavailable authority reaches the outer
-     * diagnostic boundary and prevents an unthemed child from opening.
-     * @param {Object} request
-     * @param {String} request.itemId
-     * @param {Object} request.proxyRect
-     * @param {Object} request.topologyIdentity The reserved slot, written into the vessel's carrier.
-     * @returns {Promise<{popupHeight: Number, popupWidth: Number, windowName: String}|null>}
+     * @summary Engine hook, and the one the engine detects by prototype identity —
+     * `canOpenTearOutVessel` compares this against `Workspace.prototype.openTearOutVessel`, so this
+     * override must exist as a real method or the pop-out action silently stops rendering.
+     * @param {Object} vessel
+     * @returns {Promise<Object|null>}
      * @protected
      */
-    async openTearOutVessel({itemId, proxyRect, topologyIdentity}) {
-        let me         = this,
-            {windowId} = me,
-            windowName = `tearout-${itemId}`;
-
-        // Diagnostic trail for the birth gate: absence has three distinct layers (admission
-        // refused / platform refused the window / window granted but never bound), and the
-        // failure diag must name which one this gesture died in.
-        me.lastVesselOpen = {itemId, stage: 'invoked'};
-
-        try {
-            let [winData, bootstrap] = await Promise.all([
-                    Neo.Main.getWindowData({windowId}),
-                    Neo.Main.getByPath({path: 'WorkstationBootstrap', windowId})
-                ]),
-                schemes       = bootstrap?.schemes || {},
-                selectedTheme = Object.hasOwn(schemes, me.theme)
-                    ? me.theme
-                    : bootstrap?.defaultTheme || me.theme,
-                width  = Math.max(Math.round(proxyRect?.width  || 480), 320),
-                height = Math.max(Math.round(proxyRect?.height || 360), 240),
-                left   = Math.round((proxyRect?.x ?? 120) + winData.screenLeft),
-                top    = Math.round((proxyRect?.y ?? 120) + (winData.outerHeight - winData.innerHeight) + winData.screenTop);
-
-            let opened = await Neo.Main.windowOpen({
-                nativeCapabilities: {close: true, position: true, resize: true},
-                stagedColorScheme : schemes[selectedTheme],
-                topologyIdentity,
-                url               : `./index.html?popout=${itemId}&theme=${encodeURIComponent(selectedTheme)}`,
-                windowFeatures    : `height=${height},left=${left},top=${top},width=${width}`,
-                windowId,
-                windowName
-            });
-
-            me.lastVesselOpen.stage = opened === false ? 'windowOpen-false' : 'granted';
-
-            if (opened === false) {
-                return null
-            }
-
-            me.tearOutVesselDims = {height, width};
-
-            return {popupHeight: height, popupWidth: width, windowName}
-        } catch (error) {
-            me.lastVesselOpen.stage = 'threw';
-            me.lastVesselOpen.error = String(error?.message || error);
-            return null
-        }
+    openTearOutVessel(vessel) {
+        return this.vesselController.openTearOutVessel(vessel)
     }
 
     /**
-     * The tear-out retirement seam: closes a vessel the gesture no longer needs (re-entry, cancel,
-     * or a refused model commit). Identity is the slot's lineage token — a successor admission for
-     * the same item shares the window name, never the token — so a retirement presenting a superseded
-     * token is refused and the live vessel survives it. The Group's native retirement holds the
-     * retirement fence and clears the ownership records around this call; the platform close and its
-     * receipt are this host's, and an explicit refusal retains exact retry authority.
+     * @summary Engine hook: the native lifecycle binds this as `close`.
      * @param {Object} vessel
-     * @param {String} [vessel.generationToken] The reservation's lineage token.
-     * @param {String} vessel.itemId
-     * @param {Object} [vessel.nativeRoute] Exact opener-minted physical route when available.
-     * @param {String} vessel.windowName
      * @returns {Promise<Boolean>}
      * @protected
      */
-    async closeTearOutVessel({generationToken, itemId, nativeRoute, windowName}) {
-        let me               = this,
-            entry            = me.resolveTearOutVessel(itemId),
-            admission        = me.nativeWindows?.getAdmission(me.id, itemId),
-            expected         = `tearout-${itemId}`,
-            exactToken       = entry?.generationToken ?? admission?.generationToken ?? null,
-            embodiedWindowId = entry?.windowId ?? admission?.windowId ?? me.tearOutEmbodiment.getWindowId(itemId),
-            closed           = false;
-
-        const closeReceipt = me.lastTearOutClose = {
-            identity: {
-                entryNameMatches : !entry || entry.windowName === windowName,
-                hasEntry         : Boolean(entry),
-                hasItemId        : Boolean(itemId),
-                lineageMatches   : !generationToken || !exactToken || generationToken === exactToken,
-                windowNameMatches: windowName === expected
-            },
-            itemId: itemId ?? null,
-            stage : 'validating-identity'
-        };
-
-        if (
-            !itemId || windowName !== expected || (entry && entry.windowName !== windowName) ||
-            (generationToken && exactToken && generationToken !== exactToken)
-        ) {
-            closeReceipt.stage = 'identity-refused';
-            return false
-        }
-
-        nativeRoute ??= entry?.nativeRoute ?? (
-            admission?.windowId && Neo.manager?.Window?.get(admission.windowId)?.nativeRoute
-        );
-
-        const exactWindowId = entry?.windowId ?? admission?.windowId;
-
-        closeReceipt.route = {
-            closeCapable      : !nativeRoute || nativeRoute.capabilities?.close === true,
-            exactTargetMatches: !nativeRoute || !exactWindowId || nativeRoute.targetWindowId === exactWindowId,
-            exactWindowId     : exactWindowId ?? null,
-            hasHandle         : !nativeRoute || Boolean(nativeRoute.nativeHandleKey),
-            ownerMatches      : !nativeRoute || nativeRoute.ownerWindowId === me.windowId,
-            ownerWindowId     : nativeRoute?.ownerWindowId ?? null,
-            present           : Boolean(nativeRoute),
-            targetPresent     : !nativeRoute || Boolean(nativeRoute.targetWindowId),
-            targetWindowId    : nativeRoute?.targetWindowId ?? null
-        };
-
-        if (nativeRoute && (
-            !nativeRoute.nativeHandleKey || nativeRoute.ownerWindowId !== me.windowId ||
-            !nativeRoute.targetWindowId || nativeRoute.capabilities?.close !== true ||
-            (exactWindowId && nativeRoute.targetWindowId !== exactWindowId)
-        )) {
-            closeReceipt.stage = 'route-refused';
-            return false
-        }
-
-        // The engine established retirement before this call; a refused close retains the exact
-        // route + tear-out machine slot for retry, but the content goes safely home first.
-        if (embodiedWindowId && me.tearOutEmbodiment.isStaged(itemId)) {
-            const sourceOwns = Boolean(WorkspaceDocument.findContainingTabsId(me.dockModel, itemId)),
-                  settled    = me.tearOutEmbodiment[sourceOwns ? 'restore' : 'promote']({
-                      itemId, windowId: embodiedWindowId
-                  });
-
-            closeReceipt.embodiment = {settled, sourceOwns, staged: true};
-
-            if (!settled) {
-                closeReceipt.stage = 'embodiment-refused';
-                return false
-            }
-        }
-
-        try {
-            if (nativeRoute) {
-                closeReceipt.stage = 'native-dispatched';
-                closed = await Neo.Main.windowNativeClose({
-                    nativeHandleKey: nativeRoute.nativeHandleKey,
-                    targetWindowId : nativeRoute.targetWindowId,
-                    windowId       : me.windowId
-                }) === true
-            } else {
-                closeReceipt.stage = 'semantic-dispatched';
-                // Before connect there is no exact route to correlate yet; the active tear-out
-                // slot's unguessable semantic name is the only available authority. Once a route
-                // exists, ANY invalidity above fails closed — never downgrade to same-name close.
-                await Neo.Main.windowClose({names: [windowName], windowId: me.windowId});
-                closed = true
-            }
-        } catch (error) {
-            closeReceipt.error = String(error?.message || error);
-            closeReceipt.stage = 'threw';
-            return false
-        }
-
-        closeReceipt.closed = closed;
-
-        if (!closed) {
-            closeReceipt.stage = 'platform-refused';
-            return false
-        }
-
-        delete me.tearOutParkGeometries[itemId];
-        closeReceipt.stage = 'acknowledged';
-
-        return true
+    closeTearOutVessel(vessel) {
+        return this.vesselController.closeTearOutVessel(vessel)
     }
 
-    /**
-     * @summary Resolves the exact live vessel identity for one torn item, connect- or commit-side.
-     * @param {String} itemId
-     * @returns {Object|null}
-     * @protected
-     */
-    resolveTearOutVessel(itemId) {
-        let entry = this.nativeWindows?.getConnection(this.id, itemId) ?? this.nativeWindows?.getOwner(this.id, itemId);
 
-        if (!entry?.windowId) return null;
 
-        return {
-            ...entry,
-            itemId,
-            nativeRoute: entry.nativeRoute ?? Neo.manager?.Window?.get(entry.windowId)?.nativeRoute ?? null,
-            windowName : entry.windowName ?? `tearout-${itemId}`
-        }
-    }
 
-    /**
-     * Consumes the tear-out machine's active slot, then closes its exact parked vessel — the ONE
-     * settle path for a committed conversion; a refusal retains exact retry authority.
-     * @param {Object} vessel
-     * @param {String} vessel.itemId
-     * @param {String} vessel.windowName
-     * @returns {Promise<Boolean>}
-     * @protected
-     */
-    async disposeParkedTearOutVessel({itemId, windowName}) {
-        let me    = this,
-            entry = me.resolveTearOutVessel(itemId),
-            route = entry?.nativeRoute;
-
-        const disposed = await me.tearOutHandlers.retireActiveVessel({itemId, windowName});
-
-        if (disposed) {
-            delete me.tearOutParkGeometries[itemId];
-            delete me.tearOutParkAttempts[itemId];
-
-            route?.nativeHandleKey && await Neo.main.addon.DragDrop.retireWindowDragOrphanRecovery({
-                nativeHandleKey: route.nativeHandleKey,
-                targetWindowId : route.targetWindowId,
-                windowId       : me.windowId,
-                windowName
-            })
-        }
-
-        return disposed
-    }
-
-    /**
-     * Parks one converted vessel behind its conversion target — the cover geometry that keeps
-     * the REAL OS window alive while the proxy embodies over the target. Close-and-reopen is a
-     * one-way door (mid-gesture popup acquisition reads as unsolicited), so conversion parks
-     * instead: the same exact generation re-shows on out-conversion or restore. The focus /
-     * resize / move / refocus chain is the platform-law choreography (z-order hides the parked
-     * vessel). A source whose outer frame cannot fit behind the target first shrinks through its
-     * exact native route; a refocus refusal compensates to the original extent and source rect.
-     * On the native-titlebar path to the MAIN window nothing is parked at all — the hold is the
-     * gesture: the transfer lands when the dwell completes and the popup retires right after, so the
-     * park answers satisfied with no platform effect (the platform never grants a popup an opener
-     * focus without a user activation, and an OS titlebar drag carries none).
-     * @param {Object} vessel
-     * @param {String} vessel.itemId
-     * @param {Boolean} [vessel.nativeTitlebar=false] The park follows an OS titlebar drag terminal
-     * @param {String} vessel.windowName
-     * @returns {Promise<Boolean>}
-     * @protected
-     */
-    async parkTearOutVessel({itemId, nativeTitlebar=false, windowName}) {
-        let me           = this,
-            entry        = me.resolveTearOutVessel(itemId),
-            route        = entry?.nativeRoute,
-            sourceWindow = Neo.manager?.Window?.get(entry?.windowId),
-            targetWindow = Neo.manager?.Window?.get(me.vesselConversionTargetWindowId),
-            targetRoute  = targetWindow?.nativeRoute,
-            targetIsMain = me.vesselConversionTargetWindowId === me.windowId,
-            // The size check and the authority check speak published inner-window geometry (a child
-            // omitting outerRect never rejects an authorized live vessel); the park POSITION is a
-            // frame: `moveTo` places the source frame on the target's frame origin, so the parked
-            // window lies behind the target's chrome and content alike.
-            sourceRect   = sourceWindow?.innerRect,
-            sourceOuter  = sourceWindow?.outerRect ?? sourceRect,
-            targetRect   = targetWindow?.innerRect,
-            targetOuter  = targetWindow?.outerRect ?? targetRect,
-            needsResize  = !nativeTitlebar && Boolean(sourceOuter && targetRect && (
-                sourceOuter.width > targetRect.width || sourceOuter.height > targetRect.height
-            )),
-            parkSize      = needsResize ? {
-                height: Math.min(sourceOuter.height, targetRect.height),
-                width : Math.min(sourceOuter.width, targetRect.width)
-            } : null,
-            restoreRect   = sourceOuter ? {
-                height: sourceOuter.height,
-                width : sourceOuter.width,
-                x     : sourceOuter.x,
-                y     : sourceOuter.y
-            } : null,
-            parkGeometry  = needsResize ? {
-                park   : {...parkSize, x: targetOuter?.x, y: targetOuter?.y},
-                restore: restoreRect
-            } : null;
-
-        me.lastVesselParkReceipt = {
-            authority: {
-                entryNameMatches     : entry?.windowName === windowName,
-                sourceHasHandle      : Boolean(route?.nativeHandleKey),
-                sourceOwnerMatches   : route?.ownerWindowId === me.windowId,
-                sourcePositionCapable: route?.capabilities?.position === true,
-                sourceResizeCapable  : route?.capabilities?.resize === true,
-                sourceTargetMatches  : route?.targetWindowId === entry?.windowId,
-                targetFocusCapable   : targetRoute?.capabilities?.focus === true,
-                targetHasHandle      : Boolean(targetRoute?.nativeHandleKey),
-                targetOwnerMatches   : targetRoute?.ownerWindowId === me.windowId,
-                targetTargetMatches  : targetRoute?.targetWindowId === me.vesselConversionTargetWindowId
-            },
-            needsResize,
-            parkSize,
-            sourceInner: sourceRect && {
-                height: sourceRect.height, width: sourceRect.width, x: sourceRect.x, y: sourceRect.y
-            },
-            sourceOuter: sourceOuter && {
-                height: sourceOuter.height, width: sourceOuter.width, x: sourceOuter.x, y: sourceOuter.y
-            },
-            targetInner: targetRect && {
-                height: targetRect.height, width: targetRect.width, x: targetRect.x, y: targetRect.y
-            },
-            targetOuter: targetOuter && {
-                height: targetOuter.height, width: targetOuter.width, x: targetOuter.x, y: targetOuter.y
-            }
-        };
-        me.lastVesselRestoreReceipt = null;
-
-        me.lastVesselParkReceipt.parkAttempts = me.tearOutParkAttempts[itemId] = (me.tearOutParkAttempts[itemId] ?? 0) + 1;
-
-        if (
-            !route?.nativeHandleKey || route.ownerWindowId !== me.windowId ||
-            route.targetWindowId !== entry.windowId || route.capabilities?.position !== true ||
-            (needsResize && route.capabilities?.resize !== true) ||
-            (!targetIsMain && (
-                !targetRoute?.nativeHandleKey || targetRoute.ownerWindowId !== me.windowId ||
-                targetRoute.targetWindowId !== me.vesselConversionTargetWindowId ||
-                targetRoute.capabilities?.focus !== true
-            )) ||
-            entry.windowName !== windowName || !sourceRect || !sourceOuter || !targetRect ||
-            (nativeTitlebar && (
-                sourceRect.width > targetRect.width || sourceRect.height > targetRect.height
-            ))
-        ) {
-            me.lastVesselParkReceipt.reason = 'native route or live cover geometry refused';
-            return false
-        }
-
-        // The hold is the gesture for a native-titlebar drop INTO this main window: the transfer lands
-        // when the dwell completes and the popup is retired right after, so there is nothing to park —
-        // and the park's focus step could never be granted on this path anyway (no user activation
-        // reaches a popup during an OS titlebar drag, so a popup asking its opener to take focus is
-        // declined for as long as the user holds, and after). The strict park is answered as satisfied
-        // with no physical effect; the receipt says so, the attempt counter resets as after a park, and
-        // the conversion bookkeeping around this call runs exactly as for a parked vessel. Popup
-        // targets keep the physical park below.
-        if (nativeTitlebar && targetIsMain) {
-            delete me.tearOutParkAttempts[itemId];
-            me.lastVesselParkReceipt.parked   = true;
-            me.lastVesselParkReceipt.physical = false;
-            me.lastVesselParkReceipt.reason   = 'main-window target: nothing to park, the popup retires after the commit';
-            return true
-        }
-
-        // The root window has no opener-minted nativeRoute, so a main target is focused through the
-        // popup's own Main actor (`opener.focus()`, granted under the user activation a keyboard
-        // command carries — the pointer conversion path); a popup target is focused by its owner
-        // through the handle it minted.
-        //
-        // A main-window target under a native titlebar never arrives here: it returns satisfied
-        // above, having nothing to park. So the main branch below serves the pointer conversion
-        // path alone — there is no native-titlebar main case to find.
-        const focusTarget = () => targetIsMain
-            ? Neo.Main.windowFocus({windowId: entry.windowId})
-            : Neo.Main.windowNativeFocus({
-                nativeHandleKey: targetRoute.nativeHandleKey,
-                targetWindowId : targetRoute.targetWindowId,
-                windowId       : me.windowId
-            });
-
-        try {
-            let focused = await focusTarget() === true;
-
-            me.lastVesselParkReceipt.focused = focused;
-
-            if (!focused) {
-                // A popup target: the owner focuses a window it opened, which the platform grants
-                // once the OS releases the dragged source. The coordinator retries the park.
-                me.lastVesselParkReceipt.refusedAt = 'focus';
-                return false
-            }
-
-            const moveData = {
-                nativeHandleKey: route.nativeHandleKey,
-                targetWindowId : route.targetWindowId,
-                windowId       : me.windowId,
-                windowName,
-                x              : targetOuter.x,
-                y              : targetOuter.y
-            };
-
-            if (!nativeTitlebar) {
-                moveData.parkSize    = parkSize;
-                moveData.restoreRect = restoreRect
-            }
-
-            let moved = await (nativeTitlebar
-                ? Neo.Main.windowNativeMoveTo(moveData)
-                : Neo.main.addon.DragDrop.parkWindowDrag(moveData)) === true;
-
-            me.lastVesselParkReceipt.moved = moved;
-
-            if (!moved) {
-                me.lastVesselParkReceipt.refusedAt = 'move';
-                return false
-            }
-
-            parkGeometry && (me.tearOutParkGeometries[itemId] = parkGeometry);
-
-            let refocused = await focusTarget() === true;
-
-            me.lastVesselParkReceipt.refocused = refocused;
-
-            if (!refocused) {
-                const restoreData = {
-                    nativeHandleKey: route.nativeHandleKey,
-                    targetWindowId : route.targetWindowId,
-                    windowId       : me.windowId,
-                    windowName,
-                    x              : sourceOuter.x,
-                    y              : sourceOuter.y
-                };
-                let compensated = await (nativeTitlebar
-                    ? Neo.Main.windowNativeMoveTo(restoreData)
-                    : Neo.main.addon.DragDrop.resumeWindowDrag(restoreData)) === true;
-
-                me.lastVesselParkReceipt.compensated = compensated;
-                me.lastVesselParkReceipt.parked      = !compensated;
-                me.lastVesselParkReceipt.refusedAt   = 'refocus';
-                compensated && delete me.tearOutParkGeometries[itemId];
-
-                // Recovery ownership and visual admission are separate: if target refocus failed,
-                // the real source may still cover the target. Never publish conversion-ready on
-                // that frame, even when exact source restoration also needs a later retry.
-                return false
-            }
-
-            delete me.tearOutParkAttempts[itemId];
-            me.lastVesselParkReceipt.parked = true;
-
-            return true
-        } catch (error) {
-            me.lastVesselParkReceipt.error  = String(error?.message || error);
-            me.lastVesselParkReceipt.reason = 'platform effect threw';
-            return false
-        }
-    }
-
-    /**
-     * Re-shows the same exact parked generation at the logical pointer-owned origin. During a
-     * live gesture the DragDrop addon also resumes physical pointer-follow; at a native drag
-     * terminal that addon has already reset its session, so a strict refusal falls through to
-     * the same exact Main route for the final restore; semantic-name routing is never used.
-     * @param {Object} vessel
-     * @param {String} vessel.itemId
-     * @param {Object} vessel.rect
-     * @param {Boolean} [vessel.terminal=false]
-     * @param {String} vessel.windowName
-     * @returns {Promise<Boolean>}
-     * @protected
-     */
-    async reshowTearOutVessel({itemId, rect, terminal=false, windowName}) {
-        let me       = this,
-            entry    = me.resolveTearOutVessel(itemId),
-            route    = entry?.nativeRoute,
-            geometry = me.tearOutParkGeometries[itemId] ?? null,
-            // `rect` is where the pane's CONTENT re-shows — the proxy's logical rect, or the
-            // viewport rect captured at conversion-in. `moveTo` places the FRAME, so the window's
-            // own chrome comes off the content origin; a window that never published chrome
-            // re-shows content-on-frame, the pre-chrome behaviour.
-            chrome   = Neo.manager?.Window?.get(entry?.windowId)?.chrome,
-            frame    = Number.isFinite(rect?.x) && Number.isFinite(rect?.y) ? {
-                x: rect.x - (chrome?.left ?? 0),
-                y: rect.y - (chrome?.top  ?? 0)
-            } : null;
-
-        me.lastVesselRestoreReceipt = {
-            frame,
-            geometry,
-            rect: rect && {height: rect.height, width: rect.width, x: rect.x, y: rect.y},
-            terminal
-        };
-
-        if (
-            !route?.nativeHandleKey || route.ownerWindowId !== me.windowId ||
-            route.targetWindowId !== entry.windowId || route.capabilities?.position !== true ||
-            (geometry && route.capabilities?.resize !== true) ||
-            entry.windowName !== windowName ||
-            !Number.isFinite(rect?.x) || !Number.isFinite(rect?.y)
-        ) {
-            me.lastVesselRestoreReceipt.reason = 'native route or restore geometry refused';
-            return false
-        }
-
-        let data = {
-            nativeHandleKey: route.nativeHandleKey,
-            targetWindowId : route.targetWindowId,
-            windowId       : me.windowId,
-            windowName,
-            x              : frame.x,
-            y              : frame.y
-        };
-
-        try {
-            if (!terminal) {
-                const admitted = await Neo.main.addon.DragDrop.resumeWindowDrag(data) === true;
-
-                me.lastVesselRestoreReceipt.admitted = admitted;
-                admitted && delete me.tearOutParkGeometries[itemId];
-
-                return admitted
-            }
-
-            const addonRestored = await Neo.main.addon.DragDrop.resumeWindowDrag(data) === true;
-
-            me.lastVesselRestoreReceipt.addonRestored = addonRestored;
-
-            if (addonRestored) {
-                delete me.tearOutParkGeometries[itemId];
-                me.lastVesselRestoreReceipt.admitted = true;
-
-                return true
-            }
-
-            const recoveryPending = await Neo.main.addon.DragDrop.hasWindowDragOrphanRecovery(data) === true;
-
-            me.lastVesselRestoreReceipt.recoveryPending = recoveryPending;
-
-            // A matching predecessor effect still owns exact recovery. Never race it with a second
-            // direct route mutation or degrade a required extent restore into position-only success.
-            if (recoveryPending) return false;
-
-            if (geometry) {
-                const resized = await Neo.Main.windowNativeResizeTo({
-                    nativeHandleKey: route.nativeHandleKey,
-                    targetWindowId : route.targetWindowId,
-                    windowId       : me.windowId,
-                    ...geometry.restore
-                }) === true;
-
-                me.lastVesselRestoreReceipt.resized = resized;
-
-                if (!resized) {
-                    await Neo.Main.windowNativeResizeTo({
-                        nativeHandleKey: route.nativeHandleKey,
-                        targetWindowId : route.targetWindowId,
-                        windowId       : me.windowId,
-                        ...geometry.park
-                    });
-                    return false
-                }
-            }
-
-            const moved = await Neo.Main.windowNativeMoveTo({
-                nativeHandleKey: route.nativeHandleKey,
-                targetWindowId : route.targetWindowId,
-                windowId       : me.windowId,
-                x              : rect.x,
-                y              : rect.y
-            }) === true;
-
-            me.lastVesselRestoreReceipt.moved = moved;
-
-            if (!moved) {
-                if (geometry) {
-                    const compensationResized = await Neo.Main.windowNativeResizeTo({
-                        nativeHandleKey: route.nativeHandleKey,
-                        targetWindowId : route.targetWindowId,
-                        windowId       : me.windowId,
-                        ...geometry.park
-                    }) === true;
-
-                    me.lastVesselRestoreReceipt.compensationResized = compensationResized;
-
-                    if (compensationResized) {
-                        me.lastVesselRestoreReceipt.compensationMoved =
-                            await Neo.Main.windowNativeMoveTo({
-                                nativeHandleKey: route.nativeHandleKey,
-                                targetWindowId : route.targetWindowId,
-                                windowId       : me.windowId,
-                                x              : geometry.park.x,
-                                y              : geometry.park.y
-                            }) === true
-                    }
-                }
-
-                return false
-            }
-
-            me.lastVesselRestoreReceipt.admitted = true;
-            delete me.tearOutParkGeometries[itemId];
-            await Neo.main.addon.DragDrop.acknowledgeWindowDragOrphanRecovery(data);
-
-            return true
-        } catch (error) {
-            me.lastVesselRestoreReceipt.error = String(error?.message || error);
-            return false
-        }
-    }
 
     /**
      * Resolves one dragged vessel's exact live inner rect for conversion sampling — the metric
@@ -2693,7 +2113,7 @@ class Workspace extends DockWorkspace {
      * @protected
      */
     resolveVesselConversionSourceRect({itemId}) {
-        let windowId = this.resolveTearOutVessel(itemId)?.windowId,
+        let windowId = this.vesselController.resolveTearOutVessel(itemId)?.windowId,
             rect     = windowId && Neo.manager?.Window?.get(windowId)?.innerRect;
 
         return rect && {height: rect.height, width: rect.width, x: rect.x, y: rect.y}
@@ -2903,7 +2323,7 @@ class Workspace extends DockWorkspace {
     afterTearOutWindowDisconnect({itemId, recovered=true}) {
         let me = this;
 
-        delete me.tearOutParkGeometries[itemId];
+        delete me.vesselController.tearOutParkGeometries[itemId];
         me.vesselParkHandlers.onVesselRetired({itemId, retirement: true});
         me.nativeVesselParkHandlers.onVesselRetired({itemId, retirement: true});
         recovered && me.retireVesselWorkspaceTarget(itemId)
@@ -3389,7 +2809,7 @@ class Workspace extends DockWorkspace {
             indicatorSet  = indicatorMenu?.candidateSet ?? null,
             sensor        = sourceZone?.vesselConversionSensor,
             parkedVessel  = me.vesselParkHandlers?.parkedVessel ?? null,
-            sourceVessel  = parkedItemId && me.resolveTearOutVessel(parkedItemId),
+            sourceVessel  = parkedItemId && me.vesselController.resolveTearOutVessel(parkedItemId),
             targetProxy   = parkedItemId && me.vesselProxyEmbodiment.snapshot(parkedItemId),
             snapshot      = {
                 claimCount: arbiter?.claimCount ?? 0,
@@ -4459,6 +3879,7 @@ class Workspace extends DockWorkspace {
         me.dragAffordances?.destroy();
         me.interactionService?.destroy();
         me.vesselParkHandlers?.destroy();
+        me.vesselController?.destroy();
         me.nativeVesselParkHandlers?.destroy();
         me.vesselProxyEmbodiment?.destroy();
         me.tearOutEmbodiment?.destroy();

--- a/buildScripts/util/file-size-baseline.json
+++ b/buildScripts/util/file-size-baseline.json
@@ -1,5 +1,5 @@
 {
-    "apps/workstation/view/Workspace.mjs": 2669,
+    "apps/workstation/view/Workspace.mjs": 2272,
     "examples/dashboard/crossWindow/DemoBWorkspace.mjs": 2612,
     "src/dashboard/dock/Workspace.mjs": 1035,
     "src/main/addon/DragDrop.mjs": 1267

--- a/test/playwright/unit/apps/workstation/Workspace.spec.mjs
+++ b/test/playwright/unit/apps/workstation/Workspace.spec.mjs
@@ -789,6 +789,39 @@ test.describe.serial('Workstation.view.Workspace', () => {
         }
     });
 
+    test('teardown DURING a granted open does not lose the grant', async () => {
+        const
+            workspace       = Neo.create(Workspace, {windowId: Neo.config.windowId}),
+            originalData    = Neo.Main.getWindowData,
+            originalGetPath = Neo.Main.getByPath,
+            originalOpen    = Neo.Main.windowOpen,
+            controller      = workspace.vesselController;
+
+        Neo.Main.getWindowData = async () => ({innerHeight: 700, outerHeight: 760, screenLeft: 10, screenTop: 20});
+        Neo.Main.getByPath     = async () => ({defaultTheme: 'neo-theme-neo-dark', schemes: {'neo-theme-neo-dark': 'dark'}});
+        // The platform HAS granted the window by the time teardown lands. Losing the result here
+        // leaks a real OS window that nothing owns — the grant must survive the controller.
+        Neo.Main.windowOpen = async () => {
+            controller.destroy();
+            return true
+        };
+
+        try {
+            const opened = await controller.openTearOutVessel({
+                itemId: 'alerts', proxyRect: {height: 320, width: 480, x: 40, y: 60}
+            });
+
+            expect(opened, 'a granted open still returns its vessel dims after teardown').toEqual({
+                popupHeight: 320, popupWidth: 480, windowName: 'tearout-alerts'
+            })
+        } finally {
+            Neo.Main.getWindowData = originalData;
+            Neo.Main.getByPath     = originalGetPath;
+            Neo.Main.windowOpen    = originalOpen;
+            workspace.destroy()
+        }
+    });
+
     test('teardown DURING a dispatched effect still settles it — no throw, and no receipt written back', async () => {
         const
             workspace        = Neo.create(Workspace, {windowId: Neo.config.windowId}),

--- a/test/playwright/unit/apps/workstation/Workspace.spec.mjs
+++ b/test/playwright/unit/apps/workstation/Workspace.spec.mjs
@@ -581,7 +581,7 @@ test.describe.serial('Workstation.view.Workspace', () => {
             // Group to join, and the main participant registers the moment the window id arrives.
             expect(resizeCalls).toEqual([]);
             expect(workspace.workspaceSet.ids(), 'no window, no Group, no membership yet').toEqual([]);
-            expect(workspace.vesselConversionTargetWindowId).toBeNull();
+            expect(workspace.vesselController.vesselConversionTargetWindowId).toBeNull();
 
             workspace.windowId = Neo.config.windowId;
 
@@ -592,7 +592,7 @@ test.describe.serial('Workstation.view.Workspace', () => {
             chrome.get('right-top-tabs').tab.fire('dockVesselConversionIn', {
                 itemId: 'audit', record: {sourceRect: null}, targetId: targetWorkspaceId
             });
-            expect(workspace.vesselConversionTargetWindowId).toBe('window-alerts');
+            expect(workspace.vesselController.vesselConversionTargetWindowId).toBe('window-alerts');
 
             chrome.forEach(({bar}, nodeId) => {
                 expect(bar.sortZoneConfig, `${nodeId} joins the one cross-window source group`).toMatchObject({
@@ -659,7 +659,7 @@ test.describe.serial('Workstation.view.Workspace', () => {
             windowId   : 'source-window',
             windowName : 'tearout-audit'
         });
-        workspace.vesselConversionTargetWindowId = 'target-window';
+        workspace.vesselController.vesselConversionTargetWindowId = 'target-window';
         Neo.manager.Window.get = id => records.get(id) ?? null;
         Neo.Main.windowNativeFocus = async data => {
             focusCalls.push(data);
@@ -677,7 +677,7 @@ test.describe.serial('Workstation.view.Workspace', () => {
         };
 
         try {
-            await expect(workspace.parkTearOutVessel({
+            await expect(workspace.vesselController.parkTearOutVessel({
                 itemId: 'audit', windowName: 'tearout-audit'
             })).resolves.toBe(true);
             expect(focusCalls).toEqual([
@@ -702,17 +702,17 @@ test.describe.serial('Workstation.view.Workspace', () => {
                 x              : 800,
                 y              : 120
             }]);
-            expect(workspace.tearOutParkGeometries.audit).toEqual({
+            expect(workspace.vesselController.tearOutParkGeometries.audit).toEqual({
                 park   : {height: 260, width: 360, x: 800, y: 120},
                 restore: {height: 546, width: 640, x: 40, y: 60}
             });
-            expect(workspace.lastVesselParkReceipt).toMatchObject({
+            expect(workspace.vesselController.lastVesselParkReceipt).toMatchObject({
                 needsResize: true,
                 parked     : true,
                 parkSize   : {height: 260, width: 360}
             });
 
-            await expect(workspace.reshowTearOutVessel({
+            await expect(workspace.vesselController.reshowTearOutVessel({
                 itemId    : 'audit',
                 rect      : {height: 120, width: 200, x: 420, y: 240},
                 windowName: 'tearout-audit'
@@ -726,20 +726,20 @@ test.describe.serial('Workstation.view.Workspace', () => {
                 x              : 420,
                 y              : 173
             }]);
-            expect(workspace.lastVesselRestoreReceipt).toMatchObject({
+            expect(workspace.vesselController.lastVesselRestoreReceipt).toMatchObject({
                 frame: {x: 420, y: 173},
                 rect : {height: 120, width: 200, x: 420, y: 240}
             });
-            expect(workspace.tearOutParkGeometries.audit).toBeUndefined();
+            expect(workspace.vesselController.tearOutParkGeometries.audit).toBeUndefined();
 
             sourceRoute.capabilities.resize = false;
 
-            await expect(workspace.parkTearOutVessel({
+            await expect(workspace.vesselController.parkTearOutVessel({
                 itemId: 'audit', windowName: 'tearout-audit'
             })).resolves.toBe(false);
             expect(focusCalls).toHaveLength(2);
             expect(parkCalls).toHaveLength(1);
-            expect(workspace.lastVesselParkReceipt).toMatchObject({
+            expect(workspace.vesselController.lastVesselParkReceipt).toMatchObject({
                 authority: {sourceResizeCapable: false},
                 reason   : 'native route or live cover geometry refused'
             })
@@ -778,7 +778,7 @@ test.describe.serial('Workstation.view.Workspace', () => {
             windowId   : 'source-window',
             windowName : 'tearout-audit'
         });
-        workspace.tearOutParkGeometries.audit = geometry;
+        workspace.vesselController.tearOutParkGeometries.audit = geometry;
         Neo.main.addon.DragDrop = {
             acknowledgeWindowDragOrphanRecovery: async () => true,
             hasWindowDragOrphanRecovery        : async () => false,
@@ -801,7 +801,7 @@ test.describe.serial('Workstation.view.Workspace', () => {
         };
 
         try {
-            await expect(workspace.reshowTearOutVessel(requested)).resolves.toBe(false);
+            await expect(workspace.vesselController.reshowTearOutVessel(requested)).resolves.toBe(false);
             expect(calls).toEqual([
                 ['resize', {
                     height         : 546,
@@ -836,17 +836,17 @@ test.describe.serial('Workstation.view.Workspace', () => {
                     y              : 120
                 }]
             ]);
-            expect(workspace.tearOutParkGeometries.audit).toBe(geometry);
+            expect(workspace.vesselController.tearOutParkGeometries.audit).toBe(geometry);
 
             calls.length        = 0;
             parkResizeAdmitted = false;
 
-            await expect(workspace.reshowTearOutVessel(requested)).resolves.toBe(false);
+            await expect(workspace.vesselController.reshowTearOutVessel(requested)).resolves.toBe(false);
             expect(calls.map(([type]) => type)).toEqual(['resize', 'move', 'resize']);
             expect(calls.some(([type, data]) => (
                 type === 'move' && data.x === geometry.park.x && data.y === geometry.park.y
             ))).toBe(false);
-            expect(workspace.lastVesselRestoreReceipt).toMatchObject({
+            expect(workspace.vesselController.lastVesselRestoreReceipt).toMatchObject({
                 compensationResized: false,
                 moved              : false
             });
@@ -855,10 +855,10 @@ test.describe.serial('Workstation.view.Workspace', () => {
             moveAdmitted         = true;
             parkResizeAdmitted   = true;
 
-            await expect(workspace.reshowTearOutVessel(requested)).resolves.toBe(true);
+            await expect(workspace.vesselController.reshowTearOutVessel(requested)).resolves.toBe(true);
             expect(calls.map(([type]) => type)).toEqual(['resize', 'move']);
-            expect(workspace.tearOutParkGeometries.audit).toBeUndefined();
-            expect(workspace.lastVesselRestoreReceipt).toMatchObject({
+            expect(workspace.vesselController.tearOutParkGeometries.audit).toBeUndefined();
+            expect(workspace.vesselController.lastVesselRestoreReceipt).toMatchObject({
                 admitted: true,
                 moved   : true,
                 resized : true,
@@ -918,7 +918,7 @@ test.describe.serial('Workstation.view.Workspace', () => {
             windowId   : 'source-window',
             windowName : 'tearout-audit'
         });
-        workspace.vesselConversionTargetWindowId = 'target-window';
+        workspace.vesselController.vesselConversionTargetWindowId = 'target-window';
         Neo.manager.Window.get = id => records.get(id) ?? null;
         Neo.Main.windowNativeFocus = async () => focusOutcomes.shift();
         Neo.main.addon.DragDrop = {
@@ -933,10 +933,10 @@ test.describe.serial('Workstation.view.Workspace', () => {
             for (compensate of [true, false]) {
                 focusOutcomes = [true, false];
 
-                await expect(workspace.parkTearOutVessel({
+                await expect(workspace.vesselController.parkTearOutVessel({
                     itemId: 'audit', windowName: 'tearout-audit'
                 })).resolves.toBe(false);
-                expect(workspace.lastVesselParkReceipt).toMatchObject({
+                expect(workspace.vesselController.lastVesselParkReceipt).toMatchObject({
                     compensated: compensate,
                     focused    : true,
                     parked     : !compensate,
@@ -945,9 +945,9 @@ test.describe.serial('Workstation.view.Workspace', () => {
                 expect(resumeCalls.at(-1)).toMatchObject({x: 40, y: 60});
 
                 if (compensate) {
-                    expect(workspace.tearOutParkGeometries.audit).toBeUndefined()
+                    expect(workspace.vesselController.tearOutParkGeometries.audit).toBeUndefined()
                 } else {
-                    expect(workspace.tearOutParkGeometries.audit).toEqual({
+                    expect(workspace.vesselController.tearOutParkGeometries.audit).toEqual({
                         park   : {height: 260, width: 360, x: 800, y: 120},
                         restore: {height: 546, width: 640, x: 40, y: 60}
                     })
@@ -1427,7 +1427,7 @@ test.describe.serial('Workstation.view.Workspace', () => {
 
         try {
             workspace.nativeWindows.recordOwner(workspace.id, "alerts", {windowId: sourceWindowId, windowName: 'tearout-alerts'});
-            workspace.vesselConversionTargetWindowId = ownerWindowId;
+            workspace.vesselController.vesselConversionTargetWindowId = ownerWindowId;
 
             Neo.manager.Window.get = windowId => ({
                 [sourceWindowId]: {
@@ -1440,15 +1440,15 @@ test.describe.serial('Workstation.view.Workspace', () => {
             Neo.Main.windowNativeFocus  = async data => { platformCalls.push(['nativeFocus', data]); return false };
             Neo.Main.windowNativeMoveTo = async data => { platformCalls.push(['move', data]); return false };
 
-            await expect(workspace.parkTearOutVessel({
+            await expect(workspace.vesselController.parkTearOutVessel({
                 itemId        : 'alerts',
                 nativeTitlebar: true,
                 windowName    : 'tearout-alerts'
             }), 'the park is satisfied without asking the platform').resolves.toBe(true);
 
             expect(platformCalls, 'no focus, no move — nothing was parked').toEqual([]);
-            expect(workspace.lastVesselParkReceipt).toMatchObject({parked: true, physical: false});
-            expect(workspace.lastVesselParkReceipt.authority.sourceHasHandle, 'the source route is still checked').toBe(true)
+            expect(workspace.vesselController.lastVesselParkReceipt).toMatchObject({parked: true, physical: false});
+            expect(workspace.vesselController.lastVesselParkReceipt.authority.sourceHasHandle, 'the source route is still checked').toBe(true)
         } finally {
             Neo.manager.Window.get      = originalManagerGet;
             Neo.Main.windowFocus        = originalWindowFocus;
@@ -1491,7 +1491,7 @@ test.describe.serial('Workstation.view.Workspace', () => {
                 windowId  : sourceWindowId,
                 windowName: 'tearout-alerts'
             });
-            workspace.vesselConversionTargetWindowId = targetWindowId;
+            workspace.vesselController.vesselConversionTargetWindowId = targetWindowId;
 
             Neo.manager.Window.get = windowId => ({
                 [sourceWindowId]: {
@@ -1526,7 +1526,7 @@ test.describe.serial('Workstation.view.Workspace', () => {
                 }
             };
 
-            await expect(workspace.parkTearOutVessel({
+            await expect(workspace.vesselController.parkTearOutVessel({
                 itemId        : 'alerts',
                 nativeTitlebar: true,
                 windowName    : 'tearout-alerts'
@@ -1551,13 +1551,13 @@ test.describe.serial('Workstation.view.Workspace', () => {
 
             // The second park sees its refocus refused: on a popup target the source may still cover
             // the target, so the move is compensated back to the source rect and the park is refused.
-            await expect(workspace.parkTearOutVessel({
+            await expect(workspace.vesselController.parkTearOutVessel({
                 itemId        : 'alerts',
                 nativeTitlebar: true,
                 windowName    : 'tearout-alerts'
             })).resolves.toBe(false);
 
-            expect(workspace.lastVesselParkReceipt).toMatchObject({focused: true, moved: true, refocused: false, compensated: true, refusedAt: 'refocus'});
+            expect(workspace.vesselController.lastVesselParkReceipt).toMatchObject({focused: true, moved: true, refocused: false, compensated: true, refusedAt: 'refocus'});
             expect(nativeMoveCalls.map(({x, y}) => ({x, y})), 'the park move, then the compensation').toEqual([
                 {x: targetRect.x, y: targetRect.y},
                 {x: sourceRect.x, y: sourceRect.y}
@@ -1604,7 +1604,7 @@ test.describe.serial('Workstation.view.Workspace', () => {
 
         try {
             workspace.nativeWindows.recordOwner(workspace.id, "alerts", {windowId: sourceWindowId, windowName: 'tearout-alerts'});
-            workspace.vesselConversionTargetWindowId = targetWindowId;
+            workspace.vesselController.vesselConversionTargetWindowId = targetWindowId;
 
             Neo.manager.Window.get = windowId => ({
                 [sourceWindowId]: {innerRect: sourceRect, nativeRoute: routeFor(sourceWindowId, {position: true})},
@@ -1621,34 +1621,34 @@ test.describe.serial('Workstation.view.Workspace', () => {
                 resumeWindowDrag: async () => true
             };
 
-            const park = () => workspace.parkTearOutVessel({itemId: 'alerts', nativeTitlebar: true, windowName: 'tearout-alerts'});
+            const park = () => workspace.vesselController.parkTearOutVessel({itemId: 'alerts', nativeTitlebar: true, windowName: 'tearout-alerts'});
 
             // Attempt 1: the OS still holds the source — the owner's focus of the target is refused,
             // the park is refused at the focus, and the receipt counts the attempt.
             await expect(park(), 'refused while the OS holds the window').resolves.toBe(false);
-            expect(workspace.lastVesselParkReceipt).toMatchObject({focused: false, parkAttempts: 1, refusedAt: 'focus'});
+            expect(workspace.vesselController.lastVesselParkReceipt).toMatchObject({focused: false, parkAttempts: 1, refusedAt: 'focus'});
             expect(nativeMoveCalls, 'nothing moved on a refused focus').toEqual([]);
 
             // Attempt 2: released — focus, move and refocus are granted; the park lands and the count
             // reads the retry that got it there.
             await expect(park(), 'parks on release').resolves.toBe(true);
-            expect(workspace.lastVesselParkReceipt).toMatchObject({focused: true, moved: true, refocused: true, parked: true, parkAttempts: 2});
+            expect(workspace.vesselController.lastVesselParkReceipt).toMatchObject({focused: true, moved: true, refocused: true, parked: true, parkAttempts: 2});
 
             // A later park starts a fresh count.
             await expect(park()).resolves.toBe(true);
-            expect(workspace.lastVesselParkReceipt.parkAttempts, 'the count resets after a park').toBe(1);
+            expect(workspace.vesselController.lastVesselParkReceipt.parkAttempts, 'the count resets after a park').toBe(1);
 
             // A main-window park is satisfied without a platform effect and resets the count as well.
-            workspace.tearOutParkAttempts.alerts = 3;
-            workspace.vesselConversionTargetWindowId = ownerWindowId;
+            workspace.vesselController.tearOutParkAttempts.alerts = 3;
+            workspace.vesselController.vesselConversionTargetWindowId = ownerWindowId;
             Neo.manager.Window.get = windowId => ({
                 [sourceWindowId]: {innerRect: sourceRect, nativeRoute: routeFor(sourceWindowId, {position: true})},
                 [ownerWindowId] : {innerRect: targetRect, nativeRoute: null}
             })[windowId] ?? null;
 
             await expect(park()).resolves.toBe(true);
-            expect(workspace.lastVesselParkReceipt).toMatchObject({parked: true, physical: false, parkAttempts: 4});
-            expect(workspace.tearOutParkAttempts.alerts, 'a satisfied main-window park clears the count').toBeUndefined()
+            expect(workspace.vesselController.lastVesselParkReceipt).toMatchObject({parked: true, physical: false, parkAttempts: 4});
+            expect(workspace.vesselController.tearOutParkAttempts.alerts, 'a satisfied main-window park clears the count').toBeUndefined()
         } finally {
             Neo.main.addon.DragDrop     = originalDragDrop;
             Neo.manager.Window.get      = originalManagerGet;
@@ -1682,7 +1682,7 @@ test.describe.serial('Workstation.view.Workspace', () => {
 
         try {
             workspace.nativeWindows.recordOwner(workspace.id, "alerts", {windowId: sourceWindowId, windowName: 'tearout-alerts'});
-            workspace.vesselConversionTargetWindowId = targetWindowId;
+            workspace.vesselController.vesselConversionTargetWindowId = targetWindowId;
 
             Neo.manager.Window.get = windowId => ({
                 [sourceWindowId]: {innerRect: sourceRect, nativeRoute: routeFor(sourceWindowId, {position: true})},
@@ -1699,13 +1699,13 @@ test.describe.serial('Workstation.view.Workspace', () => {
                 resumeWindowDrag: async () => true
             };
 
-            await expect(workspace.parkTearOutVessel({
+            await expect(workspace.vesselController.parkTearOutVessel({
                 itemId        : 'alerts',
                 nativeTitlebar: true,
                 windowName    : 'tearout-alerts'
             }), 'a popup target keeps the strict focus gate').resolves.toBe(false);
 
-            expect(workspace.lastVesselParkReceipt).toMatchObject({focused: false, refusedAt: 'focus'});
+            expect(workspace.vesselController.lastVesselParkReceipt).toMatchObject({focused: false, refusedAt: 'focus'});
             expect(nativeMoveCalls, 'nothing moved').toEqual([])
         } finally {
             Neo.main.addon.DragDrop     = originalDragDrop;
@@ -2084,7 +2084,7 @@ test.describe.serial('Workstation.view.Workspace', () => {
                 windowId       : 'tear-child',
                 windowName     : 'tearout-alerts'
             });
-            workspace.tearOutParkGeometries.alerts = {
+            workspace.vesselController.tearOutParkGeometries.alerts = {
                 park   : {height: 260, width: 360, x: 800, y: 120},
                 restore: {height: 546, width: 640, x: 40, y: 60}
             };
@@ -2102,7 +2102,7 @@ test.describe.serial('Workstation.view.Workspace', () => {
             await releaseVessel(workspace, 'tear-child');
 
             expect(workspace.nativeWindows.getConnection(workspace.id, 'alerts')).toBeNull();
-            expect(workspace.tearOutParkGeometries.alerts).toBeUndefined();
+            expect(workspace.vesselController.tearOutParkGeometries.alerts).toBeUndefined();
             expect(calls).toEqual([
                 ['proxy', 'tear-child'],
                 ['tear-out', {
@@ -2233,7 +2233,7 @@ test.describe.serial('Workstation.view.Workspace', () => {
 
             expect(result).toBeNull();
             expect(windowOpenCalls).toEqual([]);
-            expect(workspace.lastVesselOpen).toEqual({
+            expect(workspace.vesselController.lastVesselOpen).toEqual({
                 error : 'WorkstationBootstrap unavailable',
                 itemId: 'alerts',
                 stage : 'threw'
@@ -2265,13 +2265,13 @@ test.describe.serial('Workstation.view.Workspace', () => {
 
             await expect(workspace.closeTearOutVessel({generationToken: 'lineage-1', itemId: 'alerts', windowName: 'tearout-alerts'}))
                 .resolves.toBe(false);
-            expect(workspace.lastTearOutClose).toMatchObject({identity: {lineageMatches: false}, stage: 'identity-refused'});
+            expect(workspace.vesselController.lastTearOutClose).toMatchObject({identity: {lineageMatches: false}, stage: 'identity-refused'});
             expect(workspace.nativeWindows.getConnection(workspace.id, 'alerts'), 'the live vessel survives the stale retirement').toMatchObject({windowId: 'tear-live'});
             expect(closes, 'nothing reached the platform').toEqual([]);
 
             await expect(workspace.closeTearOutVessel({generationToken: 'lineage-2', itemId: 'alerts', windowName: 'tearout-alerts'}))
                 .resolves.toBe(true);
-            expect(workspace.lastTearOutClose.stage).toBe('acknowledged');
+            expect(workspace.vesselController.lastTearOutClose.stage).toBe('acknowledged');
             expect(closes).toEqual([{names: ['tearout-alerts'], windowId: workspace.windowId}])
         } finally {
             Neo.Main.windowClose = originalClose;

--- a/test/playwright/unit/apps/workstation/Workspace.spec.mjs
+++ b/test/playwright/unit/apps/workstation/Workspace.spec.mjs
@@ -751,6 +751,106 @@ test.describe.serial('Workstation.view.Workspace', () => {
         }
     });
 
+    test('teardown cancels an effect BEFORE dispatch — no platform call is made after destroy', async () => {
+        const
+            workspace        = Neo.create(Workspace, {windowId: Neo.config.windowId}),
+            originalDragDrop = Neo.main.addon.DragDrop,
+            originalFocus    = Neo.Main.windowNativeFocus,
+            originalOpen     = Neo.Main.windowOpen,
+            calls            = [];
+
+        Neo.main.addon.DragDrop = {
+            acknowledgeWindowDragOrphanRecovery: async () => {calls.push('acknowledge'); return true},
+            hasWindowDragOrphanRecovery        : async () => {calls.push('hasRecovery');  return false},
+            parkWindowDrag                     : async () => {calls.push('park');         return true},
+            resumeWindowDrag                   : async () => {calls.push('resume');       return true}
+        };
+        Neo.Main.windowNativeFocus = async () => {calls.push('focus');  return true};
+        Neo.Main.windowOpen        = async () => {calls.push('open');   return true};
+
+        const controller = workspace.vesselController;
+
+        try {
+            controller.destroy();
+
+            // Every effect entry point refuses in its own return shape, before any dispatch.
+            await expect(controller.parkTearOutVessel({itemId: 'audit', windowName: 'tearout-audit'})).resolves.toBe(false);
+            await expect(controller.reshowTearOutVessel({itemId: 'audit', windowName: 'tearout-audit'})).resolves.toBe(false);
+            await expect(controller.closeTearOutVessel({itemId: 'audit', windowName: 'tearout-audit'})).resolves.toBe(false);
+            await expect(controller.disposeParkedTearOutVessel({itemId: 'audit', windowName: 'tearout-audit'})).resolves.toBe(false);
+            await expect(controller.openTearOutVessel({itemId: 'audit'})).resolves.toBeNull();
+
+            expect(calls, 'a torn-down controller dispatches no platform effect').toEqual([])
+        } finally {
+            Neo.main.addon.DragDrop    = originalDragDrop;
+            Neo.Main.windowNativeFocus = originalFocus;
+            Neo.Main.windowOpen        = originalOpen;
+            workspace.destroy()
+        }
+    });
+
+    test('teardown DURING a dispatched effect still settles it — no throw, and no receipt written back', async () => {
+        const
+            workspace        = Neo.create(Workspace, {windowId: Neo.config.windowId}),
+            originalDragDrop = Neo.main.addon.DragDrop,
+            originalMove     = Neo.Main.windowNativeMoveTo,
+            originalResize   = Neo.Main.windowNativeResizeTo,
+            calls            = [],
+            sourceRoute      = {
+                capabilities   : {close: true, focus: true, position: true, resize: true},
+                nativeHandleKey: 'handle-source',
+                ownerWindowId  : workspace.windowId,
+                targetWindowId : 'source-window'
+            },
+            geometry         = {
+                park   : {height: 260, width: 360, x: 800, y: 120},
+                restore: {height: 546, width: 640, x: 40, y: 60}
+            };
+
+        workspace.nativeWindows.sources.get(workspace.id).connections.set('audit', {
+            nativeRoute: sourceRoute,
+            windowId   : 'source-window',
+            windowName : 'tearout-audit'
+        });
+
+        const controller = workspace.vesselController;
+
+        controller.tearOutParkGeometries.audit = geometry;
+
+        Neo.main.addon.DragDrop = {
+            acknowledgeWindowDragOrphanRecovery: async () => {calls.push('acknowledge'); return true},
+            hasWindowDragOrphanRecovery        : async () => {calls.push('hasRecovery'); return false},
+            // The teardown lands mid-flight: this is the platform call this path dispatches, so
+            // destroying inside it is a settlement-after-dispatch, not a cancellation.
+            resumeWindowDrag                   : async () => {
+                calls.push('resume');
+                controller.destroy();
+                return true
+            }
+        };
+        Neo.Main.windowNativeResizeTo = async () => {calls.push('resize'); return true};
+        Neo.Main.windowNativeMoveTo   = async () => {calls.push('move');   return true};
+
+        try {
+            const settled = await controller.reshowTearOutVessel({
+                itemId: 'audit', rect: {height: 120, width: 200, x: 420, y: 240}, windowName: 'tearout-audit'
+            });
+
+            expect(settled, 'an in-flight effect settles rather than throwing on cleared state').toBe(true);
+            expect(calls, 'the dispatched effect ran to completion').toEqual(['resume']);
+            // `core.Base#destroy` DELETES own properties rather than nulling them, so the honest
+            // assertion is falsiness: the point is that the settling effect did not write a receipt
+            // back onto a torn-down controller.
+            expect(controller.lastVesselRestoreReceipt, 'cleared state stays cleared — the receipt is not resurrected')
+                .toBeFalsy()
+        } finally {
+            Neo.main.addon.DragDrop       = originalDragDrop;
+            Neo.Main.windowNativeMoveTo   = originalMove;
+            Neo.Main.windowNativeResizeTo = originalResize;
+            workspace.destroy()
+        }
+    });
+
     test('terminal restore compensates safely until exact extent and position both succeed', async () => {
         let
             moveAdmitted       = false,


### PR DESCRIPTION
Resolves #18460

🌿 *Workspace can no longer be the place a vessel's park state quietly lives — the receipts still answer to it, but nothing on it owns them.*

Workstation's vessel policy — open, close, park, reshow, dispose, plus the park geometries, attempt counts and target-window state those bodies shared — moves onto `Workstation.view.VesselController`, an app controller beside the existing `WorkspaceController` precedent. Workspace keeps four short delegators, because the native lifecycle binds `keyFor` / `open` / `close` off the workspace instance in `registerSource` (`src/dashboard/dock/Workspace.mjs:584-586`) and resolves the tear-out override by prototype identity. Workspace **4,476 → 3,897** physical lines; `VesselController` **826**.

Evidence: L3 (live non-destructive probe — the workstation e2e battery executed against a real browser at this head and against a `dev` worktree; the unit tier beneath it is L2 mock dispatch) → L3 required. **Not L4**, which the ladder reserves for operator-gated destructive handoff; nothing here terminates a harness or hands off a session. Limitation, stated rather than buried: the battery is **red on `dev` itself**, so the e2e half is baseline *parity*, not a green suite. Residual-Owner: #17844.

## AC Evidence
| AC-1 | Workspace **4,476 → 3,897 physical** lines, and **2,669 → 2,272 code** lines on the size guard's own measure — the baseline is ratcheted down in `8dbfcd0241` so the reduction is locked in rather than banked as headroom. VesselController **826** (< the 2,000 bar; 764 before the teardown repair below). Eight methods and seven state fields moved; `test/playwright/unit/apps/workstation/Workspace.spec.mjs` exercises them on the controller. |
| AC-2 | Per-method disposition in **Deltas** below. Engine bindings verified at `src/dashboard/dock/Workspace.mjs:584-586`. Nothing generic was recopied, and that is measured rather than asserted: against `DemoBWorkspace`'s own bodies, `parkTearOutVessel` is 193 lines here vs 108 there (42% similar, 48 identical lines) and `reshowTearOutVessel` 138 vs 40 (22%, 15 lines). Required engine work is #18467 (linked, not bundled). |
| AC-3 | outside-CI, two instruments. **Body identity:** undoing the receiver rewrite (`me.component.` → `me.`), the eight moved bodies are **541 lines with 6 differing** — `parkTearOutVessel` (193), `reshowTearOutVessel` (138) and `closeTearOutVessel` (106) were byte-identical at the move. That is evidence the move was faithful *as a transcription* — **it is not a runtime-equivalence claim**, and this PR contains the proof it cannot be one: a missing import and a non-quiescent teardown were both invisible to it. **Baseline parity:** a four-spec e2e sample (`GridRepaint`, `CrossZoneCue`, `TearOutSourceContinuity`, `FiveBeat`) runs **11 failed / 3 passed / 3 skipped on this branch and identically on `dev@b537d0a3c8`, same failing set**. Both VesselPark owners stay separate (`Workspace.mjs:569-576`): pointer and `nativeTitlebar: true` remain two `Neo.create(VesselPark, …)` calls with distinct closures. |
| AC-4 | `me.vesselController?.destroy()` sits beside `me.vesselParkHandlers?.destroy()`; the controller's own `destroy()` clears only the seven fields it declares and touches no borrowed Group, participant, pane or store. Creator-destroys-borrower-doesn't is unchanged. |
| AC-5 | 49 unit call sites re-pointed to `workspace.vesselController.X`; **zero** E2E specs changed (see Deltas); no tour callers exist (`grep` over `apps/workstation/tour/*.mjs` returns nothing). VesselController 763 < 2,000. |

## Deltas from ticket

**Six read-only getters on Workspace, which need declaring because the ticket forbids "a forwarding method for every moved member".** These are not that. `examples/dashboard/crossWindow/DemoBWorkspace.mjs:3872` writes `lastVesselParkReceipt` on *its own* workspace, and E2E specs for both consumers read the receipts by name off the component — `app.getComponent(wsId, ['lastVesselParkReceipt'])`. That makes the receipt names a cross-consumer observation convention, not a workstation detail. Relocating *ownership* to the controller must not move that *surface*, so six guarded getters (`lastVesselParkReceipt`, `lastVesselRestoreReceipt`, `lastTearOutClose`, `lastVesselOpen`, `tearOutParkGeometries`, `vesselConversionTargetWindowId`) read through to the controller. Writes are controller-only. The payoff is measurable: **zero E2E spec changes**. The seventh moved field, `tearOutParkAttempts`, has no external reader and got no getter.

**Per-method caller disposition (AC-2):**

| Method | Authority |
|---|---|
| `tearOutWorkspaceKey` | engine `keyFor`, `src/dashboard/dock/Workspace.mjs:584` — delegator required |
| `openTearOutVessel` | engine `open`, `:585` — delegator required |
| `closeTearOutVessel` | engine `close`, `:586` — delegator required |
| `onDockTearOutExit` | app override of the engine template hook — delegator retained |
| `parkTearOutVessel` | app-owned `VesselPark` closure — re-pointed |
| `reshowTearOutVessel` | app-owned `VesselPark` closure — re-pointed |
| `disposeParkedTearOutVessel` | app-owned `VesselPark` closure — re-pointed |
| `resolveTearOutVessel` | controller-internal; 4 Workspace call sites re-pointed |

**Three defects the move introduced, all caught by tests rather than by review** — recorded because together they name the failure mode of this kind of extraction: *the diff looks like a faithful move in every case.*

- `{windowId} = me` inside `openTearOutVessel` silently began resolving to the *controller's* `windowId` once `me` changed meaning. It did not throw — it sent `null` into the bootstrap read. A member-expression grep for `me.windowId` structurally cannot see a destructuring, which is why it needed the test rather than the search.
- The diagnostic builders read receipts via `me.vesselController.X`, which throws under the prototype-call specs whose `this` is a stub with no controller. They now read the guarded getter, so one path serves both a real instance and a stub.
- **A missing import** (`58a91d2297`): `closeTearOutVessel` uses `WorkspaceDocument`, which Workspace imports and the new controller did not. Invisible to the body-identity instrument above — an import lives outside the body — and silent at runtime, because the engine's `retireVessel` swallows the seam's throw. The instrument that proves a move is faithful is precisely the one blind to what the move left behind.

**Review dispositions (@neo-gpt-emmy, `REQUEST_CHANGES` at `8dbfcd0241`).** RA-1: teardown was written for a quiescent world — an effect mid-dispatch either resurrected cleared state or reported a successful platform call as a refusal. Fixed in `9acf40a1b4` with a two-half contract (cancellation before dispatch, settlement after) and a deferred test for each. The substantive find: `delete me.tearOutParkGeometries[itemId]` sits at **six** sites and throws once the map is deleted; I first guarded the one I was reading, which fixed nothing because the failing path was another. All six now route through one `releaseParkGeometry()` seam. RA-2: applied above. RA-3: `@summary` added to the four named methods.

**Mechanical note for whoever adds the next file here:** `.gitignore:4` ignores `/apps/**/*.mjs` and `apps/workstation` has no negation whitelist, so all 16 tracked files there were force-added. `VesselController.mjs` needed `git add -f`; a plain `git add` silently skips it and the branch ships an import of a file that is not in the repo. Not changed in this PR — adding negation lines would alter what `git add` picks up for the whole app and deserves its own review.

## Test Evidence

Unit tier: **3,537 passed / 2 skipped / 3,539 selected** — the full `playwright.config.unit.mjs` run, not the single spec.

**The workstation e2e battery is red on `dev` itself** — 32 of 82 selected fail at the base, across grid repaint, splitter geometry and theme chrome. That is pre-existing and belongs to #17844 (@neo-opus-grace, open, assigned); receipt sent to her. It means this battery cannot certify AC-3 on its own, so AC-3 rests on body identity plus **baseline parity**, measured like-for-like:

| Same 4 specs, same selection, `--workers=1` | failed | passed | skipped |
|---|---|---|---|
| `dev@b537d0a3c8` (git worktree, `VesselController` absent) | 11 | 3 | 3 |
| `agent/18460-vessel-controller` @ `8dbfcd0241` | 11 | 3 | 3 |

Failing sets are **identical** — no test fails here that passes on dev.

**That parity is the second state of this branch, not the first, and the difference is the point.** The first run had two branch-only failures. `WorkstationFiveBeatNL.spec.mjs:2348` was a real regression: run in isolation it failed **2/2** here and passed **2/2** on dev. Cause — `closeTearOutVessel` calls `WorkspaceDocument.findContainingTabsId`, and the new controller did not import that module. `TearOut.mjs`'s `retireVessel` wraps the host seam in a bare `try { … } catch { return false }`, so the `ReferenceError` became an ordinary refusal to retire: nothing on the console, admission still held. Fixed in `949299ef82`. The second, `:1436`, did not reproduce and is absent from the parity run.

A note on how that number was obtained, because it is a trap on this suite: an unqualified e2e run prints `NEO_AGENTOS_RUNTIME_ROOT is unset — 85 of 105 spec files are EXCLUDED from selection` and then exits **0** having run 8 tests, none of them vessel specs. Playwright also exits 0 on a config-resolution failure. Exit code is not evidence here; the selected count is. Both runs above report theirs. (Same gate @neo-opus-grace claimed in #17844.)

## Post-Merge Validation
- [x] `apps/workstation/view/VesselController.mjs` is in the committed tree — verified at this head, not deferred: `git ls-tree -r --name-only HEAD` lists it and `git archive HEAD -- <path>` extracts it. It was force-added past `.gitignore:4`, which is why this was worth checking at all.

None outstanding.

## Commits
- `4a980acc18` — vessel policy moves to a lifecycle-owning controller
- `949299ef82` — the moved bodies need their own imports (`WorkspaceDocument`)
- `8dbfcd0241` — ratchet the size baseline 2669 → 2272
- `9acf40a1b4` — teardown is not quiescent, so effects must survive it (RA-1)

Rebased onto `dev@b537d0a3c8` (#18470 + #18472); the parity pair above was **re-measured at that base**, not carried over.

Origin Session ID: 3581aef4-0bb5-4cb4-b428-856e9e60c9b3

Authored by Vega (Opus 5, Claude Code) 🌿

