### PR TITLE
fix(dashboard): complete Demo B proxy embodiment (#18516)

### DIFF
--- a/buildScripts/util/file-size-baseline.json
+++ b/buildScripts/util/file-size-baseline.json
@@ -1,6 +1,6 @@
 {
     "apps/workstation/view/Workspace.mjs": 1252,
-    "examples/dashboard/crossWindow/DemoBWorkspace.mjs": 2505,
+    "examples/dashboard/crossWindow/DemoBWorkspace.mjs": 2546,
     "src/dashboard/dock/Workspace.mjs": 1100,
     "src/main/addon/DragDrop.mjs": 1267
 }

--- a/examples/dashboard/crossWindow/DemoBCrossWindowStage.mjs
+++ b/examples/dashboard/crossWindow/DemoBCrossWindowStage.mjs
@@ -38,6 +38,7 @@ import PreviewContract    from '../../../src/dashboard/dock/model/PreviewContrac
  * @param {Object} seams.workspaceIds `{main, popup, popup2}` semantic workspace ids (`popup2`
  *     optional — the stage parameterizes over every popup id the host registers).
  * @param {String} seams.sortGroup The shared cross-window coordinator sort group.
+ * @param {Object} seams.dragEmbodiment The host-owned proxy embodiment shared by its targets.
  * @param {Function} seams.applyWorkspaceOperation `(workspaceId, descriptor) => {document, errors}|null`
  * @param {Function} seams.adoptCommittedTransferPair `(pair) => Promise<Boolean>` — the HOST's wrappable
  *     adoption facade; `commitWholeStackReturn` routes through it (never its own internal twin)
@@ -90,6 +91,7 @@ export function createCrossWindowStage(seams) {
         workspaceSet,
         workspaceIds,
         sortGroup,
+        dragEmbodiment,
         applyWorkspaceOperation,
         attachKeydown,
         bumpStageGeneration,
@@ -167,6 +169,27 @@ export function createCrossWindowStage(seams) {
         registries.participations.get(workspaceId)?.destroy();
 
         let participation = Neo.create(Participation, {
+            dragEmbodiment,
+            /**
+             * @summary Settles the existing custom preview and exact target-local live pane.
+             * @param {Object} payload
+             * @returns {Promise<Boolean>}
+             */
+            awaitDragEmbodiment: async payload => {
+                const preview = host.down({ntype: 'dock-preview'});
+                if (!dragEmbodiment || !preview?.dockPreview) return false;
+
+                const [settled] = await Promise.all([
+                    dragEmbodiment.whenSettled({
+                        itemId        : payload.draggedItem?.dockItemId,
+                        sourceWindowId: payload.sourceWindowId,
+                        targetWindowId: windowId
+                    }),
+                    preview.promiseUpdate()
+                ]);
+                return settled === true && Boolean(preview.dockPreview)
+                    && isTargetCurrent(workspaceId, windowId, host, generation)
+            },
             clearPreview: () => clearWorkspaceAffordances(workspaceId),
             commitLocal : operation => {
                 let result = applyWorkspaceOperation(workspaceId, operation);

--- a/examples/dashboard/crossWindow/DemoBWorkspace.mjs
+++ b/examples/dashboard/crossWindow/DemoBWorkspace.mjs
@@ -1,25 +1,28 @@
-import Component                          from '../../../src/component/Base.mjs';
-import Container                          from '../../../src/container/Base.mjs';
-import CounterPane                        from './CounterPane.mjs';
-import {createCrossWindowStage}           from './DemoBCrossWindowStage.mjs';
-import DockDropIndicators                 from '../../../src/dashboard/dock/interaction/DropIndicators.mjs';
-import DockLayoutAdapter                  from '../../../src/dashboard/dock/projection/LayoutAdapter.mjs';
-import DockMotionSignal                   from '../../../src/dashboard/dock/projection/MotionSignal.mjs';
-import PerspectiveLibrary                 from '../../../src/dashboard/dock/persistence/PerspectiveLibrary.mjs';
-import Placement                          from '../../../src/dashboard/dock/window/Placement.mjs';
-import TopologySeams                      from '../../../src/dashboard/dock/window/TopologySeams.mjs';
-import DockPreview                        from '../../../src/dashboard/dock/interaction/Preview.mjs';
-import DockPreviewProducer                from '../../../src/dashboard/dock/interaction/PreviewProducer.mjs';
-import DockProjectionReconciler           from '../../../src/dashboard/dock/projection/Reconciler.mjs';
-import DockService                        from '../../../src/ai/client/DockService.mjs';
-import DockTopologyReconciler             from '../../../src/dashboard/dock/model/TopologyReconciler.mjs';
-import WorkspaceDocument                  from '../../../src/dashboard/dock/model/WorkspaceDocument.mjs';
-import Operations                         from '../../../src/dashboard/dock/model/Operations.mjs';
-import Persistence                        from '../../../src/dashboard/dock/model/Persistence.mjs';
-import InteractionService                 from '../../../src/ai/client/InteractionService.mjs';
-import {createDockKeyboardCommands}       from '../../../src/dashboard/dock/interaction/KeyboardCommands.mjs';
-import {createDockTearOutHandlers}        from '../../../src/dashboard/dock/window/TearOut.mjs';
-import {createDockVesselEmbodiment}       from '../../../src/dashboard/dock/window/VesselEmbodiment.mjs';
+import Component                    from '../../../src/component/Base.mjs';
+import Container                    from '../../../src/container/Base.mjs';
+import CounterPane                  from './CounterPane.mjs';
+import {createCrossWindowStage}     from './DemoBCrossWindowStage.mjs';
+import DockDropIndicators           from '../../../src/dashboard/dock/interaction/DropIndicators.mjs';
+import DockLayoutAdapter            from '../../../src/dashboard/dock/projection/LayoutAdapter.mjs';
+import DockMotionSignal             from '../../../src/dashboard/dock/projection/MotionSignal.mjs';
+import PerspectiveLibrary           from '../../../src/dashboard/dock/persistence/PerspectiveLibrary.mjs';
+import Placement                    from '../../../src/dashboard/dock/window/Placement.mjs';
+import TopologySeams                from '../../../src/dashboard/dock/window/TopologySeams.mjs';
+import DockPreview                  from '../../../src/dashboard/dock/interaction/Preview.mjs';
+import DockPreviewProducer          from '../../../src/dashboard/dock/interaction/PreviewProducer.mjs';
+import DockProjectionReconciler     from '../../../src/dashboard/dock/projection/Reconciler.mjs';
+import DockService                  from '../../../src/ai/client/DockService.mjs';
+import DockTopologyReconciler       from '../../../src/dashboard/dock/model/TopologyReconciler.mjs';
+import WorkspaceDocument            from '../../../src/dashboard/dock/model/WorkspaceDocument.mjs';
+import Operations                   from '../../../src/dashboard/dock/model/Operations.mjs';
+import Persistence                  from '../../../src/dashboard/dock/model/Persistence.mjs';
+import InteractionService           from '../../../src/ai/client/InteractionService.mjs';
+import {createDockKeyboardCommands} from '../../../src/dashboard/dock/interaction/KeyboardCommands.mjs';
+import {createDockTearOutHandlers}  from '../../../src/dashboard/dock/window/TearOut.mjs';
+import {
+    createDockVesselEmbodiment,
+    createDockVesselProxyEmbodiment
+} from '../../../src/dashboard/dock/window/VesselEmbodiment.mjs';
 import WorkspaceSet                       from '../../../src/dashboard/dock/window/WorkspaceSet.mjs';
 import NativeVesselTransaction            from '../../../src/dashboard/dock/window/NativeVesselTransaction.mjs';
 import VesselPark                         from '../../../src/dashboard/dock/window/VesselPark.mjs';
@@ -404,6 +407,12 @@ class DemoBWorkspace extends Container {
      */
     tearOutEmbodiment = null
     /**
+     * Target-local live pane ownership while its native source vessel is parked.
+     * @member {Object|null} vesselProxyEmbodiment=null
+     * @protected
+     */
+    vesselProxyEmbodiment = null
+    /**
      * Monotonic count of actual tear-out `windowOpen` attempts. The headed conversion witness
      * snapshots this counter at first park and after re-show; equality is the mechanical proof
      * that one continuous gesture never tries to reacquire popup activation.
@@ -504,12 +513,21 @@ class DemoBWorkspace extends Container {
         me.perspectiveStore = Neo.create(PerspectiveLibrary, {});
         me.topologyCollection = Persistence.createTopologyCollection().collection;
 
+        me.vesselProxyEmbodiment = createDockVesselProxyEmbodiment({
+            resolvePane       : itemId => me.paneCache[itemId],
+            resolveProxyConfig: ({sourceSortZone, targetWindowId}) => ({
+                ...sourceSortZone.getDragProxyConfig(),
+                appName: Neo.apps[targetWindowId]?.name ?? me.appName
+            })
+        });
+
         // The cross-window stage choreography (decomposition Phase 1): a pure decision
         // machine over host-injected seams. Stage STATE stays host-owned by contract — the
         // unit spec's stage doubles write `crossWindowTargetWindowId` and call
         // `crossWindowStageResolve` directly, so those fields remain this component's public
         // stage surface while the module owns the code manipulating them.
         me.crossWindowStage = createCrossWindowStage({
+            dragEmbodiment              : me.vesselProxyEmbodiment,
             adoptCommittedTransferPair  : pair => me.adoptCommittedTransferPair(pair),
             retireReturnedPopupWorkspace: () => me.retireReturnedPopupWorkspace(),
             applyWorkspaceOperation     : (workspaceId, descriptor) => me.applyWorkspaceOperation(workspaceId, descriptor),
@@ -1604,7 +1622,7 @@ class DemoBWorkspace extends Container {
     }
 
     /**
-     * @summary Awaits Group transfer admission and its projections before reporting the native gesture.
+     * @summary Acknowledges Group transfer admission before the deferred rendered gesture receipt.
      * @param {Object} data
      * @returns {Promise}
      * @protected
@@ -1661,11 +1679,8 @@ class DemoBWorkspace extends Container {
             .then(async () => {
                 if (!ownsTransfer()) return;
 
-                // `onRemoteDropOut()` and the source-local suppression decision both finish on
-                // the coordinator's synchronous mouseup stack, before this deferred projection.
-                // Snapshot their counters now: the source projection intentionally destroys its
-                // empty tabs zone, so reading a field from that zone after reconciliation would
-                // manufacture false evidence from a torn-down object.
+                // The admitted result lets source retirement finish before deferred projection.
+                // Read host-owned counters: projection can destroy the emptied source tabs zone.
                 let sourceDecision = {
                     localDropFires    : me.crossWindowStats.localDropFires,
                     remoteDropOutFires: me.crossWindowStats.remoteDropOutFires
@@ -1691,8 +1706,11 @@ class DemoBWorkspace extends Container {
                             && sourceDecision.localDropFires === 0,
                         targetItemPlaced        : !!targetDocument.items?.[itemId]
                             && targetTabsId === descriptor.target?.tabsNodeId,
-                        targetMountDelta: Number.isInteger(context?.vesselMountCount)
-                            ? (pane?.mountCount ?? 0) - context.vesselMountCount
+                        targetMountDelta: Number.isInteger(context?.proxyMountCount)
+                            ? (pane?.mountCount ?? 0) - context.proxyMountCount
+                            : null,
+                        proxyMountDelta: Number.isInteger(context?.proxyMountCount)
+                            ? context.proxyMountCount - context.vesselMountCount
                             : null,
                         targetTabsId,
                         transferCommits : me.crossWindowStats.transferCommits,
@@ -1710,8 +1728,9 @@ class DemoBWorkspace extends Container {
                         ['worker component instance stayed identical', proof.sameInstance],
                         ['instance heartbeat did not reset', proof.framesNotReset],
                         ['live vessel added exactly one mount', proof.vesselMountDelta === 1],
+                        ['target proxy added exactly one mount', proof.proxyMountDelta === 1],
                         ['target document added exactly one mount', proof.targetMountDelta === 1],
-                        ['live vessel and target added exactly two mounts', proof.mountDelta === 2],
+                        ['vessel, proxy and final target each mounted once', proof.mountDelta === 3],
                         ['continuity witness is complete', typeof pane?.id === 'string'
                             && Number.isInteger(pane?.mountCount)]
                     ],
@@ -1732,7 +1751,7 @@ class DemoBWorkspace extends Container {
                 me.crossWindowGestureResolve = null
             });
 
-        return me.refreshPromise.then(() => true)
+        return true
     }
 
     /**
@@ -1849,6 +1868,7 @@ class DemoBWorkspace extends Container {
             candidateSet                                  = indicators?.candidateSet ?? null,
             snapshot                                      = {
                 coordinator: coordinator?.toJSON?.() ?? null,
+                embodiment : me.vesselProxyEmbodiment.snapshot(context?.itemId),
                 engaged    : coordinator?.activeTargetZone === target,
                 indicators : {
                     activePreviewId: indicators?.activeCandidate?.preview?.previewId ?? null,
@@ -1907,17 +1927,20 @@ class DemoBWorkspace extends Container {
             renderer                        = host?.down({ntype: 'dock-preview'}),
             indicators                      = host?.down({ntype: 'dashboard-dock-drop-indicators'}),
             snapshot                        = {
-                activeTargetZone      : coordinator?.toJSON?.().activeTargetZone ?? null,
-                activeCandidateId     : indicators?.activeCandidate?.preview?.previewId ?? null,
-                candidateSetSchema    : indicators?.candidateSet?.schema ?? null,
-                dragDataPresent       : sourceZone?.data != null,
-                dragEndActive         : sourceZone?.dragEndActive === true,
-                dragPlaceholderPresent: !!sourceZone?.dragPlaceholder,
-                dragProxyPresent      : !!sourceZone?.dragProxy,
-                draggingClass         : sourceZone?.owner?.cls?.includes?.('neo-is-dragging') === true,
-                nativeCandidateCount  : coordinator?.nativeWindowDropCandidates?.size ?? 0,
-                semanticPreviewId     : participation?.target?.currentPreview?.previewId ?? null,
-                renderedPreviewId     : renderer?.dockPreview?.previewId ?? null
+                activeTargetZone       : coordinator?.toJSON?.().activeTargetZone ?? null,
+                activeCandidateId      : indicators?.activeCandidate?.preview?.previewId ?? null,
+                candidateSetSchema     : indicators?.candidateSet?.schema ?? null,
+                dragDataPresent        : sourceZone?.data != null,
+                dragEndActive          : sourceZone?.dragEndActive === true,
+                dragPlaceholderPresent : !!sourceZone?.dragPlaceholder,
+                dragProxyPresent       : !!sourceZone?.dragProxy,
+                proxyEmbodimentPresent : me.vesselProxyEmbodiment.snapshot(context?.itemId) !== null,
+                vesselEmbodimentPresent: me.tearOutEmbodiment.isStaged(context?.itemId),
+                sourcePaneRestored     : !!context?.pane && context.pane.windowId === context.sourceWindowId,
+                draggingClass          : sourceZone?.owner?.cls?.includes?.('neo-is-dragging') === true,
+                nativeCandidateCount   : coordinator?.nativeWindowDropCandidates?.size ?? 0,
+                semanticPreviewId      : participation?.target?.currentPreview?.previewId ?? null,
+                renderedPreviewId      : renderer?.dockPreview?.previewId ?? null
             };
 
         snapshot.ready = snapshot.activeTargetZone === null
@@ -1927,6 +1950,9 @@ class DemoBWorkspace extends Container {
             && snapshot.dragEndActive === false
             && snapshot.dragPlaceholderPresent === false
             && snapshot.dragProxyPresent === false
+            && snapshot.proxyEmbodimentPresent === false
+            && snapshot.vesselEmbodimentPresent === false
+            && snapshot.sourcePaneRestored === true
             && snapshot.draggingClass === false
             && snapshot.nativeCandidateCount === 0
             && snapshot.semanticPreviewId === null
@@ -2232,6 +2258,12 @@ class DemoBWorkspace extends Container {
             for (let attempt = 0; attempt <= 120 && !me.isDestroyed; attempt++) {
                 remoteSnapshot = me.readCrossWindowRemoteSnapshot(me.crossWindowGestureContext);
 
+                if (remoteSnapshot.ready) {
+                    const target = me.crossWindowParticipations.get(targetWorkspaceId)?.target;
+                    remoteSnapshot.ready = await target?.awaitRemoteDragEmbodiment(sourceZone.dragComponent) === true;
+                    remoteSnapshot.embodiment = me.vesselProxyEmbodiment.snapshot(itemId);
+                }
+
                 if (remoteSnapshot.ready || attempt === 120) break;
 
                 await me.interactionService.simulateEvent({events: [{
@@ -2319,7 +2351,7 @@ class DemoBWorkspace extends Container {
             }
 
             me.crossWindowGestureContext.remoteSnapshot = remoteSnapshot;
-            me.crossWindowGestureContext.vesselMountCount = pane.mountCount;
+            me.crossWindowGestureContext.proxyMountCount = pane.mountCount;
 
             if (roundTrip) {
                 // Remote preview can settle before the asynchronously-acquired tear-out child has
@@ -3129,6 +3161,11 @@ class DemoBWorkspace extends Container {
                     return false
                 }
 
+                const gesture = me.crossWindowGestureContext;
+                if (context.staged && gesture?.itemId === itemId && gesture.pane === me.paneCache[itemId]) {
+                    gesture.vesselMountCount = gesture.pane.mountCount
+                }
+
                 return true
             },
             // Whichever of terminal and connect lands SECOND performs adoption. Arriving here with
@@ -3326,7 +3363,7 @@ class DemoBWorkspace extends Container {
     }
 
     /**
-     * A window that held one of this workspace's slots left the shared heap: whatever pane it hosted
+     * @summary A window that held one of this workspace's slots left the shared heap: whatever pane it hosted
      * comes HOME — the reattach commit brings the item back into the document; the re-projection
      * re-adopts the parked instance. Physical death is authoritative: every state owner clears, so
      * a successor gesture can neither inherit nor be blocked by the retired generation.
@@ -3342,6 +3379,8 @@ class DemoBWorkspace extends Container {
             reservation                       = me.vesselReservations.get(workspaceKey);
 
         if (me.isDestroyed || groupId !== me.topologyGroupId) return;
+
+        me.vesselProxyEmbodiment.restoreByWindow(windowId);
 
         // A tear-out vessel's death is the Group's to observe: its slot is the vessel source's, so
         // the `released` effect restores an unsettled stage and brings a committed item home. Only
@@ -3769,9 +3808,14 @@ class DemoBWorkspace extends Container {
                 sourceRect: data.record?.sourceRect ?? null,
                 windowName: me.resolveTearOutVessel(data.itemId)?.windowName
             }),
-            onDockVesselConversionOut: data => me.vesselParkHandlers.onConversionOut({
-                rect: data.logicalRect ?? data.record?.sourceRect ?? null
-            }),
+            onDockVesselConversionOut: data => {
+                if (me.vesselProxyEmbodiment.isStaged(data.itemId)
+                    && !me.vesselProxyEmbodiment.restore({itemId: data.itemId})) return false;
+
+                return me.vesselParkHandlers.onConversionOut({
+                    rect: data.logicalRect ?? data.record?.sourceRect ?? null
+                })
+            },
             onDockVesselConversionTerminal: data => me.vesselParkHandlers.onGestureTerminal(data),
             onDockVesselConversionRetired : data => me.vesselParkHandlers.onVesselRetired(data),
             onDockZoneDocumentChange      : (nextDocument, descriptor) => me.onWorkspaceDocumentChange(workspaceId, nextDocument, {descriptor}),
@@ -3941,7 +3985,7 @@ class DemoBWorkspace extends Container {
     }
 
     /**
-     * The tear-out retirement seam: closes a vessel the gesture no longer needs (re-entry, cancel,
+     * @summary The tear-out retirement seam: closes a vessel the gesture no longer needs (re-entry, cancel,
      * or a refused model commit). Identity is the slot's lineage token — a successor admission for
      * the same item shares the window name, never the token — so a retirement presenting a superseded
      * token is refused and the live vessel survives it. The live connection remains recoverable until
@@ -3996,10 +4040,15 @@ class DemoBWorkspace extends Container {
         // committed transfer promotes the staged pane instead, letting the target-first reconciler
         // take it without a false source restoration.
         if (embodiedWindowId && me.tearOutEmbodiment.isStaged(itemId)) {
-            const sourceOwns = Boolean(WorkspaceDocument.findContainingTabsId(me.dockModel, itemId)),
-                  settled    = me.tearOutEmbodiment[sourceOwns ? 'restore' : 'promote']({
-                      itemId, windowId: embodiedWindowId
-                  });
+            const sourceOwns = Boolean(WorkspaceDocument.findContainingTabsId(me.dockModel, itemId));
+
+            // Unwind the target proxy first; its source slot lives inside this vessel.
+            if (sourceOwns && me.vesselProxyEmbodiment.isStaged(itemId)
+                && !me.vesselProxyEmbodiment.restore({itemId})) return false;
+
+            const settled = me.tearOutEmbodiment[sourceOwns ? 'restore' : 'promote']({
+                itemId, windowId: embodiedWindowId
+            });
 
             if (!settled) return false
         }
@@ -4386,7 +4435,7 @@ class DemoBWorkspace extends Container {
     }
 
     /**
-     * Tears down the runner, seam, store, and every cached pane with the workspace.
+     * @summary Tears down the runner, seam, store, and every cached pane with the workspace.
      * @param {...*} args
      */
     destroy(...args) {
@@ -4419,6 +4468,8 @@ class DemoBWorkspace extends Container {
         });
         me.vesselReservations.clear();
         me.vesselParkHandlers?.destroy();
+        me.vesselProxyEmbodiment?.destroy();
+        me.vesselProxyEmbodiment = null;
         me.tearOutEmbodiment?.destroy();
         me.tearOutEmbodiment = null;
         me.crossWindowStagePromise   = null;

--- a/test/playwright/e2e/dashboard/DemoBCrossWindowDragNL.spec.mjs
+++ b/test/playwright/e2e/dashboard/DemoBCrossWindowDragNL.spec.mjs
@@ -354,7 +354,8 @@ test.describe('Dashboard Demo B — real cross-window dock drag', () => {
         expect(result.proof).toMatchObject({
             framesNotReset           : true,
             localDropFires           : 0,
-            mountDelta               : 2,
+            mountDelta               : 3,
+            proxyMountDelta          : 1,
             remoteDropOutFires       : 1,
             sameInstance             : true,
             sourceSuppressionConsumed: true,
@@ -391,9 +392,9 @@ test.describe('Dashboard Demo B — real cross-window dock drag', () => {
                   schema: 'neo.dock.zone.v1',
                   root  : 'root',
                   items : {
-                      inspector: {reference: 'Inspector', title: 'Inspector'},
-                      timeline : {reference: 'Timeline',  title: 'Timeline'},
-                      console  : {reference: 'Console',   title: 'Console'}
+                      inspector: {title: 'Inspector'},
+                      timeline : {title: 'Timeline'},
+                      console  : {title: 'Console'}
                   },
                   nodes: {
                       root       : {type: 'edge-zone', zones: {right: {nodeId: 'side-tabs'}}},
@@ -406,7 +407,7 @@ test.describe('Dashboard Demo B — real cross-window dock drag', () => {
                   schema: 'neo.dock.zone.v1',
                   root  : 'popup-root',
                   items : {
-                      workbench: {reference: 'Workbench', title: 'Workbench'}
+                      workbench: {title: 'Workbench'}
                   },
                   nodes: {
                       'popup-root': {type: 'edge-zone', zones: {center: {nodeId: 'popup-tabs'}}},
@@ -424,7 +425,7 @@ test.describe('Dashboard Demo B — real cross-window dock drag', () => {
             transferCommits   : 1
         });
         expect(counter.id).toBe(baseline.id);
-        expect(counter.properties.mountCount).toBe(baseline.properties.mountCount + 2);
+        expect(counter.properties.mountCount).toBe(baseline.properties.mountCount + 3);
         expect(counter.properties.mounted).toBe(true);
         expect(counter.properties.windowId).not.toBe(baseline.properties.windowId);
 
@@ -553,8 +554,11 @@ test.describe('Dashboard Demo B — real cross-window dock drag', () => {
                 + `\nround-trip result: ${JSON.stringify(result)}`)
         }
 
-        await expect(tearOutPopup.locator('.agentos-dockdemo-counter-pane'),
-            'the moving tear-out vessel must render its real live pane before any terminal commit')
+        await expect(targetPopup.locator('.agentos-dockdemo-counter-pane'),
+            'the same live pane renders in the target proxy while its native source is parked')
+            .toBeVisible({timeout: 5000});
+        await expect(tearOutPopup.locator('.neo-dashboard-dock-vessel-placeholder'),
+            'the parked source reserves the pane slot until restore or commit')
             .toBeVisible({timeout: 5000});
 
         let sourceParkState;
@@ -588,24 +592,20 @@ test.describe('Dashboard Demo B — real cross-window dock drag', () => {
         // source to report false would encode a browser-harness quirk as product semantics.
         expect(parkReceipt.refocused).toBe(true);
 
-        let restoreReceipt;
+        const result         = await resultPromise,
+              restoreReceipt = result.proof?.restoreReceipt;
 
-        await expect.poll(async () => {
-            restoreReceipt = (await app.getComponent(wsId, ['lastVesselRestoreReceipt'])).lastVesselRestoreReceipt;
-            return Boolean(restoreReceipt?.requested)
-        }, {
-            message  : 'out-conversion must publish its exact restore request',
-            timeout  : 3000,
-            intervals: [10, 25, 50]
-        }).toBe(true);
+        expect(restoreReceipt?.frame,
+            'the settled out-conversion must publish its exact frame-space restore request').toEqual({
+            x: expect.any(Number),
+            y: expect.any(Number)
+        });
 
         await placePopupAtObservedOrigin(
             tearOutPopup,
-            restoreReceipt.requested,
+            restoreReceipt.frame,
             'the CDP adapter must let the real vessel reach Neo\'s exact restore request'
         );
-
-        const result = await resultPromise;
 
         expect(result.errors,
             `the full conversion round-trip must settle detached: ${JSON.stringify(result.debug ?? null)}`)
@@ -686,8 +686,8 @@ test.describe('Dashboard Demo B — real cross-window dock drag', () => {
         expect(survivingTearOut, 're-show and terminal retain the acquisition-time Page object').toBe(tearOutPopup);
         expect(finalCounterList, 'the round-trip never duplicates the live CounterPane').toHaveLength(1);
         await expect(survivingTearOut.locator('.agentos-dockdemo-counter-pane')).toBeVisible({timeout: 10000});
-        expect(Math.abs(restoredPhysical.x - result.proof.restoreReceipt.requested.x)).toBeLessThanOrEqual(2);
-        expect(Math.abs(restoredPhysical.y - result.proof.restoreReceipt.requested.y)).toBeLessThanOrEqual(2);
+        expect(Math.abs(restoredPhysical.x - result.proof.restoreReceipt.frame.x)).toBeLessThanOrEqual(2);
+        expect(Math.abs(restoredPhysical.y - result.proof.restoreReceipt.frame.y)).toBeLessThanOrEqual(2);
         expect(after.tearOutAcquisitionAttempts).toBe(1);
         expect(after.popupDocument).toEqual(before.popupDocument);
         expect(after.dockModel.items.workbench).toEqual(before.dockModel.items.workbench);
@@ -695,7 +695,7 @@ test.describe('Dashboard Demo B — real cross-window dock drag', () => {
         expect(native.owners.workbench.windowId).toBe(result.proof.firstIdentity.windowId);
         expect(after.crossWindowStats).toEqual(result.proof.stats);
         expect(finalCounter.id).toBe(baseline.id);
-        expect(finalCounter.properties.mountCount).toBe(baseline.properties.mountCount + 1);
+        expect(finalCounter.properties.mountCount).toBe(baseline.properties.mountCount + 3);
         expect(finalCounter.properties.windowId).toBe(result.proof.firstIdentity.windowId);
         expect(pageErrors).toEqual([]);
 
@@ -799,18 +799,21 @@ test.describe('Dashboard Demo B — real cross-window dock drag', () => {
             settled          : true
         });
         expect(result.proof.cleanup).toEqual({
-            activeTargetZone      : null,
-            activeCandidateId     : null,
-            candidateSetSchema    : null,
-            dragDataPresent       : false,
-            dragEndActive         : false,
-            dragPlaceholderPresent: false,
-            dragProxyPresent      : false,
-            draggingClass         : false,
-            nativeCandidateCount  : 0,
-            semanticPreviewId     : null,
-            renderedPreviewId     : null,
-            ready                 : true
+            activeTargetZone       : null,
+            activeCandidateId      : null,
+            candidateSetSchema     : null,
+            dragDataPresent        : false,
+            dragEndActive          : false,
+            dragPlaceholderPresent : false,
+            dragProxyPresent       : false,
+            proxyEmbodimentPresent : false,
+            vesselEmbodimentPresent: false,
+            sourcePaneRestored     : true,
+            draggingClass          : false,
+            nativeCandidateCount   : 0,
+            semanticPreviewId      : null,
+            renderedPreviewId      : null,
+            ready                  : true
         });
         expect(result.proof.stats).toEqual({
             localDropFires    : 0,
@@ -822,7 +825,7 @@ test.describe('Dashboard Demo B — real cross-window dock drag', () => {
         expect(after.popupDocument).toEqual(before.popupDocument);
         expect(after.crossWindowStats).toEqual(result.proof.stats);
         expect(finalCounter.id).toBe(baseline.id);
-        expect(finalCounter.properties.mountCount).toBe(baseline.properties.mountCount + 2);
+        expect(finalCounter.properties.mountCount).toBe(baseline.properties.mountCount + 3);
         expect(finalCounter.properties.windowId).toBe(baseline.properties.windowId);
         expect(trace?.events.at(-1)?.t).toBe('cancel');
         expect(runtimeErrors).toEqual([]);

--- a/test/playwright/unit/examples/dashboard/crossWindow/DemoBWorkspace.spec.mjs
+++ b/test/playwright/unit/examples/dashboard/crossWindow/DemoBWorkspace.spec.mjs
@@ -1315,6 +1315,39 @@ test.describe.serial('Neo.examples.dashboard.crossWindow.DemoBWorkspace', () => 
         expect(workspace.detachedPanes.workbench).toBeUndefined()
     });
 
+    test('cancelling a proxied tear-out restores its inner slot before the source slot', async () => {
+        const vessel = installWindowVessel(),
+              pane   = workspace.resolvePane('timeline', initialDocument.items.timeline),
+              home   = pane.parent,
+              index  = home.items.indexOf(pane),
+              moving = Neo.create(Container, {windowId: 'nested-restore-vessel'});
+
+        Neo.apps['nested-restore-vessel'] = {mainView: moving};
+        try {
+            expect(await workspace.tearOutEmbodiment.stage({itemId: 'timeline', windowId: moving.windowId})).toBe(true);
+            expect(workspace.vesselProxyEmbodiment.move({
+                draggedItem   : {dockItemId: 'timeline'},
+                proxyRect     : {height: 100, width: 200, x: 10, y: 10},
+                sourceSortZone: {getDragProxyConfig: () => ({})},
+                sourceWindowId: moving.windowId,
+                targetWindowId: 'nested-restore-target'
+            })).toBe(true);
+            expect(await workspace.vesselProxyEmbodiment.whenSettled({itemId: 'timeline'})).toBe(true);
+
+            expect(await workspace.closeTearOutVessel({itemId: 'timeline', windowName: 'tearout-timeline'})).toBe(true);
+            // The coordinator's later cancel must have no remaining proxy slot to restore.
+            expect(workspace.vesselProxyEmbodiment.restore({itemId: 'timeline'})).toBe(false);
+            expect(pane.parent).toBe(home);
+            expect(home.items[index]).toBe(pane);
+            expect(workspace.tearOutEmbodiment.isStaged('timeline')).toBe(false)
+        } finally {
+            workspace.vesselProxyEmbodiment.destroy();
+            moving.destroy();
+            delete Neo.apps['nested-restore-vessel'];
+            vessel.restore()
+        }
+    });
+
     test('a popup close during projection settlement cannot strand committed popup ownership', async () => {
         const
             pane     = workspace.resolvePane('workbench', initialDocument.items.workbench),
@@ -1368,6 +1401,8 @@ test.describe.serial('Neo.examples.dashboard.crossWindow.DemoBWorkspace', () => 
 
         await targetRefreshStarted;
 
+        // Source retirement needs the admitted outcome while target projection is still pending.
+        expect(await commit).toBe(true);
         expect(workspace.detachedPanes.workbench.windowId).toBe('window-popup');
 
         await releaseWindow('window-popup', DemoBWorkspace.POPUP_WORKSPACE_ID);


### PR DESCRIPTION
Resolves #18516

Demo B now supplies the existing target-proxy embodiment owner to every cross-window participation, waits for the exact live pane and rendered preview to settle, and unwinds nested proxy/vessel ownership in the correct order. Group admission is acknowledged before deferred projection, so the source terminal completes while its projection still exists. Cold transfer, park/re-show/detach, and Escape cancellation all pass as one headed whole-file journey.

Evidence: L3 (real headed Chrome windows plus Neural Link whole-file execution at `6ef60aa7`) → L3 required (AC-2 through AC-5). Residual: none.

`agent-preflight: not hosted here; baseline pr-body and substrate-size run in CI` — Engine has no `agent-preflight` npm script (verified exit 1). Change class: restoration → `fix`.

Micro-review eligible: no — this changes multi-window pane ownership and its native gesture witness.

## AC Evidence

| AC | Evidence |
|---|---|
| AC-1 — compose and wire the existing proxy embodiment; no engine change | CI-covered: `DemoBWorkspace` creates `createDockVesselProxyEmbodiment`, passes it through `createCrossWindowStage`, restores it before the outer vessel, and destroys it with the host. The PR changes no `src/` file. |
| AC-2 — non-zero `previewFor` calls and a settled semantic preview | Outside-CI: an observation-only patch at the exact `DragTarget.onRemoteDragMove` call site counted one `previewFor` call in both the cold-transfer and round-trip arms while the whole headed file stayed 3/3 green. The committed witness also asserts five candidates and matching semantic/rendered preview ids. No observation patch is committed. |
| AC-3 — report headed and headless modes honestly | Outside-CI: headed passes 3/3 at `6ef60aa7`; headless fails 3/3 before strict native conversion/preview admission. The headless result is disclosed as the ticket's launch-mode ceiling, not promoted to acceptance evidence. |
| AC-4 — the three arms pass together with the Brain runtime root | Outside-CI: the exact whole file passes 3/3 with one worker and the configured Brain runtime root, without `NODE_OPTIONS` or hot patching. |
| AC-5 — separately observe park/re-show/detach | Outside-CI: the round trip proves one popup acquisition, zero mid-gesture reacquisitions, the same native handle/window throughout, admitted park and frame-space restore receipts, one live pane, a cleared park slot, and zero transfer/remote-out/local-drop commits. |

## Deltas from ticket

The missing owner exposed two consumer ordering defects: the transfer promise waited for its own deferred rendered receipt, and vessel close restored the outer slot before the target proxy's inner slot. Focused controls cover both; no new engine API or coordination abstraction was added.

The prerequisite from #18522 landed through #18523 and was removed from this branch with a surgical rebase. Current `dev` also retired redundant catalog `reference` values and moved native restore coordinates into `NativeVesselTransaction`'s explicit `frame` receipt. The already-touched E2E witness now follows those contracts and waits for the settled transaction result before applying its CDP position adapter. No timeout or retry budget increased.

size-guard-growth: examples/dashboard/crossWindow/DemoBWorkspace.mjs — 2505 to 2546 code lines: compose the existing proxy embodiment and expose its settlement and cleanup receipts without adding another state machine.

## Test Evidence

Exact headed command:

```sh
NEO_AGENTOS_RUNTIME_ROOT=/path/to/neo-agent-brain \
NEO_E2E_RUN_ID=euclid-18516-head-6ef60aa7 \
npm run test-e2e -- test/playwright/e2e/dashboard/DemoBCrossWindowDragNL.spec.mjs --headed --workers=1
```

Result: **3 passed in 8.5 seconds** at `6ef60aa70062de37dd78daed6b9110621073a9f3`, with no preload or hot patch. A separate observation-only whole-file run also passed 3/3 and recorded `previewForCalls: 1` on the target for both successful transfer paths.

The matching headless command, with `--headed` omitted, failed **3/3 in 25 seconds** before the required native conversion/preview outcomes. That is the expected mode distinction named by AC-3.

Two focused red controls preceded the implementation: holding projection blocked the admitted commit promise, and cancelling nested embodiments left a later proxy restore able to move the pane back into the retiring vessel. Both pass after the repair. The rebased focused unit file passes 70/70, and the file-size ratchet reports zero violations.

The runtime used `neomjs/neo-agent-brain@1e1e4b71c021b37004dccb78d633aa0a6e0b7785`; that runtime affects the Neural Link witness transport, not the Engine product dependency graph.

## Post-Merge Validation

None — all close-target acceptance evidence is complete before handoff.

## Evolution

The rebase surfaced two stale witness assumptions rather than two product regressions. A current-`dev` control failed all three arms; the rebased consumer advanced cold transfer and Escape immediately. The remaining round-trip result was already successful, but the test polled before the shared asynchronous transaction completed and read its retired `requested` field. Reading the settled `frame` receipt fixed the witness without changing product behavior or increasing a wait budget.

Related: #18439, #18522, #18523, neomjs/neo-agent-brain#344.

Authored by Euclid (GPT-6, Codex). Session 4f9b7bbe-9dbc-4d36-a167-38fe0d288113.
