### PR TITLE
test(build): canonicalize the generated workspace root (#18488)

### DIFF
--- a/test/playwright/unit/buildScripts/buildDependencyResolution.spec.mjs
+++ b/test/playwright/unit/buildScripts/buildDependencyResolution.spec.mjs
@@ -11,7 +11,7 @@ test.describe('build programs resolve dependencies from their own module', () =>
     let root, workspace, installedEngine;
 
     test.beforeEach(() => {
-        root            = fs.mkdtempSync(path.join(os.tmpdir(), 'neo dependencies '));
+        root            = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'neo dependencies ')));
         workspace       = path.join(root, 'consumer app');
         installedEngine = path.join(workspace, 'node_modules/neo.mjs');
         // Unmodified output of createPackageJson.init('WorkspaceProbe', ...).


### PR DESCRIPTION
Resolves #18488

Carries @neo-gpt-emmy's `f518018c2a`, which landed on `codex/17868-consumer-dependency-resolution` after #18486 merged and so reached no branch any CI would read. Relabelled to #18488 at her request; `--author` preserves her. #17868 is closed and stays closed.

Evidence: L2 (red→green on a seat whose aliased tmpdir is asserted before the run; full audit of the candidate population) → L2 required. Residual: none.

## AC Evidence

| AC | Evidence |
|---|---|
| AC-1 | `fs.realpathSync(fs.mkdtempSync(…))` canonicalizes once at construction, so every derived path is correct downstream rather than normalised per comparison |
| AC-2 | **Audited empirically, and the answer narrows this ticket sharply — see below** |
| AC-3 | Predicate asserted before the run, then `4 failed 2 passed` → `6 passed`, with `/private/var` mismatches **30 → 0** |
| AC-4 | **Revised down on evidence — see Deltas** |

## The trigger

```js
os.tmpdir() !== fs.realpathSync(os.tmpdir())
```

Where that holds, a path built from `os.tmpdir()` never matches the realpath a subprocess reports. It is a per-machine `TMPDIR`, not an operating system: the launchd default `/var/folders/<hash>/T` is aliased, a `TMPDIR` of `/private/tmp` is not. **Two maintainers on the same OS therefore disagree about whether the suite passes**, and Linux CI is canonical so it can never fail. On this class neither *"works for me"* nor *"CI is green"* carries information — which is why it survived review by two maintainers.

## AC-2 — the audit, and it found almost nothing

Static narrowing was useless: 28 unit specs build paths from `os.tmpdir()`, 15 spawn a subprocess, and a heuristic for "uses the temp root in an assertion" flagged **14 of 15**. So I ran them instead, on a seat whose aliased tmpdir was asserted first.

```
14 candidate specs executed          →  13 pass
esmWorkspaceBuild.spec.mjs           →  1 failed … NOT this class
```

That one failure was a **stale local artifact**: #18486 had just merged marked production and my tree had no `dist/marked.mjs`. After `npm run bundle-marked`, it passes 9/9. My detector had counted path *mentions* rather than path *mismatches*, which is what produced the false positive.

**So the measured exposure of this class is exactly one spec, and this PR fixes it.** `check-whitespace.spec.mjs` is the instructive counter-example: it uses an unwrapped `mkdtempSync(os.tmpdir())` and is perfectly correct, because it never compares that root against subprocess output.

## Test Evidence

```
predicate  os.tmpdir() !== realpathSync(os.tmpdir())   true   (/var/folders/9b/…/T)

RED   (original)       4 failed 2 passed    /private/var mismatches: 30
GREEN (canonicalized)  6 passed             /private/var mismatches:  0

audit, 14 candidate specs, same seat        13 pass · 1 unrelated (stale dist/marked.mjs)
```

Reported by signature rather than by count: the 30 → 0 is what identifies *this* defect rather than a coincidental green.

## Deltas from ticket

**AC-4 is revised down, and the measurement is why.** The filed text required a lint, arguing that CI can never fail on this class so prose will not hold it. That argument still stands; what changed is the population. A guard flagging unwrapped `mkdtempSync(os.tmpdir())` in `test/**` would fire on ~28 sites of which **one** was ever defective, and a check with a 27:1 false-positive rate gets escaped or disabled rather than obeyed. The alternative — a shared canonicalizing helper plus a 28-spec migration — is a large diff to close a class with one measured instance.

Recorded rather than built, with the predicate and the "works for me is worthless here" reasoning in the ticket body, so the next instance is diagnosable in one command instead of an hour. If a second instance appears, that is the revalidation trigger for building the guard, and the population argument will have changed.

## Post-Merge Validation

- [ ] Nothing to observe post-merge. The fix is verifiable only on an aliased seat, which CI is not, and the evidence above is the only surface that reports it.

---

Authored by @neo-gpt-emmy (`f518018c2a`), carried by Grace (Claude Opus 5, Claude Code). Session 4927990d-fb3a-4072-99c5-7811a4e26aea.
