### PR TITLE
fix(dock): await asynchronous target settlement (#18522)

### DIFF
--- a/src/dashboard/dock/interaction/TabSortZone.mjs
+++ b/src/dashboard/dock/interaction/TabSortZone.mjs
@@ -1112,7 +1112,7 @@ class TabSortZone extends TabHeaderSortZone {
     }
 
     /**
-     * Extends the base drag-end: fires a `dockCrossZoneDrop` event on the owner tab.Container (`owner.up()`)
+     * @summary Extends the base drag-end: fires a `dockCrossZoneDrop` event on the owner tab.Container (`owner.up()`)
      * carrying the release point + dragged item id. The adapter wires the listener for it — the same
      * tab.Container node whose `moveTo` listener handles the within-container reorder — and its closure holds
      * the dock reducer (the reliable seam: a closure captured at projection time, not a cloned config nor a
@@ -1132,8 +1132,8 @@ class TabSortZone extends TabHeaderSortZone {
      *
      * Cross-window gestures close through {@link Neo.manager.DragCoordinator#onDragEnd} FIRST: a
      * release over an engaged remote target commits there, and the coordinator arms
-     * {@link #remoteDropCommitted} via {@link #onRemoteDropOut} on this same call stack — so the
-     * local decision below always sees the truth.
+     * {@link #remoteDropCommitted} via {@link #onRemoteDropOut}. Async targets settle before this
+     * source chooses its terminal; synchronous targets keep their same-stack continuation.
      * @param {Object} data
      */
     async processDragEnd(data) {
@@ -1152,22 +1152,31 @@ class TabSortZone extends TabHeaderSortZone {
               ),
               conversionTargetConverted = me.vesselConversionSensor?.targetConverted === true;
 
-        let postCleanup = null;
+        let commitError = null,
+            postCleanup = null;
+
+        try {
+            if (me.sortGroup && me.dragComponent) {
+                const completion = me.dragCoordinator?.[data.cancelled ? 'onDragCancel' : 'onDragEnd']({
+                    draggedItem   : me.dragComponent,
+                    sourceSortZone: me
+                });
+
+                if (typeof completion?.then === 'function') {
+                    await completion
+                }
+            }
+        } catch (error) {
+            commitError = error
+        }
+
+        if (me.isDestroying || me.isDestroyed) {
+            if (commitError) throw commitError;
+            return
+        }
 
         if (me.stackDragActive) {
-            let commitError    = null,
-                terminalItemId = me.dragComponent?.dockItemId ?? itemId ?? null;
-
-            try {
-                if (me.sortGroup && me.dragComponent) {
-                    me.dragCoordinator?.[data.cancelled ? 'onDragCancel' : 'onDragEnd']({
-                        draggedItem   : me.dragComponent,
-                        sourceSortZone: me
-                    })
-                }
-            } catch (error) {
-                commitError = error
-            }
+            let terminalItemId = me.dragComponent?.dockItemId ?? itemId ?? null;
 
             const committed = !data.cancelled && !commitError && me.remoteDropCommitted,
                 outcome     = committed ? 'committed' : data.cancelled ? 'cancelled' : 'rejected';
@@ -1198,19 +1207,6 @@ class TabSortZone extends TabHeaderSortZone {
             }
 
             return
-        }
-
-        let commitError = null;
-
-        try {
-            if (me.sortGroup && me.dragComponent) {
-                me.dragCoordinator?.[data.cancelled ? 'onDragCancel' : 'onDragEnd']({
-                    draggedItem   : me.dragComponent,
-                    sourceSortZone: me
-                })
-            }
-        } catch (error) {
-            commitError = error
         }
 
         if (!data.cancelled && me.releaseVoidsReorder(data || {})) {
@@ -1288,10 +1284,14 @@ class TabSortZone extends TabHeaderSortZone {
         try {
             await super.processDragEnd(data)
         } finally {
-            me.resetVesselConversion?.()
+            if (!me.isDestroying && !me.isDestroyed) {
+                me.resetVesselConversion?.()
+            }
         }
 
-        await postCleanup?.();
+        if (!me.isDestroying && !me.isDestroyed) {
+            await postCleanup?.()
+        }
 
         if (commitError) {
             throw commitError

--- a/src/draggable/container/SortZone.mjs
+++ b/src/draggable/container/SortZone.mjs
@@ -480,7 +480,7 @@ class SortZone extends DragZone {
     }
 
     /**
-     * Drag:end entry point. The drag listeners fan out across the owner and its child items, so one
+     * @summary Drag:end entry point. The drag listeners fan out across the owner and its child items, so one
      * native release can deliver multiple drag:end events. This entry latches synchronously and routes
      * exactly one delivery into {@link #processDragEnd} — without it, the async drop pipeline runs
      * twice (double traces, double layout refreshes, double lock verdicts in grids).
@@ -498,7 +498,9 @@ class SortZone extends DragZone {
         try {
             await me.processDragEnd(data)
         } finally {
-            me.dragEndActive = false
+            if (!me.isDestroying && !me.isDestroyed) {
+                me.dragEndActive = false
+            }
         }
     }
 

--- a/src/manager/DragCoordinator.mjs
+++ b/src/manager/DragCoordinator.mjs
@@ -1344,14 +1344,18 @@ class DragCoordinator extends Manager {
     }
 
     /**
-     * Finalizes a dashboard window drag by either dropping into the active target
+     * @summary Finalizes a dashboard window drag by either dropping into the active target
      * or leaving the source popup as the terminal drop state.
+     * Synchronous targets retire the source on this call stack. Async targets return completion
+     * for source cleanup to await; arbitration itself is released before another gesture starts.
      * @param {Object} data
      * @param {Neo.component.Base} data.draggedItem
      * @param {Neo.draggable.container.SortZone} data.sourceSortZone
+     * @returns {Promise<*>|undefined} Async target outcome after source retirement, when applicable.
      */
     onDragEnd(data) {
-        let me = this;
+        let me                            = this,
+            {draggedItem, sourceSortZone} = data;
 
         // The gesture reaches a terminal on every branch below, so its token dies here — the
         // committed target already lives in `activeTargetZone`; claims are hover-time state only.
@@ -1363,51 +1367,31 @@ class DragCoordinator extends Manager {
                 me.activeTargetZone.onRemoteDragLeave?.();
                 me.activeTargetZone = null
             } else if (me.activeTargetZone) {
-                // The TARGET decides whether the gesture committed: onRemoteDrop() returns the committed
-                // operation, or null when there was no preview, no operation, or the commit declined.
-                // Engagement is not commitment, so its answer cannot be discarded.
-                // `finally`, because a throwing commit is the REJECTED terminal — and a terminal that
-                // leaves `activeTargetZone` populated hands the next release a commit destination from a
-                // gesture that already failed. The error is not swallowed: cleanup is exact-once on every
-                // terminal, including the ones that raise.
+                // Engagement is not commitment: only the target's accepted outcome retires the source.
                 try {
-                    let result = me.activeTargetZone.onRemoteDrop(data.draggedItem);
+                    let result = me.activeTargetZone.onRemoteDrop(draggedItem);
 
-                // Source retirement follows the OUTCOME, not the attempt. Retiring unconditionally
-                // armed the source's `remoteDropCommitted`, whose whole meaning is "a remote target
-                // committed this transfer" — and which suppresses the source's in-window drop path on
-                // that belief. On a null commit the target never took the item while the source had
-                // already let go, so the item stranded with no owner. Leaving the flag unarmed lets the
-                // source's ordinary in-window path run and restore it: the restore is the pre-existing
-                // default, not a new capability — it was simply unreachable behind a false signal.
-                //
-                // Targets answer synchronously OR asynchronously, and the two cannot share a branch: a
-                // Promise is ALWAYS truthy, so testing the returned value directly reads every async
-                // target as committed — the identical defect wearing the fix's own shape.
-                //
-                // The split is not symmetry for its own sake; each side has a different truth deadline.
-                // A SYNC target must retire on this call stack, because the source reads
-                // `remoteDropCommitted` synchronously in its own drag-end continuation — deferring
-                // would arm the flag after the decision it exists to inform. An ASYNC target's outcome
-                // is not knowable this tick at all, so retirement waits for the resolution; that is
-                // sound only because an async target's source cleanup carries no same-call reader.
                     if (typeof result?.then === 'function') {
-                        result.then(operation => {
-                            if (operation) {
-                                data.sourceSortZone.onRemoteDropOut(data.draggedItem)
+                        return result.then(operation => {
+                            if (operation && !sourceSortZone.isDestroying && !sourceSortZone.isDestroyed) {
+                                sourceSortZone.onRemoteDropOut(draggedItem)
                             }
+
+                            return operation
                         })
-                    } else if (result) {
-                        data.sourceSortZone.onRemoteDropOut(data.draggedItem)
+                    } else if (result && !sourceSortZone.isDestroying && !sourceSortZone.isDestroyed) {
+                        sourceSortZone.onRemoteDropOut(draggedItem)
                     }
                 } finally {
                     me.activeTargetZone = null
                 }
-            } else if (data.sourceSortZone.isWindowDragging) {
-                data.sourceSortZone.onTerminalWindowDrop?.(data.draggedItem)
+            } else if (sourceSortZone.isWindowDragging) {
+                sourceSortZone.onTerminalWindowDrop?.(draggedItem)
             }
         } finally {
-            data.sourceSortZone.resetVesselConversion?.();
+            if (!sourceSortZone.isDestroying && !sourceSortZone.isDestroyed) {
+                sourceSortZone.resetVesselConversion?.()
+            }
             me.activeSourceZone           = null;
             me.activeTargetCommitEligible = false;
             me.activeTransitionOwned      = false

--- a/test/playwright/unit/dashboard/DockTabSortZone.spec.mjs
+++ b/test/playwright/unit/dashboard/DockTabSortZone.spec.mjs
@@ -10,6 +10,7 @@ import {test, expect}    from '@playwright/test';
 import Neo               from '../../../../src/Neo.mjs';
 import * as core         from '../../../../src/core/_export.mjs';
 import DockTabSortZone   from '../../../../src/dashboard/dock/interaction/TabSortZone.mjs';
+import ContainerSortZone from '../../../../src/draggable/container/SortZone.mjs';
 import TabHeaderSortZone from '../../../../src/draggable/tab/header/toolbar/SortZone.mjs';
 
 /**
@@ -325,6 +326,118 @@ test.describe('Neo.dashboard.dock.interaction.TabSortZone', () => {
                 expect(state.startIndex).toBe(-1)
             }
         })
+    });
+
+    test.describe('asynchronous target settlement', () => {
+        let coordinator, originalCleanup;
+
+        test.beforeAll(async () => {
+            coordinator = (await import('../../../../src/manager/DragCoordinator.mjs')).default
+        });
+
+        test.beforeEach(() => {
+            originalCleanup = TabHeaderSortZone.prototype.processDragEnd
+        });
+
+        test.afterEach(() => {
+            TabHeaderSortZone.prototype.processDragEnd = originalCleanup;
+            coordinator.activeSourceZone = coordinator.activeTargetZone = null;
+            coordinator.activeTargetCommitEligible = coordinator.activeTransitionOwned = false
+        });
+
+        for (const stack of [false, true]) {
+            for (const outcome of ['committed', 'refused', 'refused-false', 'rejected']) {
+                test(`${stack ? 'stack' : 'pane'} waits for ${outcome} before its terminal and cleanup`, async () => {
+                    const pending = Promise.withResolvers(),
+                          calls   = [],
+                          error   = new Error('target failure'),
+                          zone    = {
+                              dockItemIds           : ['graph'],
+                              dragComponent         : {dockItemId: 'graph', id: 'graph-button'},
+                              dragCoordinator       : coordinator,
+                              dragEnd               : () => calls.push(['cleanup']),
+                              fireDockLifecycleEvent: DockTabSortZone.prototype.fireDockLifecycleEvent,
+                              onRemoteDropOut() {
+                                  calls.push(['remote-out']);
+                                  this.remoteDropCommitted = true
+                              },
+                              owner                 : {up: () => ({fire: (name, data) => calls.push([name, data])})},
+                              processDragEnd        : DockTabSortZone.prototype.processDragEnd,
+                              releaseVoidsReorder   : () => false,
+                              remoteDropCommitted   : false,
+                              sortGroup             : 'async-dock-test',
+                              stackDragActive       : stack,
+                              startIndex            : 0,
+                              vesselConversionSensor: {converted: true, targetConverted: true}
+                          };
+
+                    TabHeaderSortZone.prototype.processDragEnd = async () => calls.push(['cleanup']);
+                    coordinator.activeTargetZone = {onRemoteDrop: () => pending.promise};
+                    const running = ContainerSortZone.prototype.onDragEnd.call(zone, {cancelled: false}),
+                          settled = running.then(() => null, failure => failure);
+
+                    expect(calls, 'pending has no source terminal, retirement or base cleanup').toEqual([]);
+                    expect(zone.dragEndActive).toBe(true);
+                    await ContainerSortZone.prototype.onDragEnd.call(zone, {});
+                    await DockTabSortZone.prototype.onDragStart.call(zone, {path: []});
+                    expect(calls).toEqual([]);
+
+                    outcome === 'rejected' ? pending.reject(error)
+                        : pending.resolve(outcome === 'committed' ? {} : outcome === 'refused-false' ? false : null);
+                    expect(await settled).toBe(outcome === 'rejected' ? error : null);
+
+                    const terminal = stack ? ['dockStackDragTerminal'] : outcome === 'committed'
+                        ? ['dockVesselConversionTerminal'] : ['dockTearOutCancel', 'dockVesselConversionRetired'];
+
+                    expect(calls.map(([name]) => name)).toEqual([
+                        ...(outcome === 'committed' ? ['remote-out'] : []), ...terminal, 'cleanup'
+                    ]);
+                    if (stack || outcome === 'committed') {
+                        expect(calls.find(([name]) => name === terminal[0])[1].outcome)
+                            .toBe(outcome === 'committed' ? 'committed' : 'rejected')
+                    }
+                    expect(zone.remoteDropCommitted).toBe(false);
+                    expect(zone.dragEndActive).toBe(false)
+                })
+            }
+
+            test(`${stack ? 'stack' : 'pane'} destroyed during settlement receives no late work or properties`, async () => {
+                const pending = Promise.withResolvers(),
+                      calls   = [],
+                      zone    = Neo.create(DockTabSortZone, {
+                          owner: {addDomListeners() {}, cls: [], dragResortable: false,
+                              items: [], on() {}, style: {}, up: () => ({fire: name => calls.push(name)})}
+                      });
+
+                try {
+                    await zone.ready();
+                    Object.assign(zone, {
+                        dragComponent  : {dockItemId: 'graph', id: 'graph-button'},
+                        dragCoordinator: coordinator,
+                        onRemoteDropOut: () => calls.push('remote-out'),
+                        sortGroup      : 'async-dock-destroy-test',
+                        stackDragActive: stack,
+                        startIndex     : 0
+                    });
+                    TabHeaderSortZone.prototype.processDragEnd = async () => calls.push('cleanup');
+                    coordinator.activeTargetZone = {onRemoteDrop: () => pending.promise};
+                    const running = zone.onDragEnd({cancelled: false});
+
+                    expect(calls).toEqual([]);
+                    zone.destroy();
+                    const keys         = Object.keys(zone).sort(),
+                          afterDestroy = [...calls];
+
+                    pending.resolve({type: 'transferItem'});
+                    await running;
+                    expect(calls).toEqual(afterDestroy);
+                    expect(Object.keys(zone).sort()).toEqual(keys);
+                    expect(Object.hasOwn(zone, 'dragEndActive')).toBe(false)
+                } finally {
+                    zone.destroy()
+                }
+            })
+        }
     });
 
     test.describe('tear-out gesture terminals — the choreography outcome routing', () => {

--- a/test/playwright/unit/manager/DragCoordinator.spec.mjs
+++ b/test/playwright/unit/manager/DragCoordinator.spec.mjs
@@ -317,6 +317,67 @@ test.describe('Neo.manager.DragCoordinator — teardown hygiene (#15248)', () =>
         ])
     });
 
+    test('async completion is returned without retaining arbitration or clearing a newer gesture', async () => {
+        const pending = Promise.withResolvers(),
+              source  = createSourceZone(),
+              item    = {id: 'tab-1'},
+              target  = createTargetZone(pending.promise);
+
+        DragCoordinator.activeSourceZone = source;
+        DragCoordinator.activeTargetZone = target;
+        const completion = DragCoordinator.onDragEnd({draggedItem: item, sourceSortZone: source});
+
+        expect(typeof completion?.then).toBe('function');
+        expect(calls).toEqual([['onRemoteDrop', 'tab-1']]);
+        expect(DragCoordinator.activeSourceZone).toBeNull();
+        expect(DragCoordinator.activeTargetZone).toBeNull();
+
+        const nextSource = createSourceZone(),
+              nextTarget = createTargetZone(null);
+
+        DragCoordinator.activeSourceZone = nextSource;
+        DragCoordinator.activeTargetZone = nextTarget;
+        DragCoordinator.activeTargetCommitEligible = true;
+        DragCoordinator.activeTransitionOwned = true;
+        pending.resolve({type: 'transferItem'});
+        await completion;
+
+        expect(calls).toEqual([['onRemoteDrop', 'tab-1'], ['onRemoteDropOut', 'tab-1']]);
+        expect(DragCoordinator.activeSourceZone).toBe(nextSource);
+        expect(DragCoordinator.activeTargetZone).toBe(nextTarget);
+        expect(DragCoordinator.activeTargetCommitEligible).toBe(true);
+        expect(DragCoordinator.activeTransitionOwned).toBe(true)
+    });
+
+    test('async rejection reaches the caller without retiring the source', async () => {
+        const pending = Promise.withResolvers(),
+              source  = createSourceZone(),
+              error   = new Error('target declined');
+
+        DragCoordinator.activeTargetZone = createTargetZone(pending.promise);
+        const completion = DragCoordinator.onDragEnd({draggedItem: {id: 'tab-1'}, sourceSortZone: source}),
+              rejected   = expect(completion).rejects.toBe(error);
+
+        pending.reject(error);
+        await rejected;
+        expect(calls).toEqual([['onRemoteDrop', 'tab-1']])
+    });
+
+    for (const flag of ['isDestroying', 'isDestroyed']) {
+        test(`async completion does not retire a source with ${flag}`, async () => {
+            const pending = Promise.withResolvers(),
+                  source  = createSourceZone();
+
+            DragCoordinator.activeTargetZone = createTargetZone(pending.promise);
+            const completion = DragCoordinator.onDragEnd({draggedItem: {id: 'tab-1'}, sourceSortZone: source});
+
+            source[flag] = true;
+            pending.resolve({type: 'transferItem'});
+            await completion;
+            expect(calls).toEqual([['onRemoteDrop', 'tab-1']])
+        })
+    }
+
     test('a SYNC commit still retires on the SAME call stack — the source reads the flag synchronously', () => {
         // The deadline that forbids simply making onDragEnd async: DockTabSortZone's processDragEnd
         // reads `remoteDropCommitted` in its own synchronous continuation, so an awaited retirement


### PR DESCRIPTION
Resolves #18522

Dock sources now wait for asynchronous target drops before selecting their terminal or cleaning up. The coordinator returns target completion while releasing its arbitration state synchronously, so an older drop cannot erase a later gesture. Synchronous targets retain same-stack source retirement. Both dock paths share one completion step, and Base destruction state fences late callbacks and latch/reset writes.

Evidence: runtime contract tests invoke the real coordinator and dock methods with controlled target settlement, plus real Neo instances for destruction. This internal completion contract is unit-verifiable. The headed consumer journey is separately owned by #18516 and is not claimed here.

## AC Evidence

| Criterion | Evidence |
|---|---|
| AC-1 | CI-covered: `DockTabSortZone.spec.mjs` — pane and stack remain pending with no terminal or cleanup. |
| AC-2 | CI-covered: deferred success, null, false and rejection controls; exact-one remote-out on success and original error propagation. |
| AC-3 | CI-covered: both dock branches, existing same-stack manager control, and unchanged cancellation controls. |
| AC-4 | CI-covered: duplicate end/start refusal while pending; real `Neo.create(DockTabSortZone)` destroyed before target resolution receives no late calls or new own properties. |
| AC-5 | CI-covered: manager interleaving installs a new source/target before the prior completion and retains every arbitration field. |
| AC-6 | CI-covered: existing manager/dock suites. Outside-CI: both new pending-success controls failed before the source repair, as recorded below. |

## Deltas from ticket

None substantive. Reused the existing end latch and Base lifecycle flags; no second gesture token, timer or registry. The shared completion step removes the duplicated stack/pane coordinator call. Change class: restoration.

`agent-preflight` is not hosted in Engine. Block alignment, ticket archaeology, diff whitespace and file-size guards were checked locally; the reusable PR baseline supplies the hosted body checks.

## Test Evidence

Before editing production source at base `335b2ca43a5ec54c823563745c276c3881e05416`, ran the two new `waits for committed` controls in `DockTabSortZone.spec.mjs`: both failed at the pending-state assertion. The pane emitted `dockTearOutCancel`, `dockVesselConversionRetired`, then cleanup; the stack emitted a rejected `dockStackDragTerminal`, then cleanup. The same controls pass with the repair.

The unrestricted local unit command cannot collect untracked legacy hook tests that import the removed Engine `ai/` tree. The complete tracked unit population was run separately using `git ls-files` as its file list and passed. No files were removed or ignored in repository configuration.

## Post-Merge Validation

No merge-only obligation for this leaf. Continue the headed Demo B consumer adoption under #18516 after this prerequisite; its embodiment and receipt changes are outside this diff.

Related: #18516, #18303, #15248.

Authored by Euclid (GPT-6, Codex). Session 4f9b7bbe-9dbc-4d36-a167-38fe0d288113.
