### PR TITLE
feat(dock): consume initial panes and zones in Workspace (#18476)

### DIFF
--- a/buildScripts/util/file-size-baseline.json
+++ b/buildScripts/util/file-size-baseline.json
@@ -1,6 +1,6 @@
 {
     "apps/workstation/view/Workspace.mjs": 1689,
     "examples/dashboard/crossWindow/DemoBWorkspace.mjs": 2612,
-    "src/dashboard/dock/Workspace.mjs": 1035,
+    "src/dashboard/dock/Workspace.mjs": 1096,
     "src/main/addon/DragDrop.mjs": 1267
 }

--- a/learn/agentos/decisions/0029-docking-design.md
+++ b/learn/agentos/decisions/0029-docking-design.md
@@ -57,7 +57,20 @@ The normative host is the engine class **`Neo.dashboard.dock.Workspace`**
 
 Interaction surfaces (splitters, drag previews, rail tabs, pin controls) emit **operation descriptors**; the reducer commits them; the view-sync re-projects. This is the only sanctioned mutation path.
 
-A consumer contributes only what is its own, through the class's template hooks: pane resolution, reveal resolution, owner-preserved item ids, pre-refresh chrome sync, extra projection options (the hover-reveal opt-in, a drag-affordance layer's cross-zone seams, tear-out policy), and the reconciler's fast-path options. The tear-out / vessel host half (`openTearOutVessel` … `onWindowDisconnect`) is not part of the class yet: its engine/app boundary is designed with the host owners under epic `#17539` before it lifts. Before this amendment the pattern existed only as the example's code, and each flagship host carried its own copy of the loop — the measurement that motivated the class lives on `#17539`.
+A basic consumer contributes plain initial `panes` and `zones` configs. Workspace captures their effective
+values in `onAfterConstructed`, after all synchronous `construct`/`onConstructed` work, before the
+constructed event and `init()`. Model `Authoring.fromZones` lowers the arrangement once; the existing
+`afterSetMounted` owner projects the absent first shell. No consumer constructor seed, resolver,
+cache or projection hook is required.
+
+A supplied valid `dockModel` takes precedence over `zones`; invalid supplied documents fail visibly.
+Later assignments or mutations of `panes`/`zones` do not replace the document or captured definitions.
+This tier is initial-only: reactive declaration reconciliation, perspective/storage configuration and
+multi-workspace authoring are separate contracts. No persisted schema changes.
+
+Template hooks remain advanced extension points for custom resolution, owner-preserved item IDs,
+pre-refresh chrome, extra projection options and reconciliation policy. Optional native lifecycle
+composition remains governed by §2.8; it is not activated by declaring panes.
 
 #### Workspace topology across windows
 
@@ -351,13 +364,26 @@ The minimal interface between the docking shell and the product surfaces that li
 
 | The embedded surface provides | The docking shell guarantees |
 |---|---|
