### PR TITLE
fix(workstation): observe tear-out ownership in its vessel (#18504)

### DIFF
--- a/apps/workstation/tour/NativeGestureDriver.mjs
+++ b/apps/workstation/tour/NativeGestureDriver.mjs
@@ -843,8 +843,7 @@ class NativeGestureDriver extends GestureDriver {
                     }
                 }
 
-                // Terminal: release while detached → dockTearOutTerminal → the detachItem commit +
-                // adoption (the vessel owns the pane now).
+                // Terminal release transfers the pane into its full vessel Workspace.
                 await driver.trap(driver.simulateEvent(run, {events: [{
                     targetId: button.id, type: 'mouseup', windowId: button.windowId,
                     options : opt(outX, outY, outSX, outSY, 0)
@@ -854,24 +853,26 @@ class NativeGestureDriver extends GestureDriver {
 
                 committed && await driver.trap(Promise.resolve(me.refreshPromise));
 
-                let
-                    documentAfter  = WorkspaceDocument.clone(me.dockModel),
-                    absentFromTree = !Object.values(documentAfter.nodes).some(zoneNode => zoneNode.items?.includes(itemId)),
-                    keptInCatalog  = Boolean(documentAfter.items?.[itemId]);
+                const {sourceDocument, targetDocument, ...ownership} = driver.getTearOutCommitState(itemId),
+                      documentAfter                                  = WorkspaceDocument.clone(sourceDocument),
+                      targetDocumentAfter                            = targetDocument && WorkspaceDocument.clone(targetDocument),
+                      catalogPreserved                               = catalogBefore.every(id => Boolean(
+                          (id === itemId ? targetDocumentAfter : documentAfter)?.items[id]
+                      )),
+                      applied = committed && ownership.transferCommitted && catalogPreserved;
 
                 return {
-                    applied: committed && absentFromTree && keptInCatalog,
-                    errors : committed && absentFromTree && keptInCatalog ? [] : ['detachItem commit did not reach committed document truth'],
-                    proof  : {
+                    applied,
+                    errors: applied ? [] : ['tear-out ownership did not settle in the expected vessel'],
+                    proof : {
+                        ...ownership,
                         born              : true,
                         survivedProbe,
                         committed,
                         documentBefore,
                         documentAfter,
-                        detachCommitted   : absentFromTree && keptInCatalog,
-                        itemAbsentFromTree: absentFromTree,
-                        itemKeptInCatalog : keptInCatalog,
-                        catalogPreserved  : catalogBefore.every(id => Boolean(documentAfter.items?.[id])),
+                        targetDocumentAfter,
+                        catalogPreserved,
                         vesselWindowName  : `tearout-${itemId}`
                     }
                 }
@@ -928,8 +929,32 @@ class NativeGestureDriver extends GestureDriver {
     }
 
     /**
-     * @summary Gates on the committed detach reaching document truth: the item leaves every node's
-     * `items` (the vessel owns it) while the catalog entry stays.
+     * @summary Reads the committed ownership of a pane transferred into its expected vessel.
+     * Source release includes tree and catalog; target ownership includes catalog and placement.
+     * @param {String} itemId
+     * @returns {Object} Source/target documents, participant keys and transfer admission.
+     * @protected
+     */
+    getTearOutCommitState(itemId) {
+        const workspace         = this.workspace,
+              sourceWorkspaceId = workspace.constructor.MAIN_WORKSPACE_ID,
+              targetWorkspaceId = workspace.constructor.vesselWorkspaceId(itemId),
+              sourceDocument    = workspace.dockModel,
+              targetDocument    = workspace.getWorkspaceDocument(targetWorkspaceId),
+              sourceReleased    = !sourceDocument.items[itemId] &&
+                  !Object.values(sourceDocument.nodes).some(node => node.items?.includes(itemId)),
+              vesselOwns        = Boolean(targetDocument?.items[itemId]) &&
+                  Object.values(targetDocument.nodes).some(node => node.items?.includes(itemId));
+
+        return {
+            sourceDocument, sourceReleased, sourceWorkspaceId,
+            targetDocument, targetWorkspaceId, vesselOwns,
+            transferCommitted: sourceReleased && vesselOwns
+        }
+    }
+
+    /**
+     * @summary Waits for source release and committed ownership in the expected vessel Workspace.
      * @param {String} itemId
      * @param {Object} [options={}]
      * @param {Number} [options.attempts=180]
@@ -938,15 +963,7 @@ class NativeGestureDriver extends GestureDriver {
      * @protected
      */
     async waitForTearOutCommit(itemId, {attempts=180, delay=16}={}) {
-        let me       = this.workspace, driver = this,
-            detached = () => {
-                let document = me.dockModel;
-
-                return !Object.values(document.nodes).some(zoneNode => zoneNode.items?.includes(itemId))
-                    && Boolean(document.items?.[itemId])
-            };
-
-        return driver.waitFor(detached, {attempts, delay})
+        return this.waitFor(() => this.getTearOutCommitState(itemId).transferCommitted, {attempts, delay})
     }
 }
 

--- a/test/playwright/e2e/workstation/WorkstationFiveBeatNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationFiveBeatNL.spec.mjs
@@ -1545,6 +1545,7 @@ test.describe('Workstation — the five-beat multi-window journey', () => {
         }
 
         const
+            documentBefore  = await readDocument(app, wsId),
             heartbeatBefore = await readHeartbeat(app, wsId),
             paneIdBefore    = (await app.callMethod(wsId, 'getPaneIdentity', ['metrics'])),
             popupPromise    = page.waitForEvent('popup', {timeout: 90000});
@@ -1561,7 +1562,11 @@ test.describe('Workstation — the five-beat multi-window journey', () => {
         expect(result.errors).toEqual([]);
         expect(result.proof.born,  'the vessel must be born MID-GESTURE (before pointer-up)').toBe(true);
         expect(result.proof.survivedProbe, 'post-birth outward moves must not reap the vessel').toBe(true);
-        expect(result.applied, 'the detached release must commit detachItem').toBe(true);
+        expect(result.applied, 'the detached release must transfer into its vessel Workspace').toBe(true);
+        expect(result.proof).toMatchObject({
+            sourceReleased   : true, vesselOwns: true, transferCommitted: true, catalogPreserved: true,
+            targetWorkspaceId: 'workstation-vessel:metrics'
+        });
 
         // The popup is a REAL OS window in Playwright's window set — and it stays alive: it owns
         // the pane now.
@@ -1612,11 +1617,17 @@ test.describe('Workstation — the five-beat multi-window journey', () => {
         }
 
         // Third-party truth: the committed document read fresh from the worker.
-        const documentAfter = await readDocument(app, wsId);
+        const documentAfter               = await readDocument(app, wsId),
+              vesselDocument              = await app.callMethod(wsId, 'getWorkspaceDocument', ['workstation-vessel:metrics']),
+              {metrics, ...sourceCatalog} = documentBefore.items;
 
         expect(Object.values(documentAfter.nodes).some(node => node.items?.includes('metrics')),
             'the torn item must be ABSENT from every node').toBe(false);
-        expect(documentAfter.items.metrics, 'the torn item must stay in the catalog').toBeTruthy();
+        expect(documentAfter.items, 'the source releases only the transferred catalog record').toEqual(sourceCatalog);
+        expect(vesselDocument, 'the expected vessel is a registered participant').toBeTruthy();
+        expect(vesselDocument.items.metrics, 'the vessel owns the unchanged catalog record').toEqual(metrics);
+        expect(Object.values(vesselDocument.nodes).some(node => node.items?.includes('metrics')),
+            'the transferred record is placed in the vessel tree').toBe(true);
         expect(documentAfter.nodes['right-top-tabs'].items, 'the sibling tab keeps the node alive')
             .toEqual(['audit']);
 
@@ -2813,11 +2824,11 @@ test.describe('Workstation — the five-beat multi-window journey', () => {
             expect(targetPopup.isClosed(), 'the first committed vessel must stay physically open').toBe(false);
 
             beatLog.push({
-                beat            : 'tear-out',
-                bornMidGesture  : true,
-                detachCommitted : ownerResult.proof.detachCommitted,
-                ownerWorkspaceId: 'workstation-vessel:metrics',
-                sourceItems     : ownerResult.proof.documentAfter.nodes['right-top-tabs'].items
+                beat             : 'tear-out',
+                bornMidGesture   : true,
+                transferCommitted: ownerResult.proof.transferCommitted,
+                ownerWorkspaceId : 'workstation-vessel:metrics',
+                sourceItems      : ownerResult.proof.documentAfter.nodes['right-top-tabs'].items
             });
 
             expect(

--- a/test/playwright/unit/apps/workstation/GestureDriver.spec.mjs
+++ b/test/playwright/unit/apps/workstation/GestureDriver.spec.mjs
@@ -164,3 +164,53 @@ test('a successful release creates no cancellation input and leaves borrowed wor
     expect(service.isDestroyed).toBe(true);
     expect(workspace.isDestroyed).toBe(false)
 });
+
+test.describe('tear-out commit ownership', () => {
+    const cases = [
+        {name: 'accepts a record placed in the expected vessel', expected: true, mutate() {}},
+        {name: 'rejects a source-only detach', expected: false, mutate({source, documents, targetId}) {
+            source.items.metrics = {};
+            delete documents[targetId]
+        }},
+        {name: 'rejects an unregistered vessel', expected: false, mutate({documents, targetId}) {
+            delete documents[targetId]
+        }},
+        {name: 'rejects a lost record', expected: false, mutate({target}) {
+            delete target.items.metrics;
+            target.nodes.target.items = []
+        }},
+        {name: 'rejects ownership in a different vessel', expected: false, mutate({documents, targetId, target}) {
+            documents[Workspace.vesselWorkspaceId('audit')] = target;
+            delete documents[targetId]
+        }},
+        {name: 'rejects duplicated source and vessel catalogs', expected: false, mutate({source}) {
+            source.items.metrics = {}
+        }},
+        {name: 'rejects a source that still places the item', expected: false, mutate({source}) {
+            source.nodes.source.items.push('metrics')
+        }},
+        {name: 'rejects an unplaced vessel record', expected: false, mutate({target}) {
+            target.nodes.target.items = []
+        }}
+    ];
+
+    for (const {name, expected, mutate} of cases) {
+        test(name, async () => {
+            const {default: NativeGestureDriver} = await import('../../../../../apps/workstation/tour/NativeGestureDriver.mjs');
+            const source                         = {items: {audit: {}}, nodes: {source: {type: 'tabs', items: ['audit']}}},
+                  target = {items: {metrics: {}}, nodes: {target: {type: 'tabs', items: ['metrics']}}},
+                  targetId = Workspace.vesselWorkspaceId('metrics'),
+                  documents = {[Workspace.MAIN_WORKSPACE_ID]: source, [targetId]: target},
+                  workspace = {constructor: Workspace, dockModel: source, isDestroyed: false,
+                      getWorkspaceDocument: key => documents[key] ?? null},
+                  driver = Neo.create(NativeGestureDriver, {workspace});
+
+            mutate({source, target, targetId, documents});
+            try {
+                await expect(driver.waitForTearOutCommit('metrics', {attempts: 0})).resolves.toBe(expected)
+            } finally {
+                driver.destroy()
+            }
+        })
+    }
+});


### PR DESCRIPTION
Resolves #18504

Workstation's tear-out journey now recognizes the pane in its expected vessel Workspace. The wait and final receipt share one ownership check: the source releases the tree and catalog entry, while the vessel owns and places it. The receipt includes both participant keys and documents, and the existing scene-two test verifies the transferred record, unchanged source catalog, live pane identity and vessel styling.

Evidence: L3 (real pointer tear-out, source/vessel document readback, rendered vessel, plain/film continuity and re-entry) → L3 required. Residual: broader source-paint/native-battery qualification, Residual-Owner: #17844.

Micro-review eligible: contained — repairs an existing tour outcome and its actual readers; no engine operation or native-window policy changes.

## AC Evidence

| AC | Evidence |
|---|---|
| AC-1 | Headed scene two returns `applied: true`, observes source release and exact `workstation-vessel:metrics` ownership, and preserves the live pane identity. |
| AC-2 | `GestureDriver.spec.mjs` has eight ownership controls. The former predicate failed the valid-transfer, source-only and duplicated-catalog cases; the repaired predicate passes all eight. Missing, lost, wrong-vessel, still-source-placed and unplaced-target cases refuse. |
| AC-3 | `getTearOutCommitState` supplies the wait and final result. `catalogPreserved` checks the moved record in the target and every other original record in the source. |
| AC-4 | Workstation's source-only catalog assertion and beat-log reader are updated together. Scene two retains store/component, theme and pane-style assertions; the re-entry journey retains zero-mutation checks. DemoB's separate readers remain unchanged. |
| AC-5 | Four selected headed witnesses pass at `dbd91de247` with the explicit Brain runtime. A separately reached whole-window entropy failure is retained on #17844, as detailed below. |

## Deltas from ticket

None substantive. The receipt replaces `detachCommitted`, `itemAbsentFromTree` and `itemKeptInCatalog` with `transferCommitted`, `sourceReleased` and `vesselOwns`, plus the exact source/target workspace keys and `targetDocumentAfter`. `documentAfter` continues to mean the source document. No new registry or production instrumentation is added.

Change class: restoration (`fix`). `agent-preflight` is not hosted in this Engine checkout (explicit Missing script result); commit hooks passed and the shared PR-baseline jobs remain the hosted gate.

## Test Evidence

At `dbd91de247`, headed macOS run `18504-final-head` passes **4/4 in 14.5s**: scene-two tear-out, zero-mutation re-entry, and plain/film-pace source continuity. Command uses `test/playwright/playwright.config.e2e.mjs`, `--workers=1 --headed`, explicit `NEO_AGENTOS_RUNTIME_ROOT`, and selects those cases by name. Source and vessel trace frames were inspected.

The initial four-case run also selected the whole-window continuity oracle: **3 passed / 1 failed**. Ownership passed, then the unchanged entropy assertion reported **0.26526** against a **3.31673** floor. The [failure and trace are retained on #17844](https://github.com/neomjs/neo/issues/17844#issuecomment-5592589386); no cause attribution, assertion relaxation or whole-film acceptance is claimed. The final run adds the existing re-entry control and does not erase that earlier sample.

## Post-Merge Validation

- [ ] Continue the broader source-paint/native battery through #17844 with the repaired ownership receipt; keep the recorded entropy sample in its evidence set.

Related: #17844 · #18502 · #18458

Authored by Emmy (GPT-6 Astra, Codex) consuming Grace's runtime handoff — session A 4927990d-fb3a-4072-99c5-7811a4e26aea, session B 153d2e0a-ebae-4087-bcd5-3c92d213132c.
