### PR TITLE
fix(workstation): apply chrome offset to terminal restores (#18514)

### DIFF
--- a/apps/workstation/view/Workspace.mjs
+++ b/apps/workstation/view/Workspace.mjs
@@ -2528,7 +2528,7 @@ class Workspace extends DockWorkspace {
     }
 
     /**
-     * Re-shows the same exact parked generation at the logical pointer-owned origin. During a
+     * @summary Re-shows the same exact parked generation at the supplied content origin. During a
      * live gesture the DragDrop addon also resumes physical pointer-follow; at a native drag
      * terminal that addon has already reset its session, so a strict refusal falls through to
      * the same exact Main route for the final restore; semantic-name routing is never used.
@@ -2636,8 +2636,8 @@ class Workspace extends DockWorkspace {
                 nativeHandleKey: route.nativeHandleKey,
                 targetWindowId : route.targetWindowId,
                 windowId       : me.windowId,
-                x              : rect.x,
-                y              : rect.y
+                x              : frame.x,
+                y              : frame.y
             }) === true;
 
             me.lastVesselRestoreReceipt.moved = moved;

--- a/test/playwright/unit/apps/workstation/Workspace.spec.mjs
+++ b/test/playwright/unit/apps/workstation/Workspace.spec.mjs
@@ -763,6 +763,7 @@ test.describe.serial('Workstation.view.Workspace', () => {
             originalDragDrop = Neo.main.addon.DragDrop,
             originalMove     = Neo.Main.windowNativeMoveTo,
             originalResize   = Neo.Main.windowNativeResizeTo,
+            originalGet      = Neo.manager.Window.get,
             calls            = [],
             sourceRoute      = {
                 capabilities   : {close: true, focus: true, position: true, resize: true},
@@ -781,6 +782,9 @@ test.describe.serial('Workstation.view.Workspace', () => {
             windowName : 'tearout-audit'
         });
         workspace.tearOutParkGeometries.audit = geometry;
+        Neo.manager.Window.get = id => id === 'source-window'
+            ? {chrome: {left: 8, top: 67}}
+            : originalGet.call(Neo.manager.Window, id);
         Neo.main.addon.DragDrop = {
             acknowledgeWindowDragOrphanRecovery: async () => true,
             hasWindowDragOrphanRecovery        : async () => false,
@@ -818,8 +822,8 @@ test.describe.serial('Workstation.view.Workspace', () => {
                     nativeHandleKey: 'handle-source',
                     targetWindowId : 'source-window',
                     windowId       : workspace.windowId,
-                    x              : 420,
-                    y              : 240
+                    x              : 412,
+                    y              : 173
                 }],
                 ['resize', {
                     height         : 260,
@@ -870,6 +874,61 @@ test.describe.serial('Workstation.view.Workspace', () => {
             Neo.main.addon.DragDrop       = originalDragDrop;
             Neo.Main.windowNativeMoveTo   = originalMove;
             Neo.Main.windowNativeResizeTo = originalResize;
+            Neo.manager.Window.get        = originalGet;
+            workspace.destroy()
+        }
+    });
+
+    test('terminal restore without resize geometry preserves the requested content origin', async () => {
+        const
+            workspace        = Neo.create(Workspace, {windowId: Neo.config.windowId}),
+            originalDragDrop = Neo.main.addon.DragDrop,
+            originalMove     = Neo.Main.windowNativeMoveTo,
+            originalGet      = Neo.manager.Window.get,
+            calls            = [],
+            sourceRoute      = {
+                capabilities   : {position: true},
+                nativeHandleKey: 'handle-source',
+                ownerWindowId  : workspace.windowId,
+                targetWindowId : 'source-window'
+            };
+
+        workspace.nativeWindows.sources.get(workspace.id).connections.set('audit', {
+            nativeRoute: sourceRoute,
+            windowId   : 'source-window',
+            windowName : 'tearout-audit'
+        });
+        Neo.main.addon.DragDrop = {
+            acknowledgeWindowDragOrphanRecovery: async () => true,
+            hasWindowDragOrphanRecovery        : async () => false,
+            resumeWindowDrag                   : async data => { calls.push(['resume', data]); return false }
+        };
+        Neo.Main.windowNativeMoveTo = async data => { calls.push(['move', data]); return true };
+
+        try {
+            for (const [chrome, expectedFrame] of [
+                [{left: 0, top: 0}, {x: 420, y: 240}],
+                [{left: 8, top: 67}, {x: 412, y: 173}]
+            ]) {
+                Neo.manager.Window.get = id => id === 'source-window'
+                    ? {chrome}
+                    : originalGet.call(Neo.manager.Window, id);
+                calls.length = 0;
+
+                await expect(workspace.reshowTearOutVessel({
+                    itemId: 'audit', rect: {x: 420, y: 240}, terminal: true, windowName: 'tearout-audit'
+                })).resolves.toBe(true);
+
+                expect(calls.map(([type, {x, y}]) => ({type, x, y}))).toEqual([
+                    {type: 'resume', ...expectedFrame},
+                    {type: 'move', ...expectedFrame}
+                ]);
+                expect(workspace.tearOutParkGeometries.audit).toBeUndefined()
+            }
+        } finally {
+            Neo.main.addon.DragDrop     = originalDragDrop;
+            Neo.Main.windowNativeMoveTo = originalMove;
+            Neo.manager.Window.get     = originalGet;
             workspace.destroy()
         }
     });


### PR DESCRIPTION
Resolves #18514

Workstation now uses the existing content-to-frame conversion when a terminal vessel restore falls back to a direct native move. With content origin `(420,240)` and chrome `(8,67)`, both addon recovery and the fallback request frame position `(412,173)`. Saved park coordinates remain unchanged during compensation.

Evidence: L2 (real Workspace method with controlled native effects) → L2 required by the position/rollback contract. No residual acceptance criteria; no new real-window or whole-film receipt is claimed.

Change class: restoration. No capability, owner or API added. Workspace remains 3,042 physical lines; the repair adds no production lines.

## AC Evidence

| Criterion | Evidence |
|---|---|
| AC-1 | CI-covered: `Workspace.spec.mjs` terminal restore controls exercise nonzero chrome with and without saved resize geometry. |
| AC-2 | Outside-CI: both controls failed on unchanged `dev@335b2ca43a` at the raw `(420,240)` move; both pass with the repair. The no-resize case also checks zero chrome. |
| AC-3 | CI-covered: existing live-resume, compensation and retry cases remain; parked-frame compensation assertions stay `(800,120)`. Orphan admission and cleanup ordering are unchanged. |
| AC-4 | CI-covered: focused Workstation and full unit configurations pass locally; checks run through the repository's custom unit config. |

## Deltas from ticket

None substantive. The branch starts at `dev`; the pending route-validation PR is not a dependency. No size-baseline edit is needed. `agent-preflight` is not hosted here (npm reports Missing script); shared baseline jobs remain the hosted check authority.

## Test Evidence

Red-first controls used the real Workspace instance and method with native calls intercepted. The resize/compensation case failed at expected `(412,173)` versus actual `(420,240)`; the no-resize case independently failed at the same fallback after its zero-chrome control passed. Neither failure was a browser-placement measurement.

## Post-Merge Validation

None required for the close target. Existing native-window and film acceptance remain separately scoped.

Related: #18058 · #18460 · #18501

Authored by Emmy (GPT-6 Astra, Codex). Session 153d2e0a-ebae-4087-bcd5-3c92d213132c.