-| A stable `componentRef` registered with the workspace's resolver | Resolution to the live instance on every projection; the instance is **moved / re-parented, never destroyed** (landed adapter rule) — one conditioned exception, see *User-triggered recreate* below |
+| A keyed `panes` component config, or a stable `componentRef` handled by an advanced resolver | Resolution through normal Container/Card creation; live declared instances are **moved / re-parented, never destroyed** during ordinary moves and rail transitions — conditioned recreate exception below; explicit close ends the instance lifetime |
 | Optionally a `blueprint` — a serializable Neo config for creation-from-saved-state | Instantiation from blueprint when no live instance exists; recoverable placeholder (never silent drop) when neither resolves (landed placeholder + stale-ref policy) |
 | Policy hints: `closable`, `pinnable`, `movable` | Enforcement at the operation layer (e.g. `setItemPinned` / `setItemAutoHidden` reject `pinnable === false`; landed) |
 | JSON-only `metadata` — no secrets, credentials, functions, DOM, live objects | No-secret validation on every persistence path (landed, #13153 class of checks) |
 | Nothing else — no layout knowledge, no dock imports, no preview access | Semantic placement continuity across moves, splits, transfers (§2.3), perspective capture/restore (§2.2), and auto-hide transitions (§2.7); item identity (`dockItemId`) stable across all of them |
 
 Two binding consequences:
+
+Declared pane keys remain independent even when they use the same component class. The host captures
+runtime configurations separately from JSON catalog records, allocates runtime component IDs and uses
+the existing component manager to resolve live instances. Lazy loaders remain normal runtime config;
+neither functions nor live bindings enter the document. Config-created rail panes can be retained by
+their Workspace owner when rail chrome releases them. Undeclared resolver/blueprint panes retain the
+existing resolution and rail ownership behavior.
+
+Closing a declared pane removes its record and retires its instance, while preserving the captured
+declaration. `Workspace.openPane(itemId, target?)` reopens through `Operations.addItem` and the ordinary
+host commit path. Placement is an optional `addTab`/`splitNode` descriptor; unknown declarations,
+existing catalog entries and invalid placements fail without partial publication. Detached catalog
+entries use move/restore operations. `addTab` still refuses absent catalog records.
 
 - **Panes are layout-blind.** An embedded surface never reads or mutates the dock document, never listens to drag surfaces, and never persists its own placement. It experiences docking exclusively as ordinary Neo component lifecycle (mount/unmount/re-parent) plus its own config updates. A pane that "helps" with layout is a contract violation.
 - **Layout is pane-blind.** The shell knows items only as catalog records. Cockpit panes and FM-UX cards add zero cases to the docking code; if a product surface needs a new docking behavior, that behavior enters through an amendment to this ADR, not through a pane-specific branch.

--- a/learn/agentos/decisions/0029-docking-design.md
+++ b/learn/agentos/decisions/0029-docking-design.md
@@ -370,8 +370,6 @@ The minimal interface between the docking shell and the product surfaces that li
 | JSON-only `metadata` — no secrets, credentials, functions, DOM, live objects | No-secret validation on every persistence path (landed, #13153 class of checks) |
 | Nothing else — no layout knowledge, no dock imports, no preview access | Semantic placement continuity across moves, splits, transfers (§2.3), perspective capture/restore (§2.2), and auto-hide transitions (§2.7); item identity (`dockItemId`) stable across all of them |
 
-Two binding consequences:
-
 Declared pane keys remain independent even when they use the same component class. The host captures
 runtime configurations separately from JSON catalog records, allocates runtime component IDs and uses
 the existing component manager to resolve live instances. Lazy loaders remain normal runtime config;
@@ -384,6 +382,8 @@ declaration. `Workspace.openPane(itemId, target?)` reopens through `Operations.a
 host commit path. Placement is an optional `addTab`/`splitNode` descriptor; unknown declarations,
 existing catalog entries and invalid placements fail without partial publication. Detached catalog
 entries use move/restore operations. `addTab` still refuses absent catalog records.
+
+Two binding consequences:
 
 - **Panes are layout-blind.** An embedded surface never reads or mutates the dock document, never listens to drag surfaces, and never persists its own placement. It experiences docking exclusively as ordinary Neo component lifecycle (mount/unmount/re-parent) plus its own config updates. A pane that "helps" with layout is a contract violation.
 - **Layout is pane-blind.** The shell knows items only as catalog records. Cockpit panes and FM-UX cards add zero cases to the docking code; if a product surface needs a new docking behavior, that behavior enters through an amendment to this ADR, not through a pane-specific branch.

--- a/learn/guides/uibuildingblocks/DockLayoutsAdoption.md
+++ b/learn/guides/uibuildingblocks/DockLayoutsAdoption.md
@@ -11,8 +11,8 @@ are only five of them. Everything else belongs to one engine class.
 
 `Neo.dashboard.dock.Workspace` centralizes the host loop that connects a dock document to its live projection:
 refresh scheduling, reconciliation, motion and cross-zone drops. Both the minimal example and the workstation use
-that engine class today. Every snippet in this guide follows one of those live consumers, so you can compare the
-adoption pattern against a small workspace or a feature-rich one.
+that engine class today. The basic path below uses initial declarations; the existing consumers also show the advanced
+extension points for richer application integration.
 
 ## One class, five decisions
 
@@ -22,8 +22,8 @@ flowchart TD
     classDef engine fill:#1b2e4e,stroke:#3498db,stroke-width:1px,color:#eee
 
     Extend["extends Neo.dashboard.dock.Workspace"]:::yours
-    Seed["Decision 1 — seed + mount<br/>your initial document, your shell placement"]:::yours
-    Panes["Decision 2 — resolvePane<br/>your components become panes"]:::yours
+    Seed["Decision 1 — zones<br/>your initial arrangement"]:::yours
+    Panes["Decision 2 — panes<br/>your component configurations"]:::yours
     Policy["Decision 3 — policies<br/>pinnable · movable · closable<br/>the reducer is the authority"]:::yours
     Skin["Decision 4 — skin by tokens<br/>override anchor, never repaint internals"]:::yours
     Persist["Decision 5 — persistence<br/>saved layouts + perspectives"]:::yours
@@ -47,139 +47,133 @@ dock host that resolves to no live container **throws** instead of leaving stale
 `null` document projects a clean empty shell instead of exploding. Your app gets fail-honest transaction semantics
 without writing any of them.
 
-## Decision 1 — seed the document, mount the first shell
+## Decision 1 — declare the initial arrangement
 
-The class owns the loop, not your boot state. Two responsibilities stay with you forever, and the engine refuses —
-loudly — to guess either one:
+A basic workspace needs two declarations: the components you want to offer, and where they begin.
+The engine turns them into a dock document and mounts its first shell. Your subclass does not need
+a constructor, a resolver or a pane cache:
 
 ```javascript readonly
 import DockWorkspace from '../../../src/dashboard/dock/Workspace.mjs';
-import WorkspaceDocument from '../../../src/dashboard/dock/model/WorkspaceDocument.mjs';
-import Persistence from '../../../src/dashboard/dock/model/Persistence.mjs';
-
-const initialDockModel = {
-    schema: 'neo.dock.zone.v1',
-    root  : 'root',
-    items : {
-        editor : {componentRef: 'Editor',  title: 'Editor',  kind: 'panel'},
-        preview: {componentRef: 'Preview', title: 'Preview', kind: 'panel'}
-    },
-    nodes: {
-        root         : {type: 'edge-zone', zones: {center: {nodeId: 'main-split'}}},
-        'main-split' : {type: 'split', orientation: 'horizontal', children: ['editor-tabs', 'side-tabs'], sizes: [0.6, 0.4]},
-        'editor-tabs': {type: 'tabs', items: ['editor'],  activeItemId: 'editor'},
-        'side-tabs'  : {type: 'tabs', items: ['preview'], activeItemId: 'preview'}
-    }
-};
+import EditorPanel from './EditorPanel.mjs';
 
 class Workspace extends DockWorkspace {
     static config = {
         className: 'MyApp.view.Workspace',
-        layout   : {ntype: 'vbox', align: 'stretch'}
-    }
-
-    construct(config) {
-        super.construct(config);
-
-        this.dockModel = WorkspaceDocument.clone(initialDockModel);
-        this.add(this.projectDockModel())
+        layout   : {ntype: 'vbox', align: 'stretch'},
+        panes    : {
+            editor: {module: EditorPanel, header: {text: 'Editor'}},
+            preview: {
+                module: () => import('./PreviewPanel.mjs'),
+                header: {text: 'Preview'}
+            }
+        },
+        zones: {
+            center: {
+                orientation: 'horizontal',
+                children   : ['editor', 'preview'],
+                sizes      : [0.6, 0.4]
+            }
+        }
     }
 }
+
+export default Neo.setupClass(Workspace);
 ```
 
-That is a complete, working docking workspace: two tabbed zones in a resizable split, drag a tab across zones, done.
-The document is plain serializable JSON — an item **catalog** (what exists) and a **node tree** (where it lives) —
-and `WorkspaceDocument.clone` gives your seed a private copy so later commits never mutate your constant.
+Each string names a pane; an array groups panes into tabs. A split declares its orientation and
+children. An edge map places those groups around a center. You describe the arrangement directly,
+without maintaining a separate table of node IDs and references. IDs are generated once and then
+travel with the committed document.
 
-Initial edge bands use the same nested descriptor shape. Give the band a committed normalized extent and opt it into
-the splitter explicitly:
+For example, a right-hand inspector band can declare its size and resize permission in the same place:
 
 ```javascript readonly
 zones: {
-    center: {nodeId: 'main-split'},
-    right : {nodeId: 'inspector-tabs', extent: 0.25, resizable: true}
+    center: 'editor',
+    right : {items: ['preview'], extent: 0.25, resizable: true}
 }
 ```
 
-The adapter projects the right boundary splitter automatically. Move frames resize only the real band under its CSS
-min/max bounds; release emits one `resizeEdgeZone` operation. The descriptor is also what auto-hide reveal and
-perspective restore read, so there is no app-side size map to maintain.
+The engine projects the splitter, previews its movement, and commits the resulting normalized
+extent. Tab activation likewise commits the selected item automatically. Neither interaction needs
+an application listener or a parallel size/selection map.
 
-Split boundaries need even less from you: every projected split splitter previews the conserved adjacent pair live by
-default — both panes track the pointer with their total constant, bounded by both members' CSS min/max — and release
-commits one `resizeSplit` equal to the final preview. There is nothing to enable; set `liveResize: false` on a
-splitter only when you explicitly want the deferred proxy-and-commit presentation back.
+**Initial means once.** Workspace captures the effective `panes` and `zones` in
+`onAfterConstructed`, after the complete synchronous `construct` and `onConstructed` chains,
+before the `constructed` event and `init()`. You can compute initial values in either construction
+hook, including after `super.onConstructed()`. Mounting still goes through the existing
+`afterSetMounted` path. Changing or mutating either declaration after capture does not replace the
+active document or the captured pane definitions; these are plain initial configs, not live
+declaration bindings.
 
-Tab activation is equally automatic. Every projected tab strip converts its live `activeIndex` change into
-`setActiveItem`; this does not depend on close-action chrome being enabled. Do not mirror the selected tab in app state
-or add a listener of your own—the next projection reads the committed `activeItemId`.
+A valid supplied `dockModel` takes precedence over `zones`. This lets a caller restore a saved
+document while supplying the current runtime pane configurations. Invalid supplied documents and
+invalid declarations fail visibly with paths; they do not silently fall back to another layout.
+With neither declarations nor a document, the existing empty-workspace behavior remains available.
 
-Two placement configs cover the layouts real apps actually have. The example app
-(`examples/dashboard/dock/MainContainer.mjs`) puts a perspective toolbar above its shell, so it declares
-`dockShellIndex: 1` (the shell is the *second* child) and `dockProjectionConfig: {flex: 1}` (the shell takes the
-remaining height in the vbox). The workstation goes further: it mounts the projection inside a dedicated child —
-`dockHostReference: 'dock-host'` — because its drag-preview renderer and drop indicators live *beside* the projected
-shell as persistent overlay siblings that must survive every re-projection. Start with neither; add them when your
-chrome asks for them.
-
-Getting these two wrong is not subtle, which is the point: the reconciler refuses to run without a mounted shell at
-the declared index, with an error that names what is missing. No half-rendered workspace, no silent guess.
-
-**Keep the application root and workspace separate.** A `DockWorkspace` is application content, not an application
-root. Your standalone app still gets a real `Neo.container.Viewport`, and the dock workspace is its flex child:
+**Keep the application root and workspace separate.** Your app still gets a real
+`Neo.container.Viewport`, with the workspace as its flex child:
 
 ```javascript readonly
 import Viewport from '../../src/container/Viewport.mjs';
-import MainContainer from './MainContainer.mjs'; // extends Neo.dashboard.dock.Workspace
+import Workspace from './Workspace.mjs';
 
 Neo.app({
     mainView: {
         module: Viewport,
-        items : [{module: MainContainer, flex: 1}]
+        items : [{module: Workspace, flex: 1}]
     }
 })
 ```
 
-The Viewport now owns what only a Viewport should own: mounting against `document.body`, the `neo-viewport` root
-class, the body contract and its own stylesheet. Do **not** copy those configs onto your workspace, and never add
-`'Neo.container.Viewport'` to `additionalThemeFiles` to make a dashboard impersonate the root.
+The Viewport owns mounting against `document.body` and its stylesheet. Workspace already declares
+the dashboard theme dependency; if you replace `additionalThemeFiles`, retain
+`'Neo.dashboard.Container'` beside your additional dependencies.
 
-The narrower theme rule still matters. `DockWorkspace` already declares `'Neo.dashboard.Container'`, which carries
-the dock token and motion contract — splitter cursors, `--dock-*` custom properties and reveal keyframes. A subclass
-that declares its own `additionalThemeFiles` list replaces the inherited list, so repeat the dashboard entry beside
-your genuine extra dependencies. That rule preserves the workspace's own styling; it does not license borrowing a
-parent class's stylesheet instead of creating the parent.
+Start with the shell inside the workspace itself. When persistent app chrome needs another
+placement, `dockShellIndex` chooses its child index, `dockProjectionConfig` configures the projected
+root, and `dockHostReference` selects a dedicated child host. These are placement options, not a
+request to implement another mount loop. Existing consumers that explicitly seed a shell can keep
+that advanced path.
 
-## Decision 2 — your components become panes
+## Decision 2 — configure the panes your application needs
 
-The document's item catalog says *what exists*; `resolvePane` says *what renders it*. It is the one hook every
-consumer overrides, and it receives the stable item id plus the persisted item record:
+A pane declaration is an ordinary component config. Use a registered `module`, `className` or
+`ntype`; use a lazy `module: () => import(...)` for a surface that should load on activation.
+Container and Card retain their normal creation and lazy-loading roles. An auto-hidden pane first
+loads when its rail is revealed.
+
+Two keys may use the same component class with different text, bindings or other config. They get
+separate component identities and keep their own state through tab moves and rail transitions.
+The pane key is its dock item identity and default persisted `componentRef`; `header.text` supplies
+its catalog title. Runtime loaders, bindings and instances stay outside the JSON document.
+
+Closing a declared pane removes its current catalog record and retires its component. The initial
+declaration survives, so a control can reopen it without rebuilding the catalog:
 
 ```javascript readonly
-resolvePane(itemId, item) {
-    return {
-        editor : {module: EditorPanel,  flag: 'editor'},
-        preview: {module: PreviewPanel, value: this.currentUrl}
-    }[itemId] ?? super.resolvePane(itemId, item)
-}
+const result = await workspace.openPane('preview', {
+    operation : 'addTab',
+    tabsNodeId: targetTabsId
+});
 ```
 
-Three return shapes are legal, and the two live consumers demonstrate the range:
+The target uses the current committed document's node ID. The call uses `Operations.addItem` and
+the normal host commit path; success includes the projection. An unknown declaration, invalid
+placement or already-existing record returns errors without a partial insertion. A detached item
+still has a catalog record: move or restore it through the normal operations rather than reopening
+it. Closing and reopening creates a fresh component; moving an existing pane preserves it.
 
-- **A config object** (the example's choice): the engine creates the component when the pane first materializes. The
-  class stamps a FLIP marker class onto plain configs automatically, so your pane joins the motion correlation
-  without you carrying any marker by hand.
-- **A live component instance** (the workstation's choice — it caches twenty panes across re-projections and tour
-  resets): returned untouched, never decorated. Identity resolves through the committed document, and the reconciler
-  hands the *same instance* into the next projection. This is the mechanism behind the system's signature move — a
-  ticking clock that keeps ticking through splits, tab moves, and tear-outs.
-- **Nothing you claim**: the inherited default renders a titled placeholder, so an item nobody resolved is visible
-  scaffolding instead of a silent hole. The default renders the title as **escaped text** — persisted titles are
-  data, never markup, and the class's unit suite pins that with a hostile `<img onerror>` title.
+The existing Reload action delegates to a pane's `dockReload()` when available. Its recreate fallback
+can also rebuild a declared pane: the fresh instance gets a new runtime ID while its dock identity,
+document and tab chrome remain. An already-loaded lazy pane uses its loaded class for that replacement.
 
-`resolveRevealPane` is the same resolution for auto-hide reveal overlays and defaults to `resolvePane`; override it
-only when a reveal should render differently from the tabbed flow. `getPaneHeaderText` feeds placeholder and default
-titles — the workstation uses it to give cached panes stable header names.
+For an advanced consumer, `resolvePane(itemId, item)` remains an extension point for application-owned
+instances or custom configs. `resolveRevealPane` can specialize reveal presentation.
+The inherited resolver handles declared keys and otherwise provides the existing escaped-title
+placeholder. Applications that override resolution retain responsibility for their custom pane
+lifetimes. The basic declaration path needs neither override.
 
 ## Decision 3 — policies live in the model, not in your UI
 

--- a/src/dashboard/dock/Workspace.mjs
+++ b/src/dashboard/dock/Workspace.mjs
@@ -404,7 +404,7 @@ class Workspace extends Container {
 
     /**
      * The live committed dock-zone document — the single source of truth the view projects from.
-     * Advanced exclusively by {@link #onDockZoneDocumentChange}; readable through the holder
+     * Seeded at construction, then advanced through the host/Group commit path; readable through the holder
      * contract's {@link #getDockZoneDocument} before any operation has run.
      * @member {Object|null} dockModel=null
      */
@@ -2140,7 +2140,7 @@ class Workspace extends Container {
      * Hook: item ids whose live panes the consumer holds OUTSIDE the current projection and that
      * the reconciler must park rather than retire — for example a click-detached pane. Engine-owned
      * tear-out handles are merged separately and never depend on an app override. The default
-     * holds none.
+     * preserves declared catalog members, including auto-hidden panes.
      * @returns {Iterable<String>}
      */
     getPreservedItemIds() {

--- a/src/dashboard/dock/Workspace.mjs
+++ b/src/dashboard/dock/Workspace.mjs
@@ -1,4 +1,5 @@
 import Component                   from '../../component/Base.mjs';
+import Authoring                   from './model/Authoring.mjs';
 import Container                   from '../../container/Base.mjs';
 import NeoArray                    from '../../util/Array.mjs';
 import {isDescriptor}              from '../../core/ConfigSymbols.mjs';
@@ -28,10 +29,10 @@ import TopologySeams               from './window/TopologySeams.mjs';
  * that hands the surviving live panes into the next projection instead of recreating them
  * ({@link #refreshDockWorkspace} over {@link Neo.dashboard.dock.projection.Reconciler}, bracketed by
  * the FLIP motion signal). Before this class, each consumer wrote that loop by hand; this class owns
- * it once, and a consumer contributes only what is genuinely its own through template hooks:
+ * it once. A basic consumer declares initial {@link #panes} and {@link #zones}; advanced consumers
+ * specialize the existing template hooks:
  *
- * - {@link #resolvePane} — which live component or config renders a catalog item (the one hook
- *   every consumer overrides);
+ * - {@link #resolvePane} — custom live component or config resolution beyond declared panes;
  * - {@link #resolveRevealPane} — the same resolution for auto-hide reveal overlays;
  * - {@link #getPreservedItemIds} — consumer-held panes that must survive a projection they are
  *   absent from (the engine adds its own tear-out handles independently);
@@ -56,8 +57,8 @@ import TopologySeams               from './window/TopologySeams.mjs';
  * {@link Neo.dashboard.dock.interaction.DragAffordances} (`dockModel` plus the reducer and the view-sync), so an
  * agent, a splitter, a rail, a drag gesture and a tour runner all commit through one path.
  *
- * Two invariants every method here protects: the committed document advances ONLY inside
- * {@link #onDockZoneDocumentChange}, and every re-projection is ONE atomic ownership transaction —
+ * After initial construction, the committed document advances through {@link #onDockZoneDocumentChange}
+ * (or Group adoption), and every re-projection is ONE atomic ownership transaction —
  * commits schedule off the SETTLED tail of {@link #refreshPromise}, so a later commit can never
  * start a second staged shell before the first settled, and a FAILED transaction stays observable
  * on its own {@link #refreshPromise} snapshot without suppressing any later one. A configured
@@ -373,8 +374,33 @@ class Workspace extends Container {
          * @member {String|null} topologyGroupId_=null
          * @reactive
          */
-        topologyGroupId_: null
+        topologyGroupId_: null,
+
+        /**
+         * Initial component configs keyed by pane ID. Captured after `onConstructed`, before
+         * mounting; later assignments or mutations do not change the consumed declarations.
+         * Modules, lazy loaders, bindings and other runtime config stay outside the document.
+         * @member {Object|null} panes=null
+         */
+        panes: null,
+
+        /**
+         * Initial nested dock arrangement. Strings/arrays name tabs; objects describe splits
+         * or edge zones. A supplied valid dockModel wins. Later assignments do not reset it.
+         * @member {Object|String|String[]|null} zones=null
+         */
+        zones: null
     }
+
+    /** Captured configs with runtime IDs resolved by the component manager.
+     * @member {Object|null} paneDeclarations=null @protected
+     */
+    paneDeclarations = null
+
+    /** Initial catalog records retained for reopening through addItem.
+     * @member {Object|null} declaredPaneItems=null @protected
+     */
+    declaredPaneItems = null
 
     /**
      * The live committed dock-zone document — the single source of truth the view projects from.
@@ -544,6 +570,93 @@ class Workspace extends Container {
      */
     applyDockZoneOperation(descriptor) {
         return Operations.applyOperation(this.dockModel, descriptor)
+    }
+
+    /**
+     * @summary Captures effective initial declarations after the complete onConstructed chain.
+     * Runs before the constructed event and init/mount; first projection remains owned by
+     * afterSetMounted. An invalid supplied document or declaration fails before publishing a seed.
+     * @protected
+     */
+    onAfterConstructed() {
+        const me = this, errors = [], supplied = me.dockModel !== null;
+
+        if (supplied) Authoring.validateDocument(me.dockModel, errors);
+        if (errors.length) throw new Error(`dockModel: ${errors.join('; ')}`);
+
+        if (me.panes !== null || me.zones !== null) {
+            const {document, errors} = Authoring.fromZones(me.panes ?? {}, supplied ? {type: 'edge-zone'} : me.zones ?? {type: 'edge-zone'});
+            if (errors.length) throw new Error(errors.join('; '));
+
+            const declarations = Neo.clone(me.panes ?? {}, true, true), ids = new Set();
+            Object.entries(declarations).forEach(([key, pane]) => {
+                pane.id ||= Neo.getId('dock-pane');
+                if (ids.has(pane.id) || Neo.get(pane.id)) errors.push(`panes.${key}.id: already in use`);
+                ids.add(pane.id)
+            });
+            if (errors.length) throw new Error(errors.join('; '));
+
+            me.paneDeclarations = declarations;
+            me.declaredPaneItems = document.items;
+            if (!supplied) me.dockModel = document
+        }
+
+        super.onAfterConstructed()
+    }
+
+    /**
+     * @summary Opens a closed declared pane through the ordinary addItem commit path.
+     * `target` is an addTab or splitNode placement descriptor; omission creates a catalog-only
+     * item. Existing records (including detached items) are refused by addItem; use normal
+     * move/restore operations for those. Awaiting success includes the host commit/projection.
+     * @param {String} itemId
+     * @param {Object} [target]
+     * @returns {Promise<{document:Object, errors:String[]}>}
+     */
+    async openPane(itemId, target) {
+        const me = this, item = me.getPaneDeclaration(itemId) && me.declaredPaneItems[itemId];
+        if (!item) return {document: me.dockModel, errors: [`unknown declared pane "${itemId}"`]};
+
+        const descriptor = {operation: 'addItem', itemId, item, ...(target === undefined ? {} : {target})},
+              result     = me.applyDockZoneOperation(descriptor);
+
+        if (!result.errors.length) await me.onDockZoneDocumentChange(result.document, descriptor, me);
+        return result.errors.length ? result : {document: me.dockModel, errors: []}
+    }
+
+    /**
+     * @summary Whether a materialized declared pane still belongs to this Workspace's catalog.
+     * Rails use this ownership decision when releasing their config-created reveal panes.
+     * @param {Neo.component.Base} pane
+     * @param {String} itemId
+     * @returns {Boolean}
+     * @protected
+     */
+    retainDeclaredPane(pane, itemId) {
+        return !!this.dockModel?.items?.[itemId] && this.getPaneDeclaration(itemId)?.id === pane?.id
+    }
+
+    /**
+     * @summary Looks up an own declaration by its stable dock item key.
+     * @param {String} itemId
+     * @returns {Object|null}
+     * @protected
+     */
+    getPaneDeclaration(itemId) {
+        const declarations = this.paneDeclarations;
+        return declarations && Object.hasOwn(declarations, itemId) ? declarations[itemId] : null
+    }
+
+    /**
+     * @summary Retires declared instances no longer owned by the catalog, including parked panes.
+     * The captured configs survive a close; the component manager owns live instance lookup.
+     * @param {Object|null} document Null releases all declarations during Workspace teardown.
+     * @protected
+     */
+    releaseDeclaredPanes(document) {
+        Object.entries(this.paneDeclarations || {}).forEach(([itemId, config]) => {
+            if (!document?.items?.[itemId]) this.settleDockPane(Neo.get(config.id))
+        })
     }
 
     /**
@@ -1146,6 +1259,7 @@ class Workspace extends Container {
      */
     destroy(...args) {
         const me = this;
+        me.releaseDeclaredPanes(null);
         me.transactionManager?.un({bind: me.onTopologyGroupBinding, scope: me});
         me.nativeWindows?.unregisterSource(me.id);
         me.tearOutHandlers?.retirePaneState?.();
@@ -2030,7 +2144,7 @@ class Workspace extends Container {
      * @returns {Iterable<String>}
      */
     getPreservedItemIds() {
-        return []
+        return Object.keys(this.paneDeclarations || {}).filter(itemId => this.dockModel?.items?.[itemId])
     }
 
     /**
@@ -2207,7 +2321,7 @@ class Workspace extends Container {
     onDockZoneDocumentChange(document, descriptor=null, source=null) {
         const me = this, set = me.workspaceSet;
         if (set && me.topologyGroupId && document !== me.dockModel) {
-            const manager = Neo.manager.Transaction;
+            const manager      = Neo.manager.Transaction;
             const workspaceKey = me.workspaceKey ?? set.ids()
                 .find(key => manager.getParticipant(me.topologyGroupId, key)?.componentId === me.id);
             if (!workspaceKey) return Promise.reject(new Error('dock participant not registered'));
@@ -2382,6 +2496,7 @@ class Workspace extends Container {
                 // serve as it is resolved, and the reload action's binding reads it.
                 resolveComponentRef      : itemResolver || ((componentRef, item, itemId) => me.publishPaneContract(itemId, me.resolveProjectedPane(itemId, item))),
                 resolveRevealComponentRef: (componentRef, item, itemId) => me.decorateFlipMarker(me.resolveRevealPane(itemId, item), itemId),
+                ...(me.paneDeclarations && {retainRevealPane: me.retainDeclaredPane.bind(me)}),
                 // Header state is data the projected chrome binds to, resolved against this
                 // workspace's provider through the tree: the engine actions carry the policy's
                 // formatters, a tabs node's container binds its locked items, a rail its revealed one.
@@ -2549,6 +2664,8 @@ class Workspace extends Container {
         // and `afterRefreshDockWorkspace` consumers read `result` as a completed projection.
         if (result === null) return;
 
+        me.releaseDeclaredPanes(document);
+
         // Awaited on purpose, in plugins order: refreshPromise is the settled-surface contract, and
         // a collaborator presentation that re-applies after it settles is a surface nobody can
         // await. A collaborator that rejects is reported and skipped — presentation never fails a
@@ -2649,15 +2766,20 @@ class Workspace extends Container {
 
     /**
      * Hook: resolves a catalog item to the live component or the plain config that renders it.
-     * The default renders a titled placeholder pane — the model contract's recoverable fallback
-     * for an item no consumer claimed — so a workspace is never silently empty; every consumer
-     * overrides this with its own panes. The title renders as ESCAPED text: persisted titles are
-     * data, never markup. A thrown error fails the projection loudly.
+     * Declared keys resolve through the component manager, or return a fresh config for ordinary
+     * Container/Card creation. Other items keep the escaped-title placeholder fallback. Override
+     * for custom application resolution; its instance lifetime remains the application's own.
      * @param {String} itemId The stable workspace identity from the item catalog.
      * @param {Object} item The persisted item record (`componentRef`, `title`, `kind`, policy hints).
      * @returns {Object|Neo.component.Base}
      */
     resolvePane(itemId, item) {
+        const declaration = this.paneDeclarations && this.getPaneDeclaration(itemId);
+
+        if (declaration) {
+            return Neo.get(declaration.id) || Neo.clone(declaration, true, true)
+        }
+
         return {
             cls  : ['neo-dock-workspace-placeholder'],
             ntype: 'component',
@@ -2713,9 +2835,8 @@ class Workspace extends Container {
     /**
      * Hook: produces a **fresh** candidate pane for an item, bypassing any live-instance cache.
      *
-     * Defaults to {@link #resolvePane} — only the consumer knows how to build its own pane. A
-     * cache-backed `resolvePane` is safe here: {@link #prepareRecreateCandidate} compares by
-     * identity and refuses with `live-instance`, leaving the live pane untouched.
+     * Declared panes use a fresh runtime ID and the already-loaded class. Other items delegate to
+     * resolvePane; prepareRecreateCandidate refuses a live-instance answer without disturbing it.
      *
      * `null` declines for that item.
      * @param {String} itemId The stable workspace identity from the item catalog.
@@ -2723,6 +2844,13 @@ class Workspace extends Container {
      * @returns {Object|Neo.component.Base|null}
      */
     resolveFreshPane(itemId, item) {
+        const declaration = this.paneDeclarations && this.getPaneDeclaration(itemId);
+        if (declaration) {
+            const config = Neo.clone(declaration, true, true), live = Neo.get(declaration.id);
+            config.id = Neo.getId('dock-pane');
+            if (Neo.typeOf(config.module) === 'Function' && live) config.module = live.constructor;
+            return config
+        }
         return this.resolvePane(itemId, item)
     }
 
@@ -2942,7 +3070,9 @@ class Workspace extends Container {
 
                     committed.error && errors.push(committed.error.message)
                 } else {
-                    pane = committed.pane
+                    pane = committed.pane;
+                    const declaration = me.paneDeclarations && me.getPaneDeclaration(itemId);
+                    if (declaration) declaration.id = pane.id
                 }
             }
         } finally {

--- a/src/dashboard/dock/interaction/Rail.mjs
+++ b/src/dashboard/dock/interaction/Rail.mjs
@@ -118,6 +118,12 @@ class Rail extends Container {
          */
         resolveComponentRef: null,
         /**
+         * Optional lifetime owner for a materialized reveal pane. True parks it on release;
+         * that owner resolves and retires the instance independently of this rail's chrome.
+         * @member {Function|null} retainRevealPane=null
+         */
+        retainRevealPane: null,
+        /**
          * Whether the item this rail currently reveals is committed locked — bound by the projection
          * to the workspace's header truth, so a lock transition while the reveal stays open reaches
          * the revealed pane through {@link #syncDockLockPane} without a second materialization.
@@ -432,6 +438,8 @@ class Rail extends Container {
      * cached reveal pane that outlives the flow pane's creation unregisters that id when the rail
      * tears down, leaving a live pane nobody can address and a refresh that throws mid-teardown.
      * Destroying it here, while it is still the id's only holder, keeps the registry honest.
+     * A Workspace which retains declared panes supplies retainRevealPane; those instances are
+     * detached without destruction and resolved by that owner on the next projection.
      *
      * Live instances are never cached (parked, never owned — see {@link #syncRevealPane}), so a
      * consumer's own pane cannot be destroyed through this path.
@@ -447,7 +455,7 @@ class Rail extends Container {
      * in-flight update that still diffs the pane's vnode — either one wedges the refresh (measured:
      * a reconcile whose `promiseUpdate` never settles).
      * @param {String} itemId
-     * @returns {Promise<void>} Settles once the pane is gone from the DOM and the registry.
+     * @returns {Promise<void>} Settles once the pane leaves this rail's slot and ownership.
      * @protected
      */
     async releaseRevealPane(itemId) {
@@ -473,19 +481,19 @@ class Rail extends Container {
             }
 
             parent = pane.parent;
+            const retain = me.retainRevealPane?.(pane, itemId) === true;
 
             // A parked pane keeps its `parentId` after `removeAt(index, false)`, so `parent` can
             // resolve a slot that no longer lists it — go through the parent only while it does.
             if (parent?.items?.includes(pane)) {
-                // `removeAt` splices the vdom BEFORE the payload is built and destroys the pane, so
-                // the removal it publishes never references the instance; hand its landing back.
-                parent.remove(pane, true);
+                // Splice the slot before publishing, then let the removal land before reuse.
+                parent.remove(pane, !retain);
                 await parent.promiseUpdate()
             } else {
                 // Parked: the dismissal already spliced it out, but that update may still be in
                 // flight with the pane's vnode in its diff — let it land before the instance goes.
                 await parent?.promiseUpdate?.();
-                pane.isDestroyed || pane.destroy()
+                retain || pane.isDestroyed || pane.destroy()
             }
         } finally {
             // `destroy()` deletes own properties, so a rail torn down across the awaits above has no
@@ -504,13 +512,22 @@ class Rail extends Container {
     destroy(...args) {
         let me = this;
 
+        const slot = me.revealOverlay?.paneSlot, pane = slot?.items?.[0];
+        if (pane && me.retainRevealPane?.(pane, me.revealOverlay.revealPaneItemId) === true) {
+            slot.remove(pane, false)
+        }
+
         me.syncOutsidePointerListener(false);
         me.revealMachine?.destroy();
         me.revealMachine = null;
         me.revealOverlay = null;
 
-        Object.values(me.revealPaneCache).forEach(pane => {
-            pane?.isDestroyed || pane?.destroy?.()
+        Object.entries(me.revealPaneCache).forEach(([itemId, pane]) => {
+            if (me.retainRevealPane?.(pane, itemId) === true) {
+                pane.parent?.items?.includes(pane) && pane.parent.remove(pane, false)
+            } else {
+                pane?.isDestroyed || pane?.destroy?.()
+            }
         });
         me.revealPaneCache = {};
         me.revealPaneLoads = {};

--- a/src/dashboard/dock/projection/LayoutAdapter.mjs
+++ b/src/dashboard/dock/projection/LayoutAdapter.mjs
@@ -474,6 +474,7 @@ class LayoutAdapter extends Base {
      *     `dockRevealLocked` — whether the item it reveals is committed locked.
      * @param {String|null} [options.dockWorkspaceId] The workspace whose header-action policy the
      *     projected containers present locks through.
+     * @param {Function} [options.retainRevealPane] Lifetime owner deciding whether a rail-released pane survives.
      * @param {Function} [options.syncDockLockPane] Workspace-owned lock presentation for a resolved
      *     rail reveal pane: `(pane, itemId) => void`, binding the pane to the item's committed lock.
      * @param {Object|null} [options.tabInsertDescriptor] Runtime-only normalized `addTab`
@@ -567,6 +568,7 @@ class LayoutAdapter extends Base {
             dockRailLockBinding               : options.dockRailLockBinding,
             dockWorkspaceId                   : options.dockWorkspaceId ?? null,
             syncDockLockPane                  : options.syncDockLockPane,
+            retainRevealPane                  : options.retainRevealPane,
             tabInsertDescriptor               : options.tabInsertDescriptor ?? null,
             vesselConversionConvertThreshold  : options.vesselConversionConvertThreshold,
             vesselConversionPointerExitGraceMs: options.vesselConversionPointerExitGraceMs,
@@ -667,8 +669,8 @@ class LayoutAdapter extends Base {
         const railId = `${nodeId}:edge-rail:${edge}`;
 
         return {
-            applyDockZoneOperation  : context.applyDockZoneOperation,
-            autoHideRevealOnHover   : context.autoHideRevealOnHover === true,
+            applyDockZoneOperation: context.applyDockZoneOperation,
+            autoHideRevealOnHover : context.autoHideRevealOnHover === true,
             // The rail binds whether the item it reveals is committed locked; presenting it is the
             // workspace's `syncDockLockPane`, the same callback first reveal goes through.
             ...(context.dockRailLockBinding && {bind: {dockRevealLocked: context.dockRailLockBinding(railId)}}),
@@ -684,6 +686,7 @@ class LayoutAdapter extends Base {
             onDockZoneDocumentChange: context.onDockZoneDocumentChange,
             railItems               : itemIds.map(itemId => this.createRailTab(itemId, edge, context)),
             resolveComponentRef     : context.resolveRevealComponentRef,
+            retainRevealPane        : context.retainRevealPane,
             revealPinTooltip        : context.dockActionTooltips?.revealPin ?? null,
             syncDockLockPane        : context.syncDockLockPane
         }

--- a/test/playwright/component/apps/dock-authoring/LazyPane.mjs
+++ b/test/playwright/component/apps/dock-authoring/LazyPane.mjs
@@ -1,0 +1,18 @@
+import Pane from './Pane.mjs';
+
+/**
+ * @class Test.Playwright.Component.DockAuthoring.LazyPane
+ * @extends Test.Playwright.Component.DockAuthoring.Pane
+ * @summary Shared lazy module whose namespace registration witnesses first activation.
+ */
+class LazyPane extends Pane {
+    /** @member {Number} sequence=0 @static */
+    static sequence = 0
+
+    static config = {
+        className: 'Test.Playwright.Component.DockAuthoring.LazyPane',
+        baseCls  : ['dock-authoring-lazy-pane']
+    }
+}
+
+export default Neo.setupClass(LazyPane);

--- a/test/playwright/component/apps/dock-authoring/Pane.mjs
+++ b/test/playwright/component/apps/dock-authoring/Pane.mjs
@@ -1,0 +1,27 @@
+import Component from '../../../../../src/component/Base.mjs';
+
+/**
+ * @class Test.Playwright.Component.DockAuthoring.Pane
+ * @extends Neo.component.Base
+ * @summary Ordinary pane with an instance-only construction witness.
+ */
+class Pane extends Component {
+    /** @member {Number} sequence=0 @static */
+    static sequence = 0
+
+    static config = {
+        className: 'Test.Playwright.Component.DockAuthoring.Pane',
+        baseCls  : ['dock-authoring-pane']
+    }
+
+    /**
+     * @summary Gives each constructed object a witness which cannot survive recreation.
+     * @param {Object} config
+     */
+    construct(config) {
+        super.construct(config);
+        this.instanceWitness = `${this.className}:${++this.constructor.sequence}`
+    }
+}
+
+export default Neo.setupClass(Pane);

--- a/test/playwright/component/apps/dock-authoring/app.mjs
+++ b/test/playwright/component/apps/dock-authoring/app.mjs
@@ -1,0 +1,195 @@
+import DockWorkspace from '../../../../../src/dashboard/dock/Workspace.mjs';
+import StateProvider from '../../../../../src/state/Provider.mjs';
+import Viewport      from '../../../../../src/container/Viewport.mjs';
+import Pane          from './Pane.mjs';
+import '../../../../../src/tab/Container.mjs';
+
+let lazyRequests = 0;
+
+const loadLazyPane = () => {
+    lazyRequests++;
+    return import('./LazyPane.mjs')
+}, paneKeys = ['alpha', 'beta', 'summary', 'lazyTab', 'lazyRail'];
+
+/**
+ * @class Test.Playwright.Component.DockAuthoring.Workspace
+ * @extends Neo.dashboard.dock.Workspace
+ * @summary Config-only consumer: the engine seeds, resolves and preserves every declared pane.
+ */
+class AuthoringWorkspace extends DockWorkspace {
+    static config = {
+        className    : 'Test.Playwright.Component.DockAuthoring.Workspace',
+        id           : 'dock-authoring-workspace',
+        layout       : {ntype: 'vbox', align: 'stretch'},
+        stateProvider: {
+            module: StateProvider,
+            data  : {alphaText: 'Alpha initial', betaText: 'Beta initial'}
+        },
+        panes: {
+            alpha: {
+                module: Pane,
+                header: {text: 'Alpha'},
+                bind  : {text: data => data.alphaText}
+            },
+            beta: {
+                module: Pane,
+                header: {text: 'Beta'},
+                bind  : {text: data => data.betaText}
+            },
+            summary : {ntype: 'component', header: {text: 'Summary'}, text: 'Summary content'},
+            lazyTab : {module: loadLazyPane, header: {text: 'Lazy tab'}, text: 'Lazy tab initial'},
+            lazyRail: {
+                module    : loadLazyPane,
+                header    : {text: 'Lazy rail'},
+                text      : 'Lazy rail initial',
+                autoHidden: true
+            }
+        },
+        zones: {
+            center: {
+                id         : 'center-split',
+                orientation: 'horizontal',
+                sizes      : [0.6, 0.4],
+                children   : [
+                    {id: 'main-tabs', items: ['alpha', 'lazyTab'], activeItemId: 'alpha'},
+                    {id: 'summary-tabs', items: ['summary']}
+                ]
+            },
+            right: {id: 'edge-tabs', items: ['beta', 'lazyRail'], activeItemId: 'beta', extent: 0.3}
+        }
+    }
+}
+
+AuthoringWorkspace = Neo.setupClass(AuthoringWorkspace);
+
+/**
+ * @class Test.Playwright.Component.DockAuthoring.Harness
+ * @extends Neo.container.Viewport
+ * @summary Separate test driver; the consumer above owns no test or lifecycle hooks.
+ */
+class AuthoringHarness extends Viewport {
+    static config = {
+        className     : 'Test.Playwright.Component.DockAuthoring.Harness',
+        id            : 'dock-authoring-harness',
+        commandJson_  : null,
+        commandResult_: null,
+        items         : [{module: AuthoringWorkspace, flex: 1}]
+    }
+
+    /** @member {Object<String,String>} observedIds={} */
+    observedIds = {}
+
+    /** @member {Object|null} capturedDocument=null */
+    capturedDocument = null
+
+    /**
+     * @summary Dispatches commands through ordinary host APIs and reports asynchronous completion.
+     * @param {String|null} value
+     * @param {String|null} oldValue
+     */
+    afterSetCommandJson(value, oldValue) {
+        if (oldValue === undefined || !value) return;
+        const command = JSON.parse(value);
+
+        this.runCommand(command).catch(error => {
+            this.commandResult = {sequence: command.sequence, failure: error.message}
+        })
+    }
+
+    /**
+     * @summary Awaits the final projection, including a replacement repair promise.
+     * @param {Neo.dashboard.dock.Workspace} workspace
+     * @returns {Promise<void>}
+     */
+    async settle(workspace) {
+        let tail;
+
+        do {
+            tail = workspace.refreshPromise;
+            await tail
+        } while (tail !== workspace.refreshPromise)
+    }
+
+    /**
+     * @summary Exercises public operations without installing a consumer resolver or projection hook.
+     * @param {Object} command
+     * @returns {Promise<void>}
+     */
+    async runCommand(command) {
+        const workspace = Neo.get('dock-authoring-workspace');
+        await this.settle(workspace);
+        const documentBefore = workspace.dockModel,
+              refreshBefore  = workspace.refreshPromise;
+        let result = {errors: []};
+
+        if (command.action === 'captureDocument') {
+            this.capturedDocument = workspace.dockModel
+        } else if (command.action === 'operation') {
+            result = workspace.applyDockZoneOperation(command.descriptor);
+            if (!result.errors.length) {
+                await workspace.onDockZoneDocumentChange(result.document, command.descriptor, workspace)
+            }
+        } else if (command.action === 'open') {
+            result = await workspace.openPane(command.itemId, command.target)
+        } else if (command.action === 'mark') {
+            const pane = workspace.resolvePane(command.itemId, workspace.dockModel.items[command.itemId]);
+            if (!pane?.isConstructed) throw new Error(`Pane ${command.itemId} is not live`);
+            pane.transientNote = command.value;
+            if (command.text !== undefined) pane.text = command.text
+        } else if (command.action === 'state') {
+            workspace.getStateProvider().data[command.key] = command.value
+        } else if (command.action === 'laterAssignment') {
+            workspace.panes = {alpha: {ntype: 'component', text: 'Replacement declaration'}};
+            workspace.zones = ['beta']
+        }
+
+        await this.settle(workspace);
+        this.commandResult = {
+            sequence                 : command.sequence,
+            errors                   : result.errors,
+            documentIdentityUnchanged: workspace.dockModel === documentBefore,
+            refreshIdentityUnchanged : workspace.refreshPromise === refreshBefore,
+            ...this.snapshot(workspace)
+        }
+    }
+
+    /**
+     * @summary Reads real instances and persisted membership without materializing dormant panes.
+     * @param {Neo.dashboard.dock.Workspace} workspace
+     * @returns {Object}
+     */
+    snapshot(workspace) {
+        const panes = Object.fromEntries(paneKeys.map(itemId => {
+            const item = workspace.dockModel.items[itemId],
+                  pane = item ? workspace.resolvePane(itemId, item) : Neo.get(this.observedIds[itemId]);
+            if (!pane?.isConstructed || pane.isDestroyed) return [itemId, null];
+            this.observedIds[itemId] = pane.id;
+            return [itemId, {
+                id             : pane.id,
+                className      : pane.className,
+                instanceWitness: pane.instanceWitness,
+                text           : pane.text,
+                transientNote  : pane.transientNote ?? null
+            }]
+        }));
+
+        return {
+            panes,
+            lazyRequests,
+            catalog             : Object.keys(workspace.dockModel.items),
+            nodes               : workspace.dockModel.nodes,
+            lazyLoaded          : !!Neo.ns('Test.Playwright.Component.DockAuthoring.LazyPane'),
+            lazyInstances       : Neo.ns('Test.Playwright.Component.DockAuthoring.LazyPane')?.sequence ?? 0,
+            sameCapturedDocument: workspace.dockModel === this.capturedDocument,
+            shellCount          : workspace.items.length
+        }
+    }
+}
+
+AuthoringHarness = Neo.setupClass(AuthoringHarness);
+
+/** @summary Boots the declaration-only consumer inside its independent test driver. */
+export const onStart = () => Neo.app({
+    mainView: {module: AuthoringHarness},
+    name    : 'Test.Playwright.DockAuthoring'
+});

--- a/test/playwright/component/apps/dock-authoring/index.html
+++ b/test/playwright/component/apps/dock-authoring/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Declarative dock workspace</title>
+</head>
+<body>
+    <script src="../../../../../src/MicroLoader.mjs" type="module"></script>
+</body>
+</html>

--- a/test/playwright/component/apps/dock-authoring/neo-config.json
+++ b/test/playwright/component/apps/dock-authoring/neo-config.json
@@ -1,0 +1,9 @@
+{
+    "appPath"         : "test/playwright/component/apps/dock-authoring/app.mjs",
+    "basePath"        : "../../../../../",
+    "environment"     : "development",
+    "mainPath"        : "./Main.mjs",
+    "mainThreadAddons": ["DockFlip", "DragDrop", "Navigator", "ResizeObserver", "Stylesheet"],
+    "themes"          : ["neo-theme-neo-dark", "neo-theme-neo-light"],
+    "useSharedWorkers": false
+}

--- a/test/playwright/component/dashboard/DockWorkspaceAuthoring.spec.mjs
+++ b/test/playwright/component/dashboard/DockWorkspaceAuthoring.spec.mjs
@@ -1,0 +1,228 @@
+import {test, expect} from '../../fixtures.mjs';
+
+const harnessId = 'dock-authoring-harness',
+      overlay   = page => page.locator('.neo-dashboard-dock-reveal-overlay:not(.neo-dashboard-dock-reveal-overlay-hidden)'),
+      railTab   = (page, text) => page.locator('.neo-dashboard-dock-rail-tab', {hasText: text}),
+      header    = (page, text) => page.locator('.neo-tab-header-button').filter({hasText: new RegExp(`^${text}$`)});
+
+let sequence = 0;
+
+/**
+ * @summary Sends one command to the independent harness and waits for the real host projection.
+ * @param {Object} page
+ * @param {Object} command
+ * @returns {Promise<Object>}
+ */
+const drive = async (page, command={action: 'snapshot'}) => {
+    const current = ++sequence;
+    await page.evaluate(data => Neo.worker.App.setConfigs(data), {
+        id         : harnessId,
+        commandJson: JSON.stringify({...command, sequence: current})
+    });
+
+    let result;
+    await expect.poll(async () => {
+        const reply = await page.evaluate(data => Neo.worker.App.getConfigs(data), {id: harnessId, keys: ['commandResult']});
+        [result] = reply?.data ?? reply;
+        return result?.sequence
+    }).toBe(current);
+    expect(result.failure).toBeUndefined();
+    return result
+};
+
+/** @summary Commits an operation through Workspace's existing reducer and presentation boundary. */
+const operate = (page, descriptor) => drive(page, {action: 'operation', descriptor});
+
+test.beforeEach(async ({page}) => {
+    await page.goto('test/playwright/component/apps/dock-authoring/index.html');
+    await expect(page.locator('#dock-authoring-workspace')).toBeAttached();
+    await expect(railTab(page, 'Lazy rail')).toBeVisible();
+    await expect(page.locator('.dock-authoring-pane').filter({hasText: 'Alpha initial'})).toBeVisible()
+});
+
+test.describe('declarative Workspace renders and owns ordinary panes', () => {
+    test('config-only consumer renders tabs, split and rail with independent same-class bindings', async ({page}) => {
+        const first         = await drive(page),
+              {alpha, beta} = first.panes;
+
+        expect(first.shellCount).toBe(1);
+        await expect(page.locator('.neo-dashboard-dock-tabs')).toHaveCount(3);
+        await expect(page.locator('.neo-dashboard-dock-split')).toBeVisible();
+        await expect(page.locator('.neo-dashboard-dock-splitter').first()).toBeVisible();
+        await expect(page.locator(`#${alpha.id}`)).toHaveText('Alpha initial');
+        await expect(page.locator(`#${beta.id}`)).toHaveText('Beta initial');
+        expect(alpha.className).toBe(beta.className);
+        expect(alpha.id).not.toBe(beta.id);
+        expect(alpha.instanceWitness).not.toBe(beta.instanceWitness);
+        expect(first.lazyLoaded).toBe(false);
+        expect(first.lazyInstances).toBe(0);
+        expect(first.panes.lazyTab).toBeNull();
+        expect(first.panes.lazyRail).toBeNull();
+
+        await drive(page, {action: 'state', key: 'alphaText', value: 'Alpha changed'});
+        await expect(page.locator(`#${alpha.id}`)).toHaveText('Alpha changed');
+        await expect(page.locator(`#${beta.id}`)).toHaveText('Beta initial')
+    });
+
+    test('two keys load the same lazy module on their own tab and rail activation', async ({page}, testInfo) => {
+        await header(page, 'Lazy tab').click();
+        await expect(page.locator('.dock-authoring-lazy-pane').filter({hasText: 'Lazy tab initial'})).toBeVisible();
+        const tab = await drive(page);
+
+        expect(tab.lazyLoaded).toBe(true);
+        expect(tab.lazyInstances).toBe(1);
+        expect(tab.panes.lazyRail).toBeNull();
+
+        await railTab(page, 'Lazy rail').click();
+        await expect(overlay(page).locator('.dock-authoring-lazy-pane')).toHaveText('Lazy rail initial');
+        const both = await drive(page);
+
+        expect(both.lazyInstances).toBe(2);
+        expect(both.panes.lazyTab.className).toBe(both.panes.lazyRail.className);
+        expect(both.panes.lazyTab.id).not.toBe(both.panes.lazyRail.id);
+        expect(both.panes.lazyTab.instanceWitness).not.toBe(both.panes.lazyRail.instanceWitness);
+        expect(both.panes.lazyTab.text).toBe('Lazy tab initial');
+        expect(both.panes.lazyRail.text).toBe('Lazy rail initial');
+
+        const screenshot = testInfo.outputPath('declarative-workspace-reveal.png');
+        await page.screenshot({path: screenshot, animations: 'disabled'});
+        await testInfo.attach('declarative-workspace-reveal', {path: screenshot, contentType: 'image/png'})
+    });
+
+    test('Reload recreates an activated lazy pane while preserving its document and tab chrome', async ({page}) => {
+        await header(page, 'Lazy tab').click();
+        await expect(page.locator('.dock-authoring-lazy-pane')).toHaveText('Lazy tab initial');
+        const first         = await drive(page, {action: 'captureDocument'}),
+              oldPane       = first.panes.lazyTab,
+              tabs          = page.locator('.neo-dashboard-dock-tabs', {has: header(page, 'Lazy tab')}),
+              toolbar       = tabs.locator('.neo-tab-header-toolbar'),
+              reload        = toolbar.locator('.neo-button:has([class*="fa-rotate-right"])'),
+              retainedNodes = await Promise.all([tabs, toolbar, header(page, 'Lazy tab')].map(locator => locator.elementHandle()));
+
+        expect(first.lazyRequests).toBe(1);
+        expect(first.lazyInstances).toBe(1);
+        await drive(page, {action: 'mark', itemId: 'lazyTab', value: 'discard on reload', text: 'Edited before reload'});
+        await expect(page.locator(`#${oldPane.id}`)).toHaveText('Edited before reload');
+        await expect(reload).toHaveCount(1);
+        await reload.click();
+        await expect(page.locator(`#${oldPane.id}`)).toHaveCount(0);
+        await expect(tabs.locator('.dock-authoring-lazy-pane')).toHaveText('Lazy tab initial');
+
+        const fresh       = await drive(page),
+              replacement = fresh.panes.lazyTab;
+        expect(replacement.id).not.toBe(oldPane.id);
+        expect(replacement.instanceWitness).not.toBe(oldPane.instanceWitness);
+        expect(replacement.transientNote).toBeNull();
+        expect(fresh.lazyRequests, 'the loaded class serves synchronous recreation').toBe(1);
+        expect(fresh.lazyInstances).toBe(2);
+        expect(fresh.sameCapturedDocument).toBe(true);
+        expect(fresh.nodes).toEqual(first.nodes);
+        for (const node of retainedNodes) expect(await node.evaluate(element => element.isConnected)).toBe(true);
+        await expect(tabs).toHaveCount(1);
+        await expect(toolbar).toHaveCount(1);
+        await expect(header(page, 'Lazy tab')).toHaveCount(1);
+
+        const moved = await operate(page, {operation: 'moveItem', itemId: 'lazyTab', targetNodeId: 'summary-tabs', index: 0});
+        expect(moved.errors).toEqual([]);
+        expect(moved.panes.lazyTab.instanceWitness).toBe(replacement.instanceWitness);
+        expect(moved.panes.lazyTab.id).toBe(replacement.id);
+        expect(moved.lazyInstances).toBe(2);
+        await expect(page.locator(`#${replacement.id}`)).toHaveText('Lazy tab initial');
+        await expect(page.locator(`#${replacement.id}`)).toHaveCount(1)
+    });
+
+    test('ordinary moves and eager tab-to-rail transitions preserve live state', async ({page}) => {
+        const first = await drive(page);
+        await drive(page, {action: 'mark', itemId: 'alpha', value: 'alpha instance state'});
+        await drive(page, {action: 'mark', itemId: 'beta', value: 'beta instance state'});
+        await drive(page, {action: 'state', key: 'betaText', value: 'Beta edited'});
+
+        const moved = await operate(page, {operation: 'moveItem', itemId: 'alpha', targetNodeId: 'summary-tabs', index: 0});
+        expect(moved.errors).toEqual([]);
+        expect(moved.panes.alpha.instanceWitness).toBe(first.panes.alpha.instanceWitness);
+        expect(moved.panes.alpha.transientNote).toBe('alpha instance state');
+        await expect(page.locator(`#${first.panes.alpha.id}`)).toBeVisible();
+        await expect(page.locator(`#${first.panes.alpha.id}`)).toHaveCount(1);
+
+        expect((await operate(page, {operation: 'setItemAutoHidden', itemId: 'beta', autoHidden: true})).errors).toEqual([]);
+        await railTab(page, 'Beta').click();
+        await expect(overlay(page).locator(`#${first.panes.beta.id}`)).toHaveText('Beta edited');
+        await page.keyboard.press('Escape');
+        await expect(overlay(page)).toHaveCount(0);
+        const parked = await drive(page);
+        expect(parked.panes.beta.instanceWitness).toBe(first.panes.beta.instanceWitness);
+        expect(parked.panes.beta.transientNote).toBe('beta instance state');
+
+        await railTab(page, 'Beta').click();
+        await overlay(page).locator('.neo-dashboard-dock-reveal-pin').click();
+        await expect(railTab(page, 'Beta')).toHaveCount(0);
+        await expect(page.locator('.neo-dashboard-dock-tabs').locator(`#${first.panes.beta.id}`)).toHaveText('Beta edited');
+        const pinned = await drive(page);
+        expect(pinned.panes.beta.instanceWitness).toBe(first.panes.beta.instanceWitness);
+        expect(pinned.panes.beta.transientNote).toBe('beta instance state');
+        await drive(page, {action: 'state', key: 'betaText', value: 'Beta after pin'});
+        await expect(page.locator(`#${first.panes.beta.id}`)).toHaveText('Beta after pin')
+    });
+
+    test('a first-reveal lazy instance survives dismissal, pinning and a second rail transition', async ({page}) => {
+        await railTab(page, 'Lazy rail').click();
+        await expect(overlay(page).locator('.dock-authoring-lazy-pane')).toBeVisible();
+        const first = await drive(page);
+        await drive(page, {action: 'mark', itemId: 'lazyRail', value: 'retained lazy state', text: 'Edited lazy rail'});
+
+        await page.keyboard.press('Escape');
+        await expect(overlay(page)).toHaveCount(0);
+        await railTab(page, 'Lazy rail').click();
+        await expect(overlay(page).locator(`#${first.panes.lazyRail.id}`)).toHaveText('Edited lazy rail');
+        await overlay(page).locator('.neo-dashboard-dock-reveal-pin').click();
+        await expect(railTab(page, 'Lazy rail')).toHaveCount(0);
+        await expect(page.locator('.neo-dashboard-dock-tabs').locator(`#${first.panes.lazyRail.id}`)).toHaveText('Edited lazy rail');
+
+        let current = await drive(page);
+        expect(current.panes.lazyRail.instanceWitness).toBe(first.panes.lazyRail.instanceWitness);
+        expect(current.panes.lazyRail.transientNote).toBe('retained lazy state');
+        expect(current.lazyInstances).toBe(1);
+        expect(current.panes.lazyTab).toBeNull();
+
+        expect((await operate(page, {operation: 'setItemPinned', itemId: 'lazyRail', pinned: false})).errors).toEqual([]);
+        expect((await operate(page, {operation: 'setItemAutoHidden', itemId: 'lazyRail', autoHidden: true})).errors).toEqual([]);
+        await railTab(page, 'Lazy rail').click();
+        await expect(overlay(page).locator(`#${first.panes.lazyRail.id}`)).toHaveText('Edited lazy rail');
+        current = await drive(page);
+        expect(current.panes.lazyRail.instanceWitness).toBe(first.panes.lazyRail.instanceWitness);
+        expect(current.lazyInstances).toBe(1)
+    });
+
+    test('later assignments do not replace declarations; close and public reopen use the consumed pane', async ({page}) => {
+        const first = await drive(page);
+        expect((await operate(page, {operation: 'moveItem', itemId: 'alpha', targetNodeId: 'summary-tabs', index: 0})).errors).toEqual([]);
+        const later = await drive(page, {action: 'laterAssignment'});
+        expect(later.documentIdentityUnchanged).toBe(true);
+        expect(later.refreshIdentityUnchanged).toBe(true);
+        expect(later.nodes['summary-tabs'].items).toContain('alpha');
+        expect(later.panes.alpha.instanceWitness).toBe(first.panes.alpha.instanceWitness);
+
+        const closed = await operate(page, {operation: 'closeItem', itemId: 'alpha'});
+        expect(closed.errors).toEqual([]);
+        expect(closed.catalog).not.toContain('alpha');
+        expect(closed.panes.alpha).toBeNull();
+        await expect(page.locator(`#${first.panes.alpha.id}`)).toHaveCount(0);
+
+        const target = {operation: 'addTab', tabsNodeId: 'main-tabs'},
+              opened = await drive(page, {action: 'open', itemId: 'alpha', target});
+        expect(opened.errors).toEqual([]);
+        expect(opened.catalog.filter(itemId => itemId === 'alpha')).toHaveLength(1);
+        expect(opened.nodes['main-tabs'].items.filter(itemId => itemId === 'alpha')).toHaveLength(1);
+        expect(opened.panes.alpha.className).toBe(first.panes.alpha.className);
+        expect(opened.panes.alpha.instanceWitness).not.toBe(first.panes.alpha.instanceWitness);
+        await expect(page.locator(`#${opened.panes.alpha.id}`)).toHaveText('Alpha initial');
+        await expect(page.locator(`#${opened.panes.alpha.id}`)).toHaveCount(1);
+
+        for (const itemId of ['alpha', 'unknown']) {
+            const refused = await drive(page, {action: 'open', itemId, target});
+            expect(refused.errors.length).toBeGreaterThan(0);
+            expect(refused.documentIdentityUnchanged).toBe(true);
+            expect(refused.refreshIdentityUnchanged).toBe(true)
+        }
+    })
+});

