### PR TITLE
test(workstation): the tear-out receipt names which participant owns the catalog (#18502)

### DIFF
--- a/test/playwright/e2e/utils/workstationGesture.mjs
+++ b/test/playwright/e2e/utils/workstationGesture.mjs
@@ -13,3 +13,34 @@ export async function callWorkstationGesture(app, workspaceId, method, args=[]) 
     await app.callMethod(controllerId, 'getGestureDriver');
     return app.callMethod(controllerId, `gestureDriver.${method}`, args)
 }
+
+/**
+ * @summary Item-catalog keys per Group participant — which document owns an item, not merely whether one does.
+ *
+ * A tear-out receipt reads the ORIGIN's `dockModel` alone, so a missing catalog record is indistinguishable
+ * from a record that moved to the vessel's participant. Catalog ownership is per-participant
+ * (`WorkspaceSet` derives `preserveItemIds` from the OTHER participants' `items`), which makes "gone" and
+ * "held elsewhere" different outcomes with opposite repairs.
+ *
+ * Reads only shipped surfaces — `getPopupStates` for registered participants, `getWorkspaceDocument` for
+ * committed truth per key — so no production instrumentation is added to observe it.
+ * @param {Object} app Connected Neural Link application.
+ * @param {String} workspaceId Main workspace owning the Group.
+ * @returns {Promise<Object<String,String[]>>} Catalog keys keyed by workspace id, `main` included.
+ */
+export async function captureCatalogsByParticipant(app, workspaceId) {
+    const
+        popupStates = await app.callMethod(workspaceId, 'getPopupStates') ?? [],
+        keys        = ['workstation-main', ...popupStates.map(state => state?.workspaceId).filter(Boolean)],
+        catalogs    = {};
+
+    for (const key of keys) {
+        const document = await app.callMethod(workspaceId, 'getWorkspaceDocument', [key]);
+
+        // `null` and `{}` are different answers: an unregistered participant versus one holding an empty
+        // catalog. Collapsing them would hide exactly the transfer this function exists to detect.
+        catalogs[key] = document ? Object.keys(document.items ?? {}) : null
+    }
+
+    return catalogs
+}

--- a/test/playwright/e2e/workstation/WorkstationFiveBeatNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationFiveBeatNL.spec.mjs
@@ -1,5 +1,5 @@
 import {callWorkstationTour}                                        from '../utils/workstationTour.mjs';
-import {callWorkstationGesture}                                     from '../utils/workstationGesture.mjs';
+import {callWorkstationGesture, captureCatalogsByParticipant}       from '../utils/workstationGesture.mjs';
 import {execFile}                                                   from 'node:child_process';
 import {createHash}                                                 from 'node:crypto';
 import path                                                         from 'node:path';
@@ -688,7 +688,16 @@ test.describe('Workstation — the five-beat multi-window journey', () => {
         // The step awaits the vessel birth internally, so its receipt is complete here. Asserting
         // it BEFORE the popup wait converts a silent 90s waitForEvent timeout into the step's own
         // arming/birth diagnostics — the receipt names the failing gate, the timeout names nothing.
-        expect(ownerResult.errors ?? [], JSON.stringify(ownerResult.proof ?? {})).toEqual([]);
+        //
+        // The receipt reads the ORIGIN document only, so `itemKeptInCatalog: false` cannot distinguish a
+        // lost record from one the vessel participant now owns. Both catalogs travel with the failure so
+        // the message answers that, rather than a later reader re-running the battery to ask it.
+        const catalogsByParticipant = await captureCatalogsByParticipant(app, wsId);
+
+        expect(
+            ownerResult.errors ?? [],
+            JSON.stringify({proof: ownerResult.proof ?? {}, catalogsByParticipant})
+        ).toEqual([]);
         expect(ownerResult.applied, 'the metrics tear-out must apply before merge staging continues').toBe(true);
 
         const


### PR DESCRIPTION
Resolves #18502

The instrument #17844's AC-5 needed to disposition its largest failure class.

A tear-out receipt read the **origin's** `dockModel` alone, so `itemKeptInCatalog: false` could not distinguish a **lost** record from one the **vessel's participant now owns**. Six of the battery's 43 invariant failures carry that signature, and the two readings have opposite repairs.

Evidence: L3 (the instrument answers the question it was built for, on the live failing path, and the answer reverses the prior conclusion) → L2 required. Residual: none.

## AC Evidence

| AC | Evidence |
|---|---|
| Distinguish transfer from loss | `captureCatalogsByParticipant` returns catalog keys per participant; run against the failing scene it reports the vessel holding the item |
| No production instrumentation | Reads only shipped surfaces — `getPopupStates`, `getWorkspaceDocument`. Zero files under `src/` or `apps/` touched |
| The failure message carries it | The snapshot is folded into the existing `expect(...)` message beside the receipt, so a reader sees it without re-running the battery |

## What it answered

```json
"catalogsByParticipant": {
  "workstation-main":           ["scale","feed","alerts", … 19 items, metrics ABSENT],
  "workstation-vessel:metrics": ["metrics"]
}
```

**Nothing is lost.** Catalog ownership is per-participant — `WorkspaceSet` derives `preserveItemIds` from the *other* participants' `items`, which only parses if an item lives in exactly one catalog. A correct tear-out therefore **moves** the record, and `waitForTearOutCommit`'s `Boolean(document.items?.[itemId])` on the origin is the plain-detach contract applied to a cross-window path — false by design after a successful tear-out.

**The tear-out works; the witness is wrong.** That repair lives in `NativeGestureDriver` and is @neo-gpt-emmy's surface, deliberately not touched here.

## Design notes

`null` and `[]` stay distinct: an unregistered participant and one holding an empty catalog are different answers, and collapsing them would hide the transfer this exists to detect.

The helper lives in `test/playwright/e2e/utils/workstationGesture.mjs` beside `callWorkstationGesture`, so `WorkstationTearOutSourceContinuityNL` — which carries the same message on two of its own failures — can use it without a second copy.

## Test Evidence

```
selection   WorkstationFiveBeatNL.spec.mjs -g "scene 3"   (BY NAME, not line)
env         NEO_AGENTOS_RUNTIME_ROOT=…/neo-agent-brain   dist rebuilt 23:50, mtime-asserted
result      1 failed  ·  catalogsByParticipant present in the failure message (2 occurrences)
```

The test still fails — that is the point. This PR does not repair the defect; it makes the receipt say **which** defect.

**A method note that nearly cost the result.** My first run selected the test by line number, my own edit had shifted it, and Playwright returned `No tests found` with **exit 1** — indistinguishable from a failure. It was caught only because the expected `catalogsByParticipant` occurrence count came back `0`. #17844's own AC already says *no line-number selectors*; I wrote that AC four hours earlier and then violated it.

## Deltas from ticket

None. This is the instrument #17844's AC-5 needed to disposition its largest class, not a change to the ACs.

## Post-Merge Validation

- [ ] When the predicate repair lands in `NativeGestureDriver`, this snapshot should show the item under the vessel key **and** the test pass — the same instrument confirming the fix rather than a new one.

---

Authored by Grace (Claude Opus 5, Claude Code). Session 4927990d-fb3a-4072-99c5-7811a4e26aea.
