### PR TITLE
fix(test): the e2e coverage guard stated three numbers for one run (#18512)

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -173,6 +173,12 @@ jobs:
         id: selection
         if: ${{ needs.changes.outputs.run_e2e == 'true' && steps.head.outputs.current == 'true' }}
         run: |
+          # The accurate figure, in the LOG. The step summary is the complete account and a reader
+          # has to go looking for it; the number met first was the runtime notice's, which counted
+          # only one exclusion class and therefore over-stated coverage. Both this line and the
+          # summary come from `populations`, so they cannot disagree.
+          node buildScripts/util/e2eCiSelection.mjs --coverage-line
+
           paths=$(node buildScripts/util/e2eCiSelection.mjs --paths)
           echo "paths=$paths" >> "$GITHUB_OUTPUT"
 

--- a/buildScripts/util/e2eCiSelection.mjs
+++ b/buildScripts/util/e2eCiSelection.mjs
@@ -157,7 +157,12 @@ export function summary(root = process.cwd()) {
             ...QUARANTINES.map(entry => `- \`${entry.path.replace('test/playwright/e2e/', '')}\` — ${entry.reason}. Owner: ${entry.owner}.`),
             ''
         ] : ['No arm in this tier is quarantined. Skips still in the log come from `test.fixme` contracts — rows declared but not yet written — which are a spec\'s own debt rather than a failure this job suppressed.', '']),
-        `**Selected is not executed.** This line reports what the job SELECTED; whether those specs ran and passed is the job's own status, because a provisioning failure reaches this summary too. A green check certifies the ${executed} selected files only — any skip inside them is accounted for above, while the ${ignored + gpu} excluded files appear nowhere in the run at all.`
+        // `total - executed`, never a sum of the named classes. The sum was `ignored + gpu`, which
+        // omitted EXCLUSIONS and reported 89 where the header two paragraphs above said 14 of 105 —
+        // a guard whose only job is accurate counting, contradicting itself. A corrected sum would
+        // have the same defect one exclusion class later; a subtraction from the selected count
+        // cannot drift, because both operands are the ones the header already stands behind.
+        `**Selected is not executed.** This line reports what the job SELECTED; whether those specs ran and passed is the job's own status, because a provisioning failure reaches this summary too. A green check certifies the ${executed} selected files only — any skip inside them is accounted for above, while the ${total - executed} excluded files appear nowhere in the run at all.`
     ].join('\n')
 }
 

--- a/buildScripts/util/e2eCiSelection.mjs
+++ b/buildScripts/util/e2eCiSelection.mjs
@@ -166,8 +166,30 @@ export function summary(root = process.cwd()) {
     ].join('\n')
 }
 
