### PR TITLE
fix(layout): key in-flight lazy loads by id when present (#18275)

### DIFF
--- a/src/layout/Card.mjs
+++ b/src/layout/Card.mjs
@@ -99,6 +99,21 @@ class Card extends Base {
     loadingModulesById = new Map()
 
     /**
+     * Every parked config participating in one in-flight load, keyed by that load's promise.
+     *
+     * Exists only so the settle handler can release what the flight registered. The initiator is
+     * known to it directly; a joiner is not, and a joiner's identity entry outliving the flight
+     * would turn the documented retry-after-settle path into a silent cache — the next caller
+     * would receive the settled promise and the previous instance instead of loading again.
+     *
+     * A `WeakMap` keyed on the promise, so a flight that somehow never settles cannot pin its
+     * participants; the explicit delete in {@link #loadModule} is the ordinary path.
+     * @member {WeakMap<Promise,Object[]>} #loadParticipants=new WeakMap()
+     * @private
+     */
+    #loadParticipants = new WeakMap()
+
+    /**
      * Modifies the CSS classes of the container items this layout is bound to.
      * Automatically gets triggered after changing the value of activeIndex.
      * Lazy loads items which use a module config containing a function.
@@ -248,6 +263,16 @@ class Card extends Base {
             inFlight = me.loadingModules.get(item) || (id ? me.loadingModulesById.get(id) : null);
 
         if (inFlight) {
+            // A joiner that matched by `id` holds no identity entry of its own, and `id` is the
+            // VOLATILE key: four sites delete it from a config as they consume it
+            // (`Neo.mjs:263`, `collection/Base.mjs:633`, `core/Base.mjs:283`,
+            // `functional/component/Base.mjs:493`). Registering the joiner under its own object
+            // identity — the one key that cannot change — keeps its join for the rest of the
+            // flight rather than only until its id is taken. Auditing those four call sites
+            // instead would be an audit that rots at the fifth.
+            me.loadingModules.set(item, inFlight);
+            me.#loadParticipants.get(inFlight)?.push(item);
+
             return inFlight
         }
 
@@ -261,14 +286,21 @@ class Card extends Base {
         // the same, now id-less object, and that caller re-enters the loader against an
         // `item.module` which has already become the resolved class. Two entries, one promise, so
         // a re-resolved config naming the item and the original object join the same load.
+        const participants = [item];
+
+        me.#loadParticipants.set(load, participants);
         me.loadingModules.set(item, load);
         id && me.loadingModulesById.set(id, load);
 
         // A rejected import must not leave the item unloadable: the entries go whatever the
         // outcome, so the next activation retries against a config that is still parked behind its
-        // placeholder. Removed by the captured id, for the same reason it was captured.
+        // placeholder. EVERY participant is removed, not just the initiator — a joiner's identity
+        // entry outliving the flight would hand the next caller a settled promise and the old
+        // instance, quietly converting the retry path into a cache. Removed by the captured id for
+        // the same reason it was captured.
         return load.finally(() => {
-            me.loadingModules.delete(item);
+            participants.forEach(participant => me.loadingModules.delete(participant));
+            me.#loadParticipants.delete(load);
             id && me.loadingModulesById.delete(id)
         })
     }

--- a/src/layout/Card.mjs
+++ b/src/layout/Card.mjs
@@ -87,9 +87,12 @@ class Card extends Base {
      * own default returns a fresh config literal. A repair pass re-resolving through that default
      * produced a new object, missed the identity guard, and constructed the item a second time.
      *
-     * An `id` names the item across those re-resolutions, so it is the stronger key where one
-     * exists. A plain `Map` rather than a `WeakMap` because a string key holds nothing alive, and
-     * entries are removed on settle by {@link #loadModule}, exactly as the identity map's are.
+     * An `id` names the item across those re-resolutions, so it is registered ALONGSIDE the
+     * identity entry rather than instead of it — never as a replacement. `core.Base.construct`
+     * deletes `config.id` while the load is still pending, so an id-only registration would stop
+     * matching the very object that started it. A plain `Map` rather than a `WeakMap` because a
+     * string key holds nothing alive, and entries are removed on settle by {@link #loadModule},
+     * exactly as the identity map's are.
      * @member {Map<String,Promise>} loadingModulesById=new Map()
      * @protected
      */
@@ -230,17 +233,19 @@ class Card extends Base {
      * surfaced as an intermittent double construction under machine load rather than as a bug.
      *
      * A second call therefore joins the in-flight promise and settles on the same instance. What
-     * counts as "the same item" is {@link #loadSlot}'s question: the config's `id` where it has one,
-     * object identity otherwise. Identity alone was not enough — a caller re-resolving the item
-     * through a documented-legal path arrives holding a new object for the same pane.
+     * counts as "the same item" is deliberately BOTH answers at once: the pending load is
+     * registered under the config's object identity and, when it has one, under its `id`. Identity
+     * alone was not enough — a caller re-resolving the item through a documented-legal path arrives
+     * holding a new object for the same pane. The `id` alone is not enough either, because
+     * construction deletes it from the config while the load is still in flight.
      * @param {Object} item
      * @param {Number} [index]
      * @returns {Promise<Neo.component.Base>}
      */
     loadModule(item, index) {
-        let me           = this,
-            {store, key} = me.#loadSlot(item),
-            inFlight     = store.get(key);
+        let me       = this,
+            {id}     = item,
+            inFlight = me.loadingModules.get(item) || (id ? me.loadingModulesById.get(id) : null);
 
         if (inFlight) {
             return inFlight
@@ -248,31 +253,24 @@ class Card extends Base {
 
         const load = me.#loadModuleOnce(item, index);
 
-        store.set(key, load);
+        // Registered under BOTH keys for the whole pending lifetime, and `id` is captured here
+        // rather than re-read on the way out — because the parked object's key CHANGES while the
+        // load is in flight. `core.Base.construct` runs `delete config.id` as it consumes the
+        // config (`src/core/Base.mjs:283`), so choosing one key per call loses a joiner in
+        // whichever direction it did not choose: an id-keyed entry misses a later caller holding
+        // the same, now id-less object, and that caller re-enters the loader against an
+        // `item.module` which has already become the resolved class. Two entries, one promise, so
+        // a re-resolved config naming the item and the original object join the same load.
+        me.loadingModules.set(item, load);
+        id && me.loadingModulesById.set(id, load);
 
-        // A rejected import must not leave the item unloadable: the entry goes whatever the outcome,
-        // so the next activation retries against a config that is still parked behind its placeholder.
-        return load.finally(() => store.delete(key))
-    }
-
-    /**
-     * The in-flight store and key for one parked item — `id` when the config carries one, object
-     * identity otherwise.
-     *
-     * A strict SUPERSET of keying on identity alone, never less, and the "otherwise" is the
-     * load-bearing half. Keying on `id` unconditionally would collide every id-less parked config
-     * onto a single `undefined` key, so a second caller would join an unrelated item's load and
-     * receive the FIRST item's instance — a worse defect than the duplicate construction this
-     * keying removes. `layout.Card` has never required an id, so that path is ordinary rather than
-     * exotic.
-     * @param {Object} item
-     * @returns {Object} `{store, key}` — the map to read and the key to read it with.
-     * @private
-     */
-    #loadSlot(item) {
-        const {id} = item;
-
-        return id ? {store: this.loadingModulesById, key: id} : {store: this.loadingModules, key: item}
+        // A rejected import must not leave the item unloadable: the entries go whatever the
+        // outcome, so the next activation retries against a config that is still parked behind its
+        // placeholder. Removed by the captured id, for the same reason it was captured.
+        return load.finally(() => {
+            me.loadingModules.delete(item);
+            id && me.loadingModulesById.delete(id)
+        })
     }
 
     /**

--- a/src/layout/Card.mjs
+++ b/src/layout/Card.mjs
@@ -69,13 +69,31 @@ class Card extends Base {
     }
 
     /**
-     * In-flight {@link #loadModule} calls, keyed by the parked item config so a second caller joins
-     * the first load instead of starting its own. Keyed by the config rather than stored on it,
-     * because the config itself is handed to `Neo.create` once the module resolves.
+     * In-flight {@link #loadModule} calls for parked items carrying no `id`, keyed by the config
+     * object so a second caller joins the first load instead of starting its own. Keyed by the
+     * config rather than stored on it, because the config itself is handed to `Neo.create` once the
+     * module resolves.
      * @member {WeakMap<Object,Promise>} loadingModules=new WeakMap()
      * @protected
      */
     loadingModules = new WeakMap()
+
+    /**
+     * In-flight {@link #loadModule} calls for parked items carrying an `id`.
+     *
+     * Object identity alone does not span a re-resolution. A consumer may legally hand `loadModule`
+     * a DIFFERENT config object for the same item: `dashboard.dock`'s reconciler documents both
+     * shapes as permitted — a cache-backed resolver returns the same instances, while the engine's
+     * own default returns a fresh config literal. A repair pass re-resolving through that default
+     * produced a new object, missed the identity guard, and constructed the item a second time.
+     *
+     * An `id` names the item across those re-resolutions, so it is the stronger key where one
+     * exists. A plain `Map` rather than a `WeakMap` because a string key holds nothing alive, and
+     * entries are removed on settle by {@link #loadModule}, exactly as the identity map's are.
+     * @member {Map<String,Promise>} loadingModulesById=new Map()
+     * @protected
+     */
+    loadingModulesById = new Map()
 
     /**
      * Modifies the CSS classes of the container items this layout is bound to.
@@ -211,16 +229,18 @@ class Card extends Base {
      * orphaning a live component. The window is exactly the import's duration, which is why it
      * surfaced as an intermittent double construction under machine load rather than as a bug.
      *
-     * A second call therefore joins the in-flight promise and settles on the same instance. The
-     * promise is keyed in a `WeakMap` by the parked config rather than stored on it, because that
-     * config is passed to `Neo.create` once it resolves.
+     * A second call therefore joins the in-flight promise and settles on the same instance. What
+     * counts as "the same item" is {@link #loadSlot}'s question: the config's `id` where it has one,
+     * object identity otherwise. Identity alone was not enough — a caller re-resolving the item
+     * through a documented-legal path arrives holding a new object for the same pane.
      * @param {Object} item
      * @param {Number} [index]
      * @returns {Promise<Neo.component.Base>}
      */
     loadModule(item, index) {
-        let me       = this,
-            inFlight = me.loadingModules.get(item);
+        let me           = this,
+            {store, key} = me.#loadSlot(item),
+            inFlight     = store.get(key);
 
         if (inFlight) {
             return inFlight
@@ -228,11 +248,31 @@ class Card extends Base {
 
         const load = me.#loadModuleOnce(item, index);
 
-        me.loadingModules.set(item, load);
+        store.set(key, load);
 
         // A rejected import must not leave the item unloadable: the entry goes whatever the outcome,
         // so the next activation retries against a config that is still parked behind its placeholder.
-        return load.finally(() => me.loadingModules.delete(item))
+        return load.finally(() => store.delete(key))
+    }
+
+    /**
+     * The in-flight store and key for one parked item — `id` when the config carries one, object
+     * identity otherwise.
+     *
+     * A strict SUPERSET of keying on identity alone, never less, and the "otherwise" is the
+     * load-bearing half. Keying on `id` unconditionally would collide every id-less parked config
+     * onto a single `undefined` key, so a second caller would join an unrelated item's load and
+     * receive the FIRST item's instance — a worse defect than the duplicate construction this
+     * keying removes. `layout.Card` has never required an id, so that path is ordinary rather than
+     * exotic.
+     * @param {Object} item
+     * @returns {Object} `{store, key}` — the map to read and the key to read it with.
+     * @private
+     */
+    #loadSlot(item) {
+        const {id} = item;
+
+        return id ? {store: this.loadingModulesById, key: id} : {store: this.loadingModules, key: item}
     }
 
     /**

--- a/test/playwright/unit/container/InsertLazyModule.spec.mjs
+++ b/test/playwright/unit/container/InsertLazyModule.spec.mjs
@@ -330,6 +330,65 @@ test.describe('Neo.container.Base#insert — a lazy module config parks, then lo
     });
 
     /**
+     * A joiner that matched by `id` must keep its join after its OWN id is consumed.
+     *
+     * The id-hit returns the in-flight promise, and it would be natural to stop there — the caller
+     * got what it asked for. But it leaves that config holding no identity entry, and `id` is the
+     * volatile key: four sites delete it from a config as they consume it. So the joiner's claim
+     * on the flight lasts only until something takes its id, after which it re-enters the loader
+     * and builds a second instance.
+     *
+     * Object identity is the one key that cannot change, which is why every participant is
+     * registered under it rather than only the initiator. Probe contributed by @neo-gpt-emmy as
+     * the open half of a review action.
+     *
+     * The second phase is the cost of that registration: participants must be RELEASED on settle,
+     * or a joiner's entry outlives the flight and the documented retry path becomes a cache.
+     */
+    test('a joiner that matched by id keeps its join after its own id is consumed, and is released on settle', async () => {
+        let resolveImport;
+
+        const deferred = new Promise(resolve => {resolveImport = resolve});
+
+        container = cardContainer();
+        container.add({id: 'insert-lazy-module-alias', module: () => deferred, text: 'lazy'});
+
+        const parked = container.items[1],
+              alias  = {id: parked.id, module: () => deferred, text: 'lazy'};
+
+        Counted.constructions = 0;
+
+        const first  = container.layout.loadModule(parked, 1),
+              joined = container.layout.loadModule(alias, 1);
+
+        // Compared as resolved instances rather than as promises: the initiator receives the
+        // `.finally()`-wrapped promise and a joiner receives the raw one, so the two are never
+        // identical by reference even when they are the same flight.
+        //
+        // The volatile key, taken exactly as construction takes it — before anything settles.
+        delete alias.id;
+
+        const afterIdLoss = container.layout.loadModule(alias, 1);
+
+        resolveImport({default: Counted});
+
+        const [a, b, c] = await Promise.all([first, joined, afterIdLoss]);
+
+        expect(Counted.constructions, 'exactly one construction across all three callers').toBe(1);
+        expect(b, 'the alias joined the flight by id').toBe(a);
+        expect(c, 'and still settles on the SAME instance after losing its id').toBe(a);
+
+        // Released on settle: the next call is a real retry, not a replay of the settled promise.
+        // `alias` was never constructed, so its `module` is still a function and a retry can run.
+        Counted.constructions = 0;
+
+        const retried = await container.layout.loadModule(alias, 1);
+
+        expect(Counted.constructions, 'a settled flight is not cached for a joiner').toBe(1);
+        expect(retried, 'and the retry yields its own instance').not.toBe(a)
+    });
+
+    /**
      * The other half of the keying, and the reason it is `id` WHEN PRESENT rather than `id`.
      *
      * `layout.Card` has never required an id on a parked config — the arms above this one carry

--- a/test/playwright/unit/container/InsertLazyModule.spec.mjs
+++ b/test/playwright/unit/container/InsertLazyModule.spec.mjs
@@ -225,6 +225,96 @@ test.describe('Neo.container.Base#insert — a lazy module config parks, then lo
         expect(container.items[1], 'the container holds the instance both callers received').toBe(a)
     });
 
+    /**
+     * The arm above holds the SAME config object twice. This one holds two different objects naming
+     * one item — which is what a re-resolution produces, and what object identity cannot see.
+     *
+     * `dashboard.dock`'s reconciler documents both resolver shapes as legal: a cache-backed one
+     * returns the same instances, the engine's own default returns a fresh config literal. Under the
+     * default, a repair pass re-resolving a pane mid-import arrived holding a new object, missed the
+     * identity-keyed guard and constructed the pane twice. That surfaced as an intermittent CI red
+     * whose two loads carried frame-identical stacks, differing only in the projection pass that
+     * raised them — so the call site could never have told them apart.
+     *
+     * Deterministic here for the same reason the arm above is: the deferred loader holds the window
+     * open rather than leaving it as wide as a real import.
+     */
+    test('a re-resolved config naming the same id joins the in-flight load instead of constructing again', async () => {
+        let resolveImport;
+
+        const deferred = new Promise(resolve => {resolveImport = resolve});
+
+        container = cardContainer();
+        container.add({id: 'insert-lazy-module-reresolved', module: () => deferred, text: 'lazy'});
+
+        const parked = container.items[1];
+
+        expect(parked, 'the config must be parked, not constructed').not.toBeInstanceOf(Neo.core.Base);
+
+        // What the repair pass holds: a fresh literal for the same pane. Built here rather than
+        // driven through the dock, because the discriminator is the pair of configs, not the route.
+        const reResolved = {id: parked.id, module: () => deferred, text: 'lazy'};
+
+        expect(reResolved, 'void unless the two configs are genuinely different objects').not.toBe(parked);
+        expect(reResolved.id, 'and genuinely name the same item').toBe(parked.id);
+
+        // File-shared counter: unscoped, this reads the constructions of every arm before it.
+        Counted.constructions = 0;
+
+        const first  = container.layout.loadModule(parked,     1),
+              second = container.layout.loadModule(reResolved, 1);
+
+        resolveImport({default: Counted});
+
+        const [a, b] = await Promise.all([first, second]);
+
+        expect(Counted.constructions, 'exactly one construction').toBe(1);
+        expect(a, 'both callers settle on the SAME instance').toBe(b);
+        expect(container.items[1], 'the container holds the instance both callers received').toBe(a)
+    });
+
+    /**
+     * The other half of the keying, and the reason it is `id` WHEN PRESENT rather than `id`.
+     *
+     * `layout.Card` has never required an id on a parked config — the arms above this one carry
+     * none — so keying on `id` alone would collide every id-less item onto a single `undefined`
+     * key. The second caller would then join an unrelated load and receive the FIRST item's
+     * instance: a container quietly holding the wrong component, which is worse than the duplicate
+     * construction the id keying exists to remove. This arm fails on that shortcut and passes on
+     * the superset.
+     */
+    test('two id-less parked configs load independently rather than colliding on one absent key', async () => {
+        let resolveA, resolveB;
+
+        const deferredA = new Promise(resolve => {resolveA = resolve}),
+              deferredB = new Promise(resolve => {resolveB = resolve});
+
+        container = cardContainer();
+        container.add({module: () => deferredA, text: 'lazy a'});
+        container.add({module: () => deferredB, text: 'lazy b'});
+
+        const parkedA = container.items[1],
+              parkedB = container.items[2];
+
+        expect(parkedA.id, 'the arm needs a genuinely id-less config').toBeUndefined();
+        expect(parkedB.id, 'the arm needs a genuinely id-less config').toBeUndefined();
+
+        Counted.constructions = 0;
+
+        // Both in flight together: a shared key is only observable while neither has settled.
+        const first  = container.layout.loadModule(parkedA, 1),
+              second = container.layout.loadModule(parkedB, 2);
+
+        resolveA({default: Counted});
+        resolveB({default: Counted});
+
+        const [a, b] = await Promise.all([first, second]);
+
+        expect(Counted.constructions, 'each id-less item constructs its own instance').toBe(2);
+        expect(a, 'two different items must not settle on one instance').not.toBe(b);
+        expect(container.items[2], 'and each slot holds its own').toBe(b)
+    });
+
     test('a failed import leaves nothing in flight, so the next call retries', async () => {
         const failing  = {module: () => Promise.reject(new Error('chunk gone')), text: 'lazy'},
               original = console.error;

--- a/test/playwright/unit/container/InsertLazyModule.spec.mjs
+++ b/test/playwright/unit/container/InsertLazyModule.spec.mjs
@@ -274,6 +274,62 @@ test.describe('Neo.container.Base#insert — a lazy module config parks, then lo
     });
 
     /**
+     * The parked object's KEY CHANGES while its load is in flight, and this arm is the only thing
+     * that says so.
+     *
+     * `core.Base.construct` runs `delete config.id` (`src/core/Base.mjs:283`) as it consumes the
+     * parked config. A caller arriving after that point holds the same object with no id —
+     * `onConstructed` is the earliest such caller, and it still sees the config literally in
+     * `container.items[1]`, because the assignment back into `items` has not happened yet.
+     *
+     * Registered under the id alone, that caller misses, re-enters `#loadModuleOnce`, and finds
+     * `item.module` already replaced by the resolved class: `TypeError: module is not a function`,
+     * with the first load still pending. Registering under BOTH keys is what makes the id an
+     * addition rather than a substitution. Found in review by @neo-gpt-emmy, who executed the Card
+     * source from both revisions rather than reading them.
+     */
+    test('a re-entrant load from onConstructed joins, though construction has consumed the id', async () => {
+        let resolveImport, reentry, parkedDuringHook;
+
+        const deferred = new Promise(resolve => {resolveImport = resolve});
+
+        container = cardContainer();
+        container.add({id: 'insert-lazy-module-reentrant', module: () => deferred, text: 'lazy'});
+
+        const parked = container.items[1];
+
+        expect(parked.id, 'the arm needs an id-bearing parked config').toBe('insert-lazy-module-reentrant');
+
+        class ReEntrant extends Button {
+            static config = {
+                className: 'Test.Unit.Container.InsertLazyModule.ReEntrant'
+            }
+
+            onConstructed() {
+                super.onConstructed();
+
+                parkedDuringHook = container.items[1] === parked;
+                reentry          = container.layout.loadModule(parked, 1).then(value => ({value}), error => ({error}))
+            }
+        }
+
+        Neo.setupClass(ReEntrant);
+
+        const first = container.layout.loadModule(parked, 1);
+
+        resolveImport({default: ReEntrant});
+
+        const a = await first,
+              b = await reentry;
+
+        expect(parkedDuringHook, 'the config is still the items entry while onConstructed runs').toBe(true);
+        expect(parked.id,        'and construction has already consumed its id').toBeUndefined();
+
+        expect(b.error, `the re-entrant caller must join, not re-enter — ${b.error?.message ?? ''}`).toBeUndefined();
+        expect(b.value, 'both callers settle on the SAME instance').toBe(a)
+    });
+
+    /**
      * The other half of the keying, and the reason it is `id` WHEN PRESENT rather than `id`.
      *
      * `layout.Card` has never required an id on a parked config — the arms above this one carry


### PR DESCRIPTION
Resolves #18275

## What was wrong

`layout.Card#loadModule` deduplicated concurrent loads through a `WeakMap` keyed on the parked config's **object identity**. That guard cannot span a re-resolution — and re-resolution is a documented-legal path. [`src/dashboard/dock/projection/Reconciler.mjs:663`](https://github.com/neomjs/neo/blob/dev/src/dashboard/dock/projection/Reconciler.mjs#L663) states both resolver shapes are permitted:

> *"A cache-backed `Workspace#resolvePane` therefore returns the same instances and nothing is rebuilt, while the engine's own default returns a fresh config literal and the repair builds replacements. **Both are legal.**"*

A dock repair pass re-resolving a pane **mid-import** arrives holding a new object for the same pane, misses the guard, and constructs it a second time — the second instance overwriting the first in `items` and orphaning a live component.

Intermittent rather than constant because the map entry is removed in `.finally()`: the second load only escapes while the first is still in flight.

## AC Evidence

| # | AC | Status |
|---|---|---|
| 1 | The double construction reproduced where a test can watch it, on demand. *"Tier is free; the direction is not."* | **MET** — deterministic unit reproducer with a green control beside it. |
| 2 | The second caller **named** from that reproduction, from evidence rather than inferred | **MET** — CI run [33968288125](https://github.com/neomjs/neo/actions/runs/33968288125) captured both loads with frame-identical stacks differing only in the pass that raised them: `pass 3` and `pass 4 REPAIR`, each `BodyContainer.insert → loadModule → #loadModuleOnce`. #18343's attribution instrumentation is what made them distinguishable. |
| 3 | A fix, arm red before and green after, against AC-1's reproduction | **MET** — three arms, each with its own mutation, below. |
| 4 | Not-reproducible fallback | **N/A** — it reproduces. |

## The fix

A pending load is registered under **both** of its keys — object identity **and**, when present, `id` — for its whole lifetime, with `id` captured at call time and reused for cleanup.

**The first version of this PR chose one key per call, and that was wrong.** @neo-gpt-emmy found it by executing the Card source from both revisions: `core.Base.construct` runs `delete config.id` (`src/core/Base.mjs:283`) as it consumes the parked config, so **the object's key changes while its own load is still in flight**. Registered under the id alone, a later caller holding the same — now id-less — object misses, re-enters `#loadModuleOnce`, and finds `item.module` already replaced by the resolved class: `TypeError: module is not a function`, with the first load still pending and the config still literally in `container.items[1]`.

`onConstructed` is the earliest such caller and an entirely ordinary one. My claim that id-keying was *"a strict superset of the previous dedup, never less"* was false, and that case is what falsifies it. Registering under both keys makes it true.

**The same review action had a second half, and the first fix did not close it.** A caller that matched by `id` received the in-flight promise and nothing else — no entry of its own. `id` is the **volatile** key: four sites delete it from a config as they consume it (`Neo.mjs:263`, `collection/Base.mjs:633`, `core/Base.mjs:283`, `functional/component/Base.mjs:493`), so that joiner's claim on the flight lasted only until something took its id, after which it re-entered and built a second instance.

Object identity is the one key that **cannot** change, so every participant is now registered under it — not only the initiator. The alternative offered in review was a source-backed defense that no production caller deletes an alias's id mid-flight; with four deletion sites that is an audit which rots at the fifth, and the invariant is cheaper to hold than to re-verify.

That registration has a cost, and it carries its own assertion: participants must be **released** on settle. A joiner's entry outliving the flight would hand the next caller a settled promise and the previous instance — quietly converting the documented retry-after-settle path into a cache.

## Test Evidence

Four arms, each proved able to red **for its own reason** by mutating this source:

| mutation | arms that red | collateral |
|---|---|---|
| identity-only keying (the original behaviour) | `a re-resolved config naming the same id …` — *"exactly one construction"*, received 2 | none |
| id-only keying | `two id-less parked configs …` | none |
| exclusive registration (this PR's first version) | `a re-entrant load from onConstructed …` — *"must join, not re-enter — module is not a function"* | none |
| joiner not registered under its own identity | `a joiner that matched by id …` — *"exactly one construction across all three callers"* | none |
| only the initiator released on settle | `a joiner that matched by id …` — *"a settled flight is not cached for a joiner"* | none |

Each control matters because the arm it reds is the **only** one that catches its case:

- The id-only shortcut **passes** the re-resolution reproducer, and the suite's pre-existing id-less arm reuses one object — so it keys to `undefined` on both sides and passes too.
- The exclusive registration **passes both** discriminators above. Nothing in the suite, before or after my first commit, could see it. That is why the regression arm drives real construction through `Neo.create` with no manual deletion of `id`, and asserts both that the config is still the items entry during the hook and that its id is already gone — so it documents the mechanism, not just the symptom.

Evidence: `11 passed` on `InsertLazyModule.spec.mjs`; `95 passed` across the `container` / `layout` / `tab` card-layout consumers; full unit suite **3604 passed / 2 skipped**.

One correction I made to my own arm while writing it: I first asserted the joiner's promise was *identical* to the initiator's. It is not, and that is not a defect — the initiator receives the `.finally()`-wrapped promise while a joiner receives the raw one. The arm compares resolved instances instead, which is what the contract is actually about.

## Post-Merge Validation

1. The dock arm this was diagnosed from (`DockRailLazyModule.spec.mjs:152`) is a **CI intermittent**. Its going green is the observation this fix predicts — local absence never cleared it before, so it is not claimed here. Watch it across the next several `dev` runs.
2. If it still reds after this lands, the identity-miss was real but not the whole cause. That evidence belongs to a **linked successor ticket**, not to reopening #18275 — the same relationship #18275 itself has to #18201. This ticket's ACs are met by what shipped.
3. Watch for `module is not a function` from `layout/Card` anywhere in CI. That string is the signature of a lost joiner, and after this change it should be unreachable.

## Deltas

- `src/layout/Card.mjs` — `loadingModulesById` added beside `loadingModules`; both hold the pending promise; `id` captured at call time and reused for cleanup. Every joiner is registered under its own object identity, and `#loadParticipants` (a `WeakMap` keyed on the promise) exists solely so the settle handler can release them all. `#loadSlot` removed — there is no per-call choice left to make. Docblocks state why the id is an addition rather than a substitution.
- `test/playwright/unit/container/InsertLazyModule.spec.mjs` — four arms: the re-resolution reproducer, the id-less collision guard, the construction re-entry regression, and the joined-alias lifetime with its release-on-settle half.

Origin Session ID: 69ff8d6f-0e9e-4c44-aff9-e8007f4d7090

Authored by ⚖️ **Ada** · `@neo-opus-ada` · Claude Opus 5 · Claude Code
