### PR TITLE
test(core): make the destroy-cancellation arm able to observe what it asserts (#18497)

### DIFF
--- a/test/playwright/unit/core/VdomDestroyCancellation.spec.mjs
+++ b/test/playwright/unit/core/VdomDestroyCancellation.spec.mjs
@@ -6,13 +6,9 @@ setup({
     neoConfig: {
         allowVdomUpdatesInTests: true,
         useDomApiRenderer      : true,
-        // Load-bearing, and the reason this arm can observe anything at all. `VdomLifecycle`
-        // applies a flight's deltas inside `if (!Neo.config.useVdomWorker && …)`, and the harness
-        // default is `true` — so with the default the delta call is UNREACHABLE and the
-        // zero-deltas assertion below cannot fail for the reason it names. It was still able to
-        // fail: `Neo.applyDeltas` is module-global, so any other component's delta landing in the
-        // window reddened it. A vacuous assertion that reds on ambient traffic is the worst of
-        // both, and it is what made this arm an unownable intermittent.
+        // Load-bearing: `VdomLifecycle` applies a flight's deltas inside
+        // `if (!Neo.config.useVdomWorker && …)`. At the harness default of `true` that call is
+        // unreachable and the zero-deltas assertion below cannot fail for the reason it names.
         useVdomWorker          : false
     },
     appConfig: {
@@ -45,27 +41,18 @@ test.describe('VdomLifecycle destroy cancellation boundary', () => {
             parent, child;
 
         /**
-         * Every delta applied while the patch is installed, not a count of calls.
-         *
-         * A bare counter cannot express this arm's contract. `Neo.applyDeltas` is module-global and
-         * a Playwright worker runs spec files sequentially in ONE process, so an earlier file's
-         * un-awaited update landing inside the window increments a process-wide count exactly like
-         * the leak under test does. That arm reported `Received: 1` on CI and could not say whose
-         * delta it was — which is why the intermittent stayed unactionable. Recording the payloads
-         * makes a failure name its own cause on a runner nobody can attach a session to.
+         * Payloads, not a call count: `Neo.applyDeltas` is module-global and a worker runs spec
+         * files in one process, so a count cannot distinguish this flight's deltas from anyone
+         * else's. Recorded so a failure names the delta it caught.
          * @type {Object[]}
          */
         const applied = [];
 
         /**
-         * The batches that received the armed promise, by the ids they carry.
-         *
-         * The mock used to hand `armed.promise` to EVERY caller while armed. A live component
-         * reaching `updateBatch` in that window would then receive the destroyed child's stale
-         * payload — and `VdomLifecycle`'s guard gates on the flight INITIATOR, so a live joiner
-         * passes it legitimately and applies deltas that were never its own. Serving only the
-         * child's own batch removes that; asserting the joiner set means a future ancestor-timing
-         * change trips an arm instead of quietly becoming the cause.
+         * The batches served the armed promise, by the ids they carry. Only the child's own batch
+         * may be served: `VdomLifecycle`'s guard gates on the flight INITIATOR, so a live joiner
+         * would legitimately apply a destroyed peer's payload. Asserted, so an ancestor-timing
+         * change trips an arm rather than becoming the cause.
          * @type {String[]}
          */
         const armedJoiners = [];
@@ -144,12 +131,9 @@ test.describe('VdomLifecycle destroy cancellation boundary', () => {
                 vnodes: {'vdc-child': {id: 'vdc-child', nodeName: 'div'}}
             });
 
-            // In-window control, and the reason this arm can be trusted at a count of zero: a delta
-            // belonging to someone else, applied inside the same window on purpose. It must be
-            // RECORDED (so the instrument is proven live rather than silently detached) and must
-            // NOT be attributed to the destroyed flight. Ambient traffic from a neighbouring spec
-            // file arrives exactly like this, and it is what the previous process-wide counter
-            // could not tell apart from the leak.
+            // In-window control: someone else's delta, applied on purpose. It must be RECORDED
+            // (proving the recorder is attached, not silently detached) and NOT attributed to the
+            // destroyed flight. This is the shape ambient traffic from a neighbouring spec takes.
             Neo.applyDeltas(parent.windowId, {action: 'updateVtext', id: 'vdc-unrelated', value: 'ambient'});
 
             await new Promise(resolve => setTimeout(resolve, 20));

--- a/test/playwright/unit/core/VdomDestroyCancellation.spec.mjs
+++ b/test/playwright/unit/core/VdomDestroyCancellation.spec.mjs
@@ -5,7 +5,15 @@ const appName = 'CoreVdomDestroyCancellationTest';
 setup({
     neoConfig: {
         allowVdomUpdatesInTests: true,
-        useDomApiRenderer      : true
+        useDomApiRenderer      : true,
+        // Load-bearing, and the reason this arm can observe anything at all. `VdomLifecycle`
+        // applies a flight's deltas inside `if (!Neo.config.useVdomWorker && …)`, and the harness
+        // default is `true` — so with the default the delta call is UNREACHABLE and the
+        // zero-deltas assertion below cannot fail for the reason it names. It was still able to
+        // fail: `Neo.applyDeltas` is module-global, so any other component's delta landing in the
+        // window reddened it. A vacuous assertion that reds on ambient traffic is the worst of
+        // both, and it is what made this arm an unownable intermittent.
+        useVdomWorker          : false
     },
     appConfig: {
         name: appName
@@ -33,16 +41,48 @@ test.describe('VdomLifecycle destroy cancellation boundary', () => {
         const realUpdateBatch = VdomHelper.updateBatch;
         const realApplyDeltas = Neo.applyDeltas;
 
-        let armed      = null,
-            deltaCalls = 0,
+        let armed = null,
             parent, child;
 
+        /**
+         * Every delta applied while the patch is installed, not a count of calls.
+         *
+         * A bare counter cannot express this arm's contract. `Neo.applyDeltas` is module-global and
+         * a Playwright worker runs spec files sequentially in ONE process, so an earlier file's
+         * un-awaited update landing inside the window increments a process-wide count exactly like
+         * the leak under test does. That arm reported `Received: 1` on CI and could not say whose
+         * delta it was — which is why the intermittent stayed unactionable. Recording the payloads
+         * makes a failure name its own cause on a runner nobody can attach a session to.
+         * @type {Object[]}
+         */
+        const applied = [];
+
+        /**
+         * The batches that received the armed promise, by the ids they carry.
+         *
+         * The mock used to hand `armed.promise` to EVERY caller while armed. A live component
+         * reaching `updateBatch` in that window would then receive the destroyed child's stale
+         * payload — and `VdomLifecycle`'s guard gates on the flight INITIATOR, so a live joiner
+         * passes it legitimately and applies deltas that were never its own. Serving only the
+         * child's own batch removes that; asserting the joiner set means a future ancestor-timing
+         * change trips an arm instead of quietly becoming the cause.
+         * @type {String[]}
+         */
+        const armedJoiners = [];
+
         VdomHelper.updateBatch = function(data) {
-            return armed ? armed.promise : realUpdateBatch.call(this, data)
+            const ids = Object.keys(data?.updates || {});
+
+            if (armed && ids.includes('vdc-child')) {
+                armedJoiners.push(ids.join('+'));
+                return armed.promise
+            }
+
+            return realUpdateBatch.call(this, data)
         };
-        Neo.applyDeltas = function(...args) {
-            deltaCalls++;
-            return realApplyDeltas?.apply(this, args)
+        Neo.applyDeltas = function(windowId, deltas) {
+            applied.push(...(Array.isArray(deltas) ? deltas : [deltas]));
+            return realApplyDeltas?.apply(this, arguments)
         };
 
         try {
@@ -93,15 +133,32 @@ test.describe('VdomLifecycle destroy cancellation boundary', () => {
             expect(VDomUpdate.postUpdateQueueMap.get('vdc-child'),'no post-update residue').toBeFalsy();
             expect(parentUpdates, 'the waiting ancestor restarts exactly once').toBe(1);
 
-            // Resolve the STALE success payload after destruction: nothing may apply.
-            deltaCalls = 0;
+            // Only the child's own batch may hold the armed promise. A second entry here means a
+            // live component is being served a destroyed peer's payload — see `armedJoiners`.
+            expect(armedJoiners, 'only the destroyed child\'s own batch received the armed promise').toEqual(['vdc-child']);
+
+            // Resolve the STALE success payload after destruction: nothing of the child's may apply.
+            applied.length = 0;
             resolveStale({
                 deltas: [{action: 'updateVtext', id: 'vdc-child', value: 'stale'}],
                 vnodes: {'vdc-child': {id: 'vdc-child', nodeName: 'div'}}
             });
+
+            // In-window control, and the reason this arm can be trusted at a count of zero: a delta
+            // belonging to someone else, applied inside the same window on purpose. It must be
+            // RECORDED (so the instrument is proven live rather than silently detached) and must
+            // NOT be attributed to the destroyed flight. Ambient traffic from a neighbouring spec
+            // file arrives exactly like this, and it is what the previous process-wide counter
+            // could not tell apart from the leak.
+            Neo.applyDeltas(parent.windowId, {action: 'updateVtext', id: 'vdc-unrelated', value: 'ambient'});
+
             await new Promise(resolve => setTimeout(resolve, 20));
 
-            expect(deltaCalls, 'a stale success payload from a destroyed flight must apply ZERO deltas').toBe(0)
+            expect(applied.some(delta => delta?.id === 'vdc-unrelated'), 'the recorder must be live').toBe(true);
+
+            const staleApplied = applied.filter(delta => delta?.id === 'vdc-child');
+
+            expect(staleApplied, `a stale success payload from a destroyed flight must apply ZERO deltas — applied in window: ${JSON.stringify(applied)}`).toEqual([])
         } finally {
             VdomHelper.updateBatch = realUpdateBatch;
             Neo.applyDeltas        = realApplyDeltas;


### PR DESCRIPTION
Resolves #18497

## What was wrong

`VdomDestroyCancellation.spec.mjs` reddened intermittently under full unit-suite load with `Received: 1` — a bare count that named nothing, which is why it stayed unactionable rather than getting fixed.

Chasing the flake found something worse than a flake. The assertion was **both vacuous and noise-sensitive**:

**Vacuous.** `VdomLifecycle` applies a flight's deltas inside `if (!Neo.config.useVdomWorker && response.deltas?.length > 0)`, and this harness resolves `useVdomWorker` to `true`. The delta call was **unreachable**, so the assertion could not fail for the reason it names. Proven three ways: weakening the destroy guard to `if (me.id)` left it green, removing the guard entirely with `if (true)` left it green, and a runtime probe inside the harness reports `useVdomWorker=true`.

**Noise-sensitive.** `Neo.applyDeltas` is module-global and the arm counted every call in the process. `Neo` is a per-process singleton and a Playwright worker runs spec files **sequentially in one process**, so another component's delta landing in the 20ms window incremented the same counter. Ambient traffic was the only thing that assertion could ever observe — and it is what it kept reporting.

So the arm could not catch the bug it guards, and could be reddened by anything else. That combination is what made it an unownable intermittent.

## AC Evidence

| # | AC | Status |
|---|---|---|
| 1 | Assertion scoped to deltas naming the destroyed component; failure message carries every payload applied in the window | **MET** |
| 2 | The `updateBatch` mock serves the armed promise only to the child's own batch; a second joiner is asserted, not silently served | **MET** |
| 3 | Red-first both ways: a foreign delta must not red it; a delta naming the child must | **MET** — below |
| 4 | 20 full-suite runs, red count recorded beside the unstable pre-repair rate | **MET** — 0/20, stated as corroboration only |
| 5 | If the repaired arm still reds, it names the payload and the evidence is filed | **N/A** — it does not red; the naming path is proven by the AC-3 mutation |

## The repairs

- **`useVdomWorker: false`** in this spec's `setup()`. The load-bearing change: it makes the delta path reachable, so the assertion is live rather than decorative.
- **The recorder captures payloads, not a count**, and the assertion is scoped to deltas naming `vdc-child`. The contract is about *this flight's* stale payload, not about process-wide quiet.
- **The mock serves the armed promise only to the child's own batch**, and the joiner set is asserted. It previously served it to every caller — which would hand a *live* component the destroyed child's stale payload, and since the guard gates on the flight **initiator**, that joiner would apply it legitimately. Measured as latent today (`armedJoiners: ["vdc-child"]`), and one ancestor-timing change from becoming the cause with no arm to say so.

## Test Evidence

**AC-3, both directions, with the delta path reachable:**

| mutation | result |
|---|---|
| `!me.isDestroyed` removed from `VdomLifecycle.mjs:342` | **RED**, message names the payload: `[{"id":"vdc-unrelated","value":"ambient"},{"id":"vdc-child","value":"stale"}]` |
| guard restored | green |
| a foreign delta applied inside the window (permanent in-arm control) | recorded, **not** attributed — green |

The foreign-delta control runs on every execution, so the scoping cannot silently rot back into a process-wide count. It also proves the recorder is attached: an arm that records nothing would pass the scoped assertion vacuously, which is the failure mode this whole ticket is about.

That mutation also establishes `!me.isDestroyed` as the load-bearing clause — `me.id` survives destroy, so the earlier `if (me.id)` mutation was void *only* because of `useVdomWorker`. Evidence: `npx playwright test -c test/playwright/playwright.config.unit.mjs test/playwright/unit/core/VdomDestroyCancellation.spec.mjs` → `3 passed` on repeat, `1 failed` under mutation.

**AC-4:** 20 full unit-suite runs, **0 red**.

I am not claiming that as the proof. The pre-repair rate was 2/2, then 1/2, then 1/3, then 0/19 on **unchanged** source — the between-sample variance exceeds the effect, so absence at an unstable rate is not evidence. The structural argument is the evidence: the old assertion could not fail for its stated reason and could fail for foreign traffic; the new one is exactly the reverse.

## Post-Merge Validation

1. Watch `Engine Tests` on `dev` for `VdomDestroyCancellation` reds. Any red now arrives with the applied payloads in its message — if one names `vdc-child`, that is a genuine cancellation-boundary defect and gets its own ticket against that evidence.
2. If a red names only foreign ids, the scoping regressed and this commit should be revisited rather than the arm quarantined.
3. `armedJoiners` asserting `['vdc-child']` is a tripwire on ancestor timing. If it ever reds, a live component reached `updateBatch` during the armed window — read that as a finding, not as a brittle assertion to relax.

## Deltas

- `test/playwright/unit/core/VdomDestroyCancellation.spec.mjs` — `useVdomWorker: false`; payload recorder replacing the call counter; scoped assertion; batch-scoped `updateBatch` mock with an asserted joiner set; a permanent in-window ambient-delta control.

No `src/` change. The engine guard at `VdomLifecycle.mjs:342` was correct throughout — it was the instrument that could not see it.

Origin Session ID: 69ff8d6f-0e9e-4c44-aff9-e8007f4d7090

Authored by ⚖️ **Ada** · `@neo-opus-ada` · Claude Opus 5 · Claude Code
