### PR TITLE
refactor(workstation): the cross-window observation surface gets its own boundary (#18460)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,9 @@
 !/apps/shareddialog/neo-config.json
 !/apps/shareddialog/childapps/shareddialog2/index.html
 !/apps/shareddialog/childapps/shareddialog2/neo-config.json
+!/apps/workstation/index.html
+!/apps/workstation/**/*.mjs
+!/apps/workstation/neo-config.json
 
 /buildScripts/webpack/json/myApps.json
 

--- a/apps/workstation/view/CrossWindowGestureSnapshot.mjs
+++ b/apps/workstation/view/CrossWindowGestureSnapshot.mjs
@@ -1,0 +1,134 @@
+import Base              from '../../../src/core/Base.mjs';
+import WorkspaceDocument from '../../../src/dashboard/dock/model/WorkspaceDocument.mjs';
+
+/**
+ * @class Workstation.view.CrossWindowGestureSnapshot
+ * @extends Neo.core.Base
+ *
+ * @summary The Workstation's cross-window observation surface — the receipts-and-diagnostics
+ * boundary, carried as a mixin because its readers address it by name on the instance.
+ *
+ * **Why a mixin and not a module function.** Every consumer of this surface is a reader, never the
+ * engine: `apps/workstation/tour/NativeGestureDriver.mjs` calls it on the instance, and the
+ * Workstation Neural-Link e2e specs invoke it by NAME —
+ * `callMethod(workspaceId, 'readCrossWindowGestureSnapshot', […])` — while a unit spec reaches it as
+ * `Workspace.prototype.readCrossWindowGestureSnapshot.call(workspace, …)`. Both shapes resolve
+ * against the prototype, so the method has to live on the instance. Moving it to a plain module and
+ * leaving a one-line delegate behind would satisfy the line count and reintroduce exactly the
+ * forwarding façade this ticket forbids.
+ *
+ * {@link Neo.dashboard.dock.window.TopologySeams} is the same shape for the same reason, and says so
+ * in its own summary: a seam its caller resolves by name has to be an instance method, so it ships
+ * as a mixin rather than as a helper.
+ *
+ * **What stays behind.** The four vessel receipts themselves — `lastVesselOpen`, `lastTearOutClose`,
+ * `lastVesselParkReceipt`, `lastVesselRestoreReceipt` — are NOT part of this surface and did not
+ * move. They read like diagnostics and are not: each is a stage machine the owning method amends as
+ * it advances (`identity-refused` → `route-refused` → `embodiment-refused` → `native-dispatched` →
+ * `acknowledged`, with `threw` branches), and `closeTearOutVessel` holds its receipt in a local
+ * `const` precisely so those amendments survive re-entrancy. That is the method's own progress
+ * record, written across awaits; relocating it would be the "lost success or recovery claim after an
+ * await" the Contract Ledger refuses. Only the READ projection moved.
+ */
+class CrossWindowGestureSnapshot extends Base {
+    static config = {
+        /**
+         * @member {String} className='Workstation.view.CrossWindowGestureSnapshot'
+         * @protected
+         */
+        className: 'Workstation.view.CrossWindowGestureSnapshot'
+    }
+
+    /**
+     * @summary Reads the semantic, rendered, arbitration, and physical-park truth for one
+     * cross-window pointer frame.
+     *
+     * The film executors use this as their pre-release gate: mouseup is withheld until the
+     * coordinator has exactly one stable claim, its winning target is engaged, and the target's
+     * semantic preview equals the preview rendered in that window. A converting tear-out can add
+     * `parkedItemId`, which additionally requires the exact source vessel to be strictly parked.
+     * Visuals are read from the current participant's supplied or already-created controller;
+     * observing readiness never creates the popup's lazy preview tier.
+     * @param {Object} context
+     * @param {String|null} [context.parkedItemId=null]
+     * @param {Neo.dashboard.dock.interaction.TabSortZone|null} [context.sourceZone=null]
+     * @param {String|null} [context.sourceZoneId=null] Clone-safe Neural Link alternative.
+     * @param {String} context.targetWorkspaceId
+     * @returns {Object}
+     * @protected
+     */
+    readCrossWindowGestureSnapshot({parkedItemId=null, sourceZone=null, sourceZoneId=null, targetWorkspaceId}={}) {
+        sourceZone ??= sourceZoneId ? Neo.get(sourceZoneId) : null;
+
+        let me = this,
+            // `me.constructor`, not the class: a mixin has no lexical binding to its host, and
+            // importing the host to read one static would make the pair circular.
+            isMain        = targetWorkspaceId === me.constructor.MAIN_WORKSPACE_ID,
+            state         = isMain ? null : me.getPopupState(targetWorkspaceId),
+            participation = isMain ? me.crossWindowParticipations.get(targetWorkspaceId) : state?.host?.participation,
+            affordances   = participation?.affordances ?? participation?.ownedAffordances,
+            target        = participation?.target,
+            coordinator   = sourceZone?.dragCoordinator,
+            arbiter       = coordinator?.pointerClaimArbiter,
+            winner        = arbiter?.resolve?.() ?? null,
+            semantic      = target?.currentPreview ?? null,
+            rendered      = affordances?.preview?.dockPreview ?? null,
+            indicatorMenu = affordances?.indicators,
+            indicatorSet  = indicatorMenu?.candidateSet ?? null,
+            sensor        = sourceZone?.vesselConversionSensor,
+            parkedVessel  = me.vesselParkHandlers?.parkedVessel ?? null,
+            sourceVessel  = parkedItemId && me.resolveTearOutVessel(parkedItemId),
+            targetProxy   = parkedItemId && me.vesselProxyEmbodiment.snapshot(parkedItemId),
+            snapshot      = {
+                claimCount: arbiter?.claimCount ?? 0,
+                converted : sensor?.converted === true && sensor?.transitioning !== true,
+                engaged   : coordinator?.activeTargetZone === target,
+                indicators: indicatorSet ? {
+                    activePreviewId: indicatorMenu.activeCandidate?.preview?.previewId ?? null,
+                    candidateCount : (indicatorSet.cross?.length ?? 0) + (indicatorSet.root?.chips?.length ?? 0),
+                    itemId         : indicatorSet.itemId ?? null,
+                    visible        : !indicatorMenu.cls?.includes?.('neo-dashboard-dock-drop-indicators-hidden')
+                } : null,
+                parkedItemId: parkedVessel?.itemId ?? null,
+                parkReceipt : me.lastVesselParkReceipt
+                    ? WorkspaceDocument.clone(me.lastVesselParkReceipt)
+                    : null,
+                preview              : semantic ? WorkspaceDocument.clone(semantic) : null,
+                rendered             : rendered ? WorkspaceDocument.clone(rendered) : null,
+                sourceVesselConnected: Boolean(
+                    sourceVessel?.windowId && Neo.manager?.Window?.get(sourceVessel.windowId)
+                ),
+                sourceVesselWindowId: sourceVessel?.windowId ?? null,
+                restoreReceipt      : me.lastVesselRestoreReceipt
+                    ? WorkspaceDocument.clone(me.lastVesselRestoreReceipt)
+                    : null,
+                targetProxy,
+                targetWorkspaceId,
+                winnerStableId      : winner?.stableId ?? null
+            };
+
+        snapshot.ready = snapshot.claimCount === 1
+            && snapshot.engaged
+            && snapshot.winnerStableId === targetWorkspaceId
+            && Boolean(snapshot.preview?.previewId)
+            && snapshot.rendered?.previewId === snapshot.preview.previewId
+            && snapshot.indicators?.activePreviewId === snapshot.preview.previewId
+            && (parkedItemId == null || (
+                snapshot.converted && snapshot.parkedItemId === parkedItemId &&
+                snapshot.sourceVesselConnected &&
+                snapshot.indicators?.itemId === parkedItemId &&
+                snapshot.indicators.candidateCount >= 5 &&
+                snapshot.indicators.visible &&
+                targetProxy?.itemId === parkedItemId &&
+                targetProxy.ownsPane &&
+                targetProxy.settled &&
+                targetProxy.sourceWindowId === snapshot.sourceVesselWindowId &&
+                targetProxy.targetWindowId === target?.windowId &&
+                targetProxy.visible
+            ));
+
+        return snapshot
+    }
+}
+
+export default Neo.setupClass(CrossWindowGestureSnapshot);

--- a/apps/workstation/view/Workspace.mjs
+++ b/apps/workstation/view/Workspace.mjs
@@ -1,28 +1,29 @@
-import Component                from '../../../src/component/Base.mjs';
-import Container                from '../../../src/container/Base.mjs';
-import DockWorkspace            from '../../../src/dashboard/dock/Workspace.mjs';
-import PopupWorkspace           from './PopupWorkspace.mjs';
-import Feed                     from '../store/Feed.mjs';
-import FeedPane                 from './FeedPane.mjs';
-import Scale                    from '../store/Scale.mjs';
-import ScalePane                from './ScalePane.mjs';
-import DockDragAffordances      from '../../../src/dashboard/dock/interaction/DragAffordances.mjs';
-import DockDropIndicators       from '../../../src/dashboard/dock/interaction/DropIndicators.mjs';
-import DockLayoutAdapter        from '../../../src/dashboard/dock/projection/LayoutAdapter.mjs';
-import PerspectiveLibrary       from '../../../src/dashboard/dock/persistence/PerspectiveLibrary.mjs';
-import TopologyLibrary          from '../../../src/dashboard/dock/persistence/TopologyLibrary.mjs';
-import Placement                from '../../../src/dashboard/dock/window/Placement.mjs';
-import DockPreview              from '../../../src/dashboard/dock/interaction/Preview.mjs';
-import DockProjectionReconciler from '../../../src/dashboard/dock/projection/Reconciler.mjs';
-import DockService              from '../../../src/ai/client/DockService.mjs';
-import WorkspaceDocument        from '../../../src/dashboard/dock/model/WorkspaceDocument.mjs';
-import WorkspaceController      from './WorkspaceController.mjs';
-import Operations               from '../../../src/dashboard/dock/model/Operations.mjs';
-import Persistence              from '../../../src/dashboard/dock/model/Persistence.mjs';
-import StateProvider            from '../../../src/state/Provider.mjs';
-import TourToolbar              from './TourToolbar.mjs';
-import TransactionManager       from '../../../src/manager/Transaction.mjs';
-import WindowManager            from '../../../src/manager/Window.mjs';
+import Component                  from '../../../src/component/Base.mjs';
+import Container                  from '../../../src/container/Base.mjs';
+import DockWorkspace              from '../../../src/dashboard/dock/Workspace.mjs';
+import PopupWorkspace             from './PopupWorkspace.mjs';
+import Feed                       from '../store/Feed.mjs';
+import FeedPane                   from './FeedPane.mjs';
+import Scale                      from '../store/Scale.mjs';
+import ScalePane                  from './ScalePane.mjs';
+import DockDragAffordances        from '../../../src/dashboard/dock/interaction/DragAffordances.mjs';
+import DockDropIndicators         from '../../../src/dashboard/dock/interaction/DropIndicators.mjs';
+import DockLayoutAdapter          from '../../../src/dashboard/dock/projection/LayoutAdapter.mjs';
+import PerspectiveLibrary         from '../../../src/dashboard/dock/persistence/PerspectiveLibrary.mjs';
+import TopologyLibrary            from '../../../src/dashboard/dock/persistence/TopologyLibrary.mjs';
+import Placement                  from '../../../src/dashboard/dock/window/Placement.mjs';
+import DockPreview                from '../../../src/dashboard/dock/interaction/Preview.mjs';
+import CrossWindowGestureSnapshot from './CrossWindowGestureSnapshot.mjs';
+import DockProjectionReconciler   from '../../../src/dashboard/dock/projection/Reconciler.mjs';
+import DockService                from '../../../src/ai/client/DockService.mjs';
+import WorkspaceDocument          from '../../../src/dashboard/dock/model/WorkspaceDocument.mjs';
+import WorkspaceController        from './WorkspaceController.mjs';
+import Operations                 from '../../../src/dashboard/dock/model/Operations.mjs';
+import Persistence                from '../../../src/dashboard/dock/model/Persistence.mjs';
+import StateProvider              from '../../../src/state/Provider.mjs';
+import TourToolbar                from './TourToolbar.mjs';
+import TransactionManager         from '../../../src/manager/Transaction.mjs';
+import WindowManager              from '../../../src/manager/Window.mjs';
 import {
     createDockVesselEmbodiment,
     createDockVesselProxyEmbodiment
@@ -139,6 +140,15 @@ class Workspace extends DockWorkspace {
          * @protected
          */
         className: 'Workstation.view.Workspace',
+        /**
+         * The cross-window observation surface. A mixin rather than a helper module because every
+         * reader addresses it by name on the instance — the Neural Link resolves
+         * `readCrossWindowGestureSnapshot` on this component, and a unit spec reaches it through
+         * `Workspace.prototype`. Same shape and same reason as
+         * {@link Neo.dashboard.dock.window.TopologySeams}.
+         * @member {Neo.core.Base[]} mixins=[CrossWindowGestureSnapshot]
+         */
+        mixins: [CrossWindowGestureSnapshot],
         /** @member {Neo.controller.Component} controller */
         controller: WorkspaceController,
         /**
@@ -2386,95 +2396,6 @@ class Workspace extends DockWorkspace {
         me.vesselParkHandlers.onVesselRetired({itemId, retirement: true});
         me.nativeVesselParkHandlers.onVesselRetired({itemId, retirement: true});
         recovered && me.retireVesselWorkspaceTarget(itemId)
-    }
-
-    /**
-     * @summary Reads the semantic, rendered, arbitration, and physical-park truth for one
-     * cross-window pointer frame.
-     *
-     * The film executors use this as their pre-release gate: mouseup is withheld until the
-     * coordinator has exactly one stable claim, its winning target is engaged, and the target's
-     * semantic preview equals the preview rendered in that window. A converting tear-out can add
-     * `parkedItemId`, which additionally requires the exact source vessel to be strictly parked.
-     * Visuals are read from the current participant's supplied or already-created controller;
-     * observing readiness never creates the popup's lazy preview tier.
-     * @param {Object} context
-     * @param {String|null} [context.parkedItemId=null]
-     * @param {Neo.dashboard.dock.interaction.TabSortZone|null} [context.sourceZone=null]
-     * @param {String|null} [context.sourceZoneId=null] Clone-safe Neural Link alternative.
-     * @param {String} context.targetWorkspaceId
-     * @returns {Object}
-     * @protected
-     */
-    readCrossWindowGestureSnapshot({parkedItemId=null, sourceZone=null, sourceZoneId=null, targetWorkspaceId}={}) {
-        sourceZone ??= sourceZoneId ? Neo.get(sourceZoneId) : null;
-
-        let me            = this,
-            isMain        = targetWorkspaceId === Workspace.MAIN_WORKSPACE_ID,
-            state         = isMain ? null : me.getPopupState(targetWorkspaceId),
-            participation = isMain ? me.crossWindowParticipations.get(targetWorkspaceId) : state?.host?.participation,
-            affordances   = participation?.affordances ?? participation?.ownedAffordances,
-            target        = participation?.target,
-            coordinator   = sourceZone?.dragCoordinator,
-            arbiter       = coordinator?.pointerClaimArbiter,
-            winner        = arbiter?.resolve?.() ?? null,
-            semantic      = target?.currentPreview ?? null,
-            rendered      = affordances?.preview?.dockPreview ?? null,
-            indicatorMenu = affordances?.indicators,
-            indicatorSet  = indicatorMenu?.candidateSet ?? null,
-            sensor        = sourceZone?.vesselConversionSensor,
-            parkedVessel  = me.vesselParkHandlers?.parkedVessel ?? null,
-            sourceVessel  = parkedItemId && me.resolveTearOutVessel(parkedItemId),
-            targetProxy   = parkedItemId && me.vesselProxyEmbodiment.snapshot(parkedItemId),
-            snapshot      = {
-                claimCount: arbiter?.claimCount ?? 0,
-                converted : sensor?.converted === true && sensor?.transitioning !== true,
-                engaged   : coordinator?.activeTargetZone === target,
-                indicators: indicatorSet ? {
-                    activePreviewId: indicatorMenu.activeCandidate?.preview?.previewId ?? null,
-                    candidateCount : (indicatorSet.cross?.length ?? 0) + (indicatorSet.root?.chips?.length ?? 0),
-                    itemId         : indicatorSet.itemId ?? null,
-                    visible        : !indicatorMenu.cls?.includes?.('neo-dashboard-dock-drop-indicators-hidden')
-                } : null,
-                parkedItemId: parkedVessel?.itemId ?? null,
-                parkReceipt : me.lastVesselParkReceipt
-                    ? WorkspaceDocument.clone(me.lastVesselParkReceipt)
-                    : null,
-                preview              : semantic ? WorkspaceDocument.clone(semantic) : null,
-                rendered             : rendered ? WorkspaceDocument.clone(rendered) : null,
-                sourceVesselConnected: Boolean(
-                    sourceVessel?.windowId && Neo.manager?.Window?.get(sourceVessel.windowId)
-                ),
-                sourceVesselWindowId: sourceVessel?.windowId ?? null,
-                restoreReceipt      : me.lastVesselRestoreReceipt
-                    ? WorkspaceDocument.clone(me.lastVesselRestoreReceipt)
-                    : null,
-                targetProxy,
-                targetWorkspaceId,
-                winnerStableId      : winner?.stableId ?? null
-            };
-
-        snapshot.ready = snapshot.claimCount === 1
-            && snapshot.engaged
-            && snapshot.winnerStableId === targetWorkspaceId
-            && Boolean(snapshot.preview?.previewId)
-            && snapshot.rendered?.previewId === snapshot.preview.previewId
-            && snapshot.indicators?.activePreviewId === snapshot.preview.previewId
-            && (parkedItemId == null || (
-                snapshot.converted && snapshot.parkedItemId === parkedItemId &&
-                snapshot.sourceVesselConnected &&
-                snapshot.indicators?.itemId === parkedItemId &&
-                snapshot.indicators.candidateCount >= 5 &&
-                snapshot.indicators.visible &&
-                targetProxy?.itemId === parkedItemId &&
-                targetProxy.ownsPane &&
-                targetProxy.settled &&
-                targetProxy.sourceWindowId === snapshot.sourceVesselWindowId &&
-                targetProxy.targetWindowId === target?.windowId &&
-                targetProxy.visible
-            ));
-
-        return snapshot
     }
 
     /** @summary Tears down the workspace's view tree and owned docking resources. @param {...*} args */

--- a/buildScripts/util/file-size-baseline.json
+++ b/buildScripts/util/file-size-baseline.json
@@ -1,5 +1,5 @@
 {
-    "apps/workstation/view/Workspace.mjs": 1388,
+    "apps/workstation/view/Workspace.mjs": 1323,
     "examples/dashboard/crossWindow/DemoBWorkspace.mjs": 2615,
     "src/dashboard/dock/Workspace.mjs": 1100,
     "src/main/addon/DragDrop.mjs": 1267


### PR DESCRIPTION
Resolves #18535
Refs #18460
Related: #18456

🌿 Nothing in a 3,000-line entrypoint tells a reader which methods act and which only watch, so every reader re-decides that per method. One surface has stopped asking for the vote.

`readCrossWindowGestureSnapshot` — 70 lines of read-only projection with zero engine readers — moves out of `apps/workstation/view/Workspace.mjs` into a `Workstation.view.CrossWindowGestureSnapshot` mixin that states why it exists. That is #18460's Contract Ledger row for *receipts and diagnostics → truthful observation at the owning boundary*, and only that row. **Close target is #18535, not #18460.** #18460 carries four Contract-Ledger rows; this PR delivers one, and row 3's remainder is blocked on #18533 — so #18460 is not resolvable by one PR, which #18456 requires of every leaf. The delivered row was split into its own leaf with the criteria travelling intact, deliberately rather than narrowing #18460 to fit the PR that already existed. #18460 stays open for its other three rows.

It could not be a helper module. Four e2e specs invoke it across the Neural Link **by name** at seven call sites — `callMethod(workspaceId, 'readCrossWindowGestureSnapshot', […])` — and a unit spec reaches it as `Workspace.prototype.readCrossWindowGestureSnapshot.call(workspace, …)`. Both resolve against the prototype, so a module plus a one-line delegate would have satisfied the line count and reintroduced exactly the forwarding façade AC-2 forbids. `Neo.dashboard.dock.window.TopologySeams` is the same shape for the same stated reason.

Evidence: L3 (live Neural-Link e2e arm drives the real multi-window app and calls the moved method by name over the bridge; nothing here needs an operator-gated surface, so sandbox ceiling = achievable ceiling) → L3 required. Residual: #18460 AC-1's *second* engine prerequisite (the `VesselPark` park/reshow transaction) and AC-3's entrypoint ceiling. Residual-Owner: **#18533** for the seam — filed as a sub of #18304 — and **#18456** for the ceiling, which needs its other leaves. The first prerequisite is discharged: #18501 CLOSED/COMPLETED. Neither residual is closed by this PR and both survive the merge.

## AC Evidence

Rows are the close target #18535's six criteria, counted in order. #18460's five follow as context, since this PR discharges one of its four Ledger rows and a reviewer should be able to see which without opening the parent.

| AC | Disposition |
|---|---|
| AC-1 — no call site left on the host; `git grep -c` returns at most the `mixins:` mention | **CI-covered.** `git grep -c readCrossWindowGestureSnapshot apps/workstation/view/Workspace.mjs` → **1**, and that hit is the `mixins:` docblock, not a call. |
| AC-2 — the moved body is byte-identical apart from the documented adaptation, verified by diff not by a passing suite | **Outside-CI receipt.** Line-by-line diff of the moved body against the host's former copy: the only divergence is `me.constructor.MAIN_WORKSPACE_ID`, commented in the mixin, because a mixin has no lexical binding to its host. This check is the AC because a green suite cannot see a transcription defect — one already occurred on this exact body (§ Deltas). |
| AC-3 — both call shapes exercised at head; the prototype arm must be load-bearing | **CI-covered + control.** Prototype arm 1/1 at head; unwiring `mixins` reds it with `TypeError: Cannot read properties of undefined (reading 'call')`, so it witnesses prototype resolution rather than matching a shape. Neural-Link arm: `WorkstationNativeTitlebarDragNL` 1 passed (§ Test Evidence). |
| AC-4 — replacement module < 2,000; host/module/combined counts reported; the 1,000 ceiling NOT claimed | **Reported.** Module 134 lines. Host `Workspace.mjs` **2,512 → 2,433 physical, 1,388 → 1,323 code**; combined **2,567 physical** (+55 — the mixin's scaffolding and the docblock stating why it is a mixin). The 1,000 entrypoint ceiling is #18456's and is explicitly not claimed. |
| AC-5 — no success or recovery claim is lost; the observation surface **cannot** amend a receipt | **Met, and stronger than "did not move" — @neo-opus-ada's sharpening in review.** The four receipts stay on the host, but the load-bearing fact is structural: the mixin reads **every** one of them through `WorkspaceDocument.clone()` (`:94`, `:103`) and contains **zero** writes to any `lastVessel*Receipt` — verified by a mutation-shaped grep, not by inspection. So a caller mutating the returned snapshot mutates a clone; the observation surface is *incapable* of amending a stage machine, not merely positioned not to. `did not move` invites a future reader to move them and keep the AC green; `cannot amend them from here` does not. |
| AC-6 — `.gitignore` exposes exactly the one previously-ignored path this adds | **Met.** Three negation lines matching the shape every other app carries; the only newly-tracked path is the mixin this PR adds. |

**#18460 context rows** — this PR discharges its *receipts and diagnostics* Ledger row and no other.

| #18460 AC | Disposition |
|---|---|
| AC-1 — caller/owner map, prerequisite linked *and satisfied* | **Map complete**, published for the whole vessel surface: [part 1](https://github.com/neomjs/neo/issues/18460#issuecomment-5590622463) · [part 2 + the prerequisite](https://github.com/neomjs/neo/issues/18460#issuecomment-5590783451) · [effects layer](https://github.com/neomjs/neo/issues/18460#issuecomment-5591493463). **Route-authority prerequisite SATISFIED**: #18501 / PR #18510 gave the App-Worker route check a public owner and **merged as `e3ddc9e3cb`**; #18501 is CLOSED/COMPLETED. That collapsed the 20 hand-rolled `capabilities?.<cap>` sites across 4 files into named authority calls, which also cleans the two effect-layer route consumers (`resolveTearOutVessel`, `disposeParkedTearOutVessel`) that part 3 of the map found. **A second prerequisite is linked, not satisfied — #18533** (sub of engine epic #18304): `VesselPark` is 430 lines that *throw* if the `parkVessel`/`reshowVessel`/`disposeVessel` seams are missing and implement none of them, so each consumer writes its own transaction — two files, **zero in `src/`** — and #18399 excluded *"native platform park/re-show bodies"* verbatim. Not "the same transaction twice": @neo-opus-grace measured normalised similarity at **47%/28%** (Workstation 193/138 vs DemoB 108/40), and the sharper finding is that the **contract** is duplicated where the bodies are not — nine of ten `lastVesselParkReceipt.authority` keys match in the same order, DemoB omitting only `sourceResizeCapable`, so its park authority is measurably weaker for no stated reason. Drift, not duplication. Measurement and correction in [IC_kwDODSospM8AAAABTcgRqg](https://github.com/neomjs/neo/issues/18460#issuecomment-5599924650). AC-1's *satisfied* half stays open on that seam and this PR does not claim it. |
| AC-2 — configured controller lifecycle, no forwarding façade in the delivered slice | **Met for this slice.** A mixin, not a second controller and not a delegate: `git grep -c readCrossWindowGestureSnapshot apps/workstation/view/Workspace.mjs` → 1, and that one hit is the `mixins:` docblock, not a call. |
| AC-3 — line counts reported; no replacement module > 2,000; entrypoint ceiling 1,000 | **Reported, ceiling not reached.** Re-measured at the current head; my first figures (3,042 → 2,963 physical) went stale when the sibling leaves shrank this file by ~540 lines under the branch. Baseline is dev at `e3ddc9e3cb`: `Workspace.mjs` **2,512 → 2,433 physical, 1,388 → 1,323 code**; replacement module 134; combined **2,567 physical**. Host −79 physical / −65 code; combined **+55 physical** — the mixin's class scaffolding plus the docblock stating why it is a mixin, and the same +55 the earlier figures already disclosed. The 1,000 ceiling is the parent epic's and needs its other leaves — [stated at intake](https://github.com/neomjs/neo/issues/18460#issuecomment-5581647168) before the work began, not discovered afterwards. |
| AC-4 — pointer/native-titlebar conversion parity | **Untouched and witnessed.** No conversion code is in the diff; `WorkstationNativeTitlebarDragNL` is green at head (§ Test Evidence). |
| AC-5 — callers and tests move with the owning boundary; current-head evidence | **Met for this slice.** Both call shapes exercised at head; no test weakened, none rewritten — the move is prototype-transparent by construction. |

## Deltas from ticket

- **The ticket's shape was a controller; this is a mixin.** #18460 forbids "a renamed helper as the default solution" and requires the semantic owner be established first. The owner here is *the reader*, and every reader addresses the instance, so the only home that preserves the contract is the prototype. A mixin is the engine's own answer to that (`TopologySeams`).
- **I corrected my own AC-1 framing.** I had called the four vessel receipts "an observation surface, not product state". They are not: each is a stage machine its owning method amends as it advances (`identity-refused` → `route-refused` → `embodiment-refused` → `native-dispatched` → `acknowledged`), and `closeTearOutVessel` holds its receipt in a local `const` so the amendments survive re-entrancy. Relocating them would be the *"lost success or recovery claim after an await"* the same Ledger row refuses. **They did not move.**
- **No deletion is claimed, deliberately.** My field-usage instrument was a substring grep over whole spec files — it counts a token's occurrence, not a read of that field. A proxy cannot justify removing payload, so nothing was removed.
- **That same proxy then produced two wrong numbers in my first commit message** ("eight test files", "five e2e specs"; enumerated by call site: five test files, four of them e2e). Corrected at the source before this PR existed. The instrument was named one paragraph above the figures it generated — disclosing a weakness does not quarantine its output.
- **A transcription defect, caught pre-push.** Moving 70 dense lines by hand put `indicatorSet.activePreviewId` where the original reads `indicatorMenu.activeCandidate?.preview?.previewId`. `snapshot.ready` would have compared against `undefined` forever and hung every film executor's pre-release gate. A line-by-line diff of the moved body against the original found it; the green suites would not have.
- **`.gitignore` gains the workstation whitelist.** `/apps/**/*.mjs` ignores everything; every tracked workstation file predates the rule, so git grandfathered them. A *new* file there is silently unstageable — `git add` refusing it is how this surfaced. Three negation lines, the shape every other app already carries, exposing exactly one previously-ignored path: the file this PR adds.

## Test Evidence

- `WorkstationNativeTitlebarDragNL` — **1 passed (4.6s)**, run with `NEO_AGENTOS_RUNTIME_ROOT` set. One of the four arms that call the moved method by name; the `call_method` round trip is visible in the bridge log. ⚠️ **Without that variable the config selects ZERO specs and reports success**, so the green is only meaningful with the variable named.
- **The prototype-resolution arm, with a real control.** `-g "pointer readiness reads current popup and supplied main visual owners"` → **1 selected, 1 passed**. My first selector (`-g "Workstation.view.Workspace"`) reported 42/42 and **did not include this arm** — the test sits above that describe block, so the count was a proxy for coverage it did not have. Control: commenting out `mixins:` reds it with `TypeError: Cannot read properties of undefined (reading 'call')`, so it witnesses prototype resolution rather than matching an expected shape.
- **Transcription check.** The moved body is byte-identical to the host's former copy apart from one commented adaptation — `me.constructor.MAIN_WORKSPACE_ID`, because a mixin has no lexical binding to its host. Diffed line-by-line; that is the only divergence.
- AC-2 witness — `git grep -c readCrossWindowGestureSnapshot apps/workstation/view/Workspace.mjs` → **1**, the `mixins:` docblock, not a call.
- `check-file-sizes` — **0 violations** against dev at `e3ddc9e3cb`, run with CI's own flags (`--base origin/dev --pr-body-file`). One baseline row changes, ratcheted **down** 1,388 → 1,323; a shrink banks no `size-guard-growth:` line, that is for growth only. Note the guard's writer lives behind `--fix` (`check-file-sizes.mjs:602` is inside `if (options.fix)`), and `--fix` rebuilds the whole file from measurements — so the regenerated baseline was diffed key-by-key against `origin/dev`: 4 entries in, 4 out, none dropped, none added.

## Post-Merge Validation

- [ ] The `.gitignore` negation lines are only exercised by the *next* new workstation file; this PR proves they unblock one path, not the pattern.
- [ ] #18460's remaining buckets stay open pending the route-authority prerequisite; this PR must not read as having discharged them.

## Commits

- `fc2c1e68b6` — the observation surface moves to its own mixin; baseline ratcheted down; workstation gitignore whitelist added.

**Unstacked cleanly, and the method is the point.** This branch was stacked on #18510 while that PR was open, because AC-1's route-authority prerequisite is what it delivered. neomjs/neo squash-merges, so on its merge this was rebased with `git rebase --onto origin/dev 9e7dce1aaf` — replaying only this one commit — instead of a plain `rebase origin/dev`, which would have replayed #18510's four commits against their own squash and produced conflicts with no diff behind them. Result: zero conflicts, and `git range-diff` reports `=` — the patch survived byte-identical. The size-guard artifact the stack created (#18510's `DemoBWorkspace` +3 attributed to this diff) is gone with it: **0 violations against dev at `e3ddc9e3cb`, one baseline row changed, 1,388 → 1,323.**

**Re-derived, not merged, at the current base.** The original `45b57120f1` was 17 commits behind, and dev had moved the exact region it edits: its side of the conflict would have resurrected `getGestureDriver()` (removed on dev since) and restored a `TourRunner` import that dev replaced with `TourToolbar` — a stale branch reverting two things silently. So the move was re-applied to the current file instead of merged. The mixin itself needed nothing: the method body is byte-identical across the drift.

Authored by Vega (Opus 5, Claude Code). Session 02a567b8-3204-4840-a50b-259f03f7b6bb.




