### PR TITLE
feat(workstation): make tour playback optional and controller-owned (#18458)

### DIFF
--- a/apps/workstation/README.md
+++ b/apps/workstation/README.md
@@ -18,12 +18,22 @@ npm run server-start
 The non-interactive theme build creates the ignored development CSS and `theme-map.json`
 artifacts a fresh checkout does not contain.
 
+Ordinary docking, live panes, saving/restoring and theme controls work without activating playback.
+The lightweight tour toolbar binds its caption and progress to the existing root state provider.
+Its playback controller, runner and gesture drivers are created only when requested.
+
 Press **Start dense tour**. The screenplay opens the real overflow menu, scrolls the 100k grid,
 promotes a live pane through `splitNode`, returns it through `addTab`, and flips both themes.
 Pane, store, component, and relevant DOM identities remain stable while the layout changes.
 
 The data-only screenplay lives in `apps/workstation/tour/denseWorkstation.mjs`; the mounted
 whitebox journey is the runtime and visual falsifier.
+
+For programmatic playback, resolve the optional owner with
+`await workspace.getController().getTourController()`, then call its `startTour()`,
+`runTourSpec()` or `getTourReceipt()`. `cancelTour()` retires that playback controller and waits
+for its started cue work; a later Start creates a fresh controller. The workspace and its stores
+remain owned by the ordinary application.
 
 ## Save and reopen a workspace
 

--- a/apps/workstation/tour/GestureDriver.mjs
+++ b/apps/workstation/tour/GestureDriver.mjs
@@ -25,6 +25,14 @@ class GestureDriver extends Base {
     /** @member {Neo.ai.client.InteractionService|null} interactionService=null */
     interactionService = null
 
+    /** @member {Promise|null} #settledPromise=null Retained cleanup boundary after destruction. */
+    #settledPromise = null
+
+    /** @summary Resolves after all started gestures finish their input and cursor cleanup. @returns {Promise} */
+    get settledPromise() {
+        return this.#settledPromise ?? Promise.all([...this.activeRuns].map(run => run.settled))
+    }
+
     /** @summary Creates the optional input service with its driver. @param {Object} config */
     construct(config) {
         super.construct(config);
@@ -40,6 +48,7 @@ class GestureDriver extends Base {
         if (this.isDestroyed || this.workspace.isDestroyed) throw Neo.isDestroyed;
         const runs = this.activeRuns,
               run  = {workspace: this.workspace, service: this.interactionService, pending: null, pointer: null};
+        run.settled = new Promise(resolve => {run.resolveSettlement = resolve});
         runs.add(run);
         try {
             return await execute(run)
@@ -58,7 +67,11 @@ class GestureDriver extends Base {
                 }
             } finally {
                 runs.delete(run);
-                this.isDestroyed && !runs.size && run.service.destroy()
+                try {
+                    this.isDestroyed && !runs.size && run.service.destroy()
+                } finally {
+                    run.resolveSettlement()
+                }
             }
         }
     }
@@ -89,6 +102,7 @@ class GestureDriver extends Base {
     destroy() {
         if (this.isDestroyed) return;
         const runs = this.activeRuns, service = this.interactionService;
+        this.#settledPromise = this.settledPromise;
         super.destroy();
         !runs.size && service.destroy()
     }

--- a/apps/workstation/tour/denseWorkstation.mjs
+++ b/apps/workstation/tour/denseWorkstation.mjs
@@ -183,3 +183,14 @@ export const workstationTourScript = Object.freeze({
         }]
     }]
 });
+
+/**
+ * @summary Initial bindable tour presentation; importing it creates no playback runtime.
+ * @type {Object}
+ */
+export const initialTourState = Object.freeze({
+    caption       : `${workstationTourScript.title} — twenty panes, 100k rows, a 10/sec feed, real overflow, and two themes.`,
+    completedCount: 0,
+    running       : false,
+    totalBeats    : workstationTourScript.scenes.flatMap(scene => scene.steps).length
+});