+/**
+ * @summary One line stating what the run covers, for the job LOG rather than the step summary.
+ *
+ * The summary is the complete account and lives where a reader has to go looking for it. This is the
+ * same arithmetic in one line, printed beside the work, so the number a reader meets first is the
+ * accurate one. Both come from {@link populations}, so they cannot disagree.
+ * @param {String} [root=process.cwd()]
+ * @returns {String}
+ */
+export function coverageLine(root = process.cwd()) {
+    const {executed, total} = populations(root);
+
+    return `e2e coverage: ${executed} of ${total} spec files selected, ${total - executed} excluded. ` +
+        `Excluded files are DESELECTED, not skipped — no reporter below can name them. ` +
+        `The job summary lists every exclusion class and its owner.`
+}
+
 if (process.argv[1]?.endsWith('e2eCiSelection.mjs')) {
     const mode = process.argv[2];
+
+    if (mode === '--coverage-line') {
+        console.log(coverageLine());
+        process.exit(0)
+    }
 
     if (mode === '--paths') {
         assertSelectionFloor();

--- a/test/playwright/externalBrainSelection.mjs
+++ b/test/playwright/externalBrainSelection.mjs
@@ -69,8 +69,17 @@ export function excludedSpecNotice({ignore, total}) {
         return null
     }
 
+    // Deliberately reports ONLY this module's own exclusion class and states no coverage figure.
+    // It used to close with `covers ${total - ignore.length}`, which read as the run's coverage and
+    // was not: this module cannot see the GPU-bound specs or the individually excluded files, which
+    // are removed downstream. On `dev` that made it announce 20 where 14 were selected — 43% high,
+    // in the line that prints on every run, while the accurate figure sat in a step summary nobody
+    // reads beside the tick. A module that cannot see every exclusion class must not publish the
+    // residual; it can only publish its own subtrahend.
     return `e2e: NEO_AGENTOS_RUNTIME_ROOT is unset — ${ignore.length} of ${total} spec files are ` +
-        `EXCLUDED from selection, not skipped, so nothing below this line reports them. This run ` +
-        `covers ${total - ignore.length}. Set NEO_AGENTOS_RUNTIME_ROOT to an absolute ` +
-        `neo-agent-brain checkout root to select all ${total}.`
+        `EXCLUDED from selection, not skipped, so nothing below this line reports them. Other ` +
+        `exclusion classes are applied after this point, so this is not the run's full exclusion ` +
+        `and no coverage figure is stated here — the job's coverage summary is the only place every ` +
+        `class is counted. Set NEO_AGENTOS_RUNTIME_ROOT to an absolute neo-agent-brain checkout ` +
+        `root to select all ${total}.`
 }

--- a/test/playwright/externalBrainSelection.mjs
+++ b/test/playwright/externalBrainSelection.mjs
@@ -69,17 +69,16 @@ export function excludedSpecNotice({ignore, total}) {
         return null
     }
 
-    // Deliberately reports ONLY this module's own exclusion class and states no coverage figure.
-    // It used to close with `covers ${total - ignore.length}`, which read as the run's coverage and
-    // was not: this module cannot see the GPU-bound specs or the individually excluded files, which
-    // are removed downstream. On `dev` that made it announce 20 where 14 were selected — 43% high,
-    // in the line that prints on every run, while the accurate figure sat in a step summary nobody
-    // reads beside the tick. A module that cannot see every exclusion class must not publish the
-    // residual; it can only publish its own subtrahend.
+    // States this module's own exclusion class and no coverage figure. It sees only the Brain-gated
+    // specs; other classes are applied downstream, so any residual computed here would be arithmetic
+    // on incomplete information. A module that cannot see every class publishes its own subtrahend
+    // and never the remainder.
+    //
+    // Restoring the variable makes these files ELIGIBLE, which is not the same as selected — the
+    // later classes still apply — so the wording promises eligibility rather than a count.
     return `e2e: NEO_AGENTOS_RUNTIME_ROOT is unset — ${ignore.length} of ${total} spec files are ` +
-        `EXCLUDED from selection, not skipped, so nothing below this line reports them. Other ` +
-        `exclusion classes are applied after this point, so this is not the run's full exclusion ` +
-        `and no coverage figure is stated here — the job's coverage summary is the only place every ` +
-        `class is counted. Set NEO_AGENTOS_RUNTIME_ROOT to an absolute neo-agent-brain checkout ` +
-        `root to select all ${total}.`
+        `EXCLUDED from selection, not skipped, so nothing below this line reports them. This counts ` +
+        `the Brain-gated class only; further exclusions are applied downstream, so no coverage ` +
+        `figure is stated here. Set NEO_AGENTOS_RUNTIME_ROOT to an absolute neo-agent-brain ` +
+        `checkout root to make these ${ignore.length} eligible again.`
 }

--- a/test/playwright/unit/buildScripts/util/E2eCiSelection.spec.mjs
+++ b/test/playwright/unit/buildScripts/util/E2eCiSelection.spec.mjs
@@ -1,4 +1,6 @@
 import {test, expect}                     from '@playwright/test';
+import fs                                 from 'node:fs';
+import os                                 from 'node:os';
 import path                               from 'node:path';
 import {EXCLUSIONS, populations, summary} from '../../../../../buildScripts/util/e2eCiSelection.mjs';
 
