### PR TITLE
feat(dock): use cancellable engine waits for reveal policy (#18494)

### DIFF
--- a/src/core/Base.mjs
+++ b/src/core/Base.mjs
@@ -1147,20 +1147,40 @@ class Base {
     }
 
     /**
-     * Stores timeoutIds internally, so that destroy() can clear them if needed
-     * @param {Number} time in milliseconds
-     * @returns {Promise<any>}
+     * @summary Waits for a delay owned by this instance, optionally cancellable by its caller.
+     * Abort rejects with the signal's reason; destruction rejects with Neo.isDestroyed.
+     * Every terminal removes the abort listener and async registration. A pre-aborted signal
+     * creates no timer. Omitting the signal retains the ordinary timeout contract.
+     * @param {Number} time Delay in milliseconds
+     * @param {Object} [options={}]
+     * @param {AbortSignal} [options.signal] Cancels this wait while leaving its owner alive
+     * @returns {Promise<void>}
      */
-    timeout(time) {
+    timeout(time, {signal}={}) {
         let me = this;
 
         return new Promise((resolve, reject) => {
-            let id = setTimeout(() => {
+            if (signal?.aborted) {
+                reject(signal.reason);
+                return
+            }
+
+            const cleanup = () => {
                 me.unregisterAsync(id);
+                signal?.removeEventListener('abort', onAbort)
+            }, fail = reason => {
+                cleanup();
+                reject(reason)
+            }, onAbort = () => {
+                clearTimeout(id);
+                fail(signal.reason)
+            }, id = setTimeout(() => {
+                cleanup();
                 resolve()
             }, time);
 
-            me.registerAsync(id, reject)
+            me.registerAsync(id, fail);
+            signal?.addEventListener('abort', onAbort, {once: true})
         })
     }
 

--- a/src/dashboard/dock/interaction/Rail.mjs
+++ b/src/dashboard/dock/interaction/Rail.mjs
@@ -250,10 +250,10 @@ class Rail extends Container {
         const me = this;
 
         return Neo.create(RevealStateMachine, {
-            dwellMs      : Number.isFinite(me.revealDwellMs)        ? me.revealDwellMs        : undefined,
-            graceMs      : Number.isFinite(me.revealDismissGraceMs) ? me.revealDismissGraceMs : undefined,
             onChange     : me.onRevealStateChange.bind(me),
-            revealOnHover: me.autoHideRevealOnHover
+            revealOnHover: me.autoHideRevealOnHover,
+            ...(Number.isFinite(me.revealDwellMs) && {dwellMs: me.revealDwellMs}),
+            ...(Number.isFinite(me.revealDismissGraceMs) && {graceMs: me.revealDismissGraceMs})
         })
     }
 

--- a/src/dashboard/dock/interaction/RevealStateMachine.mjs
+++ b/src/dashboard/dock/interaction/RevealStateMachine.mjs
@@ -1,83 +1,36 @@
 import Base from '../../../core/Base.mjs';
 
 /**
- * @summary Owns one Rail's transient reveal state, policy and dwell/dismiss timers.
+ * @summary Owns one Rail's reveal intent; Base owns its asynchronous wait and teardown.
  *
- * Methods and policy defaults support Neo.overwrites and subclassing. Each Rail creates and destroys
- * its own instance; registration does not persist interaction state. The only output is `onChange`,
- * which the Rail maps to overlay updates. Pinning remains an executor-routed operation outside this
- * machine. Timer functions remain injectable for deterministic tests.
+ * Click reveals with focus. Opt-in hover dwells before revealing without focus; leaving an
+ * unfocused reveal starts dismiss grace. Focus holds, pointer return rescues, and explicit
+ * dismissal clears the intent. Retargeting cancels the prior wait, retaining the visible pane
+ * until the new dwell completes. Each effective change publishes one next/previous snapshot.
  *
- * ## States
- *
- * | State | Meaning |
- * |---|---|
- * | `idle` | No reveal. The rail renders tabs only. |
- * | `dwell-pending` | Hover intent detected (opt-in mode); reveal fires when the dwell timer elapses. |
- * | `revealed` | Overlay open WITHOUT focus (hover-born reveal — hover never steals focus). |
- * | `revealed-focused` | Overlay open and holding focus. A focused reveal never auto-dismisses. |
- * | `dismiss-pending` | Pointer left an unfocused overlay; dismissal fires when the grace timer elapses. |
- *
- * ## Transitions
- *
- * | From | Input | To | Notes |
- * |---|---|---|---|
- * | `idle` | `tabClick(item)` | `revealed-focused` | Click-reveal is the DEFAULT interaction; focus moves into the pane. |
- * | `idle` | `tabHoverIn(item)` | `dwell-pending` | Only when `revealOnHover` (workspace opt-in — hover reveals are an a11y hazard by default). |
- * | `dwell-pending` | dwell elapsed | `revealed` | Hover reveal never steals focus. |
- * | `dwell-pending` | `tabHoverOut()` | `idle` | Pass-through hovers never flicker an overlay. |
- * | `revealed` | `tabHoverOut()` | `dismiss-pending` | Hover-born reveal whose pointer leaves the TAB without ever entering the overlay dismisses through the same grace window. |
- * | `dwell-pending` | `tabClick(item)` | `revealed-focused` | Click overrides the dwell wait. |
- * | `revealed*` | `tabClick(same item)` | `idle` | Re-clicking the tab dismisses. |
- * | `revealed*` | `tabClick(other item)` | `revealed-focused(other)` | Retarget: the reveal follows intent. |
- * | `revealed` / `dismiss-pending` | `tabHoverIn(other item)` | `dwell-pending(other)` | Hover retarget re-dwells; the current reveal survives until the new one commits. |
- * | `revealed` | `overlayPointerLeave()` | `dismiss-pending` | Grace timer starts — pointer wobble must not kill the overlay. |
- * | `dismiss-pending` | `overlayPointerEnter()` | `revealed` | Grace return. |
- * | `dismiss-pending` | grace elapsed | `idle` | Dismissed; no operation is emitted. |
- * | `revealed` / `dismiss-pending` | `overlayFocusEnter()` | `revealed-focused` | Focus rescues and holds. |
- * | `revealed-focused` | `overlayPointerLeave()` | `revealed-focused` | FOCUS-HOLD: a focused reveal never auto-dismisses. |
- * | `revealed-focused` | `overlayFocusLeave()` | `idle` | Focus leaving the overlay dismisses. |
- * | `revealed*` / `dismiss-pending` | `escape()` / `outsideClick()` | `idle` | Explicit dismissal. `outsideClick()` arrives from the rail's outside-pointer listener on the app main view (a `mousedown` outside the rail's subtree, iframes included — the stylesheet withdraws their pointer events while a reveal is open) and from the maximize path. |
- * | any | `itemCleared(item)` | `idle` | Fail-closed sync: the item left auto-hidden state (pin, restore, transfer, policy) — a reveal of it cannot survive. |
- *
- * Dismissal in every form discards runtime state only; no operation descriptor exists for it.
- *
- * ## Design constants
- *
- * Dwell + grace are interaction timings owned here; reveal/dismiss slide durations are animation
- * timings and live in CSS, not in this machine.
+ * States: idle, dwell-pending, revealed, revealed-focused, dismiss-pending.
+ * Policy configs and methods support inheritance and Neo.overwrites. Transient state stays
+ * instance-local. Animation timing belongs to CSS; document operations remain outside this owner.
  * @class Neo.dashboard.dock.interaction.RevealStateMachine
  * @extends Neo.core.Base
  */
 class RevealStateMachine extends Base {
-    /**
-     * Hover intent dwell before a reveal fires (opt-in hover mode only).
-     * @member {Number} DWELL_MS=150
-     * @static
-     */
+    /** @member {Number} DWELL_MS=150 @static */
     static DWELL_MS = 150
-    /**
-     * Grace period after the pointer leaves an unfocused overlay before it dismisses.
-     * @member {Number} DISMISS_GRACE_MS=300
-     * @static
-     */
+    /** @member {Number} DISMISS_GRACE_MS=300 @static */
     static DISMISS_GRACE_MS = 300
 
     static config = {
         /** @member {String} className='Neo.dashboard.dock.interaction.RevealStateMachine' @protected */
         className: 'Neo.dashboard.dock.interaction.RevealStateMachine',
-        /** @member {Function} clearTimeoutFn Cancels a timer owned by this instance. */
-        clearTimeoutFn: id => globalThis.clearTimeout(id),
-        /** @member {Number} dwellMs=150 Hover dwell before revealing without focus. */
-        dwellMs: RevealStateMachine.DWELL_MS,
-        /** @member {Number} graceMs=300 Pointer-leave grace before dismissal. */
-        graceMs: RevealStateMachine.DISMISS_GRACE_MS,
-        /** @member {Function|null} onChange=null Receives next and previous reveal snapshots. */
-        onChange: null,
-        /** @member {Boolean} revealOnHover=false Hover reveal is explicitly opt-in. */
-        revealOnHover: false,
-        /** @member {Function} setTimeoutFn Schedules this instance's dwell/grace callback. */
-        setTimeoutFn: (fn, ms) => globalThis.setTimeout(fn, ms)
+        /** @member {Number} dwellMs_=150 Hover dwell for subsequent transitions. @reactive */
+        dwellMs_: RevealStateMachine.DWELL_MS,
+        /** @member {Number} graceMs_=300 Dismiss grace for subsequent transitions. @reactive */
+        graceMs_: RevealStateMachine.DISMISS_GRACE_MS,
+        /** @member {Function|null} onChange_=null Receives coherent next/previous snapshots. @reactive */
+        onChange_: null,
+        /** @member {Boolean} revealOnHover_=false Hover inputs require explicit opt-in. @reactive */
+        revealOnHover_: false
     }
 
     /** @member {String|null} pendingItemId=null @protected */
@@ -86,67 +39,72 @@ class RevealStateMachine extends Base {
     revealedItemId = null
     /** @member {String} state='idle' */
     state = 'idle'
-    /** @member {Number|Object|null} timerId=null @protected */
-    timerId = null
+    /** @member {AbortController|null} transitionController=null Current intent and wait cancellation. @protected */
+    transitionController = null
 
     /**
-     * @summary Applies effective policy while retaining the established optional-config defaults.
-     * @param {Object} config
-     * @param {Function} [config.clearTimeoutFn=globalThis.clearTimeout] Injectable for fake-timer specs.
-     * @param {Number} [config.dwellMs=RevealStateMachine.DWELL_MS]
-     * @param {Number} [config.graceMs=RevealStateMachine.DISMISS_GRACE_MS]
-     * @param {Function|null} [config.onChange=null] Receives `(next, previous)` snapshots `{revealedItemId, state}`.
-     * @param {Boolean} [config.revealOnHover=false] Workspace-level opt-in; hover inputs are ignored without it.
-     * @param {Function} [config.setTimeoutFn=globalThis.setTimeout] Injectable for fake-timer specs.
-     */
-    construct(config={}) {
-        config = {...config};
-
-        for (const key of ['dwellMs', 'graceMs']) {
-            if (!Number.isFinite(config[key])) delete config[key]
-        }
-
-        if (!config.clearTimeoutFn) delete config.clearTimeoutFn;
-        if (!config.setTimeoutFn) delete config.setTimeoutFn;
-        if (Object.hasOwn(config, 'onChange') && typeof config.onChange !== 'function') config.onChange = null;
-        if (Object.hasOwn(config, 'revealOnHover')) config.revealOnHover = config.revealOnHover === true;
-
-        super.construct(config)
-    }
-
-    /**
-     * Clears any pending dwell/grace timer. Idempotent.
+     * @summary Releases the notification target through the engine's destruction hook.
+     * Base itself cancels the owned wait; no timer cleanup belongs here.
+     * @param {Boolean} value
      * @protected
      */
-    clearTimer() {
-        if (this.timerId !== null) {
-            this.clearTimeoutFn(this.timerId);
-            this.timerId = null
-        }
+    afterSetIsDestroying(value) {
+        if (value) this.onChange = null
     }
 
     /**
-     * @summary Clears owned timers and the change listener before Base teardown.
-     * @param {...*} args
+     * @summary Applies the same duration fallback to construction, overwrites and live changes.
+     * @param {Number} value
+     * @param {Number} oldValue
+     * @returns {Number}
+     * @protected
      */
-    destroy(...args) {
-        this.clearTimer();
-        this.onChange = null;
-        super.destroy(...args)
+    beforeSetDwellMs(value, oldValue) {
+        const fallback = this.constructor.config.dwellMs;
+        return Number.isFinite(value) ? value : oldValue ??
+            (Number.isFinite(fallback) ? fallback : RevealStateMachine.DWELL_MS)
     }
 
     /**
-     * `Escape` inside a revealed overlay dismisses it — runtime state only, no operation.
+     * @summary Retains the last valid grace, or the effective class default on construction.
+     * @param {Number} value
+     * @param {Number} oldValue
+     * @returns {Number}
+     * @protected
      */
+    beforeSetGraceMs(value, oldValue) {
+        const fallback = this.constructor.config.graceMs;
+        return Number.isFinite(value) ? value : oldValue ??
+            (Number.isFinite(fallback) ? fallback : RevealStateMachine.DISMISS_GRACE_MS)
+    }
+
+    /**
+     * @summary Invalid optional callbacks leave the owner without a notification target.
+     * @param {Function|null} value
+     * @returns {Function|null}
+     * @protected
+     */
+    beforeSetOnChange(value) {
+        return Neo.isFunction(value) ? value : null
+    }
+
+    /**
+     * @summary Hover reveal requires the Boolean opt-in on every config path.
+     * @param {Boolean} value
+     * @returns {Boolean}
+     * @protected
+     */
+    beforeSetRevealOnHover(value) {
+        return value === true
+    }
+
+    /** @summary Escape dismisses runtime reveal intent without a document operation. */
     escape() {
-        if (this.state !== 'idle') {
-            this.transition('idle', null)
-        }
+        if (this.state !== 'idle') this.transition('idle', null)
     }
 
     /**
-     * Fail-closed sync input: the item left committed auto-hidden state (pin escape, restore,
-     * transfer, policy flip). Any reveal of it — pending or open — cannot survive.
+     * @summary Clears a revealed or pending item which left auto-hidden state.
      * @param {String} itemId
      */
     itemCleared(itemId) {
@@ -156,113 +114,70 @@ class RevealStateMachine extends Base {
     }
 
     /**
-     * A click outside the overlay and rail dismisses the reveal.
+     * @summary A cancelled, superseded or destroyed intent cannot publish its continuation.
+     * @param {AbortController} controller
+     * @returns {Boolean}
+     * @protected
      */
+    isCurrentTransition(controller) {
+        return !this.isDestroying && !this.isDestroyed &&
+            this.transitionController === controller && !controller.signal.aborted
+    }
+
+    /** @summary A click outside the overlay and rail dismisses the reveal. */
     outsideClick() {
         this.escape()
     }
 
-    /**
-     * Focus entered the overlay: engage focus-hold — a focused reveal never auto-dismisses.
-     */
+    /** @summary Focus rescues an unfocused reveal and holds it open. */
     overlayFocusEnter() {
         if (this.state === 'revealed' || this.state === 'dismiss-pending') {
             this.transition('revealed-focused', this.revealedItemId)
         }
     }
 
-    /**
-     * Focus left the overlay: the reveal dismisses (the pointer-grace path only serves
-     * unfocused reveals).
-     */
+    /** @summary Leaving a focus-held reveal dismisses it immediately. */
     overlayFocusLeave() {
-        if (this.state === 'revealed-focused') {
-            this.transition('idle', null)
-        }
+        if (this.state === 'revealed-focused') this.transition('idle', null)
     }
 
-    /**
-     * Pointer returned to the overlay during the dismiss grace window.
-     */
+    /** @summary Returning during dismiss grace keeps the reveal open. */
     overlayPointerEnter() {
-        if (this.state === 'dismiss-pending') {
-            this.transition('revealed', this.revealedItemId)
-        }
+        if (this.state === 'dismiss-pending') this.transition('revealed', this.revealedItemId)
     }
 
-    /**
-     * Pointer left the overlay. Unfocused reveals enter the grace window; focused reveals
-     * hold (focus-hold rule).
-     */
+    /** @summary Pointer leave starts grace only for an unfocused reveal. */
     overlayPointerLeave() {
-        let me = this;
-
-        if (me.state === 'revealed') {
-            me.transition('dismiss-pending', me.revealedItemId);
-
-            me.timerId = me.setTimeoutFn(() => {
-                me.timerId = null;
-
-                if (me.state === 'dismiss-pending') {
-                    me.transition('idle', null)
-                }
-            }, me.graceMs)
-        }
+        if (this.state === 'revealed') this.transition('dismiss-pending', this.revealedItemId)
     }
 
     /**
-     * Tab click — the DEFAULT reveal interaction. Toggles: clicking the revealed item's tab
-     * dismisses; clicking another tab retargets. Click-born reveals hold focus immediately.
+     * @summary Click toggles the same item, or retargets with focus.
      * @param {String} itemId
      */
     tabClick(itemId) {
-        let me = this;
-
-        if (me.revealedItemId === itemId && me.state !== 'dwell-pending') {
-            me.transition('idle', null);
-            return
+        if (this.revealedItemId === itemId && this.state !== 'dwell-pending') {
+            this.transition('idle', null)
+        } else {
+            this.transition('revealed-focused', itemId)
         }
-
-        me.transition('revealed-focused', itemId)
     }
 
     /**
-     * Hover entered a rail tab. Ignored unless the workspace opted in via `revealOnHover`.
-     * Starts (or retargets) the dwell window; hover-born reveals never steal focus.
+     * @summary Hover starts or restarts dwell while preserving any current unfocused reveal.
      * @param {String} itemId
      */
     tabHoverIn(itemId) {
-        let me = this;
+        const me = this;
+        if (!me.revealOnHover || me.state === 'revealed-focused' ||
+            me.revealedItemId === itemId && me.state === 'revealed') return;
 
-        if (!me.revealOnHover || me.state === 'revealed-focused' || me.revealedItemId === itemId && me.state === 'revealed') {
-            return
-        }
-
-        me.clearTimer();
-        me.pendingItemId = itemId;
-
-        if (me.state !== 'dwell-pending') {
-            me.transition('dwell-pending', me.revealedItemId, itemId)
-        }
-
-        me.timerId = me.setTimeoutFn(() => {
-            me.timerId = null;
-
-            if (me.state === 'dwell-pending' && me.pendingItemId === itemId) {
-                me.transition('revealed', itemId)
-            }
-        }, me.dwellMs)
+        me.transition('dwell-pending', me.revealedItemId, itemId)
     }
 
-    /**
-     * Hover left the rail tab. Before the dwell elapsed, a pass-through must never flicker an
-     * overlay open; after a hover-born reveal opened, leaving the tab WITHOUT entering the
-     * overlay starts the same dismiss grace the overlay's own pointer-leave uses (a pointer
-     * that reaches the overlay cancels it via `overlayPointerEnter()`).
-     */
+    /** @summary Pass-through cancels dwell; leaving a hover-born reveal starts dismiss grace. */
     tabHoverOut() {
-        let me = this;
-
+        const me = this;
         if (me.state === 'dwell-pending') {
             me.transition(me.revealedItemId ? 'revealed' : 'idle', me.revealedItemId)
         } else if (me.state === 'revealed') {
@@ -271,26 +186,58 @@ class RevealStateMachine extends Base {
     }
 
     /**
-     * Central transition executor: clears timers, applies the snapshot, notifies `onChange`
-     * exactly once per effective change.
+     * @summary Replaces intent, publishes one coherent snapshot, then schedules its domain terminal.
+     * The local controller survives reentrant notification only as a stale identity: it cannot
+     * schedule after a listener destroys the owner or starts another transition, even to the same state.
      * @param {String} state
      * @param {String|null} revealedItemId
      * @param {String|null} [pendingItemId=null]
      * @protected
      */
     transition(state, revealedItemId, pendingItemId=null) {
-        let me       = this,
-            previous = {revealedItemId: me.revealedItemId, state: me.state};
+        const me = this;
+        if (me.isDestroying || me.isDestroyed) return;
 
-        me.clearTimer();
+        const previous = {revealedItemId: me.revealedItemId, state: me.state};
+        me.transitionController?.abort();
+        const controller = me.transitionController = new AbortController();
 
-        me.pendingItemId  = pendingItemId;
-        me.revealedItemId = revealedItemId;
-        me.state          = state;
+        me.set({pendingItemId, revealedItemId, state});
 
-        if ((previous.state !== state || previous.revealedItemId !== revealedItemId) && me.onChange) {
-            me.onChange({revealedItemId, state}, previous)
+        if (previous.state !== state || previous.revealedItemId !== revealedItemId) {
+            me.onChange?.({revealedItemId, state}, previous)
         }
+
+        if (state === 'dwell-pending') {
+            me.transitionAfter(me.dwellMs, 'revealed', pendingItemId, controller)
+        } else if (state === 'dismiss-pending') {
+            me.transitionAfter(me.graceMs, 'idle', null, controller)
+        }
+    }
+
+    /**
+     * @summary Completes one Base-owned wait if the same intent still owns the continuation.
+     * Cancellation cannot retract a fulfillment already queued in the microtask queue, so identity
+     * is checked on both sides of the await. Unexpected errors retain their normal failure channel.
+     * @param {Number} delay
+     * @param {String} state
+     * @param {String|null} itemId
+     * @param {AbortController} controller
+     * @returns {Promise<void>}
+     * @protected
+     */
+    async transitionAfter(delay, state, itemId, controller) {
+        const me = this;
+        if (!me.isCurrentTransition(controller)) return;
+
+        try {
+            await me.timeout(delay, {signal: controller.signal})
+        } catch (error) {
+            if (error !== Neo.isDestroyed && !(controller.signal.aborted && error === controller.signal.reason)) throw error;
+            return
+        }
+
+        if (me.isCurrentTransition(controller)) me.transition(state, itemId)
     }
 }
 

--- a/test/playwright/component/apps/dock-rail-retarget/app.mjs
+++ b/test/playwright/component/apps/dock-rail-retarget/app.mjs
@@ -47,7 +47,65 @@ class RailRetargetWorkspace extends DockWorkspace {
          * Mirrors the shape both shipping consumers give their dock host.
          * @member {Object} style={position:'relative'}
          */
-        style: {position: 'relative'}
+        style: {position: 'relative'},
+        /** @member {Boolean} observeRevealWaits_=false Enables the fixture's real-wait witness. */
+        observeRevealWaits_: false
+    }
+
+    /** @member {Object|null} revealWaitProbe=null Test observations survive the Rail's teardown. */
+    revealWaitProbe = null
+
+    /**
+     * @summary Observes the existing owner's inherited waits without replacing timer behavior.
+     * @param {Boolean} value
+     */
+    afterSetObserveRevealWaits(value) {
+        if (!value || this.revealWaitProbe) return;
+        const rail     = this.down({dockNodeType: 'edge-rail', dockEdge: 'right'}),
+              owner    = rail.revealMachine, timeout = owner.timeout,
+              register = owner.registerAsync, unregister = owner.unregisterAsync,
+              probe    = this.revealWaitProbe = {
+                  railId    : rail.id, ownerId: owner.id, owner,
+                  registered: 0, pending: new Set(), waits: []
+              };
+
+        owner.registerAsync = (id, reject) => {
+            probe.registered++;
+            probe.pending.add(id);
+            return register.call(owner, id, reject)
+        };
+        owner.unregisterAsync = id => {
+            probe.pending.delete(id);
+            return unregister.call(owner, id)
+        };
+        owner.timeout = (delay, options) => {
+            const receipt = {delay, itemId: owner.pendingItemId ?? owner.revealedItemId, state: owner.state, status: 'pending'},
+                  wait    = timeout.call(owner, delay, options);
+            probe.waits.push(receipt);
+            wait.then(() => {receipt.status = 'elapsed'}, error => {
+                receipt.status = error === Neo.isDestroyed ? 'destroyed' :
+                    options.signal.aborted && error === options.signal.reason ? 'aborted' : `error:${String(error)}`
+            });
+            return wait
+        }
+    }
+
+    /** @summary Returns serializable observations of the real reveal owner and its async lifetime. @returns {Object|null} */
+    get revealWaitState() {
+        const probe = this.revealWaitProbe;
+        if (!probe) return null;
+        return {
+            railId         : probe.railId, ownerId: probe.ownerId,
+            state          : probe.owner.state ?? null,
+            pendingItemId  : probe.owner.pendingItemId ?? null,
+            revealedItemId : probe.owner.revealedItemId ?? null,
+            registeredWaits: probe.registered,
+            pendingWaits   : probe.pending.size,
+            ownerDestroyed : probe.owner.isDestroyed === true,
+            ownerRegistered: !!Neo.get(probe.ownerId),
+            waits          : probe.waits.map(receipt => ({...receipt})),
+            documentJson   : JSON.stringify(this.dockModel)
+        }
     }
 
     /**

--- a/test/playwright/component/dashboard/DockRailRevealRetarget.spec.mjs
+++ b/test/playwright/component/dashboard/DockRailRevealRetarget.spec.mjs
@@ -1,4 +1,4 @@
-import {test, expect} from '@playwright/test';
+import {test, expect} from '../../fixtures.mjs';
 
 /**
  * Retargeting a reveal — clicking another item of the same rail while one is open — swapped the
@@ -27,6 +27,22 @@ const readSlotAnimations = overlay => overlay.evaluate(node => ({
     title: node.querySelector('.neo-dashboard-dock-reveal-title')?.textContent.trim()
 }));
 
+/** @summary Reads the app worker's real owner/wait receipt through the existing RMA fixture. */
+const readReveal = async neo => {
+    const reply = await neo.getConfig('dock-rail-retarget-workspace', 'revealWaitState');
+    return reply?.data ?? reply
+};
+
+/** @summary Configures the rendered Rail through its existing live policy configs. */
+const observeReveal = async (neo, dwellMs, graceMs) => {
+    await neo.setConfig('dock-rail-retarget-workspace', {observeRevealWaits: true});
+    const probe = await readReveal(neo);
+    await neo.setConfig(probe.railId, {
+        autoHideRevealOnHover: true, revealDwellMs: dwellMs, revealDismissGraceMs: graceMs
+    });
+    return probe
+};
+
 test.beforeEach(async ({page}) => {
     await page.goto('test/playwright/component/apps/dock-rail-retarget/index.html');
     await page.waitForSelector('#dock-rail-retarget-workspace', {state: 'attached'});
@@ -35,6 +51,81 @@ test.beforeEach(async ({page}) => {
 });
 
 test.describe('Neo.dashboard.dock.interaction.RevealOverlay — a retarget slides the incoming pane in', () => {
+    test('hover dwell reveals without taking focus, and returning cancels the real dismiss grace', async ({page, neo}, testInfo) => {
+        const main       = page.locator('#dock-rail-retarget-pane-main'), overlay = page.locator(OVERLAY),
+              mainHeader = page.locator('.neo-tab-header-button', {hasText: 'Main'});
+        await mainHeader.focus();
+        const focusedId = await mainHeader.getAttribute('id');
+        expect(await page.evaluate(() => document.activeElement.id)).toBe(focusedId);
+        const initial = await observeReveal(neo, 120, 1000);
+
+        await page.locator(TAB('Alpha')).hover();
+        await expect(overlay.locator('.dock-rail-retarget-pane-alpha')).toBeVisible();
+        await expect.poll(async () => (await readReveal(neo)).state).toBe('revealed');
+        const revealed = await readReveal(neo);
+        expect(revealed.waits).toContainEqual({delay: 120, itemId: 'alpha', state: 'dwell-pending', status: 'elapsed'});
+        expect(revealed.registeredWaits).toBeGreaterThan(0);
+        expect(revealed.pendingWaits).toBe(0);
+        expect(await page.evaluate(() => document.activeElement.id), 'hover must not steal keyboard focus').toBe(focusedId);
+
+        const screenshot = testInfo.outputPath('hover-dwell-reveal.png');
+        await page.screenshot({path: screenshot, animations: 'disabled'});
+        await testInfo.attach('hover-dwell-reveal', {path: screenshot, contentType: 'image/png'});
+
+        await overlay.locator('.dock-rail-retarget-pane-alpha').hover();
+        await expect.poll(async () => (await readReveal(neo)).pendingWaits).toBe(0);
+        const beforeReturn = await readReveal(neo);
+        await main.hover();
+        await overlay.locator('.dock-rail-retarget-pane-alpha').hover();
+        await expect.poll(async () => (await readReveal(neo)).state).toBe('revealed');
+        const rescued = await readReveal(neo);
+        expect(rescued.waits.slice(beforeReturn.waits.length)).toContainEqual({
+            delay: 1000, itemId: 'alpha', state: 'dismiss-pending', status: 'aborted'
+        });
+        expect(rescued.pendingWaits).toBe(0);
+        await expect(overlay).toBeVisible();
+
+        // A subsequent uncancelled grace supplies the elapsed-time positive control.
+        await main.hover();
+        await expect(overlay).toBeHidden();
+        const dismissed = await readReveal(neo);
+        expect(dismissed.waits.at(-1)).toEqual({delay: 1000, itemId: 'alpha', state: 'dismiss-pending', status: 'elapsed'});
+        expect(dismissed.state).toBe('idle');
+        expect(dismissed.pendingWaits).toBe(0);
+        expect(dismissed.documentJson).toBe(initial.documentJson)
+    });
+
+    test('hover retarget cancels the obsolete dwell and Rail teardown cancels its pending Base wait', async ({page, neo}) => {
+        const initial = await observeReveal(neo, 1000, 60_000), overlay = page.locator(OVERLAY);
+        await page.locator(TAB('Alpha')).hover();
+        await page.locator(TAB('Beta')).hover();
+        await expect(overlay.locator('.dock-rail-retarget-pane-beta')).toBeVisible();
+        const revealed = await readReveal(neo);
+
+        expect(revealed.waits).toContainEqual({delay: 1000, itemId: 'alpha', state: 'dwell-pending', status: 'aborted'});
+        expect(revealed.waits).toContainEqual({delay: 1000, itemId: 'beta', state: 'dwell-pending', status: 'elapsed'});
+        expect(revealed.revealedItemId).toBe('beta');
+        expect(revealed.registeredWaits).toBeGreaterThanOrEqual(2);
+        expect(revealed.pendingWaits).toBe(0);
+        await expect(overlay.locator('.dock-rail-retarget-pane-alpha')).toHaveCount(0);
+
+        await overlay.locator('.dock-rail-retarget-pane-beta').hover();
+        await page.locator('#dock-rail-retarget-pane-main').hover();
+        await expect.poll(async () => (await readReveal(neo)).pendingWaits).toBe(1);
+        expect((await readReveal(neo)).state).toBe('dismiss-pending');
+        const response = await neo.destroyComponent(initial.railId);
+        expect((response?.data ?? response).success).toBe(true);
+        await expect(page.locator('.neo-dashboard-dock-edge-rail-right')).toHaveCount(0);
+        await expect.poll(async () => (await readReveal(neo)).pendingWaits).toBe(0);
+        const retired = await readReveal(neo);
+
+        expect(retired.waits.at(-1)).toEqual({delay: 60_000, itemId: 'beta', state: 'dismiss-pending', status: 'destroyed'});
+        expect(retired.ownerDestroyed).toBe(true);
+        expect(retired.ownerRegistered).toBe(false);
+        expect(retired.documentJson).toBe(initial.documentJson);
+        await expect(page.locator('#dock-rail-retarget-pane-main')).toBeVisible()
+    });
+
     test('clicking the other item of an open rail re-runs the content entry, and the next retarget alternates', async ({page}) => {
         const overlay = page.locator(OVERLAY);
 

--- a/test/playwright/unit/core/BaseTimeout.spec.mjs
+++ b/test/playwright/unit/core/BaseTimeout.spec.mjs
@@ -1,6 +1,50 @@
-import {test, expect} from '@playwright/test';
-import Neo            from '../../../../src/Neo.mjs';
-import * as core      from '../../../../src/core/_export.mjs';
+import {test, expect}      from '@playwright/test';
+import {getEventListeners} from 'node:events';
+import Neo                 from '../../../../src/Neo.mjs';
+import * as core           from '../../../../src/core/_export.mjs';
+
+/**
+ * @summary Observes native timers and the real Base registry without replacing their behavior.
+ * @param {Neo.core.Base} instance
+ * @returns {Object} Counters and restoration for this test's scoped spies.
+ */
+const observeTimeouts = instance => {
+    const set       = globalThis.setTimeout, clear = globalThis.clearTimeout,
+          register  = instance.registerAsync, unregister = instance.unregisterAsync,
+          scheduled = [], cleared = [], registered = [], unregistered = [], pending = new Set();
+
+    globalThis.setTimeout = (...args) => {
+        const id = set(...args);
+        scheduled.push(id);
+        return id
+    };
+    globalThis.clearTimeout = id => {
+        cleared.push(id);
+        return clear(id)
+    };
+    instance.registerAsync = (id, reject) => {
+        registered.push(id);
+        pending.add(id);
+        return register.call(instance, id, reject)
+    };
+    instance.unregisterAsync = id => {
+        unregistered.push(id);
+        pending.delete(id);
+        return unregister.call(instance, id)
+    };
+
+    return {
+        scheduled, cleared, registered, unregistered, pending,
+        restore() {
+            globalThis.setTimeout = set;
+            globalThis.clearTimeout = clear;
+            if (!instance.isDestroyed) {
+                delete instance.registerAsync;
+                delete instance.unregisterAsync
+            }
+        }
+    }
+};
 
 test.describe('core/Base bounded predicate waits', () => {
     test('immediate success schedules no timeout', async () => {
@@ -87,6 +131,27 @@ test.describe('core/Base bounded predicate waits', () => {
 });
 
 test.describe('core/Base Timeout Handling', () => {
+    test('an aborted wait clears its timer while the owner remains alive', async () => {
+        const instance = Neo.create(core.Base), controller = new AbortController(),
+              clear    = globalThis.clearTimeout, cleared = [], reason = new Error('superseded');
+        let outcome;
+
+        globalThis.clearTimeout = id => { cleared.push(id); clear(id) };
+        const pending = instance.timeout(60_000, {signal: controller.signal}).catch(error => { outcome = error });
+
+        try {
+            controller.abort(reason);
+            expect(cleared).toHaveLength(1);
+            await pending;
+            expect(outcome).toBe(reason);
+            expect(instance.isDestroyed).not.toBe(true)
+        } finally {
+            instance.destroy();
+            await pending;
+            globalThis.clearTimeout = clear
+        }
+    });
+
     test('timeout() should resolve after the specified delay', async () => {
         class TestClass extends core.Base {
             static config = {
@@ -96,7 +161,7 @@ test.describe('core/Base Timeout Handling', () => {
         TestClass = Neo.setupClass(TestClass);
 
         const instance = Neo.create(TestClass);
-        const start = Date.now();
+        const start    = Date.now();
         await instance.timeout(100);
         const end = Date.now();
 
@@ -271,4 +336,141 @@ test.describe('core/Base Timeout Handling', () => {
         instance.destroy();
         expect(instance.isDestroyed).toBe(true);
     });
+});
+
+test.describe('core/Base optional timeout signals', () => {
+    test('a pre-aborted signal allocates no timer, listener or async registration', async () => {
+        const instance = Neo.create(core.Base), controller = new AbortController(),
+              reason   = {superseded: true}, observed = observeTimeouts(instance);
+
+        controller.abort(reason);
+
+        try {
+            const result = instance.timeout(60_000, {signal: controller.signal}).catch(error => error);
+
+            expect(observed.scheduled).toEqual([]);
+            expect(observed.registered).toEqual([]);
+            expect(getEventListeners(controller.signal, 'abort')).toHaveLength(0);
+            expect(await result).toBe(reason);
+            instance.destroy();
+            expect(observed.cleared).toEqual([])
+        } finally {
+            try { !instance.isDestroyed && instance.destroy() } finally { observed.restore() }
+        }
+    });
+
+    test('aborting one wait leaves its sibling registered and able to complete', async () => {
+        const instance = Neo.create(core.Base), first = new AbortController(), second = new AbortController(),
+              reason   = new Error('replace only the first wait'), observed = observeTimeouts(instance);
+        let cancelled, sibling;
+
+        try {
+            cancelled = instance.timeout(60_000, {signal: first.signal}).catch(error => error);
+            sibling = instance.timeout(0, {signal: second.signal});
+            sibling.catch(() => {});
+            const [firstId, secondId] = observed.registered;
+
+            expect(observed.pending.size).toBe(2);
+            expect(getEventListeners(first.signal, 'abort')).toHaveLength(1);
+            expect(getEventListeners(second.signal, 'abort')).toHaveLength(1);
+            first.abort(reason);
+
+            expect(observed.cleared).toEqual([firstId]);
+            expect([...observed.pending]).toEqual([secondId]);
+            expect(getEventListeners(first.signal, 'abort')).toHaveLength(0);
+            expect(getEventListeners(second.signal, 'abort')).toHaveLength(1);
+            expect(await cancelled).toBe(reason);
+            expect(await sibling).toBeUndefined();
+            expect(observed.pending.size).toBe(0);
+            expect(getEventListeners(second.signal, 'abort')).toHaveLength(0);
+            expect(instance.isDestroyed).not.toBe(true);
+            instance.destroy();
+            expect(observed.cleared).toEqual([firstId])
+        } finally {
+            try {
+                !instance.isDestroyed && instance.destroy();
+                await Promise.allSettled([cancelled, sibling])
+            } finally { observed.restore() }
+        }
+    });
+
+    for (const terminal of ['elapsed', 'aborted', 'destroyed']) {
+        test(`${terminal} removes the listener and registry entry before a late abort`, async () => {
+            const instance = Neo.create(core.Base), controller = new AbortController(),
+                  reason   = new Error('cancelled by caller'), observed = observeTimeouts(instance), settlements = [];
+            let result;
+
+            try {
+                result = instance.timeout(terminal === 'elapsed' ? 0 : 60_000, {signal: controller.signal}).then(
+                    value => { settlements.push({status: 'fulfilled', value}) },
+                    error => { settlements.push({status: 'rejected', error}) }
+                );
+                const [id] = observed.registered;
+
+                expect(observed.pending.size).toBe(1);
+                expect(getEventListeners(controller.signal, 'abort')).toHaveLength(1);
+                if (terminal === 'aborted') controller.abort(reason);
+                if (terminal === 'destroyed') instance.destroy();
+                await result;
+
+                expect(settlements).toHaveLength(1);
+                if (terminal === 'elapsed') {
+                    expect(settlements[0]).toEqual({status: 'fulfilled', value: undefined})
+                } else {
+                    expect(settlements[0].status).toBe('rejected');
+                    expect(settlements[0].error).toBe(terminal === 'aborted' ? reason : Neo.isDestroyed)
+                }
+                expect(observed.pending.size).toBe(0);
+                expect(observed.unregistered).toEqual([id]);
+                expect(getEventListeners(controller.signal, 'abort')).toHaveLength(0);
+                const clears = [...observed.cleared];
+
+                expect(clears).toEqual(terminal === 'elapsed' ? [] : [id]);
+                controller.abort(new Error('too late'));
+                !instance.isDestroyed && instance.destroy();
+                await Promise.resolve();
+
+                expect(settlements).toHaveLength(1);
+                expect(observed.cleared).toEqual(clears);
+                expect(observed.unregistered).toEqual([id]);
+                expect(getEventListeners(controller.signal, 'abort')).toHaveLength(0)
+            } finally {
+                try {
+                    !instance.isDestroyed && instance.destroy();
+                    await result
+                } finally { observed.restore() }
+            }
+        })
+    }
+
+    test('repeated cancellation retires obsolete waits before the next one is armed', async () => {
+        const instance = Neo.create(core.Base), observed = observeTimeouts(instance), controllers = [], results = [];
+
+        try {
+            for (let index = 0; index < 25; index++) {
+                const controller = new AbortController();
+                controllers.push(controller);
+                results.push(instance.timeout(60_000, {signal: controller.signal}).catch(error => error));
+                expect(observed.pending.size).toBe(1);
+                controller.abort('superseded');
+                expect(observed.pending.size).toBe(0)
+            }
+
+            expect(await Promise.all(results)).toEqual(Array(25).fill('superseded'));
+            expect(observed.registered).toHaveLength(25);
+            expect(new Set(observed.cleared)).toEqual(new Set(observed.registered));
+            expect(observed.cleared).toHaveLength(25);
+            controllers.forEach(controller => expect(getEventListeners(controller.signal, 'abort')).toHaveLength(0));
+
+            await instance.timeout(0);
+            expect(observed.pending.size).toBe(0);
+            instance.destroy();
+            expect(observed.cleared).toHaveLength(25)
+        } finally {
+            try {
+                !instance.isDestroyed && instance.destroy();
+                await Promise.allSettled(results)
+            } finally { observed.restore() }
+        }
+    })
 });

--- a/test/playwright/unit/dashboard/DockRail.spec.mjs
+++ b/test/playwright/unit/dashboard/DockRail.spec.mjs
@@ -6,9 +6,9 @@ setup({
     }
 });
 
-import {test, expect}    from '@playwright/test';
-import Neo               from '../../../../src/Neo.mjs';
-import * as core         from '../../../../src/core/_export.mjs';
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../src/Neo.mjs';
+import * as core      from '../../../../src/core/_export.mjs';
 import '../../../../src/manager/Instance.mjs'; // defines Neo.get — the registry the release witness reads
 import Button             from '../../../../src/button/Base.mjs';
 import DockLayoutAdapter  from '../../../../src/dashboard/dock/projection/LayoutAdapter.mjs';
@@ -57,6 +57,37 @@ const createStubOverlay = () => ({
     }
 });
 
+/** @summary Delivers native timers while Base retains real registration and cancellation ownership. */
+const createNativeClock = () => {
+    const set = globalThis.setTimeout, clear = globalThis.clearTimeout, pending = new Map();
+    let   now = 0, nextId = 0;
+
+    globalThis.setTimeout = (fn, delay) => {
+        const id = ++nextId;
+        pending.set(id, {fn, delay, at: now + delay});
+        return id
+    };
+    globalThis.clearTimeout = id => pending.delete(id);
+
+    return {
+        pending,
+        async advance(milliseconds) {
+            now += milliseconds;
+            for (const [id, timer] of [...pending].sort((a, b) => a[1].at - b[1].at)) {
+                if (timer.at <= now && pending.has(id)) {
+                    pending.delete(id);
+                    timer.fn();
+                    await Promise.resolve()
+                }
+            }
+        },
+        restore() {
+            globalThis.setTimeout = set;
+            globalThis.clearTimeout = clear
+        }
+    }
+};
+
 test.describe('Neo.dashboard.dock.interaction.Rail', () => {
     let rail;
 
@@ -90,51 +121,128 @@ test.describe('Neo.dashboard.dock.interaction.Rail', () => {
         expect(machine.isDestroyed).toBe(true)
     });
 
-    test('each Rail owns independent reveal state and cancels only its own pending timer', () => {
-        const pending    = new Map();
-        let   nextId     = 0;
-        const createRail = () => Neo.create(DockRail, {
-            edge: 'right', railItems: createRailItems(),
-            createRevealMachine() {
-                return Neo.create(RevealStateMachine, {
-                    onChange     : this.onRevealStateChange.bind(this),
-                    revealOnHover: true,
-                    setTimeoutFn(fn) {
-                        const id = ++nextId;
-                        pending.set(id, fn);
-                        return id
-                    },
-                    clearTimeoutFn: id => pending.delete(id)
-                })
-            }
-        });
-
-        rail = createRail();
-        const other      = createRail();
-        const firstOwner = rail.revealMachine;
+    test('each Rail owns independent reveal state and cancels only its own pending timer', async () => {
+        const clock = createNativeClock(), registrations = new Map(), registeredCalls = new Map();
+        let other;
 
         try {
-            expect(firstOwner).not.toBe(other.revealMachine);
-            firstOwner.tabHoverIn('terminal');
+            const createRail = () => {
+                const result = Neo.create(DockRail, {
+                    edge: 'right', railItems: createRailItems(), autoHideRevealOnHover: true
+                });
+                // Overlay motion has its own timer; this witness isolates the two reveal owners.
+                result.bindRevealOverlay(createStubOverlay());
+                const owner    = result.revealMachine, pending = new Set(),
+                      register = owner.registerAsync, unregister = owner.unregisterAsync;
+                registrations.set(owner, pending);
+                registeredCalls.set(owner, 0);
+                owner.registerAsync = (id, reject) => {
+                    pending.add(id);
+                    registeredCalls.set(owner, registeredCalls.get(owner) + 1);
+                    return register.call(owner, id, reject)
+                };
+                owner.unregisterAsync = id => {
+                    pending.delete(id);
+                    return unregister.call(owner, id)
+                };
+                return result
+            };
+
+            rail = createRail();
+            other = createRail();
+            const firstOwner = rail.revealMachine, secondOwner = other.revealMachine;
+
+            expect(firstOwner).not.toBe(secondOwner);
+            rail.onTabHoverIn({component: tabsOf(rail)[0]});
+            expect(registeredCalls.get(firstOwner)).toBe(1);
             expect(other.revealMachine.state).toBe('idle');
-            other.revealMachine.tabHoverIn('terminal');
-            expect(pending.size).toBe(2);
+            other.onTabHoverIn({component: tabsOf(other)[0]});
+            expect(registeredCalls.get(secondOwner)).toBe(1);
+            expect(clock.pending.size).toBe(2);
 
             rail.destroy();
+            await Promise.resolve();
             expect(firstOwner.isDestroyed).toBe(true);
-            expect(other.revealMachine.isDestroyed).not.toBe(true);
-            expect(pending.size).toBe(1);
-            const callback = [...pending.values()][0];
-            pending.clear();
-            callback();
-            expect(other.revealMachine.state).toBe('revealed');
+            expect(secondOwner.isDestroyed).not.toBe(true);
+            expect(registrations.get(firstOwner).size).toBe(0);
+            expect([...clock.pending.keys()]).toEqual([...registrations.get(secondOwner)]);
+            expect(clock.pending.size).toBe(1);
+            await clock.advance(150);
+            expect(secondOwner.state).toBe('revealed');
+            expect(registrations.get(secondOwner).size).toBe(0);
 
-            other.revealMachine.overlayPointerLeave();
-            expect(pending.size).toBe(1);
+            other.onTabHoverOut({});
+            expect(secondOwner.state).toBe('dismiss-pending');
+            expect(registeredCalls.get(secondOwner)).toBe(2);
+            expect(clock.pending.size).toBe(1);
             other.destroy();
-            expect(pending.size).toBe(0)
+            await Promise.resolve();
+            expect(clock.pending.size).toBe(0);
+            expect(registrations.get(secondOwner).size).toBe(0)
         } finally {
-            other.destroy()
+            try {
+                rail?.destroy();
+                other?.destroy();
+                await Promise.resolve()
+            } finally { clock.restore() }
+        }
+    });
+
+    test('Rail defaults and live timing or hover updates reach the existing reveal owner', async () => {
+        const clock = createNativeClock();
+
+        try {
+            rail = Neo.create(DockRail, {edge: 'right', railItems: createRailItems()});
+            rail.bindRevealOverlay(createStubOverlay());
+            const owner = rail.revealMachine, input = {component: tabsOf(rail)[0]};
+
+            expect(owner.dwellMs).toBe(150);
+            expect(owner.graceMs).toBe(300);
+            expect(owner.revealOnHover).toBe(false);
+            rail.onTabHoverIn(input);
+            expect(owner.state).toBe('idle');
+            expect(clock.pending.size).toBe(0);
+
+            rail.set({revealDwellMs: 12, revealDismissGraceMs: 34, autoHideRevealOnHover: true});
+            expect(rail.revealMachine).toBe(owner);
+            expect(owner.dwellMs).toBe(12);
+            expect(owner.graceMs).toBe(34);
+            expect(owner.revealOnHover).toBe(true);
+            rail.onTabHoverIn(input);
+            expect([...clock.pending.values()].map(timer => timer.delay)).toEqual([12]);
+            await clock.advance(11);
+            expect(owner.state).toBe('dwell-pending');
+            await clock.advance(1);
+            expect(owner.state).toBe('revealed');
+
+            rail.onTabHoverOut({});
+            expect([...clock.pending.values()].map(timer => timer.delay)).toEqual([34]);
+            await clock.advance(33);
+            expect(owner.state).toBe('dismiss-pending');
+            await clock.advance(1);
+            expect(owner.state).toBe('idle');
+            expect(clock.pending.size).toBe(0);
+
+            rail.set({revealDwellMs: NaN, revealDismissGraceMs: Infinity, autoHideRevealOnHover: 'true'});
+            expect(owner.dwellMs).toBe(12);
+            expect(owner.graceMs).toBe(34);
+            expect(owner.revealOnHover).toBe(false);
+            rail.onTabHoverIn(input);
+            expect(owner.state).toBe('idle');
+            expect(clock.pending.size).toBe(0);
+
+            rail.set({revealDwellMs: 0, revealDismissGraceMs: 0, autoHideRevealOnHover: true});
+            rail.onTabHoverIn(input);
+            await clock.advance(0);
+            expect(owner.state).toBe('revealed');
+            rail.onTabHoverOut({});
+            await clock.advance(0);
+            expect(owner.state).toBe('idle')
+        } finally {
+            try {
+                rail?.destroy();
+                await Promise.resolve()
+            } finally { clock.restore() }
         }
     });
 

--- a/test/playwright/unit/dashboard/DockRevealStateMachine.spec.mjs
+++ b/test/playwright/unit/dashboard/DockRevealStateMachine.spec.mjs
@@ -9,47 +9,44 @@ import DockRevealStateMachine from '../../../../src/dashboard/dock/interaction/R
 import {execFileSync}         from 'node:child_process';
 import {fileURLToPath}        from 'node:url';
 
+/** @summary Controls native timer delivery while the real Base timeout owns registration and cleanup. */
 const createFakeTimers = () => {
-    let nextId = 1,
-        now    = 0,
-        queue  = new Map();
-
-    return {
-        advance(ms) {
+    const nativeSet = globalThis.setTimeout, nativeClear = globalThis.clearTimeout;
+    let   nextId    = 1, now = 0;
+    const queue     = new Map(), timers = {
+        async advance(ms) {
             now += ms;
-
-            [...queue.entries()]
-                .sort((a, b) => a[1].at - b[1].at)
-                .forEach(([id, timer]) => {
-                    if (timer.at <= now && queue.has(id)) {
-                        queue.delete(id);
-                        timer.fn()
-                    }
-                })
+            [...queue.entries()].sort((a, b) => a[1].at - b[1].at).forEach(([id, timer]) => {
+                if (timer.at <= now && queue.has(id)) {
+                    queue.delete(id);
+                    timer.fn()
+                }
+            })
         },
-        clearTimeoutFn(id) {
-            queue.delete(id)
-        },
-        pendingCount() {
-            return queue.size
-        },
-        setTimeoutFn(fn, ms) {
-            let id = nextId++;
-            queue.set(id, {at: now + ms, fn});
-            return id
+        pendingCount: () => queue.size,
+        restore() {
+            globalThis.setTimeout = nativeSet;
+            globalThis.clearTimeout = nativeClear
         }
-    }
+    };
+    globalThis.setTimeout = (fn, ms) => {
+        const id = nextId++;
+        queue.set(id, {at: now + ms, fn});
+        return id
+    };
+    globalThis.clearTimeout = id => queue.delete(id);
+    return timers
 };
+
+let activeTimers = null;
 
 const machines = new Set();
 
 const createMachine = (config={}) => {
     let changes = [],
-        timers  = createFakeTimers(),
+        timers  = activeTimers ??= createFakeTimers(),
         machine = Neo.create(DockRevealStateMachine, {
-            clearTimeoutFn: timers.clearTimeoutFn.bind(timers),
             onChange      : (next, previous) => changes.push({next, previous}),
-            setTimeoutFn  : timers.setTimeoutFn.bind(timers),
             ...config
         });
 
@@ -57,13 +54,15 @@ const createMachine = (config={}) => {
     return {changes, machine, timers}
 };
 
-test.describe('DockRevealStateMachine', () => {
+test.describe('DockRevealStateMachine', async () => {
     test.afterEach(() => {
         machines.forEach(machine => machine.destroy());
-        machines.clear()
+        machines.clear();
+        activeTimers?.restore();
+        activeTimers = null
     });
 
-    test('a pre-import Neo overwrite reaches a real Rail input and its owned lifecycle', () => {
+    test('a pre-import Neo overwrite reaches a real Rail input and its owned lifecycle', async () => {
         const result = JSON.parse(execFileSync(process.execPath, ['--input-type=module', '-e', `
             await import('./src/Neo.mjs');
             await import('./src/core/_export.mjs');
@@ -71,7 +70,7 @@ test.describe('DockRevealStateMachine', () => {
             setup({appConfig: {name: 'DockRevealOverwriteTest'}});
             Neo.overwrites = {};
             const policy = Neo.ns('Neo.dashboard.dock.interaction.RevealStateMachine', true, Neo.overwrites);
-            policy.dwellMs = 75;
+            policy.dwellMs_ = 75;
             policy.tabClick = function(itemId) {
                 this.transition('revealed', itemId);
             };
@@ -94,22 +93,22 @@ test.describe('DockRevealStateMachine', () => {
         expect(result.destroyed).toBe(true)
     });
 
-    test('explicit dwell and grace durations govern their respective transitions', () => {
+    test('explicit dwell and grace durations govern their respective transitions', async () => {
         const {machine, timers} = createMachine({dwellMs: 12, graceMs: 23, revealOnHover: true});
 
         machine.tabHoverIn('terminal');
-        timers.advance(11);
+        await timers.advance(11);
         expect(machine.state).toBe('dwell-pending');
-        timers.advance(1);
+        await timers.advance(1);
         expect(machine.state).toBe('revealed');
         machine.overlayPointerLeave();
-        timers.advance(22);
+        await timers.advance(22);
         expect(machine.state).toBe('dismiss-pending');
-        timers.advance(1);
+        await timers.advance(1);
         expect(machine.state).toBe('idle')
     });
 
-    test('invalid optional timings retain defaults and hover requires true', () => {
+    test('invalid optional timings retain defaults and hover requires true', async () => {
         const {machine} = createMachine({dwellMs: NaN, graceMs: Infinity, revealOnHover: 'true'});
 
         expect(machine.dwellMs).toBe(150);
@@ -117,7 +116,68 @@ test.describe('DockRevealStateMachine', () => {
         expect(machine.revealOnHover).toBe(false)
     });
 
-    test('click-reveal is the default: click focuses, re-click dismisses', () => {
+    test('inherited policy defaults use the same validation as explicit configs', async () => {
+        class InvalidPolicy extends DockRevealStateMachine {
+            static config = {
+                className    : 'Test.Unit.Dashboard.Reveal.InvalidPolicyDefaults',
+                dwellMs      : NaN,
+                graceMs      : Infinity,
+                revealOnHover: 'true'
+            }
+        }
+        const machine = Neo.create(Neo.setupClass(InvalidPolicy));
+        machines.add(machine);
+        expect(machine.dwellMs).toBe(150);
+        expect(machine.graceMs).toBe(300);
+        expect(machine.revealOnHover).toBe(false)
+    });
+
+    test('invalid input preserves valid subclass timing defaults and ignores invalid callbacks', async () => {
+        class CustomPolicy extends DockRevealStateMachine {
+            static config = {
+                className: 'Test.Unit.Dashboard.Reveal.CustomPolicyDefaults',
+                dwellMs  : 12,
+                graceMs  : 23
+            }
+        }
+        const machine = Neo.create(Neo.setupClass(CustomPolicy), {
+            dwellMs: NaN, graceMs: Infinity, onChange: 'not a callback'
+        });
+        machines.add(machine);
+        expect([machine.dwellMs, machine.graceMs, machine.onChange]).toEqual([12, 23, null]);
+        machine.set({dwellMs: NaN, graceMs: Infinity});
+        expect([machine.dwellMs, machine.graceMs]).toEqual([12, 23])
+    });
+
+    for (const state of ['dwell-pending', 'dismiss-pending']) {
+        test(`destruction from ${state} notification schedules no later work`, async () => {
+            const set = globalThis.setTimeout, clear = globalThis.clearTimeout, pending = new Map();
+            let   id  = 0, machine;
+            globalThis.setTimeout = (fn, ms) => { pending.set(++id, {fn, ms}); return id };
+            globalThis.clearTimeout = key => pending.delete(key);
+            try {
+                machine = Neo.create(DockRevealStateMachine, {
+                    revealOnHover: true,
+                    onChange     : next => { if (next.state === state) machine.destroy() }
+                });
+                await machine.ready();
+                if (state === 'dwell-pending') machine.tabHoverIn('terminal');
+                else {
+                    machine.transition('revealed', 'terminal');
+                    machine.overlayPointerLeave()
+                }
+                expect(machine.isDestroyed).toBe(true);
+                expect(pending.size).toBe(0);
+                expect(Object.hasOwn(machine, 'timerId')).toBe(false)
+            } finally {
+                machine?.destroy();
+                globalThis.setTimeout = set;
+                globalThis.clearTimeout = clear
+            }
+        })
+    }
+
+    test('click-reveal is the default: click focuses, re-click dismisses', async () => {
         let {changes, machine} = createMachine();
 
         machine.tabClick('terminal');
@@ -132,7 +192,7 @@ test.describe('DockRevealStateMachine', () => {
         expect(changes.map(change => change.next.state)).toEqual(['revealed-focused', 'idle']);
     });
 
-    test('hover input is ignored without the workspace opt-in (a11y default)', () => {
+    test('hover input is ignored without the workspace opt-in (a11y default)', async () => {
         let {machine, timers} = createMachine();
 
         machine.tabHoverIn('terminal');
@@ -141,22 +201,22 @@ test.describe('DockRevealStateMachine', () => {
         expect(timers.pendingCount()).toBe(0);
     });
 
-    test('opt-in hover reveals after the dwell, without stealing focus', () => {
+    test('opt-in hover reveals after the dwell, without stealing focus', async () => {
         let {machine, timers} = createMachine({revealOnHover: true});
 
         machine.tabHoverIn('terminal');
 
         expect(machine.state).toBe('dwell-pending');
 
-        timers.advance(DockRevealStateMachine.DWELL_MS - 1);
+        await timers.advance(DockRevealStateMachine.DWELL_MS - 1);
         expect(machine.state).toBe('dwell-pending');
 
-        timers.advance(1);
+        await timers.advance(1);
         expect(machine.state).toBe('revealed');
         expect(machine.revealedItemId).toBe('terminal');
     });
 
-    test('a pass-through hover never flickers an overlay open', () => {
+    test('a pass-through hover never flickers an overlay open', async () => {
         let {machine, timers} = createMachine({revealOnHover: true});
 
         machine.tabHoverIn('terminal');
@@ -164,45 +224,45 @@ test.describe('DockRevealStateMachine', () => {
 
         expect(machine.state).toBe('idle');
 
-        timers.advance(DockRevealStateMachine.DWELL_MS * 2);
+        await timers.advance(DockRevealStateMachine.DWELL_MS * 2);
         expect(machine.state).toBe('idle');
     });
 
-    test('pointer-away dismisses an unfocused reveal only after the grace period', () => {
+    test('pointer-away dismisses an unfocused reveal only after the grace period', async () => {
         let {machine, timers} = createMachine({revealOnHover: true});
 
         machine.tabHoverIn('terminal');
-        timers.advance(DockRevealStateMachine.DWELL_MS);
+        await timers.advance(DockRevealStateMachine.DWELL_MS);
         machine.overlayPointerLeave();
 
         expect(machine.state).toBe('dismiss-pending');
 
-        timers.advance(DockRevealStateMachine.DISMISS_GRACE_MS - 1);
+        await timers.advance(DockRevealStateMachine.DISMISS_GRACE_MS - 1);
         expect(machine.state).toBe('dismiss-pending');
 
-        timers.advance(1);
+        await timers.advance(1);
         expect(machine.state).toBe('idle');
     });
 
-    test('a grace-window pointer return keeps the overlay open', () => {
+    test('a grace-window pointer return keeps the overlay open', async () => {
         let {machine, timers} = createMachine({revealOnHover: true});
 
         machine.tabHoverIn('terminal');
-        timers.advance(DockRevealStateMachine.DWELL_MS);
+        await timers.advance(DockRevealStateMachine.DWELL_MS);
         machine.overlayPointerLeave();
         machine.overlayPointerEnter();
 
         expect(machine.state).toBe('revealed');
 
-        timers.advance(DockRevealStateMachine.DISMISS_GRACE_MS * 2);
+        await timers.advance(DockRevealStateMachine.DISMISS_GRACE_MS * 2);
         expect(machine.state).toBe('revealed');
     });
 
-    test('focus-hold: a focused reveal never auto-dismisses; focus leave dismisses', () => {
+    test('focus-hold: a focused reveal never auto-dismisses; focus leave dismisses', async () => {
         let {machine, timers} = createMachine({revealOnHover: true});
 
         machine.tabHoverIn('terminal');
-        timers.advance(DockRevealStateMachine.DWELL_MS);
+        await timers.advance(DockRevealStateMachine.DWELL_MS);
         machine.overlayFocusEnter();
 
         expect(machine.state).toBe('revealed-focused');
@@ -210,28 +270,28 @@ test.describe('DockRevealStateMachine', () => {
         machine.overlayPointerLeave();
         expect(machine.state).toBe('revealed-focused');
 
-        timers.advance(DockRevealStateMachine.DISMISS_GRACE_MS * 10);
+        await timers.advance(DockRevealStateMachine.DISMISS_GRACE_MS * 10);
         expect(machine.state).toBe('revealed-focused');
 
         machine.overlayFocusLeave();
         expect(machine.state).toBe('idle');
     });
 
-    test('focus entering during the grace window rescues the reveal into focus-hold', () => {
+    test('focus entering during the grace window rescues the reveal into focus-hold', async () => {
         let {machine, timers} = createMachine({revealOnHover: true});
 
         machine.tabHoverIn('terminal');
-        timers.advance(DockRevealStateMachine.DWELL_MS);
+        await timers.advance(DockRevealStateMachine.DWELL_MS);
         machine.overlayPointerLeave();
         machine.overlayFocusEnter();
 
         expect(machine.state).toBe('revealed-focused');
 
-        timers.advance(DockRevealStateMachine.DISMISS_GRACE_MS * 2);
+        await timers.advance(DockRevealStateMachine.DISMISS_GRACE_MS * 2);
         expect(machine.state).toBe('revealed-focused');
     });
 
-    test('escape and outside-click dismiss from every revealed state', () => {
+    test('escape and outside-click dismiss from every revealed state', async () => {
         let {machine} = createMachine();
 
         machine.tabClick('terminal');
@@ -243,7 +303,7 @@ test.describe('DockRevealStateMachine', () => {
         expect(machine.state).toBe('idle');
     });
 
-    test('click retargets an open reveal to the other item', () => {
+    test('click retargets an open reveal to the other item', async () => {
         let {machine} = createMachine();
 
         machine.tabClick('terminal');
@@ -253,27 +313,27 @@ test.describe('DockRevealStateMachine', () => {
         expect(machine.revealedItemId).toBe('inspector');
     });
 
-    test('hover retarget re-dwells while the current reveal survives until commit', () => {
+    test('hover retarget re-dwells while the current reveal survives until commit', async () => {
         let {machine, timers} = createMachine({revealOnHover: true});
 
         machine.tabHoverIn('terminal');
-        timers.advance(DockRevealStateMachine.DWELL_MS);
+        await timers.advance(DockRevealStateMachine.DWELL_MS);
         expect(machine.revealedItemId).toBe('terminal');
 
         machine.tabHoverIn('inspector');
         expect(machine.state).toBe('dwell-pending');
         expect(machine.revealedItemId).toBe('terminal');
 
-        timers.advance(DockRevealStateMachine.DWELL_MS);
+        await timers.advance(DockRevealStateMachine.DWELL_MS);
         expect(machine.state).toBe('revealed');
         expect(machine.revealedItemId).toBe('inspector');
     });
 
-    test('a hover-born reveal dismisses through grace when the pointer leaves the tab without entering the overlay', () => {
+    test('a hover-born reveal dismisses through grace when the pointer leaves the tab without entering the overlay', async () => {
         let {machine, timers} = createMachine({revealOnHover: true});
 
         machine.tabHoverIn('terminal');
-        timers.advance(DockRevealStateMachine.DWELL_MS);
+        await timers.advance(DockRevealStateMachine.DWELL_MS);
         expect(machine.state).toBe('revealed');
 
         machine.tabHoverOut();
@@ -285,11 +345,11 @@ test.describe('DockRevealStateMachine', () => {
 
         // ...while never reaching it lets the grace dismiss.
         machine.tabHoverOut();
-        timers.advance(DockRevealStateMachine.DISMISS_GRACE_MS);
+        await timers.advance(DockRevealStateMachine.DISMISS_GRACE_MS);
         expect(machine.state).toBe('idle');
     });
 
-    test('itemCleared fail-closes any reveal or pending dwell of that item', () => {
+    test('itemCleared fail-closes any reveal or pending dwell of that item', async () => {
         let {machine, timers} = createMachine({revealOnHover: true});
 
         machine.tabClick('terminal');
@@ -303,19 +363,104 @@ test.describe('DockRevealStateMachine', () => {
         machine.itemCleared('inspector');
         expect(machine.state).toBe('idle');
 
-        timers.advance(DockRevealStateMachine.DWELL_MS * 2);
+        await timers.advance(DockRevealStateMachine.DWELL_MS * 2);
         expect(machine.state).toBe('idle');
     });
 
-    test('destroy clears pending timers and detaches the change listener', () => {
+    test('destroy clears pending timers and detaches the change listener', async () => {
         let {changes, machine, timers} = createMachine({revealOnHover: true});
 
         machine.tabHoverIn('terminal');
         machine.destroy();
 
-        timers.advance(DockRevealStateMachine.DWELL_MS * 2);
+        await timers.advance(DockRevealStateMachine.DWELL_MS * 2);
 
         expect(timers.pendingCount()).toBe(0);
         expect(changes.map(change => change.next.state)).toEqual(['dwell-pending']);
+    });
+
+    test('repeated retargets retain one native timer through the actual Base registration path', async () => {
+        const {machine, timers} = createMachine({revealOnHover: true}),
+              active            = new Set(), register = machine.registerAsync.bind(machine),
+              unregister        = machine.unregisterAsync.bind(machine);
+        let registrations = 0;
+        machine.registerAsync = (id, reject) => { registrations++; active.add(id); register(id, reject) };
+        machine.unregisterAsync = id => { active.delete(id); unregister(id) };
+
+        for (let i = 0; i < 100; i++) {
+            machine.tabHoverIn(`item-${i}`);
+            expect(timers.pendingCount()).toBe(1);
+            expect(active.size).toBe(1)
+        }
+        expect(registrations).toBe(100);
+        machine.destroy();
+        expect(timers.pendingCount()).toBe(0);
+        expect(active.size).toBe(0)
+    });
+
+    test('control: bypassing Base wait ownership is visible as obsolete native timers', async () => {
+        const {machine, timers} = createMachine({revealOnHover: true});
+        machine.timeout = ms => new Promise(resolve => setTimeout(resolve, ms));
+        machine.tabHoverIn('first');
+        machine.tabHoverIn('second');
+        expect(timers.pendingCount()).toBe(2);
+        machine.destroy();
+        expect(timers.pendingCount()).toBe(2);
+        await timers.advance(300);
+        expect(Object.hasOwn(machine, 'state')).toBe(false)
+    });
+
+    test('a fulfilled dwell cannot publish after another intent wins the microtask gap', async () => {
+        const {machine, timers, changes} = createMachine({revealOnHover: true});
+        machine.tabHoverIn('first');
+        const elapsed = timers.advance(150);
+        machine.tabHoverIn('second');
+        await elapsed;
+        expect(machine.state).toBe('dwell-pending');
+        expect(machine.revealedItemId).toBeNull();
+        expect(timers.pendingCount()).toBe(1);
+        await timers.advance(150);
+        expect(machine.revealedItemId).toBe('second');
+        expect(changes.filter(change => change.next.state === 'revealed').map(change => change.next.revealedItemId))
+            .toEqual(['second'])
+    });
+
+    test('a reentrant restart to the same pending state schedules only the newer intent', async () => {
+        const {machine, timers} = createMachine({revealOnHover: true});
+        let   restart           = true;
+        machine.onChange = next => {
+            if (next.state === 'dwell-pending' && restart) {
+                restart = false;
+                machine.escape();
+                machine.tabHoverIn('same')
+            }
+        };
+        machine.tabHoverIn('same');
+        expect(timers.pendingCount()).toBe(1);
+        await timers.advance(150);
+        expect(machine.state).toBe('revealed');
+        expect(machine.revealedItemId).toBe('same')
+    });
+
+    test('live policy validates through hooks and applies to the next wait', async () => {
+        const {machine, timers} = createMachine({revealOnHover: true, dwellMs: 12, graceMs: 23});
+        machine.tabHoverIn('first');
+        machine.set({dwellMs: 5, graceMs: 7});
+        await timers.advance(11);
+        expect(machine.state).toBe('dwell-pending');
+        await timers.advance(1);
+        expect(machine.state).toBe('revealed');
+        machine.tabHoverIn('second');
+        await timers.advance(4);
+        expect(machine.revealedItemId).toBe('first');
+        await timers.advance(1);
+        expect(machine.revealedItemId).toBe('second');
+        machine.set({dwellMs: NaN, graceMs: Infinity, revealOnHover: 'true'});
+        expect([machine.dwellMs, machine.graceMs, machine.revealOnHover]).toEqual([5, 7, false]);
+        machine.overlayPointerLeave();
+        await timers.advance(7);
+        expect(machine.state).toBe('idle');
+        machine.tabHoverIn('third');
+        expect(timers.pendingCount()).toBe(0)
     });
 });


### PR DESCRIPTION
Resolves #18494
Related: #18304, #18393

RevealStateMachine now uses Base-owned cancellable waits and Neo config hooks. Its custom scheduler/canceller configs, timer handle, constructor filtering and timer-destruction code are removed. A transition identity fences reentrant notifications and already-queued continuations; destroying the owner from a dwell/grace notification cannot start work afterward. The existing reveal, focus, retarget and notification behavior remains covered.

Evidence: L3 achieved and required (rendered Rail interactions plus real Base registration/settlement receipts). Residual: none for this leaf.

## AC Evidence

| AC | Evidence |
|---|---|
| AC-1 | CI-covered: `DockRevealStateMachine.spec.mjs` observes the actual Base registration path; 100 retargets retain one timer/registration, then zero after destruction. The deliberate Base-bypass control exposes obsolete timers. |
| AC-2 | CI-covered: the existing reveal state assertions are retained; browser reveal/iframe/retarget/animation journeys remain. New hover cases observe dwell, cancellation and positive grace expiry. |
| AC-3 | CI-covered: explicit and subclass defaults, invalid input/live changes, pre-import overwrite and live Rail forwarding. Rail now omits unset timing keys rather than passing the undefined sentinel. |
| AC-4 | CI-covered: reentrant destruction in both pending states; same-state reentrant restart; fulfillment-before-retarget microtask race; repeated pending replacement; rendered Rail destruction with an active Base wait. |
| AC-5 | CI-covered: real two-Rail ownership/cleanup and existing method specialization/overwrite witnesses. |
| AC-6 | CI-covered: `BaseTimeout.spec.mjs`, `DockRevealStateMachine.spec.mjs`, `DockRail.spec.mjs` and rendered `DockRailRevealRetarget.spec.mjs`; the browser fixture delegates the real timeout/register/unregister methods and reports their outcomes. |
| AC-7 | Reveal source: 125 → 113 code lines; 298 → 245 total measured lines. Removed responsibilities are named below; no new scheduler/state-machine module. |
| AC-8 | CI-covered: optional-signal timeout tests verify pre-abort, sibling isolation, all terminal cleanup paths, exact rejection reasons and late-terminal idempotence. Existing no-signal, numeric-ID and Node Timeout teardown controls remain. |

## Deltas from ticket

The anticipated kernel gap was reproduced before editing Base: an abort could not cancel an individual inherited wait while its owner remained alive. The ticket was amended with the precise optional `Base.timeout(time, {signal})` contract and AC-8 before implementation. This adds 14 core code lines, keeps no-signal behavior, and centralizes abort-listener and timer cleanup in the existing owner.

Policy configs become reactive so the same validation hooks process construction, inheritance and live writes. Instance/subclass keys remain bare; pre-registration `Neo.overwrites` uses the declared trailing-underscore keys, as documented in `SetupClass.md` and demonstrated by `apps/form/Overwrites.mjs`. The existing overwrite witness now uses that standard spelling and still proves real Rail behavior.

Deleted from the reveal owner: setTimeoutFn, clearTimeoutFn, timerId, clearTimer, raw-argument constructor normalization, repeated timer callbacks and custom timer teardown. The remaining transient fields describe reveal intent. The destruction config hook releases the notification target; Base cancels the wait.

Decision Record impact: aligned-with ADR 0029 §2.7. No document/persistence contract changes. The opt-in kernel contract is explicitly scoped on the operator-requested ticket; this is not a new subsystem or a broader Discussion graduation.

## Test Evidence

The first four targeted tests were red before implementation: per-wait abort, inherited invalid defaults, and reentrant destruction from dwell/dismiss notifications. All then passed. The Base-bypass negative control still demonstrates why ownership matters.

Exact-head rendered receipt: `8bd7b4ecbfaa279981920c68e16f56969abc4b8f`, explicit component config and a fresh server; all five retarget/hover/teardown cases passed. Runtime assertions run in CI. The real-browser hover screenshot was also inspected: the reveal is visible while the original main-header focus remains, matching the worker-state receipt.

## Post-Merge Validation

- [x] No merge-only observation is required for this bounded repair; the primitive and rendered consumer contracts have executable coverage.

Authored by Euclid (GPT-6, Codex). Session 4f9b7bbe-9dbc-4d36-a167-38fe0d288113.
