### PR TITLE
fix(workstation): import PreviewContract, which the flagship calls but never imported (#18480)

### DIFF
--- a/apps/workstation/view/Workspace.mjs
+++ b/apps/workstation/view/Workspace.mjs
@@ -19,6 +19,7 @@ import WorkspaceDocument        from '../../../src/dashboard/dock/model/Workspac
 import WorkspaceController      from './WorkspaceController.mjs';
 import Operations               from '../../../src/dashboard/dock/model/Operations.mjs';
 import Persistence              from '../../../src/dashboard/dock/model/Persistence.mjs';
+import PreviewContract          from '../../../src/dashboard/dock/model/PreviewContract.mjs';
 import InteractionService       from '../../../src/ai/client/InteractionService.mjs';
 import StateProvider            from '../../../src/state/Provider.mjs';
 import TourRunner               from '../../../src/ai/client/TourRunner.mjs';

--- a/buildScripts/util/file-size-baseline.json
+++ b/buildScripts/util/file-size-baseline.json
@@ -1,5 +1,5 @@
 {
-    "apps/workstation/view/Workspace.mjs": 2669,
+    "apps/workstation/view/Workspace.mjs": 2670,
     "examples/dashboard/crossWindow/DemoBWorkspace.mjs": 2612,
     "src/dashboard/dock/Workspace.mjs": 1035,
     "src/main/addon/DragDrop.mjs": 1267


### PR DESCRIPTION
Resolves #18480

size-guard-growth: apps/workstation/view/Workspace.mjs — one import line restoring a symbol the file already calls; fixes a live ReferenceError and adds no responsibility to an entrypoint #18456 is shrinking.

`apps/workstation/view/Workspace.mjs:3291` calls `PreviewContract.previewToOperation(finalPreview)`. The module never imported it. A bare `ReferenceError`, live on a real interaction path in the flagship application.

Evidence: L3 (red-first arm on the same command; residual-signature sweep across all eight affected specs; run conditions stated) → L3 required (all ACs). Residual: none.

## AC Evidence

| AC | Evidence |
|---|---|
| AC-1 | `grep -c "import PreviewContract" apps/workstation/view/Workspace.mjs` → **1**, was **0**. One file, one insertion |
| AC-2 | Same command both arms, `NEO_AGENTOS_RUNTIME_ROOT` set: **before** `1 failed` with `errors: ["PreviewContract is not defined"]`; **after** `1 passed`, exit 0, zero residual |
| AC-3 | The other seven specs re-run: **residual `PreviewContract is not defined` = 0**. Eight failures remain at unrelated lines and are explicitly *not* claimed here |
| AC-4 | Conditions below |

## The defect

```js
// apps/workstation/view/Workspace.mjs:3291 — before
let descriptor     = PreviewContract.previewToOperation(finalPreview),
    expectedResult = descriptor && Operations.applyOperation(…);
```

`Operations` and `WorkspaceDocument` on that same statement are imported explicitly; `PreviewContract` was not.

**The engine class is blameless.** `src/dashboard/dock/model/PreviewContract.mjs` is imported and exercised by `window/Participation.mjs`, `interaction/DropIndicators.mjs`, and the *passing* unit spec `unit/dashboard/DockPreview.spec.mjs`. Not a rename, not a retirement — the consumer never imported it.

## Why it survived inspection

**It reads as a policy failure rather than a crash.** The cue stringifies the `ReferenceError` into its own `errors` array, so the surface reports:

```
cue errors must be empty: {"applied":false,"errors":["PreviewContract is not defined"]}
```

`applied: false` with a contract violation looks like a refused operation. It is not — the descriptor is simply never produced. My own first reading was "the symbol is out of scope in the cue's evaluation context"; @neo-opus-vega read it correctly as a missing import, from a different Brain checkout, while working #18460. Hers is the diagnosis this PR implements.

## Why nothing reported it

**Eight spec files reach that line, and all eight are `*NL` specs** — `testIgnore`d by `playwright.config.e2e.mjs` whenever `NEO_AGENTOS_RUNTIME_ROOT` is unset, which it is in CI:

`DockSplitterZoneIdNL` · `WorkstationCrossZoneCueNL` · `WorkstationDockFlipResizeNL` · `WorkstationDockSplitChromeNL` · `WorkstationEdgeSplitterNL` · `WorkstationFiveBeatNL` · `WorkstationSplitterGridGeometryNL` · `WorkstationStarvedTourNL`

Zero matched specs reads as a pass. The flagship carried a live `ReferenceError` with no surface able to report it — which is #17844's premise, demonstrated by its first execution rather than argued.

## Test Evidence

```
red  (36e7c8f^): 1 failed — errors: ["PreviewContract is not defined"]
green (36e7c8f): 1 passed — exit 0, zero residual
AC-3 sweep, 7 specs: 8 failed / 3 skipped / 8 passed
                     residual "PreviewContract is not defined" = 0
```

**Run conditions, stated because a number without them is not a receipt** (#17844 produced 51 and 57 from the same tier under two configurations):

- `NEO_AGENTOS_RUNTIME_ROOT=/Users/Shared/claude/neomjs/neo-agent-brain` (`dev@95bea64`)
- profile `PRESENTING` (default), **headless**, `--workers=1`
- `dist/development` rebuilt and **mtime-verified** at `2026-09-08 14:38`

**The eight remaining failures are different defects.** They sit at unrelated lines, five of them (`FiveBeatNL:1301 :1522 :2388 :2459 :2676`) are among the 43 invariant across both of #17844's battery runs, and none carries this signature. They belong to that census and are deliberately not absorbed here.

## Deltas from ticket

None.

## Post-Merge Validation

- [ ] Nothing to observe post-merge that this PR does not already show: the affected specs remain CI-invisible until #17844's fail-loud AC lands, so the receipt above is the only surface that reports them.

---

Authored by Grace (Claude Opus 5, Claude Code). Session 0692d99a-6b58-4de2-aa51-e7d10f3f80d4.

