### PR TITLE
ci(test): make the e2e tier dispatchable as a flake probe (#18505)

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -241,6 +241,33 @@ jobs:
           echo "selection: ${paths}"
           echo "repeat-each: ${PROBE_REPEAT}"
 
+          # A probe must never measure LESS than it was asked to.
+          #
+          # `playwright.config.e2e.mjs` uses `testIgnore` for the Brain-dependent specs, and naming
+          # one on the command line does NOT override it. A selector mixing a gated spec with a
+          # reachable one therefore runs only the reachable half and exits 0 — measured: two files
+          # requested, one file selected, "3 passed", exit 0. That is a rate whose denominator was
+          # silently reduced, reported as a clean pass, which is precisely the false green this tier
+          # exists to remove. A gated spec named ALONE already fails with "No tests found"; it is the
+          # mixed selector that lies.
+          #
+          # Checked only when the caller named files: a directory's file count is not an assertion
+          # about what should run, so comparing against it would fail every ordinary tier run.
+          if [ -n "${PROBE_SPECS}" ]; then
+            requested=$(printf '%s\n' ${PROBE_SPECS} | grep -c '\.spec\.mjs$' || true)
+
+            if [ "${requested}" -gt 0 ]; then
+              selected=$(npx playwright test -c test/playwright/playwright.config.e2e.mjs --list ${paths} 2>&1 \
+                | grep -oE 'in [0-9]+ file' | grep -oE '[0-9]+' | tail -1)
+
+              if [ "${selected:-0}" -ne "${requested}" ]; then
+                echo "::error::probe selection mismatch — asked for ${requested} spec file(s), Playwright selected ${selected:-0}."
+                echo "Specs removed by testIgnore are dropped without warning; with NEO_AGENTOS_RUNTIME_ROOT unset that is the whole Brain-gated set."
+                exit 1
+              fi
+            fi
+          fi
+
           # Deliberately unquoted: the selection is a space-separated list that must word-split
           # into separate arguments.
           npx playwright test -c test/playwright/playwright.config.e2e.mjs --workers=1 \

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -253,15 +253,25 @@ jobs:
           #
           # Checked only when the caller named files: a directory's file count is not an assertion
           # about what should run, so comparing against it would fail every ordinary tier run.
+          # Compared by NAME, not by count. A cardinality check is defeated by mixing a file with a
+          # directory: naming one gated spec plus `e2e/colors` requests one `.spec.mjs` token and
+          # selects one file — `colors/tearOutMatrix.spec.mjs`, with zero of the spec actually named.
+          # One equals one, the guard passes, and the probe measured something nobody asked for.
+          # Every named file must therefore appear in the listing on its own account.
           if [ -n "${PROBE_SPECS}" ]; then
-            requested=$(printf '%s\n' ${PROBE_SPECS} | grep -c '\.spec\.mjs$' || true)
+            requested=$(printf '%s\n' ${PROBE_SPECS} | grep '\.spec\.mjs$' || true)
 
-            if [ "${requested}" -gt 0 ]; then
-              selected=$(npx playwright test -c test/playwright/playwright.config.e2e.mjs --list ${paths} 2>&1 \
-                | grep -oE 'in [0-9]+ file' | grep -oE '[0-9]+' | tail -1)
+            if [ -n "${requested}" ]; then
+              listing=$(npx playwright test -c test/playwright/playwright.config.e2e.mjs --list ${paths} 2>&1)
+              missing=''
 
-              if [ "${selected:-0}" -ne "${requested}" ]; then
-                echo "::error::probe selection mismatch — asked for ${requested} spec file(s), Playwright selected ${selected:-0}."
+              while read -r want; do
+                [ -z "${want}" ] && continue
+                printf '%s\n' "${listing}" | grep -qF "${want#test/playwright/e2e/}" || missing="${missing} ${want}"
+              done <<< "${requested}"
+
+              if [ -n "${missing}" ]; then
+                echo "::error::probe selection mismatch — these named specs were not selected:${missing}"
                 echo "Specs removed by testIgnore are dropped without warning; with NEO_AGENTOS_RUNTIME_ROOT unset that is the whole Brain-gated set."
                 exit 1
               fi

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -24,6 +24,24 @@ on:
     branches: [dev]
   push:
     branches: [dev]
+  # Dispatch turns the tier into a measuring instrument (#18505). Until it existed, a hosted
+  # sample cost a pull request and arrived only when someone tripped over a red — so an
+  # intermittent had failures but no DENOMINATOR, and the rerun that unblocks a PR marks the run
+  # green and erases the sample it produced. Rates measured that way wander: #18439's arm read
+  # 2/2, then 1/2, then 1/3, then 0/19 on unchanged source.
+  #
+  # Dispatch-only rather than scheduled, deliberately: #14685's nightly runner is this
+  # repository's own evidence that unowned scheduled execution decays until nobody notices it
+  # stopped. This costs nothing when unused and always has a person behind it.
+  workflow_dispatch:
+    inputs:
+      specs:
+        description: 'Spec paths to run instead of the tier selection (space-separated). Empty runs the ordinary selection.'
+        type: string
+      repeatEach:
+        description: 'Run each selected test this many times — the denominator of the measurement.'
+        type: string
+        default: '1'
 
 concurrency:
   # Matches `test.yml`: initial attempts share the ref stream so a new head supersedes
@@ -181,12 +199,37 @@ jobs:
       #
       # NEO_TEST_SKIP_CI activates the in-spec quarantine guards, the lever the unit
       # suite already uses; each guard states the condition it stands in for.
+      # The five-minute ceiling is the GATE's budget and stays exactly that for `pull_request` and
+      # `push`. A dispatch is a measurement rather than a gate — N repeats of a spec are meant to
+      # take N times as long — so it gets its own budget. Sharing the gate's ceiling would silently
+      # truncate a probe and report a rate that is an artifact of the timeout.
       - name: Run e2e (engine tier)
         if: ${{ needs.changes.outputs.run_e2e == 'true' && steps.head.outputs.current == 'true' }}
-        timeout-minutes: 5
-        run: npx playwright test -c test/playwright/playwright.config.e2e.mjs --workers=1 ${{ steps.selection.outputs.paths }}
+        timeout-minutes: ${{ github.event_name == 'workflow_dispatch' && 30 || 5 }}
         env:
           NEO_TEST_SKIP_CI: 'true'
+          # Dispatch inputs reach the shell as ENVIRONMENT, never interpolated into this script.
+          # `${{ inputs.specs }}` spliced into a `run:` is a command-injection surface, and
+          # "only maintainers can dispatch" is a mitigation rather than a fix. Read as `$PROBE_SPECS`
+          # the value is only ever word-split into arguments: shell metacharacters inside it are
+          # data, because they are not literal text in this script.
+          PROBE_SPECS: ${{ inputs.specs }}
+          PROBE_REPEAT: ${{ inputs.repeatEach || '1' }}
+          TIER_PATHS: ${{ steps.selection.outputs.paths }}
+        run: |
+          # `pipefail`, because a pipeline reports its LAST command's status: without it `tee`
+          # would return 0 over a red suite and the gate would pass on a failing run.
+          set -o pipefail
+
+          paths="${PROBE_SPECS:-$TIER_PATHS}"
+
+          echo "selection: ${paths}"
+          echo "repeat-each: ${PROBE_REPEAT}"
+
+          # Deliberately unquoted: the selection is a space-separated list that must word-split
+          # into separate arguments.
+          npx playwright test -c test/playwright/playwright.config.e2e.mjs --workers=1 \
+            --repeat-each="${PROBE_REPEAT}" ${paths} 2>&1 | tee /tmp/e2e-run.log
 
       # `always()`, because a failed run needs its coverage stated more than a green one
       # does — and the destination is unescaped on purpose: an earlier inline form wrote
@@ -196,6 +239,27 @@ jobs:
       # Conjoined with the gate: coverage describes a run, and on a skipped diff there is
       # no run to describe. Printing "covers 20 of 104" when nothing executed would be a
       # louder version of the false green this summary exists to prevent.
+      # The measurement's whole point: a rate with its DENOMINATOR, on the run page rather than
+      # reconstructed from a log by whoever reads it next. `always()`, because a probe that ends
+      # red is the one whose numbers are wanted most.
+      - name: Report probe rate
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && needs.changes.outputs.run_e2e == 'true' && steps.head.outputs.current == 'true' }}
+        env:
+          PROBE_SPECS: ${{ inputs.specs }}
+          PROBE_REPEAT: ${{ inputs.repeatEach || '1' }}
+        run: |
+          {
+            echo "### Probe result"
+            echo
+            echo "- selection: \`${PROBE_SPECS:-<tier selection>}\`"
+            echo "- repeat-each: \`${PROBE_REPEAT}\`"
+            echo
+            # Playwright's own tally is the denominator. Absent means the run died before
+            # reporting, which is itself the answer and must not read as a clean zero.
+            grep -aE '^ *[0-9]+ (passed|failed|flaky|skipped|did not run)' /tmp/e2e-run.log \
+              || echo 'no Playwright summary line — the run did not reach its reporter'
+          } >> "$GITHUB_STEP_SUMMARY"
+
       - name: Report tier coverage
         if: ${{ always() && needs.changes.outputs.run_e2e == 'true' && steps.head.outputs.current == 'true' }}
         run: node buildScripts/util/e2eCiSelection.mjs --summary >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -44,9 +44,16 @@ on:
         default: '1'
 
 concurrency:
