### PR TITLE
feat(dock): author the example with panes and zones (#18477)

### DIFF
--- a/examples/dashboard/dock/MainContainer.mjs
+++ b/examples/dashboard/dock/MainContainer.mjs
@@ -10,98 +10,19 @@ import '../../../src/tab/Container.mjs'; // registers the `tab-container` ntype 
 import '../../../src/toolbar/Base.mjs';  // registers the `toolbar` ntype used by the perspective toolbar
 
 /**
- * A representative dock-zone document (`neo.dock.zone.v1`): an edge-zone root whose center is a
- * horizontal split of a two-tab main zone and a vertical side-split of two single-tab zones, plus a
- * right edge band holding a single-tab inspector zone — the auto-hide surface (committing
- * `setItemAutoHidden` on an edge-band item collapses it to a `Neo.dashboard.dock.interaction.Rail` edge tab).
- * The shape `Neo.dashboard.dock.projection.LayoutAdapter.project` consumes — see its spec for the full contract.
- * Used as the example's INITIAL committed document; the live document advances on each commit
- * (see `MainContainer#dockModel`).
- * @type {Object}
- */
-const initialDockModel = {
-    schema: 'neo.dock.zone.v1',
-    root  : 'root',
-    items : {
-        strategy : {componentRef: 'Strategy',  title: 'Strategy',  kind: 'panel'},
-        swarm    : {componentRef: 'Swarm',     title: 'Swarm',     kind: 'panel'},
-        terminal : {componentRef: 'Terminal',  title: 'Terminal',  kind: 'terminal'},
-        logs     : {componentRef: 'Logs',      title: 'Logs',      kind: 'panel'},
-        inspector: {componentRef: 'Inspector', title: 'Inspector', kind: 'panel'},
-        metrics  : {componentRef: 'Metrics',   title: 'Metrics',   kind: 'panel'},
-        timeline : {componentRef: 'Timeline',  title: 'Timeline',  kind: 'panel'},
-        agents   : {componentRef: 'Agents',    title: 'Agents',    kind: 'panel'},
-        alerts   : {componentRef: 'Alerts',    title: 'Alerts',    kind: 'panel'},
-        history  : {componentRef: 'History',   title: 'History',   kind: 'panel'}
-    },
-    nodes: {
-        root            : {
-            type : 'edge-zone',
-            zones: {
-                center: {nodeId: 'root-split'},
-                right : {nodeId: 'inspector-tabs', extent: 0.25, resizable: true}
-            }
-        },
-        'root-split'    : {type: 'split', orientation: 'horizontal', children: ['main-tabs', 'side-split'], sizes: [0.65, 0.35]},
-        'main-tabs'     : {type: 'tabs',  items: ['strategy', 'swarm', 'metrics', 'timeline', 'agents', 'alerts', 'history'], activeItemId: 'strategy'},
-        'side-split'    : {type: 'split', orientation: 'vertical', children: ['terminal-tabs', 'logs-tabs'], sizes: [0.6, 0.4]},
-        'terminal-tabs' : {type: 'tabs',  items: ['terminal'],  activeItemId: 'terminal'},
-        'logs-tabs'     : {type: 'tabs',  items: ['logs'],      activeItemId: 'logs'},
-        'inspector-tabs': {type: 'tabs',  items: ['inspector'], activeItemId: 'inspector'}
-    }
-};
-
-const reviewDockModel = WorkspaceDocument.clone(initialDockModel);
-
-reviewDockModel.nodes['root-split'].sizes = [0.48, 0.52];
-reviewDockModel.nodes['main-tabs'].activeItemId = 'swarm';
-reviewDockModel.nodes['side-split'].sizes = [0.42, 0.58];
-
-/**
- * Example-local saved perspectives, persisted through the same `DockZoneModel` collection helpers as user-saved
- * layouts. The documents stay JSON-only and storage-backend agnostic.
- * @type {Object[]}
- */
-const seededPerspectives = [{
-    document: initialDockModel,
-    layoutId: 'operator-default',
-    title   : 'Operator'
-}, {
-    document: reviewDockModel,
-    layoutId: 'review-focus',
-    title   : 'Review'
-}];
-
-/**
- * @summary Standalone, interactive example for the dashboard dock-zone layout system — the minimal
- * consumer of {@link Neo.dashboard.dock.Workspace}.
- *
- * The engine class owns the whole host loop: the committed document ({@link #dockModel}), the pure
- * reducer (`applyDockZoneOperation`), the deferred, promise-chained re-projection through
- * `projection.LayoutAdapter` and `projection.Reconciler` (`onDockZoneDocumentChange`), the FLIP
- * motion bracket, and the in-window cross-zone drop path. Every splitter previews live by default:
- * a split boundary moves its conserved adjacent pair on the main thread (totals constant, both
- * members' CSS bounds respected) and the edge boundary resizes its band the same way — release
- * commits exactly one `resizeSplit` / `resizeEdgeZone` matching the final preview, Escape restores
- * the exact pre-drag geometry, and the layout re-projects from the new committed document — the
- * example adds nothing to that mechanism.
- *
- * What the example owns is exactly what an adopting app owns: which pane renders a catalog item
- * ({@link #resolvePane}), and its own chrome — a perspective toolbar consuming the saved-layout
- * collection helpers the model exposes (seed perspectives stored as `neo.dock.layoutCollection.v1`,
- * selecting a perspective calls `restoreActiveSavedLayout()`, Save Current upserts the live committed
- * document, Delete Active keeps a valid replacement active) plus browser-local persistence through the
- * main-thread `LocalStorage` addon, so App-Worker code never reaches for `window.localStorage` directly.
- * The toolbar re-syncs on every re-projection through the {@link #beforeRefreshDockWorkspace} hook.
- *
- * `app.mjs` composes this workspace as the flex child of a real `Neo.container.Viewport`. The
- * Viewport owns application mounting, root sizing and the body contract; this class owns only the
- * dock document, projection and example chrome.
- *
- * See `learn/agentos/DockZoneModel.md` for the model/projection contract and
- * `learn/guides/uibuildingblocks/DockLayouts.md` for the adoption guide.
  * @class Neo.examples.dashboard.dock.MainContainer
  * @extends Neo.dashboard.dock.Workspace
+ * @summary Declarative dock layout with optional example-owned perspectives and tour replay.
+ *
+ * The panes and zones configs define the complete initial arrangement. Workspace owns lowering,
+ * pane resolution, first projection and interaction lifetimes. Named structural IDs below are
+ * used by the Review preset and tour operations; other node IDs belong to the engine.
+ *
+ * The remaining methods demonstrate saved-layout collections, a persistent toolbar and LocalStorage
+ * through the main-thread addon. These features consume the captured document and are independent
+ * of initial layout authoring. A supplied document retains the host's precedence over declarations.
+ *
+ * See learn/guides/uibuildingblocks/DockLayouts.md for the adoption guide.
  */
 class MainContainer extends DockWorkspace {
     static config = {
@@ -143,7 +64,41 @@ class MainContainer extends DockWorkspace {
         /**
          * @member {Object} layout={ntype:'vbox', align:'stretch'}
          */
-        layout: {ntype: 'vbox', align: 'stretch'}
+        layout: {ntype: 'vbox', align: 'stretch'},
+        /**
+         * Ordinary pane configs keyed by their stable workspace identity. Strategy supplies
+         * the existing reload delegation demo; the other panes use the host's recreate path.
+         * @member {Object} panes
+         */
+        panes: {
+            strategy : {module: ReloadablePane, cls: ['neo-example-dock-pane'], header: {text: 'Strategy'}, componentRef: 'Strategy', kind: 'panel'},
+            swarm    : {ntype: 'component', cls: ['neo-example-dock-pane'], header: {text: 'Swarm'}, componentRef: 'Swarm', kind: 'panel', text: 'Swarm'},
+            terminal : {ntype: 'component', cls: ['neo-example-dock-pane'], header: {text: 'Terminal'}, componentRef: 'Terminal', kind: 'terminal', text: 'Terminal'},
+            logs     : {ntype: 'component', cls: ['neo-example-dock-pane'], header: {text: 'Logs'}, componentRef: 'Logs', kind: 'panel', text: 'Logs'},
+            inspector: {ntype: 'component', cls: ['neo-example-dock-pane'], header: {text: 'Inspector'}, componentRef: 'Inspector', kind: 'panel', text: 'Inspector'},
+            metrics  : {ntype: 'component', cls: ['neo-example-dock-pane'], header: {text: 'Metrics'}, componentRef: 'Metrics', kind: 'panel', text: 'Metrics'},
+            timeline : {ntype: 'component', cls: ['neo-example-dock-pane'], header: {text: 'Timeline'}, componentRef: 'Timeline', kind: 'panel', text: 'Timeline'},
+            agents   : {ntype: 'component', cls: ['neo-example-dock-pane'], header: {text: 'Agents'}, componentRef: 'Agents', kind: 'panel', text: 'Agents'},
+            alerts   : {ntype: 'component', cls: ['neo-example-dock-pane'], header: {text: 'Alerts'}, componentRef: 'Alerts', kind: 'panel', text: 'Alerts'},
+            history  : {ntype: 'component', cls: ['neo-example-dock-pane'], header: {text: 'History'}, componentRef: 'History', kind: 'panel', text: 'History'}
+        },
+        /**
+         * Nested placement: center tabs beside a vertical split, with an inspector edge band.
+         * @member {Object} zones
+         */
+        zones: {
+            center: {
+                id      : 'root-split', orientation: 'horizontal', sizes: [0.65, 0.35],
+                children: [{
+                    id   : 'main-tabs',
+                    items: ['strategy', 'swarm', 'metrics', 'timeline', 'agents', 'alerts', 'history']
+                }, {
+                    id      : 'side-split', orientation: 'vertical', sizes: [0.6, 0.4],
+                    children: ['terminal', 'logs']
+                }]
+            },
+            right: {items: ['inspector'], extent: 0.25, resizable: true}
+        }
     }
 
     /**
@@ -171,17 +126,15 @@ class MainContainer extends DockWorkspace {
     savedPerspectiveCount = 0
 
     /**
-     * @summary Creates example-owned perspective state and toolbar; the engine mounts the first shell.
-     * @param {Object} config
+     * @summary Creates perspective chrome after Workspace captures the initial declarations.
+     * @protected
      */
-    construct(config) {
-        super.construct(config);
+    onAfterConstructed() {
+        super.onAfterConstructed();
 
-        let me = this;
+        const me = this;
 
         me.layoutCollection = me.createDefaultLayoutCollection();
-        me.dockModel        = PerspectiveLibrary.restoreActiveSavedLayout(me.layoutCollection).document || WorkspaceDocument.clone(initialDockModel);
-
         me.add(me.createPerspectiveToolbar());
         me.layoutCollectionLoadPromise = me.loadLayoutCollectionFromStorage()
     }
@@ -194,30 +147,6 @@ class MainContainer extends DockWorkspace {
      */
     beforeRefreshDockWorkspace(document, refreshOptions) {
         this.syncPerspectiveToolbar()
-    }
-
-    /**
-     * Resolves a catalog item to the pane rendered inside its dock zone. For this example, a simple
-     * centered label per panel; a real app resolves each item to its feature view. The FLIP marker
-     * class is stamped by the engine class, never here.
-     * @param {String} itemId The stable workspace identity from the item catalog.
-     * @param {Object} item The persisted item record.
-     * @returns {Object}
-     */
-    resolvePane(itemId, item) {
-        // Strategy demonstrates the reload delegation contract; see ReloadablePane below.
-        if (itemId === 'strategy') {
-            return {
-                module: ReloadablePane,
-                style : {alignItems: 'center', color: '#888', display: 'flex', fontSize: '20px', justifyContent: 'center'}
-            }
-        }
-
-        return {
-            ntype: 'component',
-            style: {alignItems: 'center', color: '#888', display: 'flex', fontSize: '20px', justifyContent: 'center'},
-            html : item?.componentRef ?? itemId
-        }
     }
 
     /**
@@ -264,11 +193,23 @@ class MainContainer extends DockWorkspace {
     }
 
     /**
-     * Builds a valid default collection from the example's seeded perspectives.
+     * @summary Derives Operator and Review perspectives from the effective initial document.
      * @returns {Object}
      */
     createDefaultLayoutCollection() {
-        let layouts = seededPerspectives.map(({document, layoutId, title}) => {
+        const operator = WorkspaceDocument.clone(this.dockModel),
+              review   = WorkspaceDocument.clone(operator),
+              nodes    = review.nodes;
+
+        // Restored documents can have different topology; adjust only the matching named regions.
+        if (nodes['root-split']?.type === 'split' && nodes['root-split'].children.length === 2) nodes['root-split'].sizes = [0.48, 0.52];
+        if (nodes['main-tabs']?.items?.includes('swarm')) nodes['main-tabs'].activeItemId = 'swarm';
+        if (nodes['side-split']?.type === 'split' && nodes['side-split'].children.length === 2) nodes['side-split'].sizes = [0.42, 0.58];
+
+        let layouts = [
+                {document: operator, layoutId: 'operator-default', title: 'Operator'},
+                {document: review, layoutId: 'review-focus', title: 'Review'}
+            ].map(({document, layoutId, title}) => {
                 let {layout, errors} = Persistence.createSavedLayout(document, {
                     layoutId,
                     title,

--- a/examples/dashboard/dock/neo-config.json
+++ b/examples/dashboard/dock/neo-config.json
@@ -3,6 +3,6 @@
     "basePath"   : "../../../",
     "environment"     : "development",
     "mainPath"        : "./Main.mjs",
-    "mainThreadAddons": ["DockFlip", "DragDrop", "Navigator", "Stylesheet"],
+    "mainThreadAddons": ["DockFlip", "DragDrop", "LocalStorage", "Navigator", "Stylesheet"],
     "useAiClient": true
 }

--- a/resources/scss/src/examples/dashboard/dock/MainContainer.scss
+++ b/resources/scss/src/examples/dashboard/dock/MainContainer.scss
@@ -1,0 +1,7 @@
+.neo-example-dock-pane {
+    align-items    : center;
+    color          : #888;
+    display        : flex;
+    font-size      : 20px;
+    justify-content: center;
+}

--- a/src/dashboard/dock/projection/LayoutAdapter.mjs
+++ b/src/dashboard/dock/projection/LayoutAdapter.mjs
@@ -8,9 +8,8 @@ import WorkspaceDocument from '../model/WorkspaceDocument.mjs';
 import MotionSignal      from './MotionSignal.mjs';
 import TabOverflowPlugin from '../../../tab/plugin/Overflow.mjs';
 
-// Private runtime restoration slot for live component instances projected through the popup
-// stack grip. Symbol-keyed so it can never collide with application config or persisted data.
-const stackHeaderSource = Symbol('dockStackHeaderSource');
+// Restores a live pane's header after transient insertion or stack-grip decoration.
+const projectedHeaderSource = Symbol('dockProjectedHeaderSource');
 
 /**
  * @summary Projects dock-zone model nodes into existing Neo layout and tab configs.
@@ -123,15 +122,14 @@ class LayoutAdapter extends Base {
     }
 
     /**
-     * @summary Applies adapter-owned item metadata and one-use add-tab decoration to a pane config.
+     * @summary Applies item metadata and transient header decoration to a pane config or live instance.
      *
      * Reconciliation discovers live panes before consulting its app resolver. When a pane is genuinely
      * absent, this helper lets that resolver prepare the same config the normal projection path
      * would have emitted without copying dashboard-owned header policy into the consuming workspace.
-     * Add-tab animation remains plain-config-only. The stack handle also supports a LIVE component
-     * instance through a symbol-keyed runtime header overlay whose exact prior ownership/value is
-     * restored as soon as that instance projects without the handle; the popup affordance therefore
-     * cannot leak into the main workspace or persisted item state.
+     * Live instances retain their original header ownership/value behind both the stack grip and
+     * add-tab animation. Each call starts from that original header, so an unrelated projection
+     * removes the transient decoration without copying it into application or persisted state.
      * @param {*} component Resolved pane config or live component instance.
      * @param {String} itemId Stable item identity.
      * @param {Object} item Persisted item record.
@@ -143,35 +141,35 @@ class LayoutAdapter extends Base {
      * @static
      */
     static decorateProjectedItem(component, itemId, item, {nodeId=null, stackHandle=false, tabInsertDescriptor=null}={}) {
-        let config = this.decorateItemConfig(component, itemId, item),
+        let config      = this.decorateItemConfig(component, itemId, item),
+            isLive      = config instanceof Base,
+            canDecorate = isLive || config?.constructor === Object,
+            isInsertion = canDecorate && tabInsertDescriptor?.operation === 'addTab'
+                && tabInsertDescriptor.itemId === itemId && tabInsertDescriptor.tabsNodeId === nodeId,
             header;
 
-        if (config instanceof Base) {
-            let source = config[stackHeaderSource];
+        if (isLive) {
+            const source = config[projectedHeaderSource];
 
-            if (stackHandle) {
-                source ||= config[stackHeaderSource] = {
-                    hadOwn: Object.hasOwn(config, 'header'),
-                    value : config.header
-                };
-                config.header = this.createStackHeader(source.value, itemId, item)
-            } else if (source) {
+            if (source) {
                 if (source.hadOwn) {
                     config.header = source.value
                 } else {
                     delete config.header
                 }
 
-                delete config[stackHeaderSource]
+                delete config[projectedHeaderSource]
             }
 
-            return config
+            if (stackHandle || isInsertion) {
+                config[projectedHeaderSource] = {
+                    hadOwn: Object.hasOwn(config, 'header'),
+                    value : config.header
+                }
+            }
         }
 
-        if (config?.constructor === Object
-            && tabInsertDescriptor?.operation === 'addTab'
-            && tabInsertDescriptor.itemId === itemId
-            && tabInsertDescriptor.tabsNodeId === nodeId) {
+        if (isInsertion) {
             header = config.header || {text: item?.title || itemId};
             config.header = {
                 ...header,
@@ -184,7 +182,7 @@ class LayoutAdapter extends Base {
             }
         }
 
-        if (config?.constructor === Object && stackHandle) {
+        if (canDecorate && stackHandle) {
             config.header = this.createStackHeader(config.header, itemId, item)
         }
 

--- a/test/playwright/e2e/dashboard/DockAutoHideRevealNL.spec.mjs
+++ b/test/playwright/e2e/dashboard/DockAutoHideRevealNL.spec.mjs
@@ -112,7 +112,7 @@ test.describe('Dock auto-hide reveal/pin journey (Neural Link)', () => {
 
         await tuckInspector({ app, holderId, page });
 
-        // Product truth #1: the committed auto-hidden item projects as a REAL rail button.
+        // The committed auto-hidden item projects as a real rail button.
         const railTab = page.locator('.neo-dashboard-dock-rail-tab', { hasText: 'Inspector' }).first();
         await expect(railTab, 'the inspector must collapse to a labeled edge-rail tab').toBeVisible({ timeout: 10000 });
 
@@ -162,7 +162,7 @@ test.describe('Dock auto-hide reveal/pin journey (Neural Link)', () => {
 
         const firstRevealAnimationStarts = await page.evaluate(() => window.__neoDockRevealAnimationStarts);
 
-        // Product truth #2: reveal is runtime-only — worker truth is byte-stable across the reveal.
+        // Reveal is runtime-only: worker truth is byte-stable across the reveal.
         const revealed = await readModel();
         expect(JSON.stringify(revealed), 'the committed document must NOT change on reveal').toBe(JSON.stringify(hidden));
 
@@ -218,7 +218,7 @@ test.describe('Dock auto-hide reveal/pin journey (Neural Link)', () => {
         await overlay.locator('.neo-dashboard-dock-reveal-pin').first().click();
         await page.waitForTimeout(1500);
 
-        // Product truth #3: the pin gesture mutated worker truth through the semantic path.
+        // The pin gesture mutated worker truth through the semantic path.
         const pinned = await readModel();
         console.log('[auto-hide] inspector:', JSON.stringify(hidden?.items?.inspector), '->', JSON.stringify(pinned?.items?.inspector));
         expect(pinned?.items?.inspector?.pinned,     'the pin gesture must commit setItemPinned(true)').toBe(true);
@@ -251,14 +251,14 @@ test.describe('Dock auto-hide reveal/pin journey (Neural Link)', () => {
         await expect(overlay).toBeVisible({timeout: 10000});
         await expect(prose, 'the prose-bearing non-focusable pane must be rendered').toBeVisible();
 
-        // Honest reading interaction #1: whitespace in the pane slot keeps the focused reveal.
+        // Whitespace in the pane slot keeps the focused reveal.
         await paneSlot.click({position: {x: 12, y: 12}});
         await expect(overlay, 'inside whitespace must not dismiss the reveal').toBeVisible();
         await expect.poll(() => overlay.evaluate(element => document.activeElement === element), {
             message: 'inside mousedown must refocus the tabindex=-1 overlay root'
         }).toBe(true);
 
-        // Honest reading interaction #2: selection remains browser-native. A local listener would
+        // Selection remains browser-native. A local listener would
         // preventDefault on mousedown and make this arm red even if the overlay stayed painted.
         await prose.dblclick();
         await expect.poll(() => page.evaluate(() => document.getSelection()?.toString().trim() || ''), {

--- a/test/playwright/e2e/dashboard/DockAutoHideRevealNL.spec.mjs
+++ b/test/playwright/e2e/dashboard/DockAutoHideRevealNL.spec.mjs
@@ -91,8 +91,12 @@ test.describe('Dock auto-hide reveal/pin journey (Neural Link)', () => {
         const { app, holderId, readModel } = await bootDockExample({ page, neuralLink });
 
         // Setup truth: inspector sits visible in the right edge band; nothing rails yet.
-        const before = await readModel();
-        expect(before?.nodes?.['inspector-tabs']?.items, 'the example must seed the inspector in the right edge band').toEqual(['inspector']);
+        const before        = await readModel();
+        const inspectorNode = Object.entries(before.nodes).find(([, node]) =>
+            node.type === 'tabs' && node.items.includes('inspector'))?.[0];
+        expect(inspectorNode, 'inspector occupies a real tabs node').toBeTruthy();
+        expect(before.nodes[inspectorNode].items, 'the example must seed the inspector in the right edge band').toEqual(['inspector']);
+        expect(before.nodes[before.root].zones.right.nodeId).toBe(inspectorNode);
         expect(before?.items?.inspector?.autoHidden, 'the inspector must start visible').not.toBe(true);
         await expect(page.locator('.neo-dashboard-dock-edge-rail .neo-dashboard-dock-rail-tab')).toHaveCount(0);
 

--- a/test/playwright/e2e/dashboard/DockCrossZoneDragNL.spec.mjs
+++ b/test/playwright/e2e/dashboard/DockCrossZoneDragNL.spec.mjs
@@ -33,10 +33,12 @@ test.describe('Dock cross-zone drag journey (Neural Link)', () => {
 
         const readModel = async () => (await app.getComponent(holderId, ['dockModel'])).dockModel;
 
-        const before     = await readModel();
-        const sourceNode = tabsNodeHolding(before, 'strategy');
+        const before       = await readModel();
+        const sourceNode   = tabsNodeHolding(before, 'strategy');
+        const terminalNode = tabsNodeHolding(before, 'terminal');
         expect(sourceNode, 'strategy must start in main-tabs').toBe('main-tabs');
-        expect(tabsNodeHolding(before, 'terminal'), 'terminal must start in terminal-tabs').toBe('terminal-tabs');
+        expect(terminalNode, 'terminal must start in a tabs node').toBeTruthy();
+        expect(terminalNode, 'the terminal target must be a different zone').not.toBe(sourceNode);
 
         // drag the Strategy header (main-tabs) and drop it over the Terminal zone (a DIFFERENT tabs node)
         const strategyTab = page.locator('.neo-tab-header-button', { hasText: 'Strategy' }).first();
@@ -60,10 +62,10 @@ test.describe('Dock cross-zone drag journey (Neural Link)', () => {
 
         const after      = await readModel();
         const targetNode = tabsNodeHolding(after, 'strategy');
-        console.log('[cross-zone] strategy:', sourceNode, '->', targetNode, '| terminal-tabs items:', JSON.stringify(after?.nodes?.['terminal-tabs']?.items));
+        console.log('[cross-zone] strategy:', sourceNode, '->', targetNode, '| terminal zone items:', JSON.stringify(after?.nodes?.[terminalNode]?.items));
 
-        // worker truth: the drop relocated strategy OUT of main-tabs INTO terminal-tabs through the producer pipeline
+        // Worker truth: the producer moved strategy into the zone which held terminal before the gesture.
         expect(targetNode, 'the cross-zone drop must move strategy to the Terminal zone — the producer contract')
-            .toBe('terminal-tabs');
+            .toBe(terminalNode);
     });
 });

--- a/test/playwright/e2e/dashboard/DockMotionNL.spec.mjs
+++ b/test/playwright/e2e/dashboard/DockMotionNL.spec.mjs
@@ -229,12 +229,16 @@ test.describe('Dock motion pipeline (Neural Link) — the signal brackets real m
 
         // state-relative (shared heap): pick a REAL cross-zone move from the current doc —
         // an item out of main-tabs if it has one, else one back INTO it
-        const topo0     = await app.getDockTopology(holderId);
-        const doc0      = topo0?.document ?? topo0;
-        const mainItems = doc0.nodes['main-tabs']?.items || [];
+        const topo0        = await app.getDockTopology(holderId);
+        const doc0         = topo0?.document ?? topo0;
+        const mainItems    = doc0.nodes['main-tabs']?.items || [];
+        const terminalNode = Object.entries(doc0.nodes).find(([, node]) =>
+            node.type === 'tabs' && node.items.includes('terminal'))?.[0];
+        expect(terminalNode, 'the terminal pane must identify the other tabs node').toBeTruthy();
+        expect(terminalNode, 'the move crosses distinct zones').not.toBe('main-tabs');
         const move      = mainItems.length
-            ? { itemId: mainItems[0], targetNodeId: 'terminal-tabs' }
-            : { itemId: (doc0.nodes['terminal-tabs']?.items || [])[0], targetNodeId: 'main-tabs' };
+            ? { itemId: mainItems[0], targetNodeId: terminalNode }
+            : { itemId: (doc0.nodes[terminalNode]?.items || [])[0], targetNodeId: 'main-tabs' };
         expect(move.itemId, 'a movable item must exist in the shared-heap doc').toBeTruthy();
 
         // the moved pane's OWN marker (the per-item correlation key the projection stamps) —

--- a/test/playwright/e2e/dashboard/DockOperationsNL.spec.mjs
+++ b/test/playwright/e2e/dashboard/DockOperationsNL.spec.mjs
@@ -15,9 +15,9 @@ const values  = record => record?.properties || record || {};
  * Structural half of the op-suite ticket only — animation assertions land once the motion-contract
  * disposition settles, and the tour-replay spec waits on the Demo-A tour surface.
  *
- * Seeded workspace (examples/dashboard/dock — `initialDockModel` in the example is the live authority):
- * root edge-zone {center: root-split, right: inspector-tabs}; root-split = horizontal [main-tabs, side-split];
- * side-split = vertical [terminal-tabs{terminal}, logs-tabs{logs}]; inspector-tabs{inspector}. `main-tabs`
+ * Seeded workspace (examples/dashboard/dock — the example's panes/zones declarations are the authority):
+ * root edge-zone {center: root-split, right: inspector's tabs}; root-split = horizontal [main-tabs, side-split];
+ * side-split holds the terminal and logs tabs vertically; inspector occupies the right edge. `main-tabs`
  * carries the demo's grown tab catalog (strategy, swarm, metrics, …) and may keep growing — a spec that
  * asserts a post-operation remainder DERIVES it from a pre-operation topology read; a pinned remainder
  * literal goes stale the day the demo gains a pane, while the operations under test stay correct.
@@ -63,9 +63,149 @@ test.describe('Dock semantic operations (Neural Link, structural)', () => {
 
         expect(topo.root).toBe('root');
         expect(tabsNodeHolding(topo, 'strategy')).toBe('main-tabs');
-        expect(tabsNodeHolding(topo, 'inspector')).toBe('inspector-tabs');
+        const inspectorNode = tabsNodeHolding(topo, 'inspector');
+        expect(inspectorNode, 'inspector occupies a real tabs node').toBeTruthy();
+        expect(topo.nodes[topo.root].zones.right.nodeId).toBe(inspectorNode);
         // the read half and the holder's own committed truth are the SAME document
         expect(JSON.stringify(topo)).toBe(JSON.stringify(committed));
+    });
+
+    test('the declared default renders four pane groups with the complete title inventory and centered content', async ({page, neuralLink}, testInfo) => {
+        const {app, holderId} = await connect(page, neuralLink),
+              document        = await readTopology(app, holderId),
+              titles          = ['Strategy', 'Swarm', 'Terminal', 'Logs', 'Inspector', 'Metrics', 'Timeline', 'Agents', 'Alerts', 'History'].sort(),
+              paneKeys        = ['strategy', 'terminal', 'logs', 'inspector'],
+              nodeIds         = paneKeys.map(itemId => tabsNodeHolding(document, itemId));
+
+        expect(Object.values(document.items).map(item => item.title).sort()).toEqual(titles);
+        expect(nodeIds.every(Boolean), 'every visible pane belongs to a real tabs node').toBe(true);
+        expect(new Set(nodeIds).size).toBe(4);
+        expect(Object.values(document.nodes).filter(node => node.type === 'tabs')).toHaveLength(4);
+        expect(document.nodes['root-split']).toMatchObject({orientation: 'horizontal', sizes: [0.65, 0.35]});
+        expect(document.nodes['side-split']).toMatchObject({orientation: 'vertical', sizes: [0.6, 0.4]});
+        expect(document.nodes[document.root].zones.right.nodeId).toBe(tabsNodeHolding(document, 'inspector'));
+        await expect(page.locator('.neo-dashboard-dock-tabs')).toHaveCount(4);
+        await expect.poll(async () => (await page.locator('.neo-tab-header-button').allTextContents())
+            .map(title => title.trim()).sort()).toEqual(titles);
+
+        const boxes = {};
+        for (const itemId of paneKeys) {
+            const nodeId  = tabsNodeHolding(document, itemId),
+                  records = asArray(await app.queryComponent({dockNodeId: nodeId}, ['id'])),
+                  tabId   = records[0]?.id ?? values(records[0]).id;
+            expect(tabId, `${itemId} has projected tab chrome`).toBeTruthy();
+            expect(document.nodes[nodeId].activeItemId).toBe(itemId);
+            const tabs = page.locator(`#${tabId}`),
+                  card = await app.callMethod(tabId, 'getActiveCard', []);
+            expect(card?.id, `${itemId} has a real active component`).toBeTruthy();
+            const pane = page.locator(`#${card.id}`);
+            await expect(tabs).toBeVisible();
+            await expect(pane).toHaveText(document.items[itemId].title);
+            await expect(pane).toBeVisible();
+            await expect.poll(() => pane.evaluate(element => {
+                const style = getComputedStyle(element);
+                return {fontSize: style.fontSize, display: style.display, alignItems: style.alignItems, justifyContent: style.justifyContent}
+            })).toEqual({fontSize: '20px', display: 'flex', alignItems: 'center', justifyContent: 'center'});
+            boxes[itemId] = await tabs.boundingBox();
+            expect(boxes[itemId].width).toBeGreaterThan(0);
+            expect(boxes[itemId].height).toBeGreaterThan(0)
+        }
+
+        expect(boxes.strategy.x + boxes.strategy.width).toBeLessThanOrEqual(boxes.terminal.x + 2);
+        expect(boxes.terminal.y + boxes.terminal.height).toBeLessThanOrEqual(boxes.logs.y + 2);
+        expect(boxes.terminal.x).toBeCloseTo(boxes.logs.x, 0);
+        expect(boxes.terminal.width).toBeCloseTo(boxes.logs.width, 0);
+        expect(boxes.terminal.x + boxes.terminal.width).toBeLessThanOrEqual(boxes.inspector.x + 2);
+        expect(boxes.strategy.height).toBeGreaterThan(boxes.terminal.height);
+        expect(boxes.strategy.y).toBeCloseTo(boxes.inspector.y, 0);
+        expect((await app.getComponent(holderId, ['dockModel'])).dockModel).toEqual(document);
+
+        const screenshot = testInfo.outputPath('dock-example-declarative-default.png');
+        await page.screenshot({path: screenshot, fullPage: true, animations: 'disabled'});
+        await testInfo.attach('dock-example-declarative-default', {path: screenshot, contentType: 'image/png'})
+    });
+
+    test('Review and Operator retain toolbar identity, and a saved layout survives restore and page reload', async ({page, neuralLink}) => {
+        const {app, holderId} = await connect(page, neuralLink),
+              toolbar         = page.locator('.neo-dashboard-dock-perspective-toolbar'),
+              storageKey      = 'neo.examples.dashboard.dock.layoutCollection',
+              button          = title => toolbar.getByRole('button', {name: title, exact: true}),
+              readButtons     = () => toolbar.locator('.neo-button').evaluateAll(nodes =>
+                  nodes.map(node => ({id: node.id, text: node.textContent.trim()}))),
+              readCollection = async () => (await app.getComponent(holderId, ['layoutCollection'])).layoutCollection,
+              readStored = () => page.evaluate(key => {
+                  const value = localStorage.getItem(key);
+                  return value ? JSON.parse(value) : null
+              }, storageKey);
+
+        await expect(button('Operator')).toBeVisible();
+        await expect(button('Review')).toBeVisible();
+        const initialButtons = await readButtons(), toolbarId = await toolbar.getAttribute('id'),
+              retainedNodes  = await Promise.all([toolbar, ...initialButtons.map(entry => page.locator(`#${entry.id}`))]
+                  .map(locator => locator.elementHandle()));
+        expect(initialButtons.map(entry => entry.text)).toEqual(['Operator', 'Review', 'Save Current', 'Delete Active']);
+
+        await button('Review').click();
+        await expect.poll(async () => (await readCollection()).activeLayoutId).toBe('review-focus');
+        await expect.poll(async () => (await readTopology(app, holderId)).nodes['root-split'].sizes).toEqual([0.48, 0.52]);
+        await expect.poll(async () => (await readTopology(app, holderId)).nodes['main-tabs'].activeItemId).toBe('swarm');
+        expect((await readTopology(app, holderId)).nodes['side-split'].sizes).toEqual([0.42, 0.58]);
+        await expect(button('Review')).toHaveClass(/neo-dashboard-dock-perspective-active/);
+        expect(await readButtons()).toEqual(initialButtons);
+
+        await button('Operator').click();
+        await expect.poll(async () => (await readCollection()).activeLayoutId).toBe('operator-default');
+        await expect.poll(async () => (await readTopology(app, holderId)).nodes['root-split'].sizes).toEqual([0.65, 0.35]);
+        await expect.poll(async () => (await readTopology(app, holderId)).nodes['main-tabs'].activeItemId).toBe('strategy');
+        await expect(button('Operator')).toHaveClass(/neo-dashboard-dock-perspective-active/);
+        expect(await readButtons()).toEqual(initialButtons);
+
+        // Save a document which visibly differs from the declared Operator default.
+        await button('Review').click();
+        await expect.poll(async () => (await readTopology(app, holderId)).nodes['main-tabs'].activeItemId).toBe('swarm');
+        const savedDocument = await readTopology(app, holderId);
+        await button('Save Current').click();
+        await expect(button('Saved 1')).toBeVisible();
+        const savedId = 'saved-perspective-1';
+        await expect.poll(async () => (await readCollection()).activeLayoutId).toBe(savedId);
+        await expect.poll(async () => (await readStored())?.activeLayoutId, {
+            message: 'the Save Current gesture must reach the actual main-thread storage key'
+        }).toBe(savedId);
+        const stored = await readStored();
+        expect(stored.schema).toBe('neo.dock.layoutCollection.v1');
+        expect(stored.layouts[savedId].dockZone).toEqual(savedDocument);
+        await expect.poll(async () => (await readButtons()).map(entry => entry.text))
+            .toEqual(['Operator', 'Review', 'Saved 1', 'Save Current', 'Delete Active']);
+        const buttonsAfterSave = await readButtons();
+        for (const entry of initialButtons) {
+            expect(buttonsAfterSave.find(current => current.text === entry.text)?.id).toBe(entry.id)
+        }
+        expect(await toolbar.getAttribute('id')).toBe(toolbarId);
+        for (const node of retainedNodes) expect(await node.evaluate(element => element.isConnected)).toBe(true);
+
+        const resized = await app.executeDockOperation(holderId, {
+            operation: 'resizeSplit', splitNodeId: 'root-split', sizes: [0.5, 0.5]
+        });
+        expect(resized).toMatchObject({applied: true, errors: []});
+        await expect.poll(async () => (await readTopology(app, holderId)).nodes['root-split'].sizes).toEqual([0.5, 0.5]);
+        expect((await readStored()).layouts[savedId].dockZone).toEqual(savedDocument);
+        await button('Saved 1').click();
+        await expect.poll(() => readTopology(app, holderId)).toEqual(savedDocument);
+        expect(await readButtons()).toEqual(buttonsAfterSave);
+
+        await page.reload();
+        await expect(page.locator('.neo-dashboard-dock-tabs')).toHaveCount(4);
+        const currentHolderId = await page.locator('.neo-dock-workspace').getAttribute('id'),
+              currentApp      = await neuralLink.connectToApp('Neo.examples.dashboard.dock'),
+              currentHolders  = asArray(await currentApp.findInstances({className: 'Neo.examples.dashboard.dock.MainContainer'}, ['id']));
+        expect(currentHolderId, 'bind the post-reload read to the holder rendered in this page').toBeTruthy();
+        expect(currentHolders.map(record => record.id ?? values(record).id)).toContain(currentHolderId);
+        await expect.poll(async () => (await currentApp.getComponent(currentHolderId, ['layoutCollection'])).layoutCollection?.activeLayoutId)
+            .toBe(savedId);
+        await expect.poll(() => readTopology(currentApp, currentHolderId)).toEqual(savedDocument);
+        await expect(page.locator('.neo-dashboard-dock-perspective-toolbar').getByRole('button', {name: 'Saved 1', exact: true}))
+            .toHaveClass(/neo-dashboard-dock-perspective-active/);
+        await expect(page.locator('[class~="dock-flip-item-swarm"]')).toBeVisible()
     });
 
     test('a deferred first document cannot poison the SharedWorker mount or later edge resizes', async ({page, neuralLink}) => {
@@ -275,14 +415,17 @@ test.describe('Dock semantic operations (Neural Link, structural)', () => {
             timeout: 10000
         }).toBe(successorButtonId);
 
-        const terminalRecords = await app.queryComponent({dockNodeId: 'terminal-tabs'}, ['id', 'ntype']),
+        const terminalNode = tabsNodeHolding(after, 'terminal');
+        expect(terminalNode, 'terminal remains in its own tabs node before closing').toBeTruthy();
+
+        const terminalRecords = await app.queryComponent({dockNodeId: terminalNode}, ['id', 'ntype']),
               terminalRecord  = Array.isArray(terminalRecords) ? terminalRecords[0] : terminalRecords,
               terminalId      = terminalRecord?.id ?? terminalRecord?.properties?.id,
               terminalAction  = await app.callMethod(terminalId, 'getAction', ['close']);
 
         expect(terminalId, 'the single-item terminal stack must remain projected').toBeTruthy();
         await page.locator(`#${terminalAction.id}`).click();
-        await expect.poll(async () => (await readTopology(app, holderId)).nodes['terminal-tabs'], {
+        await expect.poll(async () => (await readTopology(app, holderId)).nodes[terminalNode], {
             message: 'closing the only item lets normalization prune its tabs node',
             timeout: 10000
         }).toBeUndefined();
@@ -297,14 +440,17 @@ test.describe('Dock semantic operations (Neural Link, structural)', () => {
         const { app, holderId } = await connect(page, neuralLink);
 
         // derive the expected remainders from the seeded document itself — exact, and growth-proof
-        const before         = await readTopology(app, holderId);
-        const mainBefore     = before.nodes['main-tabs'].items;
-        const terminalBefore = before.nodes['terminal-tabs'].items;
+        const before       = await readTopology(app, holderId);
+        const mainBefore   = before.nodes['main-tabs'].items;
+        const terminalNode = tabsNodeHolding(before, 'terminal');
+
+        expect(terminalNode, 'the target is the existing terminal tabs node').toBeTruthy();
+        const terminalBefore = before.nodes[terminalNode].items;
 
         expect(mainBefore, 'seed: swarm must start in main-tabs').toContain('swarm');
 
         const result = await app.executeDockOperation(holderId, {
-            operation: 'moveItem', itemId: 'swarm', targetNodeId: 'terminal-tabs', index: 1
+            operation: 'moveItem', itemId: 'swarm', targetNodeId: terminalNode, index: 1
         });
 
         const expectedTerminal = [...terminalBefore];
@@ -312,25 +458,27 @@ test.describe('Dock semantic operations (Neural Link, structural)', () => {
 
         expect(result.errors).toEqual([]);
         expect(result.applied).toBe(true);
-        expect(result.document.nodes['terminal-tabs'].items).toEqual(expectedTerminal);
+        expect(result.document.nodes[terminalNode].items).toEqual(expectedTerminal);
         expect(result.document.nodes['main-tabs'].items).toEqual(mainBefore.filter(id => id !== 'swarm'));
 
         const topo = await readTopology(app, holderId);
         expect(JSON.stringify(topo), 'independent read must agree with the returned delta').toBe(JSON.stringify(result.document));
-        expect(tabsNodeHolding(topo, 'swarm')).toBe('terminal-tabs');
+        expect(tabsNodeHolding(topo, 'swarm')).toBe(terminalNode);
     });
 
     test('split class: splitNode wraps the item and splits the target; delta and independent read agree', async ({ page, neuralLink }) => {
         const { app, holderId } = await connect(page, neuralLink);
 
         // derive the expected remainder from the seeded document itself — exact, and growth-proof
-        const before     = await readTopology(app, holderId);
-        const mainBefore = before.nodes['main-tabs'].items;
+        const before       = await readTopology(app, holderId);
+        const mainBefore   = before.nodes['main-tabs'].items;
+        const terminalNode = tabsNodeHolding(before, 'terminal');
 
         expect(mainBefore, 'seed: swarm must start in main-tabs').toContain('swarm');
+        expect(terminalNode, 'the split target is the existing terminal tabs node').toBeTruthy();
 
         const result = await app.executeDockOperation(holderId, {
-            operation: 'splitNode', itemId: 'swarm', targetNodeId: 'terminal-tabs', orientation: 'horizontal', edge: 'right'
+            operation: 'splitNode', itemId: 'swarm', targetNodeId: terminalNode, orientation: 'horizontal', edge: 'right'
         });
 
         expect(result.errors).toEqual([]);
@@ -340,7 +488,7 @@ test.describe('Dock semantic operations (Neural Link, structural)', () => {
         expect(JSON.stringify(topo)).toBe(JSON.stringify(result.document));
 
         // swarm left main-tabs and lives in a NEW single-tab node inside a NEW horizontal split
-        // whose children are [terminal-tabs, newTabs] (edge 'right' trails)
+        // whose children are [the original terminal node, newTabs] (edge 'right' trails)
         expect(topo.nodes['main-tabs'].items).toEqual(mainBefore.filter(id => id !== 'swarm'));
 
         const swarmTabs = tabsNodeHolding(topo, 'swarm');
@@ -350,7 +498,7 @@ test.describe('Dock semantic operations (Neural Link, structural)', () => {
         const newSplit = Object.values(topo.nodes).find(n =>
             n.type === 'split' && n.orientation === 'horizontal' && (n.children || []).includes(swarmTabs));
         expect(newSplit, 'a new horizontal split must hold the new pane').toBeTruthy();
-        expect(newSplit.children).toEqual(['terminal-tabs', swarmTabs]);
+        expect(newSplit.children).toEqual([terminalNode, swarmTabs]);
     });
 
     test('resize class: resizeSplit commits new sizes; delta and independent read agree', async ({ page, neuralLink }) => {

--- a/test/playwright/e2e/dashboard/DockPinCollapseNL.spec.mjs
+++ b/test/playwright/e2e/dashboard/DockPinCollapseNL.spec.mjs
@@ -76,6 +76,10 @@ const tabsNodeId = async (app, dockNodeId) => {
     return record?.id ?? record?.properties?.id
 };
 
+/** @summary Resolves incidental tabs-node identity from its stable pane membership. */
+const tabsNodeHolding = (document, itemId) => Object.entries(document.nodes).find(([, node]) =>
+    node.type === 'tabs' && node.items.includes(itemId))?.[0];
+
 /**
  * Clicks one pane's tab header, which is how a user gives that pane focus. The engine set is
  * FOCUS-GATED (`showOnFocus`, `visibility: hidden` while closed), so without this the actions are
@@ -149,13 +153,16 @@ test.describe('Dock pin/collapse round-trip (Neural Link)', () => {
 
         // Setup truth: the inspector sits VISIBLE in the right edge band, and nothing rails yet. The
         // sibling spec has to commit an auto-hide here; this one gets there by pressing a button.
-        const before = await readModel();
+        const before        = await readModel();
+        const inspectorNode = tabsNodeHolding(before, 'inspector');
 
-        expect(before?.nodes?.['inspector-tabs']?.items, 'the example seeds the inspector in the right edge band').toEqual(['inspector']);
+        expect(inspectorNode, 'inspector occupies a real tabs node').toBeTruthy();
+        expect(before.nodes[inspectorNode].items, 'the example seeds the inspector in the right edge band').toEqual(['inspector']);
+        expect(before.nodes[before.root].zones.right.nodeId).toBe(inspectorNode);
         expect(before?.items?.inspector?.autoHidden, 'the inspector must start visible').not.toBe(true);
         await expect(page.locator('.neo-dashboard-dock-edge-rail .neo-dashboard-dock-rail-tab')).toHaveCount(0);
 
-        const inspectorTabsId = await tabsNodeId(app, 'inspector-tabs'),
+        const inspectorTabsId = await tabsNodeId(app, inspectorNode),
               mainTabsId      = await tabsNodeId(app, 'main-tabs');
 
         expect(inspectorTabsId, 'the inspector band projects a live TabContainer').toBeTruthy();
@@ -243,7 +250,7 @@ test.describe('Dock pin/collapse round-trip (Neural Link)', () => {
         const restored = await readModel();
 
         expect(restored.items.inspector.autoHidden, 'returning clears the collapse').toBe(false);
-        expect(restored.nodes['inspector-tabs'].items, 'the pane is back in its tab flow').toEqual(['inspector']);
+        expect(restored.nodes[inspectorNode].items, 'the pane is back in its tab flow').toEqual(['inspector']);
         await expect(
             page.locator('.neo-dashboard-dock-edge-rail .neo-dashboard-dock-rail-tab'),
             'and the rail it came from is gone'
@@ -261,11 +268,13 @@ test.describe('Dock pin/collapse round-trip (Neural Link)', () => {
             const {app, readModel} = await bootDockExample({page, neuralLink, theme});
 
             const inspectorButtonId = await focusPane(app, page, 'inspector');
+            const inspectorNode     = tabsNodeHolding(await readModel(), 'inspector');
+            expect(inspectorNode, 'inspector occupies a real tabs node').toBeTruthy();
 
             await page.mouse.move(0, 0);
 
             const
-                inspectorTabsId = await tabsNodeId(app, 'inspector-tabs'),
+                inspectorTabsId = await tabsNodeId(app, inspectorNode),
                 pinAction       = await app.callMethod(inspectorTabsId, 'getAction', ['pin']),
                 pinButton       = page.locator(`#${pinAction.id}`),
                 inlineAction    = await readRevealPinStyle(pinButton),

--- a/test/playwright/unit/dashboard/DockLayoutAdapter.spec.mjs
+++ b/test/playwright/unit/dashboard/DockLayoutAdapter.spec.mjs
@@ -671,6 +671,49 @@ test.describe('Neo.dashboard.dock.projection.LayoutAdapter', () => {
         ])
     });
 
+    test('a retained live pane gets one insertion header and restores its original header afterward', () => {
+        const pane           = Neo.create(Component, {header: {text: 'Swarm', cls: ['stable-header']}}),
+              item           = {componentRef: 'Swarm', kind: 'panel', title: 'Swarm'},
+              originalHeader = pane.header,
+              options        = {
+                  nodeId             : 'main-tabs',
+                  tabInsertDescriptor: {operation: 'addTab', itemId: 'swarm', tabsNodeId: 'main-tabs'}
+              };
+
+        try {
+            expect(DockLayoutAdapter.decorateProjectedItem(pane, 'swarm', item, options)).toBe(pane);
+            expect(pane.header.module).toBe(DockTabEnterButton);
+            expect(pane.header.cls).toEqual(['stable-header', 'neo-dashboard-dock-tab-enter', 'dock-tab-enter-item-swarm']);
+            expect(originalHeader).toEqual({text: 'Swarm', cls: ['stable-header']});
+
+            DockLayoutAdapter.decorateProjectedItem(pane, 'swarm', item, {...options, stackHandle: true});
+            expect(pane.header.text[1].cls).toEqual(['neo-dock-stack-handle']);
+            expect(pane.header.cls.filter(cls => cls === 'neo-dashboard-dock-tab-enter')).toHaveLength(1);
+
+            DockLayoutAdapter.decorateProjectedItem(pane, 'swarm', item, {...options, nodeId: 'other-tabs'});
+            expect(pane.header).toBe(originalHeader);
+            expect(pane.header).not.toHaveProperty('module')
+        } finally {
+            pane.destroy()
+        }
+    });
+
+    test('a live pane without an own header regains that absence after insertion decoration', () => {
+        const pane = Neo.create(Component, {}), item = {componentRef: 'bare', title: 'Bare'};
+
+        try {
+            expect(Object.hasOwn(pane, 'header')).toBe(false);
+            DockLayoutAdapter.decorateProjectedItem(pane, 'bare', item, {
+                nodeId: 'target', tabInsertDescriptor: {operation: 'addTab', itemId: 'bare', tabsNodeId: 'target'}
+            });
+            expect(pane.header.module).toBe(DockTabEnterButton);
+            DockLayoutAdapter.decorateProjectedItem(pane, 'bare', item);
+            expect(Object.hasOwn(pane, 'header')).toBe(false)
+        } finally {
+            pane.destroy()
+        }
+    });
+
     test('projects the documented edge-zone root model through the dashboard adapter', () => {
         let result = DockLayoutAdapter.project(createEdgeZoneModel(), {
                 resolveComponentRef: componentRef => ({

--- a/test/playwright/unit/dashboard/DockWorkspaceFirstProjection.spec.mjs
+++ b/test/playwright/unit/dashboard/DockWorkspaceFirstProjection.spec.mjs
@@ -167,6 +167,42 @@ test.describe('Neo.dashboard.dock.Workspace first projection', () => {
         expect(DockReconciler.collectProjectedTabs(workspace.items[1]).size).toBe(4)
     });
 
+    test('the example derives its presets from the effective declared arrangement', async () => {
+        workspace = Neo.create(MainContainer, {
+            zones: {
+                center: {
+                    id      : 'root-split', orientation: 'horizontal', sizes: [0.25, 0.75],
+                    children: [
+                        {id: 'main-tabs', items: ['swarm', 'strategy']},
+                        {id: 'side-split', orientation: 'vertical', children: ['terminal', 'logs']}
+                    ]
+                },
+                right: {items: ['inspector'], extent: 0.2}
+            }
+        });
+
+        await workspace.layoutCollectionLoadPromise;
+
+        const {dockModel, layoutCollection} = workspace;
+
+        expect(dockModel.nodes['root-split'].sizes).toEqual([0.25, 0.75]);
+        expect(dockModel.nodes['main-tabs'].activeItemId).toBe('swarm');
+        expect(layoutCollection.layouts['operator-default'].dockZone).toEqual(dockModel);
+        expect(layoutCollection.layouts['review-focus'].dockZone.nodes['root-split'].sizes).toEqual([0.48, 0.52]);
+        expect(workspace.items[0].dockNodeType).toBe('perspective-toolbar')
+    });
+
+    test('an explicitly supplied document survives example initialization', async () => {
+        const document = createDocument();
+
+        workspace = Neo.create(MainContainer, {dockModel: document, zones: 'not-a-declared-pane'});
+        await workspace.layoutCollectionLoadPromise;
+
+        expect(workspace.dockModel).toEqual(document);
+        expect(workspace.layoutCollection.layouts['operator-default'].dockZone).toEqual(document);
+        expect(workspace.items[0].dockNodeType).toBe('perspective-toolbar')
+    });
+
     test('a rejected initial mount retires its shell and spends exactly one clean retry', async () => {
         workspace = Neo.create(DockWorkspace, {dockModel: createDocument()});
 

--- a/test/playwright/unit/dashboard/DockZoneModel.spec.mjs
+++ b/test/playwright/unit/dashboard/DockZoneModel.spec.mjs
@@ -1072,7 +1072,15 @@ test.describe('Neo.dashboard.dock.model.WorkspaceDocument', () => {
         let originalLocalStorage;
 
         function createExampleHarness() {
+            const host = Neo.create(DockWorkspace, {
+                panes: MainContainer.config.panes,
+                zones: MainContainer.config.zones
+            });
+            const dockModel = WorkspaceDocument.clone(host.dockModel);
+            host.destroy();
+
             const example = {
+                dockModel,
                 createDefaultLayoutCollection  : MainContainer.prototype.createDefaultLayoutCollection,
                 createPerspectiveButton        : MainContainer.prototype.createPerspectiveButton,
                 createPerspectiveToolbar       : MainContainer.prototype.createPerspectiveToolbar,
@@ -2438,10 +2446,10 @@ test.describe('Neo.dashboard.dock.model.WorkspaceDocument', () => {
                 plain : {componentRef: 'plain',  title: 'Plain',  kind: 'panel'}
             },
             nodes: {
-                root        : {type: 'edge-zone', zones: {center: {nodeId: 'main-tabs'}, left: {nodeId: 'inner'}}},
-                'main-tabs' : {type: 'tabs', items: ['main'], activeItemId: 'main'},
-                inner       : {type: 'edge-zone', zones: {center: {nodeId: 'plain-tabs'}, top: {nodeId: 'buried-tabs'}}},
-                'plain-tabs': {type: 'tabs', items: ['plain'],  activeItemId: 'plain'},
+                root         : {type: 'edge-zone', zones: {center: {nodeId: 'main-tabs'}, left: {nodeId: 'inner'}}},
+                'main-tabs'  : {type: 'tabs', items: ['main'], activeItemId: 'main'},
+                inner        : {type: 'edge-zone', zones: {center: {nodeId: 'plain-tabs'}, top: {nodeId: 'buried-tabs'}}},
+                'plain-tabs' : {type: 'tabs', items: ['plain'],  activeItemId: 'plain'},
                 'buried-tabs': {type: 'tabs', items: ['buried'], activeItemId: 'buried'}
             }
         });


### PR DESCRIPTION
Resolves #18477
Related: #18474, #18476

The dock example now declares its panes and nested zones. Workspace owns the initial document and pane resolution; the example retains its perspective toolbar, storage collection, presets and tour replay. A supplied dock document is preserved. The existing LocalStorage addon is now loaded so Save Current survives a page reload.

Adoption exposed one bounded adapter gap: a detached declared pane remains live, but live instances skipped addTab header decoration. The existing decoration/restoration path now handles configs and live panes equally, preserving identity and the one-use insertion animation.

Evidence: L3 achieved and required (real example geometry, identity, gestures, persisted reload and tour replay). Residual: none for the changed behavior; existing baseline test failures are disclosed below.

## AC Evidence

| AC | Evidence |
|---|---|
| AC-1 | `MainContainer.panes/zones` replaces the initial flat graph, custom resolver and redundant document assignment. No consumer compiler/cache/resolver was added. |
| AC-2 | Exact-head Neural Link journeys cover all four rendered groups, ten pane titles, actual geometry, computed pane styling, reveal/pin and cross-zone identity. A full-page screenshot was inspected. |
| AC-3 | Two initial-document unit controls went red before migration. The browser verifies Operator/Review selection, retained toolbar/button objects and ordering, actual LocalStorage publication from Save Current, restore, and a fresh-page reload of the saved document. The existing two-run tour replay passes. |
| AC-4 | Existing ReloadablePane is unchanged. The browser verifies delegated Strategy reload and the ordinary pane recreate path, alongside close/pin actions. |
| AC-5 | Five existing suites now derive incidental tab-node IDs from pane membership. Behavioral assertions remain; the separate first-mount fixture keeps its authored IDs. Exact-head results are below. |
| AC-6 | Deleted and retained responsibilities are listed below. No Workstation, guide or persistence API redesign. |
| AC-7 | The unchanged rendered addTab arm failed 3/3 with live retained panes before the adapter repair and passes afterward, including reduced-motion behavior. Unit controls preserve object/header identity, no-own-header restoration, exact correlation and stack-grip composition. |

## Deltas from ticket

The adapter prerequisite and AC-7 were added to the ticket before its source edit, after both a repeated browser failure and a focused live-instance red proof. The change generalizes the existing restoration slot; it adds no scheduler or public API.

The new storage witness also found that the example never loaded the LocalStorage addon. Enabling that existing addon in `neo-config.json` repairs the advertised save/load demonstration without changing its storage protocol.

Deleted consumer responsibilities: manual graph construction, initial document override, config-shaped pane resolution and inline pane styling. Retained: catalog/display choices, three deliberate structural IDs used by presets/tours, named-layout collection management, toolbar identity reconciliation and tour composition. Styling lives in the example's SCSS. MainContainer shrinks from 349 to 325 code lines and 610 to 551 total measured lines; LayoutAdapter stays at 732 code lines.

Intake: self-authored drift probe found no changes under the example or its browser tests since ticket creation. Parent review remains [the prior independent review](https://github.com/neomjs/neo/issues/18474#issuecomment-5586436150). Prescription checked: `src/dashboard/dock/Workspace.mjs`, `src/dashboard/dock/projection/LayoutAdapter.mjs`, `src/core/Base.mjs`, `src/Neo.mjs`.

Decision Record impact: aligned-with ADR 0029 and the landed stage-one host contract. No schema change or new Discussion graduation.

## Test Evidence

Current head: `04b5acccfc93e99463501bccc74b88cf64454c26`, based on `335b2ca43a5ec54c823563745c276c3881e05416`. Runtime implementation is unchanged from `324f5b65a4`: the follow-up only removes five old numbered comment labels misread as issue references by the published baseline guard. That same guard now passes locally.

Fresh current-head receipt: all four focused rendered-declaration, actual save/reload, reveal/pin and reload-action cases pass. The full runtime matrix below ran at `324f5b65a4`, before the comment-only follow-up.

- **Component suite: 263 passed** after the adapter repair.
- **Final tracked unit suite: 3,628 passed, 2 skipped, 1 pre-existing failure**: the old `VdomDestroyCancellation` process-wide counter reports `Received: 1`. Its reviewed repair is [PR #18498](https://github.com/neomjs/neo/pull/18498); it is not included here. The earlier full run passed 3,627 cases, and all focused adapter/initialization controls pass. No rerun-to-green claim.
- **Exact-head browser matrix: 27 passed, 2 existing screenshot differences.** Explicit `playwright.config.e2e.mjs` and configured Brain runtime selected all seven named suites: DockOperationsNL, DockAutoHideRevealNL, DockReloadActionNL, DockTourSmokeNL, DockCrossZoneDragNL, DockMotionNL and DockPinCollapseNL. All 15 cases in the ticket's three minimum suites pass.
- **Known macOS snapshots:** the enabled pin-header title differs by 86/76 pixels for neo-dark/neo-light themes. Both fail with the unchanged dev example and produce byte-identical actual PNGs under this adoption. Geometry/style-equivalence assertions and the ordinary light/dark snapshots pass. No snapshot baseline was changed.
- Source, theme and size guards pass; no size-growth exemption or baseline change.

## Post-Merge Validation

No merge-only observation is needed to prove the declaration, motion or storage changes. The independently owned cancellation-test repair and existing macOS snapshot observations remain separate from this leaf's completion.

Authored by Euclid (GPT-6, Codex). Session 4f9b7bbe-9dbc-4d36-a167-38fe0d288113.
