### PR TITLE
feat(core): the App-Worker half of the native route check gets an owner (#18501)

### DIFF
--- a/apps/workstation/view/Workspace.mjs
+++ b/apps/workstation/view/Workspace.mjs
@@ -22,6 +22,7 @@ import Persistence              from '../../../src/dashboard/dock/model/Persiste
 import StateProvider            from '../../../src/state/Provider.mjs';
 import TourToolbar              from './TourToolbar.mjs';
 import TransactionManager       from '../../../src/manager/Transaction.mjs';
+import WindowManager            from '../../../src/manager/Window.mjs';
 import {
     createDockVesselEmbodiment,
     createDockVesselProxyEmbodiment
@@ -1665,25 +1666,27 @@ class Workspace extends DockWorkspace {
             admission?.windowId && Neo.manager?.Window?.get(admission.windowId)?.nativeRoute
         );
 
-        const exactWindowId = entry?.windowId ?? admission?.windowId;
+        // Absence of a route is not a refusal here: such a vessel closes semantically. Only a route
+        // that exists and fails an axis is.
+        const
+            exactWindowId = entry?.windowId ?? admission?.windowId,
+            auth          = WindowManager.resolveNativeRoute({
+                capability: 'close', ownerWindowId: me.windowId, route: nativeRoute, targetWindowId: exactWindowId ?? null
+            });
 
         closeReceipt.route = {
-            closeCapable      : !nativeRoute || nativeRoute.capabilities?.close === true,
-            exactTargetMatches: !nativeRoute || !exactWindowId || nativeRoute.targetWindowId === exactWindowId,
+            closeCapable      : !auth.present || auth.capable,
+            exactTargetMatches: !auth.present || auth.targetMatches,
             exactWindowId     : exactWindowId ?? null,
-            hasHandle         : !nativeRoute || Boolean(nativeRoute.nativeHandleKey),
-            ownerMatches      : !nativeRoute || nativeRoute.ownerWindowId === me.windowId,
+            hasHandle         : !auth.present || auth.hasHandle,
+            ownerMatches      : !auth.present || auth.ownerMatches,
             ownerWindowId     : nativeRoute?.ownerWindowId ?? null,
-            present           : Boolean(nativeRoute),
-            targetPresent     : !nativeRoute || Boolean(nativeRoute.targetWindowId),
+            present           : auth.present,
+            targetPresent     : !auth.present || auth.hasTarget,
             targetWindowId    : nativeRoute?.targetWindowId ?? null
         };
 
-        if (nativeRoute && (
-            !nativeRoute.nativeHandleKey || nativeRoute.ownerWindowId !== me.windowId ||
-            !nativeRoute.targetWindowId || nativeRoute.capabilities?.close !== true ||
-            (exactWindowId && nativeRoute.targetWindowId !== exactWindowId)
-        )) {
+        if (auth.present && !auth.granted) {
             closeReceipt.stage = 'route-refused';
             return false
         }
@@ -1842,18 +1845,25 @@ class Workspace extends DockWorkspace {
                 restore: restoreRect
             } : null;
 
+        const
+            sourceArgs   = {ownerWindowId: me.windowId, route, targetWindowId: entry?.windowId ?? null},
+            targetArgs   = {ownerWindowId: me.windowId, route: targetRoute, targetWindowId: me.vesselConversionTargetWindowId ?? null},
+            sourcePos    = WindowManager.resolveNativeRoute({...sourceArgs, capability: 'position'}),
+            sourceResize = WindowManager.resolveNativeRoute({...sourceArgs, capability: 'resize'}),
+            targetFocus  = WindowManager.resolveNativeRoute({...targetArgs, capability: 'focus'});
+
         me.lastVesselParkReceipt = {
             authority: {
                 entryNameMatches     : entry?.windowName === windowName,
-                sourceHasHandle      : Boolean(route?.nativeHandleKey),
-                sourceOwnerMatches   : route?.ownerWindowId === me.windowId,
-                sourcePositionCapable: route?.capabilities?.position === true,
-                sourceResizeCapable  : route?.capabilities?.resize === true,
-                sourceTargetMatches  : route?.targetWindowId === entry?.windowId,
-                targetFocusCapable   : targetRoute?.capabilities?.focus === true,
-                targetHasHandle      : Boolean(targetRoute?.nativeHandleKey),
-                targetOwnerMatches   : targetRoute?.ownerWindowId === me.windowId,
-                targetTargetMatches  : targetRoute?.targetWindowId === me.vesselConversionTargetWindowId
+                sourceHasHandle      : sourcePos.hasHandle,
+                sourceOwnerMatches   : sourcePos.ownerMatches,
+                sourcePositionCapable: sourcePos.capable,
+                sourceResizeCapable  : sourceResize.capable,
+                sourceTargetMatches  : sourcePos.targetMatches,
+                targetFocusCapable   : targetFocus.capable,
+                targetHasHandle      : targetFocus.hasHandle,
+                targetOwnerMatches   : targetFocus.ownerMatches,
+                targetTargetMatches  : targetFocus.targetMatches
             },
             needsResize,
             parkSize,
@@ -1875,14 +1885,9 @@ class Workspace extends DockWorkspace {
         me.lastVesselParkReceipt.parkAttempts = me.tearOutParkAttempts[itemId] = (me.tearOutParkAttempts[itemId] ?? 0) + 1;
 
         if (
-            !route?.nativeHandleKey || route.ownerWindowId !== me.windowId ||
-            route.targetWindowId !== entry.windowId || route.capabilities?.position !== true ||
-            (needsResize && route.capabilities?.resize !== true) ||
-            (!targetIsMain && (
-                !targetRoute?.nativeHandleKey || targetRoute.ownerWindowId !== me.windowId ||
-                targetRoute.targetWindowId !== me.vesselConversionTargetWindowId ||
-                targetRoute.capabilities?.focus !== true
-            )) ||
+            !sourcePos.granted || (needsResize && !sourceResize.granted) ||
+            // A conversion target that named no window cannot be the one this route addresses.
+            (!targetIsMain && (!targetFocus.granted || !me.vesselConversionTargetWindowId)) ||
             entry.windowName !== windowName || !sourceRect || !sourceOuter || !targetRect ||
             (nativeTitlebar && (
                 sourceRect.width > targetRect.width || sourceRect.height > targetRect.height
@@ -2037,10 +2042,14 @@ class Workspace extends DockWorkspace {
             terminal
         };
 
+        // Restoring always moves and only sometimes resizes, so resize is asked for only when needed.
+        const
+            routeArgs    = {ownerWindowId: me.windowId, route, targetWindowId: entry?.windowId ?? null},
+            positionAuth = WindowManager.resolveNativeRoute({...routeArgs, capability: 'position'}),
+            resizeAuth   = geometry && WindowManager.resolveNativeRoute({...routeArgs, capability: 'resize'});
+
         if (
-            !route?.nativeHandleKey || route.ownerWindowId !== me.windowId ||
-            route.targetWindowId !== entry.windowId || route.capabilities?.position !== true ||
-            (geometry && route.capabilities?.resize !== true) ||
+            !positionAuth.granted || (geometry && !resizeAuth.granted) ||
             entry.windowName !== windowName ||
             !Number.isFinite(rect?.x) || !Number.isFinite(rect?.y)
         ) {

--- a/apps/workstation/view/Workspace.mjs
+++ b/apps/workstation/view/Workspace.mjs
@@ -1670,8 +1670,11 @@ class Workspace extends DockWorkspace {
         // that exists and fails an axis is.
         const
             exactWindowId = entry?.windowId ?? admission?.windowId,
+            // No exact window means no target to constrain, which the key's ABSENCE says; passing it
+            // as null would instead say the caller lost an id it needed, and refuse.
             auth          = WindowManager.resolveNativeRoute({
-                capability: 'close', ownerWindowId: me.windowId, route: nativeRoute, targetWindowId: exactWindowId ?? null
+                capability: 'close', ownerWindowId: me.windowId, route: nativeRoute,
+                ...(exactWindowId && {targetWindowId: exactWindowId})
             });
 
         closeReceipt.route = {
@@ -1886,8 +1889,7 @@ class Workspace extends DockWorkspace {
 
         if (
             !sourcePos.granted || (needsResize && !sourceResize.granted) ||
-            // A conversion target that named no window cannot be the one this route addresses.
-            (!targetIsMain && (!targetFocus.granted || !me.vesselConversionTargetWindowId)) ||
+            (!targetIsMain && !targetFocus.granted) ||
             entry.windowName !== windowName || !sourceRect || !sourceOuter || !targetRect ||
             (nativeTitlebar && (
                 sourceRect.width > targetRect.width || sourceRect.height > targetRect.height

--- a/buildScripts/util/file-size-baseline.json
+++ b/buildScripts/util/file-size-baseline.json
@@ -1,6 +1,6 @@
 {
-    "apps/workstation/view/Workspace.mjs": 1384,
-    "examples/dashboard/crossWindow/DemoBWorkspace.mjs": 2612,
+    "apps/workstation/view/Workspace.mjs": 1388,
+    "examples/dashboard/crossWindow/DemoBWorkspace.mjs": 2615,
     "src/dashboard/dock/Workspace.mjs": 1100,
     "src/main/addon/DragDrop.mjs": 1267
 }

--- a/examples/dashboard/crossWindow/DemoBWorkspace.mjs
+++ b/examples/dashboard/crossWindow/DemoBWorkspace.mjs
@@ -3898,8 +3898,7 @@ class DemoBWorkspace extends Container {
         me.lastVesselRestoreReceipt = null;
 
         if (
-            // A cross-window target that named no window cannot be the one this route addresses.
-            !sourcePos.granted || !targetFocus.granted || !me.crossWindowTargetWindowId ||
+            !sourcePos.granted || !targetFocus.granted ||
             entry.windowName !== windowName || !sourceRect || !targetRect || !targetWindow.innerRect ||
             sourceRect.width > targetRect.width || sourceRect.height > targetRect.height
         ) {
@@ -4132,9 +4131,11 @@ class DemoBWorkspace extends Container {
 
         const exactWindowId = entry?.windowId ?? admittedWindowId;
 
-        // Absence of a route is not a refusal here: such a vessel closes semantically.
+        // Absence of a route is not a refusal here: such a vessel closes semantically. No exact window
+        // means no target to constrain, which the key's ABSENCE says rather than a null value.
         const closeAuth = WindowManager.resolveNativeRoute({
-            capability: 'close', ownerWindowId: me.windowId, route: nativeRoute, targetWindowId: exactWindowId ?? null
+            capability: 'close', ownerWindowId: me.windowId, route: nativeRoute,
+            ...(exactWindowId && {targetWindowId: exactWindowId})
         });
 
         if (closeAuth.present && !closeAuth.granted) return false;

--- a/examples/dashboard/crossWindow/DemoBWorkspace.mjs
+++ b/examples/dashboard/crossWindow/DemoBWorkspace.mjs
@@ -24,6 +24,7 @@ import WorkspaceSet                       from '../../../src/dashboard/dock/wind
 import VesselPark                         from '../../../src/dashboard/dock/window/VesselPark.mjs';
 import TourRunner                         from '../../../src/ai/client/TourRunner.mjs';
 import TransactionManager                 from '../../../src/manager/Transaction.mjs';
+import WindowManager                      from '../../../src/manager/Window.mjs';
 import PreviewContract                    from '../../../src/dashboard/dock/model/PreviewContract.mjs';
 import {demoBTourScript, initialDocument} from './demoBPerspectives.mjs';
 import '../../../src/button/Base.mjs';   // registers the `button` ntype the bars compose
@@ -3869,17 +3870,23 @@ class DemoBWorkspace extends Container {
             sourceRect   = sourceWindow?.innerRect,
             targetRect   = targetWindow?.innerRect;
 
+        const
+            sourceArgs  = {ownerWindowId: me.windowId, route, targetWindowId: entry?.windowId ?? null},
+            targetArgs  = {ownerWindowId: me.windowId, route: targetRoute, targetWindowId: me.crossWindowTargetWindowId ?? null},
+            sourcePos   = WindowManager.resolveNativeRoute({...sourceArgs, capability: 'position'}),
+            targetFocus = WindowManager.resolveNativeRoute({...targetArgs, capability: 'focus'});
+
         me.lastVesselParkReceipt = {
             authority: {
                 entryNameMatches     : entry?.windowName === windowName,
-                sourceHasHandle      : Boolean(route?.nativeHandleKey),
-                sourceOwnerMatches   : route?.ownerWindowId === me.windowId,
-                sourcePositionCapable: route?.capabilities?.position === true,
-                sourceTargetMatches  : route?.targetWindowId === entry?.windowId,
-                targetFocusCapable   : targetRoute?.capabilities?.focus === true,
-                targetHasHandle      : Boolean(targetRoute?.nativeHandleKey),
-                targetOwnerMatches   : targetRoute?.ownerWindowId === me.windowId,
-                targetTargetMatches  : targetRoute?.targetWindowId === me.crossWindowTargetWindowId
+                sourceHasHandle      : sourcePos.hasHandle,
+                sourceOwnerMatches   : sourcePos.ownerMatches,
+                sourcePositionCapable: sourcePos.capable,
+                sourceTargetMatches  : sourcePos.targetMatches,
+                targetFocusCapable   : targetFocus.capable,
+                targetHasHandle      : targetFocus.hasHandle,
+                targetOwnerMatches   : targetFocus.ownerMatches,
+                targetTargetMatches  : targetFocus.targetMatches
             },
             source: sourceRect && {
                 height: sourceRect.height, width: sourceRect.width, x: sourceRect.x, y: sourceRect.y
@@ -3891,11 +3898,8 @@ class DemoBWorkspace extends Container {
         me.lastVesselRestoreReceipt = null;
 
         if (
-            !route?.nativeHandleKey || route.ownerWindowId !== me.windowId ||
-            route.targetWindowId !== entry.windowId || route.capabilities?.position !== true ||
-            !targetRoute?.nativeHandleKey || targetRoute.ownerWindowId !== me.windowId ||
-            targetRoute.targetWindowId !== me.crossWindowTargetWindowId ||
-            targetRoute.capabilities?.focus !== true ||
+            // A cross-window target that named no window cannot be the one this route addresses.
+            !sourcePos.granted || !targetFocus.granted || !me.crossWindowTargetWindowId ||
             entry.windowName !== windowName || !sourceRect || !targetRect || !targetWindow.innerRect ||
             sourceRect.width > targetRect.width || sourceRect.height > targetRect.height
         ) {
@@ -3986,8 +3990,9 @@ class DemoBWorkspace extends Container {
             data;
 
         if (
-            !route?.nativeHandleKey || route.ownerWindowId !== me.windowId ||
-            route.targetWindowId !== entry.windowId || route.capabilities?.position !== true ||
+            !WindowManager.resolveNativeRoute({
+                capability: 'position', ownerWindowId: me.windowId, route, targetWindowId: entry?.windowId ?? null
+            }).granted ||
             entry.windowName !== windowName ||
             !Number.isFinite(rect?.x) || !Number.isFinite(rect?.y)
         ) return false;
@@ -4127,11 +4132,12 @@ class DemoBWorkspace extends Container {
 
         const exactWindowId = entry?.windowId ?? admittedWindowId;
 
-        if (nativeRoute && (
-            !nativeRoute.nativeHandleKey || nativeRoute.ownerWindowId !== me.windowId ||
-            !nativeRoute.targetWindowId || nativeRoute.capabilities?.close !== true ||
-            (exactWindowId && nativeRoute.targetWindowId !== exactWindowId)
-        )) return false;
+        // Absence of a route is not a refusal here: such a vessel closes semantically.
+        const closeAuth = WindowManager.resolveNativeRoute({
+            capability: 'close', ownerWindowId: me.windowId, route: nativeRoute, targetWindowId: exactWindowId ?? null
+        });
+
+        if (closeAuth.present && !closeAuth.granted) return false;
 
         // The Group established retirement before this call, so a refused close retains the exact
         // route and the tear-out machine slot for retry while the content stays safely home. A

--- a/src/ai/client/RuntimeService.mjs
+++ b/src/ai/client/RuntimeService.mjs
@@ -1,6 +1,7 @@
 import DomEventManager from '../../manager/DomEvent.mjs';
 import HashHistory     from '../../util/HashHistory.mjs';
 import Service         from './Service.mjs';
+import WindowManager   from '../../manager/Window.mjs';
 
 /**
  * @summary Registers the JSON-RPC method prefixes one RuntimeService instance answers.
@@ -313,9 +314,11 @@ class RuntimeService extends Service {
             return {success: false, error: `Unknown windowId '${windowId}'.`}
         }
 
-        const {nativeRoute} = windowEntry;
+        // This runtime dispatches AS the route's owner rather than asserting it owns the window, so it
+        // asserts no owner and passes ownerWindowId straight through to Main.
+        const {route} = WindowManager.resolveNativeRoute({capability: 'close', route: windowEntry.nativeRoute});
 
-        if (!nativeRoute?.capabilities?.close) {
+        if (!route) {
             return {
                 success    : false,
                 unsupported: true,
@@ -324,9 +327,9 @@ class RuntimeService extends Service {
         }
 
         const accepted = await Neo.Main.windowNativeClose({
-            nativeHandleKey: nativeRoute.nativeHandleKey,
-            targetWindowId : nativeRoute.targetWindowId,
-            windowId       : nativeRoute.ownerWindowId
+            nativeHandleKey: route.nativeHandleKey,
+            targetWindowId : route.targetWindowId,
+            windowId       : route.ownerWindowId
         });
 
         if (accepted !== true) {
@@ -367,9 +370,9 @@ class RuntimeService extends Service {
             return {success: false, error: `Unknown windowId '${windowId}'.`}
         }
 
-        const {nativeRoute} = windowEntry;
+        const {route} = WindowManager.resolveNativeRoute({capability: 'position', route: windowEntry.nativeRoute});
 
-        if (!nativeRoute?.capabilities?.position) {
+        if (!route) {
             return {
                 success    : false,
                 unsupported: true,
@@ -378,9 +381,9 @@ class RuntimeService extends Service {
         }
 
         const positioned = await Neo.Main.windowNativeMoveTo({
-            nativeHandleKey: nativeRoute.nativeHandleKey,
-            targetWindowId : nativeRoute.targetWindowId,
-            windowId       : nativeRoute.ownerWindowId,
+            nativeHandleKey: route.nativeHandleKey,
+            targetWindowId : route.targetWindowId,
+            windowId       : route.ownerWindowId,
             x,
             y
         });
@@ -409,9 +412,9 @@ class RuntimeService extends Service {
             return {success: false, error: `Unknown windowId '${windowId}'.`}
         }
 
-        const {nativeRoute} = windowEntry;
+        const {route} = WindowManager.resolveNativeRoute({capability: 'focus', route: windowEntry.nativeRoute});
 
-        if (!nativeRoute?.capabilities?.focus) {
+        if (!route) {
             return {
                 success    : false,
                 unsupported: true,
@@ -420,9 +423,9 @@ class RuntimeService extends Service {
         }
 
         const focused = await Neo.Main.windowNativeFocus({
-            nativeHandleKey: nativeRoute.nativeHandleKey,
-            targetWindowId : nativeRoute.targetWindowId,
-            windowId       : nativeRoute.ownerWindowId
+            nativeHandleKey: route.nativeHandleKey,
+            targetWindowId : route.targetWindowId,
+            windowId       : route.ownerWindowId
         });
 
         if (focused !== true) {

--- a/src/manager/Window.mjs
+++ b/src/manager/Window.mjs
@@ -223,33 +223,49 @@ class Window extends Manager {
      * the effect lands.
      *
      * Every axis is reported separately rather than collapsed into the verdict, so a refusal says which
-     * condition failed. `ownerWindowId` is deliberately explicit: a window asserting it owns the route
-     * passes its own id, while a runtime dispatching AS the route's owner passes `null` and the result
-     * records that ownership was never asserted.
+     * condition failed.
+     *
+     * **Asserting an identity is opting in by KEY, not by value.** Omit `ownerWindowId` and ownership
+     * goes unchecked — a runtime that dispatches AS the route's owner rather than claiming to be it.
+     * Pass the key with a nullish value and the answer is no: a caller whose own id is missing cannot
+     * be shown to own anything, and reading that as a waived check would grant on absent evidence.
+     * Independently of any assertion, a granted route must itself name a handle, an owning main thread
+     * and a target — being unasserted is not the same as being unaddressable.
      * @param {Object} data
      * @param {'close'|'focus'|'position'|'resize'} data.capability
-     * @param {String|null} [data.ownerWindowId=null] Assert this owner, or `null` to not assert one
+     * @param {String} [data.ownerWindowId] Assert this owner; omit the key to not assert one
      * @param {Object|null} [data.route=null] An already-resolved route; otherwise `windowId` resolves it
-     * @param {String|null} [data.targetWindowId=null] Require the route to address this exact window
-     * @param {String|null} [data.windowId=null] Resolve the route from this window's entry
-     * @returns {Object} `{capable, granted, hasHandle, hasTarget, ownerAsserted, ownerMatches, present, route, targetMatches}`
+     * @param {String} [data.targetWindowId] Require the route to address this exact window
+     * @param {String|null} [data.windowId=null] Resolve the route from this window's entry, and require the route to address it
+     * @returns {Object} `{capable, granted, hasHandle, hasOwner, hasTarget, ownerAsserted, ownerMatches, present, route, targetMatches}`
      */
-    resolveNativeRoute({capability, ownerWindowId=null, route=null, targetWindowId=null, windowId=null}) {
-        route ??= (windowId && this.get(windowId)?.nativeRoute) || null;
-
+    resolveNativeRoute(data) {
         const
-            present       = Boolean(route),
-            capable       = present && route.capabilities?.[capability] === true,
-            hasHandle     = present && Boolean(route.nativeHandleKey),
-            hasTarget     = present && Boolean(route.targetWindowId),
-            ownerAsserted = ownerWindowId !== null,
-            ownerMatches  = present && (!ownerAsserted || route.ownerWindowId === ownerWindowId),
-            targetMatches = present && (targetWindowId === null || route.targetWindowId === targetWindowId),
-            granted       = capable && hasHandle && hasTarget && ownerMatches && targetMatches;
+            {capability, route: supplied=null, windowId=null} = data,
+            // OMITTING a key waives that check; PASSING one that is nullish is a caller whose own
+            // identity is missing, and that refuses. Collapsing the two would turn "I have no id to
+            // compare" into "no comparison needed", which is the opposite decision.
+            assertsOwner   = 'ownerWindowId'  in data,
+            assertsTarget  = 'targetWindowId' in data || windowId !== null,
+            expectedOwner  = data.ownerWindowId,
+            // Resolving by windowId asks about THAT window, so the route has to address it.
+            expectedTarget = 'targetWindowId' in data ? data.targetWindowId : windowId,
+            route          = supplied ?? ((windowId && this.get(windowId)?.nativeRoute) || null),
+            present        = Boolean(route),
+            capable        = present && route.capabilities?.[capability] === true,
+            hasHandle      = present && Boolean(route.nativeHandleKey),
+            // The route must name an owning main thread to address even when the caller does not
+            // claim to be it: unasserted ownership is not the same as an unaddressable route.
+            hasOwner       = present && Boolean(route.ownerWindowId),
+            hasTarget      = present && Boolean(route.targetWindowId),
+            ownerMatches   = present && (!assertsOwner  || (Boolean(expectedOwner)  && route.ownerWindowId  === expectedOwner)),
+            targetMatches  = present && (!assertsTarget || (Boolean(expectedTarget) && route.targetWindowId === expectedTarget)),
+            granted        = capable && hasHandle && hasOwner && hasTarget && ownerMatches && targetMatches;
 
         return {
-            capable, granted, hasHandle, hasTarget, ownerAsserted, ownerMatches, present, targetMatches,
-            route: granted ? route : null
+            capable, granted, hasHandle, hasOwner, hasTarget, ownerMatches, present, targetMatches,
+            ownerAsserted: assertsOwner,
+            route        : granted ? route : null
         }
     }
 

--- a/src/manager/Window.mjs
+++ b/src/manager/Window.mjs
@@ -213,6 +213,47 @@ class Window extends Manager {
     }
 
     /**
+     * @summary Decides whether a caller may dispatch a native window effect, before it dispatches one.
+     *
+     * Native-window authority is split in two: the App Worker resolves the topology entry, and the
+     * owning main thread revalidates the live generation before touching the handle. `Neo.Main` holds
+     * that second half and stays the last word — it additionally sees whether the window is closed,
+     * whether a same-name open replaced the entry, and whether the native method exists, none of which
+     * an App-Worker caller can observe. A grant here is therefore permission to ask, never a promise
+     * the effect lands.
+     *
+     * Every axis is reported separately rather than collapsed into the verdict, so a refusal says which
+     * condition failed. `ownerWindowId` is deliberately explicit: a window asserting it owns the route
+     * passes its own id, while a runtime dispatching AS the route's owner passes `null` and the result
+     * records that ownership was never asserted.
+     * @param {Object} data
+     * @param {'close'|'focus'|'position'|'resize'} data.capability
+     * @param {String|null} [data.ownerWindowId=null] Assert this owner, or `null` to not assert one
+     * @param {Object|null} [data.route=null] An already-resolved route; otherwise `windowId` resolves it
+     * @param {String|null} [data.targetWindowId=null] Require the route to address this exact window
+     * @param {String|null} [data.windowId=null] Resolve the route from this window's entry
+     * @returns {Object} `{capable, granted, hasHandle, hasTarget, ownerAsserted, ownerMatches, present, route, targetMatches}`
+     */
+    resolveNativeRoute({capability, ownerWindowId=null, route=null, targetWindowId=null, windowId=null}) {
+        route ??= (windowId && this.get(windowId)?.nativeRoute) || null;
+
+        const
+            present       = Boolean(route),
+            capable       = present && route.capabilities?.[capability] === true,
+            hasHandle     = present && Boolean(route.nativeHandleKey),
+            hasTarget     = present && Boolean(route.targetWindowId),
+            ownerAsserted = ownerWindowId !== null,
+            ownerMatches  = present && (!ownerAsserted || route.ownerWindowId === ownerWindowId),
+            targetMatches = present && (targetWindowId === null || route.targetWindowId === targetWindowId),
+            granted       = capable && hasHandle && hasTarget && ownerMatches && targetMatches;
+
+        return {
+            capable, granted, hasHandle, hasTarget, ownerAsserted, ownerMatches, present, targetMatches,
+            route: granted ? route : null
+        }
+    }
+
+    /**
      * @returns {Object}
      */
     toJSON() {

--- a/test/playwright/unit/apps/workstation/Workspace.spec.mjs
+++ b/test/playwright/unit/apps/workstation/Workspace.spec.mjs
@@ -760,6 +760,89 @@ test.describe.serial('Workstation.view.Workspace', () => {
         }
     });
 
+    test('a missing source or owner identity refuses reshow before any native dispatch', async () => {
+        const
+            originalDragDrop = Neo.main.addon.DragDrop,
+            originalMove     = Neo.Main.windowNativeMoveTo,
+            originalResize   = Neo.Main.windowNativeResizeTo,
+            calls            = [];
+
+        // A non-terminal re-show reaches the platform through resumeWindowDrag, so that is the seam
+        // this control counts; the Main methods are stubbed to catch a terminal path if one ran.
+        Neo.main.addon.DragDrop = {
+            acknowledgeWindowDragOrphanRecovery: async () => true,
+            hasWindowDragOrphanRecovery        : async () => false,
+            resumeWindowDrag                   : async data => {calls.push(['resume', data]); return true}
+        };
+        Neo.Main.windowNativeResizeTo = async data => {calls.push(['resize', data]); return true};
+        Neo.Main.windowNativeMoveTo   = async data => {calls.push(['move',   data]); return true};
+
+        /**
+         * @summary Runs one reshow with a crafted identity pair and counts the native seam calls.
+         * @param {Object} config
+         * @param {String|null} [config.entryWindowId='source-window']
+         * @param {String|null} [config.hostWindowId] Replaces the host's own id when supplied
+         * @returns {Promise<Object>} `{admitted, dispatches}`
+         */
+        async function attempt(overrides={}) {
+            // Keyed rather than defaulted, for the reason this whole test exists: a destructuring
+            // default fires on `undefined`, so `{entryWindowId: undefined}` would silently become the
+            // valid id and the case would pass while testing nothing.
+            const
+                entryWindowId = 'entryWindowId' in overrides ? overrides.entryWindowId : 'source-window',
+                workspace     = Neo.create(Workspace, {windowId: Neo.config.windowId});
+
+            workspace.nativeWindows.sources.get(workspace.id).connections.set('audit', {
+                nativeRoute: {
+                    capabilities   : {close: true, focus: true, position: true, resize: true},
+                    nativeHandleKey: 'handle-source',
+                    ownerWindowId  : workspace.windowId,
+                    targetWindowId : 'source-window'
+                },
+                windowId  : entryWindowId,
+                windowName: 'tearout-audit'
+            });
+
+            if ('hostWindowId' in overrides) workspace.windowId = overrides.hostWindowId;
+
+            calls.length = 0;
+
+            const admitted = await workspace.reshowTearOutVessel({
+                itemId    : 'audit',
+                rect      : {height: 120, width: 200, x: 420, y: 240},
+                windowName: 'tearout-audit'
+            });
+
+            return {admitted, dispatches: calls.length}
+        }
+
+        try {
+            // The positive control proves the probe reaches the dispatch branch at all; without it a
+            // zero-dispatch refusal would be indistinguishable from a setup that never got there.
+            expect(await attempt()).toMatchObject({admitted: true, dispatches: 1});
+
+            // An erased host identity cannot be shown to own the route. `me.windowId` is read
+            // directly rather than through a resolver, so this is the reachable regression.
+            // Only `null` is asserted here: Neo's reactive configs IGNORE an `undefined` write, so a
+            // host cannot reach that state through the class at all — measured, not assumed. The
+            // predicate battery covers `undefined` directly, where it is reachable.
+            expect(await attempt({hostWindowId: null})).toMatchObject({admitted: false, dispatches: 0});
+
+            // The entry side is additionally guarded by resolveTearOutVessel, which refuses a
+            // connection carrying no windowId before the route is ever read.
+            for (const entryWindowId of [null, undefined]) {
+                expect(await attempt({entryWindowId})).toMatchObject({admitted: false, dispatches: 0})
+            }
+
+            // A present-but-wrong id must still refuse, so the axis is not merely presence-checked.
+            expect(await attempt({entryWindowId: 'a-different-window'})).toMatchObject({admitted: false, dispatches: 0})
+        } finally {
+            Neo.main.addon.DragDrop       = originalDragDrop;
+            Neo.Main.windowNativeMoveTo   = originalMove;
+            Neo.Main.windowNativeResizeTo = originalResize
+        }
+    });
+
     test('terminal restore compensates safely until exact extent and position both succeed', async () => {
         let
             moveAdmitted       = false,

--- a/test/playwright/unit/manager/Window.spec.mjs
+++ b/test/playwright/unit/manager/Window.spec.mjs
@@ -255,6 +255,21 @@ test.describe.serial('Neo.manager.Window native route authority (#18501)', () =>
         }
     });
 
+    test('a connected window carrying no native route is refused, not treated as unrestricted', () => {
+        const windowId = 'routeless-window';
+
+        WindowManager.onWindowConnect({appName: 'DockDemo', windowData: {}, windowId});
+
+        // Distinct from the unknown-window arm above: the entry exists and is merely routeless.
+        expect(WindowManager.get(windowId).nativeRoute).toBeNull();
+
+        const result = ask({route: null, windowId});
+
+        expect(result.present).toBe(false);
+        expect(result.granted).toBe(false);
+        expect(result.route).toBeNull()
+    });
+
     test('a caller that asserts no owner is granted whatever the route owner is, and the result says so', () => {
         const route  = grantingRoute({ownerWindowId: 'some-other-window'}),
               result = ask({capability: 'close', ownerWindowId: null, route});

--- a/test/playwright/unit/manager/Window.spec.mjs
+++ b/test/playwright/unit/manager/Window.spec.mjs
@@ -145,3 +145,137 @@ test.describe.serial('Neo.manager.Window connection ordering (#15396)', () => {
         expect(reconnected.capabilities).toEqual({close: false, focus: false, position: false, resize: false})
     })
 });
+
+test.describe.serial('Neo.manager.Window native route authority (#18501)', () => {
+    let WindowManager;
+
+    test.beforeAll(async () => {
+        WindowManager = (await import('../../../../src/manager/Window.mjs')).default
+    });
+
+    test.beforeEach(() => {
+        WindowManager.items = [];
+        WindowManager.map   = new Map()
+    });
+
+    test.afterEach(() => {
+        WindowManager.items = [];
+        WindowManager.map   = new Map()
+    });
+
+    /**
+     * @summary A route granting every axis, so each test falsifies exactly one of them.
+     * @param {Object} [overrides]
+     * @returns {Object}
+     */
+    function grantingRoute(overrides={}) {
+        return {
+            capabilities   : {close: true, focus: true, position: true, resize: true},
+            nativeHandleKey: 'handle-popup-window',
+            ownerWindowId  : 'owner-window',
+            targetWindowId : 'popup-window',
+            ...overrides
+        }
+    }
+
+    /**
+     * @summary Asks for `position` as the asserted owner of the exact popup, unless overridden.
+     * @param {Object} [overrides]
+     * @returns {Object}
+     */
+    function ask(overrides={}) {
+        return WindowManager.resolveNativeRoute({
+            capability    : 'position',
+            ownerWindowId : 'owner-window',
+            route         : grantingRoute(),
+            targetWindowId: 'popup-window',
+            ...overrides
+        })
+    }
+
+    test('a route granting every axis is granted, and only then is the route handed back', () => {
+        const route  = grantingRoute(),
+              result = ask({route});
+
+        expect(result.granted).toBe(true);
+        expect(result.route).toBe(route)
+    });
+
+    test('an owner mismatch refuses on that axis alone, and withholds the route', () => {
+        const result = ask({route: grantingRoute({ownerWindowId: 'someone-else'})});
+
+        expect(result.ownerMatches).toBe(false);
+        expect(result.granted).toBe(false);
+        expect(result.route).toBeNull();
+        expect(result).toMatchObject({capable: true, hasHandle: true, hasTarget: true, present: true, targetMatches: true})
+    });
+
+    test('a target mismatch refuses on that axis alone', () => {
+        const result = ask({route: grantingRoute({targetWindowId: 'a-different-popup'})});
+
+        expect(result.targetMatches).toBe(false);
+        expect(result.granted).toBe(false);
+        expect(result).toMatchObject({capable: true, hasHandle: true, hasTarget: true, ownerMatches: true, present: true})
+    });
+
+    test('an ungranted capability refuses on that axis alone', () => {
+        const result = ask({route: grantingRoute({capabilities: {close: true, focus: true, position: false, resize: true}})});
+
+        expect(result.capable).toBe(false);
+        expect(result.granted).toBe(false);
+        expect(result).toMatchObject({hasHandle: true, hasTarget: true, ownerMatches: true, present: true, targetMatches: true})
+    });
+
+    test('a route without its opaque handle refuses on that axis alone', () => {
+        const result = ask({route: grantingRoute({nativeHandleKey: null})});
+
+        expect(result.hasHandle).toBe(false);
+        expect(result.granted).toBe(false);
+        expect(result).toMatchObject({capable: true, hasTarget: true, ownerMatches: true, present: true, targetMatches: true})
+    });
+
+    test('a route naming no target refuses on that axis alone', () => {
+        const result = ask({route: grantingRoute({targetWindowId: null}), targetWindowId: null});
+
+        expect(result.hasTarget).toBe(false);
+        expect(result.granted).toBe(false);
+        expect(result).toMatchObject({capable: true, hasHandle: true, ownerMatches: true, present: true})
+    });
+
+    test('an absent route and an unknown window both fail closed, and neither invents an axis', () => {
+        const absent  = ask({route: null}),
+              unknown = ask({route: null, windowId: 'never-connected'});
+
+        for (const result of [absent, unknown]) {
+            expect(result.granted).toBe(false);
+            expect(result.route).toBeNull();
+            expect(result).toMatchObject({
+                capable: false, hasHandle: false, hasTarget: false, ownerMatches: false, present: false, targetMatches: false
+            })
+        }
+    });
+
+    test('a caller that asserts no owner is granted whatever the route owner is, and the result says so', () => {
+        const route  = grantingRoute({ownerWindowId: 'some-other-window'}),
+              result = ask({capability: 'close', ownerWindowId: null, route});
+
+        expect(result.granted).toBe(true);
+        expect(result.ownerAsserted).toBe(false);
+        expect(result.route).toBe(route);
+        expect(ask({route}).ownerAsserted).toBe(true)
+    });
+
+    test('the route resolves from a connected window entry when the caller passes only a windowId', () => {
+        const
+            windowId = 'popup-window',
+            route    = grantingRoute();
+
+        WindowManager.onWindowConnect({
+            appName   : 'DockDemo',
+            windowData: {nativeRoute: route},
+            windowId
+        });
+
+        expect(ask({route: null, windowId}).route).toBe(route)
+    })
+});

--- a/test/playwright/unit/manager/Window.spec.mjs
+++ b/test/playwright/unit/manager/Window.spec.mjs
@@ -271,13 +271,60 @@ test.describe.serial('Neo.manager.Window native route authority (#18501)', () =>
     });
 
     test('a caller that asserts no owner is granted whatever the route owner is, and the result says so', () => {
-        const route  = grantingRoute({ownerWindowId: 'some-other-window'}),
-              result = ask({capability: 'close', ownerWindowId: null, route});
+        const route = grantingRoute({ownerWindowId: 'some-other-window'});
+
+        // Omitting the key is the opt-out; the runtime that dispatches AS the route owner uses it.
+        const result = WindowManager.resolveNativeRoute({capability: 'close', route});
 
         expect(result.granted).toBe(true);
         expect(result.ownerAsserted).toBe(false);
         expect(result.route).toBe(route);
         expect(ask({route}).ownerAsserted).toBe(true)
+    });
+
+    test('a route naming no owning main thread is refused even when the caller asserts no owner', () => {
+        const result = WindowManager.resolveNativeRoute({
+            capability: 'close', route: grantingRoute({ownerWindowId: undefined})
+        });
+
+        // Unasserted ownership is not an unaddressable route: there would be no main thread to
+        // forward the dispatch to, and the caller would pass that absence straight through.
+        expect(result.hasOwner).toBe(false);
+        expect(result.granted).toBe(false);
+        expect(result.route).toBeNull();
+        expect(result).toMatchObject({capable: true, hasHandle: true, hasTarget: true, ownerAsserted: false})
+    });
+
+    test('a nullish asserted identity refuses, where an omitted one waives the check', () => {
+        const route = grantingRoute();
+
+        for (const missing of [null, undefined]) {
+            expect(WindowManager.resolveNativeRoute({capability: 'position', ownerWindowId: missing, route}))
+                .toMatchObject({granted: false, ownerAsserted: true, ownerMatches: false});
+            expect(WindowManager.resolveNativeRoute({capability: 'position', targetWindowId: missing, route}))
+                .toMatchObject({granted: false, targetMatches: false})
+        }
+
+        // The same call with both keys absent is the waived-check case, and it grants.
+        expect(WindowManager.resolveNativeRoute({capability: 'position', route}).granted).toBe(true)
+    });
+
+    test('resolving by windowId requires the entry route to address that same window', () => {
+        const route = grantingRoute({targetWindowId: 'popup-window'});
+
+        WindowManager.onWindowConnect({
+            appName   : 'DockDemo',
+            windowData: {nativeRoute: route},
+            windowId  : 'requested-popup'
+        });
+
+        // The entry supplies a route, but it addresses a different window than the one asked about.
+        const result = WindowManager.resolveNativeRoute({capability: 'focus', windowId: 'requested-popup'});
+
+        expect(result.present).toBe(true);
+        expect(result.targetMatches).toBe(false);
+        expect(result.granted).toBe(false);
+        expect(result.route).toBeNull()
     });
 
     test('the route resolves from a connected window entry when the caller passes only a windowId', () => {


### PR DESCRIPTION
Resolves #18501

🌿 Three files each held their own answer to "may I touch this native window", and no two agreed on how many ways the answer could be no; after this, none of them can hold an answer at all.

ADR 0029 §2.8.5 already splits native-window authority in two — the App Worker resolves the topology entry, the owning main thread revalidates the live generation before touching the handle. `Main.mjs:783` `#getNativeWindowRoute` has been the second half all along, refusing on six conditions across eight call sites. The first half had no public owner, so three callers each wrote a weaker subset: `apps/workstation/view/Workspace.mjs` (10 sites), `examples/dashboard/crossWindow/DemoBWorkspace.mjs` (6) and `src/ai/client/RuntimeService.mjs` (3). This is an unimplemented ADR clause, not a new API.

`Neo.manager.Window.resolveNativeRoute()` is that first half, on the class the ADR already names and which already held the data — `:151` normalises capabilities fail-closed, `:155` stores the route. The question simply had no method.

Evidence: L3 (the live Neural-Link native arm drives real OS popups through titlebar drag and reintegration against the migrated guards; nothing here needs an operator-gated surface, so sandbox ceiling = achievable ceiling) → L3 required. Residual: none for this leaf. Residual-Owner: #18460, which this PR unblocks but does not close.

## AC Evidence

| AC | Evidence |
|---|---|
| AC-1 — one public predicate, all four capabilities | `src/manager/Window.mjs` `resolveNativeRoute({capability, ownerWindowId, route, targetWindowId, windowId})`; exercised for `close`, `focus`, `position` and `resize` across the consumers and the battery. |
| AC-2 — refuses on each axis independently, one spec per axis | CI-covered: **13 arms** in `test/playwright/unit/manager/Window.spec.mjs`, each falsifying exactly one axis and asserting the others stay true — absent route, unknown window, routeless connected entry, owner mismatch, target mismatch, ungranted capability, missing handle, missing target, **missing route owner**, **nullish-vs-omitted assertion**, **windowId lookup bound to its requested target**. Control: dropping `ownerMatches && targetMatches` from the verdict reds the owner arm, so the battery is not vacuous. |
| AC-3 — all 19 sites route through it; literal count reaches zero | `grep -c "capabilities?\."` → **0 / 0 / 0** across the three files. `src/dashboard/dock/window/Placement.mjs:306-311` is untouched, as its Out of Scope requires — it compares route *identity*, not a capability. |
| AC-4 — "refused before dispatch" distinguishable from "Main refused me" | The result is per-axis, not a boolean: a pre-dispatch refusal names the failing axis and withholds the route, while `Main`'s refusal still arrives as a false return from the dispatch call. Both park receipts now carry those axes. |
| AC-5 — no spec weakened, no tier moved green→red, every delta named | 1507 unit passed across workstation / manager / ai/client / dashboard / DemoB. No spec edited to accommodate the predicate. The three `DemoBCrossWindowDragNL` arms are **excepted, not claimed green**: a control run at merge base `335b2ca43a` reproduces them (§ Test Evidence). Refusals only got stricter — the Round-1 repair below restored three cases the first head admitted. |

## Deltas from ticket

### Round-1 repair — a nullable argument was collapsing two different states

@neo-gpt's executed probes found three defects in the first head, all one root cause: `ownerWindowId: null` meant "do not assert ownership", so a caller whose own id was **missing** read as a caller who **chose not to claim one** — and the guard granted where the base refused. The API now distinguishes them **by key, not by value**: omit the key and the check is waived; pass it nullish and the answer is no.

| RA | Disposition |
|---|---|
| RA-1 — granted route must carry every dispatch identity; bind `windowId` lookups to the requested target | `[ADDRESSED]` `hasOwner` is now unconditional alongside `hasHandle`/`hasTarget`, so an unasserted owner no longer skips checking the route *has* one — `RuntimeService` could otherwise forward `windowId: undefined` to `Main`. Resolving by `windowId` now requires the entry's route to address that same window. Four new discriminating arms; the valid "dispatch as the route owner" case still grants. |
| RA-2 — preserve source/owner assertions in both re-show paths; audit the shared park/resize args | `[ADDRESSED]` Both consumers refuse again on an erased source or owner id. The close paths keep their genuinely *optional* target by **omitting** the key when there is no exact window — the same distinction from the other side. New consumer-level dispatch-count control on the real `reshowTearOutVessel`. |
| RA-3 — align contract and evidence | `[ADDRESSED]` AC-5 rewritten on the ticket (below); the new deltas are named here; the DemoB baseline failures are now explicitly *excepted* rather than covered by a "every tier green" claim. |

**Why I missed it, which is worth more than the fix.** I flagged this exact footgun in @neo-gpt's #18500 an hour earlier, fixed it in my own diff for the *conversion target*, and never applied the same reasoning to the *owner* dimension. Worse, I had reasoned the entry case "unreachable by construction" because `resolveTearOutVessel` refuses a connection without a windowId — proving a guard's precondition holds through **one caller path** and treating that as licence to weaken the guard itself. A guard that depends on an invariant enforced elsewhere is not a guard.

**The predicate battery could not have caught this**, which is why RA-2 asking for consumer-level controls was the right call: the battery tested the predicate in isolation, where I had already made the nullable choice. The new arm drives the real method and counts native seam calls — and its positive control earned its place immediately by *failing*, since a non-terminal re-show dispatches through `resumeWindowDrag`, not the `Main` methods I had stubbed. Without it, four green "refusals" would all have been a stub returning `false`.

Two things measured rather than assumed while writing it: Neo's reactive configs **ignore an `undefined` write**, so a host id cannot reach that state through the class — the consumer arm asserts `null`, and the predicate battery covers `undefined` where it *is* reachable. And my first version of that control had this very bug: `attempt({entryWindowId: undefined})` hit a destructuring default and silently tested the valid id.

### Original deltas

- **I corrected AC-5 on my own ticket, and the correction is visible in its body.** It originally read *"Zero behavioural change in all three consumers"*. That fought AC-1: routing three consumers through one predicate necessarily makes the two that checked fewer axes refuse cases they previously handed to `Main`, so a literal zero-delta bar could only be met by not delivering the ticket. The replacement keeps "no spec weakened" and **adds** an enumeration duty — every delta named here or the AC is red. Stricter, not looser.
- **Delta 1 — malformed routes refuse earlier and more uniformly.** `RuntimeService` previously tested only the capability flag, so a route with the capability granted but no handle key or no target reached `Main` and returned classified `stale`. It now refuses before dispatch as `unsupported`. Well-formed routes are byte-identical in behaviour.
- **Delta 2 — one receipt field stops being vacuously true.** Both park receipts computed their per-axis booleans a *second* time beside the guard, from the same fields. When no route existed that made them internally inconsistent: `sourceHasHandle` false, `sourceOwnerMatches` false, but `sourceTargetMatches` **true**, because `undefined === undefined` holds. They are now a projection of the one authority result, so all axes read false together. `receipt.authority` has **zero readers** in `src`, `apps`, `examples` and `test` (verified by grep), so this is unobservable to every spec — stated anyway because it is a value change.
- **The migration was not mechanical, in three places.** Polarity differs by site: the close paths treat an *absent* route as permission, not refusal — a vessel with no native route closes semantically — so they read `present && !granted`. Park and restore ask for `resize` as a second question, only when the geometry demands a cover. And both park paths assert the conversion-target id explicitly, because passing a nullish `targetWindowId` means "do not assert a target" and would have *silently* passed a check the old code failed.
- **No simplification is claimed.** Consumers grew: workstation 1689 → 1693, DemoB 2612 → 2615 code lines, against the engine predicate. A compaction pass took the first draft down from +10 each; the rest is the cost of naming arguments. The deletion here is **19 duplicated decision sites, not lines**, and claiming otherwise would be exactly the accretion the maintainer test forbids.

size-guard-growth: apps/workstation/view/Workspace.mjs — 10 inline capability guards collapse into 4 named authority calls whose results feed both the guards and the park/close receipts, so the two stop being independent computations that can disagree. Net +4 code lines: the call objects name arguments the inline conditions left positional, and the Round-1 repair adds the omitted-vs-nullish target spread. A compaction pass already took this down from +10.

size-guard-growth: examples/dashboard/crossWindow/DemoBWorkspace.mjs — the same consolidation for its 6 guards across park, reshow and close. Net +3 code lines, same cause and same compaction pass. Keeping the second consumer on the shared owner is the point of the ticket: its independently hand-written copy is the evidence that the predicate is engine mechanism rather than app style.
- **Left undone on purpose:** both receipts would shrink ~8 lines each if `authority` embedded the auth objects instead of projecting ten booleans out of them. That changes a receipt shape, which is a different decision from route authority, so it stays out.
- ⚠️ **Baseline conflict with #18499.** That draft sets `apps/workstation/view/Workspace.mjs` to 1624; this sets it to 1692. They touch the same file for unrelated reasons, so whichever merges second must rebase and recompute rather than resolve the number by hand.

## Test Evidence

- **`WorkstationNativeTitlebarDragNL` — 1 passed (4.6s)** at this head with `NEO_AGENTOS_RUNTIME_ROOT` set: real OS popups, titlebar-driven move, reintegration under dwell, straight through the migrated close/reintegration guards. ⚠️ Without that variable the config selects ZERO specs and reports success, so the green is only meaningful with it named.
- **`DemoBCrossWindowDragNL` — 3 arms fail on my host, and they are NOT this change.** I ran it as the park-guard witness, then re-ran the identical spec on `origin/dev` at `335b2ca43a` with no local changes: the same three fail identically (`:247`, `:459`, `:706`). That control establishes *this PR did not cause them* — and nothing more.
  ✅ **Resolved — it is a real dev break, and not host-specific.** I first wrote "broken on dev", then retracted it because my seat's `headed-native-browser` capability is recorded `unknown` and my instrument could not support the attribution (`MESSAGE:d368fec4`). @neo-opus-grace then ran it on a **second host, headed and headless**: 3/3 fail at `335b2ca43a` ([#18439 receipt](https://github.com/neomjs/neo/issues/18439#issuecomment-5593722212)), with the selection, browser-launch and clean-`dist` guards all checked explicitly. Host-specificity is dead; the retraction was right to withhold the claim and her receipt is what establishes it.
  **Cause found, and it is not a September regression.** I instrumented the `:706` arm and captured `errors: ["remote target did not expose a settled semantic preview"]`; that early return's `debug` payload is field-for-field my `:247` dump, so two arms share one guard. @neo-opus-grace then bisected (corrected oracle, whole-file, both endpoints self-validated) to first-bad `3c432c50f3` — a fix that **unmasked** an older defect rather than introducing one, so this is not a September regression. Investigation continues on **#17578** with her as assignee; #18439 keeps the three arms as the observable. The *mechanism* is open — she has retracted a first reading, and re-measuring at `335b2ca43a` shows the two hosts diverge upstream (conversion and engagement) while agreeing on `candidateCount: 0` with a null schema. None of it is this PR's doing; the base control at `335b2ca43a` stands.
- **These three arms are outside CI's PR-time coverage**, which stands independently of the above: the `e2e-engine` job ran **38 tests**, while the same config lists **264** locally including these three. Nothing on a PR would have caught them either way.
- **Round-1 repair evidence:** 1507 unit passed across workstation / manager / ai/client / dashboard / DemoB. The manager battery is 13 arms; the new consumer control asserts a valid re-show dispatches exactly once and that an erased source or owner id dispatches **zero** times.
- `check-file-sizes` — 0 violations, run with **CI's own flags** (`--base origin/dev --pr-body-file`). The bare invocation is a weaker check and passed while CI failed; that is how the first head shipped without its `size-guard-growth:` lines.

## Post-Merge Validation

- [ ] `#18460`'s native bucket becomes actionable once this lands; the blocking edge should be verified as cleared rather than assumed.
- [ ] The three `DemoBCrossWindowDragNL` arms stay red for their own reason — if they go green after this merges, my control was wrong and that needs saying. Cause resolved to #17578 (reopened, @neo-opus-grace assignee); nothing here is expected to move them.

## Commits

- `35996822e7` — the predicate, its per-axis battery, and `RuntimeService`
- `f13c382de6` — the two dock consumers, receipts unified onto the same decision
- `ea869213ce` — the routeless-connected-entry arm AC-2 names explicitly
- `3ae4bcdc33` — Round-1 repair: an omitted identity waives a check, a nullish one refuses

Authored by Vega (Opus 5, Claude Code). Session 02a567b8-3204-4840-a50b-259f03f7b6bb.
