### PR TITLE
test(workstation): await edge projection settlement (#18520)

### DIFF
--- a/test/playwright/e2e/workstation/WorkstationEdgeSplitterNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationEdgeSplitterNL.spec.mjs
@@ -293,6 +293,11 @@ test.describe('Workstation edge splitters — runtime pixels commit once as docu
 
             const after = await readDocument();
 
+            // Live preview can match the commit before projection updates retained component configs.
+            await app.callMethod(workspaceId, 'refreshPromise.then');
+            expect(await app.getConsoleLogs('warn', 'Dock projection failed'),
+                `${edge}: committed projection settles without a handled failure`).toEqual([]);
+
             const settledConfig = (await findEdgeSplitter(edge))?.resizeConfig;
 
             await expect.poll(async () => Math.abs(


### PR DESCRIPTION
Resolves #18520

The edge-resize witness now awaits the committed Workspace projection before resolving final component geometry and percentage authority. A captured projection warning fails the witness. Both axes, active-tab persistence, Escape and reducer rejection keep their existing assertions.

Evidence: L3 (complete headed Chrome E2E with explicit Brain runtime) → L3 required. No residual acceptance criteria.

Change class: zero-delta — five added test lines; no production code or API change.

Micro-review eligible: existing projection-promise and captured-warning calls in one test.

## AC Evidence

| Criterion | Evidence |
|---|---|
| AC-1 | Both successful commits await `refreshPromise.then` after observing the changed document, before resolving the projected edge splitter. |
| AC-2 | The actual `onDockProjectionFailed` handler emitted a captured warning; a temporary control failed the new assertion on the first left resize. |
| AC-3 | All 41 original expect/poll expressions are token-identical; one warning assertion is added. |
| AC-4 | The complete candidate passes all four original arms in one headed test; the retained baseline fails on old component width after the first left commit. |

## Deltas from ticket

None substantive. Same-context self-authored intake carve applies. `agent-preflight` is not hosted here (explicit npm Missing script); applicable shared baseline jobs provide the hosted checks.

## Test Evidence

- [Baseline and settlement discriminator](https://github.com/neomjs/neo/issues/17844#issuecomment-5594955601): width remains `11%` at the original immediate read. The diagnostic waits 439ms/414ms, then the full original test passes.
- Candidate run `18520-candidate`: 1 selected / 1 passed, 7.2s, including both axes, Escape and reducer rejection.
- Negative run `18520-handled-failure-control`: expected failure at the new warning assertion. Injected input invokes the actual handler with retry disposition; it does not claim a real failed reconcile. Temporary probe removed.

Runs use `test/playwright/playwright.config.e2e.mjs`, `--workers=1 --headed`, and an explicit `NEO_AGENTOS_RUNTIME_ROOT`. Traces and embedded source copies remain under `test/playwright/test-results/e2e/battery/<run>/artifacts`. Candidate 71/71 and failure-control 31/31 first replies match their requested app sessions; the candidate source byte-matches committed `ff6e030cb8`. Another caller addressing the same app cannot be distinguished by those logs.

## Post-Merge Validation

None required for this close target. The broader census and nested-column Escape failure remain separate.

Related: #17844

Authored by Emmy (GPT-6 Astra, Codex). Session 153d2e0a-ebae-4087-bcd5-3c92d213132c.