--- a/test/playwright/unit/dashboard/DockImportDirection.spec.mjs
+++ b/test/playwright/unit/dashboard/DockImportDirection.spec.mjs
@@ -29,7 +29,7 @@ const staticFiles = entry => measureClosure([entry], ROOT).files,
 
       DOCK_ENTRY  = 'src/dashboard/dock/Workspace.mjs',
       TX_ENTRY    = 'src/manager/Transaction.mjs',
-      TOPOLOGY_RE = /^src\/manager\/(Transaction\.mjs|transaction\/)/,
+      TOPOLOGY_RE = /^(src\/manager\/(Transaction\.mjs|transaction\/)|src\/dashboard\/dock\/persistence\/TopologyLibrary\.mjs)/,
 
       /**
        * The manager may not reach the dock DOMAIN, not merely its two most obvious modules.
@@ -59,6 +59,7 @@ test.describe('Neo.dashboard.dock — the façade import-direction rule', () => 
         // Transitivity, not just the entry's own direct imports: `core/Base.mjs` is several hops
         // down from both entries and is reachable only if the walk actually recurses.
         expect(dock, 'the dock walk reaches transitively').toContain('src/core/Base.mjs');
+        expect(dock, 'the declaration normalizer is part of the standalone host').toContain('src/dashboard/dock/model/Authoring.mjs');
         expect(tx, 'the transaction walk reaches transitively').toContain('src/core/Base.mjs');
     });
 
@@ -97,6 +98,10 @@ test.describe('Neo.dashboard.dock — the façade import-direction rule', () => 
 
         expect(crossings([...innocent, TX_ENTRY], TOPOLOGY_RE),
             'an upward import must be caught').toEqual([TX_ENTRY]);
+
+        const library = 'src/dashboard/dock/persistence/TopologyLibrary.mjs';
+        expect(crossings([...innocent, library], TOPOLOGY_RE),
+            'optional persistence must stay outside the standalone host').toEqual([library]);
 
         expect(crossings([...innocent, 'src/manager/transaction/Commit.mjs'], TOPOLOGY_RE),
             'the folder half of the rule must be caught too').toEqual(['src/manager/transaction/Commit.mjs']);

--- a/test/playwright/unit/dashboard/DockWorkspaceAuthoring.spec.mjs
+++ b/test/playwright/unit/dashboard/DockWorkspaceAuthoring.spec.mjs
@@ -1,0 +1,167 @@
+import {setup} from '../../setup.mjs';
+
+setup({appConfig: {name: 'DashboardDockWorkspaceAuthoringTest'}});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../src/Neo.mjs';
+import * as core      from '../../../../src/core/_export.mjs';
+import '../../../../src/manager/Instance.mjs';
+import '../../../../src/tab/Container.mjs';
+import Workspace from '../../../../src/dashboard/dock/Workspace.mjs';
+import Authoring from '../../../../src/dashboard/dock/model/Authoring.mjs';
+import Container from '../../../../src/container/Base.mjs';
+import Rail      from '../../../../src/dashboard/dock/interaction/Rail.mjs';
+
+/** @summary A basic consumer contributes only normal component and dock declarations. */
+class DeclaredWorkspace extends Workspace {
+    static config = {
+        className: 'Test.Unit.Dashboard.DockWorkspaceAuthoring.DeclaredWorkspace',
+        layout   : {ntype: 'vbox', align: 'stretch'},
+        panes    : {
+            editor: {ntype: 'component', text: 'Initial editor', header: {text: 'Editor'}},
+            second: {ntype: 'component', text: 'Second editor', header: {text: 'Second'}}
+        },
+        zones: {center: ['editor', 'second']}
+    }
+}
+
+DeclaredWorkspace = Neo.setupClass(DeclaredWorkspace);
+
+/** @summary Effective declarations may be computed after the container has constructed. */
+class ComputedWorkspace extends DeclaredWorkspace {
+    static config = {className: 'Test.Unit.Dashboard.DockWorkspaceAuthoring.ComputedWorkspace'}
+
+    /** @summary Computes the initial arrangement after the complete parent construction. */
+    onConstructed() {
+        super.onConstructed();
+        this.zones = {center: 'second'}
+    }
+}
+
+ComputedWorkspace = Neo.setupClass(ComputedWorkspace);
+
+test.describe('Workspace initial pane declarations', () => {
+    let workspace;
+
+    test.afterEach(() => workspace?.destroy());
+
+    test('literal declarations seed the document before any projection', () => {
+        workspace = Neo.create(DeclaredWorkspace);
+        expect(workspace.getDockZoneDocument()).toEqual(Authoring.fromZones(workspace.panes, workspace.zones).document);
+        expect(workspace.items).toHaveLength(0);
+        expect(workspace.refreshPromise).toBeNull();
+        expect(workspace.resolvePane('editor', workspace.dockModel.items.editor).text).toBe('Initial editor')
+    });
+
+    test('the effective values include computation after super.onConstructed', () => {
+        workspace = Neo.create(ComputedWorkspace);
+        expect(workspace.dockModel.nodes['tabs-second'].items).toEqual(['second'])
+    });
+
+    test('a supplied valid document wins over even invalid default zones', () => {
+        const saved = Authoring.fromZones(DeclaredWorkspace.config.panes, {center: 'second'}).document;
+        workspace = Neo.create(DeclaredWorkspace, {dockModel: saved, zones: {center: 'unknown'}});
+        expect(workspace.dockModel).toEqual(saved);
+        expect(workspace.resolvePane('editor', saved.items.editor).text).toBe('Initial editor')
+    });
+
+    test('later replacement or mutation of declarations cannot change the captured seed', () => {
+        workspace = Neo.create(DeclaredWorkspace);
+        const document = workspace.dockModel;
+        workspace.panes.editor.text = 'mutated';
+        workspace.set({panes: {editor: {ntype: 'component', text: 'replacement'}}, zones: 'second'});
+        expect(workspace.dockModel).toBe(document);
+        expect(workspace.resolvePane('editor', document.items.editor).text).toBe('Initial editor');
+        expect(workspace.refreshPromise).toBeNull()
+    });
+
+    test('normal Container creation resolves distinct declarations of the same class', () => {
+        workspace = Neo.create(DeclaredWorkspace);
+        const host  = Neo.create(Container), document = workspace.dockModel;
+        const first = host.add(workspace.resolvePane('editor', document.items.editor)),
+              second = host.add(workspace.resolvePane('second', document.items.second));
+        first.text = 'instance state';
+        expect(first).not.toBe(second);
+        expect(first.id).not.toBe(second.id);
+        expect(workspace.resolvePane('editor', document.items.editor)).toBe(first);
+        expect(second.text).toBe('Second editor');
+        host.remove(first, false);
+        expect(workspace.resolveRevealPane('editor', document.items.editor)).toBe(first);
+        workspace.destroy();
+        expect(first.isDestroyed).toBe(true);
+        expect(second.isDestroyed).toBe(true);
+        workspace = null;
+        host.destroy()
+    });
+
+    test('invalid declaration and supplied documents fail before any shell mounts', () => {
+        for (const [config, message] of [
+            [{zones: {center: 'missing'}}, 'unknown pane "missing"'],
+            [{panes: {editor: {id: 'shared-pane'}, second: {id: 'shared-pane'}}}, 'panes.second.id: already in use'],
+            [{dockModel: {}}, 'dockModel:'],
+            [{dockModel: {schema: 'neo.dock.zone.v1', items: {}, nodes: null, root: 'root'}}, 'dockModel:']
+        ]) {
+            const id = Neo.getId('invalid-dock-authoring');
+            try {
+                expect(() => Neo.create(DeclaredWorkspace, {...config, id})).toThrow(message);
+                expect(Neo.get(id)?.items).toHaveLength(0)
+            } finally {
+                Neo.get(id)?.destroy()
+            }
+        }
+    });
+
+    test('the existing recreate transaction adopts a fresh declared identity after success', () => {
+        workspace = Neo.create(DeclaredWorkspace);
+        const host  = Neo.create(Container), document = workspace.dockModel,
+              first = host.add(workspace.resolvePane('editor', document.items.editor));
+        first.text = 'instance state';
+        const result = workspace.recreateDockPane('editor', first);
+        expect(result.errors).toEqual([]);
+        expect(first.isDestroyed).toBe(true);
+        expect(result.pane.text).toBe('Initial editor');
+        expect(workspace.resolvePane('editor', document.items.editor)).toBe(result.pane);
+        expect(workspace.retainDeclaredPane(result.pane, 'editor')).toBe(true);
+        expect(workspace.dockModel).toBe(document);
+        host.destroy()
+    });
+
+    test('open refuses unknown and already cataloged declarations without scheduling a projection', async () => {
+        workspace = Neo.create(DeclaredWorkspace);
+        const before = workspace.dockModel;
+        expect((await workspace.openPane('editor')).errors).toEqual(['item "editor" already exists or is reserved']);
+        expect((await workspace.openPane('missing')).errors).toEqual(['unknown declared pane "missing"']);
+        expect((await workspace.openPane('constructor')).errors).toEqual(['unknown declared pane "constructor"']);
+        expect(workspace.dockModel).toBe(before);
+        expect(workspace.refreshPromise).toBeNull()
+    });
+
+    test('rail release and chrome destruction preserve Workspace-owned panes until close', async () => {
+        workspace = Neo.create(DeclaredWorkspace);
+        const document = workspace.dockModel,
+              makeRail = () => Neo.create(Rail, {
+                  dockZoneDocument   : document,
+                  edge               : 'right',
+                  railItems          : [{dockEdge: 'right', dockItemId: 'editor', restorable: true, title: 'Editor'}],
+                  resolveComponentRef: (ref, item, itemId) => workspace.resolvePane(itemId, item),
+                  retainRevealPane   : workspace.retainDeclaredPane.bind(workspace)
+              });
+        let rail = makeRail();
+        rail.onTabClick({component: rail.items[0]});
+        const pane = rail.revealOverlay.paneSlot.items[0];
+        pane.text = 'retained state';
+        await rail.releaseRevealPane('editor');
+        expect(pane.isDestroyed).not.toBe(true);
+        expect(workspace.resolvePane('editor', document.items.editor)).toBe(pane);
+        rail.destroy();
+
+        rail = makeRail();
+        rail.onTabClick({component: rail.items[0]});
+        expect(rail.revealOverlay.paneSlot.items[0]).toBe(pane);
+        rail.destroy();
+        expect(pane.isDestroyed).not.toBe(true);
+        expect(pane.text).toBe('retained state');
+        workspace.releaseDeclaredPanes({items: {}});
+        expect(pane.isDestroyed).toBe(true)
+    });
+});

