### PR TITLE
feat(dock): lower declarative pane arrangements (#18475)

### DIFF
--- a/docs/output/class-hierarchy.json
+++ b/docs/output/class-hierarchy.json
@@ -233,6 +233,7 @@
  "Neo.dashboard.dock.interaction.TabContainer": "Neo.tab.Container",
  "Neo.dashboard.dock.interaction.TabEnterButton": "Neo.tab.header.Button",
  "Neo.dashboard.dock.interaction.TabSortZone": "Neo.draggable.tab.header.toolbar.SortZone",
+ "Neo.dashboard.dock.model.Authoring": "Neo.core.Base",
  "Neo.dashboard.dock.model.Operations": "Neo.core.Base",
  "Neo.dashboard.dock.model.Persistence": "Neo.core.Base",
  "Neo.dashboard.dock.model.PreviewContract": "Neo.core.Base",

--- a/learn/agentos/DockZoneModel.md
+++ b/learn/agentos/DockZoneModel.md
@@ -168,6 +168,8 @@ Any of the three node types can be the root. `WorkspaceDocument.normalizeTree` r
 and redundant splits, retaining catalog-only panes. An empty root must be an edge container.
 Unknown pane names, duplicate placements, malformed shapes and unexpected node fields fail with the
 authored path, such as `zones.center.children[1].items[0]`.
+Validation collects independent errors across catalog entries and sibling nodes in one call. It stops
+descending a branch whose shape cannot be read safely and returns no partial document.
 
 Pane keys become item IDs. `componentRef` defaults to the key; wire `title` uses `header.text`, then
 the key. Nullish values use the default. Other defined fields from
@@ -191,6 +193,7 @@ surviving node ID. On failure `config` is `null`. The default is `keepIds: true`
 structural IDs. Export includes the **complete wire catalog**, mapping `title` to the ordinary pane
 `header.text` idiom and retaining unplaced items. It cannot
 reconstruct runtime component configuration that was never persisted.
+Export likewise reports independent catalog and node errors together, without returning partial config.
 Export checks the same split grammar as lowering: missing/unknown orientation and negative sizes
 fail with a document path even though the older wire validator admits those malformed values.
 

--- a/learn/agentos/DockZoneModel.md
+++ b/learn/agentos/DockZoneModel.md
@@ -121,19 +121,88 @@ The persisted document is a versioned JSON object:
 
 `items` is an id-keyed catalog. Item ids are stable workspace identity, not necessarily component instance ids.
 
-Required item fields:
+Catalog fields used by adapters (the wire also accepts minimal records):
 
 - `componentRef`: stable reference used by the rendering adapter to locate or create the component.
 - `title`: display label for tab headers and persistence UIs.
-- `kind`: coarse category such as `panel`, `terminal`, `transcript`, `inspector`, or `tool`.
 
 Optional item fields:
 
+- `kind`: coarse category such as `panel`, `terminal`, `transcript`, `inspector`, or `tool`.
 - `blueprint`: a serializable Neo component config when the item is created from saved state rather than a live instance.
 - `closable`, `pinnable`, `movable`: UI policy hints. Defaults are adapter-defined.
 - `pinned`: semantic pin state. `true` means pinned open; `false` means auto-hide eligible when an adapter supports that affordance. Omitted preserves the adapter-defined default. `pinnable === false` means `setItemPinned` must reject pin-state changes.
 - `autoHidden`: semantic collapsed/auto-hide state. `true` means the item is committed as collapsed into an auto-hide affordance; `false` means the item is visible when the owning layout renders it. A pinned-open item must not be serialized with `autoHidden: true`; `setItemPinned(..., true)` clears `autoHidden`.
 - `metadata`: JSON-only descriptive data. It must not contain DOM nodes, functions, secrets, PATs, or live component objects.
+
+### Authoring a Nested Arrangement
+
+`Neo.dashboard.dock.model.Authoring` converts pane declarations and a nested arrangement into the
+same committed document. Consumers describe placement without maintaining a flat structural graph:
+
+```javascript
+import Authoring from './src/dashboard/dock/model/Authoring.mjs';
+
+const {document, errors} = Authoring.fromZones({
+    nav   : {header: {text: 'Navigator'}},
+    editor: {header: {text: 'Editor'}}
+}, {
+    left  : {items: ['nav'], extent: 0.2, resizable: true},
+    center: 'editor'
+});
+```
+
+This pure model API returns `{document, errors}`; on failure `document` is `null`. It neither
+constructs components nor mutates its inputs. Host consumption and component ownership are separate
+from conversion. Successful output passes the existing document and saved-layout boundaries.
+
+| Authored shape | Meaning and defaults |
+|---|---|
+| `'editor'` or `['nav', 'editor']` | Tabs shorthand; first pane is active. |
+| `{items: ['nav', 'editor'], activeItemId: 'editor'}` | Tabs with an explicit selection. `null` preserves no selection. |
+| `{children: ['nav', 'editor'], orientation: 'horizontal'}` | Split; omitted sizes are equal fractions. Explicit sizes contain one finite nonnegative fraction per child, summing to 1. `vertical` stacks the children. |
+| `{left: {items: ['nav'], extent: 0.2}, center: 'editor'}` | Edge container. `extent` and `resizable` sit beside the child node but lower into its edge descriptor. |
+| `{type: 'edge-zone'}` | Empty edge container. An explicit `type` is also legal for tabs and splits. |
+
+Any of the three node types can be the root. `WorkspaceDocument.normalizeTree` removes empty tabs
+and redundant splits, retaining catalog-only panes. An empty root must be an edge container.
+Unknown pane names, duplicate placements, malformed shapes and unexpected node fields fail with the
+authored path, such as `zones.center.children[1].items[0]`.
+
+Pane keys become item IDs. `componentRef` defaults to the key; wire `title` uses `header.text`, then
+the key. Nullish values use the default. Other defined fields from
+`WorkspaceDocument.dockZoneItemKeys`, including optional `kind`, policies, `metadata` and `blueprint`,
+are copied after JSON/model validation. Ordinary runtime config such as `module`, listeners and
+stores stays outside the document. A function inside a catalog field instead fails with its pane
+path. Unplaced declarations remain in the catalog, so detachment and closure stay distinguishable.
+
+An optional `id` on a structural node requests its wire ID. All explicit IDs are reserved before
+generation; duplicate IDs and a child claiming an unnamed root's `root` ID fail before lowering.
+Generated names use `root` for an unnamed root and readable `tabs-…`, `split-…` or `edge-…` prefixes
+elsewhere. Occupied names gain a `-0`, `-1`, … suffix through the existing node-ID generator. Pane
+names joined by delimiters are only naming hints: the occupancy check provides uniqueness.
+The existing document clone cannot preserve an own `__proto__` key. Authoring refuses that pane/node
+ID or nested catalog key with a path error, preventing silent loss at this boundary.
+
+### Export and Round-Trip Equality
+
+`Authoring.toConfig(document, {keepIds: true})` returns `{config: {panes, zones}, errors}` with every
+surviving node ID. On failure `config` is `null`. The default is `keepIds: true`; `false` omits all
+structural IDs. Export includes the **complete wire catalog**, mapping `title` to the ordinary pane
+`header.text` idiom and retaining unplaced items. It cannot
+reconstruct runtime component configuration that was never persisted.
+Export checks the same split grammar as lowering: missing/unknown orientation and negative sizes
+fail with a document path even though the older wire validator admits those malformed values.
+
+Lowering the retained-ID export equals the original after `normalizeTree` and the documented
+catalog defaults. Lowering an IDs-dropped export preserves that same catalog and ordered structure,
+with generated IDs. This is equality after defaults, not byte equality with a minimal record that
+omitted `title` or `componentRef`. Complete-field controls retain their values.
+
+The model specs exercise the standalone dock example, Demo A, Demo B and Workstation documents,
+named collision and catalog-loss controls, and 400 deterministic generated trees. The generated
+domain has bounded depth, all three root types, tabs, splits, nested/empty edges, JSON policy fields
+and unplaced items; it is not a proof over every possible input.
 
 ### Stale Component References
 

--- a/src/dashboard/dock/model/Authoring.mjs
+++ b/src/dashboard/dock/model/Authoring.mjs
@@ -9,6 +9,7 @@ import WorkspaceDocument from './WorkspaceDocument.mjs';
  * `fromZones` accepts component configurations but copies only the document catalog fields.
  * `toConfig` exports that catalog and a nested tree; it cannot recover runtime configuration.
  * Both APIs fail closed, leave inputs untouched and apply WorkspaceDocument.normalizeTree.
+ * Independent validation failures accumulate; malformed branches stop before unsafe traversal.
  * Round trips compare after normalization and catalog defaults, not byte-for-byte with an
  * input that omitted title/componentRef. No component construction or host lifecycle lives here.
  */
@@ -45,26 +46,30 @@ class Authoring extends Base {
      * Catalog defaults: componentRef is the pane key; title is header.text, then the key
      * (nullish values use the default). Other defined catalog fields pass
      * through the existing JSON/model checks. Unplaced panes remain in the catalog.
+     * Independent failures are collected across readable branches; malformed branches stop
+     * safely, and any error prevents lowering from publishing a partial document.
      * @param {Object<String,Object>} panes Pane configs keyed by stable item ID
      * @param {Object|String|String[]} zones Nested root
      * @returns {{document:(Object|null), errors:String[]}}
      * @static
      */
     static fromZones(panes, zones) {
+        const errors = [];
         try {
-            if (!WorkspaceDocument.isJsonRecord(panes)) throw new Error('panes: must be a record of pane configurations');
-            this.validateJson(zones, 'zones');
-
-            const items    = Object.fromEntries(Object.entries(panes).map(([key, pane]) => [key, this.toItem(key, pane)])),
+            const catalogKnown = WorkspaceDocument.isJsonRecord(panes);
+            if (!catalogKnown) errors.push('panes: must be a record of pane configurations');
+            this.validateJson(zones, 'zones', errors);
+            const items    = Object.fromEntries(Object.entries(catalogKnown ? panes : {}).map(([key, pane]) => [key, this.toItem(key, pane, errors)])),
                   occupied = {},
                   explicit = new Set(),
                   placed   = new Set(),
                   rootId   = WorkspaceDocument.isJsonRecord(zones) && Object.hasOwn(zones, 'id') ? zones.id : 'root';
 
-            occupied[rootId] = true;
-            const tree     = this.readNode(zones, 'zones', {explicit, placed, rootId, items}, true),
+            const tree     = this.readNode(zones, 'zones', {explicit, placed, rootId, items, catalogKnown, errors, seen: new WeakSet()}, true),
                   document = {schema: WorkspaceDocument.SCHEMA, root: rootId, items, nodes: {}};
 
+            if (errors.length) return {document: null, errors};
+            occupied[rootId] = true;
             explicit.forEach(id => { occupied[id] = true });
 
             const lower = (node, isRoot=false) => {
@@ -89,11 +94,12 @@ class Authoring extends Base {
 
             document.root = lower(tree, true);
             const normalized = WorkspaceDocument.normalizeTree(document);
-            if (!Object.hasOwn(normalized.nodes, normalized.root)) throw new Error('zones: normalizes to an empty root; use an empty edge-zone instead');
-            const errors = WorkspaceDocument.validate(normalized);
+            if (!Object.hasOwn(normalized.nodes, normalized.root)) errors.push('normalizes to an empty root; use an empty edge-zone instead');
+            else errors.push(...WorkspaceDocument.validate(normalized));
             return errors.length ? {document: null, errors: errors.map(error => `zones: ${error}`)} : {document: normalized, errors: []}
         } catch (error) {
-            return {document: null, errors: [error.message]}
+            errors.push(error.message);
+            return {document: null, errors}
         }
     }
 
@@ -103,6 +109,8 @@ class Authoring extends Base {
      * Retained IDs reproduce the normalized document after fromZones' catalog defaults.
      * `keepIds: false` preserves catalog and tree semantics with freshly generated node IDs.
      * Runtime-only component configuration is unavailable in a document and is never invented.
+     * Readable records contribute errors independently. Recursive graph validation and
+     * normalization run only after their JSON/shape prerequisites are satisfied.
      * @param {Object} document A JSON-only dock-zone document
      * @param {Object} [options]
      * @param {Boolean} [options.keepIds=true] Include every surviving node ID
@@ -110,34 +118,17 @@ class Authoring extends Base {
      * @static
      */
     static toConfig(document, options={}) {
+        const errors = [];
         try {
-            if (!WorkspaceDocument.isJsonRecord(options)) throw new Error('options: must be a record');
-            const {keepIds=true} = options;
-            if (typeof keepIds !== 'boolean') throw new Error('options.keepIds: must be a boolean');
-            this.validateJson(document, 'document');
-            if (!WorkspaceDocument.isJsonRecord(document)) throw new Error('document: must be a record');
-            if (!WorkspaceDocument.isJsonRecord(document.items)) throw new Error('document.items: must be a record');
-            if (!WorkspaceDocument.isJsonRecord(document.nodes)) throw new Error('document.nodes: must be a record');
-            for (const [id, node] of Object.entries(document.nodes)) {
-                const path = this.path('document.nodes', id);
-                if (!WorkspaceDocument.isJsonRecord(node)) throw new Error(`${path}: must be a node record`);
-                if (!Object.hasOwn(WorkspaceDocument.dockZoneNodeKeys, node.type)) throw new Error(`${path}.type: must be a supported node type`);
-                if (node.type === 'split') {
-                    if (!Array.isArray(node.children)) throw new Error(`${path}.children: must be an array`);
-                    this.validateSplit(node, path, node.children.length);
-                }
-                if (node.type === 'tabs' && !Array.isArray(node.items)) throw new Error(`${path}.items: must be an array`);
-            }
-            const unexpected = WorkspaceDocument.findUnexpectedDockZoneKey(document, 'document');
-            if (unexpected) throw new Error(`${unexpected.path}: ${unexpected.reason}`);
-
-            const shape = WorkspaceDocument.computeShapeFingerprint(document);
-            if (shape.errors.length) return {config: null, errors: shape.errors};
-            const errors = WorkspaceDocument.validate(document);
+            const optionsValid = WorkspaceDocument.isJsonRecord(options),
+                  {keepIds=true} = optionsValid ? options : {};
+            if (!optionsValid) errors.push('options: must be a record');
+            else if (typeof keepIds !== 'boolean') errors.push('options.keepIds: must be a boolean');
+            this.validateDocument(document, errors);
             if (errors.length) return {config: null, errors};
 
             const normalized = WorkspaceDocument.normalizeTree(document);
-            if (!Object.hasOwn(normalized.nodes, normalized.root)) throw new Error('document.root: normalizes to an empty root');
+            if (!Object.hasOwn(normalized.nodes, normalized.root)) return {config: null, errors: ['document.root: normalizes to an empty root']};
 
             const inline = id => {
                 const node = normalized.nodes[id], out = keepIds ? {id} : {};
@@ -166,7 +157,8 @@ class Authoring extends Base {
             }));
             return {config: {panes, zones: inline(normalized.root)}, errors: []}
         } catch (error) {
-            return {config: null, errors: [error.message]}
+            errors.push(error.message);
+            return {config: null, errors}
         }
     }
 
@@ -174,81 +166,110 @@ class Authoring extends Base {
      * @summary Copies one pane's wire fields and validates them before cloning.
      * @param {String} key
      * @param {Object} pane
-     * @returns {Object}
+     * @param {String[]} errors Collected independent refusals.
+     * @returns {Object|null}
      * @protected
      * @static
      */
-    static toItem(key, pane) {
+    static toItem(key, pane, errors) {
         const path = this.path('panes', key);
-        if (key === '__proto__') throw new Error(`${path}: is not supported by the document clone boundary`);
-        if (!WorkspaceDocument.isJsonRecord(pane)) throw new Error(`${path}: must be a pane configuration record`);
-        const item = Object.fromEntries([...WorkspaceDocument.dockZoneItemKeys]
+        if (key === '__proto__') errors.push(`${path}: is not supported by the document clone boundary`);
+        if (!WorkspaceDocument.isJsonRecord(pane)) {
+            errors.push(`${path}: must be a pane configuration record`);
+            return null
+        }
+        const start = errors.length;
+        const item  = Object.fromEntries([...WorkspaceDocument.dockZoneItemKeys]
             .filter(field => field !== 'title' && pane[field] !== undefined).map(field => [field, pane[field]]));
         item.componentRef ??= key;
         item.title = pane.header?.text ?? key;
-        this.validateJson(item.title, `${path}.header.text`);
-        this.validateJson(item, path);
-        const errors = WorkspaceDocument.validate({schema: WorkspaceDocument.SCHEMA, root: 'root', items: {[key]: item}, nodes: {root: {type: 'edge-zone', zones: {}}}});
-        if (errors.length) throw new Error(`${path}: ${errors.join('; ')}`);
-        return WorkspaceDocument.clone(item)
+        this.validateJson(item.title, `${path}.header.text`, errors);
+        this.validateJson({...item, title: null}, path, errors);
+        this.validateItemPolicy(key, item, path, errors);
+        return errors.length === start ? WorkspaceDocument.clone(item) : null
     }
 
     /**
      * @summary Checks authored grammar and reserves explicit IDs before building the flat graph.
      * @param {*} value
      * @param {String} path
-     * @param {Object} context Shared explicit IDs, pane placement and catalog
+     * @param {Object} context Shared errors, visited objects, explicit IDs, pane placement and catalog
      * @param {Boolean} [isRoot=false]
      * @param {Boolean} [isEdgeChild=false]
-     * @returns {Object} Parsed node with deterministic naming hints
+     * @returns {Object|null} Parsed node, or null when this branch cannot be inspected safely
      * @protected
      * @static
      */
     static readNode(value, path, context, isRoot=false, isEdgeChild=false) {
         const shorthand = typeof value === 'string' || Array.isArray(value),
-              record    = shorthand ? {} : value;
-        if (!WorkspaceDocument.isJsonRecord(record)) throw new Error(`${path}: must be a node record, pane name or pane array`);
+              record    = shorthand ? {} : value,
+              {errors}  = context;
+        if (!WorkspaceDocument.isJsonRecord(record)) {
+            errors.push(`${path}: must be a node record, pane name or pane array`);
+            return null
+        }
+        if (value && typeof value === 'object') {
+            if (context.seen.has(value)) {
+                errors.push(`${path}: cyclic or repeated node configuration`);
+                return null
+            }
+            context.seen.add(value)
+        }
         const edges = [...WorkspaceDocument.dockZoneEdgeKeys],
               type  = shorthand ? 'tabs' : Object.hasOwn(record, 'type') ? record.type : (Object.hasOwn(record, 'items') ? 'tabs'
                   : Object.hasOwn(record, 'children') ? 'split' : edges.some(edge => Object.hasOwn(record, edge)) ? 'edge-zone' : null);
-        if (!Object.hasOwn(WorkspaceDocument.dockZoneNodeKeys, type)) throw new Error(`${path}: needs items, children, an edge key or a supported type`);
+        if (typeof type !== 'string' || !Object.hasOwn(WorkspaceDocument.dockZoneNodeKeys, type)) {
+            errors.push(`${path}: needs items, children, an edge key or a supported type`);
+            return null
+        }
         const allowed = new Set(type === 'edge-zone' ? ['type', ...edges] : WorkspaceDocument.dockZoneNodeKeys[type]);
         allowed.add('id');
         if (isEdgeChild) { allowed.add('extent'); allowed.add('resizable') }
-        const unexpected = WorkspaceDocument.findUnexpectedKey(record, allowed, path);
-        if (unexpected) throw new Error(`${unexpected.path}: is not part of this node type`);
+        for (const key of Reflect.ownKeys(record)) {
+            if (!allowed.has(key)) errors.push(`${this.path(path, String(key))}: is not part of this node type`)
+        }
 
         const node = {type};
         if (Object.hasOwn(record, 'id')) {
             const id = record.id;
-            if (typeof id !== 'string' || !id.trim()) throw new Error(`${path}.id: must be a non-empty string`);
-            if (id === '__proto__') throw new Error(`${path}.id: "__proto__" is not supported by the document clone boundary`);
-            if (context.explicit.has(id) || (!isRoot && id === context.rootId)) throw new Error(`${path}.id: duplicate or reserved node ID "${id}"`);
-            context.explicit.add(id);
-            node.id = id;
+            if (typeof id !== 'string' || !id.trim()) errors.push(`${path}.id: must be a non-empty string`);
+            else if (id === '__proto__') errors.push(`${path}.id: "__proto__" is not supported by the document clone boundary`);
+            else if (context.explicit.has(id) || (!isRoot && id === context.rootId)) errors.push(`${path}.id: duplicate or reserved node ID "${id}"`);
+            else {
+                context.explicit.add(id);
+                node.id = id
+            }
         }
 
         if (type === 'tabs') {
             const items = typeof value === 'string' ? [value] : Array.isArray(value) ? value : record.items;
-            if (!Array.isArray(items)) throw new Error(`${path}.items: must be an array of pane names`);
+            if (!Array.isArray(items)) {
+                errors.push(`${path}.items: must be an array of pane names`);
+                return null
+            }
             items.forEach((key, index) => {
                 const itemPath = typeof value === 'string' ? path : `${path}${Array.isArray(value) ? '' : '.items'}[${index}]`;
-                if (typeof key !== 'string' || !Object.hasOwn(context.items, key)) throw new Error(`${itemPath}: unknown pane "${key}"`);
-                if (context.placed.has(key)) throw new Error(`${itemPath}: pane "${key}" is already placed`);
-                context.placed.add(key);
+                if (typeof key !== 'string') errors.push(`${itemPath}: must be a pane name`);
+                else if (context.catalogKnown && !Object.hasOwn(context.items, key)) errors.push(`${itemPath}: unknown pane "${key}"`);
+                else if (context.placed.has(key)) errors.push(`${itemPath}: pane "${key}" is already placed`);
+                else context.placed.add(key);
             });
             node.items = [...items];
             node.activeItemId = Object.hasOwn(record, 'activeItemId') ? record.activeItemId : items[0] ?? null;
-            if (node.activeItemId !== null && !items.includes(node.activeItemId)) throw new Error(`${path}.activeItemId: must name one of this node's panes or be null`);
-            node.firstPane = items[0];
-            node.prefix = `tabs-${items[0] ?? 'empty'}`;
+            if (node.activeItemId !== null && !items.includes(node.activeItemId)) errors.push(`${path}.activeItemId: must name one of this node's panes or be null`);
+            node.firstPane = typeof items[0] === 'string' ? items[0] : undefined;
+            node.prefix = `tabs-${node.firstPane ?? 'empty'}`;
         } else if (type === 'split') {
-            if (!Array.isArray(record.children)) throw new Error(`${path}.children: must be an array of nodes`);
+            if (!Array.isArray(record.children)) {
+                errors.push(`${path}.children: must be an array of nodes`);
+                this.validateSplit(record, path, null, errors);
+                return null
+            }
             node.orientation = record.orientation;
-            node.children = record.children.map((child, i) => this.readNode(child, `${path}.children[${i}]`, context));
-            node.sizes = Object.hasOwn(record, 'sizes') ? record.sizes : node.children.map(() => 1 / node.children.length);
-            this.validateSplit(node, path, node.children.length);
-            node.sizes = [...node.sizes];
+            node.children = record.children.map((child, i) => this.readNode(child, `${path}.children[${i}]`, context)).filter(Boolean);
+            node.sizes = Object.hasOwn(record, 'sizes') ? record.sizes : record.children.map(() => 1 / record.children.length);
+            this.validateSplit(node, path, record.children.length, errors);
+            if (Array.isArray(node.sizes)) node.sizes = [...node.sizes];
             node.firstPane = node.children.find(child => child.firstPane !== undefined)?.firstPane;
             node.prefix = `split-${node.children.map(child => child.firstPane ?? 'empty').join('-')}`;
         } else {
@@ -256,16 +277,16 @@ class Authoring extends Base {
                 const value = record[edge], descriptor = {};
                 if (WorkspaceDocument.isJsonRecord(value)) {
                     if (Object.hasOwn(value, 'extent')) {
-                        if (typeof value.extent !== 'number' || !(value.extent > 0 && value.extent < 1)) throw new Error(`${path}.${edge}.extent: must be a fraction between 0 and 1`);
+                        if (typeof value.extent !== 'number' || !(value.extent > 0 && value.extent < 1)) errors.push(`${path}.${edge}.extent: must be a fraction between 0 and 1`);
                         descriptor.extent = value.extent;
                     }
                     if (Object.hasOwn(value, 'resizable')) {
-                        if (typeof value.resizable !== 'boolean') throw new Error(`${path}.${edge}.resizable: must be a boolean`);
+                        if (typeof value.resizable !== 'boolean') errors.push(`${path}.${edge}.resizable: must be a boolean`);
                         descriptor.resizable = value.resizable;
                     }
                 }
                 return {edge, descriptor, child: this.readNode(value, `${path}.${edge}`, context, false, true)}
-            });
+            }).filter(({child}) => child);
             const panes = node.children.map(({child}) => child.firstPane).filter(key => key !== undefined);
             node.firstPane = panes[0];
             node.prefix = panes.length ? `edge-${panes.join('-')}` : 'edge';
@@ -274,46 +295,174 @@ class Authoring extends Base {
     }
 
     /**
-     * @summary Applies the same split grammar at the authoring and export boundaries.
-     * @param {Object} node
+     * @summary Applies canonical item-policy validation while retaining the authored path.
+     * @param {String} key
+     * @param {Object} item
      * @param {String} path
-     * @param {Number} count
+     * @param {String[]} errors
      * @protected
      * @static
      */
-    static validateSplit(node, path, count) {
-        const {orientation, sizes} = node;
+    static validateItemPolicy(key, item, path, errors) {
+        errors.push(...WorkspaceDocument.validateItemPolicy(key, item).map(error => `${path}: ${error}`))
+    }
 
-        if (!this.orientations.includes(orientation)) {
-            throw new Error(`${path}.orientation: must be ${this.orientations.join(' or ')}`)
+    /**
+     * @summary Collects record-shape errors before admitting the existing wire validators.
+     *
+     * Catalog/node siblings remain inspectable when another record is malformed. Canonical wire
+     * validation continues across malformed node records; recursive fingerprinting waits for a
+     * traversable shape. No synthetic repairs or parallel schema authority normalize invalid input.
+     * @param {*} document
+     * @param {String[]} errors
+     * @protected
+     * @static
+     */
+    static validateDocument(document, errors) {
+        const jsonStart = errors.length;
+        this.validateJson(document, 'document', errors);
+        const jsonSafe = errors.length === jsonStart;
+        if (!WorkspaceDocument.isJsonRecord(document)) {
+            errors.push('document: must be a record');
+            return
         }
-
-        if (!Array.isArray(sizes) || sizes.length !== count ||
-            sizes.some(size => !Number.isFinite(size) || size < 0) ||
-            (sizes.length && Math.abs(sizes.reduce((a, b) => a + b, 0) - 1) > 1e-6)) {
-            throw new Error(`${path}.sizes: must contain one finite nonnegative fraction per child, summing to 1`)
+        for (const key of Object.keys(document)) {
+            if (!WorkspaceDocument.dockZoneDocumentKeys.has(key)) errors.push(`${this.path('document', key)}: is outside the document schema`)
+        }
+        const catalogKnown = WorkspaceDocument.isJsonRecord(document.items),
+              nodesKnown   = WorkspaceDocument.isJsonRecord(document.nodes), catalog = [];
+        let traversable = catalogKnown && nodesKnown, safeReferences = true;
+        if (typeof document.root !== 'string') {
+            errors.push('document.root: must be a node ID');
+            traversable = safeReferences = false
+        }
+        if (!catalogKnown) errors.push('document.items: must be a record');
+        else for (const [key, item] of Object.entries(document.items)) {
+            const path = this.path('document.items', key);
+            if (!WorkspaceDocument.isJsonRecord(item)) {
+                errors.push(`${path}: must be an item record`);
+                traversable = false;
+                continue
+            }
+            for (const field of Object.keys(item)) {
+                if (!WorkspaceDocument.dockZoneItemKeys.has(field)) errors.push(`${this.path(path, field)}: is outside the item schema`)
+            }
+            catalog.push({key, item, path})
+        }
+        if (!nodesKnown) errors.push('document.nodes: must be a record');
+        else for (const [id, node] of Object.entries(document.nodes)) {
+            const path = this.path('document.nodes', id);
+            if (!WorkspaceDocument.isJsonRecord(node)) {
+                errors.push(`${path}: must be a node record`);
+                traversable = false;
+                continue
+            }
+            if (typeof node.type !== 'string' || !Object.hasOwn(WorkspaceDocument.dockZoneNodeKeys, node.type)) {
+                errors.push(`${path}.type: must be a supported node type`);
+                traversable = false;
+                continue
+            }
+            for (const field of Object.keys(node)) {
+                if (!WorkspaceDocument.dockZoneNodeKeys[node.type].has(field)) errors.push(`${this.path(path, field)}: is outside this node type`)
+            }
+            if (node.type === 'split') {
+                const readable = Array.isArray(node.children);
+                this.validateSplit(node, path, readable ? node.children.length : null, errors);
+                if (!readable) {
+                    errors.push(`${path}.children: must be an array`);
+                    traversable = false
+                } else node.children.forEach((childId, index) => {
+                    if (typeof childId !== 'string') {
+                        errors.push(`${path}.children[${index}]: must be a node ID`);
+                        traversable = safeReferences = false
+                    }
+                });
+            } else if (node.type === 'tabs') {
+                if (!Array.isArray(node.items)) {
+                    errors.push(`${path}.items: must be an array`);
+                    traversable = false
+                } else node.items.forEach((itemId, index) => {
+                    if (typeof itemId !== 'string') {
+                        errors.push(`${path}.items[${index}]: must be an item ID`);
+                        traversable = safeReferences = false
+                    }
+                });
+            } else if (node.type === 'edge-zone' && !WorkspaceDocument.isJsonRecord(node.zones)) {
+                errors.push(`${path}.zones: must be a record`);
+                traversable = false
+            }
+        }
+        // Graph traversal still requires readable shapes; the canonical validator can report
+        // malformed node containers and continue checking independent records without recursion.
+        if (traversable && jsonSafe) errors.push(...WorkspaceDocument.computeShapeFingerprint(document).errors);
+        if (catalogKnown && nodesKnown && jsonSafe && safeReferences) {
+            errors.push(...WorkspaceDocument.validate(document))
+        } else {
+            // Safe catalog records still have independent policy failures even when an unrelated
+            // node prevents calling the whole-document validator.
+            catalog.forEach(({key, item, path}) => this.validateItemPolicy(key, item, path, errors))
         }
     }
 
     /**
-     * @summary Rejects non-JSON values and keys that the document clone cannot preserve.
-     * @param {*} value
+     * @summary Applies the same split grammar at the authoring and export boundaries.
+     * @param {Object} node
      * @param {String} path
+     * @param {Number|null} count Null when malformed children prevent checking arity.
+     * @param {String[]} errors
      * @protected
      * @static
      */
-    static validateJson(value, path) {
-        const failure = WorkspaceDocument.findNonJsonValue(value, path);
-        if (failure) throw new Error(`${failure.path}: ${failure.reason}`);
-        const checkKeys = (value, path) => {
-            if (value === null || typeof value !== 'object') return;
-            for (const key of Object.keys(value)) {
-                const childPath = Array.isArray(value) ? `${path}[${key}]` : this.path(path, key);
-                if (key === '__proto__') throw new Error(`${childPath}: is not supported by the document clone boundary`);
-                checkKeys(value[key], childPath);
+    static validateSplit(node, path, count, errors) {
+        const {orientation, sizes} = node;
+
+        if (!this.orientations.includes(orientation)) {
+            errors.push(`${path}.orientation: must be ${this.orientations.join(' or ')}`)
+        }
+
+        if (count === null && sizes === undefined) return;
+        if (!Array.isArray(sizes) || (count !== null && sizes.length !== count) ||
+            sizes.some(size => !Number.isFinite(size) || size < 0) ||
+            (sizes.length && Math.abs(sizes.reduce((a, b) => a + b, 0) - 1) > 1e-6)) {
+            errors.push(`${path}.sizes: must contain one finite nonnegative fraction per child, summing to 1`)
+        }
+    }
+
+    /**
+     * @summary Collects JSON/clone-boundary failures, stopping at an invalid or repeated object.
+     * @param {*} value
+     * @param {String} path
+     * @param {String[]} errors
+     * @param {WeakSet<Object>} [seen=new WeakSet()]
+     * @protected
+     * @static
+     */
+    static validateJson(value, path, errors, seen=new WeakSet()) {
+        if (!Array.isArray(value) && !WorkspaceDocument.isJsonRecord(value)) {
+            const failure = WorkspaceDocument.findNonJsonValue(value, path);
+            if (failure) errors.push(`${failure.path}: ${failure.reason}`);
+            return
+        }
+        if (seen.has(value)) {
+            errors.push(`${path}: cyclic or repeated object is not JSON-serializable`);
+            return
+        }
+        seen.add(value);
+        const array = Array.isArray(value),
+              keys  = array ? [
+                  ...Array.from({length: value.length}, (_, i) => String(i)),
+                  ...Reflect.ownKeys(value).filter(key => key !== 'length' &&
+                      (typeof key !== 'string' || !/^(0|[1-9]\d*)$/.test(key) || Number(key) >= value.length))
+              ] : Reflect.ownKeys(value);
+        for (const key of keys) {
+            const childPath = array ? `${path}[${String(key)}]` : this.path(path, String(key));
+            if (typeof key === 'symbol') errors.push(`${childPath}: symbol keys are not JSON-serializable`);
+            else {
+                if (key === '__proto__') errors.push(`${childPath}: is not supported by the document clone boundary`);
+                if (WorkspaceDocument.forbiddenPreviewKeys.has(key)) errors.push(`${childPath}: runtime-only field must not enter committed dock-zone state`);
+                this.validateJson(value[key], childPath, errors, seen)
             }
-        };
-        checkKeys(value, path)
+        }
     }
 
     /**

--- a/src/dashboard/dock/model/Authoring.mjs
+++ b/src/dashboard/dock/model/Authoring.mjs
@@ -13,6 +13,14 @@ import WorkspaceDocument from './WorkspaceDocument.mjs';
  * input that omitted title/componentRef. No component construction or host lifecycle lives here.
  */
 class Authoring extends Base {
+    /**
+     * Valid values for a split node's orientation.
+     * @member {String[]} orientations=['horizontal','vertical']
+     * @protected
+     * @static
+     */
+    static orientations = ['horizontal', 'vertical']
+
     static config = {
         /**
          * @member {String} className='Neo.dashboard.dock.model.Authoring'
@@ -44,8 +52,8 @@ class Authoring extends Base {
      */
     static fromZones(panes, zones) {
         try {
-            this.require(WorkspaceDocument.isJsonRecord(panes), 'panes', 'must be a record of pane configurations');
-            this.requireJson(zones, 'zones');
+            if (!WorkspaceDocument.isJsonRecord(panes)) throw new Error('panes: must be a record of pane configurations');
+            this.validateJson(zones, 'zones');
 
             const items    = Object.fromEntries(Object.entries(panes).map(([key, pane]) => [key, this.toItem(key, pane)])),
                   occupied = {},
@@ -81,7 +89,7 @@ class Authoring extends Base {
 
             document.root = lower(tree, true);
             const normalized = WorkspaceDocument.normalizeTree(document);
-            this.require(Object.hasOwn(normalized.nodes, normalized.root), 'zones', 'normalizes to an empty root; use an empty edge-zone instead');
+            if (!Object.hasOwn(normalized.nodes, normalized.root)) throw new Error('zones: normalizes to an empty root; use an empty edge-zone instead');
             const errors = WorkspaceDocument.validate(normalized);
             return errors.length ? {document: null, errors: errors.map(error => `zones: ${error}`)} : {document: normalized, errors: []}
         } catch (error) {
@@ -103,25 +111,25 @@ class Authoring extends Base {
      */
     static toConfig(document, options={}) {
         try {
-            this.require(WorkspaceDocument.isJsonRecord(options), 'options', 'must be a record');
+            if (!WorkspaceDocument.isJsonRecord(options)) throw new Error('options: must be a record');
             const {keepIds=true} = options;
-            this.require(typeof keepIds === 'boolean', 'options.keepIds', 'must be a boolean');
-            this.requireJson(document, 'document');
-            this.require(WorkspaceDocument.isJsonRecord(document), 'document', 'must be a record');
-            this.require(WorkspaceDocument.isJsonRecord(document.items), 'document.items', 'must be a record');
-            this.require(WorkspaceDocument.isJsonRecord(document.nodes), 'document.nodes', 'must be a record');
+            if (typeof keepIds !== 'boolean') throw new Error('options.keepIds: must be a boolean');
+            this.validateJson(document, 'document');
+            if (!WorkspaceDocument.isJsonRecord(document)) throw new Error('document: must be a record');
+            if (!WorkspaceDocument.isJsonRecord(document.items)) throw new Error('document.items: must be a record');
+            if (!WorkspaceDocument.isJsonRecord(document.nodes)) throw new Error('document.nodes: must be a record');
             for (const [id, node] of Object.entries(document.nodes)) {
                 const path = this.path('document.nodes', id);
-                this.require(WorkspaceDocument.isJsonRecord(node), path, 'must be a node record');
-                this.require(Object.hasOwn(WorkspaceDocument.dockZoneNodeKeys, node.type), `${path}.type`, 'must be a supported node type');
+                if (!WorkspaceDocument.isJsonRecord(node)) throw new Error(`${path}: must be a node record`);
+                if (!Object.hasOwn(WorkspaceDocument.dockZoneNodeKeys, node.type)) throw new Error(`${path}.type: must be a supported node type`);
                 if (node.type === 'split') {
-                    this.require(Array.isArray(node.children), `${path}.children`, 'must be an array');
+                    if (!Array.isArray(node.children)) throw new Error(`${path}.children: must be an array`);
                     this.validateSplit(node, path, node.children.length);
                 }
-                if (node.type === 'tabs') this.require(Array.isArray(node.items), `${path}.items`, 'must be an array');
+                if (node.type === 'tabs' && !Array.isArray(node.items)) throw new Error(`${path}.items: must be an array`);
             }
             const unexpected = WorkspaceDocument.findUnexpectedDockZoneKey(document, 'document');
-            if (unexpected) this.require(false, unexpected.path, unexpected.reason);
+            if (unexpected) throw new Error(`${unexpected.path}: ${unexpected.reason}`);
 
             const shape = WorkspaceDocument.computeShapeFingerprint(document);
             if (shape.errors.length) return {config: null, errors: shape.errors};
@@ -129,7 +137,7 @@ class Authoring extends Base {
             if (errors.length) return {config: null, errors};
 
             const normalized = WorkspaceDocument.normalizeTree(document);
-            this.require(Object.hasOwn(normalized.nodes, normalized.root), 'document.root', 'normalizes to an empty root');
+            if (!Object.hasOwn(normalized.nodes, normalized.root)) throw new Error('document.root: normalizes to an empty root');
 
             const inline = id => {
                 const node = normalized.nodes[id], out = keepIds ? {id} : {};
@@ -172,16 +180,16 @@ class Authoring extends Base {
      */
     static toItem(key, pane) {
         const path = this.path('panes', key);
-        this.require(key !== '__proto__', path, 'is not supported by the document clone boundary');
-        this.require(WorkspaceDocument.isJsonRecord(pane), path, 'must be a pane configuration record');
+        if (key === '__proto__') throw new Error(`${path}: is not supported by the document clone boundary`);
+        if (!WorkspaceDocument.isJsonRecord(pane)) throw new Error(`${path}: must be a pane configuration record`);
         const item = Object.fromEntries([...WorkspaceDocument.dockZoneItemKeys]
             .filter(field => field !== 'title' && pane[field] !== undefined).map(field => [field, pane[field]]));
         item.componentRef ??= key;
         item.title = pane.header?.text ?? key;
-        this.requireJson(item.title, `${path}.header.text`);
-        this.requireJson(item, path);
+        this.validateJson(item.title, `${path}.header.text`);
+        this.validateJson(item, path);
         const errors = WorkspaceDocument.validate({schema: WorkspaceDocument.SCHEMA, root: 'root', items: {[key]: item}, nodes: {root: {type: 'edge-zone', zones: {}}}});
-        this.require(!errors.length, path, errors.join('; '));
+        if (errors.length) throw new Error(`${path}: ${errors.join('; ')}`);
         return WorkspaceDocument.clone(item)
     }
 
@@ -199,43 +207,43 @@ class Authoring extends Base {
     static readNode(value, path, context, isRoot=false, isEdgeChild=false) {
         const shorthand = typeof value === 'string' || Array.isArray(value),
               record    = shorthand ? {} : value;
-        this.require(WorkspaceDocument.isJsonRecord(record), path, 'must be a node record, pane name or pane array');
+        if (!WorkspaceDocument.isJsonRecord(record)) throw new Error(`${path}: must be a node record, pane name or pane array`);
         const edges = [...WorkspaceDocument.dockZoneEdgeKeys],
               type  = shorthand ? 'tabs' : Object.hasOwn(record, 'type') ? record.type : (Object.hasOwn(record, 'items') ? 'tabs'
                   : Object.hasOwn(record, 'children') ? 'split' : edges.some(edge => Object.hasOwn(record, edge)) ? 'edge-zone' : null);
-        this.require(Object.hasOwn(WorkspaceDocument.dockZoneNodeKeys, type), path, 'needs items, children, an edge key or a supported type');
+        if (!Object.hasOwn(WorkspaceDocument.dockZoneNodeKeys, type)) throw new Error(`${path}: needs items, children, an edge key or a supported type`);
         const allowed = new Set(type === 'edge-zone' ? ['type', ...edges] : WorkspaceDocument.dockZoneNodeKeys[type]);
         allowed.add('id');
         if (isEdgeChild) { allowed.add('extent'); allowed.add('resizable') }
         const unexpected = WorkspaceDocument.findUnexpectedKey(record, allowed, path);
-        if (unexpected) this.require(false, unexpected.path, 'is not part of this node type');
+        if (unexpected) throw new Error(`${unexpected.path}: is not part of this node type`);
 
         const node = {type};
         if (Object.hasOwn(record, 'id')) {
             const id = record.id;
-            this.require(typeof id === 'string' && !!id.trim(), `${path}.id`, 'must be a non-empty string');
-            this.require(id !== '__proto__', `${path}.id`, '"__proto__" is not supported by the document clone boundary');
-            this.require(!context.explicit.has(id) && (isRoot || id !== context.rootId), `${path}.id`, `duplicate or reserved node ID "${id}"`);
+            if (typeof id !== 'string' || !id.trim()) throw new Error(`${path}.id: must be a non-empty string`);
+            if (id === '__proto__') throw new Error(`${path}.id: "__proto__" is not supported by the document clone boundary`);
+            if (context.explicit.has(id) || (!isRoot && id === context.rootId)) throw new Error(`${path}.id: duplicate or reserved node ID "${id}"`);
             context.explicit.add(id);
             node.id = id;
         }
 
         if (type === 'tabs') {
             const items = typeof value === 'string' ? [value] : Array.isArray(value) ? value : record.items;
-            this.require(Array.isArray(items), `${path}.items`, 'must be an array of pane names');
+            if (!Array.isArray(items)) throw new Error(`${path}.items: must be an array of pane names`);
             items.forEach((key, index) => {
                 const itemPath = typeof value === 'string' ? path : `${path}${Array.isArray(value) ? '' : '.items'}[${index}]`;
-                this.require(typeof key === 'string' && Object.hasOwn(context.items, key), itemPath, `unknown pane "${key}"`);
-                this.require(!context.placed.has(key), itemPath, `pane "${key}" is already placed`);
+                if (typeof key !== 'string' || !Object.hasOwn(context.items, key)) throw new Error(`${itemPath}: unknown pane "${key}"`);
+                if (context.placed.has(key)) throw new Error(`${itemPath}: pane "${key}" is already placed`);
                 context.placed.add(key);
             });
             node.items = [...items];
             node.activeItemId = Object.hasOwn(record, 'activeItemId') ? record.activeItemId : items[0] ?? null;
-            this.require(node.activeItemId === null || items.includes(node.activeItemId), `${path}.activeItemId`, 'must name one of this node\'s panes or be null');
+            if (node.activeItemId !== null && !items.includes(node.activeItemId)) throw new Error(`${path}.activeItemId: must name one of this node's panes or be null`);
             node.firstPane = items[0];
             node.prefix = `tabs-${items[0] ?? 'empty'}`;
         } else if (type === 'split') {
-            this.require(Array.isArray(record.children), `${path}.children`, 'must be an array of nodes');
+            if (!Array.isArray(record.children)) throw new Error(`${path}.children: must be an array of nodes`);
             node.orientation = record.orientation;
             node.children = record.children.map((child, i) => this.readNode(child, `${path}.children[${i}]`, context));
             node.sizes = Object.hasOwn(record, 'sizes') ? record.sizes : node.children.map(() => 1 / node.children.length);
@@ -248,11 +256,11 @@ class Authoring extends Base {
                 const value = record[edge], descriptor = {};
                 if (WorkspaceDocument.isJsonRecord(value)) {
                     if (Object.hasOwn(value, 'extent')) {
-                        this.require(typeof value.extent === 'number' && value.extent > 0 && value.extent < 1, `${path}.${edge}.extent`, 'must be a fraction between 0 and 1');
+                        if (typeof value.extent !== 'number' || !(value.extent > 0 && value.extent < 1)) throw new Error(`${path}.${edge}.extent: must be a fraction between 0 and 1`);
                         descriptor.extent = value.extent;
                     }
                     if (Object.hasOwn(value, 'resizable')) {
-                        this.require(typeof value.resizable === 'boolean', `${path}.${edge}.resizable`, 'must be a boolean');
+                        if (typeof value.resizable !== 'boolean') throw new Error(`${path}.${edge}.resizable: must be a boolean`);
                         descriptor.resizable = value.resizable;
                     }
                 }
@@ -274,23 +282,17 @@ class Authoring extends Base {
      * @static
      */
     static validateSplit(node, path, count) {
-        this.require(['horizontal', 'vertical'].includes(node.orientation), `${path}.orientation`, 'must be horizontal or vertical');
-        this.require(Array.isArray(node.sizes) && node.sizes.length === count &&
-            node.sizes.every(size => typeof size === 'number' && Number.isFinite(size) && size >= 0) &&
-            (!node.sizes.length || Math.abs(node.sizes.reduce((a, b) => a + b, 0) - 1) <= 1e-6),
-            `${path}.sizes`, 'must contain one finite nonnegative fraction per child, summing to 1');
-    }
+        const {orientation, sizes} = node;
 
-    /**
-     * @summary Raises a path-labelled authoring error.
-     * @param {Boolean} condition
-     * @param {String} path
-     * @param {String} reason
-     * @protected
-     * @static
-     */
-    static require(condition, path, reason) {
-        if (!condition) throw new Error(`${path}: ${reason}`)
+        if (!this.orientations.includes(orientation)) {
+            throw new Error(`${path}.orientation: must be ${this.orientations.join(' or ')}`)
+        }
+
+        if (!Array.isArray(sizes) || sizes.length !== count ||
+            sizes.some(size => !Number.isFinite(size) || size < 0) ||
+            (sizes.length && Math.abs(sizes.reduce((a, b) => a + b, 0) - 1) > 1e-6)) {
+            throw new Error(`${path}.sizes: must contain one finite nonnegative fraction per child, summing to 1`)
+        }
     }
 
     /**
@@ -300,14 +302,14 @@ class Authoring extends Base {
      * @protected
      * @static
      */
-    static requireJson(value, path) {
+    static validateJson(value, path) {
         const failure = WorkspaceDocument.findNonJsonValue(value, path);
-        if (failure) this.require(false, failure.path, failure.reason);
+        if (failure) throw new Error(`${failure.path}: ${failure.reason}`);
         const checkKeys = (value, path) => {
             if (value === null || typeof value !== 'object') return;
             for (const key of Object.keys(value)) {
                 const childPath = Array.isArray(value) ? `${path}[${key}]` : this.path(path, key);
-                this.require(key !== '__proto__', childPath, 'is not supported by the document clone boundary');
+                if (key === '__proto__') throw new Error(`${childPath}: is not supported by the document clone boundary`);
                 checkKeys(value[key], childPath);
             }
         };

--- a/src/dashboard/dock/model/Authoring.mjs
+++ b/src/dashboard/dock/model/Authoring.mjs
@@ -1,0 +1,330 @@
+import Base              from '../../../core/Base.mjs';
+import WorkspaceDocument from './WorkspaceDocument.mjs';
+
+/**
+ * @class Neo.dashboard.dock.model.Authoring
+ * @extends Neo.core.Base
+ * @summary Pure conversion between nested pane arrangements and the committed dock document.
+ *
+ * `fromZones` accepts component configurations but copies only the document catalog fields.
+ * `toConfig` exports that catalog and a nested tree; it cannot recover runtime configuration.
+ * Both APIs fail closed, leave inputs untouched and apply WorkspaceDocument.normalizeTree.
+ * Round trips compare after normalization and catalog defaults, not byte-for-byte with an
+ * input that omitted title/componentRef. No component construction or host lifecycle lives here.
+ */
+class Authoring extends Base {
+    static config = {
+        /**
+         * @member {String} className='Neo.dashboard.dock.model.Authoring'
+         * @protected
+         */
+        className: 'Neo.dashboard.dock.model.Authoring'
+    }
+
+    /**
+     * @summary Lowers a pane catalog and one nested root into `neo.dock.zone.v1`.
+     *
+     * A string or array abbreviates tabs. Objects discriminate by `items`, `children`, or
+     * edge names; an explicit `type` supports all three node types, including an empty edge.
+     * Edge-child `extent`/`resizable` belong to the descriptor. Splits require orientation;
+     * omitted sizes are even fractions. Omitted activeItemId selects the first pane; null
+     * preserves no selection. Empty/redundant descendants follow normal tree normalization.
+     *
+     * Explicit IDs are reserved before any generated allocation. The unnamed root reserves
+     * `root`; other nodes use readable pane-derived prefixes and occupancy suffixes (`-0`, …).
+     * Prefixes are hints, not a uniqueness guarantee. Errors name the authored config path.
+     *
+     * Catalog defaults: componentRef is the pane key; title is header.text, then the key
+     * (nullish values use the default). Other defined catalog fields pass
+     * through the existing JSON/model checks. Unplaced panes remain in the catalog.
+     * @param {Object<String,Object>} panes Pane configs keyed by stable item ID
+     * @param {Object|String|String[]} zones Nested root
+     * @returns {{document:(Object|null), errors:String[]}}
+     * @static
+     */
+    static fromZones(panes, zones) {
+        try {
+            this.require(WorkspaceDocument.isJsonRecord(panes), 'panes', 'must be a record of pane configurations');
+            this.requireJson(zones, 'zones');
+
+            const items    = Object.fromEntries(Object.entries(panes).map(([key, pane]) => [key, this.toItem(key, pane)])),
+                  occupied = {},
+                  explicit = new Set(),
+                  placed   = new Set(),
+                  rootId   = WorkspaceDocument.isJsonRecord(zones) && Object.hasOwn(zones, 'id') ? zones.id : 'root';
+
+            occupied[rootId] = true;
+            const tree     = this.readNode(zones, 'zones', {explicit, placed, rootId, items}, true),
+                  document = {schema: WorkspaceDocument.SCHEMA, root: rootId, items, nodes: {}};
+
+            explicit.forEach(id => { occupied[id] = true });
+
+            const lower = (node, isRoot=false) => {
+                let id = node.id;
+                if (id === undefined) {
+                    const prefix = node.prefix;
+                    id = isRoot ? rootId : Object.hasOwn(occupied, prefix)
+                        ? WorkspaceDocument.genId({nodes: occupied}, prefix) : prefix;
+                }
+                occupied[id] = true;
+
+                const wire = node.type === 'tabs'
+                    ? {type: 'tabs', items: node.items, activeItemId: node.activeItemId}
+                    : node.type === 'split'
+                        ? {type: 'split', orientation: node.orientation, children: node.children.map(child => lower(child)), sizes: node.sizes}
+                        : {type: 'edge-zone', zones: Object.fromEntries(node.children.map(({edge, child, descriptor}) =>
+                            [edge, {nodeId: lower(child), ...descriptor}]))};
+
+                Object.defineProperty(document.nodes, id, {value: wire, enumerable: true, writable: true, configurable: true});
+                return id
+            };
+
+            document.root = lower(tree, true);
+            const normalized = WorkspaceDocument.normalizeTree(document);
+            this.require(Object.hasOwn(normalized.nodes, normalized.root), 'zones', 'normalizes to an empty root; use an empty edge-zone instead');
+            const errors = WorkspaceDocument.validate(normalized);
+            return errors.length ? {document: null, errors: errors.map(error => `zones: ${error}`)} : {document: normalized, errors: []}
+        } catch (error) {
+            return {document: null, errors: [error.message]}
+        }
+    }
+
+    /**
+     * @summary Exports the complete catalog and normalized nested arrangement from a wire document.
+     *
+     * Retained IDs reproduce the normalized document after fromZones' catalog defaults.
+     * `keepIds: false` preserves catalog and tree semantics with freshly generated node IDs.
+     * Runtime-only component configuration is unavailable in a document and is never invented.
+     * @param {Object} document A JSON-only dock-zone document
+     * @param {Object} [options]
+     * @param {Boolean} [options.keepIds=true] Include every surviving node ID
+     * @returns {{config:(Object|null), errors:String[]}}
+     * @static
+     */
+    static toConfig(document, options={}) {
+        try {
+            this.require(WorkspaceDocument.isJsonRecord(options), 'options', 'must be a record');
+            const {keepIds=true} = options;
+            this.require(typeof keepIds === 'boolean', 'options.keepIds', 'must be a boolean');
+            this.requireJson(document, 'document');
+            this.require(WorkspaceDocument.isJsonRecord(document), 'document', 'must be a record');
+            this.require(WorkspaceDocument.isJsonRecord(document.items), 'document.items', 'must be a record');
+            this.require(WorkspaceDocument.isJsonRecord(document.nodes), 'document.nodes', 'must be a record');
+            for (const [id, node] of Object.entries(document.nodes)) {
+                const path = this.path('document.nodes', id);
+                this.require(WorkspaceDocument.isJsonRecord(node), path, 'must be a node record');
+                this.require(Object.hasOwn(WorkspaceDocument.dockZoneNodeKeys, node.type), `${path}.type`, 'must be a supported node type');
+                if (node.type === 'split') {
+                    this.require(Array.isArray(node.children), `${path}.children`, 'must be an array');
+                    this.validateSplit(node, path, node.children.length);
+                }
+                if (node.type === 'tabs') this.require(Array.isArray(node.items), `${path}.items`, 'must be an array');
+            }
+            const unexpected = WorkspaceDocument.findUnexpectedDockZoneKey(document, 'document');
+            if (unexpected) this.require(false, unexpected.path, unexpected.reason);
+
+            const shape = WorkspaceDocument.computeShapeFingerprint(document);
+            if (shape.errors.length) return {config: null, errors: shape.errors};
+            const errors = WorkspaceDocument.validate(document);
+            if (errors.length) return {config: null, errors};
+
+            const normalized = WorkspaceDocument.normalizeTree(document);
+            this.require(Object.hasOwn(normalized.nodes, normalized.root), 'document.root', 'normalizes to an empty root');
+
+            const inline = id => {
+                const node = normalized.nodes[id], out = keepIds ? {id} : {};
+                if (node.type === 'tabs') {
+                    out.items = [...node.items];
+                    out.activeItemId = node.activeItemId;
+                } else if (node.type === 'split') {
+                    out.orientation = node.orientation;
+                    out.children = node.children.map(inline);
+                    out.sizes = [...node.sizes];
+                } else {
+                    if (!Object.keys(node.zones).length) out.type = 'edge-zone';
+                    for (const edge of WorkspaceDocument.dockZoneEdgeKeys) {
+                        if (!Object.hasOwn(node.zones, edge)) continue;
+                        const {nodeId, ...descriptor} = node.zones[edge];
+                        out[edge] = {...inline(nodeId), ...descriptor};
+                    }
+                }
+                return out
+            };
+
+            const panes = Object.fromEntries(Object.entries(normalized.items).map(([key, item]) => {
+                const {title, ...pane} = item;
+                if (title !== undefined) pane.header = {text: title};
+                return [key, pane]
+            }));
+            return {config: {panes, zones: inline(normalized.root)}, errors: []}
+        } catch (error) {
+            return {config: null, errors: [error.message]}
+        }
+    }
+
+    /**
+     * @summary Copies one pane's wire fields and validates them before cloning.
+     * @param {String} key
+     * @param {Object} pane
+     * @returns {Object}
+     * @protected
+     * @static
+     */
+    static toItem(key, pane) {
+        const path = this.path('panes', key);
+        this.require(key !== '__proto__', path, 'is not supported by the document clone boundary');
+        this.require(WorkspaceDocument.isJsonRecord(pane), path, 'must be a pane configuration record');
+        const item = Object.fromEntries([...WorkspaceDocument.dockZoneItemKeys]
+            .filter(field => field !== 'title' && pane[field] !== undefined).map(field => [field, pane[field]]));
+        item.componentRef ??= key;
+        item.title = pane.header?.text ?? key;
+        this.requireJson(item.title, `${path}.header.text`);
+        this.requireJson(item, path);
+        const errors = WorkspaceDocument.validate({schema: WorkspaceDocument.SCHEMA, root: 'root', items: {[key]: item}, nodes: {root: {type: 'edge-zone', zones: {}}}});
+        this.require(!errors.length, path, errors.join('; '));
+        return WorkspaceDocument.clone(item)
+    }
+
+    /**
+     * @summary Checks authored grammar and reserves explicit IDs before building the flat graph.
+     * @param {*} value
+     * @param {String} path
+     * @param {Object} context Shared explicit IDs, pane placement and catalog
+     * @param {Boolean} [isRoot=false]
+     * @param {Boolean} [isEdgeChild=false]
+     * @returns {Object} Parsed node with deterministic naming hints
+     * @protected
+     * @static
+     */
+    static readNode(value, path, context, isRoot=false, isEdgeChild=false) {
+        const shorthand = typeof value === 'string' || Array.isArray(value),
+              record    = shorthand ? {} : value;
+        this.require(WorkspaceDocument.isJsonRecord(record), path, 'must be a node record, pane name or pane array');
+        const edges = [...WorkspaceDocument.dockZoneEdgeKeys],
+              type  = shorthand ? 'tabs' : Object.hasOwn(record, 'type') ? record.type : (Object.hasOwn(record, 'items') ? 'tabs'
+                  : Object.hasOwn(record, 'children') ? 'split' : edges.some(edge => Object.hasOwn(record, edge)) ? 'edge-zone' : null);
+        this.require(Object.hasOwn(WorkspaceDocument.dockZoneNodeKeys, type), path, 'needs items, children, an edge key or a supported type');
+        const allowed = new Set(type === 'edge-zone' ? ['type', ...edges] : WorkspaceDocument.dockZoneNodeKeys[type]);
+        allowed.add('id');
+        if (isEdgeChild) { allowed.add('extent'); allowed.add('resizable') }
+        const unexpected = WorkspaceDocument.findUnexpectedKey(record, allowed, path);
+        if (unexpected) this.require(false, unexpected.path, 'is not part of this node type');
+
+        const node = {type};
+        if (Object.hasOwn(record, 'id')) {
+            const id = record.id;
+            this.require(typeof id === 'string' && !!id.trim(), `${path}.id`, 'must be a non-empty string');
+            this.require(id !== '__proto__', `${path}.id`, '"__proto__" is not supported by the document clone boundary');
+            this.require(!context.explicit.has(id) && (isRoot || id !== context.rootId), `${path}.id`, `duplicate or reserved node ID "${id}"`);
+            context.explicit.add(id);
+            node.id = id;
+        }
+
+        if (type === 'tabs') {
+            const items = typeof value === 'string' ? [value] : Array.isArray(value) ? value : record.items;
+            this.require(Array.isArray(items), `${path}.items`, 'must be an array of pane names');
+            items.forEach((key, index) => {
+                const itemPath = typeof value === 'string' ? path : `${path}${Array.isArray(value) ? '' : '.items'}[${index}]`;
+                this.require(typeof key === 'string' && Object.hasOwn(context.items, key), itemPath, `unknown pane "${key}"`);
+                this.require(!context.placed.has(key), itemPath, `pane "${key}" is already placed`);
+                context.placed.add(key);
+            });
+            node.items = [...items];
+            node.activeItemId = Object.hasOwn(record, 'activeItemId') ? record.activeItemId : items[0] ?? null;
+            this.require(node.activeItemId === null || items.includes(node.activeItemId), `${path}.activeItemId`, 'must name one of this node\'s panes or be null');
+            node.firstPane = items[0];
+            node.prefix = `tabs-${items[0] ?? 'empty'}`;
+        } else if (type === 'split') {
+            this.require(Array.isArray(record.children), `${path}.children`, 'must be an array of nodes');
+            node.orientation = record.orientation;
+            node.children = record.children.map((child, i) => this.readNode(child, `${path}.children[${i}]`, context));
+            node.sizes = Object.hasOwn(record, 'sizes') ? record.sizes : node.children.map(() => 1 / node.children.length);
+            this.validateSplit(node, path, node.children.length);
+            node.sizes = [...node.sizes];
+            node.firstPane = node.children.find(child => child.firstPane !== undefined)?.firstPane;
+            node.prefix = `split-${node.children.map(child => child.firstPane ?? 'empty').join('-')}`;
+        } else {
+            node.children = edges.filter(edge => Object.hasOwn(record, edge)).map(edge => {
+                const value = record[edge], descriptor = {};
+                if (WorkspaceDocument.isJsonRecord(value)) {
+                    if (Object.hasOwn(value, 'extent')) {
+                        this.require(typeof value.extent === 'number' && value.extent > 0 && value.extent < 1, `${path}.${edge}.extent`, 'must be a fraction between 0 and 1');
+                        descriptor.extent = value.extent;
+                    }
+                    if (Object.hasOwn(value, 'resizable')) {
+                        this.require(typeof value.resizable === 'boolean', `${path}.${edge}.resizable`, 'must be a boolean');
+                        descriptor.resizable = value.resizable;
+                    }
+                }
+                return {edge, descriptor, child: this.readNode(value, `${path}.${edge}`, context, false, true)}
+            });
+            const panes = node.children.map(({child}) => child.firstPane).filter(key => key !== undefined);
+            node.firstPane = panes[0];
+            node.prefix = panes.length ? `edge-${panes.join('-')}` : 'edge';
+        }
+        return node
+    }
+
+    /**
+     * @summary Applies the same split grammar at the authoring and export boundaries.
+     * @param {Object} node
+     * @param {String} path
+     * @param {Number} count
+     * @protected
+     * @static
+     */
+    static validateSplit(node, path, count) {
+        this.require(['horizontal', 'vertical'].includes(node.orientation), `${path}.orientation`, 'must be horizontal or vertical');
+        this.require(Array.isArray(node.sizes) && node.sizes.length === count &&
+            node.sizes.every(size => typeof size === 'number' && Number.isFinite(size) && size >= 0) &&
+            (!node.sizes.length || Math.abs(node.sizes.reduce((a, b) => a + b, 0) - 1) <= 1e-6),
+            `${path}.sizes`, 'must contain one finite nonnegative fraction per child, summing to 1');
+    }
+
+    /**
+     * @summary Raises a path-labelled authoring error.
+     * @param {Boolean} condition
+     * @param {String} path
+     * @param {String} reason
+     * @protected
+     * @static
+     */
+    static require(condition, path, reason) {
+        if (!condition) throw new Error(`${path}: ${reason}`)
+    }
+
+    /**
+     * @summary Rejects non-JSON values and keys that the document clone cannot preserve.
+     * @param {*} value
+     * @param {String} path
+     * @protected
+     * @static
+     */
+    static requireJson(value, path) {
+        const failure = WorkspaceDocument.findNonJsonValue(value, path);
+        if (failure) this.require(false, failure.path, failure.reason);
+        const checkKeys = (value, path) => {
+            if (value === null || typeof value !== 'object') return;
+            for (const key of Object.keys(value)) {
+                const childPath = Array.isArray(value) ? `${path}[${key}]` : this.path(path, key);
+                this.require(key !== '__proto__', childPath, 'is not supported by the document clone boundary');
+                checkKeys(value[key], childPath);
+            }
+        };
+        checkKeys(value, path)
+    }
+
+    /**
+     * @summary Names record keys without confusing dotted pane IDs with nested paths.
+     * @param {String} parent
+     * @param {String} key
+     * @returns {String}
+     * @protected
+     * @static
+     */
+    static path(parent, key) {
+        return /^[A-Za-z_$][\w$]*$/.test(key) ? `${parent}.${key}` : `${parent}[${JSON.stringify(key)}]`
+    }
+}
+
+export default Neo.setupClass(Authoring);

--- a/src/dashboard/dock/model/WorkspaceDocument.mjs
+++ b/src/dashboard/dock/model/WorkspaceDocument.mjs
@@ -902,6 +902,7 @@ class WorkspaceDocument extends Base {
      * items all resolve), each item appears at most once across the tree, committed item-state
      * booleans have the right type, split sizes match child count and sum to 1, and
      * `tabs.activeItemId` is null or one of `tabs.items`.
+     * Malformed node records or containers report errors without hiding safe sibling checks.
      * @param {Object} document
      * @returns {String[]} the (possibly empty) list of invariant violations
      * @static
@@ -927,37 +928,26 @@ class WorkspaceDocument extends Base {
             itemUse = {};
 
         for (const [itemId, item] of Object.entries(items)) {
-            if (WorkspaceDocument.isJsonRecord(item) && Object.hasOwn(item, 'pinned') && typeof item.pinned !== 'boolean') {
-                errors.push(`item "${itemId}" pinned must be a boolean`)
-            }
-
-            if (WorkspaceDocument.isJsonRecord(item) && Object.hasOwn(item, 'autoHidden') && typeof item.autoHidden !== 'boolean') {
-                errors.push(`item "${itemId}" autoHidden must be a boolean`)
-            }
-
-            if (WorkspaceDocument.isJsonRecord(item) && Object.hasOwn(item, 'lockable') && typeof item.lockable !== 'boolean') {
-                errors.push(`item "${itemId}" lockable must be a boolean`)
-            }
-
-            if (WorkspaceDocument.isJsonRecord(item) && Object.hasOwn(item, 'locked') && typeof item.locked !== 'boolean') {
-                errors.push(`item "${itemId}" locked must be a boolean`)
-            }
-
-            if (WorkspaceDocument.isJsonRecord(item) && item.pinned === true && item.autoHidden === true) {
-                errors.push(`item "${itemId}" cannot be pinned and autoHidden at the same time`)
-            }
+            errors.push(...WorkspaceDocument.validateItemPolicy(itemId, item))
         }
 
         for (const [nodeId, node] of Object.entries(nodes)) {
+            if (!WorkspaceDocument.isJsonRecord(node)) {
+                errors.push(`node "${nodeId}" must be a node record`);
+                continue
+            }
             if (node.type === 'split') {
-                (node.children || []).forEach(childId => {
+                const children = node.children || [];
+                if (!Array.isArray(children)) errors.push(`split "${nodeId}" children must be an array`);
+                else children.forEach(childId => {
                     if (!nodes[childId]) errors.push(`split "${nodeId}" references missing node "${childId}"`)
                 });
 
                 let sizes = node.sizes || [];
 
-                if (sizes.length !== (node.children || []).length) {
-                    errors.push(`split "${nodeId}" sizes length ${sizes.length} != children length ${(node.children || []).length}`)
+                if (!Array.isArray(sizes)) errors.push(`split "${nodeId}" sizes must be an array`);
+                else if (Array.isArray(children) && sizes.length !== children.length) {
+                    errors.push(`split "${nodeId}" sizes length ${sizes.length} != children length ${children.length}`)
                 } else if (sizes.length && Math.abs(sizes.reduce((a, b) => a + b, 0) - 1) > 1e-6) {
                     errors.push(`split "${nodeId}" sizes do not sum to 1`)
                 }
@@ -1009,12 +999,17 @@ class WorkspaceDocument extends Base {
                     }
                 }
             } else if (node.type === 'tabs') {
-                (node.items || []).forEach(itemId => {
+                const members = node.items || [];
+                if (!Array.isArray(members)) {
+                    errors.push(`tabs "${nodeId}" items must be an array`);
+                    continue
+                }
+                members.forEach(itemId => {
                     if (!items[itemId]) errors.push(`tabs "${nodeId}" references missing item "${itemId}"`);
                     itemUse[itemId] = (itemUse[itemId] || 0) + 1
                 });
 
-                if (node.activeItemId !== null && node.activeItemId !== undefined && !(node.items || []).includes(node.activeItemId)) {
+                if (node.activeItemId !== null && node.activeItemId !== undefined && !members.includes(node.activeItemId)) {
                     errors.push(`tabs "${nodeId}" activeItemId "${node.activeItemId}" is not one of its items`)
                 }
             }
@@ -1024,6 +1019,38 @@ class WorkspaceDocument extends Base {
             if (count > 1) errors.push(`item "${itemId}" appears ${count} times in the tree (must be at most once)`)
         });
 
+        return errors
+    }
+
+    /**
+     * @summary Validates item policy independently of opaque catalog payloads and tree structure.
+     *
+     * Both document validation and authoring use this authority. A malformed metadata/blueprint
+     * payload must not hide an independent policy error; JSON admission is checked separately.
+     * @param {String} itemId
+     * @param {Object} item
+     * @returns {String[]}
+     * @static
+     */
+    static validateItemPolicy(itemId, item) {
+        const errors = [];
+        if (!WorkspaceDocument.isJsonRecord(item)) return errors;
+
+        if (Object.hasOwn(item, 'pinned') && typeof item.pinned !== 'boolean') {
+            errors.push(`item "${itemId}" pinned must be a boolean`)
+        }
+        if (Object.hasOwn(item, 'autoHidden') && typeof item.autoHidden !== 'boolean') {
+            errors.push(`item "${itemId}" autoHidden must be a boolean`)
+        }
+        if (Object.hasOwn(item, 'lockable') && typeof item.lockable !== 'boolean') {
+            errors.push(`item "${itemId}" lockable must be a boolean`)
+        }
+        if (Object.hasOwn(item, 'locked') && typeof item.locked !== 'boolean') {
+            errors.push(`item "${itemId}" locked must be a boolean`)
+        }
+        if (item.pinned === true && item.autoHidden === true) {
+            errors.push(`item "${itemId}" cannot be pinned and autoHidden at the same time`)
+        }
         return errors
     }
 

--- a/test/playwright/unit/dashboard/DockAuthoring.spec.mjs
+++ b/test/playwright/unit/dashboard/DockAuthoring.spec.mjs
@@ -1,0 +1,163 @@
+import {setup} from '../../setup.mjs';
+
+setup({appConfig: {name: 'NeoDockAuthoringTest'}});
+
+import {test, expect}    from '@playwright/test';
+import Neo               from '../../../../src/Neo.mjs';
+import * as core         from '../../../../src/core/_export.mjs';
+import Authoring         from '../../../../src/dashboard/dock/model/Authoring.mjs';
+import WorkspaceDocument from '../../../../src/dashboard/dock/model/WorkspaceDocument.mjs';
+import Persistence       from '../../../../src/dashboard/dock/model/Persistence.mjs';
+
+test('reserves explicit IDs before generated allocation and preserves both panes', () => {
+    const panes  = {a: {}, b: {}},
+          zones  = {center: {orientation: 'horizontal', children: ['a', {id: 'tabs-a', items: ['b']}]}},
+          input  = structuredClone({panes, zones}),
+          result = Authoring.fromZones(panes, zones);
+
+    expect(result.errors).toEqual([]);
+    expect(result.document.nodes['tabs-a'].items).toEqual(['b']);
+    expect(result.document.nodes['tabs-a-0'].items).toEqual(['a']);
+    expect(Object.values(result.document.nodes).filter(n => n.type === 'tabs').flatMap(n => n.items)).toEqual(['a', 'b']);
+    expect(WorkspaceDocument.validate(result.document)).toEqual([]);
+    expect({panes, zones}).toEqual(input);
+
+    // The old overwrite leaves a valid-looking document with both references pointing at b.
+    const corrupt = structuredClone(result.document),
+          split   = Object.values(corrupt.nodes).find(n => n.type === 'split');
+    split.children = ['tabs-a', 'tabs-a'];
+    delete corrupt.nodes['tabs-a-0'];
+    expect(WorkspaceDocument.validate(WorkspaceDocument.normalizeTree(corrupt))).toEqual([]);
+});
+
+test('nested first-pane and delimiter collisions preserve every authored pane', () => {
+    for (const zones of [
+        {orientation: 'horizontal', children: [{orientation: 'vertical', children: ['a', 'b']}, 'c']},
+        {left: {orientation: 'horizontal', children: ['a-b', 'c']}, right: {orientation: 'horizontal', children: ['a', 'b-c']}}
+    ]) {
+        const {document, errors} = Authoring.fromZones({'a-b': {}, c: {}, a: {}, b: {}, 'b-c': {}}, zones),
+              expected           = Object.hasOwn(zones, 'left') ? ['a', 'a-b', 'b-c', 'c'] : ['a', 'b', 'c'];
+        expect(errors).toEqual([]);
+        expect(Object.values(document.nodes).filter(n => n.type === 'tabs').flatMap(n => n.items).sort()).toEqual(expected);
+        expect(WorkspaceDocument.validate(document)).toEqual([]);
+    }
+});
+
+test('runtime pane config stays outside the wire while catalog policies round-trip', () => {
+    const module             = () => {}, store = new Map([['live', true]]),
+          panes              = {a: {module, store, header: {text: 'A'}, kind: 'panel', locked: false, metadata: {label: 'safe'}, blueprint: {ntype: 'panel'}}},
+          {document, errors} = Authoring.fromZones(panes, 'a');
+
+    expect(errors).toEqual([]);
+    expect(document.items.a).toEqual({componentRef: 'a', title: 'A', kind: 'panel', locked: false, metadata: {label: 'safe'}, blueprint: {ntype: 'panel'}});
+    expect(panes.a.module).toBe(module);
+    expect(panes.a.store).toBe(store);
+    document.items.a.metadata.label = 'changed';
+    expect(panes.a.metadata.label).toBe('safe');
+    const saved = Persistence.createSavedLayout(document, {layoutId: 'authoring', title: 'Authoring'});
+    expect(saved.errors).toEqual([]);
+    expect(Persistence.restoreSavedLayout(saved.layout).document).toEqual(document);
+});
+
+test('uses the ordinary pane header for authoring and export, without duplicate title metadata', () => {
+    const {document, errors} = Authoring.fromZones({a: {header: {text: 'Tab label'}, title: 'Component-only title'}, b: {title: 'Component config'}}, ['a', 'b']);
+    expect(errors).toEqual([]);
+    expect(document.items.a.title).toBe('Tab label');
+    expect(document.items.b.title).toBe('b');
+    const {config} = Authoring.toConfig(document);
+    expect(config.panes.a.header).toEqual({text: 'Tab label'});
+    expect(config.panes.a).not.toHaveProperty('title');
+    expect(Authoring.fromZones(config.panes, config.zones).document).toEqual(document);
+});
+
+const invalid = [
+    ['duplicate explicit', {center: {children: [{id: 'x', items: ['a']}, {id: 'x', items: ['b']}], orientation: 'horizontal'}}, 'zones.center.children[1].id'],
+    ['implicit root collision', {center: {id: 'root', items: ['a']}}, 'zones.center.id'],
+    ['blank explicit', {id: '', items: ['a']}, 'zones.id'],
+    ['unknown pane', {center: ['missing']}, 'zones.center[0]'],
+    ['duplicate pane', {left: 'a', center: 'a'}, 'zones.center'],
+    ['ambiguous node', {items: ['a'], children: ['b']}, 'zones.children'],
+    ['unknown field', {center: {items: ['a'], itemz: []}}, 'zones.center.itemz'],
+    ['missing discriminator', {}, 'zones'],
+    ['bad orientation', {children: ['a', 'b'], orientation: 'diagonal'}, 'zones.orientation'],
+    ['bad sizes', {children: ['a', 'b'], orientation: 'horizontal', sizes: [1]}, 'zones.sizes'],
+    ['null sizes', {children: ['a', 'b'], orientation: 'horizontal', sizes: null}, 'zones.sizes'],
+    ['bad active pane', {items: ['a'], activeItemId: 'b'}, 'zones.activeItemId'],
+    ['bad extent', {left: {items: ['a'], extent: 2}}, 'zones.left.extent'],
+    ['bad resizable', {left: {items: ['a'], resizable: 'yes'}}, 'zones.left.resizable'],
+    ['empty tabs root', [], 'zones']
+];
+
+for (const [name, zones, path] of invalid) {
+    test(`rejects ${name} at its authored path without partial output`, () => {
+        const input = structuredClone(zones), result = Authoring.fromZones({a: {}, b: {}}, zones);
+        expect(result.document).toBeNull();
+        expect(result.errors.join('\n')).toContain(path);
+        expect(zones).toEqual(input);
+    });
+}
+
+test('explicit root and independent explicit names are legal controls', () => {
+    expect(Authoring.fromZones({a: {}}, {id: 'root', items: ['a']}).errors).toEqual([]);
+    expect(Authoring.fromZones({a: {}}, {id: 'shell', center: {id: 'root', items: ['a']}}).errors).toEqual([]);
+});
+
+test('rejects invalid pane records and non-JSON catalog paths', () => {
+    for (const [pane, path] of [[null, 'panes.a'], [{metadata: {fn: () => {}}}, 'panes.a.metadata.fn'], [{header: {text: () => {}}}, 'panes.a.header.text'], [{pinned: true, autoHidden: true}, 'panes.a'], [{metadata: {pointerX: 4}}, 'panes.a']]) {
+        const result = Authoring.fromZones({a: pane}, 'a');
+        expect(result.document).toBeNull();
+        expect(result.errors.join('\n')).toContain(path);
+    }
+});
+
+test('rejects cyclic authoring input and a cyclic wire graph without recursion failure', () => {
+    const zones = {type: 'edge-zone'};
+    zones.center = zones;
+    expect(Authoring.fromZones({}, zones).errors.join()).toContain('zones.center');
+    const document = {schema: WorkspaceDocument.SCHEMA, root: 'root', items: {}, nodes: {root: {type: 'edge-zone', zones: {center: {nodeId: 'root'}}}}};
+    const result   = Authoring.toConfig(document);
+    expect(result.config).toBeNull();
+    expect(result.errors.length).toBeGreaterThan(0);
+});
+
+test('refuses prototype-setter keys that the existing document clone would silently lose', () => {
+    const panes    = JSON.parse('{"__proto__": {}}'),
+          catalog  = Authoring.fromZones(panes, '__proto__'),
+          metadata = Authoring.fromZones({a: {metadata: JSON.parse('{"__proto__": {"label": "keep"}}')}}, 'a'),
+          explicit = Authoring.fromZones({a: {}}, {id: '__proto__', items: ['a']});
+    for (const result of [catalog, metadata, explicit]) {
+        expect(result.document).toBeNull();
+        expect(result.errors.join()).toContain('__proto__');
+    }
+    const wire = {schema: WorkspaceDocument.SCHEMA, root: 'root', items: panes, nodes: {root: {type: 'edge-zone', zones: {}}}};
+    expect(Authoring.toConfig(wire).config).toBeNull();
+    expect(Authoring.fromZones({constructor: {}, toString: {}}, ['constructor', 'toString']).errors).toEqual([]);
+});
+
+test('export refuses split fields that cannot return through the authoring grammar', () => {
+    const source = Authoring.fromZones({a: {}, b: {}}, {orientation: 'horizontal', children: ['a', 'b']}).document;
+    for (const [field, value] of [['orientation', 'diagonal'], ['orientation', undefined], ['sizes', [2, -1]]]) {
+        const document = structuredClone(source);
+        if (value === undefined) delete document.nodes.root[field];
+        else document.nodes.root[field] = value;
+        // Existing wire validation is permissive here; export must not promise a broken inverse.
+        expect(WorkspaceDocument.validate(document)).toEqual([]);
+        expect(Persistence.createSavedLayout(document).errors).toEqual([]);
+        const result = Authoring.toConfig(document);
+        expect(result.config).toBeNull();
+        expect(result.errors.join()).toContain(`document.nodes.root.${field}`);
+    }
+    const exported = Authoring.toConfig(source);
+    expect(exported.errors).toEqual([]);
+    expect(Authoring.fromZones(exported.config.panes, exported.config.zones).document).toEqual(source);
+});
+
+test('export names malformed options and unsupported node types without throwing', () => {
+    const source = Authoring.fromZones({a: {}}, 'a').document;
+    expect(Authoring.toConfig(source, null).errors.join()).toContain('options');
+    expect(Authoring.toConfig(source, {keepIds: 'yes'}).errors.join()).toContain('options.keepIds');
+    source.nodes.root.type = 'constructor';
+    const result = Authoring.toConfig(source);
+    expect(result.config).toBeNull();
+    expect(result.errors.join()).toContain('document.nodes.root.type');
+});

--- a/test/playwright/unit/dashboard/DockAuthoring.spec.mjs
+++ b/test/playwright/unit/dashboard/DockAuthoring.spec.mjs
@@ -154,10 +154,92 @@ test('export refuses split fields that cannot return through the authoring gramm
 
 test('export names malformed options and unsupported node types without throwing', () => {
     const source = Authoring.fromZones({a: {}}, 'a').document;
+    expect(Authoring.toConfig(source, {keepIds: undefined})).toEqual(Authoring.toConfig(source));
+    expect(Authoring.toConfig(source, {keepIds: null}).errors.join()).toContain('options.keepIds');
     expect(Authoring.toConfig(source, null).errors.join()).toContain('options');
     expect(Authoring.toConfig(source, {keepIds: 'yes'}).errors.join()).toContain('options.keepIds');
     source.nodes.root.type = 'constructor';
     const result = Authoring.toConfig(source);
     expect(result.config).toBeNull();
     expect(result.errors.join()).toContain('document.nodes.root.type');
+});
+
+test('lowering reports independent catalog, node and sibling errors in one refusal', () => {
+    const panes = {a: {locked: 'yes'}, b: null, c: {locked: 'yes', metadata: {first: () => {}, second: () => {}}}},
+          zones = {left: {items: ['missing'], extent: 2, resizable: 'yes'},
+              center: {orientation: 'diagonal', sizes: [1], children: ['a', {items: ['b'], activeItemId: 'other'}]}},
+          result = Authoring.fromZones(panes, zones);
+
+    expect(result.document).toBeNull();
+    for (const path of ['panes.a', 'panes.b', 'panes.c.metadata.first', 'panes.c.metadata.second',
+        'zones.left.items[0]', 'zones.left.extent', 'zones.left.resizable',
+        'zones.center.orientation', 'zones.center.sizes', 'zones.center.children[1].activeItemId']) {
+        expect(result.errors.join('\n'), path).toContain(path)
+    }
+    expect(result.errors.join('\n')).not.toContain('unknown pane "b"');
+    expect(result.errors.join('\n')).toContain('panes.c: item "c" locked must be a boolean');
+});
+
+test('lowering stops a cyclic or malformed branch while checking its independent siblings', () => {
+    const zones = {type: 'edge-zone', left: null, right: {items: ['missing']}};
+    zones.center = zones;
+    const result = Authoring.fromZones({a: {pinned: true, autoHidden: true}}, zones);
+
+    expect(result.document).toBeNull();
+    for (const path of ['panes.a', 'zones.left', 'zones.right.items[0]', 'zones.center']) {
+        expect(result.errors.join('\n'), path).toContain(path)
+    }
+    expect(result.errors.join('\n')).toContain('cyclic');
+    expect(result.errors.join('\n')).not.toMatch(/call stack|zones\.center\./);
+});
+
+test('lowering retains JSON admission for symbols, hidden properties and non-JSON array members', () => {
+    const hidden = () => {}, key = Symbol('hidden'),
+          zones  = {left: ['a'], right: {items: ['b']}, center: [hidden]};
+    zones.left[key] = hidden;
+    Object.defineProperty(zones.right, 'opaque', {value: hidden});
+    const result = Authoring.fromZones({a: {}, b: {}}, zones);
+
+    expect(result.document).toBeNull();
+    for (const path of ['zones.left[Symbol(hidden)]', 'zones.right.opaque', 'zones.center[0]']) {
+        expect(result.errors.join('\n'), path).toContain(path)
+    }
+    expect(zones.left[key]).toBe(hidden);
+    expect(Object.getOwnPropertyDescriptor(zones.right, 'opaque').value).toBe(hidden);
+});
+
+test('export reports catalog and sibling node failures even when another node is malformed', () => {
+    const document = {schema: WorkspaceDocument.SCHEMA, root: 'root', items: {a: {locked: 'yes'}, b: null}, nodes: {
+        root    : {type: 'split', orientation: 'diagonal', sizes: [1], children: ['broken', 'tabs']},
+        broken  : null,
+        tabs    : {type: 'tabs', items: ['a'], activeItemId: 'other'},
+        badSplit: {type: 'split', orientation: 'vertical', children: {}, sizes: {}},
+        badTabs : {type: 'tabs', items: {a: true}}
+    }}, before = structuredClone(document), result = Authoring.toConfig(document, {keepIds: 'yes'});
+
+    expect(result.config).toBeNull();
+    for (const path of ['options.keepIds', 'item "a" locked', 'document.items.b',
+        'document.nodes.root.orientation', 'document.nodes.root.sizes', 'document.nodes.broken',
+        'tabs "tabs" activeItemId', 'split "badSplit" children', 'split "badSplit" sizes', 'tabs "badTabs" items']) {
+        expect(result.errors.join('\n'), path).toContain(path)
+    }
+    expect(result.errors.join('\n')).not.toContain('document.nodes.broken.');
+    expect(document).toEqual(before);
+    const canonicalErrors = WorkspaceDocument.validate(document).join('\n');
+    for (const message of ['node "broken"', 'split "badSplit" children', 'split "badSplit" sizes', 'tabs "badTabs" items', 'tabs "tabs" activeItemId']) {
+        expect(canonicalErrors).toContain(message)
+    }
+});
+
+test('export detects a graph cycle without hiding independent catalog and node errors', () => {
+    const document = {schema: WorkspaceDocument.SCHEMA, root: 'root', items: {a: {locked: 'yes'}}, nodes: {
+        root: {type: 'edge-zone', zones: {left: {nodeId: 'root'}, center: {nodeId: 'tabs'}}},
+        tabs: {type: 'tabs', items: ['a'], activeItemId: 'missing'}
+    }}, result = Authoring.toConfig(document);
+
+    expect(result.config).toBeNull();
+    expect(result.errors.join('\n')).toContain('item "a" locked');
+    expect(result.errors.join('\n')).toContain('tabs "tabs" activeItemId');
+    expect(result.errors.join('\n')).toContain('cycle');
+    expect(result.errors.join('\n')).not.toContain('call stack');
 });

--- a/test/playwright/unit/dashboard/DockAuthoringRoundTrip.spec.mjs
+++ b/test/playwright/unit/dashboard/DockAuthoringRoundTrip.spec.mjs
@@ -1,0 +1,259 @@
+import {setup} from '../../setup.mjs';
+
+setup({appConfig: {name: 'NeoDashboardDockAuthoringRoundTripTest'}});
+
+import {test, expect}                   from '@playwright/test';
+import Neo                              from '../../../../src/Neo.mjs';
+import * as core                        from '../../../../src/core/_export.mjs';
+import Authoring                        from '../../../../src/dashboard/dock/model/Authoring.mjs';
+import Operations                       from '../../../../src/dashboard/dock/model/Operations.mjs';
+import Persistence                      from '../../../../src/dashboard/dock/model/Persistence.mjs';
+import WorkspaceDocument                from '../../../../src/dashboard/dock/model/WorkspaceDocument.mjs';
+import {initialDocument as demoA}       from '../../../../examples/dashboard/choreography/demoADockChoreography.mjs';
+import {initialDocument as demoB}       from '../../../../examples/dashboard/crossWindow/demoBPerspectives.mjs';
+import {initialDocument as workstation} from '../../../../apps/workstation/tour/denseWorkstation.mjs';
+
+const EDGES = ['top', 'right', 'bottom', 'left', 'center'];
+
+/**
+ * @summary The standalone dock example's non-exported initial document, without importing its UI.
+ * @type {Object}
+ */
+const example = {
+    schema: 'neo.dock.zone.v1',
+    root  : 'root',
+    items : {
+        strategy : {componentRef: 'Strategy',  title: 'Strategy',  kind: 'panel'},
+        swarm    : {componentRef: 'Swarm',     title: 'Swarm',     kind: 'panel'},
+        terminal : {componentRef: 'Terminal',  title: 'Terminal',  kind: 'terminal'},
+        logs     : {componentRef: 'Logs',      title: 'Logs',      kind: 'panel'},
+        inspector: {componentRef: 'Inspector', title: 'Inspector', kind: 'panel'},
+        metrics  : {componentRef: 'Metrics',   title: 'Metrics',   kind: 'panel'},
+        timeline : {componentRef: 'Timeline',  title: 'Timeline',  kind: 'panel'},
+        agents   : {componentRef: 'Agents',    title: 'Agents',    kind: 'panel'},
+        alerts   : {componentRef: 'Alerts',    title: 'Alerts',    kind: 'panel'},
+        history  : {componentRef: 'History',   title: 'History',   kind: 'panel'}
+    },
+    nodes: {
+        root            : {type: 'edge-zone', zones: {center: {nodeId: 'root-split'}, right: {nodeId: 'inspector-tabs', extent: 0.25, resizable: true}}},
+        'root-split'    : {type: 'split', orientation: 'horizontal', children: ['main-tabs', 'side-split'], sizes: [0.65, 0.35]},
+        'main-tabs'     : {type: 'tabs', items: ['strategy', 'swarm', 'metrics', 'timeline', 'agents', 'alerts', 'history'], activeItemId: 'strategy'},
+        'side-split'    : {type: 'split', orientation: 'vertical', children: ['terminal-tabs', 'logs-tabs'], sizes: [0.6, 0.4]},
+        'terminal-tabs' : {type: 'tabs', items: ['terminal'], activeItemId: 'terminal'},
+        'logs-tabs'     : {type: 'tabs', items: ['logs'], activeItemId: 'logs'},
+        'inspector-tabs': {type: 'tabs', items: ['inspector'], activeItemId: 'inspector'}
+    }
+};
+
+/**
+ * @summary The comparison contract: normalize structure, then default only catalog title/reference.
+ * @param {Object} document
+ * @returns {Object}
+ */
+function expectedDocument(document) {
+    const result = WorkspaceDocument.normalizeTree(document);
+
+    for (const [key, item] of Object.entries(result.items)) {
+        result.items[key] = {...item, componentRef: item.componentRef ?? key, title: item.title ?? key}
+    }
+
+    return result
+}
+
+/**
+ * @summary Removes structural naming from the oracle through ordered DFS renaming; catalog stays exact.
+ * @param {Object} document A normalized tree.
+ * @returns {Object}
+ */
+function canonical(document) {
+    const ids = new Map(), nodes = {};
+
+    const visit = oldId => {
+        const id = `n${ids.size}`, node = structuredClone(document.nodes[oldId]);
+        ids.set(oldId, id);
+        nodes[id] = node;
+
+        if (node.type === 'split') node.children = node.children.map(visit);
+        if (node.type === 'edge-zone') {
+            for (const edge of EDGES) {
+                if (node.zones[edge]) node.zones[edge].nodeId = visit(node.zones[edge].nodeId)
+            }
+        }
+
+        return id
+    };
+
+    return {schema: document.schema, root: visit(document.root), items: document.items, nodes}
+}
+
+/**
+ * @summary Checks both export modes against the model oracle and checks all inputs remain unchanged.
+ * @param {Object} document
+ * @param {String} label
+ * @returns {void}
+ */
+function assertRoundTrip(document, label) {
+    const before = structuredClone(document), expected = expectedDocument(document);
+
+    expect(WorkspaceDocument.validate(expected), `${label}: valid source`).toEqual([]);
+    expect(Persistence.createSavedLayout(expected).errors, `${label}: persistable source`).toEqual([]);
+
+    for (const keepIds of [true, false]) {
+        const exported = keepIds ? Authoring.toConfig(document) : Authoring.toConfig(document, {keepIds});
+        expect(exported.errors, `${label}: export keepIds=${keepIds}`).toEqual([]);
+        expect(exported.config, `${label}: exported config`).not.toBeNull();
+
+        const configBefore = structuredClone(exported.config),
+              lowered      = Authoring.fromZones(exported.config.panes, exported.config.zones);
+
+        expect(lowered.errors, `${label}: lower keepIds=${keepIds}`).toEqual([]);
+        expect(lowered.document, `${label}: lowered document`).not.toBeNull();
+        expect(WorkspaceDocument.validate(lowered.document), `${label}: valid result`).toEqual([]);
+        expect(Persistence.createSavedLayout(lowered.document).errors, `${label}: persistable result`).toEqual([]);
+        expect(keepIds ? lowered.document : canonical(lowered.document), `${label}: round trip keepIds=${keepIds}`)
+            .toEqual(keepIds ? expected : canonical(expected));
+        expect(Authoring.fromZones(exported.config.panes, exported.config.zones), `${label}: deterministic lowering`).toEqual(lowered);
+        expect(exported.config, `${label}: untouched authored input`).toEqual(configBefore)
+    }
+
+    expect(document, `${label}: untouched wire input`).toEqual(before)
+}
+
+/**
+ * @summary Generates bounded JSON trees, not arbitrary valid documents: depth <= 3, all root types,
+ * empty edge zones, one-to-three-item tabs, two/three-child splits, policy flags and catalog-only items.
+ * @param {Number} seed
+ * @returns {Object}
+ */
+function randomDocument(seed) {
+    let   state   = seed >>> 0, nodeIndex = 0, itemIndex = 0;
+    const items   = {}, nodes = {};
+    const random  = () => ((state = (Math.imul(state, 1664525) + 1013904223) >>> 0) / 0x100000000);
+    const integer = max => Math.floor(random() * max);
+
+    const item = () => {
+        const id = `pane-${seed}-${itemIndex++}`, record = {}, autoHidden = random() < 0.25;
+        if (random() < 0.7) record.componentRef = `component-${id}`;
+        if (random() < 0.7) record.title = `Pane ${id}`;
+        if (random() < 0.5) record.kind = 'panel';
+        Object.assign(record, {autoHidden, pinned: !autoHidden && random() < 0.3,
+            closable: random() < 0.8, pinnable: random() < 0.8, lockable: random() < 0.8,
+            locked  : random() < 0.3, movable: random() < 0.8});
+        if (random() < 0.5) record.metadata = {sample: seed, labels: ['generated', null, true]};
+        if (random() < 0.3) record.blueprint = {ntype: 'component', text: id, data: {sample: seed}};
+        items[id] = record;
+        return id
+    };
+
+    const tree = (depth, forced) => {
+        const id = `node-${nodeIndex++}`, type = forced ?? (depth >= 3 ? 0 : integer(3));
+        if (type === 0) {
+            const members = Array.from({length: 1 + integer(3)}, item);
+            nodes[id] = {type: 'tabs', items: members};
+            if (random() < 0.8) nodes[id].activeItemId = random() < 0.2 ? null : members[integer(members.length)]
+        } else if (type === 1) {
+            const children = Array.from({length: 2 + integer(2)}, () => tree(depth + 1));
+            nodes[id] = {type: 'split', orientation: random() < 0.5 ? 'horizontal' : 'vertical',
+                children, sizes: children.map(() => 1 / children.length)}
+        } else {
+            const zones = {};
+            for (const edge of EDGES) {
+                if (random() < 0.35) {
+                    zones[edge] = {nodeId: tree(depth + 1)};
+                    if (random() < 0.7) zones[edge].extent = (1 + integer(4)) / 10;
+                    if (random() < 0.7) zones[edge].resizable = random() < 0.5
+                }
+            }
+            nodes[id] = {type: 'edge-zone', zones}
+        }
+        return id
+    };
+
+    const root = tree(0, seed % 3);
+    for (let i = integer(3); i > 0; i--) item();
+
+    return WorkspaceDocument.normalizeTree({schema: WorkspaceDocument.SCHEMA, root, items, nodes})
+}
+
+test.describe('Neo.dashboard.dock.model.Authoring round trips', () => {
+    for (const [name, document] of Object.entries({example, demoA, demoB, workstation})) {
+        test(`preserves the representative ${name} document in both export modes`, () => {
+            assertRoundTrip(document, name)
+        })
+    }
+
+    test('preserves every catalog field and defaults minimal records without losing catalog-only items', () => {
+        const document = {
+            schema: WorkspaceDocument.SCHEMA, root: 'main',
+            items : {
+                a: {componentRef: 'OtherFactory', title: 'Full pane', kind: 'panel', closable: false,
+                    pinnable : true, pinned: true, autoHidden: false, lockable: true, locked: true, movable: false,
+                    metadata : {label: 'catalog', values: [1, null, false]},
+                    blueprint: {ntype: 'component', text: 'Recovery', data: {record: 7}}},
+                b: {}, c: {title: 'Catalog only'}
+            },
+            nodes: {main: {type: 'tabs', items: ['a', 'b'], activeItemId: null}}
+        };
+
+        assertRoundTrip(document, 'complete and minimal catalog');
+        const {config} = Authoring.toConfig(document);
+        expect(Object.keys(config.panes).sort()).toEqual(['a', 'b', 'c'])
+    });
+
+    test('keeps detached and closed catalogs distinct even when their normalized trees are equal', () => {
+        const detached = Operations.detachItem(example, {itemId: 'inspector'}),
+              closed   = Operations.closeItem(example, {itemId: 'inspector'});
+
+        expect(detached.errors).toEqual([]);
+        expect(closed.errors).toEqual([]);
+        expect(detached.document.nodes).toEqual(closed.document.nodes);
+        expect(detached.document.items.inspector).toBeDefined();
+        expect(closed.document.items.inspector).toBeUndefined();
+        assertRoundTrip(detached.document, 'detached');
+        assertRoundTrip(closed.document, 'closed')
+    });
+
+    test('preserves empty nested edges and normalizes an emptied tabs child without deleting its catalog', () => {
+        assertRoundTrip({schema: WorkspaceDocument.SCHEMA, root: 'shell', items: {a: {}}, nodes: {
+            shell       : {type: 'edge-zone', zones: {left: {nodeId: 'empty-edge'}, center: {nodeId: 'empty-tabs'}}},
+            'empty-edge': {type: 'edge-zone', zones: {}},
+            'empty-tabs': {type: 'tabs', items: []}
+        }}, 'empty nested edge and pruned tabs');
+        assertRoundTrip({schema: WorkspaceDocument.SCHEMA, root: 'empty', items: {},
+            nodes: {empty: {type: 'edge-zone', zones: {}}}}, 'empty root')
+    });
+
+    test('accepts a split root without adding an edge wrapper', () => {
+        assertRoundTrip({schema: WorkspaceDocument.SCHEMA, root: 'split-root', items: {a: {}, b: {}}, nodes: {
+            'split-root': {type: 'split', orientation: 'vertical', children: ['left', 'right'], sizes: [0.3, 0.7]},
+            left        : {type: 'tabs', items: ['a'], activeItemId: 'a'},
+            right       : {type: 'tabs', items: ['b'], activeItemId: 'b'}
+        }}, 'split root')
+    });
+
+    test('round-trips 400 seeded bounded trees with explicit domain-coverage controls', () => {
+        const rootTypes   = new Set();
+        let   catalogOnly = 0, nestedEdges = 0, autoHidden = 0, missingFields = 0, blueprints = 0;
+
+        for (let seed = 1; seed <= 400; seed++) {
+            const document = randomDocument(seed), placed = new Set();
+            rootTypes.add(document.nodes[document.root].type);
+            for (const [id, node] of Object.entries(document.nodes)) {
+                if (node.type === 'tabs') node.items.forEach(itemId => placed.add(itemId));
+                if (node.type === 'edge-zone' && id !== document.root) nestedEdges++
+            }
+            catalogOnly += Object.keys(document.items).filter(id => !placed.has(id)).length;
+            for (const item of Object.values(document.items)) {
+                if (item.autoHidden) autoHidden++;
+                if (item.title === undefined || item.componentRef === undefined) missingFields++;
+                if (item.blueprint) blueprints++
+            }
+            assertRoundTrip(document, `seed ${seed}`)
+        }
+
+        expect([...rootTypes].sort()).toEqual(['edge-zone', 'split', 'tabs']);
+        for (const [dimension, count] of Object.entries({catalogOnly, nestedEdges, autoHidden, missingFields, blueprints})) {
+            expect(count, `generator actually exercises ${dimension}`).toBeGreaterThan(0)
+        }
+    });
+});


### PR DESCRIPTION
Resolves #18475

Adds `model.Authoring.fromZones(panes, zones)` and `toConfig(document, {keepIds})`: pure conversion between nested pane arrangements and the existing dock document. Explicit IDs are reserved before generated allocation, catalog-only panes survive export, and runtime component configuration stays outside the wire. Errors name the authored path. The model reference documents defaults, normalization and the inverse contract.

Related: #18474
Refs #18476
Refs #18477

Evidence: L2 (executed pure model, schema and persistence round trips) → L2 required (this leaf's model boundary). No residual ACs.

## AC Evidence

| Criterion | Evidence |
|---|---|
| AC-1 | `Authoring.mjs` imports only Base and WorkspaceDocument; static-closure receipt below. CI-covered: `DockAuthoring*.spec.mjs` checks untouched inputs and deterministic lowering. |
| AC-2 | CI-covered: `DockAuthoringRoundTrip.spec.mjs` exercises the dock example, Demo A/B, Workstation, full/minimal/unplaced catalogs, detached versus closed, empty edges and all roots; 400 seeded bounded trees with domain coverage assertions. `DockAuthoring.spec.mjs` carries the named collision controls. |
| AC-3 | CI-covered: retained-ID comparison after defaults + normalizeTree, IDs-dropped canonical DFS comparison, and unchanged complete-field control in `DockAuthoringRoundTrip.spec.mjs`. |
| AC-4 | CI-covered: explicit/generated collision preserves both panes; duplicate/root IDs fail before lowering; the old corrupt graph still passing model validation is pinned as a red control. |
| AC-5 | CI-covered: authored-path refusal, independent error aggregation, malformed/cyclic branch controls, no partial output, executable config exclusion and Persistence save/read controls in `DockAuthoring.spec.mjs`. |
| AC-6 | `learn/agentos/DockZoneModel.md` documents authoring/export/defaults and makes kind optional; `Authoring` JSDoc documents the public API. `npm run generate-docs-json` supplies the tracked class-hierarchy entry. |
| AC-7 | Deletion ledger below names the concrete consumer responsibility and its dependent delivery owner. |

## Deltas from ticket

The sibling-module structural fast-path matches `TopologyDiff` and leaves existing model/host owners unchanged. Both public methods return a null result with errors on refusal. Export uses `header.text`, preserving the discussion's pane-header idiom.

Validation accumulates independent errors across readable catalog and node branches, with no partial result. A named static `orientations` list follows the `button.Base.iconPositions` convention; the custom `require` assertion helper is removed. Malformed/cyclic branches stop safely before recursive graph operations.

`WorkspaceDocument.validate` now reports malformed node containers and continues safe siblings. Its existing item-policy rules are factored into one shared method, so invalid opaque metadata does not hide an independent policy error and Authoring does not duplicate those rules. The valid wire contract is unchanged.

Two additional refusal controls prevent a misleading successful inverse: own `__proto__` keys are rejected before the existing clone can lose them; missing/unknown split orientation and negative weights are rejected on export despite the older wire validator admitting them. These limits are documented and tested here; no core clone or wire-validator change is included.

Decision Record impact: aligned with ADR 0029's JSON-first model. The consuming-surface amendment remains in the dependent host leaf.

## Deletion ledger

| Engine addition | Consumer responsibility removed | Delivery owner |
|---|---|---|
| `model.Authoring` | Hand-maintained structural node IDs, node references and flat initial graph in `examples/dashboard/dock/MainContainer.mjs` | #18477, after host #18476. The deletion is pending and is not claimed as shipped by this model prerequisite. |

## Test Evidence

All behavioral coverage runs in CI. Local static closure (`node buildScripts/util/static-closure.mjs --list src/dashboard/dock/model/Authoring.mjs`) contains 10 modules: the new helper, WorkspaceDocument and their existing core dependencies. No host/projection, Transaction, History, TopologyLibrary, bare import or dynamic target enters it.

The unrestricted local unit command encounters pre-existing untracked hook specs importing retired Engine `ai/` paths. The tracked Engine unit selection plus both new specs passes; those unrelated local files were preserved.

## Signal Ledger

Stage-one source: [D18468 graduation record](https://github.com/neomjs/neo/discussions/18468). The five native leaves and both required guides were independently reviewed on the parent.

| Family | Signal | Anchor |
|---|---|---|
| claude | Vega author signal and Mnemosyne step-back, scoped to standalone static authoring | Discussion body; [step-back](https://github.com/neomjs/neo/discussions/18468#discussioncomment-18348991) |
| gpt | Euclid graduation approval for that stage | [approval](https://github.com/neomjs/neo/discussions/18468#discussioncomment-18349155) |

## Unresolved Dissent

None for the graduated stage. Persistence, multi-window and bound-pane tiers remain outside this leaf and its approval.

## Unresolved Liveness

Not applicable per the source graduation record: no consensus/core-value mutation.

## Post-Merge Validation

None required for this model-only close target. Host, example and guide adoption remain open on the native dependency graph.

## Commits

- `be46415ead` — pure model conversion, regression corpus and reference contract.
- `bb97e142cc` — generator-produced class-hierarchy registration.
- `1a162cda6c` — named orientation values and direct validation guards; removes the custom assertion wrapper.
- `c599004a40` — reports independent authoring errors together, reusing shared item policy and safely guarded document validation.

Authored by Euclid (GPT-6, Codex). Session 4f9b7bbe-9dbc-4d36-a167-38fe0d288113.
