### PR TITLE
The view declares its topology bar; the controller fills it

### DIFF
--- a/apps/workstation/view/Workspace.mjs
+++ b/apps/workstation/view/Workspace.mjs
@@ -380,6 +380,58 @@ class Workspace extends DockWorkspace {
     #feedIntervalId = null
 
     /**
+     * @summary Declares the topology bar: explicit save/close, the Group's undo/redo, and the
+     * reference through which its controller fills the per-workspace recovery buttons.
+     *
+     * The structure is the view's; the live membership is the controller's. A factory rather than a
+     * module because the undo/redo formatters need this instance — `state.Provider#createBinding`
+     * calls a formatter with the provider as scope, so a `static config` on a separate toolbar class
+     * could not reach {@link #topologyGroupId}. Same reason `createStatusBar` is a factory.
+     *
+     * Handlers are declarative names resolved through the configured controller chain, so nothing
+     * here closes over the controller instance.
+     * @returns {Object}
+     * @protected
+     */
+    createTopologyBar() {
+        let me = this;
+
+        return {
+            ntype: 'toolbar',
+            // Undo and redo are the Group's, and they read it WHERE IT LIVES. `getData` resolves to
+            // that leaf's own `core.Config`, so the formatter registers it and re-runs on change —
+            // no mirror to keep in step with `setHistoryDepth`, which publishes without a commit.
+            // A retired or unknown Group resolves to nothing and reads disabled, so the control
+            // fails closed on the same expression rather than through a separate teardown.
+            actions: [{
+                action     : 'undo',
+                bind       : {disabled: () => TransactionManager.getProvider(me.topologyGroupId)?.getData('canUndo') !== true},
+                handler    : () => TransactionManager.undo({groupId: me.topologyGroupId}),
+                iconCls    : 'fa fa-rotate-left',
+                showOnFocus: false,
+                text       : 'Undo'
+            }, {
+                action     : 'redo',
+                bind       : {disabled: () => TransactionManager.getProvider(me.topologyGroupId)?.getData('canRedo') !== true},
+                handler    : () => TransactionManager.redo({groupId: me.topologyGroupId}),
+                iconCls    : 'fa fa-rotate-right',
+                showOnFocus: false,
+                text       : 'Redo'
+            }],
+            cls : ['workstation-topologybar'],
+            flex: 'none',
+            // Exactly `WorkspaceController.authoredTopologyButtonCount` items: the controller
+            // replaces everything after them and must not be able to destroy these.
+            items : [
+                {ntype: 'button', handler: 'saveTopology',  text: 'Save workspace'},
+                {ntype: 'button', handler: 'closeTopology', text: 'Close workspace'}
+            ],
+            layout   : {ntype: 'flexbox', align: 'center', direction: 'row', wrap: 'wrap'},
+            reference: 'topology-toolbar'
+        }
+    }
+
+    /**
      * @summary Creates all cold semantic owners before constructing their presentation.
      * @param {Object} config
      */
@@ -419,7 +471,7 @@ class Workspace extends DockWorkspace {
 
         me.appendFeedBatch(25);
 
-        me.add([{module: TourToolbar}, me.createStatusBar(), me.getController().createTopologyBar(), {
+        me.add([{module: TourToolbar}, me.createStatusBar(), me.createTopologyBar(), {
             module: Container,
             cls   : ['workstation-dock-host', 'neo-dashboard', 'neo-dashboard-dock-query-host'],
             flex  : 1,

--- a/apps/workstation/view/WorkspaceController.mjs
+++ b/apps/workstation/view/WorkspaceController.mjs
@@ -13,6 +13,15 @@ class WorkspaceController extends Controller {
         className: 'Workstation.view.WorkspaceController'
     }
 
+    /**
+     * How many topology-bar buttons the VIEW authors. `syncTopologyBar` replaces everything after
+     * them, so this is the one number both sides must agree on — named here rather than repeated as
+     * a literal on each side, which is how the two would drift.
+     * @member {Number} authoredTopologyButtonCount=2
+     * @static
+     */
+    static authoredTopologyButtonCount = 2
+
     /** @member {Promise|null} tourControllerPromise=null */
     tourControllerPromise = null
 
@@ -102,53 +111,62 @@ class WorkspaceController extends Controller {
     }
 
     /**
-     * @summary Provides explicit save/close and user-activated recovery for headless saved windows.
-     * @returns {Object} Toolbar configuration.
+     * @summary Populates the reference-addressed parts of the view once its tree exists.
+     *
+     * The engine's own seam for controllers that need references, so the view never has to hand
+     * itself over to be finished.
      */
-    createTopologyBar() {
-        const me    = this,
-              items = [{ntype: 'button', text: 'Save workspace', handler: () => me.saveTopology()},
-                  {ntype: 'button', text: 'Close workspace', handler: () => me.closeTopology()}];
+    onComponentConstructed() {
+        this.syncTopologyBar()
+    }
 
-        for (const workspaceKey of me.component.getPopupStates().map(state => state.workspaceId)) {
-            items.push(
-                {ntype: 'button', text: `Open ${workspaceKey} as window`, handler: () => me.openTopologyWorkspace(workspaceKey)},
-                {ntype: 'button', text: `Show ${workspaceKey} here`, handler: () => me.mountTopologyWorkspace(workspaceKey, me.component)}
-            )
-        }
+    /**
+     * @summary Fills the view-declared topology bar's per-workspace recovery buttons.
+     *
+     * The bar itself is declared by the view, which owns its structure; this reaches it through
+     * its reference and supplies only the part that depends on live Group membership.
+     *
+     * Idempotent and re-callable, but wired to {@link #onComponentConstructed} alone — the same
+     * single population the previous shape performed. `WorkspaceSet` publishes no membership
+     * signal, so a participant registered after boot still gains no buttons until a reload; that
+     * is unchanged here and needs a signal in the engine, not a second reader in this file.
+     * @returns {Boolean} Whether the bar was reachable.
+     */
+    syncTopologyBar() {
+        const me  = this,
+              bar = me.getReference('topology-toolbar');
 
-        return {
-            ntype: 'toolbar',
-            // Undo and redo are the Group's, not this bar's — and they read it WHERE IT LIVES.
-            // `state.Provider#getData` resolves to the leaf's own `core.Config`, so a formatter that
-            // reads the Group's provider inside a binding effect registers that exact leaf and
-            // re-runs when it changes. No copy is kept here, which means there is no second
-            // publication path to keep in step: `setHistoryDepth` publishes without a commit, and a
-            // mirror fed by commits alone would have gone stale exactly there.
-            //
-            // A retired or unknown Group resolves to nothing and reads disabled, so the control fails
-            // closed on the same expression rather than through a separate teardown.
-            actions: [{
-                action     : 'undo',
-                bind       : {disabled: () => TransactionManager.getProvider(me.component.topologyGroupId)?.getData('canUndo') !== true},
-                handler    : () => TransactionManager.undo({groupId: me.component.topologyGroupId}),
-                iconCls    : 'fa fa-rotate-left',
-                showOnFocus: false,
-                text       : 'Undo'
-            }, {
-                action     : 'redo',
-                bind       : {disabled: () => TransactionManager.getProvider(me.component.topologyGroupId)?.getData('canRedo') !== true},
-                handler    : () => TransactionManager.redo({groupId: me.component.topologyGroupId}),
-                iconCls    : 'fa fa-rotate-right',
-                showOnFocus: false,
-                text       : 'Redo'
-            }],
-            cls      : ['workstation-topologybar'],
-            flex     : 'none',
-            items,
-            layout   : {ntype: 'flexbox', align: 'center', direction: 'row', wrap: 'wrap'},
-            reference: 'topology-toolbar'
-        }
+        if (!bar || bar.isDestroyed) return false;
+
+        const recovery = me.component.getPopupStates().flatMap(({workspaceId}) => [
+            {handler: 'onOpenTopologyWorkspace', text: `Open ${workspaceId} as window`, workspaceKey: workspaceId},
+            {handler: 'onMountTopologyWorkspace', text: `Show ${workspaceId} here`,      workspaceKey: workspaceId}
+        ]).map(config => ({ntype: 'button', ...config}));
+
+        // The two authored buttons are the view's and stay; only the derived tail is replaced, so
+        // a resync cannot destroy structure the view declared.
+        bar.items.slice(me.constructor.authoredTopologyButtonCount).forEach(item => item.destroy());
+        bar.items.length = me.constructor.authoredTopologyButtonCount;
+
+        recovery.length && bar.add(recovery);
+
+        return true
+    }
+
+    /**
+     * @summary Declarative handler: opens the addressed participant in its own window.
+     * @param {Object} data
+     */
+    onOpenTopologyWorkspace(data) {
+        return this.openTopologyWorkspace(data.component.workspaceKey)
+    }
+
+    /**
+     * @summary Declarative handler: mounts the addressed participant into the root inline.
+     * @param {Object} data
+     */
+    onMountTopologyWorkspace(data) {
+        return this.mountTopologyWorkspace(data.component.workspaceKey, this.component)
     }
 
     /**

--- a/buildScripts/util/file-size-baseline.json
+++ b/buildScripts/util/file-size-baseline.json
@@ -1,5 +1,5 @@
 {
-    "apps/workstation/view/Workspace.mjs": 1211,
+    "apps/workstation/view/Workspace.mjs": 1240,
     "examples/dashboard/crossWindow/DemoBWorkspace.mjs": 2505,
     "src/dashboard/dock/Workspace.mjs": 1100,
     "src/main/addon/DragDrop.mjs": 1267

--- a/test/playwright/unit/apps/workstation/Workspace.spec.mjs
+++ b/test/playwright/unit/apps/workstation/Workspace.spec.mjs
@@ -14,14 +14,15 @@ import WorkspaceDocument        from '../../../../../src/dashboard/dock/model/Wo
 import Operations               from '../../../../../src/dashboard/dock/model/Operations.mjs';
 import DockParticipation        from '../../../../../src/dashboard/dock/window/Participation.mjs';
 import '../../../../../src/manager/Instance.mjs';
-import TransactionManager from '../../../../../src/manager/Transaction.mjs';
-import FeedPane           from '../../../../../apps/workstation/view/FeedPane.mjs';
-import ScalePane          from '../../../../../apps/workstation/view/ScalePane.mjs';
-import Workspace          from '../../../../../apps/workstation/view/Workspace.mjs';
-import PopupWorkspace     from '../../../../../apps/workstation/view/PopupWorkspace.mjs';
-import GestureDriver      from '../../../../../apps/workstation/tour/GestureDriver.mjs';
-import TourController     from '../../../../../apps/workstation/view/TourController.mjs';
-import DockService        from '../../../../../src/ai/client/DockService.mjs';
+import TransactionManager  from '../../../../../src/manager/Transaction.mjs';
+import FeedPane            from '../../../../../apps/workstation/view/FeedPane.mjs';
+import ScalePane           from '../../../../../apps/workstation/view/ScalePane.mjs';
+import Workspace           from '../../../../../apps/workstation/view/Workspace.mjs';
+import PopupWorkspace      from '../../../../../apps/workstation/view/PopupWorkspace.mjs';
+import GestureDriver       from '../../../../../apps/workstation/tour/GestureDriver.mjs';
+import TourController      from '../../../../../apps/workstation/view/TourController.mjs';
+import DockService         from '../../../../../src/ai/client/DockService.mjs';
+import WorkspaceController from '../../../../../apps/workstation/view/WorkspaceController.mjs';
 
 import {initialDocument} from '../../../../../apps/workstation/tour/denseWorkstation.mjs';
 
@@ -3162,5 +3163,70 @@ test.describe('getRefreshOptions — the geometry admission is the ENGINE\'s, no
         expect(refreshOptionsFor({operation: 'moveItem', preserveItemIds: ['editor']}),
             'and a commit-scoped park still rides along')
             .toEqual({geometryOnly: false, retainTopology: false, preserveItemIds: ['editor']})
+    })
+});
+
+test.describe('Workstation topology bar — the view declares it, the controller fills it (#18460)', () => {
+    test('the topology bar carries undo and redo as bound actions that dispatch to the Group and own no history logic', () => {
+        // The factory reads the Group id off the host and nothing else — the per-participant rows
+        // are the controller's, so this arm stays on the two Group actions.
+        const host       = {topologyGroupId: 'topology-bar-group'},
+              bar        = Workspace.prototype.createTopologyBar.call(host),
+              actions    = Object.fromEntries((bar.actions || []).map(action => [action.action, action])),
+              dispatched = [];
+
+        expect(Object.keys(actions).sort()).toEqual(['redo', 'undo']);
+
+        // The authored head is the view's contract with its controller: `syncTopologyBar` replaces
+        // everything after exactly this many items, so the count is asserted against the number the
+        // controller reads rather than against a literal repeated on both sides.
+        expect(bar.reference).toBe('topology-toolbar');
+        expect(bar.items.map(item => item.handler)).toEqual(['saveTopology', 'closeTopology']);
+        expect(bar.items).toHaveLength(WorkspaceController.authoredTopologyButtonCount);
+
+        // Persistent, not focus-gated: an undo control that appears only once the bar holds focus is
+        // undiscoverable exactly when a user reaches for it.
+        expect(actions.undo.showOnFocus).toBe(false);
+        expect(actions.redo.showOnFocus).toBe(false);
+
+        // Enablement reads the Group's own leaf where it lives. `getData` resolves to that leaf's
+        // `core.Config`, so a binding effect running this formatter registers it and re-runs when it
+        // changes — no copy is held here, so there is no second publication path that could go stale
+        // when `setHistoryDepth` publishes without a commit.
+        const group = TransactionManager.bind({windowId: 'topology-bar-window', workspaceKey: 'main'});
+
+        host.topologyGroupId = group.groupId;
+
+        expect(actions.undo.bind.disabled(), 'an empty history disables Undo').toBe(true);
+        expect(actions.redo.bind.disabled()).toBe(true);
+
+        TransactionManager.getProvider(group.groupId).setData({canRedo: true, canUndo: true});
+
+        expect(actions.undo.bind.disabled(), 'the Group\'s own leaf enables it').toBe(false);
+        expect(actions.redo.bind.disabled()).toBe(false);
+
+        // Fails closed on the SAME expression rather than through a separate teardown path.
+        TransactionManager.retireGroup(group.groupId);
+        expect(actions.undo.bind.disabled(), 'a retired Group reads disabled').toBe(true);
+
+        host.topologyGroupId = 'topology-bar-group';
+
+        const originals = {redo: TransactionManager.redo, undo: TransactionManager.undo};
+
+        TransactionManager.redo = data => {dispatched.push(['redo', data]); return Promise.resolve()};
+        TransactionManager.undo = data => {dispatched.push(['undo', data]); return Promise.resolve()};
+
+        try {
+            actions.undo.handler();
+            actions.redo.handler()
+        } finally {
+            Object.assign(TransactionManager, originals)
+        }
+
+        // The whole of the consumer's contribution: the Group id and the command name.
+        expect(dispatched).toEqual([
+            ['undo', {groupId: 'topology-bar-group'}],
+            ['redo', {groupId: 'topology-bar-group'}]
+        ])
     })
 });

--- a/test/playwright/unit/apps/workstation/WorkspaceController.spec.mjs
+++ b/test/playwright/unit/apps/workstation/WorkspaceController.spec.mjs
@@ -5,8 +5,10 @@ setup({appConfig: {name: 'WorkstationTopologyControllerTest'}});
 import {test, expect}      from '@playwright/test';
 import Neo                 from '../../../../../src/Neo.mjs';
 import * as core           from '../../../../../src/core/_export.mjs';
+import '../../../../../src/manager/Instance.mjs';
 import Transaction         from '../../../../../src/manager/Transaction.mjs';
 import TopologyLibrary     from '../../../../../src/dashboard/dock/persistence/TopologyLibrary.mjs';
+import Toolbar             from '../../../../../src/toolbar/Base.mjs';
 import WorkspaceController from '../../../../../apps/workstation/view/WorkspaceController.mjs';
 
 /**
@@ -121,59 +123,54 @@ test.describe('Workstation topology save and close coordination', () => {
         }
     });
 
-    test('the topology bar carries undo and redo as bound actions that dispatch to the Group and own no history logic', () => {
-        // Popup rows come from Group participant identity; supplying none keeps the arm on the two
-        // Group actions rather than on the bar's row building.
-        const component  = {getPopupStates: () => [], topologyGroupId: 'topology-bar-group'},
-              bar        = WorkspaceController.prototype.createTopologyBar.call({component}),
-              actions    = Object.fromEntries((bar.actions || []).map(action => [action.action, action])),
-              dispatched = [];
+    test('the controller fills only the tail of the view-declared bar and cannot destroy what the view authored', () => {
+        // A real toolbar, so `bar.add` and `item.destroy` are the engine's and not a double's; the
+        // reference is how the controller finds it, exactly as it does in the live view.
+        const bar = Neo.create(Toolbar, {
+            items    : [{ntype: 'button', handler: 'saveTopology', text: 'Save workspace'},
+                        {ntype: 'button', handler: 'closeTopology', text: 'Close workspace'}],
+            reference: 'topology-toolbar'
+        });
 
-        expect(Object.keys(actions).sort()).toEqual(['redo', 'undo']);
+        let participants = ['alpha'];
 
-        // Persistent, not focus-gated: an undo control that appears only once the bar holds focus is
-        // undiscoverable exactly when a user reaches for it.
-        expect(actions.undo.showOnFocus).toBe(false);
-        expect(actions.redo.showOnFocus).toBe(false);
+        // `isConstructed` sends `controller.Component#construct` down its immediate branch, so the
+        // engine's own `onComponentConstructed` seam runs here — the wiring is under test, not just
+        // the method it calls.
+        const controller = Neo.create(WorkspaceController, {
+            component: {
+                down          : () => bar,
+                getPopupStates: () => participants.map(workspaceId => ({workspaceId})),
+                isConstructed : true
+            }
+        });
 
-        // Enablement reads the Group's own leaf where it lives. `getData` resolves to that leaf's
-        // `core.Config`, so a binding effect running this formatter registers it and re-runs when it
-        // changes — no copy is held here, so there is no second publication path that could go stale
-        // when `setHistoryDepth` publishes without a commit.
-        const group = Transaction.bind({windowId: 'topology-bar-window', workspaceKey: 'main'});
+        expect(bar.items.map(item => item.text), 'the lifecycle hook already populated it').toEqual([
+            'Save workspace', 'Close workspace', 'Open alpha as window', 'Show alpha here'
+        ]);
 
-        component.topologyGroupId = group.groupId;
+        expect(controller.syncTopologyBar()).toBe(true);
+        expect(bar.items.map(item => item.text), 'and a resync is not additive').toEqual([
+            'Save workspace', 'Close workspace', 'Open alpha as window', 'Show alpha here'
+        ]);
 
-        expect(actions.undo.bind.disabled(), 'an empty history disables Undo').toBe(true);
-        expect(actions.redo.bind.disabled()).toBe(true);
+        // Each derived button carries the participant it addresses, which is the whole of what the
+        // declarative handlers read — no closure over the controller or over this call.
+        expect(bar.items.slice(2).map(item => [item.handler, item.workspaceKey])).toEqual([
+            ['onOpenTopologyWorkspace', 'alpha'], ['onMountTopologyWorkspace', 'alpha']
+        ]);
 
-        Transaction.getProvider(group.groupId).setData({canRedo: true, canUndo: true});
+        // Re-running is not additive, and the authored head survives a resync that removes every
+        // participant — the failure mode of replacing the whole list instead of its tail.
+        participants = [];
 
-        expect(actions.undo.bind.disabled(), 'the Group\'s own leaf enables it').toBe(false);
-        expect(actions.redo.bind.disabled()).toBe(false);
+        expect(controller.syncTopologyBar()).toBe(true);
+        expect(bar.items.map(item => item.handler)).toEqual(['saveTopology', 'closeTopology']);
 
-        // Fails closed on the SAME expression rather than through a separate teardown path.
-        Transaction.retireGroup(group.groupId);
-        expect(actions.undo.bind.disabled(), 'a retired Group reads disabled').toBe(true);
+        // An unreachable bar is reported, never assumed: a destroyed view must not read as synced.
+        bar.destroy();
+        expect(controller.syncTopologyBar(), 'a destroyed bar is not a synced bar').toBe(false);
 
-        component.topologyGroupId = 'topology-bar-group';
-
-        const originals = {redo: Transaction.redo, undo: Transaction.undo};
-
-        Transaction.redo = data => {dispatched.push(['redo', data]); return Promise.resolve()};
-        Transaction.undo = data => {dispatched.push(['undo', data]); return Promise.resolve()};
-
-        try {
-            actions.undo.handler();
-            actions.redo.handler()
-        } finally {
-            Object.assign(Transaction, originals)
-        }
-
-        // The whole of the consumer's contribution: the Group id and the command name.
-        expect(dispatched).toEqual([
-            ['undo', {groupId: 'topology-bar-group'}],
-            ['redo', {groupId: 'topology-bar-group'}]
-        ])
+        controller.destroy()
     })
 });


### PR DESCRIPTION
Resolves #18545
Parent: #18460

🌿 A controller could describe a view's furniture and a view could ask its controller for its own child; after this, neither sentence has a place to be written in Workstation's topology bar.

`Workspace.mjs` called `me.getController().createTopologyBar()` inside its own `add([...])`. Two directions were wrong in one expression. The view now declares the bar — `reference`, the two authored buttons with declarative handler names, the Group's undo/redo — and the controller reaches it through `getReference()` to fill only the per-participant tail, on the engine's own `onComponentConstructed` seam.

**View-to-controller dispatch sites in `apps/workstation/view/`: 5 → 4.** The four that remain are a different shape and are dispositioned below rather than folded in.

Evidence: L2 (the change is model-level view/controller wiring, fully covered by the unit tier at exact head; the Workstation witness suite is the integration evidence) → L2 required. Residual: the bar's rendered appearance is unchanged by construction, and the e2e arm that queries `{reference: 'topology-toolbar'}` (`WorkstationDragAffordancesNL.spec.mjs:640`) is the rendered proof CI runs.

`agent-preflight: not hosted here` (no such npm script; exit 1); the baseline `PR body`, `Substrate size`, `Source comment archaeology` and `PR base` jobs carry its checks. §3.1 class: `zero-delta → refactor`.

## AC Evidence

| AC | Disposition |
|---|---|
| AC-1 — the view declares the bar; no `getController()` site consumes view config; the PR reports the full population, not just the site removed | **Met, as a measurement.** `git grep -c 'getController()'` on `apps/workstation/view/`: dev = `Viewport.mjs:3` + `Workspace.mjs:2`; head = `Viewport.mjs:3` + `Workspace.mjs:1`. The one removed is the only site anywhere in the app where a controller produced view config. The four remaining, each with its reason for staying, are in § Deltas. |
| AC-2 — the controller fills the bar through `getReference()` and cannot destroy the view-authored head | **CI-covered.** `syncTopologyBar()` slices from `static authoredTopologyButtonCount` and truncates to it, so the authored two are outside everything it touches. The witness populates one participant, empties the participant set, resyncs, and asserts `['saveTopology', 'closeTopology']` survives — the failure mode of replacing the whole list. It runs against a real `toolbar.Base`, so `add`/`destroy` are the engine's. |
| AC-3 — the lifecycle wiring is witnessed, not just the method it calls | **CI-covered + control.** The double sets `isConstructed: true`, which sends `controller.Component#construct` down its immediate branch, so the seam runs inside `Neo.create`. The arm asserts the bar is *already* filled before any explicit call, and reddens when `onComponentConstructed` stops calling through (control 2). |
| AC-4 — behaviour parity claimed and measured; the stale-after-tear-out limit reported as unchanged, not silently fixed | **Met.** One population, at the same point in the lifecycle the config literal was evaluated. `WorkspaceSet` publishes no membership signal (`ids()` and nothing else), so a participant registered at `Workspace.mjs:2140` still gains no buttons until a reload — true before, true now, and named in `syncTopologyBar`'s docblock as needing an engine signal rather than a second reader in this file. |
| AC-5 — witnesses green at head; the stale caller moves to the surface that owns it | **CI-covered.** Workstation unit **96/96**, full unit tier **3737 passed / 0 failed / 2 skipped**. The declaration arm moved from `WorkspaceController.spec.mjs` to `Workspace.spec.mjs` — the factory is the view's now — and lost the `getPopupStates` fake it no longer needs; the controller spec gained the membership arm. Movement detail in § Deltas. |
| AC-6 — three mutation controls, each reddening a named arm | **Met.** Table in § Test Evidence. |

## Deltas from ticket

- **The four remaining dispatch sites, with dispositions.** `Viewport.mjs:59` · `:70` (`mountTopologyWorkspace`) and `:151` (`attachTopologyLibrary`) address *another component's* controller — cross-component reach-through, not a view finishing its own child, and their fix is a different shape with its own callers. `Workspace.mjs:795` (`saveTopology`) is a shipped surface: `WorkstationTopologyGroupsNL.spec.mjs:229` reaches it through `app.callMethod`, and `Viewport.mjs:153` calls it as a component method. Removing it breaks a rendered journey. Both classes were named Out of Scope in #18545 before this branch existed, not after measuring the cost.
- **A separate `TopologyToolbar` module was the first shape I tried, and the engine refuses it.** `TourToolbar.mjs` sits one line above in the same `add([...])` and is a `toolbar.Base` subclass, which made a module look like the idiom. It is not available here: `state/Provider.mjs:463` invokes a bind formatter as `formatter.call(me, hierarchicalData)` — `this` is the **provider**, not the component — so a `static config` on a separate class cannot read `topologyGroupId` off the workspace. The undo/redo controls need exactly that. `createStatusBar()`, also in that same `add([...])`, is the factory idiom for configs needing the instance, and this follows it. The reason is now in the docblock, so the next author does not re-try the module.
- **This grows the entrypoint, and that works against a sibling row of #18460.** `Workspace.mjs` 2295 → 2347 physical (+52; 30 code, 21 comment, 2 blank), `WorkspaceController.mjs` 263 → 281 (+18). Roughly 35 of those lines are the bar config *moving* out of the controller's 45-line `createTopologyBar`; the rest is `syncTopologyBar`, the two handlers, the static and the lifecycle hook. #18460 AC-3's 1,000-line entrypoint ceiling is **not** claimed here and this leaf makes it 52 lines harder. Stated rather than netted away: the direction fix and the size row want opposite things in this one file, and the size row's answer is extraction of *behaviour*, which #18460's other leaves own.
size-guard-growth: apps/workstation/view/Workspace.mjs — 1211 to 1240 code lines. The bar's config moves in from `WorkspaceController#createTopologyBar`, which the view was calling into for its own child; the controller sheds that 45-line method and gains the reference-based sync instead. Baseline ratcheted to the measured 1240 and diffed key-by-key against dev (4 keys in, 4 out, none dropped, one changed). Not netted away: this leaf makes #18460 AC-3's entrypoint ceiling 29 code lines harder, and that row's answer is behaviour extraction, owned by its other leaves.

- **The controller's docblock carries the limitation, not the history.** First draft explained what the shape used to be. Durable source states intent; the archaeology is in the commit.

## Test Evidence

Outside-CI evidence only — the controls, plus one finding the controls did not produce.

| Mutation | Arm that reddens |
|---|---|
| The view's `reference` renamed to `topology-toolbar-x` | `Workspace.spec.mjs` › *the topology bar carries undo and redo…* — `expect(bar.reference).toBe('topology-toolbar')`. 1 failed / 95 passed. |
| `onComponentConstructed()` emptied | `WorkspaceController.spec.mjs` › *the controller fills only the tail…* — `'the lifecycle hook already populated it'`. 1 failed / 95 passed. |
| `syncTopologyBar` replaces the whole list (`slice(0)`, `length = 0`) | The same arm, at the same assertion: the hook's own population arrives with the authored head already gone. 1 failed / 95 passed. |

- **My new arm was green partly on a sibling file's import, and the first control exposed it.** Control 1 initially reddened *two* arms — the second with `Neo.get is not a function` at `component/Abstract.mjs:369`, from `bar.destroy()`. `WorkspaceController.spec.mjs` never imported `src/manager/Instance.mjs`; it was reaching `Neo.get` only because `Workspace.spec.mjs` sorts before it in the same worker and imports it. Under the mutation that file failed earlier and the incidental import stopped arriving. The spec now imports it explicitly, as the view spec always did, and control 1 reddens exactly one arm. A passing arm whose dependency is another file's import is an arm that passes for a reason it does not state.
- Guards: `check-ticket-archaeology` clean on all touched files; `check-file-sizes` with the workflow's full argv — result in the commit.
- Full unit tier at head: 3737 passed / 0 failed / 2 skipped (1.7m).

## Post-Merge Validation

- [ ] `WorkstationDragAffordancesNL` queries `{reference: 'topology-toolbar'}` at `:640`. The reference moved from a controller-authored config to a view-authored one; a rendered run is what shows the id still resolves through the same reference.
- [ ] The bar's recovery buttons are only reachable in a session with saved headless participants. The unit witness supplies them through a double; a rendered topology restore is what shows the real `getPopupStates()` feeding the same tail.

## Commits

- `e929bdb328` — the view declares the bar; the controller fills its tail through `getReference()`.
- `2b4c84fe29` — the entrypoint baseline ratcheted to its measured count, not left as headroom.

Authored by Vega (Opus 5, Claude Code). Session 206b8400-7fe8-472e-8018-446e550b784b.
