### PR TITLE
refactor(themes): the code, toolbar and tree value sheets declare at :where() weight (#18508)

### DIFF
--- a/learn/guides/uibuildingblocks/StylingAndTheming.md
+++ b/learn/guides/uibuildingblocks/StylingAndTheming.md
@@ -320,7 +320,9 @@ The engine's value sheets therefore declare at `:where(.neo-theme-neo-dark)` wei
 }
 ```
 
-The dock layer and the tooltip sheets carry this weight today; the remaining value sheets move family by family, each one measured first, because a sheet's own rules may have relied on outranking an equal-weight structure rule. While a family still declares at theme-root weight, project into it with more specificity than the engine sheet — an element-scoped rule such as `body:has(.myapp-viewport) .neo-tooltip` — rather than relying on load order.
+Families move to this weight one at a time, each measured before it moves, because a sheet's own rules may have relied on outranking an equal-weight structure rule. While a family still declares at theme-root weight, project into it with more specificity than the engine sheet — an element-scoped rule such as `body:has(.myapp-viewport) .neo-tooltip` — rather than relying on load order.
+
+Which families have moved is a property of the tree, not of this sentence: `grep -rl ':where(.neo-theme-neo-dark)' resources/scss/theme-neo-dark` answers it, and stays right without an edit here.
 
 ### Bad Practice & The Right Way Forward
 

--- a/resources/scss/theme-neo-dark/code/LivePreview.scss
+++ b/resources/scss/theme-neo-dark/code/LivePreview.scss
@@ -1,3 +1,3 @@
-:root .neo-theme-neo-dark {
+:where(.neo-theme-neo-dark) {
     --live-preview-border-color: #000;
 }

--- a/resources/scss/theme-neo-dark/toolbar/Base.scss
+++ b/resources/scss/theme-neo-dark/toolbar/Base.scss
@@ -1,4 +1,4 @@
-:root .neo-theme-neo-dark { // .neo-toolbar
+:where(.neo-theme-neo-dark) { // .neo-toolbar
     --toolbar-background-color: var(--sem-color-surface-neutral-default);
     --toolbar-padding         : 5px;
 }

--- a/resources/scss/theme-neo-dark/tree/List.scss
+++ b/resources/scss/theme-neo-dark/tree/List.scss
@@ -1,4 +1,4 @@
-:root .neo-theme-neo-dark { // .neo-tree-list
+:where(.neo-theme-neo-dark) { // .neo-tree-list
     --tree-list-color          : var(--sem-color-text-neutral-default);
     --tree-list-indent-base    : 16px;
     --tree-list-indent-step    : 16px;

--- a/resources/scss/theme-neo-light/code/LivePreview.scss
+++ b/resources/scss/theme-neo-light/code/LivePreview.scss
@@ -1,3 +1,3 @@
-:root .neo-theme-neo-light {
+:where(.neo-theme-neo-light) {
     --live-preview-border-color: #e6e6e6;
 }

--- a/resources/scss/theme-neo-light/toolbar/Base.scss
+++ b/resources/scss/theme-neo-light/toolbar/Base.scss
@@ -1,4 +1,4 @@
-:root .neo-theme-neo-light { // .neo-toolbar
+:where(.neo-theme-neo-light) { // .neo-toolbar
     --toolbar-background-color: #fff;
     --toolbar-padding         : 5px;
 }

--- a/resources/scss/theme-neo-light/tree/List.scss
+++ b/resources/scss/theme-neo-light/tree/List.scss
@@ -1,4 +1,4 @@
-:root .neo-theme-neo-light { // .neo-tree-list
+:where(.neo-theme-neo-light) { // .neo-tree-list
     --tree-list-color          : #666;
     --tree-list-indent-base    : 16px;
     --tree-list-indent-step    : 16px;


### PR DESCRIPTION
Resolves #18508

Batch 1 of #18107's sweep. The parent stays open until the last batch lands, which is why the batch carries its own close-target.

Three families, six sheets, seven variables per theme: `code`, `toolbar`, `tree`.

Evidence: L3 (emitted CSS diffed byte-for-byte **and** rendered computed styles read in both themes with the intended sheets verified loaded) → L3 required, because changing specificity changes which declaration wins and identical declaration bytes cannot speak to that. Residual: none.

## AC Evidence

| AC | Evidence |
|---|---|
| AC-1 — all six sheets declare at `:where(.neo-theme-neo-*)` | Six of six. `grep -c` per sheet: `:root=0 :where=1` in both themes for `code/LivePreview`, `toolbar/Base`, `tree/List` |
| AC-2 — before/after emitted CSS diffed, both builds mtime-asserted, `-e dev`, selector-only | Six files, **exactly one changed line each**, zero declaration deltas. Build mtimes advanced `00:39:37 → 01:02:08`; rebuilt sheets read `:root=0 :where=1` |
| AC-3 — #18107 stays open; this batch does not touch the guide clause that ticket's AC-3 governs | Parent open. The theme-root projection guidance is untouched; only the sentence *enumerating converted families* changed, because that one rots per batch |
| AC-4 — non-converting sheets in these families named with the reason | **None.** These three families contain exactly six sheets across both themes and all six convert. The answer is an empty set, not a list |

## Rendered-cascade evidence

`apps/portal` runs the `neo-theme-neo-*` family and renders a nav tree, toolbars and live previews, so it exercises all three families at once. Both arms measured on the same page at `#/learn`, with the three sheets asserted loaded and the tree asserted rendered before reading.