--- a/test/playwright/unit/dashboard/DockWorkspaceAuthoring.spec.mjs
+++ b/test/playwright/unit/dashboard/DockWorkspaceAuthoring.spec.mjs
@@ -66,7 +66,8 @@ test.describe('Workspace initial pane declarations', () => {
     });
 
     test('later replacement or mutation of declarations cannot change the captured seed', () => {
-        workspace = Neo.create(DeclaredWorkspace);
+        const panes = Neo.clone(DeclaredWorkspace.config.panes, true, true);
+        workspace = Neo.create(DeclaredWorkspace, {panes});
         const document = workspace.dockModel;
         workspace.panes.editor.text = 'mutated';
         workspace.set({panes: {editor: {ntype: 'component', text: 'replacement'}}, zones: 'second'});


### PR DESCRIPTION
Resolves #18476
Related: #18474

A basic DockWorkspace now consumes plain initial `panes` and `zones`: no consumer constructor seed, resolver, cache or projection hook. Capture runs after the complete synchronous construction chain; a supplied valid document wins, and later declaration changes leave the consumed configuration alone. Container/Card and the component manager own creation and lookup. Declared instances survive moves and rail transitions; `openPane()` restores a closed declaration through `addItem`. The existing Reload recreate transaction adopts its replacement only after successful insertion.

Evidence: L3 rendered browser journeys plus L2 unit controls; L3 required for the real consumer and lifecycle contract. Residual: none for this leaf.

## AC Evidence

| AC | Evidence |
|---|---|
| AC-1 | CI-covered: component `dashboard/DockWorkspaceAuthoring.spec.mjs` renders the config-only fixture's tabs, split and rail. |
| AC-2 | CI-covered: unit `dashboard/DockWorkspaceAuthoring.spec.mjs` covers literal/computed capture, supplied-document precedence, invalid inputs and later mutation; the rendered later-assignment journey preserves moved state. |
| AC-3 | CI-covered: rendered same-class independent provider bindings, separate lazy activations, eager and lazy tab/rail identity witnesses; unit rail release/teardown ownership control. |
| AC-4 | CI-covered: rendered close removes the record and instance; public reopen restores exactly one from the captured config; existing/unknown declarations refuse. Existing recreate integration also preserves the declared lookup after replacement. |
| AC-5 | CI-covered: existing dashboard Workspace/first-projection/Group-context and browser suites; no seed logic enters `projectDockZoneDocument`. |
| AC-6 | CI-covered: `DockImportDirection.spec.mjs` checks normalizer inclusion and Transaction/History/TopologyLibrary exclusion with crossing controls. Measured static closure: 79 → 80 modules; 1,545,156 → 1,577,104 bytes (+31,948). Normalizer: 24,829 bytes; final host: 163,606 bytes. |
| AC-7 | ADR 0029 §§2.1/2.6, Workspace JSDoc and adoption Decisions 1–2 updated together. The guide's changed Mermaid labels were render-verified. |
| AC-8 | Host code lines: 1,035 → 1,096. Baseline records the measured count; the explicit growth declaration below supplies the exception. No ceiling above the measurement. |

## Deltas from ticket

The rail's existing release path gains an optional lifetime-owner callback so a declared config-created pane can leave rail chrome without being destroyed. Undeclared panes retain existing ownership behavior. Declared Reload uses the existing two-phase recreate protocol; it does not introduce another recreation mechanism.

The config-only fixture replaces the constructor/resolver/cache burden with declarations. Production consumer migrations remain in the existing dependent leaves; this host leaf enables their deletion rather than editing their owned surfaces. Pure lowering stays in the already-merged model.

size-guard-growth: src/dashboard/dock/Workspace.mjs — Initial capture, declared-pane lifetime, resolution and reopening belong to the existing Workspace owner; the model remains pure and Container/Card continue to create components. This adds no second mount loop or eager optional subsystem.

Decision Record impact: amends ADR 0029 §§2.1/2.6; no persisted schema change.

## Test Evidence

First red control: four new initial-consumption/resolution assertions failed on the pre-change host, then passed. The unchanged rail-release tests retain the opposite control: panes with no external lifetime owner are destroyed.

The adoption Mermaid diagram was rendered with the repository's Mermaid build in Chromium and inspected for clipping. Runtime coverage listed above runs in CI.

## Signal Ledger

Source: [graduated stage-one discussion](https://github.com/orgs/neomjs/discussions/18468), unchanged scope.

| Family | Seat | Signal |
|---|---|---|
| claude | Vega | AUTHOR_SIGNAL / GRADUATION_PROPOSED in the current discussion body |
| claude | Mnemo | STEP_BACK, `DC_kwDODSospM4BF_u_` |
| gpt | Euclid | GRADUATION_APPROVED, `DC_kwDODSospM4BF_xj` |

## Unresolved Dissent

None in the stage-one graduation. Persistence, multi-workspace authoring and reactive declarations remain outside this leaf.

## Unresolved Liveness

Not applicable per the graduation record; this is an architecture implementation, not a core-value/consensus mutation.

## Commits

- `0f31dd46bd` — declaration consumption, lifetime/reopen/recreate integration, tests and normative docs.
- `e0ecfaa2fc` — comment-only clarification of initial and retained ownership.
- `e518148b1a` — isolate the intentionally mutated unit-test input from shared class defaults.

## Post-Merge Validation

- [x] No merge-only validation remains; the reproducible consumer and lifetime journeys run in CI.

Authored by Euclid (GPT-6, Codex). Session 4f9b7bbe-9dbc-4d36-a167-38fe0d288113.