--- a/apps/workstation/view/TourController.mjs
+++ b/apps/workstation/view/TourController.mjs
@@ -1,0 +1,552 @@
+import Controller                               from '../../../src/controller/Component.mjs';
+import ClassSystem                              from '../../../src/util/ClassSystem.mjs';
+import TourRunner                               from '../../../src/ai/client/TourRunner.mjs';
+import NativeGestureDriver                      from '../tour/NativeGestureDriver.mjs';
+import WorkspaceDocument                        from '../../../src/dashboard/dock/model/WorkspaceDocument.mjs';
+import {workstationTourScript, initialDocument} from '../tour/denseWorkstation.mjs';
+
+/**
+ * @summary Optional playback controller attached to Workstation's tour toolbar.
+ * Owns runner, gesture driver and settlement queues; borrows workspace, provider and stores.
+ * @class Workstation.view.TourController
+ * @extends Neo.controller.Component
+ */
+class TourController extends Controller {
+    static config = {
+        /** @member {String} className='Workstation.view.TourController' */
+        className: 'Workstation.view.TourController',
+        /** @member {Workstation.view.Workspace|null} workspace=null */
+        workspace: null,
+        /** @member {Neo.ai.client.TourRunner|null} tourRunner_=null @reactive */
+        tourRunner_: null,
+        /** @member {Workstation.tour.NativeGestureDriver|null} gestureDriver_=null @reactive */
+        gestureDriver_: null
+    }
+
+    /** @member {Promise} cuePromise */
+    cuePromise = Promise.resolve()
+    /** @member {Map<String,Promise>} cueSettlements */
+    cueSettlements = new Map()
+    /** @member {Promise} progressPromise */
+    progressPromise = Promise.resolve()
+    /** @member {String[]} cueErrors */
+    cueErrors = []
+    /** @member {Object[]} cueReceipts */
+    cueReceipts = []
+    /** @member {Object|null} lastTourReceipt=null */
+    lastTourReceipt = null
+    /** @member {Promise|null} playbackPromise=null */
+    playbackPromise = null
+    /** @member {Set<Neo.ai.client.TourRunner>} specRunners */
+    specRunners = new Set()
+
+    /** @summary Retires playback before its workspace starts disposing the borrowed services. */
+    onComponentConstructed() {
+        this.observeConfig(this.workspace, 'isDestroying', value => value && this.destroy())
+    }
+
+    /**
+     * @summary Creates the configured owned runner with the host settlement boundary.
+     * @param {Object|Neo.ai.client.TourRunner|null} value
+     * @param {Neo.ai.client.TourRunner|null} oldValue
+     * @returns {Neo.ai.client.TourRunner|null}
+     */
+    beforeSetTourRunner(value, oldValue) {
+        oldValue?.destroy();
+        if (!value) return value;
+        return ClassSystem.beforeSetInstance(value, TourRunner, {
+            componentId   : this.workspace.id,
+            dockService   : this.workspace.dockService,
+            mode          : 'demo',
+            script        : workstationTourScript,
+            stepSettlement: data => this.settleTourStep(data),
+            listeners     : {
+                beat : 'onTourBeat', complete: 'onTourComplete', error: 'onTourError',
+                scene: 'onTourScene', stepSettled: 'onTourStepSettled', scope: this
+            }
+        })
+    }
+
+    /**
+     * @summary Normalizes an owned driver; its own destruction retains pending input cleanup.
+     * @param {Object|Workstation.tour.NativeGestureDriver|null} value
+     * @param {Workstation.tour.NativeGestureDriver|null} oldValue
+     * @returns {Workstation.tour.NativeGestureDriver|null}
+     */
+    beforeSetGestureDriver(value, oldValue) {
+        oldValue?.destroy();
+        return value ? ClassSystem.beforeSetInstance(value, NativeGestureDriver, {workspace: this.workspace}) : value
+    }
+
+    /** @summary Creates the owned runner on first playback. @returns {Neo.ai.client.TourRunner} */
+    getTourRunner() {
+        if (this.isDestroyed) throw Neo.isDestroyed;
+        this.tourRunner ||= {};
+        return this.tourRunner
+    }
+
+    /** @summary Creates the owned gesture driver on an explicit request. @returns {Workstation.tour.NativeGestureDriver} */
+    getGestureDriver() {
+        if (this.isDestroyed) throw Neo.isDestroyed;
+        this.gestureDriver ||= {};
+        return this.gestureDriver
+    }
+
+    /** @summary Publishes caption state through the existing root provider. @param {String} text */
+    setTourCaption(text) {
+        if (!this.isDestroyed) this.setState({'tour.caption': text})
+    }
+
+    /**
+     * @summary Publishes progress through bindings and awaits its actual view paint.
+     * @param {Number} count
+     * @returns {Promise<void>}
+     */
+    async setPipProgress(count) {
+        if (this.isDestroyed) throw Neo.isDestroyed;
+        this.setState({'tour.completedCount': count});
+        await this.getReference('tour-pips')?.promiseUpdate()
+    }
+
+    /** @summary Starts at most one visible playback, including its entry projection. @returns {Promise<Object>} */
+    startTour() {
+        if (this.isDestroyed) return Promise.reject(Neo.isDestroyed);
+        if (this.playbackPromise) {
+            this.setTourCaption('Tour already running — the live stores continue underneath it.');
+            return this.playbackPromise
+        }
+        return this.playbackPromise = this.runVisibleTour().catch(error => {
+            if (error === Neo.isDestroyed) return {completed: false, cancelled: true, errors: ['Tour cancelled'], log: []};
+            throw error
+        }).finally(() => {
+            if (!this.isDestroyed) {
+                this.playbackPromise = null;
+                this.setState({'tour.running': false})
+            }
+        })
+    }
+
+    /** @summary Cancels this playback owner and waits for its already-started cue work. @returns {Promise<void>} */
+    async cancelTour() {
+        const pending = [this.playbackPromise, this.cuePromise, this.progressPromise];
+        this.component.controller = null;
+        await Promise.allSettled(pending)
+    }
+
+    /** @summary Retires playback-owned objects without disposing borrowed workspace state. */
+    destroy() {
+        if (this.isDestroyed) return;
+        const provider = this.getStateProvider();
+        this.tourRunner = null;
+        this.gestureDriver = null;
+        this.specRunners.forEach(runner => runner.isDestroyed || runner.destroy());
+        super.destroy();
+        provider && !provider.isDestroyed && provider.setData({'tour.running': false})
+    }
+
+    /**
+     * Executes a surface cue for the visual take. Spec-mode correctness waits on explicit
+     * E2E oracles because TourRunner intentionally does not await event listeners.
+     * @param {Object} cue
+     * @returns {Promise<*>}
+     */
+    async executeCue(cue) {
+        switch (cue.type) {
+            case 'overflow':
+                return this.navigateOverflowMenu(cue.itemId)
+            case 'scroll':
+                return this.scrollScaleGrid(cue.index)
+            case 'canvas-update':
+                await this.workspace.refreshPromise;
+                return this.workspace.pulseScaleSparkline()
+            case 'cross-zone-showcase':
+                return (await this.getGestureDriver()).executeCrossZoneShowcaseStep(cue, cue.options)
+            case 'theme':
+                return this.workspace.setWorkspaceTheme(cue.theme)
+            default:
+                return false
+        }
+    }
+
+    /**
+     * @summary Returns the last fully settled visible-tour receipt.
+     * @returns {Object|null}
+     */
+    getTourReceipt() {
+        return this.lastTourReceipt
+    }
+
+    /**
+     * @summary Opens the real overflow control, briefly shows its menu, then invokes the first menu
+     * item's ordinary activeIndex handler. The E2E clicks this same surface as a human.
+     * @param {String} itemId Narrated target id (used for the caption/evidence contract).
+     * @returns {Promise<Boolean>}
+     */
+    async navigateOverflowMenu(itemId) {
+        // The reducer schedules projection asynchronously. Resolve the consumer only after that transaction,
+        // otherwise `down()` can capture the retiring source toolbar and wait on its deliberately hidden control.
+        await this.workspace.refreshPromise;
+
+        let tabs   = this.workspace.down({dockNodeId: 'heavy-tabs'}),
+            plugin = tabs?.getTabBar()?.getPlugin('tab-overflow'),
+            control;
+
+        // The hidden staging transaction already captured natural widths. This consumer boundary only
+        // refreshes the visible extent so the cue never turns a stable cache into a second measurement pass.
+        await plugin?.project(false);
+        control = await this.workspace.waitForOverflowMenu(plugin);
+
+        if (!control) return false;
+
+        await control.toggleMenu();
+        await this.timeout(700);
+
+        const
+            menuItems = control.menuList?.items || [],
+            item      = menuItems.find(entry => entry.text === this.workspace.dockModel.items[itemId]?.title);
+
+        item?.handler?.();
+        control.menuList && (control.menuList.hidden = true);
+
+        return item ? {activatedItemId: itemId, menuItemCount: menuItems.length} : false
+    }
+
+    /**
+     * @summary Sequences a beat's surface cue and preserves its diagnostic receipt.
+     * @param {Object} data
+     */
+    onTourBeat(data) {
+        let me            = this, workspace = me.workspace,
+            cueSettlement = Promise.resolve();
+
+        data.caption && me.setTourCaption(data.caption);
+
+        if (data.cue) {
+            const cue = data.cue;
+
+            me.cuePromise = me.cuePromise.then(async () => {
+                if (me.isDestroyed) return false;
+                const receipt = await me.executeCue(cue);
+                if (me.isDestroyed) return false;
+
+                if (!receipt) {
+                    throw new Error(`${cue.type} returned no observable receipt`)
+                }
+
+                me.cueReceipts.push({cue: {...cue}, receipt});
+
+                // Settlement is the cue's EFFECT, not its promise: executors report `errors`
+                // and `applied` (a cancel terminal settles legitimately un-applied). The
+                // receipt stays pushed either way, so a failure carries its own forensics.
+                if (receipt.errors?.length) {
+                    throw new Error(receipt.errors.join('; '))
+                }
+
+                if (receipt.applied === false && !receipt.cancelled) {
+                    throw new Error('terminal effect did not apply')
+                }
+
+                return receipt
+            }).catch(error => {
+                if (me.isDestroyed) return false;
+                const message = `${cue.type}: ${error?.message || String(error)}`;
+
+                me.cueErrors.push(message);
+                me.setTourCaption(`Surface cue failed: ${message}`);
+
+                return false
+            });
+            cueSettlement = me.cuePromise
+        }
+
+        me.cueSettlements.set(`${data.sceneIndex}:${data.stepIndex}`, cueSettlement)
+    }
+
+    /**
+     * Settles the hosting surface for one runner step before the next screenplay beat may begin.
+     * @summary Prevents a following document operation from re-projecting the dock while the
+     * current surface cue still owns a live gesture, dwell, or paint boundary.
+     * @param {Object} data `TourRunner` settlement payload.
+     * @returns {Promise<void>}
+     */
+    async settleTourStep(data) {
+        if (this.isDestroyed) throw Neo.isDestroyed;
+        let me            = this, workspace = me.workspace,
+            key           = `${data.sceneIndex}:${data.stepIndex}`,
+            cueSettlement = me.cueSettlements.get(key) || Promise.resolve();
+
+        await cueSettlement;
+        await workspace.refreshPromise
+    }
+
+    /**
+     * @summary Projects one successful runner step after the injected host barrier has settled its cue and
+     * dock refresh. The listener remains observational: it serializes the independent pip paint
+     * without making event delivery an execution boundary for `TourRunner`.
+     * @param {Object} data `TourRunner.stepSettled` payload.
+     */
+    onTourStepSettled(data) {
+        let me            = this, workspace = me.workspace,
+            key           = `${data.sceneIndex}:${data.stepIndex}`,
+            cueSettlement = me.cueSettlements.get(key) || Promise.resolve();
+
+        me.cueSettlements.delete(key);
+        me.progressPromise = me.progressPromise.then(async () => {
+            if (me.isDestroyed) return;
+            await cueSettlement;
+            if (me.isDestroyed) return;
+            await workspace.refreshPromise;
+            await me.setPipProgress(data.completedCount);
+            // Adjacent document operations can settle within one browser frame. Keep each
+            // evidenced state visible long enough to read instead of letting VDOM paints coalesce.
+            await me.timeout(90)
+        })
+    }
+
+    /**
+     * @summary Publishes completion while final surface work settles.
+     * @param {Object} data
+     */
+    onTourComplete(data) {
+        this.setTourCaption(`WorkspaceDocument playback complete — settling ${data.log.length} deterministic beats and surface cues.`)
+    }
+
+    /**
+     * @summary Clears unsettled beat entries and publishes the runner failure.
+     * @param {Object} data
+     */
+    onTourError(data) {
+        this.cueSettlements.clear();
+        this.setTourCaption(`Tour stopped: ${data.errors[0] || 'unknown reason'}`)
+    }
+
+    /**
+     * @summary Publishes the current scene caption.
+     * @param {Object} data
+     */
+    onTourScene(data) {
+        this.setTourCaption(`${data.title}${data.caption ? ' — ' + data.caption : ''}`)
+    }
+
+    /**
+     * @summary Replays one script's document tier from a fresh document in spec mode. Runtime-only
+     * cues remain the visible tour's responsibility and are verified through its receipt.
+     * By default the replay result stays live (the driver contract journey specs and the film
+     * pipeline continue from); `restoreDocument: true` turns the replay into a pure probe that
+     * restores the displaced live document afterwards.
+     * @param {Object} [script=workstationTourScript] `null` also resolves to the default script.
+     * @param {Object} [opts]
+     * @param {Boolean} [opts.restoreDocument=false] Restore the pre-replay live document after the run.
+     * @returns {Promise<Object>}
+     */
+    async runTourSpec(script=workstationTourScript, {restoreDocument=false}={}) {
+        let me           = this, workspace = me.workspace,
+            dockService  = workspace.dockService,
+            specRunners  = me.specRunners,
+            liveDocument = workspace.dockModel,
+            runner;
+
+        // Transport callers can only deliver `null` for "use the default script".
+        script ??= workstationTourScript;
+
+        runner = Neo.create(TourRunner, {
+            componentId: workspace.id,
+            dockService,
+            mode       : 'spec',
+            script
+        });
+
+        specRunners.add(runner);
+
+        // Two consumer contracts share this front door. As a DRIVER (default), the replay's
+        // resulting document stays live — the film pipeline and journey specs continue from it.
+        // As a PROBE (`restoreDocument: true`), the displaced live document is restored after
+        // the replay, so a replay can never edit the surface it measures. The transaction owns
+        // the baseline swap too: a rejecting entry projection must still destroy the runner and
+        // service, and must still restore the probe's displaced document.
+        //
+        // The ENTRY projection REQUESTS `geometryOnly` — a validated in-place ADMISSION, not a
+        // skip, and not a claim about the outcome. What reaches `DockFlip.play` is the reconciler's
+        // reported `landedInPlace`, so a reset across a diverged layout can no longer declare
+        // stable topology over a swap that already happened:
+        // `DockProjectionReconciler.reconcileProjection` (:314) attempts
+        // `reconcileStableTopology` (:130), which returns null on ANY node/type/ancestry/order/
+        // orientation delta and falls back to the full staged transaction. The workspace boots
+        // from the same `initialDocument` the entry re-stages, so the proven-stable in-place
+        // path applies and the staged shell swap — whose intermediate state presents a cleared
+        // workspace body on camera (one compositor frame, measured at capture minFrameIndex
+        // 7/59, minEntropy 0.41 vs baseline 5.30) — never runs on the same-topology path. A
+        // genuinely changed topology still takes the staged path unchanged (the residual blank
+        // for that branch is documented on the ticket; present-no-intermediate-state is the
+        // deferred stronger shape). The RESTORE projection stays full deliberately: at
+        // probe-restore time the shell typically diverges from the displaced document, so
+        // admission would validate-and-fall-back with no gain.
+        let completed = false,
+            out       = null;
+
+        try {
+            workspace.dockModel = WorkspaceDocument.clone(initialDocument);
+            await workspace.refreshDockWorkspace(null, workspace.dockModel, {geometryOnly: true});
+
+            // The entry projection is finished and the replay has not begun. Published because a
+            // frame-capturing consumer cannot otherwise tell the two apart: both happen inside one
+            // `runTourSpec` call, so an oracle measuring the whole call attributes an entry-time
+            // frame to the replay step it names. A wall-clock stamp rather than a marker element or
+            // an event, so the consumer bands frames it has ALREADY collected instead of racing a
+            // poll against frame arrival — the boundary is read after the fact, never observed live.
+            const entryCompletedAt = Date.now(),
+                  result           = await me.trap(runner.start());
+
+            await workspace.refreshPromise;
+
+            out = {...result, document: WorkspaceDocument.clone(workspace.dockModel), phases: {entryCompletedAt}};
+
+            // A structured runner failure is a primary outcome the caller must receive intact —
+            // only a genuinely clean replay may let a restore failure replace the return.
+            completed = result?.completed === true && !result?.errors?.length;
+
+            return out
+        } finally {
+            specRunners.delete(runner);
+            runner.isDestroyed || runner.destroy();
+
+            if (restoreDocument && !workspace.isDestroyed) {
+                workspace.dockModel = liveDocument;
+
+                // The document assignment IS the restore. Restore-projection failure precedence:
+                // a clean replay propagates it (a probe may not report success over an
+                // un-projected surface); a structured primary keeps its result and RECORDS the
+                // restore failure as a namespaced entry in the returned errors; a thrown primary
+                // owns the return channel and the restore failure stays suppressed.
+                completed
+                    ? await workspace.refreshDockWorkspace()
+                    : await workspace.refreshDockWorkspace().catch(error => {
+                        out?.errors?.push(`restore projection failed: ${error.message}`)
+                    })
+            }
+        }
+    }
+
+    /**
+     * @summary Scrolls the scale grid through one View-owned VDOM update.
+     *
+     * The View is the closest common parent of the native scrollport and every pooled body.
+     * Retargeting its VNode `scrollTop` together with `syncBodies()` therefore lets one delta
+     * move the viewport and recycle the fixed rows atomically, without a transient blank frame.
+     *
+     * @param {Number} index
+     * @returns {Promise<Boolean>}
+     */
+    async scrollScaleGrid(index=50000) {
+        let pane = this.workspace.paneCache.scale,
+            target;
+
+        if (!pane?.view?.id) return false;
+
+        target = Math.max(0, Math.min(index, pane.store.count - 1)) * pane.rowHeight;
+        pane.view.vdom.scrollTop = target;
+        pane.view.syncBodies(target);
+        await pane.view.promiseUpdate();
+
+        return Math.abs(pane.view.scrollTop - target) <= pane.rowHeight
+    }
+
+    /**
+     * @summary Runs the screenplay from a fresh document on every replay.
+     * @returns {Promise<Object>|undefined}
+     */
+    async runVisibleTour() {
+        let me = this, workspace = me.workspace;
+
+        me.getTourRunner();
+
+        if (me.tourRunner.running) {
+            me.setTourCaption('Tour already running — the live stores continue underneath it.');
+            return
+        }
+
+        me.setState({'tour.running': true});
+        me.cueErrors       = [];
+        me.cuePromise      = Promise.resolve();
+        me.cueReceipts     = [];
+        me.cueSettlements.clear();
+        me.lastTourReceipt = null;
+        me.progressPromise = Promise.resolve();
+        workspace.dockModel       = WorkspaceDocument.clone(initialDocument);
+        await me.trap(me.setPipProgress(0));
+
+        await me.trap(workspace.refreshDockWorkspace(null, workspace.dockModel, {geometryOnly: true}));
+
+        const
+            feedStore      = me.getStateProvider().getStore('feed'),
+            feedStartCount = feedStore.count,
+            feedStartBatch = workspace.feedBatchCount,
+            startedAt      = Date.now(),
+            runnerResult   = await me.trap(me.tourRunner.start());
+
+        const
+            errors      = [...runnerResult.errors, ...me.cueErrors],
+            appendError = (label, result) => {
+                if (result.status === 'rejected') {
+                    const
+                        detail          = result.reason?.message || String(result.reason),
+                        alreadyRecorded = errors.some(error => error === detail || error.endsWith(`: ${detail}`));
+
+                    alreadyRecorded || errors.push(`${label} failed: ${detail}`)
+                }
+            },
+            settlements = await Promise.allSettled([
+                me.cuePromise,
+                workspace.refreshPromise,
+                me.progressPromise
+            ]);
+
+        ['surface cue settlement', 'dock refresh settlement', 'progress settlement']
+            .forEach((label, index) => appendError(label, settlements[index]));
+
+        const [finalProgress] = await Promise.allSettled([
+            me.setPipProgress(TourController.totalBeats().length)
+        ]);
+
+        appendError('final progress paint', finalProgress);
+
+        const
+            elapsedMs    = Date.now() - startedAt,
+            feedEndCount = feedStore.count,
+            receipt      = {
+                completed  : runnerResult.completed && errors.length === 0,
+                cueReceipts: me.cueReceipts.map(entry => ({cue: {...entry.cue}, receipt: entry.receipt})),
+                document   : WorkspaceDocument.clone(workspace.dockModel),
+                elapsedMs,
+                errors,
+                feed       : {
+                    batches       : workspace.feedBatchCount - feedStartBatch,
+                    configuredRate: workspace.constructor.FEED_BATCH_SIZE * 1000 / workspace.constructor.FEED_INTERVAL_MS,
+                    endCount      : feedEndCount,
+                    growth        : feedEndCount - feedStartCount,
+                    maxRecords    : feedStore.maxRecords,
+                    produced      : (workspace.feedBatchCount - feedStartBatch) * workspace.constructor.FEED_BATCH_SIZE,
+                    startCount    : feedStartCount
+                },
+                log       : runnerResult.log
+            };
+
+        me.lastTourReceipt = receipt;
+        me.setTourCaption(receipt.completed
+            ? `Tour complete — ${receipt.log.length} deterministic beats and ${receipt.cueReceipts.length} surface cues settled.`
+            : `Tour stopped — ${errors[0]}`);
+
+        return receipt
+    }
+
+    /**
+     * @summary Returns the screenplay's flattened steps for progress presentation.
+     * @returns {Object[]} Flattened screenplay steps.
+     * @static
+     */
+    static totalBeats() {
+        return workstationTourScript.scenes.flatMap(scene => scene.steps)
+    }
+}
+
+export default Neo.setupClass(TourController);

