### PR TITLE
fix(dock): classify Group batches before projection (#18524)

### DIFF
--- a/buildScripts/util/file-size-baseline.json
+++ b/buildScripts/util/file-size-baseline.json
@@ -1,6 +1,6 @@
 {
     "apps/workstation/view/Workspace.mjs": 1689,
     "examples/dashboard/crossWindow/DemoBWorkspace.mjs": 2612,
-    "src/dashboard/dock/Workspace.mjs": 1096,
+    "src/dashboard/dock/Workspace.mjs": 1100,
     "src/main/addon/DragDrop.mjs": 1267
 }

--- a/src/dashboard/dock/Workspace.mjs
+++ b/src/dashboard/dock/Workspace.mjs
@@ -2165,47 +2165,25 @@ class Workspace extends Container {
     }
 
     /**
-     * Hook: the reconciler's fast-path options for the refresh a commit schedules —
-     * `{geometryOnly}` for a pure boundary move, `{retainTopology}` for item-only deltas on a
-     * proven-identical shell, `{preserveItemIds}` for owner-held ids known only at THIS commit (a
-     * pane parked by the operation itself), merged with the standing {@link #getPreservedItemIds}
-     * set. The default derives both fast paths from the operation's declared change class, so a
-     * consumer that overrides nothing already gets them. The committing surface passes
-     * `descriptor` as it identifies the operation — engine surfaces pass the semantic descriptor;
-     * a host's own paths may pass their options object — and the override maps whatever shapes its
-     * commit sites produce.
-     * @param {Object|null} descriptor The semantic operation that produced the document, when known.
+     * @summary Selects reconciliation fast paths from scalar or Group operation change classes.
+     * Nonempty homogeneous batches admit a fast path; others use full reconciliation.
+     * The reconciler still validates structure and reports the actual path as `landedInPlace`.
+     * Overrides may add `preserveItemIds`, merged with {@link #getPreservedItemIds}.
+     * @param {Object|null} descriptor A semantic operation or a Group descriptor with `operations`.
      * @param {Object|null} source The committing surface, when it identifies itself.
      * @returns {Object}
      */
     getRefreshOptions(descriptor, source) {
-        // Derived, not declined. `model/Operations` declares what each operation can change beside
-        // the reducer that implements it, so the engine answers from knowledge a consumer cannot
-        // have: only the reducer knows `setItemLocked` assigns one item field and touches `nodes`
-        // nowhere, while `moveItem` restructures. Before this, the default was `{}` — the full
-        // staged transaction for every commit — so one lock click re-parented the splits and edge
-        // rows and every retained header in the app repainted.
-        //
-        // An operation with no declared class falls through to `topology`, i.e. exactly the old
-        // behaviour, so a vocabulary that outgrows the map degrades to slow rather than to wrong.
-        // `topology` is the one class with nothing to emit, because it IS the full transaction.
-        //
-        // Both emitted values are admission REQUESTS, never claims: `reconcileStableTopology`
-        // returns null on any node/type/ancestry/order/orientation delta and the caller falls
-        // through to the staged transaction, with `landedInPlace` reporting the path actually
-        // taken. A class that were ever wrong would therefore cost one refused validation pass,
-        // not a wrong projection — which is why the fast path can be derived at all.
-        switch (Operations.changeClassFor(descriptor?.operation)) {
-            // Both resize reducers clone the document and write exactly one field —
-            // `nodes[id].sizes`, `nodes[id].zones[edge].extent` — and survive `WorkspaceDocument.commit`,
-            // normalization included, with the node tree, the node id set and `items` all
-            // byte-identical. Nothing moved but the boundary, so nothing needs restaging.
+        const operations = Object.hasOwn(descriptor ?? {}, 'operations') ? descriptor.operations : [descriptor],
+              classes    = new Set(Array.isArray(operations)
+                  ? operations.map(value => Operations.changeClassFor(value?.operation)) : []);
+
+        if (classes.size !== 1) return {};
+
+        switch (classes.values().next().value) {
             case 'geometry':
                 return {geometryOnly: true};
 
-            // The item-flag reducers write one `items[id]` field and touch `nodes` nowhere, so the
-            // shell is stable and only items reconcile — a railed item included: its rail is stable
-            // topology too, keyed by its edge-zone node and edge, and reconciles its items in place.
             case 'itemFlags':
                 return {retainTopology: true}
         }

--- a/test/playwright/unit/dashboard/DockWorkspace.spec.mjs
+++ b/test/playwright/unit/dashboard/DockWorkspace.spec.mjs
@@ -18,6 +18,7 @@ import DockService              from '../../../../src/ai/client/DockService.mjs'
 import DockWorkspace            from '../../../../src/dashboard/dock/Workspace.mjs';
 import TransactionManager       from '../../../../src/manager/Transaction.mjs';
 import WorkspaceDocument        from '../../../../src/dashboard/dock/model/WorkspaceDocument.mjs';
+import WorkspaceSet             from '../../../../src/dashboard/dock/window/WorkspaceSet.mjs';
 import Operations               from '../../../../src/dashboard/dock/model/Operations.mjs';
 import Persistence              from '../../../../src/dashboard/dock/model/Persistence.mjs';
 import DomApiVnodeCreator       from '../../../../src/vdom/util/DomApiVnodeCreator.mjs';
@@ -543,6 +544,76 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
         // Every fixture bound its host into a Group; retire them so no arm inherits another's slots.
         [...TransactionManager.items].forEach(group => TransactionManager.retireGroup(group.id));
         TransactionManager.reconnectLeaseMs = 20000
+    });
+
+    test.describe('Group refresh classification', () => {
+        const geometry = {operation: 'resizeSplit'},
+              itemFlag = {operation: 'setItemLocked'};
+
+        for (const [name, descriptor, expected] of [
+            ['one geometry operation', {operations: [geometry]}, {geometryOnly: true}],
+            ['different geometry operations', {operations: [geometry, {operation: 'resizeEdgeZone'}]}, {geometryOnly: true}],
+            ['item flags', {operations: [itemFlag, itemFlag]}, {retainTopology: true}],
+            ['scalar geometry', geometry, {geometryOnly: true}],
+            ['scalar item flag', itemFlag, {retainTopology: true}],
+            ['mixed classes', {operations: [geometry, itemFlag]}, {}],
+            ['structural operation', {operations: [geometry, {operation: 'moveItem'}]}, {}],
+            ['unknown final operation', {operations: [geometry, {operation: 'futureOperation'}]}, {}],
+            ['unknown first operation', {operations: [{operation: 'futureOperation'}, geometry]}, {}],
+            ['inherited operation name', {operations: [geometry, {operation: 'toString'}]}, {}],
+            ['empty batch', {operation: 'resizeSplit', operations: []}, {}],
+            ['malformed batch', {operation: 'resizeSplit', operations: {}}, {}],
+            ['missing operation', {operations: [geometry, null]}, {}],
+            ['missing descriptor', null, {}]
+        ]) {
+            test(name, () => {
+                const before = structuredClone(descriptor);
+
+                expect(DockWorkspace.prototype.getRefreshOptions(descriptor)).toEqual(expected);
+                expect(descriptor, 'classification does not rewrite committed context').toEqual(before)
+            })
+        }
+
+        test('a real Group resize batch updates geometry without replacing the shell', async () => {
+            const {groupId} = TransactionManager.bind({windowId: 'dock-batch-projection-test', workspaceKey: 'main'});
+            TransactionManager.setHistoryDepth({groupId, depth: 5});
+            workspace = Neo.create(PlainWorkspace, {dockModel: createDocument(), topologyGroupId: groupId});
+
+            const set = Neo.create(WorkspaceSet, {
+                documentModel: WorkspaceDocument,
+                getGroupId   : () => groupId,
+                manager      : TransactionManager
+            }),
+                shell = workspace.getDockHost().items[0],
+                split = shell.down({dockNodeId: 'root-split'}),
+                afterRefresh = workspace.afterRefreshDockWorkspace.bind(workspace);
+
+            let outcome;
+
+            workspace.afterRefreshDockWorkspace = context => {
+                outcome = context.result;
+                return afterRefresh(context)
+            };
+
+            try {
+                expect(set.register('main', {
+                    getDocument: () => workspace.dockModel,
+                    setDocument: value => workspace.dockModel = value,
+                    project    : context => workspace.projectDockCommit(context)
+                })).toBe(true);
+                await set.commit('main', [{operation: 'resizeSplit', splitNodeId: 'root-split', sizes: [0.75, 0.25]}]);
+                await workspace.refreshPromise;
+
+                expect(workspace.dockModel.nodes['root-split'].sizes, 'the Group write really committed').toEqual([0.75, 0.25]);
+                expect(outcome?.landedInPlace, 'the actual reconciler accepted stable topology').toBe(true);
+                expect(workspace.getDockHost().items[0]).toBe(shell);
+                expect(shell.down({dockNodeId: 'root-split'})).toBe(split);
+                expect(split.items.filter(item => item.dockNodeType === 'tabs').map(item => item.flex)).toEqual([0.75, 0.25]);
+                expect(TransactionManager.get(workspace.topologyGroupId).history.count).toBe(1)
+            } finally {
+                set.destroy()
+            }
+        })
     });
 
     test.describe('#17947 pop-out dispatches the drag terminal, never a second lifecycle', () => {


### PR DESCRIPTION
Resolves #18524

Group operation batches now reach the existing dock refresh classification. A nonempty homogeneous geometry or item-flag batch requests the corresponding fast path; mixed, unknown, empty and malformed batches retain full reconciliation. The operation-name authority remains `Operations.changeClassFor`, and the reconciler still validates structural identity.

This prevents an ordinary Group resize from replacing nested chrome while the next pointer gesture is arming. Workstation's existing geometry delegation consumes the repair. The engine file loses 22 physical lines by replacing historical commentary with the current contract.

Evidence: L3 (unchanged headed Workstation journeys, plus real Group unit integration) → L3 required. No residual acceptance criteria.

Change class: restoration (`fix`) — restores declared geometry classification across the existing Group descriptor boundary.

size-guard-growth: src/dashboard/dock/Workspace.mjs — Four executable lines interpret Group batches at the existing classification owner; Workstation already delegates geometry there. The measured baseline is updated to1100 while the file loses22 physical lines.

## AC Evidence

| Criterion | Evidence |
|---|---|
| AC-1 | CI-covered: `DockWorkspace.spec.mjs` covers homogeneous geometry/item flags and unchanged scalar classification. |
| AC-2 | CI-covered: mixed classes, both unknown-operation positions, inherited names, empty/malformed precedence and input immutability. Removing the homogeneity guard makes five controls fail. |
| AC-3 | CI-covered: a real WorkspaceSet commit changes geometry, reports `landedInPlace:true`, retains shell/split identity and writes one history entry. Existing validator-refusal coverage remains. |
| AC-4 | Outside CI: complete unchanged NestedColumnResize passes at committed `cbe905d41d`; active-FLIP admission, reverse preview, Escape, pane identity and document assertions remain intact. The extra EdgeSplitter case still needs its separate settlement repair. |
| AC-5 | Focused and full units passed locally. Baseline Group projection fails on `landedInPlace:false`; runtime correlation/control receipts are linked below. |

## Deltas from ticket

The measured size baseline is updated from1096 to1100 code lines. The first hosted ratchet exposed that omission: the local pre-commit invocation had not exercised the committed diff. Same-context self-authored intake carve applies. Workstation's separate `retainTopology` override remains with `#18208`; this PR makes no Workstation lock-path claim. `agent-preflight` is not hosted here (explicit npm Missing script); shared baseline jobs provide the applicable hosted checks.

## Test Evidence

- [Runtime correlation](https://github.com/neomjs/neo/issues/17844#issuecomment-5595091021): the real Group resize arrives with an operations array, both refresh flags false, and a replacing projection before Escape. The original failure remains recorded.
- [Single-operation discriminator](https://github.com/neomjs/neo/issues/17844#issuecomment-5595136053): delegating that entry through the existing scalar classifier preserves the shell and passes the unchanged full nested test. It is a controlled intervention, not a general batch certificate.
- Candidate run `18524-candidate`: two complete, unmodified specs, 2 passed in11.4s. Command uses `test/playwright/playwright.config.e2e.mjs`, `--workers=1 --headed`, and explicit `NEO_AGENTOS_RUNTIME_ROOT`. Traces remain under `test/playwright/test-results/e2e/battery/18524-candidate/artifacts`.
- Final committed-head run `18524-final-head`: **1 passed / 1 failed**,10.4s. Nested passes. Edge repeats its pre-existing immediate component-width read (`11%` versus `17.655…%`), tracked by `#18520` / PR `#18521`; its red is retained. Correct classification does not replace an explicit projection-completion wait.
- The candidate run overlapped full-unit execution; the final run did not. This pair establishes neither a rate nor a cause for that timing difference.
- Mutation: removing the homogeneous-class guard admits the first geometry class from unsafe mixed batches; all five targeted controls fail. Mutation removed.

First-response audits match the requested app session: candidate Edge65/65 and Nested18/18; final run Edge28/28 and Nested18/18. Embedded spec sources are byte-identical. These logs cannot distinguish a foreign caller addressing the same app.

## Post-Merge Validation

None required for this close target. The wider NL census and the separate edge-witness repair remain open.

Related: #17844 · #18303

## Commits

- `cbe905d41d` — classifier and regression coverage.
- `ca8c95a644` — measured baseline only; tested engine and spec bytes unchanged.

Authored by Emmy (GPT-6 Astra, Codex). Session 153d2e0a-ebae-4087-bcd5-3c92d213132c.
