### PR TITLE
chore(deps): exact-pin neo-agent-skills so a release cannot land unread (#18484)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,9 +18,14 @@ updates:
     groups:
       all-deps:
         patterns: ["*"]
-        # Monaco is exact-pinned: a version bump requires addon/wrapper compatibility checks.
-        # Keep its update in a standalone PR so it cannot hide inside the bulk dependency diff.
-        exclude-patterns: ["monaco-editor"]
+        # Both exclusions are exact-pinned, for the same reason: their diff has to be read, and a
+        # standalone PR is the only place that happens. Inside the bulk bump it gets skimmed.
+        #
+        # Monaco: a version bump requires addon/wrapper compatibility checks.
+        # neo-agent-skills: `.claude/skills/*` symlinks into it, so a release rewrites the workflows
+        # every agent in this checkout obeys. A caret would let install date decide which rules an
+        # agent reads; the exact pin makes that a reviewed fact instead.
+        exclude-patterns: ["monaco-editor", "neo-agent-skills"]
 
   - package-ecosystem: github-actions
     directory: "/"

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
                 "marked": "^18.0.11",
                 "mermaid": "^11.17.2",
                 "monaco-editor": "0.56.0",
-                "neo-agent-skills": "^0.1.3",
+                "neo-agent-skills": "0.1.4",
                 "parse5": "^8.0.1",
                 "postcss": "^8.5.28",
                 "sass": "^1.104.0",
@@ -6136,9 +6136,9 @@
             }
         },
         "node_modules/neo-agent-skills": {
-            "version": "0.1.3",
-            "resolved": "https://registry.npmjs.org/neo-agent-skills/-/neo-agent-skills-0.1.3.tgz",
-            "integrity": "sha512-RQsVHa7uhw6T5DVmhpR66/Kicige5TmqdMpiKr4unKDcDMQT/AOvGSn/wnsbIA/PlhE0oS/5IdxascVsJsTx0g==",
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/neo-agent-skills/-/neo-agent-skills-0.1.4.tgz",
+            "integrity": "sha512-N/oASEW/1OATIhrD74uXjwTJeeDffEBoZP3FuYAPuBsHUi5/as57/AznmguiLJJqm4w01iNfr+/vCzdZJrVhjA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -6148,7 +6148,8 @@
                 "neo-agent-skills-materialize": "scripts/materialize-harness-skills.mjs",
                 "neo-agent-skills-pr-body": "scripts/check-pr-body.mjs",
                 "neo-agent-skills-substrate-size": "scripts/check-substrate-size.mjs",
-                "neo-agent-skills-ticket-archaeology": "scripts/check-ticket-archaeology.mjs"
+                "neo-agent-skills-ticket-archaeology": "scripts/check-ticket-archaeology.mjs",
+                "neo-agent-skills-workflow-concurrency": "scripts/check-workflow-concurrency.mjs"
             },
             "engines": {
                 "node": ">=24.0.0"

--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
         "marked"                       : "^18.0.11",
         "mermaid"                      : "^11.17.2",
         "monaco-editor"                : "0.56.0",
-        "neo-agent-skills"             : "^0.1.3",
+        "neo-agent-skills"             : "0.1.4",
         "parse5"                       : "^8.0.1",
         "postcss"                      : "^8.5.28",
         "sass"                         : "^1.104.0",


### PR DESCRIPTION
Resolves #18484

`.claude/skills/*` symlink into `node_modules/neo-agent-skills`. The lockfile pinned **0.1.3**; **0.1.4** has been on npm since this morning. Every agent in a fresh checkout was reading 0.1.3's `ticket-intake`, which still instructs them to apply the `not-code-ready` label that neomjs/neo-agent-skills#52 / neomjs/neo-agent-skills#53 retired.

Evidence: L2 (mechanism probe on the installed bytes, both arms; repo history as the discriminator for the no-bot claim) → L2 required. Residual: none.

## AC Evidence

| AC | Evidence |
|---|---|
| AC-1 | `package.json` declares `"neo-agent-skills": "0.1.4"`, was `"^0.1.3"`. Rationale sits in `.github/dependabot.yml` beside the `monaco-editor` precedent, because JSON carries no comments |
| AC-2 | Installed version **0.1.4**. On `ticket-intake-workflow.md`: `update_issue_relationship` → **2** (was 0), `not-code-ready` → **0** (was 3). Identical counts through `.claude/skills/ticket-intake/…`, the path agents actually read |
| AC-3 | `gh pr checks` on this head. **Narrowed from the filed text** — CI pins its baseline by git SHA, not by npm version, so this diff cannot move it |

## Why no bot moved it

`^0.1.3` already spans 0.1.4 on a 0.x version, so the manifest requirement is satisfied and no version-update PR is raised. Supported by this repo's history rather than by documented behaviour:

- Dependabot is live here — #18464, #18442, #18325, #18326, #18132 all merged.
- It has **never** moved `neo-agent-skills`. Both hops were hand-authored: `40edf8abfa` (#18045) and `21da68021a` (#17799).
- `^0.1.2` likewise already permitted 0.1.3. Same shape, twice, in the same window.

## What this diff does not add

No script, no workflow, no guard. The exact pin puts future releases outside the declared range so the existing daily `all-deps` group raises the PR, and the group exclusion keeps that diff standalone rather than buried in a bulk bump — the rationale this file already applies to `monaco-editor`.

The load-bearing reason is not automation. Under a caret the substrate version is decided by **install date**, so two agents on the same commit can read different rules. The pin makes the governing substrate a reviewed fact.

## Scope boundary

neomjs/neo-agent-skills#56 owns the producer half — merged substrate coupled to no published version. This is the consumer half; neither subsumes the other.

0.1.4 also ships a `neo-agent-skills-workflow-concurrency` bin that this repo calls zero times. Executed against this branch it reports **17 cancelling blocks of 20 across 28 workflow files, all rerun-safe, exit 0** — no defect, so no scope is added here. The absent caller belongs with neomjs/neo-agent-skills#38.

Out of scope: neo's tracked `.agents/skills/**` copy, superseded by #17799 and no longer on the load path.

## Test Evidence

No behavioural code changed, so the evidence is the installed bytes and the checks that run against them.

```
installed neo-agent-skills             0.1.4   (was 0.1.3)

ticket-intake-workflow.md
  update_issue_relationship            2       (was 0)
  not-code-ready                       0       (was 3)
  same via .claude/skills/…            2       (the path agents read)

package-lock.json diff                 neo-agent-skills only — 1 version, 1 resolved
check-whitespace.mjs (pre-commit)      pass
neo-agent-skills-workflow-concurrency  17/20 blocks, all rerun-safe, exit 0
```

The 0.1.3 → 0.1.4 package diff is 8 workflow files plus one new script. `.agents/` is the only tree `.claude/skills/*` resolves into, so those 8 files are the whole behavioural surface of this bump.

## Deltas from ticket

AC-3 narrowed before this PR opened. The filed text claimed CI would exercise 0.1.4's baseline; `.github/workflows/pr-baseline.yml:73` pins `reusable-pr-baseline.yml@f5fcb7f1` by SHA, so the npm version and the CI baseline are independent surfaces — the exact conflation this ticket exists to separate. Recorded at [#18484 comment](https://github.com/neomjs/neo/issues/18484#issuecomment-5587575433).

## Post-Merge Validation

- [ ] When 0.1.5 publishes, a **standalone** Dependabot PR for `neo-agent-skills` appears with no human action. That is the mechanism claim, and it cannot be demonstrated pre-merge.

---

Authored by Grace (Claude Opus 5, Claude Code). Session 4927990d-fb3a-4072-99c5-7811a4e26aea.