-  # Matches `test.yml`: initial attempts share the ref stream so a new head supersedes
+  # Gate runs match `test.yml`: initial attempts share the ref stream so a new head supersedes
   # old work, while reruns keep their run_id and cannot cancel a newer head (#15593).
-  group: tests-${{ github.workflow }}-${{ github.run_attempt == '1' && github.ref || github.run_id }}
+  #
+  # A DISPATCH gets its own key instead, and this was measured rather than anticipated: two probes
+  # dispatched on one ref shared the ref-keyed group, and the second cancelled the first
+  # mid-measurement. Superseding is right for a gate — only the newest head matters — and wrong for
+  # an instrument, where every sample is wanted and repeated runs are the entire point. Keying a
+  # dispatch on its own run_id makes each probe a group of one: it cancels nothing and nothing
+  # cancels it.
+  group: tests-${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && github.run_id || (github.run_attempt == '1' && github.ref || github.run_id) }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -74,7 +74,15 @@ jobs:
     needs: changes
     # Bounds provisioning plus tests. The test-time ceiling is the step below; this
     # exists so a hung install cannot occupy a runner indefinitely.
-    timeout-minutes: 12
+    # The gate keeps its twelve minutes: provisioning plus a five-minute test step, so a hung
+    # install cannot occupy a runner indefinitely.
+    #
+    # A dispatch needs its own, and the reason is that a job bound SILENTLY CAPS a step bound. The
+    # dispatch test step below asks for thirty minutes; under a twelve-minute job it would have got
+    # twelve, and a probe killed at the job bound reports a rate that is an artifact of a limit
+    # nothing in the log names. Forty-five leaves the thirty-minute step its full allowance plus
+    # provisioning and reporting, so the step's own bound is the one that actually binds.
+    timeout-minutes: ${{ github.event_name == 'workflow_dispatch' && 45 || 12 }}
 
     steps:
       # The classifier's verdict is a PREREQUISITE's output, and re-running a failed job does not
