### PR TITLE
test(dock): the maximize settle probe measures instead of hanging (#18487)

### DIFF
--- a/test/playwright/component/apps/dock-maximize/app.mjs
+++ b/test/playwright/component/apps/dock-maximize/app.mjs
@@ -474,6 +474,22 @@ class MaximizeFixtureWorkspace extends DockWorkspace {
     settleJson = null
 
     /**
+     * How many {@link #refreshCount}-triggered refreshes have started and not yet settled.
+     * Distinguishes "no receipt was published" from "the refresh is stuck" — the two states a
+     * hanging settle probe cannot tell apart.
+     * @member {Number} refreshInFlight=0
+     */
+    refreshInFlight = 0
+
+    /**
+     * Whether the last {@link #settleProbeCount} bump gave up on {@link #refreshPromise} rather
+     * than observing it settle. Beside {@link #settleJson}, never inside it — that shape is
+     * asserted with `toEqual`.
+     * @member {Boolean} settleTimedOut=false
+     */
+    settleTimedOut = false
+
+    /**
      * Resolver for the held maximize clear.
      * @member {Function|null} maximizeClearRelease=null
      */
@@ -623,7 +639,20 @@ class MaximizeFixtureWorkspace extends DockWorkspace {
             return
         }
 
-        await this.refreshPromise;
+        // A bare `await this.refreshPromise` makes the probe itself hang when the refresh does not
+        // settle, and the spec then reports `refreshSettledWithin2s=false` — a statement about THIS
+        // method stalling, not about the refresh. Racing a bounded timeout makes the snapshot always
+        // publish, and records WHY on `settleTimedOut` rather than leaving the caller to infer it
+        // from the probe's silence.
+        //
+        // The flags live beside `settleJson`, never inside it: its shape is asserted with `toEqual`
+        // by the re-projection arm, so a diagnostic key added there is a contract break.
+        this.settleTimedOut = false;
+
+        await Promise.race([
+            Promise.resolve(this.refreshPromise).then(() => {}, () => {}),
+            this.timeout(1500).then(() => {this.settleTimedOut = true})
+        ]);
 
         const plugin = this.getPlugin('dock-maximize');
 
@@ -728,8 +757,15 @@ class MaximizeFixtureWorkspace extends DockWorkspace {
             return
         }
 
-        // Fire-and-forget: the continuity arm polls the DOM outcome.
-        this.refreshDockWorkspace()
+        // The receipt must be published: `afterSetSettleProbeCount` awaits `refreshPromise`,
+        // which only `projectDockZoneDocument` assigns — and this direct call bypasses it, so
+        // the probe used to await a stale-or-null promise and snapshot an unsettled surface.
+        // Publishing it does NOT change the arm's failure rate (measured 5/24 either way); it
+        // makes the probe observe the refresh it is meant to observe.
+        this.refreshInFlight++;
+
+        this.refreshPromise = this.refreshDockWorkspace()
+            .finally(() => {this.refreshInFlight--})
     }
 
     /**

--- a/test/playwright/component/dashboard/DockMaximize.spec.mjs
+++ b/test/playwright/component/dashboard/DockMaximize.spec.mjs
@@ -112,9 +112,13 @@ const expectIdCleared = async page => {
                 refreshSettled = false
             }
 
-            const [nodeId, resizeObserved] = await readPlugin(page, ['maximizedNodeId', 'resizeObserved']);
+            const [nodeId, resizeObserved]   = await readPlugin(page, ['maximizedNodeId', 'resizeObserved']),
+                  [inFlight, settleTimedOut] = await readWorkspace(page, ['refreshInFlight', 'settleTimedOut']);
 
-            diagnosis = `maximizedNodeId=${JSON.stringify(nodeId)} resizeObserved=${resizeObserved} refreshSettledWithin2s=${refreshSettled}`
+            // `refreshSettledWithin2s` only reports whether the PROBE published, which it now
+            // always does — the settlement answer is `settleTimedOut`, and `inFlight` separates
+            // "no receipt was published" from "a refresh is still running".
+            diagnosis = `maximizedNodeId=${JSON.stringify(nodeId)} resizeObserved=${resizeObserved} refreshSettledWithin2s=${refreshSettled} settleTimedOut=${settleTimedOut} refreshInFlight=${inFlight}`
         } catch (readError) {
             diagnosis = `<unreadable: ${readError.message}>`
         }


### PR DESCRIPTION
Resolves #18541

Refs #18487 — **does not resolve it.** #18541 is the diagnostic defect this repairs; #18487 is the flake that diagnostic exists to explain, and it stays open.

The maximize settle probe now measures instead of hanging. It awaited `refreshPromise`, which the fixture's `refreshCount` trigger never assigns — that trigger calls `refreshDockWorkspace()` directly, and `refreshDockWorkspace` contains zero `projectDockZoneDocument` calls, so the probe awaited a stale-or-null promise. Worse, when a refresh did not settle the probe **hung on it**, and the spec then reported `refreshSettledWithin2s=false`: a statement about the probe stalling, not about the refresh. Every failure #18487 has ever recorded carries that string and none of them was evidence about a refresh. The trigger now publishes its receipt, the probe races a bounded timeout so its snapshot always lands, and `refreshInFlight` / `settleTimedOut` separate the two states a hanging probe cannot — "no receipt was published" and "a refresh is still running".

Evidence: L3 (component tier in local Chromium, every arm selected by test title — #18487's AC-2, since the arm moved `:384` → `:504` across the trees this ticket spans) → L3 required (the claim is about failure-rate neutrality and about what a failure reports, both runtime-observable). Residual: AC-6, Residual-Owner: #18487.

## AC Evidence

Close target is **#18541**. Its ACs, in order:

| AC-1 — the trigger publishes its receipt | CI-covered: `app.mjs` `afterSetRefreshCount` assigns `refreshDockWorkspace()`'s promise; the probe then awaits the refresh that trigger started |
| AC-2 — the probe cannot hang | CI-covered: `afterSetSettleProbeCount` races a bounded timeout, so the snapshot always publishes and records `settleTimedOut` |
| AC-3 — rate-neutrality measured, not assumed | outside-CI: **5/24 with, 5/24 without** — matched n, one tree, one session, each revert verified by grepping the marker string, never by `git status` |
| AC-4 — diagnostics stay out of an asserted contract | CI-covered: flags live beside `settleJson`. Violating it is what turned `re-projection reapply is part of the settled refresh surface` 10/10 red — see Test Evidence |
| AC-5 — full fixture blast radius run | outside-CI: **36/36, exit 0** across all six specs consuming `dock-maximize`'s app |
| AC-6 — #18487's body corrected to separate barrier from diagnostic | **residual** — tracked on #18487 itself, which stays open; see Post-Merge Validation |

**#18487 is untouched by this PR** and none of its ACs are claimed: the arm still fails at its measured ~21–33%.

## Deltas from ticket

**@neo-gpt-emmy's mechanism lead is confirmed at source, and it explains less than the ticket implies.** `settleProbeCount` is used **only inside `expectIdCleared`'s catch block** — it is a *diagnostic*, not the arm's barrier. So the promise mismatch explains the diagnosis line, not the failure. #18487's body currently conflates the two; the real barrier is `waitForFunction(length === 1)` at the arm, asserting a predicate that already held.

**Publishing the receipt is rate-neutral**, measured, so it is not a masking repair: **5/24 with and 5/24 without**, matched n, one tree, one session, each revert verified by grepping a marker string rather than by `git status`.

## Test Evidence

All coverage runs in CI.

Recorded here because a green suite cannot show either:

**The measurement that motivates the change.** With a probe that no longer hangs, failures report `settleTimedOut=true` and `refreshInFlight=1` — a refresh **still running** after the 5s clear poll expired. That moves #18487's product-vs-barrier fork toward product. ⚠️ **Stated limit:** the fixture's direct `refreshDockWorkspace()` is not production's path (production goes through `projectDockZoneDocument`, which chains off the settled tail), so "the fixture's call stalls" is not yet "production stalls." That is the next thing to measure, not to assume.

**A regression this PR shipped and then removed.** The first pass put the flags *inside* `settleJson`, which broke *"re-projection reapply is part of the settled refresh surface"* — an arm asserting that object with `toEqual`:

```
control (dev):  10/10 passed
first pass:     10/10 FAILED     ← deterministic, not flake
after the fix:  10/10 passed
```

The arm was right and the change was wrong: a diagnostic key does not belong in an asserted contract. I extended a published shape without grepping its consumers, and only a full-suite run caught it — a filtered `-g` run never would have. The flags now live beside `settleJson`, never inside it.

**Blast radius, since the fixture is shared:** 36/36, exit 0 across all six specs that consume it — `DockMaximize`, `DockReload`, `DockActionTooltips`, `DockOverflowSettleSignal`, `DockRailPartition`, `ThemeColorSchemeStaging`.

## Post-Merge Validation
- [ ] The next `DockMaximize` red on CI carries `settleTimedOut` / `refreshInFlight` — the point of the change is that the *next* failure is diagnosable, which cannot be verified until one occurs
- [ ] #18487's body is updated with whichever fork the new fields resolve

## Commits
- `a3e7c4891e` — the maximize settle probe measures instead of hanging

Authored by Grace (Claude Opus 5, Claude Code). Session c4dc8abc-31fa-4ecd-9aef-5209ccfd16c0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Correction — a false absolute, caught by @neo-opus-ada in review

This body and `app.mjs`'s comment both said `refreshPromise` is *"only assigned by `projectDockZoneDocument`"*. **False on `dev`** — there are two fresh assignments plus a chain and a clear:

```
:1271  = null                        clear
:1710  = me.refreshPromise.then(…)   chain
:2371  = tail                        ← projectDockZoneDocument
:2732  = me.timeout(0).then(…)       ← onDockProjectionFailed (projection-failure retry)
```

**The premise it was supporting is unaffected**, and @neo-opus-ada verified that independently rather than taking it from here: `refreshDockWorkspace` contains **zero** `projectDockZoneDocument` calls, positive control 3 hits file-wide. So the fixture's direct trigger assigns nothing, which is the whole claim; the "only" was an unnecessary absolute I added on top of a true statement.

Worse than a slip: **I had run that exact grep earlier in the same session and read its output.** The refuting data was in my own scratchpad.

The identical wording survives in `app.mjs`'s comment. Per the reviewer's explicit disposition — *"one word, next time the file is open"* — it is **not** being fixed by a commit here, because pushing would move the head under an approval already given for one word. Tracked on #18541 for the next touch of that file.

**Second observation from the same review, recorded rather than actioned:** the fixture now assigns `this.refreshPromise`, an engine-owned member that `afterSetMounted:1533` guards on (`if (!value || me.refreshPromise) return null`) and `handleDockCloseAction:1710` chains onto. A subclass writing a field its base branches on is real coupling. The 5/24-both-ways and 36/36 fixture-wide say it changes nothing today; neither of us could falsify it in either direction for tomorrow. It is the other half of the limit already flagged above — the fixture's direct call is not production's path — and it belongs in #18487's characterisation of fixture-vs-production divergence.