| custom property | dark before → after | light before → after |
|---|---|---|
| `--live-preview-border-color` | `#000` → `#000` | `#e6e6e6` → `#e6e6e6` |
| `--toolbar-background-color` | `#0E0F0D` → `#0E0F0D` | `#fff` → `#fff` |
| `--toolbar-padding` | `5px` → `5px` | `5px` → `5px` |
| `--tree-list-color` | `#F0F2F0` → `#F0F2F0` | `#666` → `#666` |
| `--tree-list-indent-base` | `16px` → `16px` | `16px` → `16px` |
| `--tree-list-indent-step` | `16px` → `16px` | `16px` → `16px` |
| `--tree-list-menu-item-color` | `#5472E4` → `#5472E4` | `#1c60a0` → `#1c60a0` |

**14 of 14 computed values identical.** The consuming component agrees: `.neo-tree-list` computes `color: rgb(240, 242, 240)` before and after, which is `--tree-list-color` resolved through to paint rather than merely declared.

Guards the measurement carries, because each one had a way to pass while proving nothing:

```
theme family    the first page I measured used .neo-theme-dark — a DIFFERENT family from
                the .neo-theme-neo-dark sheets under change. It would have reported "no
                difference" for the wrong reason. Re-measured on apps/portal.
sheets loaded   Neo loads per-class theme sheets on first use. On the portal landing page
                tree/List.css was NOT loaded and the tree variables read empty; asserted
                loaded === true for all three before reading anything.
tree rendered   asserted, so the consuming component actually exists in the DOM
arm flipped     rebuilt sheets grepped :root=0 :where=1, so the "after" arm really is after
```

## The change

```scss
:root .neo-theme-neo-dark { … }        // (0,2,0)
:where(.neo-theme-neo-dark) { … }      // (0,0,0)
```

An application projecting into an engine token family declares at `:root .neo-theme-neo-*` — the same (0,2,0). An equal-weight engine declaration therefore won ties by **load order**, and the engine appends its per-class theme sheets after the app's own. At `:where()` the projection wins by weight instead. The table above is the evidence that nothing *else* moved when weight did.

## Test Evidence

```
build   npm run build-themes -- -f -n -e dev -t all      both arms, mtime asserted
        (-e dev, so the compared tree is the one development examples load)

before  :root .neo-theme-neo-dark {          after   :where(.neo-theme-neo-dark) {

diff -r  6 files · exactly one changed line each · zero declaration deltas
render   apps/portal #/learn · 7 vars × 2 themes · 14/14 identical · tree paint unchanged
```

The first attempt at the emitted-CSS measurement was **void and reported as such**: I built `-e esm` while asserting mtime on `dist/development`, so both captures were the same stale files and the diff was empty. The mtime assertion caught it; re-run with `-e dev` and both arms advanced.

## Deltas from ticket

One, a guide sentence rather than an AC. The `:where()` subsection **enumerated** which families had converted — *"The dock layer and the tooltip sheets carry this weight today"* — which needed an edit per batch and was wrong between them. It now states the rule without the list and points at the tree, which answers the question without an edit here. The theme-root projection guidance #18107's AC-3 governs is untouched and still applies to every unconverted family.

## Post-Merge Validation

- [ ] Nothing. Both measurements are complete pre-merge: the emitted diff shows the declarations are unchanged, and the computed-style read shows the cascade winner is unchanged. Neither needs merge to observe.

---

Authored by Grace (Claude Opus 5, Claude Code). Session 4927990d-fb3a-4072-99c5-7811a4e26aea.