@@ -258,6 +266,13 @@ jobs:
           {
             echo "### Probe result"
             echo
+            if [ -n "${PROBE_SPECS}" ]; then
+              echo "**This run covers the selection below and nothing else** — it is a measurement,"
+              echo "not a tier run, and its green says nothing about the tier's coverage."
+            else
+              echo "Ordinary tier selection; see the coverage section for the population it certifies."
+            fi
+            echo
             echo "- selection: \`${PROBE_SPECS:-<tier selection>}\`"
             echo "- repeat-each: \`${PROBE_REPEAT}\`"
             echo
@@ -267,8 +282,15 @@ jobs:
               || echo 'no Playwright summary line — the run did not reach its reporter'
           } >> "$GITHUB_STEP_SUMMARY"
 
+      # NOT emitted for a probe that named its own specs. `e2eCiSelection --summary` describes the
+      # TIER's population — "selected 14 of 105" — which is a true statement about the tier and a
+      # false one about a run that executed a single spec. Printing it beside a one-spec probe
+      # would manufacture exactly the coverage-that-was-not-run claim this summary exists to
+      # prevent, and it would do it in the honesty guard itself.
+      #
+      # A probe's population is reported by `Report probe rate` above, from its actual selection.
       - name: Report tier coverage
-        if: ${{ always() && needs.changes.outputs.run_e2e == 'true' && steps.head.outputs.current == 'true' }}
+        if: ${{ always() && needs.changes.outputs.run_e2e == 'true' && steps.head.outputs.current == 'true' && (github.event_name != 'workflow_dispatch' || inputs.specs == '') }}
         run: node buildScripts/util/e2eCiSelection.mjs --summary >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload test artifacts on failure

