### PR TITLE
docs(dock): the adoption guide teaches the declarative path a real app takes (#18479)

### DIFF
--- a/learn/guides/uibuildingblocks/DockLayouts.md
+++ b/learn/guides/uibuildingblocks/DockLayouts.md
@@ -183,24 +183,29 @@ of the guide series this page fronts. Once you extend the class, the adoption su
 1. **Extend `Neo.dashboard.dock.Workspace`.** The engine class owns the committed `dockModel`, the pure reducer
    (`applyDockZoneOperation` — `Operations.applyOperation` over the current document), the deferred, promise-chained
    re-projection (`onDockZoneDocumentChange` → `projection.LayoutAdapter` → `projection.Reconciler`, bracketed by FLIP
-   motion) and the in-window cross-zone drop path. Your subclass overrides `resolvePane(itemId, item)` and, when it has
-   them, the handful of hooks for owner-preserved panes, chrome that syncs on every re-projection, and extra projection
-   options. `examples/dashboard/dock/MainContainer.mjs` is the minimal consumer.
-2. **Seed the document, mount the first shell.** The class owns the loop, not your boot state. Your subclass supplies
-   the initial committed `dockModel` before the first projection — assign it in `construct` (restore a saved layout,
-   or clone your default document) — and mounts the initial shell itself by placing `this.projectDockModel()` into its
-   items, at `dockShellIndex` when chrome precedes it. Every re-projection after that is the engine's job; the
-   reconciler refuses to run without that first shell, loudly. Two prerequisites travel with this step: keep a real
-   `Neo.container.Viewport` as the application root and compose the dock workspace as its flex child — never borrow
-   Viewport ownership through `additionalThemeFiles`. `DockWorkspace` already carries `'Neo.dashboard.Container'`;
-   if your subclass declares its own theme list, repeat that genuine workspace dependency. The FLIP motion rides the
-   `DockFlip` main-thread addon and degrades to instant landing when it is absent.
-3. **Register your panes.** Each item's key is the stable identity your resolver maps to a live instance (or a
-   serializable `blueprint` for creation-from-saved-state). `pinnable` and `movable` are enforced at the operation
-   layer — a `pinnable: false` item refuses `setItemAutoHidden` in the model, not in your UI code. `closable` is a
-   declared forward contract whose close-routing enforcement has not landed yet; the
+   motion) and the in-window cross-zone drop path. `examples/dashboard/dock/MainContainer.mjs` is the minimal consumer.
+2. **Declare `panes` and `zones`.** Two plain static configs, and they are the whole boot surface: `panes` is a keyed
+   catalog of ordinary component configurations, `zones` is where those keys begin. The class lowers them into the
+   committed document and mounts the first shell itself — you write no constructor, no node-id table, no mount call.
+   Two prerequisites still travel with this step: keep a real `Neo.container.Viewport` as the application root with the
+   workspace as its flex child, and if your subclass declares its own `additionalThemeFiles`, repeat the genuine
+   `'Neo.dashboard.Container'` dependency. The FLIP motion rides the `DockFlip` main-thread addon and degrades to
+   instant landing when it is absent.
+3. **The pane key is your reference.** A key is the item's identity in the document *and* the `reference` the engine
+   stamps onto the projected pane — so `getReference('editor')`, a view controller, and `data-ref="editor"` in the DOM
+   all reach the same live component, and you maintain no second name for it. A pane declaration is an ordinary
+   component config: a registered `module`, an `ntype`, or a lazy `module: () => import(…)` that loads on first
+   activation. `pinnable` and `movable` are enforced at the operation layer — a `pinnable: false` item refuses
+   `setItemAutoHidden` in the model, not in your UI code. `closable` is a declared forward contract whose close-routing
+   enforcement has not landed yet; the
    [adoption guide](DockLayoutsAdoption.md#decision-3--policies-live-in-the-model-not-in-your-ui) keeps that split
    explicit.
+
+   **The advanced paths remain, demoted rather than removed.** A consumer that already owns a valid document supplies
+   it as `dockModel` and it takes precedence over `zones`. `resolvePane(itemId, item)` is still the extension point for
+   application-owned instances or custom configs, and `dockShellIndex` / `dockProjectionConfig` / `dockHostReference`
+   place the shell when persistent chrome shares the root. None of them is the starting path any more, and reaching for
+   one before you have tried the declarations is how consumers used to end up re-implementing the host loop.
 4. **Give vessels a render target.** Tear-out windows load a viewport that is deliberately empty — a render target
    that joins the SharedWorker session; detached panes arrive at runtime. The canonical example is the cross-window
    demo's `?popout` boot branch (`examples/dashboard/crossWindow/Viewport.mjs`), whose own JSDoc says it all: "This

--- a/learn/guides/uibuildingblocks/DockLayoutsAdoption.md
+++ b/learn/guides/uibuildingblocks/DockLayoutsAdoption.md
@@ -107,10 +107,76 @@ hook, including after `super.onConstructed()`. Mounting still goes through the e
 active document or the captured pane definitions; these are plain initial configs, not live
 declaration bindings.
 
-A valid supplied `dockModel` takes precedence over `zones`. This lets a caller restore a saved
-document while supplying the current runtime pane configurations. Invalid supplied documents and
-invalid declarations fail visibly with paths; they do not silently fall back to another layout.
-With neither declarations nor a document, the existing empty-workspace behavior remains available.
+### A supplied document wins, and that is the whole restore story
+
+Most real applications do not start empty on the second visit. They have a document already — from
+storage, from a server, from the perspective the user left open — and they still want their pane
+configurations declared in one readable place. Both at once is the normal case, not an advanced one:
+
+```javascript readonly
+class Workspace extends DockWorkspace {
+    static config = {
+        className: 'MyApp.view.Workspace',
+        panes    : {editor: {module: EditorPanel, header: {text: 'Editor'}},
+                    preview: {module: PreviewPanel, header: {text: 'Preview'}}},
+        // The declared default: side by side.
+        zones    : {center: {orientation: 'horizontal', children: ['editor', 'preview']}}
+    }
+
+    construct(config) {
+        super.construct(config);
+
+        // A restored document — deliberately NOT the arrangement declared above.
+        const saved = MyApp.storage.readLayout();
+
+        saved && (this.dockModel = saved)
+    }
+}
+```
+
+The restored arrangement is what mounts. `zones` is the default for a first visit and nothing more;
+a valid `dockModel` supersedes it, while `panes` continues to supply the live component
+configurations the restored document's keys resolve against. That separation is the point — the
+document carries *where things are*, your declaration carries *what they are*, and only one of them
+needs to survive a release.
+
+Invalid input on either side fails visibly with the authored path rather than falling back to some
+other layout, so a typo in a declaration and a corrupt saved document produce a complaint you can
+act on instead of a plausible-looking wrong arrangement.
+
+### Initial means once — and a later assignment will not undo the user's work
+
+This is the contract most worth internalising, because the alternative is a class of bug that only
+appears in front of a customer. `panes` and `zones` are consumed **once**, at first creation. After
+that the committed document is the truth, and the user is editing it.
+
+So a later assignment does not recompile anything:
+
+```javascript readonly
+// The user has dragged Preview into its own edge band. Then some code does this:
+workspace.zones = {center: {items: ['editor']}}
+```
+
+The committed document does not move. Not the node graph, not the tab order, not the active item —
+the arrangement the user built is still exactly what they see. The assignment changes a *future*
+default, never the current layout.
+
+That is worth stating as loudly as the guide can, because the intuitive reading is the opposite one.
+If you want to change the live arrangement, you use a documented operation and it commits through the
+reducer like every other change:
+
+```javascript readonly
+const {errors} = workspace.applyDockZoneOperation({
+    operation   : 'moveItem',
+    itemId      : 'preview',
+    targetNodeId: someTabsNodeId
+});
+```
+
+**Altering a future default and changing the current layout are two different acts**, and the engine
+refuses to conflate them. A workspace that silently re-seeded itself whenever a config was touched
+would throw away a user's arrangement on a re-render, which is precisely the failure this contract
+exists to make impossible.
 
 **Keep the application root and workspace separate.** Your app still gets a real
 `Neo.container.Viewport`, with the workspace as its flex child:
@@ -151,6 +217,56 @@ The pane key is its dock item identity, and the projection lowers it onto the pa
 Nothing is persisted for that — name a `reference` on the record only if you want a different one.
 `header.text` supplies the catalog title. Runtime loaders, bindings and instances stay outside the
 JSON document.
+
+Here is what all of that looks like in one catalog — a lazy surface, two keys sharing a class, and
+policy travelling with the record rather than with your UI:
+
+```javascript readonly
+panes: {
+    // Loads on first activation, not at boot. An auto-hidden pane loads when its rail is revealed.
+    reports: {module: () => import('./ReportsPanel.mjs'), header: {text: 'Reports'}},
+
+    // Two keys, ONE class, different configuration — and two independent component identities.
+    logsApp : {module: LogPanel, header: {text: 'App log'},  source: 'app'},
+    logsHttp: {module: LogPanel, header: {text: 'HTTP log'}, source: 'http'},
+
+    // Policy is a property of the item, so every caller meets the same refusal.
+    console: {module: ConsolePanel, header: {text: 'Console'}, closable: false, movable: false}
+}
+```
+
+`logsApp` and `logsHttp` are not one component shown twice. They are two instances that keep their
+own scroll position, their own bindings and their own state through tab moves and rail transitions —
+which is the behaviour you want and the one a keyed catalog gives you for free. Their keys are also
+their references, so a controller reaches each by the name you already wrote.
+
+Notice what does *not* appear in that catalog: no ids, no `reference`, no title field. The key is the
+identity, `header.text` is the label, and the persisted record for a pane like `reports` is exactly
+`{title: 'Reports'}` — one field. Everything else on those declarations is ordinary runtime component
+config that never enters the document.
+
+**Computing the initial declaration.** Real applications rarely know their opening arrangement
+statically — it depends on the user's role, their last session, the data that loaded. Compute it in
+either construction hook; the effective values are captured once, after the synchronous `construct`
+and `onConstructed` chains have run:
+
+```javascript readonly
+construct(config) {
+    super.construct(config);
+
+    const tabs = ['editor', 'preview'];
+
+    MyApp.user.canAudit && tabs.push('audit');
+
+    this.zones = {center: {items: tabs}}
+}
+```
+
+That is a **static choice made from data you have at construction**, and it is worth being precise
+about what it is not: it is not a live subscription. If the user's permissions change later, this
+declaration does not re-run and the arrangement does not rearrange itself — see *Initial means once*
+above. Recomputing an opening layout and reacting to a change are different problems, and only the
+first one is solved here.
 
 Closing a declared pane removes its current catalog record and retires its component. The initial
 declaration survives, so a control can reopen it without rebuilding the catalog:
@@ -280,6 +396,69 @@ The deeper mechanics of the journey (claims, vessels, conversion, reintegration)
 needs tear-out today, read the workstation's composition first. The pending engine leaf will shrink the generic
 admission, document-mutation and window-lifecycle glue; the render target remains yours, as do product-specific
 vessel embodiment, open/close and grant policy.
+
+## Migrating a consumer that already does this by hand
+
+If you adopted docking before the declarations existed, you wrote the boot half yourself: a document
+built in `construct`, a `resolvePane` switch mapping ids to components, often a cache so the switch
+did not rebuild a live pane on every projection, and a hand-placed first shell. That code worked. It
+is also the code the engine now owns, and the migration is mostly deletion.
+
+**Before** — every consumer wrote some version of this:
+
+```javascript readonly
+construct(config) {
+    super.construct(config);
+
+    this.dockModel = structuredClone(myDefaultDocument);   // hand-maintained node ids
+    this.paneCache = {};                                   // so resolvePane stops rebuilding
+}
+
+resolvePane(itemId, item) {
+    if (this.paneCache[itemId]) {
+        return this.paneCache[itemId]
+    }
+
+    switch (itemId) {                                      // a second registry of the same names
+        case 'editor' : return this.paneCache[itemId] = Neo.create(EditorPanel,  {…});
+        case 'preview': return this.paneCache[itemId] = Neo.create(PreviewPanel, {…});
+    }
+}
+
+createItems() {                                            // mounting the first shell by hand
+    return [this.projectDockModel()]
+}
+```
+
+**After:**
+
+```javascript readonly
+static config = {
+    panes: {editor : {module: EditorPanel,  header: {text: 'Editor'}},
+            preview: {module: PreviewPanel, header: {text: 'Preview'}}},
+    zones: {center: {orientation: 'horizontal', children: ['editor', 'preview']}}
+}
+```
+
+**What disappears, and why it was never yours.** The hand-maintained document goes because `zones`
+lowers into one, generating the structural ids you used to keep in your head. The `resolvePane`
+switch goes because the catalog already maps keys to configurations — it was a second registry of
+the same names, and two registries drift. The cache goes because the engine preserves pane identity
+across re-projections itself; the cache existed to compensate for a resolver being called repeatedly,
+which is the engine's problem and not yours. The `createItems` mount goes because the class mounts
+its own first shell.
+
+**What legitimately stays application code.** Perspective toolbars, tour or replay drivers, saved
+layout collections, storage adapters, anything that consumes the committed document — none of that
+is layout authoring and none of it is absorbed. The minimal example keeps its perspective toolbar and
+its tour adapter for exactly this reason, and they are unchanged by the migration. If you have a
+genuine reason to own a pane's construction, `resolvePane` is still there; the difference is that it
+is now an extension point you reach for deliberately rather than the price of entry.
+
+**Do it in one commit and read the diff.** The satisfying part of this migration is that the diff is
+almost entirely red, and the arrangement on screen is identical afterwards — which is the check worth
+making. If your layout looks different after migrating, your hand-built document and your declaration
+disagreed about something, and that disagreement was already in your code.
 
 ## The hooks ladder — adopt at the depth your app needs
 


### PR DESCRIPTION
Resolves #18479

The adoption guide's normative corrections had already landed with the host, so what was missing was the explanation. It now teaches the path a real application takes: declare ordinary panes, compute an opening arrangement, restore a document you already own, and stop maintaining plumbing the engine owns. `DockLayouts.md`'s front-door checklist no longer sends readers down the manual path first.

Evidence: L3 (the standalone example driven in local Chromium — declared keys observed reaching the DOM as `data-ref`, the lowered document read back, the post-boot assignment contract measured) → L3 required (AC-2/AC-3 are runtime-observable). Residual: AC-6 Mermaid rasterisation, Residual-Owner: #18548.

> ⚠️ **CORRECTED after merge — the pointer was wrong, caught by @neo-opus-grace at review.** This line read `Residual-Owner: #18474`. That ticket is *"A dock arrangement should be declared, not programmed"*; it does not own Mermaid rendering and would have closed with the residual still open and nobody looking for it. The surviving owner is **#18548**, which now names this PR and #18543 explicitly and carries both render checks.
>
> The rule this broke: a `Residual-Owner` must be a **surviving ticket that owns the residual's cause** — not a person, and not a ticket that merely sits nearby in the same epic. #18543 hit the other half of the same rule on the same residual, naming *"this PR's reviewer"* as owner. The original pointer is quoted here rather than silently swapped.

## AC Evidence

| AC | Evidence |
|---|---|
| AC-1 — complete stage-one guide, same route, normative semantics preserved | Route untouched: `learn/tree.json:75` and `seo/generate.mjs:105` unchanged. Four sections added, no competing guide. |
| AC-2 — lazy pane, header/policy, two same-class panes, computed initial selection | outside-CI: ran the example; all ten declared keys reach the DOM as `data-ref`, and the lowered record for a simple pane is exactly `{title}`. Same-class pair is CI-covered by `DockWorkspaceAuthoring.spec.mjs` *"two keys load the same lazy module on their own tab and rail activation"*. The guide documents observed behaviour and states outright that a computed declaration is **not** a live subscription. |
| AC-3 — supplied-document precedence + post-move assignment | CI-covered: `DockWorkspaceFirstProjection.spec.mjs:195` supplies a document with a deliberately invalid `zones` and asserts the document wins — **6 passed** at head. Post-boot half measured live: assigning a different `zones` after boot left the committed document byte-identical (node graph, tab order, active item) and the UI unchanged. |
| AC-4 — concrete manual-to-declarative migration | Before/after in the guide: hand-built document, `resolvePane` switch, pane cache and manual first-shell mount all go; perspective toolbars, tour drivers and storage adapters explicitly stay as application code. |
| AC-5 — `DockLayouts.md` stops teaching manual adoption as default | Step 2 was *"Seed the document, mount the first shell"*; it is now *"Declare `panes` and `zones`"*. Advanced paths (supplied `dockModel`, `resolvePane`, shell placement) kept and demoted, not deleted. |
| AC-6 — render-verify the whole guide in the portal | **RESIDUAL — not met.** See Post-Merge Validation. |
| AC-7 — no later-stage APIs, no tracker archaeology, no generated SEO commits | `git diff | grep '#[0-9]{3,}'` → none. No `sitemap.xml` / `llms.txt` in the diff. No perspectives/persistence/workspaces/bound-panes APIs taught. |

## Deltas from ticket

**The `kind` retirement landed mid-lane and improved the story.** My first grounding read the committed item as `{kind, title}`; after that merge it is exactly `{title}`. I re-took the reading rather than writing against the stale one, and the guide now makes the one-field record a teaching point.

**AC-1's "rewrite" is an extension, not a replacement.** The existing Decisions 1–5 were already accurate and declarative — the normative half had shipped. Rewriting accurate prose to satisfy the word "rewrite" would have been churn; the four missing explanations were added instead.

## Test Evidence

- `DockWorkspaceFirstProjection.spec.mjs` — **6 passed** at head, including the supplied-document precedence arm behind AC-3.
- **Live grounding, not inferable from CI:** ten declared pane keys observed as `data-ref` in the running example; the lowered document's generated structural ids (`tabs-terminal`, `tabs-logs`, `tabs-inspector`) read back from a `children: ['terminal','logs']` declaration; a post-boot `zones` assignment measured as a no-op against the committed document.
- `check-relative-links` green (169 links, 159 files); whitespace green. `ai:lint-guides` is Brain-hosted and does not resolve in this corpus — stated, not skipped.

## Post-Merge Validation

- [ ] **AC-6 Mermaid rasterisation.** The Browser pane is hidden in my session, so layout never runs: `scrollHeight` stays 720px against 29k characters of loaded content and no SVG is produced. The container is present with its source consumed, so it is wired into the pipeline — but the output is unverified and I am not claiming it renders. The diagram is pre-existing and untouched by this diff. Render-check routed to @neo-opus-grace, who holds the sibling tutorial.
- [ ] The sibling tutorial links into this guide once it lands; the cross-link belongs in the later of the two PRs.

## Commits

- `82c1482286` — the four missing explanations, plus the front-door section in `DockLayouts.md`

Authored by Ada (Claude Opus 5, Claude Code). Session 79638906-f00c-46ed-9770-80d1c3d35278.


