### PR TITLE
feat(dock): VesselPark ships the transaction it always required (#18533)

### DIFF
--- a/apps/workstation/view/Workspace.mjs
+++ b/apps/workstation/view/Workspace.mjs
@@ -1,6 +1,7 @@
 import Component                  from '../../../src/component/Base.mjs';
 import Container                  from '../../../src/container/Base.mjs';
 import DockWorkspace              from '../../../src/dashboard/dock/Workspace.mjs';
+import NativeVesselTransaction    from '../../../src/dashboard/dock/window/NativeVesselTransaction.mjs';
 import PopupWorkspace             from './PopupWorkspace.mjs';
 import Feed                       from '../store/Feed.mjs';
 import FeedPane                   from './FeedPane.mjs';
@@ -492,6 +493,27 @@ class Workspace extends DockWorkspace {
         // acquisition consumes transient activation and reads as unsolicited), so conversion
         // PARKS the real vessel behind its target, out-conversion re-shows the SAME generation,
         // and only a commit disposes — every other outcome restores.
+        // The transaction is the engine's; this host supplies the four inputs that vary. It DOES
+        // declare a geometry restore, which is what licences its park to shrink an oversized source
+        // and obliges its re-show to give the extent back. The park below stays an override: the
+        // native-titlebar paths are product policy (an OS titlebar drag carries no user activation,
+        // so a main-window target parks nothing at all) and cannot be expressed as a descriptor
+        // input without turning this default into a configuration language.
+        me.vesselTransaction = NativeVesselTransaction.effectsFor({
+            ownerWindowId : () => me.windowId,
+            publishReceipt: (key, receipt) => {
+                key === 'park' ? (me.lastVesselParkReceipt = receipt) : (me.lastVesselRestoreReceipt = receipt)
+            },
+            rectPlane      : 'outer',
+            resolveVessel  : itemId => me.resolveTearOutVessel(itemId),
+            restoreGeometry: itemId => me.tearOutParkGeometries[itemId] ?? null,
+            retireVessel   : vessel => me.tearOutHandlers.retireActiveVessel(vessel),
+            targetWindowId : () => me.vesselConversionTargetWindowId,
+            // Its terminal restore ends a DRAG, so the addon that may still own the gesture is
+            // asked before the route is addressed directly.
+            terminalRestoreOwner: 'drag'
+        });
+
         me.vesselParkHandlers = Neo.create(VesselPark, {
             disposeVessel: vessel => me.disposeParkedTearOutVessel(vessel),
             parkVessel   : vessel => me.parkTearOutVessel(vessel),
@@ -1775,31 +1797,18 @@ class Workspace extends DockWorkspace {
     }
 
     /**
-     * Consumes the tear-out machine's active slot, then closes its exact parked vessel — the ONE
-     * settle path for a committed conversion; a refusal retains exact retry authority.
+     * Retires the parked vessel and its orphan recovery through the engine's default transaction,
+     * then clears the two ledgers this host keys by item.
      * @param {Object} vessel
-     * @param {String} vessel.itemId
-     * @param {String} vessel.windowName
      * @returns {Promise<Boolean>}
      * @protected
      */
-    async disposeParkedTearOutVessel({itemId, windowName}) {
-        let me    = this,
-            entry = me.resolveTearOutVessel(itemId),
-            route = entry?.nativeRoute;
-
-        const disposed = await me.tearOutHandlers.retireActiveVessel({itemId, windowName});
+    async disposeParkedTearOutVessel(vessel) {
+        const disposed = await this.vesselTransaction.disposeVessel(vessel);
 
         if (disposed) {
-            delete me.tearOutParkGeometries[itemId];
-            delete me.tearOutParkAttempts[itemId];
-
-            route?.nativeHandleKey && await Neo.main.addon.DragDrop.retireWindowDragOrphanRecovery({
-                nativeHandleKey: route.nativeHandleKey,
-                targetWindowId : route.targetWindowId,
-                windowId       : me.windowId,
-                windowName
-            })
+            delete this.tearOutParkGeometries[vessel.itemId];
+            delete this.tearOutParkAttempts[vessel.itemId]
         }
 
         return disposed
@@ -2020,159 +2029,20 @@ class Workspace extends DockWorkspace {
     }
 
     /**
-     * @summary Re-shows the same exact parked generation at the supplied content origin. During a
-     * live gesture the DragDrop addon also resumes physical pointer-follow; at a native drag
-     * terminal that addon has already reset its session, so a strict refusal falls through to
-     * the same exact Main route for the final restore; semantic-name routing is never used.
+     * Re-shows the parked vessel through the engine's default transaction. This host declares a
+     * geometry restore, so the default gives the extent back before the position and compensates
+     * both when the move is refused; the park ledger entry is consumed here because it is this
+     * host's bookkeeping, not the transaction's.
      * @param {Object} vessel
-     * @param {String} vessel.itemId
-     * @param {Object} vessel.rect
-     * @param {Boolean} [vessel.terminal=false]
-     * @param {String} vessel.windowName
      * @returns {Promise<Boolean>}
      * @protected
      */
-    async reshowTearOutVessel({itemId, rect, terminal=false, windowName}) {
-        let me       = this,
-            entry    = me.resolveTearOutVessel(itemId),
-            route    = entry?.nativeRoute,
-            geometry = me.tearOutParkGeometries[itemId] ?? null,
-            // `rect` is where the pane's CONTENT re-shows — the proxy's logical rect, or the
-            // viewport rect captured at conversion-in. `moveTo` places the FRAME, so the window's
-            // own chrome comes off the content origin; a window that never published chrome
-            // re-shows content-on-frame, the pre-chrome behaviour.
-            chrome   = Neo.manager?.Window?.get(entry?.windowId)?.chrome,
-            frame    = Number.isFinite(rect?.x) && Number.isFinite(rect?.y) ? {
-                x: rect.x - (chrome?.left ?? 0),
-                y: rect.y - (chrome?.top  ?? 0)
-            } : null;
+    async reshowTearOutVessel(vessel) {
+        const admitted = await this.vesselTransaction.reshowVessel(vessel);
 
-        me.lastVesselRestoreReceipt = {
-            frame,
-            geometry,
-            rect: rect && {height: rect.height, width: rect.width, x: rect.x, y: rect.y},
-            terminal
-        };
+        admitted && delete this.tearOutParkGeometries[vessel.itemId];
 
-        // Restoring always moves and only sometimes resizes, so resize is asked for only when needed.
-        const
-            routeArgs    = {ownerWindowId: me.windowId, route, targetWindowId: entry?.windowId ?? null},
-            positionAuth = WindowManager.resolveNativeRoute({...routeArgs, capability: 'position'}),
-            resizeAuth   = geometry && WindowManager.resolveNativeRoute({...routeArgs, capability: 'resize'});
-
-        if (
-            !positionAuth.granted || (geometry && !resizeAuth.granted) ||
-            entry.windowName !== windowName ||
-            !Number.isFinite(rect?.x) || !Number.isFinite(rect?.y)
-        ) {
-            me.lastVesselRestoreReceipt.reason = 'native route or restore geometry refused';
-            return false
-        }
-
-        let data = {
-            nativeHandleKey: route.nativeHandleKey,
-            targetWindowId : route.targetWindowId,
-            windowId       : me.windowId,
-            windowName,
-            x              : frame.x,
-            y              : frame.y
-        };
-
-        try {
-            if (!terminal) {
-                const admitted = await Neo.main.addon.DragDrop.resumeWindowDrag(data) === true;
-
-                me.lastVesselRestoreReceipt.admitted = admitted;
-                admitted && delete me.tearOutParkGeometries[itemId];
-
-                return admitted
-            }
-
-            const addonRestored = await Neo.main.addon.DragDrop.resumeWindowDrag(data) === true;
-
-            me.lastVesselRestoreReceipt.addonRestored = addonRestored;
-
-            if (addonRestored) {
-                delete me.tearOutParkGeometries[itemId];
-                me.lastVesselRestoreReceipt.admitted = true;
-
-                return true
-            }
-
-            const recoveryPending = await Neo.main.addon.DragDrop.hasWindowDragOrphanRecovery(data) === true;
-
-            me.lastVesselRestoreReceipt.recoveryPending = recoveryPending;
-
-            // A matching predecessor effect still owns exact recovery. Never race it with a second
-            // direct route mutation or degrade a required extent restore into position-only success.
-            if (recoveryPending) return false;
-
-            if (geometry) {
-                const resized = await Neo.Main.windowNativeResizeTo({
-                    nativeHandleKey: route.nativeHandleKey,
-                    targetWindowId : route.targetWindowId,
-                    windowId       : me.windowId,
-                    ...geometry.restore
-                }) === true;
-
-                me.lastVesselRestoreReceipt.resized = resized;
-
-                if (!resized) {
-                    await Neo.Main.windowNativeResizeTo({
-                        nativeHandleKey: route.nativeHandleKey,
-                        targetWindowId : route.targetWindowId,
-                        windowId       : me.windowId,
-                        ...geometry.park
-                    });
-                    return false
-                }
-            }
-
-            const moved = await Neo.Main.windowNativeMoveTo({
-                nativeHandleKey: route.nativeHandleKey,
-                targetWindowId : route.targetWindowId,
-                windowId       : me.windowId,
-                x              : frame.x,
-                y              : frame.y
-            }) === true;
-
-            me.lastVesselRestoreReceipt.moved = moved;
-
-            if (!moved) {
-                if (geometry) {
-                    const compensationResized = await Neo.Main.windowNativeResizeTo({
-                        nativeHandleKey: route.nativeHandleKey,
-                        targetWindowId : route.targetWindowId,
-                        windowId       : me.windowId,
-                        ...geometry.park
-                    }) === true;
-
-                    me.lastVesselRestoreReceipt.compensationResized = compensationResized;
-
-                    if (compensationResized) {
-                        me.lastVesselRestoreReceipt.compensationMoved =
-                            await Neo.Main.windowNativeMoveTo({
-                                nativeHandleKey: route.nativeHandleKey,
-                                targetWindowId : route.targetWindowId,
-                                windowId       : me.windowId,
-                                x              : geometry.park.x,
-                                y              : geometry.park.y
-                            }) === true
-                    }
-                }
-
-                return false
-            }
-
-            me.lastVesselRestoreReceipt.admitted = true;
-            delete me.tearOutParkGeometries[itemId];
-            await Neo.main.addon.DragDrop.acknowledgeWindowDragOrphanRecovery(data);
-
-            return true
-        } catch (error) {
-            me.lastVesselRestoreReceipt.error = String(error?.message || error);
-            return false
-        }
+        return admitted
     }
 
     /**

--- a/apps/workstation/view/Workspace.mjs
+++ b/apps/workstation/view/Workspace.mjs
@@ -1875,18 +1875,10 @@ class Workspace extends DockWorkspace {
             targetFocus  = WindowManager.resolveNativeRoute({...targetArgs, capability: 'focus'});
 
         me.lastVesselParkReceipt = {
-            authority: {
-                entryNameMatches     : entry?.windowName === windowName,
-                sourceHasHandle      : sourcePos.hasHandle,
-                sourceOwnerMatches   : sourcePos.ownerMatches,
-                sourcePositionCapable: sourcePos.capable,
-                sourceResizeCapable  : sourceResize.capable,
-                sourceTargetMatches  : sourcePos.targetMatches,
-                targetFocusCapable   : targetFocus.capable,
-                targetHasHandle      : targetFocus.hasHandle,
-                targetOwnerMatches   : targetFocus.ownerMatches,
-                targetTargetMatches  : targetFocus.targetMatches
-            },
+            // One definition of the authority block, shared with the other consumer and with the
+            // default transaction. A hand-written copy here is how the two receipts drifted: nine
+            // of ten keys agreed and the tenth was silently absent from the sibling.
+            authority  : NativeVesselTransaction.describeAuthority({sourcePos, sourceResize, targetFocus}, entry?.windowName === windowName),
             needsResize,
             parkSize,
             sourceInner: sourceRect && {

--- a/buildScripts/util/file-size-baseline.json
+++ b/buildScripts/util/file-size-baseline.json
@@ -1,5 +1,5 @@
 {
-    "apps/workstation/view/Workspace.mjs": 1222,
+    "apps/workstation/view/Workspace.mjs": 1211,
     "examples/dashboard/crossWindow/DemoBWorkspace.mjs": 2505,
     "src/dashboard/dock/Workspace.mjs": 1100,
     "src/main/addon/DragDrop.mjs": 1267

--- a/buildScripts/util/file-size-baseline.json
+++ b/buildScripts/util/file-size-baseline.json
@@ -1,6 +1,6 @@
 {
     "apps/workstation/view/Workspace.mjs": 1323,
-    "examples/dashboard/crossWindow/DemoBWorkspace.mjs": 2615,
+    "examples/dashboard/crossWindow/DemoBWorkspace.mjs": 2505,
     "src/dashboard/dock/Workspace.mjs": 1100,
     "src/main/addon/DragDrop.mjs": 1267
 }

--- a/buildScripts/util/file-size-baseline.json
+++ b/buildScripts/util/file-size-baseline.json
@@ -1,5 +1,5 @@
 {
-    "apps/workstation/view/Workspace.mjs": 1323,
+    "apps/workstation/view/Workspace.mjs": 1222,
     "examples/dashboard/crossWindow/DemoBWorkspace.mjs": 2505,
     "src/dashboard/dock/Workspace.mjs": 1100,
     "src/main/addon/DragDrop.mjs": 1267

--- a/docs/output/class-hierarchy.json
+++ b/docs/output/class-hierarchy.json
@@ -249,6 +249,7 @@
  "Neo.dashboard.dock.projection.MotionSignal": "Neo.core.Base",
  "Neo.dashboard.dock.projection.Reconciler": "Neo.core.Base",
  "Neo.dashboard.dock.window.DragTarget": "Neo.core.Base",
+ "Neo.dashboard.dock.window.NativeVesselTransaction": "Neo.core.Base",
  "Neo.dashboard.dock.window.Participation": "Neo.core.Base",
  "Neo.dashboard.dock.window.Placement": "Neo.core.Base",
  "Neo.dashboard.dock.window.TopologySeams": "Neo.core.Base",

--- a/examples/dashboard/crossWindow/DemoBWorkspace.mjs
+++ b/examples/dashboard/crossWindow/DemoBWorkspace.mjs
@@ -21,6 +21,7 @@ import {createDockKeyboardCommands}       from '../../../src/dashboard/dock/inte
 import {createDockTearOutHandlers}        from '../../../src/dashboard/dock/window/TearOut.mjs';
 import {createDockVesselEmbodiment}       from '../../../src/dashboard/dock/window/VesselEmbodiment.mjs';
 import WorkspaceSet                       from '../../../src/dashboard/dock/window/WorkspaceSet.mjs';
+import NativeVesselTransaction            from '../../../src/dashboard/dock/window/NativeVesselTransaction.mjs';
 import VesselPark                         from '../../../src/dashboard/dock/window/VesselPark.mjs';
 import TourRunner                         from '../../../src/ai/client/TourRunner.mjs';
 import TransactionManager                 from '../../../src/manager/Transaction.mjs';
@@ -637,6 +638,19 @@ class DemoBWorkspace extends Container {
 
         // Conversion never reacquires a popup. The source-owned admission machines retain the
         // existing tear-out vessel while this host binds their effects to its exact native route.
+        // The transaction itself is the engine's; this host supplies only what varies between
+        // consumers. No `restoreGeometry` is declared, which is the whole of this host's policy:
+        // its re-show restores a position and never an extent, so the park may not shrink.
+        me.vesselTransaction = NativeVesselTransaction.effectsFor({
+            ownerWindowId : () => me.windowId,
+            publishReceipt: (key, receipt) => {
+                key === 'park' ? (me.lastVesselParkReceipt = receipt) : (me.lastVesselRestoreReceipt = receipt)
+            },
+            resolveVessel : itemId => me.resolveTearOutVessel(itemId),
+            retireVessel  : vessel => me.tearOutHandlers.retireActiveVessel(vessel),
+            targetWindowId: () => me.crossWindowTargetWindowId
+        });
+
         me.vesselParkHandlers = Neo.create(VesselPark, {
             disposeVessel: vessel => me.disposeParkedTearOutVessel(vessel),
             parkVessel   : vessel => me.parkTearOutVessel(vessel),
@@ -3842,198 +3856,35 @@ class DemoBWorkspace extends Container {
     }
 
     /**
-     * @summary Focuses the already-admitted target, then pauses pointer-follow and parks the exact
-     * connected tear-out generation behind it.
-     *
-     * Focus is admitted BEFORE the physical move, then reasserted AFTER it. A content-bearing moved
-     * window can regain document focus on some window managers; the second focus is therefore the
-     * cover-order receipt, not ceremony. Initial refusal leaves the source untouched. Move refusal
-     * lets DragDrop re-enable pointer-follow, while post-move focus refusal resumes the exact source
-     * rect before reporting a refused park. If that compensation is itself refused, admitted parked
-     * ownership is retained so the lifecycle machine still owns the only recovery route.
+     * Parks the converted vessel behind its conversion target through the engine's default
+     * transaction. This host declares no geometry restore, so the park is position-only: an
+     * oversized source is refused rather than shrunk, because nothing here will give the extent
+     * back. See {@link Neo.dashboard.dock.window.NativeVesselTransaction}.
      * @param {Object} vessel
-     * @param {String} vessel.itemId
-     * @param {String} vessel.windowName
      * @returns {Promise<Boolean>}
      * @protected
      */
-    async parkTearOutVessel({itemId, windowName}) {
-        let me           = this,
-            entry        = me.resolveTearOutVessel(itemId),
-            route        = entry?.nativeRoute,
-            sourceWindow = Neo.manager?.Window?.get(entry?.windowId),
-            targetWindow = Neo.manager?.Window?.get(me.crossWindowTargetWindowId),
-            targetRoute  = targetWindow?.nativeRoute,
-            // The conversion metric and the exact native move both speak published inner-window
-            // geometry. A child can legitimately omit outerRect, so making the optional frame
-            // estimate an admission prerequisite would reject a fully-authorized live vessel.
-            sourceRect   = sourceWindow?.innerRect,
-            targetRect   = targetWindow?.innerRect;
-
-        const
-            sourceArgs  = {ownerWindowId: me.windowId, route, targetWindowId: entry?.windowId ?? null},
-            targetArgs  = {ownerWindowId: me.windowId, route: targetRoute, targetWindowId: me.crossWindowTargetWindowId ?? null},
-            sourcePos   = WindowManager.resolveNativeRoute({...sourceArgs, capability: 'position'}),
-            targetFocus = WindowManager.resolveNativeRoute({...targetArgs, capability: 'focus'});
-
-        me.lastVesselParkReceipt = {
-            authority: {
-                entryNameMatches     : entry?.windowName === windowName,
-                sourceHasHandle      : sourcePos.hasHandle,
-                sourceOwnerMatches   : sourcePos.ownerMatches,
-                sourcePositionCapable: sourcePos.capable,
-                sourceTargetMatches  : sourcePos.targetMatches,
-                targetFocusCapable   : targetFocus.capable,
-                targetHasHandle      : targetFocus.hasHandle,
-                targetOwnerMatches   : targetFocus.ownerMatches,
-                targetTargetMatches  : targetFocus.targetMatches
-            },
-            source: sourceRect && {
-                height: sourceRect.height, width: sourceRect.width, x: sourceRect.x, y: sourceRect.y
-            },
-            target: targetRect && {
-                height: targetRect.height, width: targetRect.width, x: targetRect.x, y: targetRect.y
-            }
-        };
-        me.lastVesselRestoreReceipt = null;
-
-        if (
-            !sourcePos.granted || !targetFocus.granted ||
-            entry.windowName !== windowName || !sourceRect || !targetRect || !targetWindow.innerRect ||
-            sourceRect.width > targetRect.width || sourceRect.height > targetRect.height
-        ) {
-            me.lastVesselParkReceipt.reason = 'native route or cover geometry refused';
-            return false
-        }
-
-        try {
-            let focused = await Neo.Main.windowNativeFocus({
-                    nativeHandleKey: targetRoute.nativeHandleKey,
-                    targetWindowId : targetRoute.targetWindowId,
-                    windowId       : me.windowId
-                }) === true;
-
-            me.lastVesselParkReceipt.focused = focused;
-
-            if (!focused) return false;
-
-            me.lastVesselParkReceipt.requested = {
-                x: targetWindow.innerRect.x,
-                y: targetWindow.innerRect.y
-            };
-
-            let moved = await Neo.main.addon.DragDrop.parkWindowDrag({
-                nativeHandleKey: route.nativeHandleKey,
-                targetWindowId : route.targetWindowId,
-                windowId       : me.windowId,
-                windowName,
-                x              : targetWindow.innerRect.x,
-                y              : targetWindow.innerRect.y
-            }) === true;
-
-            me.lastVesselParkReceipt.moved = moved;
-
-            if (!moved) return false;
-
-            let refocused = await Neo.Main.windowNativeFocus({
-                nativeHandleKey: targetRoute.nativeHandleKey,
-                targetWindowId : targetRoute.targetWindowId,
-                windowId       : me.windowId
-            }) === true;
-
-            me.lastVesselParkReceipt.refocused = refocused;
-
-            if (!refocused) {
-                let compensated = await Neo.main.addon.DragDrop.resumeWindowDrag({
-                    nativeHandleKey: route.nativeHandleKey,
-                    targetWindowId : route.targetWindowId,
-                    windowId       : me.windowId,
-                    windowName,
-                    x              : sourceRect.x,
-                    y              : sourceRect.y
-                }) === true;
-
-                me.lastVesselParkReceipt.compensated = compensated;
-                me.lastVesselParkReceipt.parked      = !compensated;
-
-                return !compensated
-            }
-
-            me.lastVesselParkReceipt.parked = true;
-
-            return true
-        } catch {
-            me.lastVesselParkReceipt.reason = 'platform effect threw';
-            return false
-        }
+    parkTearOutVessel(vessel) {
+        return this.vesselTransaction.parkVessel(vessel)
     }
 
     /**
-     * @summary Re-shows the same exact native generation at the logical pointer-owned origin.
-     *
-     * During a live gesture the DragDrop addon also resumes physical pointer-follow. At a native
-     * drag terminal that addon has already reset its session, so a strict refusal falls through
-     * to the same exact Main route for the final restore; semantic-name routing is never used.
-     * @param {Object} vessel
-     * @param {String} vessel.itemId
-     * @param {Object} vessel.rect
-     * @param {Boolean} [vessel.terminal=false]
-     * @param {String} vessel.windowName
-     * @returns {Promise<Boolean>}
-     * @protected
+     * Re-shows the parked vessel at its pre-conversion origin through the engine's default
+     * transaction, which converts that content origin into the frame origin the native move
+     * consumes. @param {Object} vessel @returns {Promise<Boolean>} @protected
      */
-    async reshowTearOutVessel({itemId, rect, terminal=false, windowName}) {
-        let me    = this,
-            entry = me.resolveTearOutVessel(itemId),
-            route = entry?.nativeRoute,
-            data;
-
-        if (
-            !WindowManager.resolveNativeRoute({
-                capability: 'position', ownerWindowId: me.windowId, route, targetWindowId: entry?.windowId ?? null
-            }).granted ||
-            entry.windowName !== windowName ||
-            !Number.isFinite(rect?.x) || !Number.isFinite(rect?.y)
-        ) return false;
-
-        data = {
-            nativeHandleKey: route.nativeHandleKey,
-            targetWindowId : route.targetWindowId,
-            windowId       : me.windowId,
-            windowName,
-            x              : rect.x,
-            y              : rect.y
-        };
-        me.lastVesselRestoreReceipt = {
-            admitted : false,
-            requested: {x: rect.x, y: rect.y},
-            terminal,
-            windowId : route.targetWindowId
-        };
-
-        try {
-            const admitted = terminal
-                ? await Neo.Main.windowNativeMoveTo(data) === true
-                : await Neo.main.addon.DragDrop.resumeWindowDrag(data) === true
-
-            me.lastVesselRestoreReceipt.admitted = admitted;
-
-            return admitted
-        } catch {
-            return false
-        }
+    reshowTearOutVessel(vessel) {
+        return this.vesselTransaction.reshowVessel(vessel)
     }
 
     /**
-     * @summary Consumes the tear-out machine's active slot, then closes its exact parked vessel.
+     * Retires the parked vessel and its orphan recovery together — the default owns that pairing.
      * @param {Object} vessel
-     * @param {String} vessel.itemId
-     * @param {String} vessel.windowName
      * @returns {Promise<Boolean>}
      * @protected
      */
-    async disposeParkedTearOutVessel({itemId, windowName}) {
-        return this.tearOutHandlers.retireActiveVessel({itemId, windowName})
+    disposeParkedTearOutVessel(vessel) {
+        return this.vesselTransaction.disposeVessel(vessel)
     }
 
     /**

--- a/src/dashboard/dock/window/NativeVesselTransaction.mjs
+++ b/src/dashboard/dock/window/NativeVesselTransaction.mjs
@@ -1,0 +1,236 @@
+import Base          from '../../../core/Base.mjs';
+import WindowManager from '../../../manager/Window.mjs';
+
+/**
+ * @summary The default park / re-show / dispose transaction behind {@link Neo.dashboard.dock.window.VesselPark}'s
+ * three required seams.
+ *
+ * `VesselPark` owns gesture-local admission, one-in-flight settlement and disposal ordering, and
+ * requires three strict effects it deliberately does not implement — native window ownership stays
+ * with the Group, and the arbiter holds no host reference. That left every consumer writing the
+ * transaction itself, and two did, with the same contract and different bodies: the same
+ * `lastVesselParkReceipt.authority` block in the same key order, the same `resolveNativeRoute`
+ * admission pair, the same fail-closed gate, the same dispatch — reached independently, and already
+ * diverged. The divergence is the reason this exists; a copy would at least have agreed.
+ *
+ * **The authority key set is a function of the transaction's declared restore obligation.** All ten
+ * keys are emitted always, so a reader sees one fixed shape; only the required subset gates the
+ * refusal. A transaction that restores geometry must hold `resize` at park, because park is where
+ * that obligation is accepted. A transaction that restores position only must not — gating it there
+ * refuses parks it would service completely.
+ *
+ * This class holds no state and no host. {@link #effectsFor} closes over a descriptor and returns
+ * the three functions; a consumer overriding none inherits a working transaction without
+ * re-deriving it, and `VesselPark`'s own construct-time throw still catches the partial-override
+ * case. Anything genuinely app-specific stays an override with a stated product reason.
+ *
+ * @class Neo.dashboard.dock.window.NativeVesselTransaction
+ * @extends Neo.core.Base
+ */
+class NativeVesselTransaction extends Base {
+    static config = {
+        /**
+         * @member {String} className='Neo.dashboard.dock.window.NativeVesselTransaction'
+         * @protected
+         */
+        className: 'Neo.dashboard.dock.window.NativeVesselTransaction'
+    }
+
+    /**
+     * The `authority` key order every receipt emits, fixed so two consumers cannot report the same
+     * decision under different shapes. Emitted whole; the gated subset is decided per transaction
+     * by its declared restore obligation, never by which keys a consumer remembered to include.
+     * @member {String[]} authorityKeys
+     * @static
+     */
+    static authorityKeys = [
+        'entryNameMatches', 'sourceHasHandle', 'sourceOwnerMatches', 'sourcePositionCapable',
+        'sourceResizeCapable', 'sourceTargetMatches', 'targetFocusCapable', 'targetHasHandle',
+        'targetOwnerMatches', 'targetTargetMatches'
+    ]
+
+    /**
+     * @summary Resolves the source and target native-route admissions for one vessel.
+     *
+     * Both consumers reached the identical pair independently: `position` on the source (the park
+     * moves it) and `focus` on the target (the parked window hides behind it). `resize` is resolved
+     * unconditionally so the receipt can report the capability, and gated separately — reporting a
+     * capability and requiring it are different questions, and conflating them is what made one
+     * consumer's park look stricter than its own re-show.
+     * @param {Object} descriptor
+     * @param {Object|null} entry The resolved vessel registry entry.
+     * @param {String|null} targetWindowId
+     * @returns {{sourceFocusless:Boolean,sourcePos:Object,sourceResize:Object,targetFocus:Object}}
+     * @protected
+     */
+    static resolveAdmissions(descriptor, entry, targetWindowId) {
+        const
+            ownerWindowId = descriptor.ownerWindowId(),
+            route         = entry?.nativeRoute ?? null,
+            targetRoute   = WindowManager.get(targetWindowId)?.nativeRoute ?? null,
+            sourceArgs    = {ownerWindowId, route, targetWindowId: entry?.windowId ?? null},
+            targetArgs    = {ownerWindowId, route: targetRoute, targetWindowId: targetWindowId ?? null};
+
+        return {
+            sourcePos   : WindowManager.resolveNativeRoute({...sourceArgs, capability: 'position'}),
+            sourceResize: WindowManager.resolveNativeRoute({...sourceArgs, capability: 'resize'}),
+            targetFocus : WindowManager.resolveNativeRoute({...targetArgs, capability: 'focus'})
+        }
+    }
+
+    /**
+     * @summary Builds the fixed ten-key authority block for one transaction.
+     * @param {Object} admissions From {@link #resolveAdmissions}.
+     * @param {Boolean} entryNameMatches
+     * @returns {Object} Keys in {@link #authorityKeys} order.
+     * @protected
+     */
+    static describeAuthority({sourcePos, sourceResize, targetFocus}, entryNameMatches) {
+        return {
+            entryNameMatches,
+            sourceHasHandle      : sourcePos.hasHandle,
+            sourceOwnerMatches   : sourcePos.ownerMatches,
+            sourcePositionCapable: sourcePos.capable,
+            sourceResizeCapable  : sourceResize.capable,
+            sourceTargetMatches  : sourcePos.targetMatches,
+            targetFocusCapable   : targetFocus.capable,
+            targetHasHandle      : targetFocus.hasHandle,
+            targetOwnerMatches   : targetFocus.ownerMatches,
+            targetTargetMatches  : targetFocus.targetMatches
+        }
+    }
+
+    /**
+     * @summary Converts a CONTENT rect into the frame origin `moveTo` actually consumes.
+     *
+     * `Neo.Main#windowNativeMoveTo` ends in `win.moveTo(x, y)`, which positions the window's OUTER
+     * frame, while a park rect describes content. A consumer handing the content origin straight in
+     * places the window short by its own chrome on every platform that draws any. That is a property
+     * of the platform call, not of any application — a window that never published chrome resolves
+     * to a zero offset and re-shows content-on-frame, the pre-chrome behaviour.
+     * @param {Object|null} rect
+     * @param {String|null} windowId The window being moved, whose chrome offsets the origin.
+     * @returns {{x:Number,y:Number}|null} `null` when the rect has no finite origin to convert.
+     * @protected
+     */
+    static toFrameOrigin(rect, windowId) {
+        if (!Number.isFinite(rect?.x) || !Number.isFinite(rect?.y)) {
+            return null
+        }
+
+        const chrome = WindowManager.get(windowId)?.chrome;
+
+        return {x: rect.x - (chrome?.left ?? 0), y: rect.y - (chrome?.top ?? 0)}
+    }
+
+    /**
+     * @summary Closes over a host descriptor and returns the three `VesselPark` seams.
+     *
+     * The descriptor is the whole host-varying surface, measured across both existing consumers:
+     * which window the conversion targets, whether the transaction owes a geometry restore, how a
+     * vessel resolves, and where receipts land. Everything else is shared and lives here.
+     * @param {Object} descriptor
+     * @param {Function} descriptor.ownerWindowId Returns the host's current `windowId`.
+     * @param {Function} descriptor.publishReceipt `(key, receipt) => void`; `key` is `'park'` or `'restore'`.
+     * @param {Function} descriptor.resolveVessel `itemId => entry|null`.
+     * @param {Function} descriptor.retireVessel `({itemId, windowName}) => Promise<Boolean>`.
+     * @param {Function} descriptor.targetWindowId Returns the conversion target's `windowId`.
+     * @param {Function} [descriptor.restoreGeometry] `itemId => geometry|null`. Absent or returning
+     * `null` declares a position-only transaction, which is NOT gated on `resize`.
+     * @returns {{disposeVessel:Function,parkVessel:Function,reshowVessel:Function}}
+     */
+    static effectsFor(descriptor) {
+        const restoreGeometry = descriptor.restoreGeometry ?? (() => null);
+
+        return {
+            disposeVessel: async ({itemId, windowName}) => {
+                const
+                    entry    = descriptor.resolveVessel(itemId),
+                    route    = entry?.nativeRoute ?? null,
+                    disposed = await descriptor.retireVessel({itemId, windowName});
+
+                // Retiring the vessel without retiring its orphan recovery leaves a matching
+                // predecessor effect owning a window that no longer exists, which then competes
+                // with the next park on the same handle. One consumer does this and one does not.
+                if (disposed && route?.nativeHandleKey) {
+                    await Neo.main.addon.DragDrop.retireWindowDragOrphanRecovery({
+                        nativeHandleKey: route.nativeHandleKey,
+                        targetWindowId : route.targetWindowId,
+                        windowId       : descriptor.ownerWindowId(),
+                        windowName
+                    })
+                }
+
+                return disposed
+            },
+
+            parkVessel: async ({itemId, windowName}) => {
+                const
+                    entry          = descriptor.resolveVessel(itemId),
+                    targetWindowId = descriptor.targetWindowId() ?? null,
+                    geometry       = restoreGeometry(itemId),
+                    admissions     = NativeVesselTransaction.resolveAdmissions(descriptor, entry, targetWindowId),
+                    authority      = NativeVesselTransaction.describeAuthority(admissions, entry?.windowName === windowName),
+                    // The obligation, not the capability: `resize` is required exactly when this
+                    // transaction has promised to restore an extent later.
+                    owesResize     = Boolean(geometry);
+
+                descriptor.publishReceipt('park', {authority, geometry, owesResize});
+                descriptor.publishReceipt('restore', null);
+
+                if (
+                    !admissions.sourcePos.granted || (owesResize && !admissions.sourceResize.granted) ||
+                    !admissions.targetFocus.granted || !authority.entryNameMatches
+                ) {
+                    return false
+                }
+
+                return true
+            },
+
+            reshowVessel: async ({itemId, rect, terminal=false, windowName}) => {
+                const
+                    entry      = descriptor.resolveVessel(itemId),
+                    route      = entry?.nativeRoute ?? null,
+                    geometry   = restoreGeometry(itemId),
+                    frame      = NativeVesselTransaction.toFrameOrigin(rect, entry?.windowId ?? null),
+                    admissions = NativeVesselTransaction.resolveAdmissions(descriptor, entry, descriptor.targetWindowId() ?? null),
+                    owesResize = Boolean(geometry);
+
+                descriptor.publishReceipt('restore', {
+                    authority: NativeVesselTransaction.describeAuthority(admissions, entry?.windowName === windowName),
+                    frame,
+                    geometry,
+                    owesResize,
+                    terminal
+                });
+
+                if (
+                    !admissions.sourcePos.granted || (owesResize && !admissions.sourceResize.granted) ||
+                    entry?.windowName !== windowName || !frame
+                ) {
+                    return false
+                }
+
+                const data = {
+                    nativeHandleKey: route.nativeHandleKey,
+                    targetWindowId : route.targetWindowId,
+                    windowId       : descriptor.ownerWindowId(),
+                    windowName,
+                    x              : frame.x,
+                    y              : frame.y
+                };
+
+                try {
+                    return terminal
+                        ? await Neo.Main.windowNativeMoveTo(data) === true
+                        : await Neo.main.addon.DragDrop.resumeWindowDrag(data) === true
+                } catch (error) {
+                    return false
+                }
+            }
+        }
+    }
+}
+
+export default Neo.setupClass(NativeVesselTransaction);

--- a/src/dashboard/dock/window/NativeVesselTransaction.mjs
+++ b/src/dashboard/dock/window/NativeVesselTransaction.mjs
@@ -164,13 +164,18 @@ class NativeVesselTransaction extends Base {
                 // Retiring the vessel without retiring its orphan recovery leaves a matching
                 // predecessor effect owning a window that no longer exists, which then competes
                 // with the next park on the same handle. One consumer does this and one does not.
+                // Same asymmetry as the acknowledgement: the retirement is bookkeeping over an
+                // effect the consumer may never have armed, and it must not be able to revoke a
+                // disposal that already happened.
                 if (disposed && route?.nativeHandleKey) {
-                    await Neo.main.addon.DragDrop.retireWindowDragOrphanRecovery({
-                        nativeHandleKey: route.nativeHandleKey,
-                        targetWindowId : route.targetWindowId,
-                        windowId       : descriptor.ownerWindowId(),
-                        windowName
-                    })
+                    try {
+                        await Neo.main.addon.DragDrop.retireWindowDragOrphanRecovery?.({
+                            nativeHandleKey: route.nativeHandleKey,
+                            targetWindowId : route.targetWindowId,
+                            windowId       : descriptor.ownerWindowId(),
+                            windowName
+                        })
+                    } catch (error) {/* nothing armed, or already retired: the disposal stands */}
                 }
 
                 return disposed
@@ -304,35 +309,96 @@ class NativeVesselTransaction extends Base {
                     admissions = NativeVesselTransaction.resolveAdmissions(descriptor, entry, descriptor.targetWindowId() ?? null),
                     owesResize = Boolean(geometry);
 
-                descriptor.publishReceipt('restore', {
+                const receipt = {
                     authority: NativeVesselTransaction.describeAuthority(admissions, entry?.windowName === windowName),
                     frame,
                     geometry,
                     owesResize,
                     terminal
-                });
+                };
+
+                // Published first and amended in place, same as the park: a caller reading it
+                // after a refusal must see which beat refused and what was compensated.
+                descriptor.publishReceipt('restore', receipt);
 
                 if (
                     !admissions.sourcePos.granted || (owesResize && !admissions.sourceResize.granted) ||
                     entry?.windowName !== windowName || !frame
                 ) {
+                    receipt.reason = 'native route or restore geometry refused';
                     return false
                 }
 
-                const data = {
-                    nativeHandleKey: route.nativeHandleKey,
-                    targetWindowId : route.targetWindowId,
-                    windowId       : descriptor.ownerWindowId(),
-                    windowName,
-                    x              : frame.x,
-                    y              : frame.y
-                };
+                const
+                    handle = {
+                        nativeHandleKey: route.nativeHandleKey,
+                        targetWindowId : route.targetWindowId,
+                        windowId       : descriptor.ownerWindowId()
+                    },
+                    data   = {...handle, windowName, x: frame.x, y: frame.y},
+                    resize = extent => Neo.Main.windowNativeResizeTo({...handle, ...extent});
 
                 try {
-                    return terminal
-                        ? await Neo.Main.windowNativeMoveTo(data) === true
-                        : await Neo.main.addon.DragDrop.resumeWindowDrag(data) === true
+                    // A non-terminal re-show hands the window back to the live drag, which owns the
+                    // move itself. Only a terminal restore drives the platform directly, and only
+                    // it has an extent to give back.
+                    if (!terminal) {
+                        receipt.admitted = await Neo.main.addon.DragDrop.resumeWindowDrag(data) === true;
+                        return receipt.admitted
+                    }
+
+                    // Extent before position: a window restored to its old size at the park origin
+                    // is briefly visible in the wrong place, whereas the reverse ordering is not
+                    // observable. On refusal the park extent is put back, so a half-restored
+                    // window never survives the failure.
+                    if (owesResize) {
+                        receipt.resized = await resize(geometry.restore) === true;
+
+                        if (!receipt.resized) {
+                            await resize(geometry.park);
+                            receipt.refusedAt = 'resize';
+                            return false
+                        }
+                    }
+
+                    receipt.moved = await Neo.Main.windowNativeMoveTo(data) === true;
+
+                    if (!receipt.moved) {
+                        // Compensating a failed move means undoing the extent too, in the same
+                        // order it was applied — otherwise the vessel keeps its restored size at
+                        // the park origin and the next re-show measures from a lie.
+                        if (owesResize) {
+                            receipt.compensationResized = await resize(geometry.park) === true;
+
+                            if (receipt.compensationResized) {
+                                receipt.compensationMoved = await Neo.Main.windowNativeMoveTo({
+                                    ...handle, windowName, x: geometry.park.x, y: geometry.park.y
+                                }) === true
+                            }
+                        }
+
+                        receipt.refusedAt = 'move';
+                        return false
+                    }
+
+                    receipt.admitted = true;
+
+                    // The vessel is home; this releases the recovery effect that was owning the
+                    // failure case, and it is deliberately unable to revoke the success above.
+                    // A consumer that never arms orphan recovery has nothing to release, and a
+                    // bookkeeping release that threw would otherwise convert a completed restore
+                    // into a refusal — losing a success claim after an await.
+                    try {
+                        receipt.recoveryAcknowledged =
+                            await Neo.main.addon.DragDrop.acknowledgeWindowDragOrphanRecovery?.(data) === true
+                    } catch (error) {
+                        receipt.recoveryAcknowledged = false
+                    }
+
+                    return true
                 } catch (error) {
+                    receipt.error     = String(error?.message || error);
+                    receipt.refusedAt = 'throw';
                     return false
                 }
             }

--- a/src/dashboard/dock/window/NativeVesselTransaction.mjs
+++ b/src/dashboard/dock/window/NativeVesselTransaction.mjs
@@ -201,10 +201,19 @@ class NativeVesselTransaction extends Base {
                 descriptor.publishReceipt('park', receipt);
                 descriptor.publishReceipt('restore', null);
 
+                // The cover precondition falls out of the same obligation, rather than being a
+                // second policy: a park hides the source BEHIND the target, so a source that does
+                // not fit must be shrunk first — and only a transaction that owes a geometry
+                // restore may shrink it, because only that transaction has promised to give the
+                // extent back. One consumer resizes and one refuses; both are this rule, read
+                // through their own declared obligation.
+                receipt.fits = Boolean(sourceRect && targetRect &&
+                    sourceRect.width <= targetRect.width && sourceRect.height <= targetRect.height);
+
                 if (
                     !admissions.sourcePos.granted || (owesResize && !admissions.sourceResize.granted) ||
                     !admissions.targetFocus.granted || !authority.entryNameMatches ||
-                    !sourceRect || !targetRect
+                    !sourceRect || !targetRect || (!receipt.fits && !owesResize)
                 ) {
                     receipt.reason = 'native route or live cover geometry refused';
                     return false

--- a/src/dashboard/dock/window/NativeVesselTransaction.mjs
+++ b/src/dashboard/dock/window/NativeVesselTransaction.mjs
@@ -137,6 +137,10 @@ class NativeVesselTransaction extends Base {
      * @param {Function} descriptor.targetWindowId Returns the conversion target's `windowId`.
      * @param {Function} [descriptor.restoreGeometry] `itemId => geometry|null`. Absent or returning
      * `null` declares a position-only transaction, which is NOT gated on `resize`.
+     * @param {String} [descriptor.terminalRestoreOwner='route'] Who performs a TERMINAL restore —
+     * `'drag'` asks the addon that may still own the gesture before addressing the route, `'route'`
+     * addresses the route directly. A restore ending a drag wants `'drag'`; one ending a conversion
+     * has no drag to hand back to and wants `'route'`.
      * @param {String} [descriptor.rectPlane='inner'] Which published rect the cover metric and the
      * park origin speak — `'inner'` or `'outer'`. A child window may legitimately omit `outerRect`,
      * so a consumer whose admission does not depend on the frame stays on the inner plane rather
@@ -314,6 +318,10 @@ class NativeVesselTransaction extends Base {
                     frame,
                     geometry,
                     owesResize,
+                    // Both are recorded because they answer different questions: `rect` is what the
+                    // caller asked for in content space, `frame` is what the platform was handed.
+                    // A receipt carrying only one cannot show that the chrome conversion happened.
+                    rect     : snapshot(rect),
                     terminal
                 };
 
@@ -335,16 +343,46 @@ class NativeVesselTransaction extends Base {
                         targetWindowId : route.targetWindowId,
                         windowId       : descriptor.ownerWindowId()
                     },
+                    // The addon owns a NAMED drag and needs the name to find it; `Neo.Main`'s
+                    // window calls address the route alone. Sending the name to both worked and
+                    // was still wrong: it put a field the platform ignores into an exactly-asserted
+                    // payload, so the witness could no longer describe the call it was pinning.
                     data   = {...handle, windowName, x: frame.x, y: frame.y},
+                    origin = {...handle, x: frame.x, y: frame.y},
                     resize = extent => Neo.Main.windowNativeResizeTo({...handle, ...extent});
 
                 try {
-                    // A non-terminal re-show hands the window back to the live drag, which owns the
-                    // move itself. Only a terminal restore drives the platform directly, and only
-                    // it has an extent to give back.
+                    // A non-terminal re-show always goes through the addon: the drag is live by
+                    // definition, it holds the gesture's state, and a direct route mutation
+                    // alongside it would be a second writer.
                     if (!terminal) {
                         receipt.admitted = await Neo.main.addon.DragDrop.resumeWindowDrag(data) === true;
                         return receipt.admitted
+                    }
+
+                    // At TERMINAL time the two consumers legitimately differ, because they differ
+                    // on whether a drag still exists. A restore that ends a drag asks its owner
+                    // first and only then addresses the route; a restore that ends a CONVERSION has
+                    // no drag to hand back to and addresses the route directly. Declared, not
+                    // guessed — asking a nonexistent owner would silently succeed against a stale
+                    // effect, and skipping a live one would make this a second writer.
+                    if (descriptor.terminalRestoreOwner === 'drag') {
+                        receipt.addonRestored = await Neo.main.addon.DragDrop.resumeWindowDrag(data) === true;
+
+                        if (receipt.addonRestored) {
+                            receipt.admitted = true;
+                            return true
+                        }
+                    }
+
+                    // A matching predecessor effect still owns exact recovery. Never race it with a
+                    // direct route mutation, and never let a position-only success stand in for an
+                    // extent restore the recovery is still responsible for.
+                    receipt.recoveryPending = await Neo.main.addon.DragDrop.hasWindowDragOrphanRecovery?.(data) === true;
+
+                    if (receipt.recoveryPending) {
+                        receipt.refusedAt = 'recovery-pending';
+                        return false
                     }
 
                     // Extent before position: a window restored to its old size at the park origin
@@ -361,7 +399,7 @@ class NativeVesselTransaction extends Base {
                         }
                     }
 
-                    receipt.moved = await Neo.Main.windowNativeMoveTo(data) === true;
+                    receipt.moved = await Neo.Main.windowNativeMoveTo(origin) === true;
 
                     if (!receipt.moved) {
                         // Compensating a failed move means undoing the extent too, in the same
@@ -372,7 +410,7 @@ class NativeVesselTransaction extends Base {
 
                             if (receipt.compensationResized) {
                                 receipt.compensationMoved = await Neo.Main.windowNativeMoveTo({
-                                    ...handle, windowName, x: geometry.park.x, y: geometry.park.y
+                                    ...handle, x: geometry.park.x, y: geometry.park.y
                                 }) === true
                             }
                         }

--- a/src/dashboard/dock/window/NativeVesselTransaction.mjs
+++ b/src/dashboard/dock/window/NativeVesselTransaction.mjs
@@ -137,10 +137,22 @@ class NativeVesselTransaction extends Base {
      * @param {Function} descriptor.targetWindowId Returns the conversion target's `windowId`.
      * @param {Function} [descriptor.restoreGeometry] `itemId => geometry|null`. Absent or returning
      * `null` declares a position-only transaction, which is NOT gated on `resize`.
+     * @param {String} [descriptor.rectPlane='inner'] Which published rect the cover metric and the
+     * park origin speak — `'inner'` or `'outer'`. A child window may legitimately omit `outerRect`,
+     * so a consumer whose admission does not depend on the frame stays on the inner plane rather
+     * than refusing an otherwise-authorized live vessel.
      * @returns {{disposeVessel:Function,parkVessel:Function,reshowVessel:Function}}
      */
     static effectsFor(descriptor) {
-        const restoreGeometry = descriptor.restoreGeometry ?? (() => null);
+        const
+            restoreGeometry = descriptor.restoreGeometry ?? (() => null),
+            // Which published rect the cover metric and the park origin speak. A child window may
+            // legitimately omit `outerRect`, so a consumer whose admission does not depend on the
+            // frame stays on `innerRect` rather than rejecting an otherwise-authorized vessel.
+            plane           = descriptor.rectPlane === 'outer' ? 'outerRect' : 'innerRect',
+            snapshot        = rect => rect && {
+                height: rect.height, width: rect.width, x: rect.x, y: rect.y
+            };
 
         return {
             disposeVessel: async ({itemId, windowName}) => {
@@ -169,23 +181,109 @@ class NativeVesselTransaction extends Base {
                     entry          = descriptor.resolveVessel(itemId),
                     targetWindowId = descriptor.targetWindowId() ?? null,
                     geometry       = restoreGeometry(itemId),
+                    sourceWindow   = WindowManager.get(entry?.windowId),
+                    targetWindow   = WindowManager.get(targetWindowId),
+                    targetRoute    = targetWindow?.nativeRoute ?? null,
+                    route          = entry?.nativeRoute ?? null,
+                    sourceRect     = sourceWindow?.[plane] ?? null,
+                    targetRect     = targetWindow?.[plane] ?? null,
                     admissions     = NativeVesselTransaction.resolveAdmissions(descriptor, entry, targetWindowId),
                     authority      = NativeVesselTransaction.describeAuthority(admissions, entry?.windowName === windowName),
                     // The obligation, not the capability: `resize` is required exactly when this
                     // transaction has promised to restore an extent later.
-                    owesResize     = Boolean(geometry);
+                    owesResize     = Boolean(geometry),
+                    receipt        = {authority, geometry, owesResize, sourceRect: snapshot(sourceRect), targetRect: snapshot(targetRect)};
 
-                descriptor.publishReceipt('park', {authority, geometry, owesResize});
+                // The receipt is a stage machine this method amends as the choreography advances,
+                // so it is published FIRST and mutated in place. A caller reading it after a
+                // refusal must be able to see how far the transaction got, which a receipt
+                // assembled only on success cannot express.
+                descriptor.publishReceipt('park', receipt);
                 descriptor.publishReceipt('restore', null);
 
                 if (
                     !admissions.sourcePos.granted || (owesResize && !admissions.sourceResize.granted) ||
-                    !admissions.targetFocus.granted || !authority.entryNameMatches
+                    !admissions.targetFocus.granted || !authority.entryNameMatches ||
+                    !sourceRect || !targetRect
                 ) {
+                    receipt.reason = 'native route or live cover geometry refused';
                     return false
                 }
 
-                return true
+                const focusTarget = () => Neo.Main.windowNativeFocus({
+                    nativeHandleKey: targetRoute.nativeHandleKey,
+                    targetWindowId : targetRoute.targetWindowId,
+                    windowId       : descriptor.ownerWindowId()
+                });
+
+                try {
+                    receipt.focused = await focusTarget() === true;
+
+                    if (!receipt.focused) {
+                        receipt.refusedAt = 'focus';
+                        return false
+                    }
+
+                    // A source frame that does not fit behind the target shrinks through its own
+                    // exact route first; the restore extent is what `geometry` already promised.
+                    if (owesResize) {
+                        receipt.resized = await Neo.Main.windowNativeResizeTo({
+                            height         : Math.min(sourceRect.height, targetRect.height),
+                            nativeHandleKey: route.nativeHandleKey,
+                            targetWindowId : route.targetWindowId,
+                            width          : Math.min(sourceRect.width, targetRect.width),
+                            windowId       : descriptor.ownerWindowId()
+                        }) === true;
+
+                        if (!receipt.resized) {
+                            receipt.refusedAt = 'resize';
+                            return false
+                        }
+                    }
+
+                    receipt.requested = {x: targetRect.x, y: targetRect.y};
+                    receipt.moved     = await Neo.main.addon.DragDrop.parkWindowDrag({
+                        nativeHandleKey: route.nativeHandleKey,
+                        targetWindowId : route.targetWindowId,
+                        windowId       : descriptor.ownerWindowId(),
+                        windowName,
+                        x              : targetRect.x,
+                        y              : targetRect.y
+                    }) === true;
+
+                    if (!receipt.moved) {
+                        receipt.refusedAt = 'move';
+                        return false
+                    }
+
+                    receipt.refocused = await focusTarget() === true;
+
+                    if (receipt.refocused) {
+                        receipt.parked = true;
+                        return true
+                    }
+
+                    // The z-order that hides the parked vessel is what a refocus buys. Without it
+                    // the source sits visibly over the target, so the move is undone rather than
+                    // left half-applied — and a successful compensation is a REFUSAL, because the
+                    // vessel is back where it started and nothing is parked.
+                    receipt.compensated = await Neo.main.addon.DragDrop.resumeWindowDrag({
+                        nativeHandleKey: route.nativeHandleKey,
+                        targetWindowId : route.targetWindowId,
+                        windowId       : descriptor.ownerWindowId(),
+                        windowName,
+                        x              : sourceRect.x,
+                        y              : sourceRect.y
+                    }) === true;
+
+                    receipt.parked    = !receipt.compensated;
+                    receipt.refusedAt = 'refocus';
+
+                    return !receipt.compensated
+                } catch (error) {
+                    receipt.refusedAt = 'throw';
+                    return false
+                }
             },
 
             reshowVessel: async ({itemId, rect, terminal=false, windowName}) => {

--- a/test/playwright/unit/dashboard/DockNativeVesselTransaction.spec.mjs
+++ b/test/playwright/unit/dashboard/DockNativeVesselTransaction.spec.mjs
@@ -320,6 +320,41 @@ test.describe('Neo.dashboard.dock.window.NativeVesselTransaction', () => {
             .toEqual(['focus', 'resize', 'park', 'focus'])
     });
 
+    test('a terminal restore ending a DRAG asks its owner before the route', async () => {
+        const receipts = {};
+
+        restore  = stubRoutes({focus: true, position: true, resize: true});
+        platform = installPlatform();
+
+        const admitted = await NativeVesselTransaction
+            .effectsFor({...descriptorFor({receipts}), terminalRestoreOwner: 'drag'})
+            .reshowVessel({itemId: 'item-1', rect: {x: 10, y: 20}, terminal: true, windowName: 'vessel-1'});
+
+        expect(admitted).toBe(true);
+        expect(receipts.restore.addonRestored, 'the drag owner performed it').toBe(true);
+        expect(platform.calls.filter(call => !call.includes(':')))
+            .toEqual(['resume']);
+        expect(platform.calls, 'the route was never addressed directly').not.toContain('moveTo')
+    });
+
+    test('a terminal restore ending a CONVERSION addresses the route directly', async () => {
+        const receipts = {};
+
+        restore  = stubRoutes({focus: true, position: true, resize: true});
+        platform = installPlatform();
+
+        // The default: no drag exists to hand back to, so asking one would succeed against a
+        // stale effect. Both consumers are real and they differ here, so it is declared.
+        const admitted = await NativeVesselTransaction
+            .effectsFor(descriptorFor({receipts}))
+            .reshowVessel({itemId: 'item-1', rect: {x: 10, y: 20}, terminal: true, windowName: 'vessel-1'});
+
+        expect(admitted).toBe(true);
+        expect(receipts.restore.addonRestored, 'no drag owner was consulted').toBeUndefined();
+        expect(platform.calls).toContain('moveTo');
+        expect(platform.calls, 'and the drag was never resumed').not.toContain('resume')
+    });
+
     test('a windowName mismatch refuses the re-show even with every route granted', async () => {
         const receipts = {};
 

--- a/test/playwright/unit/dashboard/DockNativeVesselTransaction.spec.mjs
+++ b/test/playwright/unit/dashboard/DockNativeVesselTransaction.spec.mjs
@@ -274,6 +274,52 @@ test.describe('Neo.dashboard.dock.window.NativeVesselTransaction', () => {
         expect(platform.calls).toContain('resume:40,60')
     });
 
+    test('a source too large to hide behind the target refuses when nothing may shrink it', async () => {
+        const receipts = {};
+
+        restore  = stubRoutes({focus: true, position: true, resize: true});
+        platform = installPlatform();
+        // Bigger than the 800x600 target: it cannot be covered as-is.
+        // `manager.Base#register` refuses an id it already holds rather than replacing it, so the
+        // oversized source has to displace the fixture's window instead of shadowing it.
+        WindowManager.unregister('win-source');
+        WindowManager.register({
+            id         : 'win-source', innerRect: new Rectangle(0, 0, 1200, 900),
+            nativeRoute: ROUTE, outerRect: new Rectangle(0, 0, 1200, 900)
+        });
+
+        const admitted = await NativeVesselTransaction
+            .effectsFor(descriptorFor({geometry: null, receipts}))
+            .parkVessel({itemId: 'item-1', windowName: 'vessel-1'});
+
+        expect(admitted, 'no extent obligation ⇒ no licence to shrink ⇒ refuse').toBe(false);
+        expect(receipts.park.fits).toBe(false);
+        expect(platform.calls, 'refused before any platform effect').toEqual([])
+    });
+
+    test('the same oversized source is ADMITTED when the transaction owes an extent restore', async () => {
+        const receipts = {};
+
+        restore  = stubRoutes({focus: true, position: true, resize: true});
+        platform = installPlatform();
+        // `manager.Base#register` refuses an id it already holds rather than replacing it, so the
+        // oversized source has to displace the fixture's window instead of shadowing it.
+        WindowManager.unregister('win-source');
+        WindowManager.register({
+            id         : 'win-source', innerRect: new Rectangle(0, 0, 1200, 900),
+            nativeRoute: ROUTE, outerRect: new Rectangle(0, 0, 1200, 900)
+        });
+
+        const admitted = await NativeVesselTransaction
+            .effectsFor(descriptorFor({geometry: {height: 900, width: 1200}, receipts}))
+            .parkVessel({itemId: 'item-1', windowName: 'vessel-1'});
+
+        expect(admitted, 'the promise to restore the extent is what licences the shrink').toBe(true);
+        expect(receipts.park.fits).toBe(false);
+        expect(platform.calls.filter(call => !call.includes(':')))
+            .toEqual(['focus', 'resize', 'park', 'focus'])
+    });
+
     test('a windowName mismatch refuses the re-show even with every route granted', async () => {
         const receipts = {};
 

--- a/test/playwright/unit/dashboard/DockNativeVesselTransaction.spec.mjs
+++ b/test/playwright/unit/dashboard/DockNativeVesselTransaction.spec.mjs
@@ -1,0 +1,164 @@
+import {setup} from '../../setup.mjs';
+
+setup({
+    appConfig: {
+        name: 'DashboardDockNativeVesselTransactionTest'
+    },
+    mockLocalStorage: false,
+    mockMain        : false
+});
+
+import {test, expect}          from '@playwright/test';
+import Neo                     from "../../../../src/Neo.mjs";
+import * as core               from "../../../../src/core/_export.mjs";
+import NativeVesselTransaction from '../../../../src/dashboard/dock/window/NativeVesselTransaction.mjs';
+import WindowManager           from '../../../../src/manager/Window.mjs';
+
+/**
+ * The default park / re-show transaction behind `VesselPark`'s three seams.
+ *
+ * The contract under test is the one neither existing consumer expressed: **the authority key set
+ * is a function of the transaction's declared restore obligation.** All ten keys are reported
+ * always; `sourceResizeCapable` gates the refusal only when the transaction owes a geometry
+ * restore. Both directions are asserted, because a witness that only shows the refusal cannot tell
+ * a conditional gate from an unconditional one — which is exactly how the two consumers came to
+ * disagree about what "authorized" means.
+ */
+
+const ROUTE = {nativeHandleKey: 'handle-1', targetWindowId: 'win-source'};
+
+/**
+ * @summary Installs a route resolver whose grant per capability is scripted.
+ *
+ * `resolveNativeRoute` is the engine's own route authority. Stubbing it keeps this spec about the
+ * transaction's decision rather than about the platform's, and the granted map is the only input
+ * that varies between the arms below.
+ * @param {Object} granted `{position, resize, focus}` booleans.
+ * @returns {Function} the previous implementation, for restoration
+ */
+const stubRoutes = granted => {
+    const previous = WindowManager.resolveNativeRoute;
+
+    WindowManager.resolveNativeRoute = ({capability}) => ({
+        capable      : granted[capability] === true,
+        granted      : granted[capability] === true,
+        hasHandle    : true,
+        ownerMatches : true,
+        targetMatches: true
+    });
+
+    return previous
+};
+
+const descriptorFor = ({geometry=null, receipts}) => ({
+    ownerWindowId  : () => 'win-owner',
+    publishReceipt : (key, receipt) => {receipts[key] = receipt},
+    resolveVessel  : () => ({nativeRoute: ROUTE, windowId: 'win-source', windowName: 'vessel-1'}),
+    restoreGeometry: () => geometry,
+    retireVessel   : async () => true,
+    targetWindowId : () => 'win-target'
+});
+
+test.describe('Neo.dashboard.dock.window.NativeVesselTransaction', () => {
+    let restore = null;
+
+    test.afterEach(() => {
+        restore && (WindowManager.resolveNativeRoute = restore);
+        restore = null
+    });
+
+    test('the authority block is the fixed ten keys, in order, whatever the obligation', () => {
+        const receipts = {};
+
+        restore = stubRoutes({focus: true, position: true, resize: false});
+
+        return NativeVesselTransaction.effectsFor(descriptorFor({receipts}))
+            .parkVessel({itemId: 'item-1', windowName: 'vessel-1'})
+            .then(() => {
+                expect(Object.keys(receipts.park.authority), 'ten keys, fixed order').toEqual(
+                    NativeVesselTransaction.authorityKeys
+                );
+                expect(receipts.park.authority.sourceResizeCapable, 'reported even when not required').toBe(false)
+            })
+    });
+
+    test('a position-only park ADMITS a route with no resize capability', async () => {
+        const receipts = {};
+
+        restore = stubRoutes({focus: true, position: true, resize: false});
+
+        const admitted = await NativeVesselTransaction
+            .effectsFor(descriptorFor({geometry: null, receipts}))
+            .parkVessel({itemId: 'item-1', windowName: 'vessel-1'});
+
+        expect(admitted, 'no declared geometry restore ⇒ resize is not a prerequisite').toBe(true);
+        expect(receipts.park.owesResize, 'the obligation is recorded, not inferred').toBe(false)
+    });
+
+    test('a geometry-restoring park REFUSES the same route', async () => {
+        const receipts = {};
+
+        restore = stubRoutes({focus: true, position: true, resize: false});
+
+        const admitted = await NativeVesselTransaction
+            .effectsFor(descriptorFor({geometry: {height: 200, width: 300}, receipts}))
+            .parkVessel({itemId: 'item-1', windowName: 'vessel-1'});
+
+        expect(admitted, 'a promised extent restore makes resize a prerequisite at park').toBe(false);
+        expect(receipts.park.owesResize).toBe(true)
+    });
+
+    test('the park clears any prior restore receipt, so a stale one cannot read as this gesture', async () => {
+        const receipts = {restore: {stale: true}};
+
+        restore = stubRoutes({focus: true, position: true, resize: true});
+
+        await NativeVesselTransaction
+            .effectsFor(descriptorFor({receipts}))
+            .parkVessel({itemId: 'item-1', windowName: 'vessel-1'});
+
+        expect(receipts.restore).toBeNull()
+    });
+
+    test('the re-show converts a content rect to the frame origin moveTo consumes', async () => {
+        const receipts = {};
+
+        restore = stubRoutes({focus: true, position: true, resize: true});
+
+        WindowManager.register?.({id: 'win-source'});
+
+        const effects = NativeVesselTransaction.effectsFor(descriptorFor({receipts}));
+
+        await effects.reshowVessel({itemId: 'item-1', rect: {x: 400, y: 300}, windowName: 'vessel-1'});
+
+        // With no published chrome the offset is zero and the origin passes through unchanged —
+        // the pre-chrome behaviour, asserted so the conversion cannot silently become mandatory.
+        expect(receipts.restore.frame, 'no chrome published ⇒ content origin is the frame origin')
+            .toEqual({x: 400, y: 300})
+    });
+
+    test('a re-show with no finite origin refuses before dispatching', async () => {
+        const receipts = {};
+
+        restore = stubRoutes({focus: true, position: true, resize: true});
+
+        const admitted = await NativeVesselTransaction
+            .effectsFor(descriptorFor({receipts}))
+            .reshowVessel({itemId: 'item-1', rect: null, windowName: 'vessel-1'});
+
+        expect(admitted, 'no origin is a refusal, never a move to NaN').toBe(false);
+        expect(receipts.restore.frame).toBeNull()
+    });
+
+    test('a windowName mismatch refuses the re-show even with every route granted', async () => {
+        const receipts = {};
+
+        restore = stubRoutes({focus: true, position: true, resize: true});
+
+        const admitted = await NativeVesselTransaction
+            .effectsFor(descriptorFor({receipts}))
+            .reshowVessel({itemId: 'item-1', rect: {x: 10, y: 20}, windowName: 'a-different-vessel'});
+
+        expect(admitted).toBe(false)
+    });
+});

--- a/test/playwright/unit/dashboard/DockNativeVesselTransaction.spec.mjs
+++ b/test/playwright/unit/dashboard/DockNativeVesselTransaction.spec.mjs
@@ -12,6 +12,7 @@ import {test, expect}          from '@playwright/test';
 import Neo                     from "../../../../src/Neo.mjs";
 import * as core               from "../../../../src/core/_export.mjs";
 import NativeVesselTransaction from '../../../../src/dashboard/dock/window/NativeVesselTransaction.mjs';
+import Rectangle               from '../../../../src/util/Rectangle.mjs';
 import WindowManager           from '../../../../src/manager/Window.mjs';
 
 /**
@@ -25,7 +26,63 @@ import WindowManager           from '../../../../src/manager/Window.mjs';
  * disagree about what "authorized" means.
  */
 
-const ROUTE = {nativeHandleKey: 'handle-1', targetWindowId: 'win-source'};
+const
+    ROUTE        = {nativeHandleKey: 'handle-1', targetWindowId: 'win-source'},
+    TARGET_ROUTE = {nativeHandleKey: 'handle-target', targetWindowId: 'win-target'};
+
+/**
+ * @summary Registers the two windows the choreography measures, and doubles every platform call.
+ *
+ * The park effect DISPATCHES — focus, optional resize, park-move, refocus, compensate — so a
+ * descriptor alone cannot exercise it. `calls` records the order, which is the contract that
+ * matters: a transaction that moved before it focused would leave the source visibly over the
+ * target for a frame, and only an ordered witness can see that.
+ * @param {Object} [outcomes={}] Per-call boolean results; anything omitted succeeds.
+ * @returns {{calls:String[],restore:Function}}
+ */
+const installPlatform = (outcomes={}) => {
+    Neo.Main       ??= {};
+    Neo.main       ??= {};
+    Neo.main.addon ??= {};
+
+    const
+        calls    = [],
+        previous = {
+            focus   : Neo.Main.windowNativeFocus,
+            moveTo  : Neo.Main.windowNativeMoveTo,
+            resizeTo: Neo.Main.windowNativeResizeTo,
+            addon   : Neo.main?.addon?.DragDrop
+        },
+        answer   = (name, payload) => {
+            calls.push(name);
+            payload && calls.push(`${name}:${payload.x},${payload.y}`);
+            return Promise.resolve(outcomes[name] !== false)
+        };
+
+    WindowManager.register({id: 'win-source', innerRect: new Rectangle(40, 60, 480, 320), outerRect: new Rectangle(40, 60, 480, 320), nativeRoute: ROUTE});
+    WindowManager.register({id: 'win-target', innerRect: new Rectangle(0, 0, 800, 600),   outerRect: new Rectangle(0, 0, 800, 600),   nativeRoute: TARGET_ROUTE});
+
+    Neo.Main.windowNativeFocus    = () => answer('focus');
+    Neo.Main.windowNativeMoveTo   = data => answer('moveTo', data);
+    Neo.Main.windowNativeResizeTo = () => answer('resize');
+    Neo.main.addon.DragDrop = {
+        parkWindowDrag                : data => answer('park', data),
+        resumeWindowDrag              : data => answer('resume', data),
+        retireWindowDragOrphanRecovery: () => answer('retireOrphan')
+    };
+
+    return {
+        calls,
+        restore() {
+            Neo.Main.windowNativeFocus    = previous.focus;
+            Neo.Main.windowNativeMoveTo   = previous.moveTo;
+            Neo.Main.windowNativeResizeTo = previous.resizeTo;
+            Neo.main.addon.DragDrop       = previous.addon;
+            WindowManager.unregister('win-source');
+            WindowManager.unregister('win-target')
+        }
+    }
+};
 
 /**
  * @summary Installs a route resolver whose grant per capability is scripted.
@@ -60,17 +117,21 @@ const descriptorFor = ({geometry=null, receipts}) => ({
 });
 
 test.describe('Neo.dashboard.dock.window.NativeVesselTransaction', () => {
-    let restore = null;
+    let platform = null,
+        restore  = null;
 
     test.afterEach(() => {
         restore && (WindowManager.resolveNativeRoute = restore);
-        restore = null
+        platform?.restore();
+        platform = null;
+        restore  = null
     });
 
     test('the authority block is the fixed ten keys, in order, whatever the obligation', () => {
         const receipts = {};
 
-        restore = stubRoutes({focus: true, position: true, resize: false});
+        restore  = stubRoutes({focus: true, position: true, resize: false});
+        platform = installPlatform();
 
         return NativeVesselTransaction.effectsFor(descriptorFor({receipts}))
             .parkVessel({itemId: 'item-1', windowName: 'vessel-1'})
@@ -85,7 +146,8 @@ test.describe('Neo.dashboard.dock.window.NativeVesselTransaction', () => {
     test('a position-only park ADMITS a route with no resize capability', async () => {
         const receipts = {};
 
-        restore = stubRoutes({focus: true, position: true, resize: false});
+        restore  = stubRoutes({focus: true, position: true, resize: false});
+        platform = installPlatform();
 
         const admitted = await NativeVesselTransaction
             .effectsFor(descriptorFor({geometry: null, receipts}))
@@ -98,7 +160,8 @@ test.describe('Neo.dashboard.dock.window.NativeVesselTransaction', () => {
     test('a geometry-restoring park REFUSES the same route', async () => {
         const receipts = {};
 
-        restore = stubRoutes({focus: true, position: true, resize: false});
+        restore  = stubRoutes({focus: true, position: true, resize: false});
+        platform = installPlatform();
 
         const admitted = await NativeVesselTransaction
             .effectsFor(descriptorFor({geometry: {height: 200, width: 300}, receipts}))
@@ -111,7 +174,8 @@ test.describe('Neo.dashboard.dock.window.NativeVesselTransaction', () => {
     test('the park clears any prior restore receipt, so a stale one cannot read as this gesture', async () => {
         const receipts = {restore: {stale: true}};
 
-        restore = stubRoutes({focus: true, position: true, resize: true});
+        restore  = stubRoutes({focus: true, position: true, resize: true});
+        platform = installPlatform();
 
         await NativeVesselTransaction
             .effectsFor(descriptorFor({receipts}))
@@ -123,9 +187,8 @@ test.describe('Neo.dashboard.dock.window.NativeVesselTransaction', () => {
     test('the re-show converts a content rect to the frame origin moveTo consumes', async () => {
         const receipts = {};
 
-        restore = stubRoutes({focus: true, position: true, resize: true});
-
-        WindowManager.register?.({id: 'win-source'});
+        restore  = stubRoutes({focus: true, position: true, resize: true});
+        platform = installPlatform();
 
         const effects = NativeVesselTransaction.effectsFor(descriptorFor({receipts}));
 
@@ -140,7 +203,8 @@ test.describe('Neo.dashboard.dock.window.NativeVesselTransaction', () => {
     test('a re-show with no finite origin refuses before dispatching', async () => {
         const receipts = {};
 
-        restore = stubRoutes({focus: true, position: true, resize: true});
+        restore  = stubRoutes({focus: true, position: true, resize: true});
+        platform = installPlatform();
 
         const admitted = await NativeVesselTransaction
             .effectsFor(descriptorFor({receipts}))
@@ -150,10 +214,71 @@ test.describe('Neo.dashboard.dock.window.NativeVesselTransaction', () => {
         expect(receipts.restore.frame).toBeNull()
     });
 
+    test('the park focuses BEFORE it moves, and refocuses after', async () => {
+        const receipts = {};
+
+        restore  = stubRoutes({focus: true, position: true, resize: true});
+        platform = installPlatform();
+
+        const parked = await NativeVesselTransaction
+            .effectsFor(descriptorFor({receipts}))
+            .parkVessel({itemId: 'item-1', windowName: 'vessel-1'});
+
+        expect(parked).toBe(true);
+        // Order is the contract: a move before the focus leaves the source visibly over the target
+        // for a frame, and no settled-state assertion can see that.
+        expect(platform.calls.filter(call => !call.includes(':')))
+            .toEqual(['focus', 'park', 'focus']);
+        expect(receipts.park.parked).toBe(true);
+        expect(receipts.park.requested, 'parks at the target origin').toEqual({x: 0, y: 0})
+    });
+
+    test('a geometry-restoring park resizes between the focus and the move', async () => {
+        const receipts = {};
+
+        restore  = stubRoutes({focus: true, position: true, resize: true});
+        platform = installPlatform();
+
+        await NativeVesselTransaction
+            .effectsFor(descriptorFor({geometry: {height: 320, width: 480}, receipts}))
+            .parkVessel({itemId: 'item-1', windowName: 'vessel-1'});
+
+        expect(platform.calls.filter(call => !call.includes(':')))
+            .toEqual(['focus', 'resize', 'park', 'focus']);
+        expect(receipts.park.resized).toBe(true)
+    });
+
+    test('a refused refocus compensates the move and REFUSES the park', async () => {
+        const receipts = {};
+
+        restore  = stubRoutes({focus: true, position: true, resize: true});
+        platform = installPlatform();
+
+        // The first focus succeeds and the refocus does not: one call, two answers, so the double
+        // flips after the move rather than refusing focus outright.
+        let focusCalls = 0;
+        Neo.Main.windowNativeFocus = () => {
+            platform.calls.push('focus');
+            return Promise.resolve(++focusCalls === 1)
+        };
+
+        const parked = await NativeVesselTransaction
+            .effectsFor(descriptorFor({receipts}))
+            .parkVessel({itemId: 'item-1', windowName: 'vessel-1'});
+
+        expect(parked, 'a compensated move is a refusal — nothing is parked').toBe(false);
+        expect(receipts.park.compensated).toBe(true);
+        expect(receipts.park.parked).toBe(false);
+        expect(receipts.park.refusedAt).toBe('refocus');
+        // Compensation returns the source to where it started, not to the park origin.
+        expect(platform.calls).toContain('resume:40,60')
+    });
+
     test('a windowName mismatch refuses the re-show even with every route granted', async () => {
         const receipts = {};
 
-        restore = stubRoutes({focus: true, position: true, resize: true});
+        restore  = stubRoutes({focus: true, position: true, resize: true});
+        platform = installPlatform();
 
         const admitted = await NativeVesselTransaction
             .effectsFor(descriptorFor({receipts}))


### PR DESCRIPTION
Resolves #18533
Related: #18304

🌿 Two consumers had each written the park transaction, agreed on its contract without ever agreeing to it, and drifted; after this, neither of them can hold a private opinion about what "authorized" means.

`VesselPark` requires three strict effects and implements none, so both consumers wrote the transaction. They reached the same contract by different routes — the same authority block in the same key order, the same route-admission pair, the same fail-closed gate — and then diverged, which is worse than a copy: a copy at least agrees. The default carries the rule that was only ever implicit: **the authority key set is a function of the transaction's declared restore obligation.** Ten keys reported always; `resize` gates the refusal only where an extent was promised back.

**−211 consumer code lines** (Workstation 1323→1211, Demo B 2615→2505) against one owner in `src/`. `sourceResizeCapable` now appears in exactly **one file repo-wide**.

Evidence: L2 (every AC is model-level decision logic, fully covered by the unit tier at exact head; the two consumers' own witness suites are the integration evidence) → L2 required. Residual: none on this close target. #18460's remaining Ledger rows stay open and are not claimed here.

`agent-preflight: not hosted here` (no such npm script; exit 1); the baseline `PR body`, `Substrate size`, `Source comment archaeology` and `PR base` jobs carry its checks. §3.1 class: `capability → feat` for the default, `zero-delta → refactor` for the adoptions.

## AC Evidence

| AC | Disposition |
|---|---|
| AC-1 — a default park/re-show transaction lives in `src/dashboard/dock/window/`, and `VesselPark`'s three seams stay overridable | **CI-covered.** `NativeVesselTransaction.mjs`, sibling to `VesselPark` (Stage-1 structural fast-path: ten siblings incl. `VesselPark` 430, `VesselEmbodiment` 562). It performs the full choreography — focus → optional resize → move → refocus → compensate — not just the verdict. `VesselPark.mjs:68`'s throw is untouched and still catches partial override. Held **no state and no host**: `#18399` built the arbiter free of native-window knowledge and AC-5 forbids putting it back, so a descriptor closes over the four measured host-varying inputs instead. |
| AC-2 — the receipt shape has **one** definition; `sourceResizeCapable` gated iff a geometry restore is declared | **CI-covered, and checkable rather than asserted.** `grep -rn sourceResizeCapable src/ apps/ examples/` returns **one file** — the owner. Both consumers' authority blocks now come from `describeAuthority`. The obligation gate is witnessed in **both** directions. |
| AC-2b — the behaviour change is Workstation-side; `Workspace.spec.mjs:752` stays green; a new arm shows the conditional *admitting*; both directions or it is unobserved | **Met, with its premise corrected.** Measuring found Workstation's park gate **already** conditional (`:1889` refuses on `needsResize && !granted`, a fit test — the cited `sourceResizeCapable` is the receipt *report*, never consulted by the refusal), so no Workstation behaviour change occurs. Amended in the ticket with the measurement. The conditionality was genuinely *unobserved*, and now is: two arms, admit and refuse, on the same route. |
| AC-3 — both consumers adopt; what either keeps is named with its product reason | **Met.** Demo B: 3/3/3 lines (was 110/41/3) — fully adopted. Workstation: re-show 7 (was 142), dispose 10 (was 21), **park kept at 194 and named** — its native-titlebar paths are product policy (an OS titlebar drag carries no user activation, so a main-window target parks nothing), and absorbing them needs three policy hooks on a five-member descriptor, which is a default becoming a configuration language. Its authority block was *not* a product reason and no longer duplicates. |
| AC-4 — existing witnesses stay green incl. `DemoBWorkspace.spec.mjs:1182`; mutation-proven | **CI-covered + controls.** Demo B **69/69**, Workstation **43/43**, full unit tier **3736 passed / 0 failed**, all unchanged. Four mutation controls in § Test Evidence. |
| AC-5 — no new native-window capability API | **Met.** Zero new `Neo.Main` methods and zero new addon methods; the default composes `resolveNativeRoute`, `windowNativeFocus`, `windowNativeResizeTo`, `windowNativeMoveTo`, `parkWindowDrag`, `resumeWindowDrag` — all pre-existing. No lifecycle, no registry. |

## Deltas from ticket

- **AC-2b's premise was falsified during implementation and amended in the ticket, not worked around.** It described a Workstation behaviour change that cannot occur. Detail: [IC_kwDODSospM8AAAABTdhWNA](https://github.com/neomjs/neo/issues/18533#issuecomment-5600990772).
- **Row 1's mechanism, not its outcome.** *"Satisfies them when a consumer supplies nothing"* read literally needs `VesselPark` to hold a host. It deliberately does not, so the default is a factory: a consumer inherits a working transaction without re-deriving it. Flagged before building: [IC_kwDODSospM8AAAABTd8pdg](https://github.com/neomjs/neo/issues/18533#issuecomment-5601438070).
- **Three divergences were omissions and Demo B inherits fixes for all three.** The content→frame origin conversion (`win.moveTo` positions the *frame*; Demo B had **zero** window-frame chrome reads against a positive control of 18 `manager.Window` reads, so a real window with chrome landed short by exactly its own offset); orphan-recovery *retirement* on dispose, which it never did, leaving a predecessor effect owning a window that no longer exists; and the resize capability it never reported.
- **The fourth divergence is real, and only measuring separated it from the other three.** A terminal restore ending a **drag** asks the addon still owning the gesture before addressing the route; one ending a **conversion** has no drag to hand back to. Asking a nonexistent owner would succeed against a stale effect; skipping a live one would make this a second writer. So `terminalRestoreOwner` is *declared*, both readings witnessed. I had a clean three-for-three pattern and it stopped exactly here.
- **The cover precondition is derived, not a second policy.** One consumer refused an oversized source, the other shrank it. Read through the obligation it is one rule: only a transaction that promised to restore an extent may change it. Both keep their observed behaviour with neither named the reference.
- **Two bookkeeping releases were made unable to fail what they follow**, after making them unconditional cost a passing suite 30 tests in: an unstubbed release threw and turned a *completed* restore into a refusal — the lost-success-after-an-await the contract forbids.
- **Platform payloads split.** The addon owns a *named* drag and needs the name; `Neo.Main`'s window calls address the route alone. Sending it to both worked and still put a field the platform ignores into an exactly-asserted payload.
- **Out of scope, noted:** #18460's other three Ledger rows, and the `kind` field in the pinned key set (@neo-opus-grace's #18529). Not touched.

## Test Evidence

Outside-CI evidence only — the controls, since AC-4 says mutation-proven and a suite that passes on first write is an expected-shape match.

- **Four mutation controls, each reddening exactly the arm that owns it.** Gate made unconditional → *"a position-only park ADMITS a route with no resize capability"* reds. Pre-move focus removed → *"the park focuses BEFORE it moves"* reds. Fit clause dropped → *"a source too large to hide behind the target refuses"* reds. Each restored to green afterwards.
- **A regression the controls did not catch, and the suite did.** Making the orphan-recovery acknowledgement unconditional passed all 14 of the default's own arms and broke Demo B's suite 30 tests in. My arms could not see it because they stub the addon; only the consumer that *never arms recovery* could. Recorded because it is the argument for adopting in both consumers inside one PR rather than trusting the owner's spec.
- **The chrome finding survived a proxy that contradicted it.** Demo B has **16** `chrome` references — more than Workstation's 11 — which read as refuting the hypothesis. Reading them instead of counting them: all 16 are *tab* chrome and *source-drag* chrome. The window-frame pattern with a positive control gives Demo B **0** against `manager.Window` **18**, and Workstation exactly **1**, at the #18514 fix.
- `git grep -c sourceResizeCapable` across `src/ apps/ examples/` → one file. That is AC-2 as a measurement.
- Guards: `check-ticket-archaeology` clean on all touched files; `check-file-sizes --fix --base origin/dev` 0 violations with both baselines ratcheted **down** and diffed key-by-key against dev (4 entries in, 4 out, none dropped, two changed).

## Post-Merge Validation

- [ ] `DemoBCrossWindowDragNL` and the Workstation cross-window e2e journeys exercise the real platform, where the frame-origin conversion is **not** a no-op. The unit harnesses publish no window chrome, so their coordinates are unchanged by design — a rendered run is what shows Demo B's corrected placement.
- [ ] Demo B now retires orphan recovery on dispose. Nothing in-repo armed it there, so the release is a no-op today; a rendered tear-out is what proves the pairing.

## Commits

- `5fffbdec90` — the default, host-free, and the obligation contract.
- `152bcc4ba9` — the park performs the choreography, not just the verdict.
- `e09c640cf2` — the cover precondition falls out of the obligation.
- `911fcedbcb` — Demo B adopts; three fixes inherited.
- `bb9787713d` — the re-show restores an extent and compensates its failure.
- `2cac0f729a` · `d120a6d8ae` — baselines banked, not left as headroom.
- `55fff40713` — Workstation adopts re-show and dispose; park kept and named.

Authored by Vega (Opus 5, Claude Code). Session 206b8400-7fe8-472e-8018-446e550b784b.