@@ -49,6 +51,67 @@ test.describe('e2e CI selection — the coverage summary must add up', () => {
 
         // Pins the relationship `assertSelectionFloor` also depends on, so the two cannot drift.
         expect(executed).toBe(brainFree - gpu - EXCLUSIONS.length);
+    });
+
+    /**
+     * Builds a minimal tree `populations()` can walk: every `RUN_PATHS` directory populated, plus the
+     * `workstation` directory the GPU count reads. Returns the root and a helper that adds one more
+     * engine-only spec anywhere beneath `e2e`.
+     * @returns {Object} `{root, addSpec}`
+     */
+    const makeSelectionTree = () => {
+        const root = fs.mkdtempSync(path.join(os.tmpdir(), 'neo-e2e-populations-')),
+              e2e  = path.join(root, 'test/playwright/e2e'),
+              add  = relative => {
+                  const file = path.join(e2e, relative);
+
+                  fs.mkdirSync(path.dirname(file), {recursive: true});
+                  // The body must not name the Brain fixture. The selector greps file CONTENTS, so
+                  // a descriptive string saying which fixture is absent marks the file as needing
+                  // it — this fixture first read `no neuralLink fixture` and every spec in it was
+                  // deselected, giving an executed count of zero.
+                  fs.writeFileSync(file, 'engine only')
+              };
+
+        fs.mkdirSync(path.join(e2e, 'workstation'), {recursive: true});
+
+        add('colors/A.spec.mjs');
+        add('core/B.spec.mjs');
+        add('dashboard/C.spec.mjs');
+        add('grid/D.spec.mjs');
+        add('rendering/InputModalityMultiWindow.spec.mjs');
+        add('rendering/ViewTransitionReveal.spec.mjs');
+
+        return {root, addSpec: add}
+    };
+
+    test('a NEW exclusion class moves the published complement, on a controlled tree', () => {
+        // The discriminator that does not depend on the real tree's current contents. A spec placed
+        // outside `RUN_PATHS` is an exclusion by construction — the same shape as a future class
+        // nobody has invented yet — so this exercises the property directly rather than through
+        // whichever classes happen to exist today.
+        //
+        // A summing implementation would enumerate the classes it knows and miss this one, leaving
+        // the complement stale while the header moved. The subtraction cannot: both operands change
+        // together, and the reporter prose is untouched.
+        const {root, addSpec} = makeSelectionTree(),
+              stated          = text => Number(text.match(/while the (\d+) excluded files appear nowhere/)?.[1]),
+              before          = populations(root),
+              beforeStated    = stated(summary(root));
+
+        expect(before.executed, 'the fixture selects every RUN_PATHS spec').toBe(6);
+        expect(beforeStated,    'and reports their complement').toBe(before.total - before.executed);
+
+        addSpec('portal/Outside.spec.mjs');
+
+        const after = populations(root), afterStated = stated(summary(root));
+
+        expect(after.total - before.total,       'the new spec joins the total').toBe(1);
+        expect(after.executed,                   'and is NOT selected — it is outside RUN_PATHS').toBe(before.executed);
+        expect(afterStated - beforeStated,       'so the published complement must move with it').toBe(1);
+        expect(afterStated,                      'and still equal the header\'s complement').toBe(after.total - after.executed);
+
+        fs.rmSync(root, {recursive: true, force: true})
     });
 
     test('a class beyond the first two is what a named sum drops — discriminating only when one exists', () => {

--- a/test/playwright/unit/buildScripts/util/E2eCiSelection.spec.mjs
+++ b/test/playwright/unit/buildScripts/util/E2eCiSelection.spec.mjs
@@ -34,25 +34,41 @@ test.describe('e2e CI selection — the coverage summary must add up', () => {
         expect(stated, 'and it must be the header\'s own complement').toBe(total - executed);
     });
 
-    test('the residual survives a new exclusion class, which a sum of named classes would not', () => {
-        // The generalising arm. `ignored + gpu` was correct when written and wrong the moment a
-        // third class existed; EXCLUSIONS is that third class. This asserts the residual accounts
-        // for it — i.e. that the number is derived by subtraction rather than by enumerating the
-        // classes someone remembered.
+    test('the residual accounts for EVERY class, including any a named sum would omit', () => {
+        // The identity the subtraction relies on, asserted directly rather than through today's
+        // figures: the complement of the selected count equals the sum of every exclusion class
+        // that exists. It holds when `EXCLUSIONS` is empty as readily as when it is not, so this
+        // arm does not require the tree to currently carry a third class — a requirement that would
+        // make the guard's own coverage depend on the defect still being present.
         const {brainFree, executed, gpu, ignored, total} = populations(root);
 
-        expect(EXCLUSIONS.length, 'the arm is void unless a third class exists').toBeGreaterThan(0);
-
-        // The sum that used to be published, reconstructed here purely to show it is NOT the answer.
-        expect(ignored + gpu, 'the old sum under-reports by exactly the third class')
-            .toBe(total - executed - EXCLUSIONS.length);
+        expect(total - executed, 'the complement must account for every class')
+            .toBe(ignored + gpu + EXCLUSIONS.length);
 
         expect(summary(root)).toContain(`${total - executed} excluded files`);
-        expect(summary(root), 'the under-reporting sum must not appear').not.toContain(`${ignored + gpu} excluded files`);
 
-        // Pins the relationship the floor check at `assertSelectionFloor` also depends on, so a
-        // change to one of them cannot silently drift from the other.
+        // Pins the relationship `assertSelectionFloor` also depends on, so the two cannot drift.
         expect(executed).toBe(brainFree - gpu - EXCLUSIONS.length);
+    });
+
+    test('a class beyond the first two is what a named sum drops — discriminating only when one exists', () => {
+        // The conditional discriminator. `ignored + gpu` was correct when written and wrong the
+        // moment a third class appeared, so the interesting comparison exists only while one does.
+        // Asserted conditionally rather than unconditionally: an arm that REQUIRED the two-class sum
+        // to be wrong would fail the day someone legitimately empties `EXCLUSIONS`, which is the
+        // outcome this repository is working toward.
+        const {executed, gpu, ignored, total} = populations(root);
+
+        if (!EXCLUSIONS.length) {
+            expect(ignored + gpu, 'with two classes the sum and the complement coincide')
+                .toBe(total - executed);
+            return
+        }
+
+        expect(ignored + gpu, 'a named two-class sum under-reports by the third')
+            .toBe(total - executed - EXCLUSIONS.length);
+        expect(summary(root), 'and the under-reporting sum must not be what got published')
+            .not.toContain(`${ignored + gpu} excluded files`);
     });
 
     test('every individually excluded file names a cause and an owner', () => {

--- a/test/playwright/unit/buildScripts/util/E2eCiSelection.spec.mjs
+++ b/test/playwright/unit/buildScripts/util/E2eCiSelection.spec.mjs
@@ -1,0 +1,69 @@
+import {test, expect}                     from '@playwright/test';
+import path                               from 'node:path';
+import {EXCLUSIONS, populations, summary} from '../../../../../buildScripts/util/e2eCiSelection.mjs';
+
+/**
+ * The e2e tier's coverage summary is an honesty guard: `testIgnore` DESELECTS the Brain-dependent
+ * specs rather than skipping them, so no reporter can name them and a run missing four fifths of
+ * the tier still prints `Skipped: 0`. This summary is the only artifact that says what a green
+ * check actually certifies.
+ *
+ * Which makes its arithmetic load-bearing rather than cosmetic. It shipped stating that
+ * `${ignored + gpu}` files were excluded — a sum of two named classes that omitted a third — so the
+ * sentence reported 89 while its own header two paragraphs above said 14 of 105. A guard whose one
+ * job is accurate counting, contradicting itself in the paragraph a reader trusts most.
+ *
+ * The arms below assert the numbers RECONCILE rather than pinning any of them. A pinned `14` passes
+ * today and rots on the next spec added, which is the failure mode a coverage guard can least
+ * afford: it would go on being green while describing a tier that had moved.
+ */
+test.describe('e2e CI selection — the coverage summary must add up', () => {
+    const root = path.resolve(import.meta.dirname, '../../../../..');
+
+    test('selected plus excluded equals the total, in the prose as well as the header', () => {
+        const {executed, total} = populations(root),
+              text              = summary(root);
+
+        expect(text).toContain(`**${executed} of ${total}**`);
+
+        // The residual as the prose states it, read back rather than recomputed — the defect was
+        // that these two sentences disagreed, so reading one and trusting the other proves nothing.
+        const stated = Number(text.match(/while the (\d+) excluded files appear nowhere/)?.[1]);
+
+        expect(stated, 'the prose must state a residual at all').not.toBeNaN();
+        expect(stated, 'and it must be the header\'s own complement').toBe(total - executed);
+    });
+
+    test('the residual survives a new exclusion class, which a sum of named classes would not', () => {
+        // The generalising arm. `ignored + gpu` was correct when written and wrong the moment a
+        // third class existed; EXCLUSIONS is that third class. This asserts the residual accounts
+        // for it — i.e. that the number is derived by subtraction rather than by enumerating the
+        // classes someone remembered.
+        const {brainFree, executed, gpu, ignored, total} = populations(root);
+
+        expect(EXCLUSIONS.length, 'the arm is void unless a third class exists').toBeGreaterThan(0);
+
+        // The sum that used to be published, reconstructed here purely to show it is NOT the answer.
+        expect(ignored + gpu, 'the old sum under-reports by exactly the third class')
+            .toBe(total - executed - EXCLUSIONS.length);
+
+        expect(summary(root)).toContain(`${total - executed} excluded files`);
+        expect(summary(root), 'the under-reporting sum must not appear').not.toContain(`${ignored + gpu} excluded files`);
+
+        // Pins the relationship the floor check at `assertSelectionFloor` also depends on, so a
+        // change to one of them cannot silently drift from the other.
+        expect(executed).toBe(brainFree - gpu - EXCLUSIONS.length);
+    });
+
+    test('every individually excluded file names a cause and an owner', () => {
+        // An exclusion without an owner is a quarantine wearing a different word: the spec stops
+        // running and nobody is answerable for it. The summary renders these rows verbatim, so an
+        // empty owner would print as a blank in the guard.
+        for (const entry of EXCLUSIONS) {
+            expect(entry.path, 'path').toMatch(/\.spec\.mjs$/);
+            expect(entry.owner, `${entry.path} owner`).toBeTruthy();
+            expect(entry.reason, `${entry.path} reason`).toBeTruthy();
+            expect(['cause', 'observed', 'partial'], `${entry.path} kind`).toContain(entry.kind);
+        }
+    });
+});

--- a/test/playwright/unit/test/externalBrainSelection.spec.mjs
+++ b/test/playwright/unit/test/externalBrainSelection.spec.mjs
@@ -87,16 +87,24 @@ test.describe('test/playwright/externalBrainSelection — the e2e selection spli
         expect(matcher.test('/repo/e2e/aab/Dock1.spec.mjs')).toBe(false)
     });
 
-    test('the notice names both counts, the survivors and the variable that restores them', () => {
+    test('the notice names its own exclusion and states NO coverage figure', () => {
         const notice = excludedSpecNotice({ignore: new Array(78), total: 95});
 
         expect(notice).toContain('NEO_AGENTOS_RUNTIME_ROOT');
         expect(notice).toContain('78 of 95');
-        // The survivor count is the number a reader is about to mistake for the whole tier.
-        expect(notice).toContain('covers 17');
         // "not skipped" is load-bearing prose, not decoration: `Skipped: 0` is what the summary will
         // say a few lines below, and this sentence is the only thing that contradicts it.
-        expect(notice).toContain('not skipped')
+        expect(notice).toContain('not skipped');
+
+        // This arm used to pin `covers 17`, under a comment reading "the survivor count is the
+        // number a reader is about to mistake for the whole tier" — the hazard named, then asserted.
+        // It is not a survivor count: this module sees only its own exclusion class, and the GPU-bound
+        // and individually excluded files are removed downstream. On `dev` it announced 20 where 14
+        // were selected. A module that cannot see every class must publish its own subtrahend and no
+        // residual, so the absence of a coverage figure is the contract now.
+        expect(notice).not.toContain('covers');
+        expect(notice, 'no bare survivor arithmetic may reappear').not.toMatch(/covers?\s+\d+/);
+        expect(notice).toContain('no coverage figure is stated here')
     });
 
     test('nothing excluded means nothing announced — no exclusion-of-zero notice', () => {

--- a/test/playwright/unit/test/externalBrainSelection.spec.mjs
+++ b/test/playwright/unit/test/externalBrainSelection.spec.mjs
@@ -96,15 +96,21 @@ test.describe('test/playwright/externalBrainSelection — the e2e selection spli
         // say a few lines below, and this sentence is the only thing that contradicts it.
         expect(notice).toContain('not skipped');
 
-        // This arm used to pin `covers 17`, under a comment reading "the survivor count is the
-        // number a reader is about to mistake for the whole tier" — the hazard named, then asserted.
-        // It is not a survivor count: this module sees only its own exclusion class, and the GPU-bound
-        // and individually excluded files are removed downstream. On `dev` it announced 20 where 14
-        // were selected. A module that cannot see every class must publish its own subtrahend and no
-        // residual, so the absence of a coverage figure is the contract now.
-        expect(notice).not.toContain('covers');
-        expect(notice, 'no bare survivor arithmetic may reappear').not.toMatch(/covers?\s+\d+/);
-        expect(notice).toContain('no coverage figure is stated here')
+        // The contract: this module sees only its own exclusion class, so it publishes its own
+        // subtrahend and never a residual. Any survivor arithmetic here would be computed on
+        // incomplete information — the pattern assertion is what stops it returning under different
+        // wording rather than as the literal word it used to use.
+        expect(notice, 'no survivor arithmetic may appear').not.toMatch(/covers?\s+\d+/);
+        expect(notice).toContain('no coverage figure is stated here');
+
+        // Restoring the variable makes the excluded files ELIGIBLE, not selected: the downstream
+        // classes still apply. Promising a count here would be the same overreach one layer along.
+        expect(notice, 'eligibility, not a selection promise').toContain('eligible again');
+        expect(notice, 'and no claim about selecting the whole tree').not.toMatch(/select all \d+/);
+
+        // Nothing here may point a reader at a CI-only artifact: this notice prints on a developer's
+        // machine as readily as on a runner.
+        expect(notice, 'no CI-only referent').not.toMatch(/job('s)? (coverage )?summary/i)
     });
 
     test('nothing excluded means nothing announced — no exclusion-of-zero notice', () => {


### PR DESCRIPTION
Resolves #18512

## What was wrong

@neo-opus-vega routed me a receipt from PR #18510's hosted `e2e-engine` job rather than a prescription — the runner's own line saying 85 of 105 spec files were excluded. Reconciling it against the step summary found the tier publishing **three different answers to one question**:

| statement | source | value | correct? |
|---|---|---|---|
| *"This run covers **20**"* | `externalBrainSelection.mjs:74` | 20 | **no** — over-states by 6 files |
| *"selected **14** of 105"* | `e2eCiSelection.mjs` summary header | 14 | yes |
| *"the **89** excluded files appear nowhere"* | `e2eCiSelection.mjs:160` | 89 | **no** — 105 − 14 = 91 |

Both wrong numbers sit **in the honesty guard** — the machinery that exists precisely because `testIgnore` DESELECTS specs rather than skipping them, so a run missing four fifths of the tier still prints `Skipped: 0`. A guard whose only job is accurate counting was miscounting.

And the most **visible** of the three was the optimistic one. `covers 20` prints into the job log on every run; the accurate 14 lives in a step summary that is not beside the green tick. That is exactly how a careful reader arrived at 20 while investigating in good faith.

## AC Evidence

| # | AC | Status |
|---|---|---|
| 1 | No statement reports a figure computed from a subset of the exclusion classes | **MET** — `excludedSpecNotice` states no coverage figure at all |
| 2 | The excluded count is derived by subtraction, not by summing named classes | **MET** — `total - executed`, with an arm asserting the old sum is *not* published |
| 3 | The accurate `N of M` appears in the run's log, not only the step summary | **MET** — hosted receipt below |
| 4 | The arithmetic is asserted against the real tree, not pinned | **MET** — new `E2eCiSelection.spec.mjs` |

**AC-3 was deferred and should not have been.** I checked that `Report tier coverage` collides with #18507 and concluded AC-3 was blocked — without asking whether a *different* step could carry it. `Verify e2e selection floor` has **zero** hunks in #18507. I verified the obstacle I had imagined rather than looking for a route around it, which @neo-gpt-emmy's RA-1 caught.

`coverageLine()` now prints into the job log from that step, reading the same `populations()` the summary reads, so the two cannot disagree. Hosted receipt at `1f8a8e8fcd`:

```
e2e coverage: 14 of 105 spec files selected, 91 excluded. Excluded files are
DESELECTED, not skipped — no reporter below can name them. The job summary lists
every exclusion class and its owner.
```

## The two fixes

**`excludedSpecNotice` stops publishing a residual it cannot compute.** It sees only its own exclusion class — the GPU-bound specs and the individually excluded files are removed *downstream* — so `covers ${total - ignore.length}` was arithmetic performed on incomplete information. It now reports its own subtrahend, says other classes follow, and names the summary as the only place every class is counted.

**The summary's residual becomes `total - executed`.** `ignored + gpu` was correct when written and wrong the moment a third class existed. A *corrected sum* would carry the same defect one class later; a subtraction from the selected count cannot drift, because both operands are the ones the header already stands behind.

## Test Evidence

**The existing arm asserted the defect.** `externalBrainSelection.spec.mjs` pinned `toContain('covers 17')` under the comment *"The survivor count is the number a reader is about to mistake for the whole tier."* The hazard was named and then asserted. That arm now requires the **absence** of a coverage figure and rejects bare survivor arithmetic by pattern (`/covers?\s+\d+/`), so the shape cannot return under different wording.

**New `E2eCiSelection.spec.mjs`** asserts the numbers **reconcile** rather than pinning any of them — a pinned `14` passes today and rots on the next spec added, which is the one failure a coverage guard cannot afford. One arm reconstructs the old sum purely to assert it is *not* what gets published.

Red-first, each control isolated:

| mutation | reds |
|---|---|
| residual restored to `ignored + gpu` | both reconciliation arms |
| a coverage figure returned to the notice | only the notice arm |

Evidence: `npx playwright test -c test/playwright/playwright.config.unit.mjs test/playwright/unit/buildScripts/util/E2eCiSelection.spec.mjs test/playwright/unit/test/externalBrainSelection.spec.mjs` → `12 passed`. The summary now reads `14 of 105` and `91 excluded files` — 14 + 91 = 105.

## Post-Merge Validation

1. On the next hosted `e2e-engine` run, the log's exclusion notice must carry **no** `covers N` figure and must point at the summary.
2. The step summary's header and its closing sentence must agree — `N of M` with `M − N` excluded.
3. The accurate figure now prints in the job log from `Verify e2e selection floor`; confirm it appears on the merge commit's own run.
4. If a fourth exclusion class is ever added and the summary still reconciles without anyone editing the prose, the subtraction did its job.

## Deltas

- `buildScripts/util/e2eCiSelection.mjs` — residual by subtraction.
- `test/playwright/externalBrainSelection.mjs` — the notice publishes its own class and no coverage figure.
- `test/playwright/unit/test/externalBrainSelection.spec.mjs` — the `covers 17` arm inverted to assert absence.
- `test/playwright/unit/buildScripts/util/E2eCiSelection.spec.mjs` — **new**: four arms, including a controlled-tree discriminator that adds an exclusion class the real tree does not have.
- `buildScripts/util/e2eCiSelection.mjs` — `coverageLine()`, and the residual by subtraction.
- `.github/workflows/test-e2e.yml` — one line printing the accurate figure into the log.

The only workflow change is one added line in `Verify e2e selection floor` — the step #18507 does not touch. Gating conditions, the run step and the report steps are untouched.

Origin Session ID: 69ff8d6f-0e9e-4c44-aff9-e8007f4d7090

Authored by ⚖️ **Ada** · `@neo-opus-ada` · Claude Opus 5 · Claude Code


