### PR TITLE
docs(dock): explain ordinary pane ownership (#18034)

### DIFF
--- a/buildScripts/docs/seo/generate.mjs
+++ b/buildScripts/docs/seo/generate.mjs
@@ -103,6 +103,7 @@ const PRIORITIES = new Map([
     ['guides/uibuildingblocks/Layouts'                , 0.8],
     ['guides/uibuildingblocks/DockLayouts'            , 0.8],
     ['guides/uibuildingblocks/DockLayoutsAdoption'    , 0.8],
+    ['guides/uibuildingblocks/DockLayoutsPanes'       , 0.8],
     ['guides/datahandling/Grids'                      , 0.8],
     ['guides/userinteraction/Forms'                   , 0.8],
 

--- a/learn/guides/uibuildingblocks/DockLayoutsPanes.md
+++ b/learn/guides/uibuildingblocks/DockLayoutsPanes.md
@@ -1,0 +1,321 @@
+# Dock Layouts: Panes Are Ordinary Components
+
+A work queue is useful because it remembers the work. You mark a task complete, move the queue beside
+your editor, and keep going. Collapsing it into a side rail should not reset its records. Closing its
+view should not silently throw away application data that another view still needs.
+
+Those expectations sound like docking requirements, but they begin with ordinary component ownership.
+The layout decides where a pane belongs. Your application decides what the pane displays, who owns its
+data, and how long that data should live. Keeping those decisions separate lets you add docking to a
+useful component without teaching that component about tab groups, rails or saved layouts.
+
+This guide builds a small work queue and follows it through those changes. The
+[adoption guide](DockLayoutsAdoption.md) covers application bootstrap and initial layout declarations.
+Here, the question is what belongs **inside** a pane, and what should outlive it.
+
+## Start with the owners
+
+Our example has a queue pane and a summary pane. The queue contains a button and a grid. Its controller
+completes the next task; the grid observes the changed record. The summary displays the last completed
+task through a state binding.
+
+Both views consume state owned by a provider at their common workspace root. That provider creates the
+queue Store. The Store uses a Model to define its records. Neither view needs a private copy of the queue,
+and neither needs to tell the other to repaint.
+
+```mermaid
+flowchart TD
+    classDef owner fill:#1b2e4e,stroke:#6497e0,color:#eee
+    classDef view fill:#1a3c34,stroke:#2ecc71,color:#eee
+    Workspace["Workspace<br/>placement and pane declarations"]:::owner
+    Provider["Root state provider<br/>shared state and owned Store"]:::owner
+    Store["QueueStore + QueueModel<br/>task records"]:::owner
+    Queue["QueueContainer<br/>ordinary pane"]:::view
+    Controller["QueueController<br/>application actions"]:::view
+    Grid["Grid<br/>bound to stores.queue"]:::view
+    Summary["Summary component<br/>bound to lastAction"]:::view
+
+    Workspace --> Provider
+    Provider --> Store
+    Workspace --> Queue
+    Queue --> Controller
+    Queue --> Grid
+    Workspace --> Summary
+    Store -.-> Grid
+    Provider -.-> Summary
+```
+
+The placement document is deliberately absent from the action path. Completing a task changes a record
+and shared application state. Moving the queue changes placement. There is no reason for either operation
+to serialize the other one's objects.
+
+## Give the queue a real data model
+
+The three records are small enough that an array would be tempting. Using a Store here is about ownership
+and observation, rather than volume: the grid consumes records, and an application action updates the
+same records through the Store. This remains the same composition when you replace the initial data with
+a loading pipeline.
+
+The following modules share an application directory. Their engine imports assume a location three
+levels below the repository root, as in the dashboard examples; adjust the paths for your application.
+
+`QueueModel.mjs` defines the record fields:
+
+```javascript readonly
+import Model from '../../../src/data/Model.mjs';
+
+class QueueModel extends Model {
+    static config = {
+        className: 'WorkQueue.model.Task',
+        fields: [
+            {name: 'id', type: 'String'},
+            {name: 'title', type: 'String'},
+            {name: 'status', type: 'String'}
+        ]
+    }
+}
+
+export default Neo.setupClass(QueueModel);
+```
+
+`QueueStore.mjs` supplies the data:
+
+```javascript readonly
+import QueueModel from './QueueModel.mjs';
+import Store from '../../../src/data/Store.mjs';
+
+class QueueStore extends Store {
+    static config = {
+        className: 'WorkQueue.store.Tasks',
+        model: QueueModel,
+        data: [
+            {id: 'design', title: 'Review the design', status: 'Ready'},
+            {id: 'build', title: 'Build the preview', status: 'Ready'},
+            {id: 'check', title: 'Check the result', status: 'Ready'}
+        ]
+    }
+}
+
+export default Neo.setupClass(QueueStore);
+```
+
+The Model declares the schema; the Store exposes the records. A docking item named `queue` will eventually
+display these tasks, but `queue` is not a record ID. The record `design` keeps its business meaning wherever
+the view is placed.
+
+The [Store source reference](../../../src/data/Store.mjs) covers loading, searching and record behavior.
+The [data pipeline guide](../datahandling/DataPipelines.md) explains how to replace the small initial dataset
+with application data. Docking adds no alternate data path.
+
+## Keep the action in a view controller
+
+`QueueController.mjs` implements an ordinary application action:
+
+```javascript readonly
+import Controller from '../../../src/controller/Component.mjs';
+
+class QueueController extends Controller {
+    static config = {
+        className: 'WorkQueue.view.QueueController'
+    }
+
+    onCompleteNext() {
+        const record = this.getStore('queue').find('status', 'Ready', true);
+
+        if (record) {
+            record.status = 'Done';
+            this.setState({lastAction: `Completed: ${record.title}`})
+        }
+    }
+}
+
+export default Neo.setupClass(QueueController);
+```
+
+The controller resolves `queue` through its component's state-provider hierarchy. The Store's `find`
+accepts a field and value; the final `true` requests the first matching record. Updating `record.status`
+notifies the grid through its existing Store integration. Updating `lastAction` gives the summary something
+to display through its binding.
+
+The controller does not locate the summary component, write its text, or subscribe to docking events.
+Its action remains useful if the queue later appears in a normal panel with no docking at all.
+
+## The pane is a container you already know
+
+`QueueContainer.mjs` composes that controller with a button and grid:
+
+```javascript readonly
+import Button from '../../../src/button/Base.mjs';
+import Container from '../../../src/container/Base.mjs';
+import Grid from '../../../src/grid/Container.mjs';
+import QueueController from './QueueController.mjs';
+
+class QueueContainer extends Container {
+    static config = {
+        className: 'WorkQueue.view.QueueContainer',
+        controller: QueueController,
+        layout: {ntype: 'vbox', align: 'stretch'},
+        items: [{
+            module: Button,
+            flex: 'none',
+            text: 'Complete next task',
+            handler: 'onCompleteNext'
+        }, {
+            module: Grid,
+            flex: 1,
+            bind: {store: 'stores.queue'},
+            columns: [
+                {dataField: 'title', text: 'Task', flex: 1},
+                {dataField: 'status', text: 'Status', width: 100}
+            ]
+        }]
+    }
+}
+
+export default Neo.setupClass(QueueContainer);
+```
+
+There is no dock import in this module. The button's string handler resolves through the normal controller
+chain. The grid's binding resolves a Store; it does not map an array into replacement row configurations.
+The container gives its children a layout and owns its controller's lifetime.
+
+These are the same class-system mechanisms used by other Neo components. If they are new to you,
+[class setup](../coreengine/SetupClass.md) and [state providers](../datahandling/StateProviders.md) explain
+the underlying behavior. A pane does not need another component base class or a parallel event system.
+
+## Put shared state at the common root
+
+The workspace now supplies the shared provider and declares the ordinary components as panes:
+
+```javascript readonly
+import Component from '../../../src/component/Base.mjs';
+import Provider from '../../../src/state/Provider.mjs';
+import Workspace from '../../../src/dashboard/dock/Workspace.mjs';
+import QueueContainer from './QueueContainer.mjs';
+import QueueStore from './QueueStore.mjs';
+
+class QueueWorkspace extends Workspace {
+    static config = {
+        className: 'WorkQueue.view.QueueWorkspace',
+        layout: {ntype: 'vbox', align: 'stretch'},
+        stateProvider: {
+            module: Provider,
+            data: {lastAction: 'Pick a task to complete.'},
+            stores: {queue: QueueStore}
+        },
+        panes: {
+            summary: {
+                module: Component,
+                header: {text: 'Summary'},
+                bind: {text: data => data.lastAction}
+            },
+            notes: {
+                module: Component,
+                header: {text: 'Notes'},
+                text: 'The workspace owns the work queue.'
+            },
+            queue: {
+                module: QueueContainer,
+                header: {text: 'Work queue'}
+            },
+            help: {
+                module: Component,
+                header: {text: 'Help'},
+                text: 'Complete a task, then move the queue.'
+            }
+        },
+        zones: {
+            center: ['summary', 'notes'],
+            right: {items: ['queue', 'help'], extent: 0.55, resizable: true}
+        }
+    }
+}
+
+export default Neo.setupClass(QueueWorkspace);
+```
+
+Mount `QueueWorkspace` inside your application's Viewport using the
+[adoption guide's bootstrap](DockLayoutsAdoption.md). The extra tabs make the movement easy to explore:
+the center and right-hand groups remain available when the queue leaves either one.
+
+The provider is at the lowest common root of the consumers that need it. It creates the Store from the
+`QueueStore` class and owns that Store's retirement. The queue pane merely uses it. A provider inside the
+queue would establish a different lifetime and sharing boundary; adding one to every pane would obscure
+the decision this example is making.
+
+## Move the work without rebuilding it
+
+Complete the first task. Its row changes to `Done`, and the summary reads “Completed: Review the design.”
+Move the queue into the center tab group, then return it to the right edge. Collapse it into the right rail,
+reveal it, and pin it open again.
+
+The interesting result is not just that the text looks unchanged. The pane is the same container object.
+Its controller, provider, Store and first record are also the same objects. The grid is still subscribed to
+the Store, and its button still resolves the same application action. Docking changed the component's
+placement without requiring the component to rebuild its application relationships.
+
+I am Euclid, a Neo maintainer. While preparing this example, I kept references to those five objects in a
+temporary inspection harness and compared them by strict identity after each operation. The first task
+remained `Done` through the tab move, collapse, reveal and pin. After pinning, the pane's two children also
+matched across its component items, virtual DOM and rendered DOM. I used semantic dock operations for
+the moves and the live button events for completing, revealing and pinning; this establishes the ownership
+journey, rather than testing pointer-drag choreography.
+
+That inspection also caught a small mistake before it became advice: my first controller used an
+Array-style predicate with the Store's `find` method. The live button failed immediately. Reading the Store's
+actual contract produced the field/value lookup above. A realistic pane benefits from the engine's existing
+abstractions only when its author uses their actual semantics.
+
+## Closing the view is a different decision
+
+Close the queue, leaving its Help tab behind. The workspace removes the queue's current catalog entry and
+retires the container. The container destroys its controller. The grid releases its Store listeners; it does
+not destroy the shared Store.
+
+The workspace and its provider remain alive. Consequently the first record remains `Done`, and the summary
+can still display the last action even though the queue view is gone.
+
+Your application can reopen the declared pane through `workspace.openPane('queue', placement)`. Choose
+the target from the **current** committed document, as shown in the adoption guide. The initial declaration
+is still available, so the workspace can create a new container and controller bound to the surviving Store.
+The new grid displays the completed task without an application-side restore loop.
+
+In the inspected journey, strict comparison reported a new pane and controller, the old pair marked
+destroyed, and the original provider, Store and record still present. The new pane reused the declared
+runtime component ID. That detail matters when debugging: an equal ID is not proof that an object survived.
+The dock key, runtime component ID and JavaScript object lifetime answer different questions.
+
+This is in-memory continuity under a live workspace. It is not persistence across restarting the application.
+Saving task data remains an application data responsibility; saving a dock layout records placement.
+
+## Reload, lazy creation and asynchronous work keep their ordinary meanings
+
+A lazy pane has no component instance until it first materializes. A normal lazy module declaration lets
+Container/Card and the rail's reveal path perform that first creation. After creation, the declared instance
+participates in the same movement and retention rules. Lazy view creation does not make this example's
+root-owned Store lazy: the provider creates it independently of whether the pane has been opened.
+
+The Reload action first delegates to a pane's optional `dockReload()` method. A pane can use that contract
+to refresh its content while keeping its instance. Without that delegation, the workspace's user-triggered
+recreate path prepares a fresh candidate, installs it through container ownership, and only then destroys
+the old pane. It preserves the dock item and slot; it deliberately replaces the component instance.
+
+Application state survives that replacement only when its owner survives. The root-owned queue Store is
+one such choice. A private editor buffer held solely by the old pane is another choice with a different
+outcome; the layout document is not an implicit backup of it.
+
+For asynchronous work, use the lifecycle of the object that owns the work. Components and controllers
+already inherit `core.Base`'s async registration and `trap()` behavior. Closing a pane destroys its controller;
+an operation owned by that controller must respect that destruction boundary. A load that should continue
+for other consumers belongs with a longer-lived data owner. The
+[async destruction guide](../fundamentals/AsyncDestruction.md) explains the trap pattern; docking does not
+require custom cancellation timers or another lifecycle implementation.
+
+The broader native-window contract is recorded in
+[Docking Design](../../agentos/decisions/0029-docking-design.md). Windows are render targets, while
+application objects and their owners live in the worker. Native lifecycle integration and cross-workspace
+binding policies still belong to the host. The single-workspace tab and rail journey here demonstrates
+ordinary composition without asking a pane to manage either responsibility.
+
+The practical design question is now concrete: **which owner should survive this user action?** Put shared
+records and state there, let ordinary components consume them, and let the workspace move the views.

--- a/learn/tree.json
+++ b/learn/tree.json
@@ -73,6 +73,7 @@
             {"name": "Layouts",                                        "parentId": "guides/uibuildingblocks",                             "id": "guides/uibuildingblocks/Layouts"},
             {"name": "Dock Layouts",                                   "parentId": "guides/uibuildingblocks",                             "id": "guides/uibuildingblocks/DockLayouts"},
             {"name": "Dock Layouts: Adopting in Your App",             "parentId": "guides/uibuildingblocks",                             "id": "guides/uibuildingblocks/DockLayoutsAdoption"},
+            {"name": "Dock Layouts: Panes Are Ordinary Components",   "parentId": "guides/uibuildingblocks",                             "id": "guides/uibuildingblocks/DockLayoutsPanes"},
             {"name": "Fragments",                                      "parentId": "guides/uibuildingblocks",                             "id": "guides/uibuildingblocks/Fragments"},
             {"name": "Custom Components",                              "parentId": "guides/uibuildingblocks",                             "id": "guides/uibuildingblocks/CustomComponents"},
             {"name": "Working with VDom",                              "parentId": "guides/uibuildingblocks",                             "id": "guides/uibuildingblocks/WorkingWithVDom"},


### PR DESCRIPTION
Resolves #18034

Explain how ordinary Neo components become dock panes without acquiring layout logic. A work-queue example composes a Model, Store, root state provider, view controller and bound Grid, then follows their object identities through tab moves, rail reveal/pin and close/reopen. The guide distinguishes placement, view lifetime and application-data lifetime, and is registered in the guide tree and SEO priorities.

Related: #17540

Evidence: L2 source/docs validation plus local Chromium/Neural Link ownership and Portal-render receipts. Required: independent cross-family whole-guide review before merge; no native-window qualification is claimed.

Change class: zero-delta.
Micro-review eligible: docs — no engine behavior or API change; whole-guide authoring bar still applies.
Decision Record impact: aligned-with ADR 0029.
agent-preflight: not hosted here (verified Missing script); shared baseline jobs are the CI handoff gate.

## AC Evidence

| AC | Evidence |
|---|---|
| AC-1 | Source- and live-tool-grounded work-queue narrative, attributed inspection account, and a seven-node `flowchart TD` rendered and visually inspected in Portal. |
| AC-2 | Explanation with a focused component example, links to generic reference, and an explicit ticket-ID scan: zero findings. |
| AC-3 | Only the new guide, `learn/tree.json` entry and SEO `PRIORITIES` entry change. Both in-memory SEO outputs include the route; generated outputs are untouched. |
| AC-4 | Guide lint: zero findings. Tree lint: one identical base/current `AgentInterfaces` grouping violation, detailed below. Portal heading, navigation, article and diagram rendered without page errors. Independent whole-guide review remains the requested merge gate. |
| AC-5 | Five extracted code blocks ran together: QueueModel → QueueStore → workspace Provider; QueueContainer owns a controller and a Grid bound to `stores.queue`. A real button click updated the record and summary. |
| AC-6 | Live strict-reference receipts distinguish pane/controller retirement from retained provider/Store/record identity. Lazy creation, delegated reload and user-triggered recreation are scoped to current Workspace/core lifecycle contracts. |
| AC-7 | Complete task → move to center tabs → return to right edge → collapse → reveal → pin → close → reopen; ownership results below. |
| AC-8 | Links to class setup, State Providers, Store source, Data Pipelines, Async Destruction and ADR 0029; no copied API catalog. |

## Deltas from ticket

None substantive. The live journey stays within one workspace's tabs and rail. Native-window integration is explained as a host boundary, not newly qualified by this guide. Intake reuses the parent's independent review and its explicit reopening correction: [intake record](https://github.com/neomjs/neo/issues/18034#issuecomment-5594088880).

## Test Evidence

The guide's five JavaScript fences were extracted into modules and mounted inside a normal Viewport. Clicking **Complete next task** changed `design.status` to `Done` and the summary to `Completed: Review the design`; no browser page errors. Source patterns were checked against `examples/stateProvider/table/`, `examples/grid/cellEditing/`, `examples/stateProvider/extendedClass/`, and the core Model/Store/Provider/Controller classes.

Live Neural Link inspection used a temporary harness holding strict references to the pane, controller, provider, Store and record. Moves used `execute_dock_operation`; completion/reveal/pin used the rendered buttons' event path:

| Checkpoint | Pane / controller | Provider / Store / record | Edited status |
|---|---|---|---|
| Center-tab move, right-edge return, collapse, reveal, pin | All original objects | All original objects | Done |
| Close | Both original objects destroyed | All original objects alive | Done |
| Reopen | Fresh objects; pane runtime ID reused | All original objects alive | Done |

After pinning, `verify_component_consistency` matched the pane's two children across items, VDOM and DOM with zero mismatches. This is ownership/embodiment evidence, not pointer-drag or native-popup qualification. Generic lifecycle claims are anchored in Workspace resolution/recreate/openPane, Provider-owned store retirement, Grid listener cleanup and Component-owned controller destruction.

The current Brain-hosted lint exports were invoked with explicit Engine content/paths rather than silently linting the Brain checkout. `lintGuide` + `checkTicketIds` returned no findings. `lintTree` returned the same `GROUP_SPANS_FOLDERS` violation for `AgentInterfaces` on both `335b2ca43a` and this tree; it is unrelated to the new UI-building-blocks entry. Engine `getSitemapXml` / `getLlmsTxt` produced the new route in memory. No generated file was written.

Portal rendered the new heading, navigation entry, article and Mermaid SVG without page errors. Visual inspection corrected an inherited button flex size and diagram contrast before this handoff.

## Post-Merge Validation

None deferred. Cross-family whole-guide review is required before merge.

Authored by Euclid (GPT-6, Codex) consuming Emmy's guide-series ticket — session A 309a78d7-2d95-4f23-bdfc-69d2ae393a5d, session B 4f9b7bbe-9dbc-4d36-a167-38fe0d288113.
Origin Session ID: 4f9b7bbe-9dbc-4d36-a167-38fe0d288113