--- a/test/playwright/unit/buildScripts/util/WorkflowScopeClassifier.spec.mjs
+++ b/test/playwright/unit/buildScripts/util/WorkflowScopeClassifier.spec.mjs
@@ -247,6 +247,15 @@ test.describe('Tests scope classifier — the outputs the changes job actually d
         // Scoped to named files: an ordinary tier run passes directories, whose file count is not a
         // caller assertion, and a guard that compared against those would fail every gate run.
         expect(run).toContain('if [ -n "${PROBE_SPECS}" ]');
+
+        // By NAME, never by count. A cardinality check is defeated by mixing a file with a
+        // directory — one gated spec plus `e2e/colors` requests one `.spec.mjs` token and selects
+        // one file, a different one, so one equals one and the probe measures something nobody
+        // asked for. The guard must therefore search the listing for each named spec.
+        expect(run, 'each named spec must be sought in the listing').toContain('grep -qF');
+        expect(run, 'and the failure must name what was missing').toContain('were not selected');
+        expect(run, 'a bare cardinality comparison is the defeated form')
+            .not.toMatch(/-ne\s+"\$\{requested\}"/);
     });
 
     test('a dispatch is not silently capped by the job bound', () => {

--- a/test/playwright/unit/buildScripts/util/WorkflowScopeClassifier.spec.mjs
+++ b/test/playwright/unit/buildScripts/util/WorkflowScopeClassifier.spec.mjs
@@ -213,6 +213,40 @@ test.describe('Tests scope classifier — the outputs the changes job actually d
         }
     });
 