--- a/apps/workstation/view/TourController.mjs
+++ b/apps/workstation/view/TourController.mjs
@@ -40,6 +40,12 @@ class TourController extends Controller {
     /** @member {Set<Neo.ai.client.TourRunner>} specRunners */
     specRunners = new Set()
 
+    /** @member {Promise|null} #settledPromise=null Retains cleanup completion after the controller retires. */
+    #settledPromise = null
+
+    /** @summary The owned playback/driver cleanup boundary used before reactivation. @returns {Promise|null} */
+    get settledPromise() { return this.#settledPromise }
+
     /** @summary Retires playback before its workspace starts disposing the borrowed services. */
     onComponentConstructed() {
         this.observeConfig(this.workspace, 'isDestroying', value => value && this.destroy())
@@ -105,7 +111,7 @@ class TourController extends Controller {
     async setPipProgress(count) {
         if (this.isDestroyed) throw Neo.isDestroyed;
         this.setState({'tour.completedCount': count});
-        await this.getReference('tour-pips')?.promiseUpdate()
+        await this.trap(Promise.resolve(this.getReference('tour-pips')?.promiseUpdate()))
     }
 
     /** @summary Starts at most one visible playback, including its entry projection. @returns {Promise<Object>} */
@@ -128,18 +134,21 @@ class TourController extends Controller {
 
     /** @summary Cancels this playback owner and waits for its already-started cue work. @returns {Promise<void>} */
     async cancelTour() {
-        const pending = [this.playbackPromise, this.cuePromise, this.progressPromise];
-        this.component.controller = null;
-        await Promise.allSettled(pending)
+        const bar = this.component;
+        this.destroy();
+        await this.settledPromise;
+        if (!bar.isDestroyed && bar.controller === this) bar.controller = null
     }
 
     /** @summary Retires playback-owned objects without disposing borrowed workspace state. */
     destroy() {
         if (this.isDestroyed) return;
-        const provider = this.getStateProvider();
+        const provider = this.getStateProvider(), driver = this.gestureDriver,
+              pending  = [this.playbackPromise, this.cuePromise, this.progressPromise];
         this.tourRunner = null;
         this.gestureDriver = null;
         this.specRunners.forEach(runner => runner.isDestroyed || runner.destroy());
+        this.#settledPromise = Promise.allSettled([...pending, driver?.settledPromise]);
         super.destroy();
         provider && !provider.isDestroyed && provider.setData({'tour.running': false})
     }
@@ -157,7 +166,7 @@ class TourController extends Controller {
             case 'scroll':
                 return this.scrollScaleGrid(cue.index)
             case 'canvas-update':
-                await this.workspace.refreshPromise;
+                await this.trap(Promise.resolve(this.workspace.refreshPromise));
                 return this.workspace.pulseScaleSparkline()
             case 'cross-zone-showcase':
                 return (await this.getGestureDriver()).executeCrossZoneShowcaseStep(cue, cue.options)
@@ -185,30 +194,31 @@ class TourController extends Controller {
     async navigateOverflowMenu(itemId) {
         // The reducer schedules projection asynchronously. Resolve the consumer only after that transaction,
         // otherwise `down()` can capture the retiring source toolbar and wait on its deliberately hidden control.
-        await this.workspace.refreshPromise;
+        const workspace = this.workspace;
+        await this.trap(Promise.resolve(workspace.refreshPromise));
 
-        let tabs   = this.workspace.down({dockNodeId: 'heavy-tabs'}),
+        let tabs   = workspace.down({dockNodeId: 'heavy-tabs'}),
             plugin = tabs?.getTabBar()?.getPlugin('tab-overflow'),
             control;
 
         // The hidden staging transaction already captured natural widths. This consumer boundary only
         // refreshes the visible extent so the cue never turns a stable cache into a second measurement pass.
-        await plugin?.project(false);
-        control = await this.workspace.waitForOverflowMenu(plugin);
+        await this.trap(Promise.resolve(plugin?.project(false)));
+        control = await this.trap(workspace.waitForOverflowMenu(plugin));
 
         if (!control) return false;
 
-        await control.toggleMenu();
-        await this.timeout(700);
-
-        const
-            menuItems = control.menuList?.items || [],
-            item      = menuItems.find(entry => entry.text === this.workspace.dockModel.items[itemId]?.title);
-
-        item?.handler?.();
-        control.menuList && (control.menuList.hidden = true);
-
-        return item ? {activatedItemId: itemId, menuItemCount: menuItems.length} : false
+        try {
+            await control.toggleMenu();
+            if (this.isDestroyed) throw Neo.isDestroyed;
+            await this.timeout(700);
+            const menuItems = control.menuList?.items || [],
+                  item      = menuItems.find(entry => entry.text === workspace.dockModel.items[itemId]?.title);
+            item?.handler?.();
+            return item ? {activatedItemId: itemId, menuItemCount: menuItems.length} : false
+        } finally {
+            if (control.menuList && !control.menuList.isDestroyed) control.menuList.hidden = true
+        }
     }
 
     /**
@@ -216,7 +226,7 @@ class TourController extends Controller {
      * @param {Object} data
      */
     onTourBeat(data) {
-        let me            = this, workspace = me.workspace,
+        let me            = this,
             cueSettlement = Promise.resolve();
 
         data.caption && me.setTourCaption(data.caption);
@@ -335,11 +345,30 @@ class TourController extends Controller {
      * pipeline continue from); `restoreDocument: true` turns the replay into a pure probe that
      * restores the displaced live document afterwards.
      * @param {Object} [script=workstationTourScript] `null` also resolves to the default script.
-     * @param {Object} [opts]
-     * @param {Boolean} [opts.restoreDocument=false] Restore the pre-replay live document after the run.
+     * @param {Object} [options]
+     * @param {Boolean} [options.restoreDocument=false] Restore the pre-replay live document after the run.
      * @returns {Promise<Object>}
      */
-    async runTourSpec(script=workstationTourScript, {restoreDocument=false}={}) {
+    runTourSpec(script=workstationTourScript, options={}) {
+        if (this.isDestroyed) return Promise.reject(Neo.isDestroyed);
+        if (this.playbackPromise) return Promise.reject(new Error('A Workstation playback is already running'));
+        this.setState({'tour.running': true});
+        return this.playbackPromise = this.runSpecTour(script, options).finally(() => {
+            if (!this.isDestroyed) {
+                this.playbackPromise = null;
+                this.setState({'tour.running': false})
+            }
+        })
+    }
+
+    /**
+     * @summary Executes one owned spec replay and restores its displaced document when requested.
+     * @param {Object} script
+     * @param {Object} options
+     * @param {Boolean} [options.restoreDocument=false]
+     * @returns {Promise<Object>}
+     */
+    async runSpecTour(script, {restoreDocument=false}={}) {
         let me           = this, workspace = me.workspace,
             dockService  = workspace.dockService,
             specRunners  = me.specRunners,
@@ -358,35 +387,16 @@ class TourController extends Controller {
 
         specRunners.add(runner);
 
-        // Two consumer contracts share this front door. As a DRIVER (default), the replay's
-        // resulting document stays live — the film pipeline and journey specs continue from it.
-        // As a PROBE (`restoreDocument: true`), the displaced live document is restored after
-        // the replay, so a replay can never edit the surface it measures. The transaction owns
-        // the baseline swap too: a rejecting entry projection must still destroy the runner and
-        // service, and must still restore the probe's displaced document.
-        //
-        // The ENTRY projection REQUESTS `geometryOnly` — a validated in-place ADMISSION, not a
-        // skip, and not a claim about the outcome. What reaches `DockFlip.play` is the reconciler's
-        // reported `landedInPlace`, so a reset across a diverged layout can no longer declare
-        // stable topology over a swap that already happened:
-        // `DockProjectionReconciler.reconcileProjection` (:314) attempts
-        // `reconcileStableTopology` (:130), which returns null on ANY node/type/ancestry/order/
-        // orientation delta and falls back to the full staged transaction. The workspace boots
-        // from the same `initialDocument` the entry re-stages, so the proven-stable in-place
-        // path applies and the staged shell swap — whose intermediate state presents a cleared
-        // workspace body on camera (one compositor frame, measured at capture minFrameIndex
-        // 7/59, minEntropy 0.41 vs baseline 5.30) — never runs on the same-topology path. A
-        // genuinely changed topology still takes the staged path unchanged (the residual blank
-        // for that branch is documented on the ticket; present-no-intermediate-state is the
-        // deferred stronger shape). The RESTORE projection stays full deliberately: at
-        // probe-restore time the shell typically diverges from the displaced document, so
-        // admission would validate-and-fall-back with no gain.
+        // A driver leaves its result live; a probe restores the exact displaced document even
+        // when entry projection rejects. The request owns its runner and borrows the dock service.
+        // Entry requests validated in-place admission; a topology mismatch still stages normally.
+        // Restore remains a full projection because the replay can have changed that topology.
         let completed = false,
             out       = null;
 
         try {
             workspace.dockModel = WorkspaceDocument.clone(initialDocument);
-            await workspace.refreshDockWorkspace(null, workspace.dockModel, {geometryOnly: true});
+            await me.trap(workspace.refreshDockWorkspace(null, workspace.dockModel, {geometryOnly: true}));
 
             // The entry projection is finished and the replay has not begun. Published because a
             // frame-capturing consumer cannot otherwise tell the two apart: both happen inside one
@@ -397,7 +407,7 @@ class TourController extends Controller {
             const entryCompletedAt = Date.now(),
                   result           = await me.trap(runner.start());
 
-            await workspace.refreshPromise;
+            await me.trap(Promise.resolve(workspace.refreshPromise));
 
             out = {...result, document: WorkspaceDocument.clone(workspace.dockModel), phases: {entryCompletedAt}};
 
@@ -495,18 +505,18 @@ class TourController extends Controller {
                     alreadyRecorded || errors.push(`${label} failed: ${detail}`)
                 }
             },
-            settlements = await Promise.allSettled([
+            settlements = await me.trap(Promise.allSettled([
                 me.cuePromise,
                 workspace.refreshPromise,
                 me.progressPromise
-            ]);
+            ]));
 
         ['surface cue settlement', 'dock refresh settlement', 'progress settlement']
             .forEach((label, index) => appendError(label, settlements[index]));
 
-        const [finalProgress] = await Promise.allSettled([
+        const [finalProgress] = await me.trap(Promise.allSettled([
             me.setPipProgress(TourController.totalBeats().length)
-        ]);
+        ]));
 
         appendError('final progress paint', finalProgress);
 

--- a/apps/workstation/view/TourToolbar.mjs
+++ b/apps/workstation/view/TourToolbar.mjs
@@ -1,0 +1,60 @@
+import Toolbar from '../../../src/toolbar/Base.mjs';
+
+/**
+ * @summary Lightweight tour chrome bound to the workspace's provider before playback is activated.
+ * @class Workstation.view.TourToolbar
+ * @extends Neo.toolbar.Base
+ */
+class TourToolbar extends Toolbar {
+    static config = {
+        /** @member {String} className='Workstation.view.TourToolbar' */
+        className: 'Workstation.view.TourToolbar',
+        /** @member {String[]} cls */
+        cls: ['workstation-tourbar'],
+        /** @member {String} flex='none' */
+        flex: 'none',
+        /** @member {Object} layout */
+        layout: {ntype: 'hbox', align: 'center'},
+        /** @member {String} reference='tour-bar' */
+        reference: 'tour-bar',
+        /** @member {Object[]} items */
+        items: [{
+            bind     : {disabled: 'tour.running'},
+            cls      : ['workstation-tour-play'],
+            handler  : 'onStartTour',
+            iconCls  : 'fa fa-play',
+            ntype    : 'button',
+            reference: 'tour-play',
+            text     : 'Start dense tour'
+        }, {
+            cls   : ['workstation-tour-story'],
+            flex  : 1,
+            ntype : 'container',
+            layout: {ntype: 'vbox', align: 'stretch', pack: 'center'},
+            items : [{
+                bind     : {html: 'tour.caption'},
+                cls      : ['workstation-tour-caption'],
+                flex     : 'none',
+                ntype    : 'component',
+                reference: 'tour-caption'
+            }, {
+                bind: {html: data => Array.from({length: data.tour.totalBeats}, (_, index) =>
+                    `<div class="workstation-pip${index < data.tour.completedCount ? ' workstation-pip-done' : ''}"></div>`
+                ).join('')},
+                cls      : ['workstation-tour-pips'],
+                flex     : 'none',
+                ntype    : 'component',
+                reference: 'tour-pips'
+            }]
+        }, {
+            cls      : ['workstation-theme-button'],
+            handler  : 'onToggleWorkspaceTheme',
+            iconCls  : 'fa fa-sun',
+            ntype    : 'button',
+            reference: 'theme-toggle',
+            text     : 'Light mode'
+        }]
+    }
+}
+
+export default Neo.setupClass(TourToolbar);

--- a/apps/workstation/view/Workspace.mjs
+++ b/apps/workstation/view/Workspace.mjs
@@ -20,15 +20,15 @@ import WorkspaceController      from './WorkspaceController.mjs';
 import Operations               from '../../../src/dashboard/dock/model/Operations.mjs';
 import Persistence              from '../../../src/dashboard/dock/model/Persistence.mjs';
 import StateProvider            from '../../../src/state/Provider.mjs';
-import TourRunner               from '../../../src/ai/client/TourRunner.mjs';
+import TourToolbar              from './TourToolbar.mjs';
 import TransactionManager       from '../../../src/manager/Transaction.mjs';
 import {
     createDockVesselEmbodiment,
     createDockVesselProxyEmbodiment
 }                                                from '../../../src/dashboard/dock/window/VesselEmbodiment.mjs';
-import WorkspaceSet                             from '../../../src/dashboard/dock/window/WorkspaceSet.mjs';
-import VesselPark                               from '../../../src/dashboard/dock/window/VesselPark.mjs';
-import {workstationTourScript, initialDocument} from '../tour/denseWorkstation.mjs';
+import WorkspaceSet                        from '../../../src/dashboard/dock/window/WorkspaceSet.mjs';
+import VesselPark                          from '../../../src/dashboard/dock/window/VesselPark.mjs';
+import {initialTourState, initialDocument} from '../tour/denseWorkstation.mjs';
 import '../../../src/button/Base.mjs';
 import '../../../src/tab/Container.mjs';
 import '../../../src/toolbar/Base.mjs';
@@ -194,6 +194,7 @@ class Workspace extends DockWorkspace {
          */
         stateProvider: {
             module: StateProvider,
+            data  : {tour: initialTourState},
             stores: {
                 feed : {module: Feed},
                 scale: {module: Scale}
@@ -233,20 +234,15 @@ class Workspace extends DockWorkspace {
      * @member {Object|null} initialTopology=null
      */
     initialTopology = null
-    /**
-     * @member {Neo.ai.client.TourRunner|null} tourRunner=null
-     */
-    tourRunner = null
+
     /**
      * The shared drag-affordance gesture controller (producer lifecycle, memoized geometry,
      * release-truth drop, generation guards) — composed at construct, destroyed with the view.
      * @member {Neo.dashboard.dock.interaction.DragAffordances|null} dragAffordances=null
      */
     dragAffordances = null
-    /** @member {Workstation.tour.NativeGestureDriver|null} gestureDriver=null */
-    gestureDriver = null
-    /** @member {Promise|null} gestureDriverPromise=null */
-    gestureDriverPromise = null
+
+
     /**
      * @member {Object} paneCache={}
      * @protected
@@ -345,46 +341,7 @@ class Workspace extends DockWorkspace {
      * @member {Number} feedSequence=0
      */
     feedSequence = 0
-    /**
-     * Serialized surface-cue chain for the current visible tour.
-     * @member {Promise} cuePromise
-     * @protected
-     */
-    cuePromise = Promise.resolve()
-    /**
-     * Hosting-surface cue promises indexed by the runner's scene/step identity. The injected
-     * `TourRunner.stepSettlement` callback awaits an entry before `stepSettled`; that event then
-     * consumes it for the independent progress-paint chain. The map never becomes runner state.
-     * @member {Map<String,Promise>} cueSettlements
-     * @protected
-     */
-    cueSettlements = new Map()
-    /**
-     * Serialized, paint-confirmed tour progress. `TourRunner.stepSettled` arrives after this
-     * host's cue/refresh barrier, but events are observational and the next beat can start as soon
-     * as the listener returns. This local chain therefore re-awaits the keyed settlement before
-     * painting each pip in order; it never becomes part of runner execution.
-     * @member {Promise} progressPromise
-     * @protected
-     */
-    progressPromise = Promise.resolve()
-    /**
-     * Fail-closed surface-cue errors for the current visible tour.
-     * @member {String[]} cueErrors
-     * @protected
-     */
-    cueErrors = []
-    /**
-     * Ordered observable receipts returned by the screenplay's surface cues.
-     * @member {Object[]} cueReceipts
-     * @protected
-     */
-    cueReceipts = []
-    /**
-     * The most recent fully settled visible-tour result.
-     * @member {Object|null} lastTourReceipt=null
-     */
-    lastTourReceipt = null
+
     /**
      * Most recent exact-handle park admission receipt.
      *
@@ -448,26 +405,9 @@ class Workspace extends DockWorkspace {
 
         me.registerMainWorkspace();
 
-        me.tourRunner  = Neo.create(TourRunner, {
-            componentId   : me.id,
-            dockService   : me.dockService,
-            mode          : 'demo',
-            script        : workstationTourScript,
-            stepSettlement: data => me.settleTourStep(data)
-        });
-
-        me.tourRunner.on({
-            beat       : me.onTourBeat,
-            complete   : me.onTourComplete,
-            error      : me.onTourError,
-            scene      : me.onTourScene,
-            stepSettled: me.onTourStepSettled,
-            scope      : me
-        });
-
         me.appendFeedBatch(25);
 
-        me.add([me.createTourBar(), me.createStatusBar(), me.getController().createTopologyBar(), {
+        me.add([{module: TourToolbar}, me.createStatusBar(), me.getController().createTopologyBar(), {
             module: Container,
             cls   : ['workstation-dock-host', 'neo-dashboard', 'neo-dashboard-dock-query-host'],
             flex  : 1,
@@ -556,6 +496,7 @@ class Workspace extends DockWorkspace {
         // re-apply the active language now that the host is live (both orders converge).
         me.previewLanguage && me.afterSetPreviewLanguage(me.previewLanguage, null);
 
+        me.syncThemeToggle(me.theme);
         me.updateStatusBar();
         me.#feedIntervalId = setInterval(
             () => me.appendFeedBatch(Workspace.FEED_BATCH_SIZE),
@@ -633,81 +574,6 @@ class Workspace extends DockWorkspace {
     }
 
     /**
-     * @returns {Object} Tour toolbar config.
-     */
-    createTourBar() {
-        let me      = this,
-            isLight = me.theme === 'neo-theme-neo-light';
-
-        return {
-            cls   : ['workstation-tourbar'],
-            flex  : 'none',
-            layout: {ntype: 'hbox', align: 'center'},
-            ntype : 'toolbar',
-            // The boot containment chain asserts tourbar→statusbar→dock-host adjacency
-            // via component-id rects — the bar needs a stable reference to be one of them.
-            reference: 'tour-bar',
-            items    : [{
-                cls      : ['workstation-tour-play'],
-                handler  : () => me.startTour(),
-                iconCls  : 'fa fa-play',
-                ntype    : 'button',
-                reference: 'tour-play',
-                text     : 'Start dense tour'
-            }, {
-                module: Container,
-                cls   : ['workstation-tour-story'],
-                flex  : 1,
-                items : [{
-                    cls      : ['workstation-tour-caption'],
-                    flex     : 'none',
-                    html     : `${workstationTourScript.title} — twenty panes, 100k rows, a 10/sec feed, real overflow, and two themes.`,
-                    ntype    : 'component',
-                    reference: 'tour-caption'
-                }, {
-                    cls      : ['workstation-tour-pips'],
-                    flex     : 'none',
-                    ntype    : 'component',
-                    reference: 'tour-pips',
-                    vdom     : {cn: Workspace.totalBeats().map(() => ({cls: ['workstation-pip']}))}
-                }],
-                layout: {ntype: 'vbox', align: 'stretch', pack: 'center'}
-            }, {
-                cls      : ['workstation-theme-button'],
-                handler  : data => me.toggleWorkspaceTheme(data),
-                iconCls  : isLight ? 'fa fa-moon' : 'fa fa-sun',
-                ntype    : 'button',
-                reference: 'theme-toggle',
-                text     : isLight ? 'Dark mode' : 'Light mode'
-            }]
-        }
-    }
-
-    /**
-     * Executes a surface cue for the visual take. Spec-mode correctness waits on explicit
-     * E2E oracles because TourRunner intentionally does not await event listeners.
-     * @param {Object} cue
-     * @returns {Promise<*>}
-     */
-    async executeCue(cue) {
-        switch (cue.type) {
-            case 'overflow':
-                return this.navigateOverflowMenu(cue.itemId)
-            case 'scroll':
-                return this.scrollScaleGrid(cue.index)
-            case 'canvas-update':
-                await this.refreshPromise;
-                return this.pulseScaleSparkline()
-            case 'cross-zone-showcase':
-                return (await this.getGestureDriver()).executeCrossZoneShowcaseStep(cue, cue.options)
-            case 'theme':
-                return this.setWorkspaceTheme(cue.theme)
-            default:
-                return false
-        }
-    }
-
-    /**
      * The current projection shell's instance id — the discriminator between the reconciler's
      * stable-topology fast path (shell retained) and the staged full path (shell replaced).
      * Pane instances AND their DOM survive either path; only the shell identity flips.
@@ -738,156 +604,6 @@ class Workspace extends DockWorkspace {
         }
 
         return item ? me.resolvePane(itemId, item).id : null
-    }
-
-    /**
-     * Returns the last fully settled visible-tour receipt.
-     * @returns {Object|null}
-     */
-    getTourReceipt() {
-        return this.lastTourReceipt
-    }
-
-    /**
-     * Opens the real overflow control, briefly shows its menu, then invokes the first menu
-     * item's ordinary activeIndex handler. The E2E clicks this same surface as a human.
-     * @param {String} itemId Narrated target id (used for the caption/evidence contract).
-     * @returns {Promise<Boolean>}
-     */
-    async navigateOverflowMenu(itemId) {
-        // The reducer schedules projection asynchronously. Resolve the consumer only after that transaction,
-        // otherwise `down()` can capture the retiring source toolbar and wait on its deliberately hidden control.
-        await this.refreshPromise;
-
-        let tabs   = this.down({dockNodeId: 'heavy-tabs'}),
-            plugin = tabs?.getTabBar()?.getPlugin('tab-overflow'),
-            control;
-
-        // The hidden staging transaction already captured natural widths. This consumer boundary only
-        // refreshes the visible extent so the cue never turns a stable cache into a second measurement pass.
-        await plugin?.project(false);
-        control = await this.waitForOverflowMenu(plugin);
-
-        if (!control) return false;
-
-        await control.toggleMenu();
-        await this.timeout(700);
-
-        const
-            menuItems = control.menuList?.items || [],
-            item      = menuItems.find(entry => entry.text === this.dockModel.items[itemId]?.title);
-
-        item?.handler?.();
-        control.menuList && (control.menuList.hidden = true);
-
-        return item ? {activatedItemId: itemId, menuItemCount: menuItems.length} : false
-    }
-
-    /**
-     * @param {Object} data
-     */
-    onTourBeat(data) {
-        let me            = this,
-            cueSettlement = Promise.resolve();
-
-        data.caption && me.setTourCaption(data.caption);
-
-        if (data.cue) {
-            const cue = data.cue;
-
-            me.cuePromise = me.cuePromise.then(async () => {
-                const receipt = await me.executeCue(cue);
-
-                if (!receipt) {
-                    throw new Error(`${cue.type} returned no observable receipt`)
-                }
-
-                me.cueReceipts.push({cue: {...cue}, receipt});
-
-                // Settlement is the cue's EFFECT, not its promise: executors report `errors`
-                // and `applied` (a cancel terminal settles legitimately un-applied). The
-                // receipt stays pushed either way, so a failure carries its own forensics.
-                if (receipt.errors?.length) {
-                    throw new Error(receipt.errors.join('; '))
-                }
-
-                if (receipt.applied === false && !receipt.cancelled) {
-                    throw new Error('terminal effect did not apply')
-                }
-
-                return receipt
-            }).catch(error => {
-                const message = `${cue.type}: ${error.message}`;
-
-                me.cueErrors.push(message);
-                me.setTourCaption(`Surface cue failed: ${message}`);
-
-                return false
-            });
-            cueSettlement = me.cuePromise
-        }
-
-        me.cueSettlements.set(`${data.sceneIndex}:${data.stepIndex}`, cueSettlement)
-    }
-
-    /**
-     * Settles the hosting surface for one runner step before the next screenplay beat may begin.
-     * @summary Prevents a following document operation from re-projecting the dock while the
-     * current surface cue still owns a live gesture, dwell, or paint boundary.
-     * @param {Object} data `TourRunner` settlement payload.
-     * @returns {Promise<void>}
-     */
-    async settleTourStep(data) {
-        let me            = this,
-            key           = `${data.sceneIndex}:${data.stepIndex}`,
-            cueSettlement = me.cueSettlements.get(key) || Promise.resolve();
-
-        await cueSettlement;
-        await me.refreshPromise
-    }
-
-    /**
-     * Projects one successful runner step after the injected host barrier has settled its cue and
-     * dock refresh. The listener remains observational: it serializes the independent pip paint
-     * without making event delivery an execution boundary for `TourRunner`.
-     * @param {Object} data `TourRunner.stepSettled` payload.
-     */
-    onTourStepSettled(data) {
-        let me            = this,
-            key           = `${data.sceneIndex}:${data.stepIndex}`,
-            cueSettlement = me.cueSettlements.get(key) || Promise.resolve();
-
-        me.cueSettlements.delete(key);
-        me.progressPromise = me.progressPromise.then(async () => {
-            await cueSettlement;
-            await me.refreshPromise;
-            await me.setPipProgress(data.completedCount);
-            // Adjacent document operations can settle within one browser frame. Keep each
-            // evidenced state visible long enough to read instead of letting VDOM paints coalesce.
-            await me.timeout(90)
-        })
-    }
-
-    /**
-     * @param {Object} data
-     */
-    onTourComplete(data) {
-        this.setTourCaption(`WorkspaceDocument playback complete — settling ${data.log.length} deterministic beats and surface cues.`)
-    }
-
-    /**
-     * @param {Object} data
-     */
-    onTourError(data) {
-        this.cueSettlements.clear();
-        this.setTourCaption(`Tour stopped: ${data.errors[0] || 'unknown reason'}`)
-    }
-
-    /**
-     * @param {Object} data
-     */
-    onTourScene(data) {
-        this.setTourCaption(`${data.title}${data.caption ? ' — ' + data.caption : ''}`)
     }
 
     /**
@@ -1728,154 +1444,6 @@ class Workspace extends DockWorkspace {
     }
 
     /**
-     * Replays one script's document tier from a fresh document in spec mode. Runtime-only
-     * cues remain the visible tour's responsibility and are verified through its receipt.
-     * By default the replay result stays live (the driver contract journey specs and the film
-     * pipeline continue from); `restoreDocument: true` turns the replay into a pure probe that
-     * restores the displaced live document afterwards.
-     * @param {Object} [script=workstationTourScript] `null` also resolves to the default script.
-     * @param {Object} [opts]
-     * @param {Boolean} [opts.restoreDocument=false] Restore the pre-replay live document after the run.
-     * @returns {Promise<Object>}
-     */
-    async runTourSpec(script=workstationTourScript, {restoreDocument=false}={}) {
-        let me           = this,
-            dockService  = Neo.create(DockService, {}),
-            liveDocument = me.dockModel,
-            runner;
-
-        // Transport callers can only deliver `null` for "use the default script".
-        script ??= workstationTourScript;
-
-        runner = Neo.create(TourRunner, {
-            componentId: me.id,
-            dockService,
-            mode       : 'spec',
-            script
-        });
-
-        // Two consumer contracts share this front door. As a DRIVER (default), the replay's
-        // resulting document stays live — the film pipeline and journey specs continue from it.
-        // As a PROBE (`restoreDocument: true`), the displaced live document is restored after
-        // the replay, so a replay can never edit the surface it measures. The transaction owns
-        // the baseline swap too: a rejecting entry projection must still destroy the runner and
-        // service, and must still restore the probe's displaced document.
-        //
-        // The ENTRY projection REQUESTS `geometryOnly` — a validated in-place ADMISSION, not a
-        // skip, and not a claim about the outcome. What reaches `DockFlip.play` is the reconciler's
-        // reported `landedInPlace`, so a reset across a diverged layout can no longer declare
-        // stable topology over a swap that already happened:
-        // `DockProjectionReconciler.reconcileProjection` (:314) attempts
-        // `reconcileStableTopology` (:130), which returns null on ANY node/type/ancestry/order/
-        // orientation delta and falls back to the full staged transaction. The workspace boots
-        // from the same `initialDocument` the entry re-stages, so the proven-stable in-place
-        // path applies and the staged shell swap — whose intermediate state presents a cleared
-        // workspace body on camera (one compositor frame, measured at capture minFrameIndex
-        // 7/59, minEntropy 0.41 vs baseline 5.30) — never runs on the same-topology path. A
-        // genuinely changed topology still takes the staged path unchanged (the residual blank
-        // for that branch is documented on the ticket; present-no-intermediate-state is the
-        // deferred stronger shape). The RESTORE projection stays full deliberately: at
-        // probe-restore time the shell typically diverges from the displaced document, so
-        // admission would validate-and-fall-back with no gain.
-        let completed = false,
-            out       = null;
-
-        try {
-            me.dockModel = WorkspaceDocument.clone(initialDocument);
-            await me.refreshDockWorkspace(null, me.dockModel, {geometryOnly: true});
-
-            // The entry projection is finished and the replay has not begun. Published because a
-            // frame-capturing consumer cannot otherwise tell the two apart: both happen inside one
-            // `runTourSpec` call, so an oracle measuring the whole call attributes an entry-time
-            // frame to the replay step it names. A wall-clock stamp rather than a marker element or
-            // an event, so the consumer bands frames it has ALREADY collected instead of racing a
-            // poll against frame arrival — the boundary is read after the fact, never observed live.
-            const entryCompletedAt = Date.now(),
-                  result           = await runner.start();
-
-            await me.refreshPromise;
-
-            out = {...result, document: WorkspaceDocument.clone(me.dockModel), phases: {entryCompletedAt}};
-
-            // A structured runner failure is a primary outcome the caller must receive intact —
-            // only a genuinely clean replay may let a restore failure replace the return.
-            completed = result?.completed === true && !result?.errors?.length;
-
-            return out
-        } finally {
-            runner.destroy();
-            dockService.destroy();
-
-            if (restoreDocument && !me.isDestroyed) {
-                me.dockModel = liveDocument;
-
-                // The document assignment IS the restore. Restore-projection failure precedence:
-                // a clean replay propagates it (a probe may not report success over an
-                // un-projected surface); a structured primary keeps its result and RECORDS the
-                // restore failure as a namespaced entry in the returned errors; a thrown primary
-                // owns the return channel and the restore failure stays suppressed.
-                completed
-                    ? await me.refreshDockWorkspace()
-                    : await me.refreshDockWorkspace().catch(error => {
-                        out?.errors?.push(`restore projection failed: ${error.message}`)
-                    })
-            }
-        }
-    }
-
-    /**
-     * Scrolls the scale grid through one View-owned VDOM update.
-     *
-     * The View is the closest common parent of the native scrollport and every pooled body.
-     * Retargeting its VNode `scrollTop` together with `syncBodies()` therefore lets one delta
-     * move the viewport and recycle the fixed rows atomically, without a transient blank frame.
-     *
-     * @param {Number} index
-     * @returns {Promise<Boolean>}
-     */
-    async scrollScaleGrid(index=50000) {
-        let pane = this.paneCache.scale,
-            target;
-
-        if (!pane?.view?.id) return false;
-
-        target = Math.max(0, Math.min(index, pane.store.count - 1)) * pane.rowHeight;
-        pane.view.vdom.scrollTop = target;
-        pane.view.syncBodies(target);
-        await pane.view.promiseUpdate();
-
-        return Math.abs(pane.view.scrollTop - target) <= pane.rowHeight
-    }
-
-    /**
-     * @param {Number} count
-     */
-    async setPipProgress(count) {
-        const pips = this.getReference('tour-pips');
-
-        if (!pips) return;
-
-        let {vdom} = pips;
-
-        vdom.cn.forEach((pip, index) => {
-            pip.cls = index < count
-                ? ['workstation-pip', 'workstation-pip-done']
-                : ['workstation-pip']
-        });
-        pips.update();
-        await pips.promiseUpdate()
-    }
-
-    /**
-     * @param {String} text
-     */
-    setTourCaption(text) {
-        const caption = this.getReference('tour-caption');
-
-        caption && (caption.html = text)
-    }
-
-    /**
      * Applies the theme to every render target of this app, not only to the workspace.
      *
      * A theme in Neo is a CSS class an ancestor carries, and `afterSetTheme` writes it onto the
@@ -1964,99 +1532,6 @@ class Workspace extends DockWorkspace {
         return me.setWorkspaceTheme(me.theme === 'neo-theme-neo-light'
             ? 'neo-theme-neo-dark'
             : 'neo-theme-neo-light')
-    }
-
-    /**
-     * Runs the screenplay from a fresh document on every replay.
-     * @returns {Promise<Object>|undefined}
-     */
-    async startTour() {
-        let me = this;
-
-        if (me.tourRunner.running) {
-            me.setTourCaption('Tour already running — the live stores continue underneath it.');
-            return
-        }
-
-        me.cueErrors       = [];
-        me.cuePromise      = Promise.resolve();
-        me.cueReceipts     = [];
-        me.cueSettlements.clear();
-        me.lastTourReceipt = null;
-        me.progressPromise = Promise.resolve();
-        me.dockModel       = WorkspaceDocument.clone(initialDocument);
-        await me.setPipProgress(0);
-
-        await me.refreshDockWorkspace(null, me.dockModel, {geometryOnly: true});
-
-        const
-            feedStore      = me.getStateProvider().getStore('feed'),
-            feedStartCount = feedStore.count,
-            feedStartBatch = me.feedBatchCount,
-            startedAt      = Date.now(),
-            runnerResult   = await me.tourRunner.start();
-
-        const
-            errors      = [...runnerResult.errors, ...me.cueErrors],
-            appendError = (label, result) => {
-                if (result.status === 'rejected') {
-                    const
-                        detail          = result.reason?.message || String(result.reason),
-                        alreadyRecorded = errors.some(error => error === detail || error.endsWith(`: ${detail}`));
-
-                    alreadyRecorded || errors.push(`${label} failed: ${detail}`)
-                }
-            },
-            settlements = await Promise.allSettled([
-                me.cuePromise,
-                me.refreshPromise,
-                me.progressPromise
-            ]);
-
-        ['surface cue settlement', 'dock refresh settlement', 'progress settlement']
-            .forEach((label, index) => appendError(label, settlements[index]));
-
-        const [finalProgress] = await Promise.allSettled([
-            me.setPipProgress(Workspace.totalBeats().length)
-        ]);
-
-        appendError('final progress paint', finalProgress);
-
-        const
-            elapsedMs    = Date.now() - startedAt,
-            feedEndCount = feedStore.count,
-            receipt      = {
-                completed  : runnerResult.completed && errors.length === 0,
-                cueReceipts: me.cueReceipts.map(entry => ({cue: {...entry.cue}, receipt: entry.receipt})),
-                document   : WorkspaceDocument.clone(me.dockModel),
-                elapsedMs,
-                errors,
-                feed       : {
-                    batches       : me.feedBatchCount - feedStartBatch,
-                    configuredRate: Workspace.FEED_BATCH_SIZE * 1000 / Workspace.FEED_INTERVAL_MS,
-                    endCount      : feedEndCount,
-                    growth        : feedEndCount - feedStartCount,
-                    maxRecords    : feedStore.maxRecords,
-                    produced      : (me.feedBatchCount - feedStartBatch) * Workspace.FEED_BATCH_SIZE,
-                    startCount    : feedStartCount
-                },
-                log       : runnerResult.log
-            };
-
-        me.lastTourReceipt = receipt;
-        me.setTourCaption(receipt.completed
-            ? `Tour complete — ${receipt.log.length} deterministic beats and ${receipt.cueReceipts.length} surface cues settled.`
-            : `Tour stopped — ${errors[0]}`);
-
-        return receipt
-    }
-
-    /**
-     * @returns {Object[]} Flattened screenplay steps.
-     * @static
-     */
-    static totalBeats() {
-        return workstationTourScript.scenes.flatMap(scene => scene.steps)
     }
 
     /**
@@ -2991,24 +2466,10 @@ class Workspace extends DockWorkspace {
         return snapshot
     }
 
-    /**
-     * @summary Loads and creates scripted gestures only when a demo or explicit caller needs them.
-     * @returns {Promise<Workstation.tour.NativeGestureDriver>}
-     */
-    async getGestureDriver() {
-        const me = this;
-        if (me.isDestroyed) throw Neo.isDestroyed;
-        return me.gestureDriverPromise ??= (async () => {
-            const {default: Driver} = await me.trap(import('../tour/NativeGestureDriver.mjs'));
-            return me.gestureDriver = Neo.create(Driver, {workspace: me})
-        })()
-    }
-
-    /** @summary Tears down the workspace and its optional gesture driver. @param {...*} args */
+    /** @summary Tears down the workspace's view tree and owned docking resources. @param {...*} args */
     destroy(...args) {
         let me = this;
 
-        me.gestureDriver?.destroy();
 
         if (me.#feedIntervalId !== null) {
             clearInterval(me.#feedIntervalId);
@@ -3018,7 +2479,6 @@ class Workspace extends DockWorkspace {
         me.crossWindowParticipations.forEach(participation => participation?.destroy());
         me.crossWindowParticipations.clear();
         me.getPopupStates().forEach(state => state.host?.destroy());
-        me.tourRunner?.destroy();
         me.dockService?.destroy();
         me.perspectiveStore?.destroy();
         me.workspaceSet?.destroy();
@@ -3028,7 +2488,6 @@ class Workspace extends DockWorkspace {
         me.nativeVesselParkHandlers?.destroy();
         me.vesselProxyEmbodiment?.destroy();
         me.tearOutEmbodiment?.destroy();
-        me.cueSettlements.clear();
 
         Object.values(me.paneCache).forEach(pane => {
             pane?.isDestroyed || pane?.destroy?.()

--- a/apps/workstation/view/WorkspaceController.mjs
+++ b/apps/workstation/view/WorkspaceController.mjs
@@ -25,6 +25,7 @@ class WorkspaceController extends Controller {
         if (me.isDestroyed || !bar || bar.isDestroyed) throw Neo.isDestroyed;
         if (bar.controller && !bar.controller.isDestroyed) return bar.controller;
         return me.tourControllerPromise ??= (async () => {
+            await me.trap(Promise.resolve(bar.controller?.settledPromise));
             const {default: TourController} = await me.trap(import('./TourController.mjs'));
             if (bar.isDestroyed) throw Neo.isDestroyed;
             bar.controller = {module: TourController, workspace: me.component};

--- a/apps/workstation/view/WorkspaceController.mjs
+++ b/apps/workstation/view/WorkspaceController.mjs
@@ -3,7 +3,7 @@ import Persistence        from '../../../src/dashboard/dock/model/Persistence.mj
 import TransactionManager from '../../../src/manager/Transaction.mjs';
 
 /**
- * @summary Workstation's durable topology selection and user-activated render targets.
+ * @summary Workstation actions, durable topology and optional tour-controller activation.
  * @class Workstation.view.WorkspaceController
  * @extends Neo.controller.Component
  */
@@ -11,6 +11,37 @@ class WorkspaceController extends Controller {
     static config = {
         /** @member {String} className='Workstation.view.WorkspaceController' */
         className: 'Workstation.view.WorkspaceController'
+    }
+
+    /** @member {Promise|null} tourControllerPromise=null */
+    tourControllerPromise = null
+
+    /**
+     * @summary Installs the optional playback controller on its real toolbar at first activation.
+     * @returns {Promise<Workstation.view.TourController>}
+     */
+    async getTourController() {
+        const me = this, bar = me.getReference('tour-bar');
+        if (me.isDestroyed || !bar || bar.isDestroyed) throw Neo.isDestroyed;
+        if (bar.controller && !bar.controller.isDestroyed) return bar.controller;
+        return me.tourControllerPromise ??= (async () => {
+            const {default: TourController} = await me.trap(import('./TourController.mjs'));
+            if (bar.isDestroyed) throw Neo.isDestroyed;
+            bar.controller = {module: TourController, workspace: me.component};
+            return bar.controller
+        })().finally(() => {
+            if (!me.isDestroyed) me.tourControllerPromise = null
+        })
+    }
+
+    /** @summary Routes the declarative start action to the activated playback controller. @returns {Promise<Object>} */
+    async onStartTour() {
+        return (await this.getTourController()).startTour()
+    }
+
+    /** @summary Keeps the ordinary theme action independent of playback activation. @param {Object} data @returns {Promise<String>} */
+    onToggleWorkspaceTheme(data) {
+        return this.component.toggleWorkspaceTheme(data)
     }
 
     /**

--- a/buildScripts/util/file-size-baseline.json
+++ b/buildScripts/util/file-size-baseline.json
@@ -1,5 +1,5 @@
 {
-    "apps/workstation/view/Workspace.mjs": 1689,
+    "apps/workstation/view/Workspace.mjs": 1384,
     "examples/dashboard/crossWindow/DemoBWorkspace.mjs": 2612,
     "src/dashboard/dock/Workspace.mjs": 1096,
     "src/main/addon/DragDrop.mjs": 1267

--- a/test/playwright/e2e/utils/workstationGesture.mjs
+++ b/test/playwright/e2e/utils/workstationGesture.mjs
@@ -1,3 +1,5 @@
+import {getWorkstationTour} from './workstationTour.mjs';
+
 /**
  * @summary Activates Workstation's optional driver and invokes its actual instance methods.
  * @param {Object} app Connected Neural Link application.
@@ -7,6 +9,7 @@
  * @returns {Promise<*>}
  */
 export async function callWorkstationGesture(app, workspaceId, method, args=[]) {
-    await app.callMethod(workspaceId, 'getGestureDriver');
-    return app.callMethod(workspaceId, `gestureDriver.${method}`, args)
+    const controllerId = await getWorkstationTour(app, workspaceId);
+    await app.callMethod(controllerId, 'getGestureDriver');
+    return app.callMethod(controllerId, `gestureDriver.${method}`, args)
 }

--- a/test/playwright/e2e/utils/workstationTour.mjs
+++ b/test/playwright/e2e/utils/workstationTour.mjs
@@ -1,0 +1,22 @@
+/**
+ * @summary Resolves the optional playback controller through the workspace's ordinary controller.
+ * @param {Object} app Connected Neural Link application.
+ * @param {String} workspaceId Workspace owning the toolbar.
+ * @returns {Promise<String>} Registered playback-controller id.
+ */
+export async function getWorkstationTour(app, workspaceId) {
+    const controller = await app.callMethod(workspaceId, 'controller.getTourController');
+    return controller.id
+}
+
+/**
+ * @summary Calls the actual playback owner without retaining removed Workspace facade methods.
+ * @param {Object} app Connected Neural Link application.
+ * @param {String} workspaceId Workspace owning the toolbar.
+ * @param {String} method Playback method.
+ * @param {Array} args Method arguments.
+ * @returns {Promise<*>}
+ */
+export async function callWorkstationTour(app, workspaceId, method, args=[]) {
+    return app.callMethod(await getWorkstationTour(app, workspaceId), method, args)
+}

--- a/test/playwright/e2e/workstation/WorkstationCrossZoneCueNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationCrossZoneCueNL.spec.mjs
@@ -1,11 +1,12 @@
-import {test, expect} from '../../fixtures.mjs';
+import {test, expect}        from '../../fixtures.mjs';
+import {callWorkstationTour} from '../utils/workstationTour.mjs';
 
 /**
  * @summary Whitebox E2E witness for the dense tour's audit cross-zone cue, invoked standalone.
  *
  * The tour runner fires surface cues without consuming their results, so a cue whose terminal
  * commit produces no document mutation still lets the tour report every cue as settled. This
- * spec invokes the exact tour cue directly on the Workspace and binds the executor's own
+ * spec invokes the exact tour cue on its playback controller and binds the executor's own
  * return contract — `applied`, empty `errors`, the two-dwell beat log, and the committed
  * document — so a silent commit no-op fails loudly with the executor's full forensic payload
  * in the assertion message.
@@ -52,7 +53,7 @@ test.describe('Workstation — the audit cross-zone cue commits what it previews
 
         // The exact cue the dense tour fires (apps/workstation/tour/denseWorkstation.mjs),
         // invoked through the same entry the tour runner uses.
-        const result = await app.callMethod(wsId, 'executeCue', [{
+        const result = await callWorkstationTour(app, wsId, 'executeCue', [{
             type        : 'cross-zone-showcase',
             itemId      : 'audit',
             sourceNodeId: 'right-top-tabs',

--- a/test/playwright/e2e/workstation/WorkstationDockSplitChromeNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationDockSplitChromeNL.spec.mjs
@@ -1,4 +1,5 @@
-import {test, expect} from '../../fixtures.mjs';
+import {test, expect}        from '../../fixtures.mjs';
+import {callWorkstationTour} from '../utils/workstationTour.mjs';
 
 /**
  * @summary Whitebox E2E witness: docking one tab to a grid's edge must not restyle every OTHER
@@ -93,7 +94,7 @@ test.describe('Workstation — docking a tab to a grid edge leaves every other h
         // The cue executor requires two distinct foreign zones AND two distinct placement kinds, so
         // the first dwell is a pass-through over another node; the LAST dwell is what the terminal
         // commits, and that one is the reported drop.
-        const result = await app.callMethod(wsId, 'executeCue', [{
+        const result = await callWorkstationTour(app, wsId, 'executeCue', [{
             type        : 'cross-zone-showcase',
             itemId      : 'alerts',
             sourceNodeId: 'heavy-tabs',

--- a/test/playwright/e2e/workstation/WorkstationFiveBeatNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationFiveBeatNL.spec.mjs
@@ -1,3 +1,4 @@
+import {callWorkstationTour}                                        from '../utils/workstationTour.mjs';
 import {callWorkstationGesture}                                     from '../utils/workstationGesture.mjs';
 import {execFile}                                                   from 'node:child_process';
 import {createHash}                                                 from 'node:crypto';
@@ -1197,7 +1198,7 @@ test.describe('Workstation — the five-beat multi-window journey', () => {
             // workspace's own spec-mode front door: fresh document, reducer op, runner-owned
             // deterministic log — the same contract the film's recording pipeline replays. ──
             const runSpec = () =>
-                app.callMethod(wsId, 'runTourSpec', [{
+                callWorkstationTour(app, wsId, 'runTourSpec', [{
                     schema: 'neo.tour.script.v1',
                     id    : 'five-beat-scene1',
                     title : 'scene 1 — the room answers',
@@ -2746,7 +2747,7 @@ test.describe('Workstation — the five-beat multi-window journey', () => {
 
             controlReceipt && controlReceipts.push(controlReceipt);
 
-            const roomSpec = await app.callMethod(wsId, 'runTourSpec', [{
+            const roomSpec = await callWorkstationTour(app, wsId, 'runTourSpec', [{
                 schema: 'neo.tour.script.v1',
                 id    : 'five-beat-signature-room',
                 title : 'scene 5 — the room is alive',

--- a/test/playwright/e2e/workstation/WorkstationNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationNL.spec.mjs
@@ -1,3 +1,4 @@
+import {callWorkstationTour}                         from '../utils/workstationTour.mjs';
 import {test, expect}                                from '../../fixtures.mjs';
 import {workstationTourScript}                       from '../../../../apps/workstation/tour/denseWorkstation.mjs';
 import {placeNativeWindow, resolveFilmDisplayBounds} from '../utils/filmStage.mjs';
@@ -1824,13 +1825,13 @@ test.describe('Workstation — dense living-data composition', () => {
         }, beforeIdentity);
 
         await page.click('.workstation-tour-play');
-        await expect.poll(async () => Boolean(await app.callMethod(workspaceId, 'getTourReceipt')), {
+        await expect.poll(async () => Boolean(await callWorkstationTour(app, workspaceId, 'getTourReceipt')), {
             message  : 'the native tour button settles document and surface tiers',
             timeout  : 30000,
             intervals: [100, 250]
         }).toBe(true);
 
-        const tourReceipt        = await app.callMethod(workspaceId, 'getTourReceipt'),
+        const tourReceipt        = await callWorkstationTour(app, workspaceId, 'getTourReceipt'),
               canvasFailureState = tourReceipt.completed ? [] : await readScaleSparklines(app, page),
               monitor            = await page.evaluate(async () => {
                   globalThis.__workstationMonitor.done = true;
@@ -1995,8 +1996,8 @@ test.describe('Workstation — dense living-data composition', () => {
 
         // Two fresh document-tier spec runs remain byte-identical; the real-button receipt above
         // is the separate authority for asynchronous surface cues.
-        const run1 = await app.callMethod(workspaceId, 'runTourSpec', [null, {restoreDocument: true}]),
-              run2 = await app.callMethod(workspaceId, 'runTourSpec', [null, {restoreDocument: true}]);
+        const run1 = await callWorkstationTour(app, workspaceId, 'runTourSpec', [null, {restoreDocument: true}]),
+              run2 = await callWorkstationTour(app, workspaceId, 'runTourSpec', [null, {restoreDocument: true}]);
 
         expect(run1.completed, `run 1 errors: ${JSON.stringify(run1.errors)}`).toBe(true);
         expect(run1.errors).toEqual([]);
@@ -2044,7 +2045,7 @@ test.describe('Workstation — dense living-data composition', () => {
 
         const
             postTourDocument = (await app.getDockTopology(workspaceId)).document,
-            postTourReceipt  = await app.callMethod(workspaceId, 'getTourReceipt', []),
+            postTourReceipt  = await callWorkstationTour(app, workspaceId, 'getTourReceipt', []),
             crossZoneCue     = postTourReceipt?.cueReceipts
                 ?.find(entry => entry.cue?.type === 'cross-zone-showcase')?.receipt;
 

--- a/test/playwright/e2e/workstation/WorkstationStarvedTourNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationStarvedTourNL.spec.mjs
@@ -1,4 +1,5 @@
-import {test, expect} from '../../fixtures.mjs';
+import {callWorkstationTour} from '../utils/workstationTour.mjs';
+import {test, expect}        from '../../fixtures.mjs';
 
 /**
  * Whitebox-e2e: the dense tour and the Sparkline offscreen pipeline survive rendering starvation.
@@ -125,7 +126,7 @@ test.describe('Workstation rendering starvation: sparkline registration + dense 
         // TOUR LEG: the full dense tour settles with a complete receipt. The RPC is fired
         // without awaiting so no bridge timeout can shadow the app-side truth; the receipt
         // poll is the settle gate.
-        const tourRpc = app.callMethod(workspaceId, 'startTour').catch(error => ({rpcError: String(error)}));
+        const tourRpc = callWorkstationTour(app, workspaceId, 'startTour').catch(error => ({rpcError: String(error)}));
 
         await expect.poll(async () => {
             try {

--- a/test/playwright/e2e/workstation/WorkstationStarvedTourNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationStarvedTourNL.spec.mjs
@@ -1,5 +1,5 @@
-import {callWorkstationTour} from '../utils/workstationTour.mjs';
-import {test, expect}        from '../../fixtures.mjs';
+import {getWorkstationTour} from '../utils/workstationTour.mjs';
+import {test, expect}       from '../../fixtures.mjs';
 
 /**
  * Whitebox-e2e: the dense tour and the Sparkline offscreen pipeline survive rendering starvation.
@@ -126,11 +126,12 @@ test.describe('Workstation rendering starvation: sparkline registration + dense 
         // TOUR LEG: the full dense tour settles with a complete receipt. The RPC is fired
         // without awaiting so no bridge timeout can shadow the app-side truth; the receipt
         // poll is the settle gate.
-        const tourRpc = callWorkstationTour(app, workspaceId, 'startTour').catch(error => ({rpcError: String(error)}));
+        const tourControllerId = await getWorkstationTour(app, workspaceId),
+              tourRpc          = app.callMethod(tourControllerId, 'startTour').catch(error => ({rpcError: String(error)}));
 
         await expect.poll(async () => {
             try {
-                const state = await app.getComponent(workspaceId, ['lastTourReceipt']);
+                const state = await app.getComponent(tourControllerId, ['lastTourReceipt']);
                 return !!state?.lastTourReceipt
             } catch {
                 return false
@@ -139,7 +140,7 @@ test.describe('Workstation rendering starvation: sparkline registration + dense 
 
         await tourRpc;
 
-        const {lastTourReceipt} = await app.getComponent(workspaceId, ['lastTourReceipt']);
+        const {lastTourReceipt} = await app.getComponent(tourControllerId, ['lastTourReceipt']);
 
         expect(lastTourReceipt.errors, 'the starved tour reports zero errors').toEqual([]);
         expect(lastTourReceipt.completed, 'the starved tour completes').toBe(true);

--- a/test/playwright/e2e/workstation/WorkstationTourActivationNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationTourActivationNL.spec.mjs
@@ -23,10 +23,10 @@ test('Workstation activates one playback controller through Start and retains it
     expect(await readController()).toBeNull();
     expect(await readRuntime()).toEqual([false, false, false]);
     const resize = await app.executeDockOperation(workspaceId, {
-        operation: 'resizeSplit', splitNodeId: 'split-main', sizes: [0.55, 0.45]
+        operation: 'resizeSplit', splitNodeId: 'split-main', sizes: [0.625, 0.375]
     });
     expect(resize.applied).toBe(true);
-    expect((await app.getDockTopology(workspaceId)).document.nodes['split-main'].sizes).toEqual([0.55, 0.45]);
+    expect((await app.getDockTopology(workspaceId)).document.nodes['split-main'].sizes).toEqual([0.625, 0.375]);
     expect(await readRuntime(), 'ordinary docking must not load playback').toEqual([false, false, false]);
     const initialTheme = (await app.getComponent(workspaceId, ['theme'])).theme;
     await page.locator('.workstation-theme-button').click();

--- a/test/playwright/e2e/workstation/WorkstationTourActivationNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationTourActivationNL.spec.mjs
@@ -1,0 +1,57 @@
+import {test, expect} from '../../fixtures.mjs';
+
+/**
+ * @summary Proves ordinary controls work before lazy playback and the real Start action completes it.
+ */
+test('Workstation activates one playback controller through Start and retains its ordinary owners', async ({page, neuralLink}, testInfo) => {
+    test.setTimeout(120000);
+    const pageErrors = [];
+    page.on('pageerror', error => pageErrors.push(String(error)));
+    await page.goto('/apps/workstation/index.html');
+    await page.waitForSelector('.workstation-tour-play');
+    await page.waitForSelector('.neo-tab-overflow-control');
+    const app            = await neuralLink.connectToApp('Workstation'),
+          workspaces     = await app.findInstances({className: 'Workstation.view.Workspace'}, ['id']),
+          workspaceId    = workspaces[0].id,
+          bar            = await app.callMethod(workspaceId, 'getReference', ['tour-bar']),
+          provider       = await app.callMethod(workspaceId, 'getStateProvider'),
+          paneIds        = await Promise.all(['scale', 'feed'].map(id => app.callMethod(workspaceId, 'getPaneIdentity', [id]))),
+          readController = async () => (await app.getComponent(bar.id, ['controller'])).controller,
+          namespaces     = ['Workstation.view.TourController', 'Workstation.tour.GestureDriver', 'Workstation.tour.NativeGestureDriver'],
+          readRuntime    = () => Promise.all(namespaces.map(async name => (await app.checkNamespace(name)).exists));
+
+    expect(await readController()).toBeNull();
+    expect(await readRuntime()).toEqual([false, false, false]);
+    const resize = await app.executeDockOperation(workspaceId, {
+        operation: 'resizeSplit', splitNodeId: 'split-main', sizes: [0.55, 0.45]
+    });
+    expect(resize.applied).toBe(true);
+    expect((await app.getDockTopology(workspaceId)).document.nodes['split-main'].sizes).toEqual([0.55, 0.45]);
+    expect(await readRuntime(), 'ordinary docking must not load playback').toEqual([false, false, false]);
+    const initialTheme = (await app.getComponent(workspaceId, ['theme'])).theme;
+    await page.locator('.workstation-theme-button').click();
+    await expect.poll(async () => (await app.getComponent(workspaceId, ['theme'])).theme).not.toBe(initialTheme);
+    expect(await readController(), 'ordinary theme controls must not activate playback').toBeNull();
+    expect(await readRuntime()).toEqual([false, false, false]);
+
+    await page.locator('.workstation-tour-play').click();
+    await expect.poll(async () => (await readController())?.id).toBeTruthy();
+    const controller = await readController();
+    expect(controller.className).toBe('Workstation.view.TourController');
+    let receipt;
+    await expect.poll(async () => {
+        receipt = await app.callMethod(controller.id, 'getTourReceipt');
+        return Boolean(receipt)
+    }, {timeout: 60000, intervals: [100, 250, 500]}).toBe(true);
+    expect(receipt.errors, JSON.stringify(receipt)).toEqual([]);
+    expect(receipt.completed).toBe(true);
+    await expect(page.locator('.workstation-tour-caption')).toContainText('Tour complete');
+    await expect(page.locator('.workstation-pip-done')).toHaveCount(receipt.log.length);
+    await expect(page.locator('.workstation-tour-play')).toBeEnabled();
+    expect((await readController()).id).toBe(controller.id);
+    expect((await app.callMethod(workspaceId, 'getStateProvider')).id).toBe(provider.id);
+    expect(await Promise.all(['scale', 'feed'].map(id => app.callMethod(workspaceId, 'getPaneIdentity', [id])))).toEqual(paneIds);
+    expect(await readRuntime(), 'the same worker-side probe must see the activated runtime').toEqual([true, true, true]);
+    expect(pageErrors).toEqual([]);
+    await testInfo.attach('tour-complete', {body: await page.screenshot(), contentType: 'image/png'})
+});

--- a/test/playwright/unit/apps/workstation/GestureDriver.spec.mjs
+++ b/test/playwright/unit/apps/workstation/GestureDriver.spec.mjs
@@ -23,14 +23,15 @@ test('normal construction stays driver-free; explicit calls reach one registered
     const workspace = Neo.create(Workspace, {windowId: Neo.config.windowId}),
           service   = Neo.create(InstanceService);
     try {
-        expect(workspace.gestureDriver).toBeNull();
-        expect(workspace.gestureDriverPromise).toBeNull();
+        expect(workspace.getController().getReference('tour-bar').controller).toBeFalsy();
+        expect(workspace.gestureDriver).toBeUndefined();
         expect(workspace.executeTearOutStep).toBeUndefined();
-        const [first, second] = await Promise.all([workspace.getGestureDriver(), workspace.getGestureDriver()]);
+        const controller      = await workspace.getController().getTourController();
+        const [first, second] = await Promise.all([controller.getGestureDriver(), controller.getGestureDriver()]);
         expect(first).toBe(second);
         expect(first.workspace).toBe(workspace);
         expect(Neo.get(first.id)).toBe(first);
-        const receipt = await service.callMethod({id: workspace.id, method: 'gestureDriver.executeTearOutStep', args: [{}]});
+        const receipt = await service.callMethod({id: controller.id, method: 'gestureDriver.executeTearOutStep', args: [{}]});
         expect(receipt.result.applied).toBe(false);
         expect(receipt.result.errors.length).toBeGreaterThan(0);
         workspace.destroy();
@@ -43,7 +44,7 @@ test('normal construction stays driver-free; explicit calls reach one registered
 
 test('root destruction during the lazy import cannot create an orphan driver', async () => {
     const workspace = Neo.create(Workspace, {windowId: Neo.config.windowId}),
-          pending   = workspace.getGestureDriver();
+          pending   = workspace.getController().getTourController();
     workspace.destroy();
     await expect(pending).rejects.toBe(Neo.isDestroyed)
 });

--- a/test/playwright/unit/apps/workstation/TourController.spec.mjs
+++ b/test/playwright/unit/apps/workstation/TourController.spec.mjs
@@ -6,6 +6,142 @@ import Workspace      from '../../../../../apps/workstation/view/Workspace.mjs';
 
 setup({appConfig: {name: 'WorkstationTourControllerTest'}});
 
+/** @summary A caller-controlled acknowledgement boundary. @returns {Object} */
+function deferred() {
+    let resolve;
+    const promise = new Promise(done => resolve = done);
+    return {promise, resolve}
+}
+
+test('the configured runner cannot begin its next beat before the controller cue settles', async () => {
+    const workspace  = Neo.create(Workspace, {windowId: Neo.config.windowId}),
+          controller = await workspace.getController().getTourController(),
+          cue        = deferred(), entered = deferred(), beats = [];
+    controller.executeCue = () => {entered.resolve(); return cue.promise};
+    controller.setPipProgress = async () => {};
+    controller.tourRunner = {script: {
+        schema: 'neo.tour.script.v1', id: 'settlement-control', title: 'Settlement control',
+        scenes: [{id: 's', title: 'Scene', steps: [
+            {type: 'pause', ms: 0, cue: {type: 'test-cue'}},
+            {type: 'pause', ms: 0}
+        ]}]
+    }};
+    const runner = controller.tourRunner;
+    runner.on('beat', data => beats.push(data.stepIndex));
+    try {
+        const run = runner.start();
+        await entered.promise;
+        await new Promise(setImmediate);
+        expect(beats).toEqual([0]);
+        cue.resolve({applied: true, errors: []});
+        expect((await run).completed).toBe(true);
+        expect(beats).toEqual([0, 1]);
+        await controller.progressPromise
+    } finally {cue.resolve({applied: true, errors: []}); workspace.destroy()}
+});
+
+test('repeated starts share the entry projection and cancellation does not start the runner afterward', async () => {
+    const workspace  = Neo.create(Workspace, {windowId: Neo.config.windowId}),
+          controller = await workspace.getController().getTourController(),
+          entry      = deferred(), entered = deferred(), runner = controller.getTourRunner();
+    let starts = 0, projections = 0;
+    controller.setPipProgress = async () => {};
+    workspace.refreshDockWorkspace = () => {projections++; entered.resolve(); return entry.promise};
+    runner.start = async () => {starts++; return {completed: true, errors: [], log: []}};
+    try {
+        const first = controller.startTour();
+        await entered.promise;
+        expect(controller.startTour()).toBe(first);
+        expect(projections).toBe(1);
+        await controller.cancelTour();
+        expect(await first).toMatchObject({completed: false, cancelled: true});
+        entry.resolve();
+        await new Promise(setImmediate);
+        expect(starts).toBe(0);
+        expect(workspace.isDestroyed).toBeFalsy()
+    } finally {entry.resolve(); workspace.destroy()}
+});
+
+test('cancelling a replay probe waits for its displaced-document restoration', async () => {
+    const workspace  = Neo.create(Workspace, {windowId: Neo.config.windowId}),
+          controller = await workspace.getController().getTourController(),
+          live       = workspace.dockModel, entry = deferred(), entered = deferred(),
+          restore    = deferred(), restoring = deferred();
+    let calls = 0;
+    workspace.refreshDockWorkspace = () => {
+        if (++calls === 1) {entered.resolve(); return entry.promise}
+        restoring.resolve();
+        return restore.promise
+    };
+    const run = controller.runTourSpec(null, {restoreDocument: true});
+    run.catch(() => {});
+    try {
+        await entered.promise;
+        let   settled      = false;
+        const cancellation = controller.cancelTour().then(() => {settled = true});
+        await restoring.promise;
+        expect(workspace.dockModel).toBe(live);
+        await new Promise(setImmediate);
+        expect(settled).toBe(false);
+        entry.resolve();
+        restore.resolve();
+        await cancellation;
+        await expect(run).rejects.toBe(Neo.isDestroyed);
+        expect(calls).toBe(2)
+    } finally {entry.resolve(); restore.resolve(); workspace.destroy()}
+});
+
+test('cancellation during final settlement returns cancellation rather than reading a disposed owner', async () => {
+    const workspace  = Neo.create(Workspace, {windowId: Neo.config.windowId}),
+          controller = await workspace.getController().getTourController(),
+          refresh    = deferred(), started = deferred(), runner = controller.getTourRunner();
+    controller.setPipProgress = async () => {};
+    workspace.refreshDockWorkspace = async () => {};
+    runner.start = async () => {
+        workspace.refreshPromise = refresh.promise;
+        started.resolve();
+        return {completed: true, errors: [], log: []}
+    };
+    try {
+        const run = controller.startTour();
+        await started.promise;
+        await new Promise(setImmediate);
+        await controller.cancelTour();
+        expect(await run).toMatchObject({completed: false, cancelled: true});
+        expect(workspace.isDestroyed).toBeFalsy()
+    } finally {refresh.resolve(); workspace.destroy()}
+});
+
+test('cancellation and reactivation wait for a driver input that was already dispatched', async () => {
+    const workspace = Neo.create(Workspace, {windowId: Neo.config.windowId}),
+          root      = workspace.getController(), controller = await root.getTourController(),
+          driver    = controller.getGestureDriver(), service = driver.interactionService,
+          input     = deferred(), started = deferred(), events = [];
+    service.simulateEvent = () => {started.resolve(); return input.promise};
+    service.dispatch = async ({type}) => {events.push(type); return true};
+    const gesture = driver.runGesture(run => driver.simulateEvent(run, {events: [{
+        targetId: 'held-tab', windowId: workspace.windowId, type: 'mousedown', options: {buttons: 1}
+    }]}));
+    gesture.catch(() => {});
+    try {
+        await started.promise;
+        let   cancelled    = false, reactivated = false;
+        const cancellation = controller.cancelTour().then(() => {cancelled = true}),
+              next = root.getTourController().then(value => {reactivated = true; return value});
+        await new Promise(setImmediate);
+        expect(cancelled).toBe(false);
+        expect(reactivated).toBe(false);
+        expect(Neo.get(service.id)).toBe(service);
+        input.resolve(true);
+        await cancellation;
+        await expect(gesture).rejects.toBe(Neo.isDestroyed);
+        const replacement = await next;
+        expect(replacement).not.toBe(controller);
+        expect(events).toEqual(['keydown', 'mouseup']);
+        expect(service.isDestroyed).toBe(true)
+    } finally {input.resolve(true); workspace.destroy()}
+});
+
 test('normal chrome binds the root provider without a playback controller or runner', () => {
     const workspace = Neo.create(Workspace, {windowId: Neo.config.windowId});
     try {

--- a/test/playwright/unit/apps/workstation/TourController.spec.mjs
+++ b/test/playwright/unit/apps/workstation/TourController.spec.mjs
@@ -1,0 +1,132 @@
+import {setup}        from '../../../setup.mjs';
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../src/Neo.mjs';
+import * as core      from '../../../../../src/core/_export.mjs';
+import Workspace      from '../../../../../apps/workstation/view/Workspace.mjs';
+
+setup({appConfig: {name: 'WorkstationTourControllerTest'}});
+
+test('normal chrome binds the root provider without a playback controller or runner', () => {
+    const workspace = Neo.create(Workspace, {windowId: Neo.config.windowId});
+    try {
+        const controller = workspace.getController(), bar = controller.getReference('tour-bar'),
+              provider   = workspace.getStateProvider(), caption = controller.getReference('tour-caption'),
+              pips       = controller.getReference('tour-pips'), play = controller.getReference('tour-play');
+        expect(bar.controller).toBeFalsy();
+        expect(workspace.tourRunner).toBeUndefined();
+        expect(workspace.startTour).toBeUndefined();
+        expect(play.handler).toBe('onStartTour');
+        provider.setData({'tour.caption': 'Bound independently', 'tour.completedCount': 2, 'tour.running': true});
+        expect(caption.html).toBe('Bound independently');
+        expect([...pips.html.matchAll(/workstation-pip-done/g)]).toHaveLength(2);
+        expect(play.disabled).toBe(true);
+        provider.setData({'tour.running': false});
+        expect(play.disabled).toBe(false);
+        expect(bar.controller).toBeFalsy()
+    } finally {workspace.destroy()}
+});
+
+test('the actual string handler reaches the workspace controller through engine resolution', async () => {
+    const workspace = Neo.create(Workspace, {windowId: Neo.config.windowId});
+    try {
+        const controller = workspace.getController(), play = controller.getReference('tour-play');
+        let   calls      = 0;
+        play.useRippleEffect = false;
+        controller.getTourController = async () => ({startTour: () => calls++});
+        play.onClick({});
+        await new Promise(setImmediate);
+        expect(calls).toBe(1)
+    } finally {workspace.destroy()}
+});
+
+test('concurrent activation installs one real toolbar controller; collaborators stay demand-created', async () => {
+    const workspace   = Neo.create(Workspace, {windowId: Neo.config.windowId});
+    const dockService = workspace.dockService;
+    try {
+        const root = workspace.getController(), [first, second] = await Promise.all([
+            root.getTourController(), root.getTourController()
+        ]);
+        expect(first).toBe(second);
+        expect(first.component).toBe(root.getReference('tour-bar'));
+        expect(first.workspace).toBe(workspace);
+        expect(first.getReference('tour-caption')).toBe(root.getReference('tour-caption'));
+        expect(first.tourRunner).toBeNull();
+        expect(first.gestureDriver).toBeNull();
+        const runner = first.getTourRunner(), driver = first.getGestureDriver();
+        expect(runner.dockService).toBe(dockService);
+        expect(driver.workspace).toBe(workspace);
+        runner.fire('scene', {title: 'Resolved string listener', caption: 'caption'});
+        expect(root.getReference('tour-caption').html).toBe('Resolved string listener — caption');
+        await first.cancelTour();
+        expect(first.isDestroyed).toBe(true);
+        expect(runner.isDestroyed).toBe(true);
+        expect(driver.isDestroyed).toBe(true);
+        expect(Neo.get(dockService.id)).toBe(dockService);
+        expect(workspace.isDestroyed).toBeFalsy();
+        const replacement = await root.getTourController();
+        expect(replacement).not.toBe(first)
+    } finally {workspace.destroy()}
+});
+
+test('root destruction during lazy activation cannot attach a late controller', async () => {
+    const workspace = Neo.create(Workspace, {windowId: Neo.config.windowId}),
+          pending   = workspace.getController().getTourController();
+    workspace.destroy();
+    await expect(pending).rejects.toBe(Neo.isDestroyed)
+});
+
+test('playback observes workspace destruction before its borrowed dock service is retired', async () => {
+    const workspace  = Neo.create(Workspace, {windowId: Neo.config.windowId}),
+          controller = await workspace.getController().getTourController(),
+          runner     = controller.getTourRunner(), driver = controller.getGestureDriver(),
+          service    = workspace.dockService, destroy = service.destroy.bind(service);
+    let checked = false;
+    service.destroy = () => {
+        expect(controller.isDestroyed).toBe(true);
+        expect(runner.isDestroyed).toBe(true);
+        expect(driver.isDestroyed).toBe(true);
+        checked = true;
+        return destroy()
+    };
+    workspace.destroy();
+    expect(checked).toBe(true)
+});
+
+test('configured collaborators preserve class and instance defaults and execute the selected controller', async () => {
+    const {default: TourController} = await import('../../../../../apps/workstation/view/TourController.mjs');
+    const {default: TourRunner}     = await import('../../../../../src/ai/client/TourRunner.mjs');
+    let   scenes                    = 0;
+    class ConfiguredController extends TourController {
+        static config = {className: 'Test.Unit.WorkstationTour.ConfiguredController'}
+        onTourScene(data) {scenes++; super.onTourScene(data)}
+    }
+    class ConfiguredRunner extends TourRunner {
+        static config = {className: 'Test.Unit.WorkstationTour.ConfiguredRunner', paceMultiplier: 4}
+    }
+    Neo.setupClass(ConfiguredController);
+    Neo.setupClass(ConfiguredRunner);
+    const workspace = Neo.create(Workspace, {windowId: Neo.config.windowId});
+    try {
+        const root = workspace.getController(), bar = root.getReference('tour-bar');
+        bar.controller = {module: ConfiguredController, workspace};
+        const controller = await root.getTourController();
+        expect(controller).toBe(bar.controller);
+        controller.tourRunner = {module: ConfiguredRunner};
+        const first = controller.tourRunner;
+        expect(first.paceMultiplier).toBe(4);
+        first.fire('scene', {title: 'Class default'});
+        expect(scenes).toBe(1);
+        expect(controller.getReference('tour-caption').html).toBe('Class default');
+        controller.tourRunner = {module: ConfiguredRunner, paceMultiplier: 2};
+        const second = controller.tourRunner;
+        expect(first.isDestroyed).toBe(true);
+        expect(second.paceMultiplier).toBe(2);
+        second.fire('scene', {title: 'Instance override'});
+        expect(scenes).toBe(2);
+        expect(controller.getReference('tour-caption').html).toBe('Instance override');
+        controller.tourRunner = null;
+        expect(second.isDestroyed).toBe(true);
+        expect(controller.tourRunner).toBeNull();
+        expect(Neo.get(workspace.dockService.id)).toBe(workspace.dockService)
+    } finally {workspace.destroy()}
+});

--- a/test/playwright/unit/apps/workstation/Workspace.spec.mjs
+++ b/test/playwright/unit/apps/workstation/Workspace.spec.mjs
@@ -2481,7 +2481,7 @@ async function runTourProbe(workspace, ...args) {
     const service = Neo.create(DockService);
     workspace.dockService = service;
     try {
-        return await TourController.prototype.runTourSpec.call({
+        return await TourController.prototype.runSpecTour.call({
             workspace, specRunners: new Set(), trap: promise => promise
         }, ...args)
     } finally {

--- a/test/playwright/unit/apps/workstation/Workspace.spec.mjs
+++ b/test/playwright/unit/apps/workstation/Workspace.spec.mjs
@@ -20,6 +20,8 @@ import ScalePane          from '../../../../../apps/workstation/view/ScalePane.m
 import Workspace          from '../../../../../apps/workstation/view/Workspace.mjs';
 import PopupWorkspace     from '../../../../../apps/workstation/view/PopupWorkspace.mjs';
 import GestureDriver      from '../../../../../apps/workstation/tour/GestureDriver.mjs';
+import TourController     from '../../../../../apps/workstation/view/TourController.mjs';
+import DockService        from '../../../../../src/ai/client/DockService.mjs';
 
 import {initialDocument} from '../../../../../apps/workstation/tour/denseWorkstation.mjs';
 
@@ -305,7 +307,7 @@ test.describe.serial('Workstation.view.Workspace', () => {
             };
 
             let   settled = false;
-            const driver  = await workspace.getGestureDriver(),
+            const driver  = (await workspace.getController().getTourController()).getGestureDriver(),
                   retirement = driver.retireFilmCursorDot(cursorDot)
                 .then(value => {
                     settled = true;
@@ -349,7 +351,7 @@ test.describe.serial('Workstation.view.Workspace', () => {
             const results = [];
 
             for (let boundary = 0; boundary < 6; boundary++) {
-                results.push(await (await workspace.getGestureDriver()).retireFilmCursorDot(null))
+                results.push(await ((await workspace.getController().getTourController()).getGestureDriver()).retireFilmCursorDot(null))
             }
 
             expect(results).toEqual([false, false, false, false, false, false]);
@@ -396,7 +398,12 @@ test.describe.serial('Workstation.view.Workspace', () => {
             }
         };
 
-        const receipt = await Workspace.prototype.startTour.call(host);
+        host.workspace = host;
+        host.constructor = Workspace;
+        host.getTourRunner = () => host.tourRunner;
+        host.setState = () => {};
+        host.trap = promise => promise;
+        const receipt = await TourController.prototype.runVisibleTour.call(host);
 
         expect(receipt).toBe(host.lastTourReceipt);
         expect(receipt.completed).toBe(false);
@@ -2424,7 +2431,7 @@ test.describe('cue settlement truth-binding (prototype-call)', () => {
     test('an un-applied, error-free, non-cancel receipt fails the settlement and retains its forensics', async () => {
         const host = createCueHost({applied: false, errors: []});
 
-        Workspace.prototype.onTourBeat.call(host, beat);
+        TourController.prototype.onTourBeat.call(host, beat);
         await host.cueSettlements.get('0:0');
 
         expect(host.cueErrors).toEqual(['cross-zone-showcase: terminal effect did not apply']);
@@ -2436,7 +2443,7 @@ test.describe('cue settlement truth-binding (prototype-call)', () => {
     test('a receipt carrying errors fails the settlement with those errors', async () => {
         const host = createCueHost({applied: true, errors: ['zone unreachable', 'no candidate']});
 
-        Workspace.prototype.onTourBeat.call(host, beat);
+        TourController.prototype.onTourBeat.call(host, beat);
         await host.cueSettlements.get('0:0');
 
         expect(host.cueErrors).toEqual(['cross-zone-showcase: zone unreachable; no candidate']);
@@ -2446,7 +2453,7 @@ test.describe('cue settlement truth-binding (prototype-call)', () => {
     test('a cancel terminal settles legitimately un-applied', async () => {
         const host = createCueHost({applied: false, cancelled: true, errors: []});
 
-        Workspace.prototype.onTourBeat.call(host, beat);
+        TourController.prototype.onTourBeat.call(host, beat);
         await host.cueSettlements.get('0:0');
 
         expect(host.cueErrors).toEqual([]);
@@ -2456,13 +2463,32 @@ test.describe('cue settlement truth-binding (prototype-call)', () => {
     test('a healthy applied receipt settles clean', async () => {
         const host = createCueHost({applied: true, beatLog: [], errors: []});
 
-        Workspace.prototype.onTourBeat.call(host, beat);
+        TourController.prototype.onTourBeat.call(host, beat);
         await host.cueSettlements.get('0:0');
 
         expect(host.cueErrors).toEqual([]);
         expect(host.cueReceipts).toHaveLength(1)
     });
 });
+
+/**
+ * @summary Runs the actual playback owner's probe against a borrowed workspace service fixture.
+ * @param {Object} workspace
+ * @param {...*} args
+ * @returns {Promise<Object>}
+ */
+async function runTourProbe(workspace, ...args) {
+    const service = Neo.create(DockService);
+    workspace.dockService = service;
+    try {
+        return await TourController.prototype.runTourSpec.call({
+            workspace, specRunners: new Set(), trap: promise => promise
+        }, ...args)
+    } finally {
+        expect(Neo.get(service.id), 'the playback probe must retain its borrowed service').toBe(service);
+        service.destroy()
+    }
+}
 
 test.describe('replay probe transaction (prototype-call)', () => {
     test('a rejecting entry projection still restores the displaced document under restoreDocument', async () => {
@@ -2484,7 +2510,7 @@ test.describe('replay probe transaction (prototype-call)', () => {
             };
 
         await expect(
-            Workspace.prototype.runTourSpec.call(host, null, {restoreDocument: true}),
+            runTourProbe(host, null, {restoreDocument: true}),
             'the transaction error propagates'
         ).rejects.toThrow('entry projection rejected');
 
@@ -2518,7 +2544,7 @@ test.describe('replay probe transaction (prototype-call)', () => {
             };
 
         await expect(
-            Workspace.prototype.runTourSpec.call(host, script, {restoreDocument: true}),
+            runTourProbe(host, script, {restoreDocument: true}),
             'a probe may not report success over an un-projected surface'
         ).rejects.toThrow('restore projection rejected');
 
@@ -2556,7 +2582,7 @@ test.describe('replay probe transaction (prototype-call)', () => {
                 }]
             };
 
-        const result = await Workspace.prototype.runTourSpec.call(host, script, {restoreDocument: true});
+        const result = await runTourProbe(host, script, {restoreDocument: true});
 
         expect(result.completed, 'the structured failure reaches the caller').toBe(false);
         expect(
@@ -2598,7 +2624,7 @@ test.describe('replay probe transaction (prototype-call)', () => {
                 scenes: [{id: 's1', title: 'pause', steps: [{type: 'pause', ms: 1}]}]
             };
 
-        await Workspace.prototype.runTourSpec.call(host, script, {restoreDocument: true});
+        await runTourProbe(host, script, {restoreDocument: true});
 
         // Entry declares admission to the validated in-place path (reconcileStableTopology
         // null-falls-back to the staged transaction on any topology delta — the fallback
@@ -2630,7 +2656,7 @@ test.describe('replay probe transaction (prototype-call)', () => {
             };
 
         await expect(
-            Workspace.prototype.runTourSpec.call(host, null)
+            runTourProbe(host, null)
         ).rejects.toThrow('entry projection rejected');
 
         expect(host.dockModel, 'the driver contract keeps the baseline (no silent restore)')


### PR DESCRIPTION
Resolves #18458

Workstation's toolbar is now lightweight declarative chrome. Start and theme actions resolve through the controller hierarchy; the actual tour-toolbar ViewController loads on first playback request. It owns the runner, drivers and settlement queues. Caption, progress and button state bind to the existing root Provider, while ordinary docking and theme controls remain usable before activation.

Workspace falls from **3,042 to 2,501 physical lines**. The new TourController is **562** lines and TourToolbar **60**; total app `.mjs` change is **+138** lines, including explicit cancellation/reactivation behavior. The parent entrypoint target remains a later integration outcome.

Evidence: L3 (live worker namespace checks, real Start-driven 11-beat tour, rendered progress and owner identity) → L3 required (selected playback witnesses). Residual: broader provider-census/native/film qualification and the sampled starvation dwell failure, Residual-Owner: #17844.

## AC Evidence

| AC | Evidence |
|---|---|
| AC-1 | Workspace's playback methods, queues, receipts and driver fields are removed. TourController is attached through the toolbar's ordinary `controller` config; callers target that registered owner. |
| AC-2 | `WorkstationTourActivationNL` observes all three runtime namespaces absent before/after ordinary resize and theme use, then present after the real Start click. Provider and scale/feed pane identities survive the full tour. |
| AC-3 | Provider-bound caption/pips/running state; string actions/listeners. `TourController.spec.mjs` checks actual callback resolution, configured class/instance precedence, single activation/start and the real runner's cue-settlement barrier. |
| AC-4 | Unit controls hold dispatched input, entry projection, probe restoration and final settlement across cancellation. Reactivation awaits the retired owner's cleanup. Root destruction retires playback before borrowed services; borrowed workspace/service identities remain alive on playback cancellation. |
| AC-5 | Existing assertions retained and callers retargeted. New modules remain under 2,000 lines. Selected runtime receipts and their limits are below; no whole-film acceptance is claimed. |

## Deltas from ticket

The playback owner is the actual toolbar ViewController, avoiding a separate helper/controller forwarding pair; the [intake clarification](https://github.com/neomjs/neo/issues/18458#issuecomment-5590721033) was folded into the ticket before implementation. Owned collaborator configs use `beforeSetInstance` with explicit null/retirement policy. `GestureDriver.settledPromise` lets cancellation and reactivation wait for already-dispatched input and cursor cleanup; its regression test failed before that boundary was added. Spec replays borrow the existing dock service.

Agent-preflight is not hosted in this Engine repository (explicit Missing script result). Local hooks, parse, theme and size checks passed; shared CI remains a separate gate. Documentation regeneration leaves the tracked hierarchy unchanged.

## Test Evidence

At `16fa13d3c3`, the Workstation unit directory passes **85/85**. The selected existing CrossZoneCue standalone, FiveBeat scene-1 and StarvedTour witnesses pass **3/3** (31.4s, headed macOS Chrome, explicit Brain runtime root); artifacts: `test/playwright/test-results/e2e/battery/18458-integrated-existing/artifacts/`.

At `16fa13d3c3`, `WorkstationTourActivationNL.spec.mjs` **passes 1/1** in headed macOS Chrome (19.2s total), with `NEO_AGENTOS_RUNTIME_ROOT` explicitly set and the custom e2e config. It verifies ordinary resize/theme use before activation, worker-side namespace absence/presence with a positive control, all 11 production beats, completion caption/pips and preserved provider/pane identities. The captured completion view was inspected. Artifacts: `test/playwright/test-results/e2e/battery/18458-integrated-activation/artifacts/`.

The existing standalone cross-zone cue and the FiveBeat scene containing two spec replays passed after retargeting. [Provider-census control](https://github.com/neomjs/neo/issues/17844#issuecomment-5591371100): the larger dense witness stops before playback, expecting one root Provider and seeing two, including with pre-extraction Workspace source. [Starvation samples](https://github.com/neomjs/neo/issues/17844#issuecomment-5591732423): one candidate dwell-expiry failure, one passing pre-extraction control, then three passes on the unchanged candidate. The failure is retained; no assertion, timeout or dwell was relaxed.

Hosted engine E2E [attempt 1](https://github.com/neomjs/neo/actions/runs/34278962950/attempts/1) and [attempt 2](https://github.com/neomjs/neo/actions/runs/34278962950/attempts/2) both report **34 passed / 1 failed / 3 skipped**: grid `ThumbDragPause:222` observed nine, then ten blank frames. [Both samples remain on #18439](https://github.com/neomjs/neo/issues/18439#issuecomment-5592051647). An [independent hosted control without this PR's Workstation changes](https://github.com/neomjs/neo/actions/runs/34287880651) then reproduced the signature in **5/20** ThumbDragPause executions. With that new evidence, [attempt 3](https://github.com/neomjs/neo/actions/runs/34278962950/attempts/3) passed at unchanged `16fa13d3c3`: **35 passed / 3 skipped**. This restores the CI review gate; the adaptive retry sequence is not a failure-rate estimate and does not resolve the underlying grid issue.

## Post-Merge Validation

- [ ] Requalify the broader existing Workstation/native/film witnesses through #17844, retaining the recorded census and intermittent-dwell evidence.

## Commits

- `ab903dfde0` — optional actual controller, declarative chrome and caller migration.
- `6f735345c0` — cancellation/retirement boundary and activation witness.
- `16fa13d3c3` — exact binary resize fractions in the new fixture.

Related: #18456 · #18490

Authored by Emmy (GPT-6 Astra, Codex). Session 153d2e0a-ebae-4087-bcd5-3c92d213132c.
