### PR TITLE
test(workstation): await committed projection in grid witnesses (#18518)

### DIFF
--- a/test/playwright/e2e/workstation/WorkstationGridRepaintNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationGridRepaintNL.spec.mjs
@@ -41,38 +41,6 @@ const resolveSplitSplitterId = page => page.evaluate(() =>
     document.querySelector('.neo-dashboard-dock-split-horizontal > .neo-dashboard-dock-splitter-horizontal')?.id);
 
 /**
- * Arms a MutationObserver that flips a page-global flag the moment the workspace enters the
- * shared dock-motion lifecycle — the positive barrier that absence-of-residue checks can
- * never provide (zero `.neo-dashboard-dock-animating` is the natural state BEFORE the
- * deferred projection starts; only a seen-entry proves the gates run after it).
- * @param {import('@playwright/test').Page} page
- */
-const armSplitterMotionWitness = page => page.evaluate(() => {
-    const root = document.querySelector('.workstation-workspace');
-
-    globalThis.__gridRepaintSplitterMotion?.observer?.disconnect();
-    globalThis.__gridRepaintSplitterMotion = {
-        observer: new MutationObserver(() => {
-            root.classList.contains('neo-dashboard-dock-animating')
-                && (globalThis.__gridRepaintSplitterMotion.seen = true)
-        }),
-        seen: root.classList.contains('neo-dashboard-dock-animating')
-    };
-    globalThis.__gridRepaintSplitterMotion.observer.observe(root, {
-        attributeFilter: ['class'],
-        attributes     : true
-    })
-});
-
-/**
- * Retires the armed motion witness.
- * @param {import('@playwright/test').Page} page
- */
-const disarmSplitterMotionWitness = page => page.evaluate(() => {
-    globalThis.__gridRepaintSplitterMotion?.observer?.disconnect()
-});
-
-/**
  * @summary Whitebox E2E witness for the grid-freeze-after-splitter hypothesis.
  *
  * Separates three truths that green backend receipts alone conflate:
@@ -81,7 +49,7 @@ const disarmSplitterMotionWitness = page => page.evaluate(() => {
  *   (3) the exact visible row/cell repaints the new value (DOM truth).
  *
  * Protocol: pre-drag rendered-cell control → a real pointer drag on the projected
- * horizontal DockSplitter (await the committed resizeSplit document + motion settlement)
+ * horizontal DockSplitter (await the committed resizeSplit document + projection settlement)
  * → the same rendered-cell control again. A green pre-drag control with a red post-drag
  * control reproduces the freeze; both green closes the hypothesis with a falsifying receipt.
  *
@@ -265,7 +233,6 @@ test.describe('Workstation — grid repaint truth across a real splitter drag', 
                   geometryBefore = await readHorizontalSplitGeometry(page),
                   direction      = cycle % 2 === 0 ? -90 : 90;
 
-            await armSplitterMotionWitness(page);
             await dragSplitter(direction);
 
             // Settlement off the committed document — never a fixed delay
@@ -274,8 +241,13 @@ test.describe('Workstation — grid repaint truth across a real splitter drag', 
                 {message: `cycle ${cycle}: the resizeSplit document must commit with new sizes`, timeout: 8000, intervals: [100]}
             ).not.toBe(JSON.stringify(sizesBefore));
 
-            // Positive projection barrier 1: the deferred projection must apply the committed
-            // split to LIVE DOM extents — a document commit alone says nothing about projection
+            // The observed commit has scheduled its projection. Await that owner even when FLIP
+            // lands instantly and its worker-side class pulse never reaches the DOM.
+            await app.callMethod(wsId, 'refreshPromise.then');
+            expect(await app.getConsoleLogs('warn', 'Dock projection failed'),
+                `cycle ${cycle}: a handled projection failure must not count as clean settlement`).toEqual([]);
+
+            // Live preview alone can change these extents; check them after projection settlement.
             await expect.poll(
                 async () => {
                     const geometry = await readHorizontalSplitGeometry(page);
@@ -284,14 +256,7 @@ test.describe('Workstation — grid repaint truth across a real splitter drag', 
                 {message: `cycle ${cycle}: the deferred projection must apply the committed split to live DOM extents`, timeout: 8000, intervals: [100]}
             ).toBeGreaterThan(20);
 
-            // Positive projection barrier 2: the shared dock-motion lifecycle must have been
-            // ENTERED — only then do the residue gates run after, not before, projection
-            await expect.poll(
-                async () => page.evaluate(() => globalThis.__gridRepaintSplitterMotion.seen),
-                {message: `cycle ${cycle}: the committed resize must enter the dock-motion lifecycle`, timeout: 8000, intervals: [50]}
-            ).toBe(true);
-
-            // Residue gates — meaningful only behind both positive barriers
+            // Residue gates follow the completed projection, not an unrelated header pulse.
             await expect.poll(
                 async () => page.locator('.neo-dashboard-dock-animating').count(),
                 {message: `cycle ${cycle}: projection animation must settle`, timeout: 8000, intervals: [100]}
@@ -300,8 +265,6 @@ test.describe('Workstation — grid repaint truth across a real splitter drag', 
                 async () => page.locator('.neo-dock-flip-fixed-stage').count(),
                 {message: `cycle ${cycle}: the FLIP staging frame must be fully retired`, timeout: 8000, intervals: [100]}
             ).toBe(0);
-
-            await disarmSplitterMotionWitness(page);
 
             // live identities after cycle 1 only — later cycles re-prove the repaint discriminant
             if (cycle === 1) {
@@ -460,8 +423,6 @@ test.describe('Workstation — grid repaint truth across a real splitter drag', 
         const sizesBefore    = (await app.getDockTopology(wsId)).document.nodes['split-main'].sizes,
               geometryBefore = await readHorizontalSplitGeometry(page);
 
-        await armSplitterMotionWitness(page);
-
         await app.simulateEvent([{
             options : {bubbles: true, button: 0, clientX: cx, clientY: cy},
             targetId: splitterDomId2, type: 'mousedown', windowId: windowId2
@@ -488,8 +449,12 @@ test.describe('Workstation — grid repaint truth across a real splitter drag', 
             {message: 'the resizeSplit document must commit with new sizes', timeout: 8000, intervals: [100]}
         ).not.toBe(JSON.stringify(sizesBefore));
 
-        // Positive projection barrier 1: the deferred projection must apply the committed
-        // split to LIVE DOM extents — a document commit alone says nothing about projection
+        // Await the new projection, then reject a handled failure that scheduled recovery.
+        await app.callMethod(wsId, 'refreshPromise.then');
+        expect(await app.getConsoleLogs('warn', 'Dock projection failed'),
+            'a handled projection failure must not count as clean settlement').toEqual([]);
+
+        // Live preview alone can change these extents; check them after projection settlement.
         await expect.poll(
             async () => {
                 const geometry = await readHorizontalSplitGeometry(page);
@@ -498,14 +463,7 @@ test.describe('Workstation — grid repaint truth across a real splitter drag', 
             {message: 'the deferred projection must apply the committed split to live DOM extents', timeout: 8000, intervals: [100]}
         ).toBeGreaterThan(20);
 
-        // Positive projection barrier 2: the shared dock-motion lifecycle must have been
-        // ENTERED — only then do the residue gates run after, not before, projection
-        await expect.poll(
-            async () => page.evaluate(() => globalThis.__gridRepaintSplitterMotion.seen),
-            {message: 'the committed resize must enter the dock-motion lifecycle', timeout: 8000, intervals: [50]}
-        ).toBe(true);
-
-        // Residue gates — meaningful only behind both positive barriers
+        // Residue gates follow the completed projection.
         await expect.poll(
             async () => page.locator('.neo-dashboard-dock-animating').count(),
             {message: 'projection animation must settle', timeout: 8000, intervals: [100]}
@@ -514,8 +472,6 @@ test.describe('Workstation — grid repaint truth across a real splitter drag', 
             async () => page.locator('.neo-dock-flip-fixed-stage').count(),
             {message: 'the FLIP staging frame must be fully retired', timeout: 8000, intervals: [100]}
         ).toBe(0);
-
-        await disarmSplitterMotionWitness(page);
 
         // Same-run identity reassert: pane, store, and row-record must be the SAME instances
         // the pre-drag controls bound — projection must not have swapped them

--- a/test/playwright/e2e/workstation/WorkstationSplitterGridGeometryNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationSplitterGridGeometryNL.spec.mjs
@@ -28,10 +28,9 @@ import { test, expect } from '../../fixtures.mjs';
  *      `offsetLeft`/layout width — plus worker `containerWidth`/`availableWidth` against the
  *      container/button layout truth.
  *
- * Settlement is event/state-based only, with a POSITIVE motion-entry barrier: a MutationObserver
- * must first witness the dock-motion lifecycle class ENTER (guarding against asserting before
- * the deferred projection even starts), then release (class absent, zero fixed-stage residue,
- * transform-free grid). No fixed-delay sleeps, per the ticket's walls.
+ * Settlement awaits the committed projection, including instant FLIP landings whose worker-side
+ * class pulse need not reach the DOM. Handled projection failures remain explicit failures, and
+ * the settled surface must have no motion class, fixed-stage residue or grid transform.
  *
  * The race itself is pinned RACE-FREE by the first test: it freezes a "mid-motion" frame (a
  * static ancestor scale transform), triggers the measurement through the projection's own
@@ -353,7 +352,12 @@ test.describe('Workstation splitter drags: grid geometry stays attributable (#16
 
         const boot = await readMatrix(page);
 
-        /** One committed drag + positive-entry settlement + the keyed attribution matrix. */
+        /**
+         * @summary Awaits one committed projection before checking the keyed attribution matrix.
+         * @param {Number} deltaX
+         * @param {String} tag
+         * @returns {Promise<void>}
+         */
         async function dragAndVerify(deltaX, tag) {
             // resizable edge zones share the orientation class — only the SPLIT container's own
             // child is the resizeSplit affordance this journey commits through
@@ -363,19 +367,6 @@ test.describe('Workstation splitter drags: grid geometry stays attributable (#16
                   sy                       = box.y + box.height / 2,
                   before                   = await readMatrix(page),
                   {dockModel: modelBefore} = await app.getComponent(workspaceId, ['dockModel']);
-
-            // positive motion-entry barrier: witness the lifecycle ENTER, not just its absence later
-            await page.evaluate(() => {
-                const el = document.querySelector('.workstation-workspace');
-                globalThis.__motion16375?.observer.disconnect();
-                globalThis.__motion16375 = {
-                    seen    : el.classList.contains('neo-dashboard-dock-animating'),
-                    observer: new MutationObserver(() => {
-                        el.classList.contains('neo-dashboard-dock-animating') && (globalThis.__motion16375.seen = true)
-                    })
-                };
-                globalThis.__motion16375.observer.observe(el, {attributes: true, attributeFilter: ['class']})
-            });
 
             await page.mouse.move(sx, sy);
             await page.mouse.down();
@@ -400,21 +391,19 @@ test.describe('Workstation splitter drags: grid geometry stays attributable (#16
                 intervals: [50, 100]
             }).toBeGreaterThan(0.02);
 
-            // 2. the deferred projection applied the committed extent to live DOM
+            // 2. the observed commit's projection settles, including an instant FLIP landing.
+            await app.callMethod(workspaceId, 'refreshPromise.then');
+            expect(await app.getConsoleLogs('warn', 'Dock projection failed'),
+                `${tag}: a handled projection failure must not count as clean settlement`).toEqual([]);
+
+            // 3. the committed extent is reflected in live DOM after that settlement.
             await expect.poll(async () => (await readMatrix(page)).layoutWidth, {
                 message  : `${tag}: the projection applies the committed split to the grid layout box`,
                 timeout  : 10000,
                 intervals: [50, 100]
             }).toBeCloseTo(before.layoutWidth + deltaX, 0);
 
-            // 3. the motion lifecycle ENTERED (positive barrier) ...
-            await expect.poll(() => page.evaluate(() => globalThis.__motion16375.seen), {
-                message  : `${tag}: the committed resize enters the dock-motion lifecycle`,
-                timeout  : 10000,
-                intervals: [25, 50]
-            }).toBe(true);
-
-            // ... and fully released the presentation
+            // The completed projection must fully release the presentation.
             await expect(root, `${tag}: the dock motion lifecycle settles`)
                 .not.toHaveClass(/neo-dashboard-dock-animating/, {timeout: 10000});
             await expect(page.locator('.neo-dock-flip-fixed-stage'),


### PR DESCRIPTION
Resolves #18518

The grid witnesses now await the committed Workspace projection after observing the changed split, including instant FLIP landings whose worker-side motion class need not reach the DOM. They reject captured handled-projection failures before checking the rendered result. The unused pulse observers are removed: 55 net lines leave the two specs.

Evidence: L3 (headed Chrome, explicit Brain runtime, complete selected E2E files) → L3 required. No residual acceptance criteria; no whole-film, native matrix or new animation claim.

Change class: zero-delta. This changes test synchronization, with no production code or API change.

Micro-review eligible: test-only use of the existing projection promise and captured logs.

## AC Evidence

| Criterion | Evidence |
|---|---|
| AC-1 | Three direct root-pulse barriers replaced by `refreshPromise.then` after the observed commit; their observer state/helpers removed. |
| AC-2 | AST/token comparison: the other 79 expect expressions are identical, including the deterministic transformed-geometry control. Input paths, ten feed cycles, scale-record mutation, both-direction geometry and residue checks remain. |
| AC-3 | The linked ten-cycle trace records a fresh post-gesture refresh settlement each time. A negative runtime control invokes the actual handled-failure producer and fails the new captured-warning assertion on cycle 1. |
| AC-4 | Both complete files run headed with the custom E2E config and explicit Brain checkout; baseline 3 failed/1 passed, candidate 4 passed. |

## Deltas from ticket

No production changes. A typed projection failure may resolve its attempt while replacing the retry promise, so the test also checks the existing captured warning. `agent-preflight` is not hosted here (npm Missing script); shared baseline jobs remain the hosted check authority.

## Test Evidence

- Baseline `335b2ca43a`: both full files, 4 selected — the three old motion-entry assertions fail; the deterministic geometry control passes. Run ID `18518-baseline-335b`.
- Candidate: both full files, 4 selected/4 passed in 24.9s. Run ID `18518-candidate`. Repeated after commit hooks at `d8a0fea5cdb31ff1b37d87ca690eb4a13fefff2f`: 4/4 passed in 24.5s, run ID `18518-final-head`.
- Negative control: the actual `onDockProjectionFailed` handler, with retry disposition to avoid scheduling another attempt, emitted a warning retrieved by the same `getConsoleLogs` assertion; the diagnostic failed on that assertion in 2.6s. Run ID `18518-handled-failure-control`. Temporary probe removed.
- [Ten-cycle settlement and repaint discriminator](https://github.com/neomjs/neo/issues/17844#issuecomment-5594404970): fresh settlement and repaint pass each cycle, while the retained old pulse requirements fail as soft assertions. The diagnostic remains red; it is not counted as a passing suite.

Commands use `test/playwright/playwright.config.e2e.mjs`, `--workers=1 --headed`, and `NEO_AGENTOS_RUNTIME_ROOT` pointing to the provisioned Brain checkout.

After [Brain #343](https://github.com/neomjs/neo-agent-brain/issues/343) was reported, the retained send/first-response sequences were audited: final 136/136, candidate 136/136, negative control 13/13 and baseline 42/42 all match the requested app session. Baseline received 66 unsolicited foreign-app replies, none against a pending call. Final embedded spec sources match this head byte-for-byte. These logs cannot distinguish another caller addressing the same app; this is a bounded receipt audit, not a general transport certification.

## Post-Merge Validation

None required for this close target. The broader census and dedicated motion/film gates remain separate.

Related: #17844

Authored by Emmy (GPT-6 Astra, Codex). Session 153d2e0a-ebae-4087-bcd5-3c92d213132c.