+    test('a custom-selection probe does not claim the tier\'s coverage, and the gate still does', () => {
+        // `e2eCiSelection --summary` prints "selected 14 of 105" — true of the TIER, false of a run
+        // that executed one named spec. Emitted beside a probe it would manufacture a
+        // coverage-that-was-not-run claim inside the honesty guard itself, which is the one place
+        // it would be believed. Discriminating on purpose: the gate must still emit it, so a
+        // condition that silenced the summary everywhere would pass a one-sided assertion.
+        const steps    = readWorkflow('test-e2e.yml').jobs['e2e-engine'].steps,
+              coverage = steps.find(step => step.name === 'Report tier coverage'),
+              probe    = steps.find(step => step.name === 'Report probe rate');
+
+        expect(coverage, 'the tier coverage step must exist to be conditioned').toBeTruthy();
+        expect(probe,    'and the probe reports its own population').toBeTruthy();
+
+        // Suppressed only when a dispatch named its own specs — never for `pull_request` / `push`.
+        expect(coverage.if).toContain("github.event_name != 'workflow_dispatch' || inputs.specs == ''");
+        expect(probe.if).toContain("github.event_name == 'workflow_dispatch'");
+    });
+
+    test('a dispatch is not silently capped by the job bound', () => {
+        // A job `timeout-minutes` CAPS a step's: the dispatch test step asks for 30, and under the
+        // gate's 12-minute job it would have received 12 — a probe killed by a limit nothing in the
+        // log names, reporting a rate that is an artifact of the bound. The job allowance must
+        // exceed the step's, and the gate's own numbers must be untouched.
+        const job  = readWorkflow('test-e2e.yml').jobs['e2e-engine'],
+              step = job.steps.find(s => s.name === 'Run e2e (engine tier)');
+
+        const nums = String(job['timeout-minutes']).match(/\d+/g).map(Number),
+              sNum = String(step['timeout-minutes']).match(/\d+/g).map(Number);
+
+        expect(Math.max(...nums), 'the dispatch job allowance').toBeGreaterThan(Math.max(...sNum));
+        expect(Math.min(...nums), 'the gate job bound is unchanged').toBe(12);
+        expect(Math.min(...sNum), 'the gate test-step ceiling is unchanged').toBe(5);
+    });
+
     test('the e2e job consumes BOTH gates on every step that costs anything', () => {
         // `test.yml` resolves its flag once into `matrix.run`; the single-job e2e pipeline has no
         // matrix to hang it on, so each step carries the conditions itself. An ungated provisioning

--- a/test/playwright/unit/buildScripts/util/WorkflowScopeClassifier.spec.mjs
+++ b/test/playwright/unit/buildScripts/util/WorkflowScopeClassifier.spec.mjs
@@ -231,6 +231,24 @@ test.describe('Tests scope classifier — the outputs the changes job actually d
         expect(probe.if).toContain("github.event_name == 'workflow_dispatch'");
     });
 
+    test('a probe refuses to measure less than it was asked to', () => {
+        // `testIgnore` deselects the Brain-gated specs, and naming one on the command line does not
+        // override it — so a selector mixing a gated spec with a reachable one runs only the
+        // reachable half and exits 0. Measured on this tree: two files requested, one selected,
+        // "3 passed". A rate whose denominator was silently reduced, dressed as a clean pass.
+        //
+        // A gated spec named ALONE already fails with "No tests found"; the mixed selector is the
+        // one that lies, so the guard compares requested spec FILES against what Playwright selects.
+        const run = readWorkflow('test-e2e.yml').jobs['e2e-engine'].steps
+            .find(step => step.name === 'Run e2e (engine tier)').run;
+
+        expect(run, 'the guard must compare requested against selected').toContain('probe selection mismatch');
+        expect(run, 'and it must exit non-zero rather than warn').toMatch(/probe selection mismatch[\s\S]*exit 1/);
+        // Scoped to named files: an ordinary tier run passes directories, whose file count is not a
+        // caller assertion, and a guard that compared against those would fail every gate run.
+        expect(run).toContain('if [ -n "${PROBE_SPECS}" ]');
+    });
+
     test('a dispatch is not silently capped by the job bound', () => {
         // A job `timeout-minutes` CAPS a step's: the dispatch test step asks for 30, and under the
         // gate's 12-minute job it would have received 12 — a probe killed by a limit nothing in the

--- a/test/playwright/unit/buildScripts/util/WorkflowScopeClassifier.spec.mjs
+++ b/test/playwright/unit/buildScripts/util/WorkflowScopeClassifier.spec.mjs
@@ -103,7 +103,8 @@ const createRuntime = ({
     getContentError = null,
     forkOwner       = null,
     forkUnreadable  = false,
-    liveHead        = 'head-sha'
+    liveHead        = 'head-sha',
+    eventName       = 'pull_request'
 } = {}) => {
     const outputs = new Map(),
           info    = [],
@@ -151,7 +152,7 @@ const createRuntime = ({
               }
           },
           context = {
-              eventName: 'pull_request',
+              eventName,
               payload  : {
                   pull_request: {
                       base: { sha: baseSha },
@@ -463,6 +464,27 @@ test.describe('Tests scope classifier — unit admission on docs and content pat
 });
 
 test.describe('Tests scope classifier — unavailable diffs', () => {
+
+    test('a workflow_dispatch admits every suite, and does so on purpose', async () => {
+        // The e2e tier is dispatchable as a measuring instrument, and a dispatch has no diff to
+        // classify: `getChangedFiles` returns null for any event that is not a pull request or a
+        // push, which lands on the unavailable branch and admits everything. That is the right
+        // answer — a probe naming its own specs must not be gated on paths nobody changed — but it
+        // arrives by falling through rather than by decision, and an untested fall-through is one
+        // refactor from becoming a dispatch that silently runs nothing.
+        const runtime = createRuntime({ eventName: 'workflow_dispatch' });
+
+        await executeScript(scopeScript(), runtime);
+
+        expect(runtime.calls.listFiles, 'a dispatch has no diff to list').toBe(0);
+        expect(runtime.calls.pullsGet,  'and no head to compare').toBe(0);
+        expect(outputsOf(runtime)).toMatchObject({
+            run_components: 'true',
+            run_e2e       : 'true',
+            run_unit      : 'true',
+            skip_reason   : 'changed files unavailable'
+        });
+    });
 
     test('an empty changed-file set runs both suites', async () => {
         const runtime = createRuntime({ files: [] });


### PR DESCRIPTION
Resolves #18505

## What was wrong

Three tickets I hold — #18439, #18427, #18422 — are hosted-runner-only symptoms, and all three are stuck at the same step: **there is no way to run a spec N times on a hosted runner and read the rate.**

Today a hosted sample costs a pull request and arrives only when someone trips over a red. That produces **failures with no denominator** — #18439 had six samples and no idea across how many runs — and the `gh run rerun` that unblocks a PR marks the run green, so the sample it produced becomes invisible to any later count. The process consumes its own evidence. Rates measured that way wander: #18439's arm read **2/2, then 1/2, then 1/3, then 0/19 on unchanged source.**

## The shape

`test-e2e.yml` gains a `workflow_dispatch` with `specs` and `repeatEach`. **No new workflow** — the tier already knew how to run itself; it needed exposing, not rebuilding. Dispatch-only rather than scheduled: #14685's nightly runner is this repository's own evidence that unowned scheduled execution decays until nobody notices it stopped.

## AC Evidence — all six, measured on the hosted runner

| # | AC | Status |
|---|---|---|
| 1 | A dispatch naming one spec at `repeatEach: N` runs it N times and nothing else | **MET** — [run 34287410002](https://github.com/neomjs/neo/actions/runs/34287410002) |
| 2 | Inputs reach the command through `env:`, so metacharacters cannot execute | **MET** — [run 34287850005](https://github.com/neomjs/neo/actions/runs/34287850005), plus a local positive control |
| 3 | Default behaviour untouched; `pull_request` / `push` parse identical | **MET** — YAML comparison against `dev` |
| 4 | The classifier's dispatch path asserted, not left to the fail-open branch by luck | **MET** — new arm; classifier spec 44 passed, was 43 |
| 5 | The test-time budget accommodates the repeat rather than truncating it | **MET at `d5c876adc9`** — and it was **not** met when I first claimed it; see RA-1 |
| 6 | First use recorded on #18439 with rate **and denominator** | **MET** — [run 34287880651](https://github.com/neomjs/neo/actions/runs/34287880651) |

### A claim in this PR's first body was wrong, and a reviewer falsified it

I wrote that AC-1 and AC-6 *"cannot be evidenced before merge, and that is a platform constraint rather than a choice"* — that GitHub only offers `workflow_dispatch` for workflows on the default branch.

**That is false.** @neo-gpt-emmy tested it instead of accepting it ([run 34287187187](https://github.com/neomjs/neo/actions/runs/34287187187)), and I reproduced it independently: `gh workflow run --ref <branch>` dispatches an unmerged branch's workflow. Every AC above is therefore evidenced **pre-merge**, on the real runner.

It was one command away from being checked and I asserted it instead. The correction matters beyond this PR: "the platform won't let me" is the most self-serving shape a deferral can take, and it should be the first thing tested rather than the last.

## AC-6 — the measurement, and it separates the two failure modes

```
specs:       ThumbDragPause.spec.mjs  TreeBigData.spec.mjs
repeat-each: 20

ThumbDragPause    5 red / 20      25%
TreeBigData       0 red / 100     0%     (5 tests x 20)

failure: "no frame blanked during or after the pause"  Expected 0, Received 8
```

Six opportunistic samples could never have produced this. It shows:

- **ThumbDragPause is a 25% flake on hosted hardware** — not rare, and it reproduced in a **two-file** selection with no tier depth. Combined with 0/13 locally, that makes it **host-dependent and NOT position-dependent**, which retires one of #18439's two standing hypotheses.
- **TreeBigData did not reproduce once in 100 executions** here, yet has three observed failures in full-tier runs at position ~24. So the selection mode may be the position-sensitive one after all — the opposite of what a merged "rotating casualty" description implied.

Two modes, two different rates, two different dependencies. Recorded on #18439.

## Two more defects, from review — both the class this workflow exists to prevent

**RA-1 — a job `timeout-minutes` silently CAPS a step's.** The dispatch test step asks for thirty minutes; the job allowed twelve. A long probe would have been killed at twelve by a limit nothing in the log names, reporting a rate that is an artifact of the bound rather than a property of the arm.

**My AC-5 claim was therefore wrong when I made it.** It held for the ten-minute probe I happened to run and not for the case the AC describes, and I generalised from the run to the contract. A dispatch job now allows forty-five; the gate keeps twelve and its five-minute step exactly.

**RA-2 — the probe was claiming the tier's coverage.** `e2eCiSelection --summary` prints *"selected 14 of 105"*: true of the tier, false of a run that executed one named spec, and it was emitted beside every probe. A coverage claim about specs that did not run, printed inside the honesty guard, is the most credible place to put a false one — and this workflow's entire reason for having that guard is that `testIgnore` already makes green certify less than it appears to.

Suppressed now when a dispatch names its own specs; the probe report states the run covers its selection **and nothing else**. Gate reporting untouched.

**Verified on the runner** at `d5c876adc9` ([run 34289449733](https://github.com/neomjs/neo/actions/runs/34289449733), `repeatEach: 2`): the tier claim is absent, the coverage step is skipped, the probe report is present, and the run is green.

Both arms are two-sided where it matters — the coverage arm asserts the **gate still emits** the summary, so a condition that silenced it everywhere would pass a one-sided check while removing the guard from the runs that need it.

## A false green found in review, before merge — and it is this instrument's own defect class

@neo-opus-vega caught it while I was about to recommend the opposite. `playwright.config.e2e.mjs` uses `testIgnore` for the Brain-dependent specs, and **naming one on the command line does not override it.** So a selector mixing a gated spec with a reachable one runs only the reachable half and exits 0. Measured on this tree:

```
DemoBCrossWindowDragNL.spec.mjs + grid/Tree.spec.mjs
  -> "Total: 3 tests in 1 file"  ->  "3 passed"  ->  exit 0
```

Two files requested, one selected, **green**. With `repeatEach` that is a rate whose denominator was silently reduced, handed back as a clean pass — worse than no data, because it looks like data. A gated spec named **alone** already fails with `No tests found`; it is the mixed selector that lies, and that is the one a person reaching for a probe would naturally write.

The run step now compares requested spec **files** against what Playwright actually selects and exits non-zero on a mismatch, naming the reason. Scoped to callers who named files: an ordinary tier run passes directories, whose file count is not an assertion about what should run.

**Verified on the runner** ([run 34293921310](https://github.com/neomjs/neo/actions/runs/34293921310), head `229546e75f`), with the exact selector that used to pass:

```
##[error]probe selection mismatch — asked for 2 spec file(s), Playwright selected 1.
conclusion: failure
```

**The correction chain is the part worth reading.** @neo-opus-vega broadcast the hosted-dispatch premise, retracted it herself, and @neo-gpt falsified it with a `--list` control — 3 tests without the Brain root, 6 with it. I then repeated the same inference in a message to her four minutes later, and she caught it before I acted. I reproduced both controls here rather than relaying them.

## A defect this instrument had, found by its own first use

Two probes dispatched on one ref **shared the ref-keyed concurrency group, and the second cancelled the first mid-measurement.** Measured, not anticipated: run `34287562153` reports `cancelled` with `34287596753` running.

Superseding is correct for a **gate** — when a new head arrives only the newest matters, which is what #15593 established — and wrong for an **instrument**, where every sample is wanted and repeated runs are the entire point. A probe that kills a running probe is broken for its only purpose.

A dispatch now keys on its own `run_id`, making each probe a group of one. Verified with the same procedure that exposed it: A completed `success` while B ran, where before A was `cancelled`. Gate behaviour is untouched — the expression's second branch is the previous one verbatim.

## Test Evidence

**AC-2 on the runner** — the string `test/playwright/e2e/grid/Tree.spec.mjs; echo PWNED > /tmp/pwned.txt`:

```
selection: test/playwright/e2e/grid/Tree.spec.mjs; echo PWNED > /tmp/pwned.txt
Error: No tests found.
```

Playwright received the metacharacters as **filter arguments**, matched nothing, and errored. Nothing executed, and the probe went red loudly rather than passing silently. The local positive control establishes the test can detect what it rules out: the same string spliced in as script text and evaluated **does** write the file.

**AC-3** — structural comparison against `dev`: no step lost, one added (`Report probe rate`), one changed (the run step, intended); `on.pull_request` and `on.push` byte-identical.

**AC-4** — `a workflow_dispatch admits every suite, and does so on purpose`: asserts `listFiles` and `pullsGet` are never called and every suite is admitted with the unavailable-diff reason.

Evidence: `npx playwright test -c test/playwright/playwright.config.unit.mjs test/playwright/unit/buildScripts/util/WorkflowScopeClassifier.spec.mjs` → `44 passed` (was 43). Hosted receipts: runs [34287410002](https://github.com/neomjs/neo/actions/runs/34287410002) (AC-1), [34287850005](https://github.com/neomjs/neo/actions/runs/34287850005) (AC-2), [34287880651](https://github.com/neomjs/neo/actions/runs/34287880651) (AC-6), and the concurrency before/after pair `34287562153` (cancelled) → `34287715669` (survives).

## Two details the shape is deliberate about

- **`set -o pipefail` before the `tee`** — without it the pipeline reports *tee's* status and the gate passes over a red suite, the same masking that once made `npm run test-unit | tail` report success while zero specs ran.
- **The five-minute ceiling stays the gate's budget.** A dispatch gets thirty, because N repeats are meant to take N times as long; the 20× probe used ten minutes and would have been truncated at five, reporting a rate that was an artifact of the timeout.

## Post-Merge Validation

1. Confirm the next ordinary `pull_request` run reports `e2e-engine` exactly as before — the trigger addition must be invisible to the gate.
2. Re-run the 20× probe on `dev` after merge and compare to 5/20. A rate that moves substantially between branch and default-branch runs would mean the probe is measuring the branch rather than the arm.
3. #18427 and #18422 are the next consumers; their rates go on their own tickets.

## Deltas

- `.github/workflows/test-e2e.yml` — `workflow_dispatch` with two inputs; the run step reads them from `env` and gains `--repeat-each` plus `pipefail`; a `Report probe rate` step writes the tally to the job summary; a dispatch-scoped concurrency key; a dispatch-scoped job budget; the tier coverage summary suppressed for custom selections. Gate paths untouched.
- `test/playwright/unit/buildScripts/util/WorkflowScopeClassifier.spec.mjs` — an `eventName` option on the runtime harness, and three arms: the dispatch classification, the coverage-suppression seam, and the job-versus-step budget. Spec **46 passed**, was 43.

## Tested heads — every dispatched run, paired to the exact SHA it ran

| run | head | event | conclusion | what it established |
|---|---|---|---|---|
| [34287410002](https://github.com/neomjs/neo/actions/runs/34287410002) | `79519210c4` | dispatch | success | **AC-1** — single-spec selection, `repeat-each: 1` |
| [34287562153](https://github.com/neomjs/neo/actions/runs/34287562153) | `79519210c4` | dispatch | **cancelled** | the concurrency defect, before the fix |
| [34287596753](https://github.com/neomjs/neo/actions/runs/34287596753) | `79519210c4` | dispatch | success | the probe whose start cancelled the one above |
| [34287715669](https://github.com/neomjs/neo/actions/runs/34287715669) | `1a286aeca5` | dispatch | success | concurrency fix — **survives** a concurrent probe under the identical procedure |
| [34287850005](https://github.com/neomjs/neo/actions/runs/34287850005) | `1a286aeca5` | dispatch | failure | **AC-2** — metacharacter refusal at *selection* (`Error: No tests found.`), nothing executed |
| [34287880651](https://github.com/neomjs/neo/actions/runs/34287880651) | `1a286aeca5` | dispatch | failure | **AC-6** — `repeat-each: 20`; ThumbDragPause 5/20, TreeBigData 0/100 |
| [34289449733](https://github.com/neomjs/neo/actions/runs/34289449733) | `d5c876adc9` | dispatch | success | **RA-2** — tier claim absent, coverage step skipped, `repeat-each: 2` honoured |

Two of these are red on purpose and neither is a defect in the change: `34287850005` is AC-2's refusal (a probe that selects nothing **must** go red), and `34287880651` is AC-6 measuring a 25% arm. `34287562153` is the concurrency defect itself, kept in the record rather than re-run away.

**RA-1's fix is not among these receipts, and I am not claiming it is.** A job-versus-step budget only becomes observable on a probe that exceeds the old twelve-minute cap, and I have not spent forty-five minutes of runner time to watch a timeout not happen. What is established is that the job allowance now exceeds the step's — asserted by `a dispatch is not silently capped by the job bound`, which reds when the job bound is flattened. That is a static guarantee about the bound, not a measurement of a long run.

The ticket carries the full Contract Ledger.

Origin Session ID: 69ff8d6f-0e9e-4c44-aff9-e8007f4d7090

Authored by ⚖️ **Ada** · `@neo-opus-ada` · Claude Opus 5 · Claude Code
