### PR TITLE
fix(dock): the maximize FLIP stops waiting for a tree that never leaves (#18027)

### DIFF
--- a/src/dashboard/dock/plugin/Maximize.mjs
+++ b/src/dashboard/dock/plugin/Maximize.mjs
@@ -474,7 +474,7 @@ class Maximize extends Plugin {
         MotionSignal.enter(owner);
 
         try {
-            played = flip.play({hostId: host.id, markerPrefix: me.markerPrefix, windowId: host.windowId})
+            played = flip.play({geometryOnly: true, hostId: host.id, markerPrefix: me.markerPrefix, windowId: host.windowId})
         } catch (error) {
             played = Promise.reject(error)
         }

--- a/src/dashboard/dock/plugin/Maximize.mjs
+++ b/src/dashboard/dock/plugin/Maximize.mjs
@@ -474,6 +474,16 @@ class Maximize extends Plugin {
         MotionSignal.enter(owner);
 
         try {
+            // `geometryOnly` is a CONSUMER DECLARATION that no topology swap can be pending — the
+            // addon does not re-detect one. Against a swap still in flight all three landed-in-place
+            // checks pass (the outgoing markers are still the exact set, their lineage is unchanged,
+            // and this transition's own geometry write supplies the movement), so the promise has to
+            // be kept here rather than verified there.
+            //
+            // It holds on this path by construction, twice over: the gesture path awaits the owner's
+            // refreshPromise before applying, and every route that can run WHILE a swap is pending —
+            // the refresh-owned reapply, operation-driven clears, fail-safes — lands with
+            // `animate: false` and never reaches this call at all.
             played = flip.play({geometryOnly: true, hostId: host.id, markerPrefix: me.markerPrefix, windowId: host.windowId})
         } catch (error) {
             played = Promise.reject(error)

--- a/test/playwright/component/dashboard/DockMaximize.spec.mjs
+++ b/test/playwright/component/dashboard/DockMaximize.spec.mjs
@@ -147,6 +147,117 @@ const maximizedRectMatchesHost = page => page.waitForFunction(() => {
         && a.top >= chrome.getBoundingClientRect().bottom - 0.5
 });
 
+/**
+ * @summary Resolves once a FLIP has actually landed: the inline transform is released AND no
+ * transition is still running on the node.
+ *
+ * `waitForFunction(() => !el.style.transform)` is NOT a settle condition. When a maximize play
+ * exposes its destination for a stretch of frames, the inline transform is empty for that whole
+ * exposure, so the check resolves instantly — mid-flash — and callers measure the committed
+ * geometry by accident. Once the invert installs in time, the same check resolves at RELEASE
+ * instead, with the node still gliding, and a geometry read there is simply wrong.
+ *
+ * Deliberately says nothing about WHERE the node lands: callers assert that themselves, so this
+ * wait cannot quietly subsume the assertion it is protecting.
+ * @param {Object} page
+ * @param {String} selector
+ * @returns {Promise<void>}
+ */
+const waitForFlipSettled = (page, selector) => page.waitForFunction(sel => {
+    const el = document.querySelector(sel);
+
+    // Rect stability is NOT sufficient on its own: an eased transition moves well under a pixel
+    // across its first frame, so "unchanged since last frame" reports settled at the START of the
+    // glide. The running transition is the authority — it exists for exactly as long as the
+    // motion does — and the cleared inline transform confirms the invert was released rather
+    // than never installed.
+    return el && !el.style.transform && el.getAnimations().length === 0
+}, selector, {timeout: 5000});
+
+/**
+ * @summary Starts a per-frame sampler on the tabs node, for witnessing a FLIP at frame resolution.
+ *
+ * The defect this exists for is invisible to every settled-state assertion and to
+ * `waitForFunction`: both sample asynchronously, long after the exposed frames are gone. It also
+ * cannot key on the marker class, which lands in the same mutation as the geometry — a sampler
+ * started from the marker never sees the frames before it. So the node is addressed by its stable
+ * pane id, and sampling starts BEFORE the gesture.
+ *
+ * `getBoundingClientRect()` is the right probe precisely because it includes transforms: an
+ * inverted node measures at its FIRST rect, an un-inverted one at its destination. That is the
+ * whole discriminator.
+ * @param {Object} page
+ * @returns {Promise<void>}
+ */
+const startFlipSampler = page => page.evaluate(() => {
+    window.__flipFrames = [];
+
+    let stop = false;
+
+    window.__flipStop = () => {stop = true};
+
+    const tick = () => {
+        const el = document.getElementById('dock-maximize-pane-alpha')?.closest('.neo-dashboard-dock-tabs');
+
+        if (el) {
+            const rect = el.getBoundingClientRect();
+
+            window.__flipFrames.push({
+                height   : Math.round(rect.height),
+                transform: getComputedStyle(el).transform,
+                width    : Math.round(rect.width)
+            })
+        }
+
+        stop || requestAnimationFrame(tick)
+    };
+
+    requestAnimationFrame(tick)
+});
+
+/**
+ * @summary Counts frames that painted the node at its destination before the glide began.
+ *
+ * Purely geometric, and deliberately so. The obvious rule — "at the destination while the
+ * transform is still identity" — is unusable on the restore path: a settled maximized node
+ * already carries a committed non-identity matrix, so "the first non-identity frame" is frame 0
+ * and the ordering clause it anchors selects nothing. That version reported a clean 0 on source
+ * measured to expose 16 frames, which is the exact failure AC-3 forbids.
+ *
+ * So the pivot is motion itself. A healthy FLIP walks `start → intermediate → … → destination`;
+ * an exposed one jumps `start → destination → start → intermediate → … → destination`. Anything
+ * sitting at the destination *before the first intermediate size* was therefore painted there
+ * without an inverse transform holding it back, whichever direction is under test and whatever
+ * residual transform the node started with.
+ *
+ * Start and destination come from the first and last sampled frames, so neither direction needs
+ * the host rect or the gap token, and restore's flow slot need not be predicted.
+ * @param {Object} page
+ * @returns {Promise<Object>} `{destination, flashes, frames, glideAt, start}`
+ */
+const readFlipFrames = async page => {
+    await page.evaluate(() => window.__flipStop());
+
+    return page.evaluate(() => {
+        const frames      = window.__flipFrames,
+              start       = frames[0],
+              destination = frames[frames.length - 1],
+              near        = (a, b) => Math.abs(a.width - b.width) < 2 && Math.abs(a.height - b.height) < 2,
+              // The first frame at neither end of the journey: proof the glide is under way.
+              glideAt     = frames.findIndex(frame => !near(frame, start) && !near(frame, destination));
+
+        return {
+            destination: `${destination.width}x${destination.height}`,
+            flashes    : frames.filter((frame, index) =>
+                (glideAt < 0 || index < glideAt) && near(frame, destination) && !near(start, destination)
+            ).length,
+            frames: frames.length,
+            glideAt,
+            start : `${start.width}x${start.height}`
+        }
+    })
+};
+
 /** The rendered maximize chrome: the shadow token applied, no residual band cap. */
 const readMaximizedChrome = page => page.evaluate(() => {
     const el = document.querySelector('.neo-dock-maximized'),
@@ -249,7 +360,12 @@ test.describe('dock maximize — presentation, never topology', () => {
         // Read the geometry once the presentation settled; the numbers name the failure when
         // the measurement authority is wrong (root ⇒ the pane starts at the root's gap inset,
         // above the chrome's bottom edge).
-        await page.waitForFunction(() => !document.querySelector('.neo-dock-maximized')?.style.transform);
+        //
+        // This waited on `!style.transform`, which is not settle: it is satisfied during a play's
+        // exposed frames, so the read landed on the committed rect only because the invert had not
+        // arrived yet — passing BECAUSE of the exposure. With the invert installed in time the same
+        // check resolves at release, mid-glide, and reads the flow slot instead.
+        await waitForFlipSettled(page, '.neo-dock-maximized');
 
         const geometry = await page.evaluate(() => {
             const rect = id => document.querySelector(id).getBoundingClientRect(),
@@ -722,19 +838,28 @@ test.describe('dock maximize — presentation, never topology', () => {
         // The restore glide: the workspace holds `neo-dock-maximize-restoring` (the paint-order
         // hold) for exactly the motion window — it must appear with the gesture and leave when
         // the play settles, leaving no inline rect values behind.
+        // The restore glide is a REAL inverted transform on the restoring node, not only the
+        // paint-order sentinel — witnessed from a per-frame log rather than by racing a poll
+        // against the motion window. Two `waitForFunction` round-trips could only catch that
+        // transform while an exposed window held it open for many frames; once the invert installs
+        // and releases promptly, a poll lands on either side of it at random. The sampler cannot
+        // miss it, and the assertion it feeds is strictly stronger than the poll it replaces.
+        await startFlipSampler(page);
         await actionButton(main, 'fa-window-minimize').click();
 
         await page.waitForFunction(() => document.querySelector('.neo-dock-maximize-restoring') !== null, undefined, {timeout: 3000});
-
-        // The restore glide is a REAL inverted transform on the restoring node, not only the
-        // paint-order sentinel.
-        await page.waitForFunction(() => {
-            const el = document.querySelector('.neo-dock-maximize-restoring');
-
-            return el && el.style.transform !== ''
-        }, undefined, {timeout: 3000});
-
         await expect(page.locator('.neo-dock-maximized')).toHaveCount(0);
+        await page.waitForFunction(() => document.querySelector('.neo-dock-maximize-restoring') === null, undefined, {timeout: 5000});
+
+        const restoreGlide = await page.evaluate(() => {
+            window.__flipStop();
+
+            return window.__flipFrames.some(frame =>
+                frame.transform && frame.transform !== 'none' && frame.transform !== 'matrix(1, 0, 0, 1, 0, 0)'
+            )
+        });
+
+        expect(restoreGlide, 'the restore rode a real inverted transform, not only the paint-order sentinel').toBe(true);
         await page.waitForFunction(() => document.querySelector('.neo-dock-maximize-restoring') === null);
 
         await page.waitForFunction(() => {
@@ -751,5 +876,100 @@ test.describe('dock maximize — presentation, never topology', () => {
 
             throw new Error(`restore left residual inline style: ${residual} · worker-side: ${worker}`)
         })
+    })
+
+    /**
+     * The double-take: the node paints its destination rect bare for a quarter of a second, snaps
+     * back, and only then animates — so the FLIP plays *after* a visible jump.
+     *
+     * `DockFlip.play`'s stage-A detach poll spins up to `maxFrames` waiting for the OUTGOING
+     * tree's markers to disconnect. A maximize keeps every marker node and its lineage, so that
+     * predicate never falsifies and the poll burns its whole budget with the committed geometry
+     * already painted and un-inverted. `hasLandedInPlace()` exists for exactly this case and its
+     * docblock names this symptom — but it is gated behind a consumer-declared `geometryOnly`,
+     * which the maximize play did not pass. Measured before that admission: **16 exposed frames
+     * in each direction**, ~250ms.
+     *
+     * These two arms are separate on purpose. The apply and clear paths reach the play through
+     * different code and the restore half was reported as milder, so a maximize-only witness
+     * would leave it asserted by assumption.
+     */
+    test('maximize installs its inverse transform before any frame paints the target rect (#18027)', async ({page}) => {
+        const main = tabsNodeWith(page, 'Alpha');
+
+        await tabButton(main, 'Alpha').click();
+        await startFlipSampler(page);
+        await actionButton(main, 'fa-window-maximize').click();
+
+        // Bracket the motion window by its own observable rather than a fixed sleep: the invert
+        // arrives, then releases. Both bounds are the contract the :697 arm already relies on.
+        await page.waitForFunction(() => {
+            const el = document.querySelector('.neo-dock-maximized');
+
+            return el && el.style.transform !== ''
+        }, undefined, {timeout: 3000});
+
+        await page.waitForFunction(() => {
+            const el = document.querySelector('.neo-dock-maximized');
+
+            return el && el.style.transform === ''
+        }, undefined, {timeout: 3000});
+
+        // Sample through to SETTLE, not merely to release. Clearing the inline transform starts
+        // the transition; the node is still at First and gliding. Reading the log there makes the
+        // last frame a mid-animation size, `readFlipFrames` infers that as the destination, and
+        // every pre-invert frame at First is convicted — 11 phantom flashes on correct source.
+        await maximizedRectMatchesHost(page);
+
+        const {flashes, frames, glideAt} = await readFlipFrames(page);
+
+        expect(frames, 'the sampler observed the transition').toBeGreaterThan(4);
+        expect(glideAt, 'the node glided through intermediate geometry — otherwise this arm proves nothing').toBeGreaterThan(-1);
+        expect(flashes, 'frames painting the maximized rect before the glide began').toBe(0)
+    })
+
+    test('restore installs its inverse transform before any frame paints the flow slot (#18027)', async ({page}) => {
+        const main = tabsNodeWith(page, 'Alpha');
+
+        await tabButton(main, 'Alpha').click();
+        await actionButton(main, 'fa-window-maximize').click();
+
+        // The setup must reach a genuinely SETTLED maximize, and the order of these two waits is
+        // the whole reason: on defective source the inline transform is `''` throughout the
+        // exposed frames, so a lone `=== ''` check passes instantly and the restore gesture fires
+        // into an in-flight FLIP. `clearPresentation` then serializes on `Maximize#play` and what
+        // this arm measures is a transition confounded by the previous one — which reported a
+        // clean 0 flashes on source that flashes 16. Wait for the invert to EXIST, then release.
+        await page.waitForFunction(() => {
+            const el = document.querySelector('.neo-dock-maximized');
+
+            return el && el.style.transform !== ''
+        }, undefined, {timeout: 3000});
+
+        await page.waitForFunction(() => {
+            const el = document.querySelector('.neo-dock-maximized');
+
+            return el && el.style.transform === ''
+        }, undefined, {timeout: 3000});
+
+        await maximizedRectMatchesHost(page);
+        await startFlipSampler(page);
+        await actionButton(main, 'fa-window-minimize').click();
+
+        await page.waitForFunction(() => {
+            const el = document.querySelector('.neo-dock-maximize-restoring');
+
+            return el && el.style.transform !== ''
+        }, undefined, {timeout: 3000});
+
+        await page.waitForFunction(() => document.querySelector('.neo-dock-maximize-restoring') === null, undefined, {timeout: 5000});
+
+        const {flashes, frames, glideAt} = await readFlipFrames(page);
+
+        expect(frames, 'the sampler observed the transition').toBeGreaterThan(4);
+        expect(glideAt, 'the node glided through intermediate geometry — otherwise this arm proves nothing').toBeGreaterThan(-1);
+        expect(flashes, 'frames painting the restored flow slot before the glide began').toBe(0);
+
+        await expectMaximizedCount(page, 0)
     })
 });

--- a/test/playwright/e2e/dashboard/DockExampleMaximizeGeometry.spec.mjs
+++ b/test/playwright/e2e/dashboard/DockExampleMaximizeGeometry.spec.mjs
@@ -54,7 +54,19 @@ test.describe('examples/dashboard/dock — maximize keeps the perspective toolba
         await maximize.click();
 
         await expect(page.locator('.neo-dock-maximized')).toHaveCount(1);
-        await page.waitForFunction(() => !document.querySelector('.neo-dock-maximized')?.style.transform);
+
+        // A cleared inline transform is not a settled FLIP, and reading geometry there is the
+        // whole failure mode this arm guards. While a maximize play exposed its committed rect
+        // before installing the inverse, the inline transform was empty for that entire window,
+        // so this resolved mid-exposure and measured the destination by accident. With the
+        // invert installed in time it resolves at RELEASE instead — the node still gliding — and
+        // the read lands one gap short. The running transition is the authority: it exists for
+        // exactly as long as the motion does.
+        await page.waitForFunction(() => {
+            const el = document.querySelector('.neo-dock-maximized');
+
+            return el && !el.style.transform && el.getAnimations().length === 0
+        }, undefined, {timeout: 15000});
 
         const geometry = await page.evaluate(readGeometry);
 


### PR DESCRIPTION
Resolves #18027

🌿 The maximize glide was never late; it was waiting for an outgoing tree that never leaves — and after this, a transition that has already landed can no longer be asked to prove it departed.

Maximize and restore each painted their destination bare for **16 frames** (~250ms), snapped back, and only then animated. `DockFlip.play` opens with a bounded poll waiting for the OUTGOING tree's markers to disconnect; a maximize repaints the *same* DOM node and never re-projects, so that predicate cannot falsify and the poll spends its whole budget with the committed geometry already flushed and un-inverted. `hasLandedInPlace()` exists for precisely this case — its docblock names the symptom, "the double-take" — but is gated behind a consumer-declared `geometryOnly` the maximize play never passed. Declaring it is the fix, and it adds no mutation.

Evidence: L3 (rendered Chromium component fixture; the live transition sampled per animation frame, which is the only resolution at which this defect exists — no settled-state assertion or poll can observe it) → L3 required (AC-1, AC-2, AC-3). Residual: none on this close target.

`agent-preflight: not hosted here` (no such npm script in this repo; exit 1); the baseline `PR body`, `Substrate size`, `Source comment archaeology` and `PR base` jobs carry its checks. Change class declared per §3.1: commit 1 `zero-delta → test`, commit 2 `restoration → fix` (corrects defined motion behaviour, adds no capability).

## AC Evidence

| AC | Disposition |
|---|---|
| AC-1 — a rendered capture proves no frame paints the node at its target rect without the inverse transform, for **maximize** | **CI-covered** — `DockMaximize.spec.mjs` › *maximize installs its inverse transform before any frame paints the target rect*. Per-frame sampler; asserts zero frames at the destination before the glide begins. |
| AC-2 — the same for **restore**, asserted separately | **CI-covered** — `DockMaximize.spec.mjs` › *restore installs its inverse transform before any frame paints the flow slot*. A separate arm with its own gesture and its own settle, not a parameterisation of AC-1. |
| AC-3 — the arm reds before the fix; a settled-geometry sampler does not count | **Outside-CI receipt** — reverting only the one-line admission and re-running the final spec reds **both** arms at exactly **16** flash frames each, matching the standalone measurement. Receipt in § Test Evidence. |
| AC-4 — the instant path still lands with no animation and no flash | **Met by construction, and CI-covered.** When `Maximize#motion` is `'instant'`, `animate` is false at `Maximize.mjs:267` and `captureFirst`/`playFlip` are never reached — this diff cannot alter that path. The suite's instant/reduced-motion arms stay green (20/20). |
| AC-5 — the existing maximize suite stays green | **CI-covered** — full `DockMaximize.spec.mjs`: **20/20 passed**. Baseline comparison in § Test Evidence, since the file gained arms. |
| AC-6 — added mutations are owned by `DockFlip`'s `styleSnapshot` cleanup, or an equally idempotent path | **Met by construction.** The diff adds **no mutation**: it declares an existing flag. Every style the transition installs is still installed and cleaned by `play` exactly as before, so an interrupted transition cannot strand a transform for any new reason. |

## Deltas from ticket

- **The ticket's mechanism was wrong, and I corrected its body rather than quietly building something else.** It blamed the App-Worker→main round trip between the geometry flush and `playFlip`, and both Fix options were shaped around that. The exposure is a bounded detach poll on main. Neither option was needed and both are **withdrawn** in the ticket: returning the resolved gap so the worker could compute the invert, and moving the whole transition onto main. Each would have restructured the geometry-ownership contract — `rectStyle`'s `calc()` against `--dock-maximize-gap` is deliberate, so a consumer can tune the gap without a worker round trip — to repair a poll.
- **AC-4 named a config that does not exist.** There is no `dockMaximizeMotion`; the one-shot intent is `Maximize#motion`. Corrected in the ticket, with the requirement unchanged.
- **Two existing arms depended on the defect, and are repaired rather than relaxed.** `a host-less workspace … maximizes onto the SHELL` read its geometry after `waitForFunction(() => !style.transform)`, which was satisfied *during* the un-inverted frames — it measured the committed rect only because the invert had not arrived, and reds by 8px (exactly the gap) once it does. `both transitions ride the FLIP motion window` raced two poll round-trips against the motion window, catchable only while the defect held it open. Both now use deterministic waits and **pass on fixed and unfixed source alike**, so neither doubles as a smuggled defect-detector; the two new arms own that job.
- **A settle helper, because `!style.transform` is not settle.** `waitForFlipSettled` gates on the running transition (`getAnimations()`), not on rect stability — an eased transition moves well under a pixel across its first frame, so "unchanged since last frame" reports settled at the *start* of the glide. That intermediate version produced the 8px failure above and is the reason the helper is written this way.
- **Out of scope, pre-existing — settled by measurement, after my first framing was wrong.** The destroy-race in `a plugin destroyed while its owner lives …` is a pre-existing flake, and the evidence for that is a determinism check, not a rerun.

  **My original claim here was that the arm "passed on the untouched-dev baseline". @neo-opus-ada falsified it:** she ran `--repeat-each=8` on the named arm against **pure `dev` @ `e3ddc9e3cb` — my exact baseline commit — and got 2/8 failures, p ≈ 0.25.** My single baseline pass was the 75% case. It was never evidence of anything, and a rerun going green was not either.

  Re-run to her standard at this head, same arm matched **by name** (`--repeat-each=8`, serial):

  | tree | samples | failed |
  |---|---:|---:|
  | pure `dev` @ `e3ddc9e3cb` (@neo-opus-ada) | 8 | **2** |
  | this branch @ `d459cff0c7` | 8 | **1** |

  Her stated signal threshold was **≥5/8 at my head**; observed 1/8, below the baseline null itself. **So the timing caveat I raised is discharged by measurement rather than by convenience** — this diff does not detectably elevate the rate. Stated honestly: n=8 cannot exclude a *small* elevation, and 1/8 vs 2/8 is emphatically not evidence the change improves it. It rules out the effect size that would matter.

  Arm identity confirmed rather than assumed: on `dev` this test opens at `:621`; on this branch the added helpers displace it to `:737`, and `:737` here matches by name. Instrumentation shipped in #18380 / #18378; not touched.

- **Prior art, and it shrinks this finding in a good way.** `hasLandedInPlace` was built for exactly this class — #16391 / PR #16403, @neo-kimi-phoebe, 2026-08-03: *"classify same-node resizes as landed-in-place, skipping the stage-A double-take."* Same symptom name, five weeks earlier. **The engine half has been correct since August; the maximize play simply never opted in.** This PR is a consumer declaration catching up, not a new mechanism — which makes withdrawing the ticket's two restructurings clearer still, since the engine already held the answer.
- **Corrected in review by @neo-opus-grace: the addon does NOT re-detect a pending swap.** I first wrote that the flag is "an admission request, not an assertion — a maximize that coincides with a re-projection falls back on its own." That is false: against a pending swap all three `hasLandedInPlace` checks pass, because the outgoing markers are still the exact set, lineage is unchanged, and this transition's own geometry write supplies the movement. `geometryOnly` is a **consumer declaration**, so the promise is kept at the call site or not at all. It holds here twice over — the gesture path awaits `owner.refreshPromise` before applying (`Maximize.mjs:282`), and every route that can run while a swap is pending lands `animate: false` and never reaches the call, since `playFlip` sits inside `if (animate)`. Stated at the call site in `7dd05308b5`; the line previously carried no comment at all, which is the gap the finding exposed. ⚠️ The commit message of `b52e04823b` still carries the original overstatement — not amended, because that is a force-push on an approved PR.

## Test Evidence

Everything below is outside what a green suite shows, because AC-3 is a claim about the *instrument*.

- **Red-first control, run against the final spec.** Reverting only `geometryOnly: true` and re-running the whole file: **3 failed / 17 passed** — both new arms red at `Received: 16`, plus the pre-existing `ghost-tabs` flake. Restoring the one line: **20/20 passed**.
- **Standalone measurement, before any arm existed.** A throwaway per-frame probe on the rendered fixture: maximize **16** exposed frames at t+134→383ms with the invert arriving at frame 24; restore **16** at t+84→333ms, invert at frame 22. With the fix: **0 and 0**, invert at frames 8 and 5. The post-fix log is a textbook FLIP — the marker class lands already carrying `matrix(0.446203, 0, 0, 1.02417, -8, -8)`, then glides outward through 741×674, 888×671.
- **The instrument was falsified twice before it was trusted**, which is the substance of AC-3. A transform-based pivot ("at the destination while the transform is identity") reported a clean **0 flashes on source measured to expose 16**: a settled maximized node already carries a committed non-identity matrix, so "first non-identity frame" is frame 0 and the ordering clause selects nothing. Separately, sampling that stopped at transform *release* rather than settle made the last frame a mid-animation size and manufactured **11 phantom flashes on correct source**. The shipped pivot is purely geometric — destination-sized frames occurring before the first intermediate-sized frame — and is direction-agnostic and residual-agnostic.
- **Baseline separation (AC-5).** Untouched dev at `e3ddc9e3cb` with dev's spec: 18 tests, **1 failed** (`ghost-tabs`). This branch: 20 tests, **20 passed**. The one baseline failure is a known flake, not a fix.
- Guards run locally: `check-ticket-archaeology` (0 refs in touched files — four durable comments rewritten to describe behaviour instead of citing the ticket), `check-fixed-sleeps` (0 new), `check-file-sizes --base origin/dev` (0 violations; neither touched file is ledgered).

### e2e-engine is red on a rotating grid casualty — stated, not reran away

The `e2e-engine` context is failing, and it is **not** this diff. Four runs, three distinct casualties, and **two of them on a commit that changes only comments** (`7dd05308b5`: 10 inserted lines, all `//`):

| # | head | casualty |
|---|---|---|
| 1 | `d459cff0c7` | `ThumbDragPause.spec.mjs:49` — `no frame blanked during or after the pause` |
| 2 | `d459cff0c7` rerun | **none — 35 passed** |
| 3 | `7dd05308b5` *(comment-only)* | `HeaderCellRectSync.spec.mjs:99` — no cell under header after sliding left |
| 4 | `7dd05308b5` rerun | `ThumbDragPause.spec.mjs:49` — same signature as #1 |

Every run: 34–35 passed, exactly one failed, and **the dock arms this PR touches passed in all four**. Both signatures are already on record from @neo-gpt-emmy — `ThumbDragPause` with a same-head green/red pair, and `HeaderCellRectSync` on a run with production source unchanged from dev. This is @neo-opus-ada's **#18439** class (*"BigData grid arms fail intermittently with a rotating casualty"*); census posted there as [IC_kwDODSospM8AAAABTdigEw](https://github.com/neomjs/neo/issues/18439#issuecomment-5601009683).

**I have stopped rerunning.** More samples of the same shape buy nondeterminism, not cause — Emmy's phrasing, and correct. The red is left standing and named rather than cycled until it goes green, so the merge decision is made against the real state.

## Post-Merge Validation

- [ ] Watch `DockMaximize.spec.mjs` on CI for the `ghost-tabs` flake under shared-runner load; it is pre-existing and unrelated, but this file now runs 20 arms rather than 18.
- [ ] The two new arms are the first per-frame witnesses in the component tier. If they prove load-sensitive on CI, the sampler — not the assertion — is the thing to harden.

## Commits

- `ac94f0400d` — the frame-resolution witnesses, the settle helper, and the two arm repairs.
- `b52e04823b` — the one-line admission.

Authored by Vega (Opus 5, Claude Code). Session 206b8400-7fe8-472e-8018-446e550b784b.




