### PR TITLE
docs(learn): stop teaching a hand-authored node id in the tutorial (#18549)

### DIFF
--- a/learn/tutorials/DockLayoutsFirstLayout.md
+++ b/learn/tutorials/DockLayoutsFirstLayout.md
@@ -152,19 +152,20 @@ The engine derives them from what you wrote, and the benefit is not that the alg
 benefit is that there is nothing to keep in sync.** You never invented `center-split-0`, so you can never
 misspell it, never leave it behind after a rename, and never have two nodes accidentally sharing one.
 
-You *can* name a node when you want to address it later:
+That is the whole rule, and the rule is that there is no rule to follow: **write your panes and your
+zones, and let the engine name the structure.**
 
-```javascript
-zones: {
-    center: {
-        id         : 'main-split',
-        orientation: 'horizontal',
-        children   : [{id: 'code-tabs', items: ['editor']}, {items: ['preview']}]
-    }
-}
-```
+It is worth being explicit about the thing you might otherwise reach for, because the reflex from other
+layout systems is to hand-author an identifier so you can find it again. Do not. Every Neo component id
+must be unique **across the whole application**, not just within one layout — so the moment a second copy
+of your workspace exists on the page, a name you chose by hand is a name you now have to make unique
+yourself, per instance, forever. A derived identity has never had that problem, which is the point of the
+section you have just read.
 
-Name the ones you will refer to; let the engine handle the rest. That is the whole rule.
+You do not need to address a structural node to build a layout, and this tutorial deliberately does not
+show you how. If you later find you genuinely do, that is a question about your application's identity
+strategy rather than about the dock, and it is worth answering deliberately instead of by adding a string
+to a config.
 
 ## What the engine does with your two configs
 

--- a/learn/tutorials/DockLayoutsFirstLayout.md
+++ b/learn/tutorials/DockLayoutsFirstLayout.md
@@ -152,20 +152,16 @@ The engine derives them from what you wrote, and the benefit is not that the alg
 benefit is that there is nothing to keep in sync.** You never invented `center-split-0`, so you can never
 misspell it, never leave it behind after a rename, and never have two nodes accidentally sharing one.
 
-That is the whole rule, and the rule is that there is no rule to follow: **write your panes and your
-zones, and let the engine name the structure.**
+That is the whole rule: **write your panes and your zones, and let the engine name the structure.**
 
-It is worth being explicit about the thing you might otherwise reach for, because the reflex from other
-layout systems is to hand-author an identifier so you can find it again. Do not. Every Neo component id
-must be unique **across the whole application**, not just within one layout — so the moment a second copy
-of your workspace exists on the page, a name you chose by hand is a name you now have to make unique
-yourself, per instance, forever. A derived identity has never had that problem, which is the point of the
-section you have just read.
+Most layout systems make you invent a name so you can find a node again, so the reflex to hand-author one
+is worth naming. You do not need it here, and this is what the paragraph above is for: a name you never
+wrote is a name that cannot drift out of sync with anything.
 
-You do not need to address a structural node to build a layout, and this tutorial deliberately does not
-show you how. If you later find you genuinely do, that is a question about your application's identity
-strategy rather than about the dock, and it is worth answering deliberately instead of by adding a string
-to a config.
+**You do not need to address a structural node to build a layout, and this tutorial deliberately does not
+show you how.** If you later find that you genuinely do, that is a question about your application's
+identity strategy rather than about the dock, and it is worth answering deliberately instead of by adding
+a string to a config.
 
 ## What the engine does with your two configs
 

--- a/learn/tutorials/DockLayoutsFirstLayout.md
+++ b/learn/tutorials/DockLayoutsFirstLayout.md
@@ -152,17 +152,6 @@ The engine derives them from what you wrote, and the benefit is not that the alg
 benefit is that there is nothing to keep in sync.** You never invented `center-split-0`, so you can never
 misspell it, never leave it behind after a rename, and never have two nodes accidentally sharing one.
 
-That is the whole rule: **write your panes and your zones, and let the engine name the structure.**
-
-Most layout systems make you invent a name so you can find a node again, so the reflex to hand-author one
-is worth naming. You do not need it here, and this is what the paragraph above is for: a name you never
-wrote is a name that cannot drift out of sync with anything.
-
-**You do not need to address a structural node to build a layout, and this tutorial deliberately does not
-show you how.** If you later find that you genuinely do, that is a question about your application's
-identity strategy rather than about the dock, and it is worth answering deliberately instead of by adding
-a string to a config.
-
 ## What the engine does with your two configs
 
 ```mermaid
@@ -219,7 +208,7 @@ contract on one pane.
 - **[Dock Layouts Adoption](../guides/uibuildingblocks/DockLayoutsAdoption.md)** — computing a layout from application data and
   integrating the workspace into an existing view hierarchy.
 - **Dock Zone Model** (`learn/agentos/DockZoneModel.md`) — the reference for the document vocabulary: the
-  exact fields a pane record and a zone node accept, including the ones this tutorial has no use for.
+  exact fields a pane record and a zone node accept.
 
 Start with the second example on this page. Change a key, add a pane, move it to another zone, and watch
 what the engine builds for you.

--- a/learn/tutorials/DockLayoutsFirstLayout.md
+++ b/learn/tutorials/DockLayoutsFirstLayout.md
@@ -219,7 +219,7 @@ contract on one pane.
 - **[Dock Layouts Adoption](../guides/uibuildingblocks/DockLayoutsAdoption.md)** — computing a layout from application data and
   integrating the workspace into an existing view hierarchy.
 - **Dock Zone Model** (`learn/agentos/DockZoneModel.md`) — the reference for the document vocabulary: the
-  exact fields a pane record and a zone node accept.
+  exact fields a pane record and a zone node accept, including the ones this tutorial has no use for.
 
 Start with the second example on this page. Change a key, add a pane, move it to another zone, and watch
 what the engine builds for you.


### PR DESCRIPTION
Resolves #18549

A section arguing that derived ids leave nothing to keep in sync ended by showing you how to hand-author two. The block is gone. Nothing replaces it, because nothing needed to.

Evidence: L3 (the tutorial rendered from the local portal at this head, on a cache-busted boot) → L3 required (AC-4 is the only runtime AC and a render is what it asks for). No residuals.

## AC Evidence

| AC | Evidence |
|---|---|
| AC-1 — the `id`-authoring block is removed; the section keeps its argument | 14 lines out, none back in. The section now poses the question, answers it, and states the benefit, ending at *"never have two nodes accidentally sharing one."* |
| AC-2 — nothing teaches a hand-authored node id as routine | Nothing teaches it at all. The trailing sentence *"Name the ones you will refer to; let the engine handle the rest"* went with the block: it taught the same affordance in prose, which the code fence had merely illustrated. |
| AC-3 — ⚠️ do not assert the multi-instance case in either direction | The file says nothing about it. Met by having no replacement text to get wrong — see Deltas, because I got this wrong twice before arriving here. |
| AC-4 — the tutorial renders and both live previews still run | Outside-CI, at `353a1fac3f`: `#/learn/tutorials/DockLayoutsFirstLayout` renders, the section ends straight into *What the engine does with your two configs*, `main-split` / `code-tabs` return zero hits in the rendered text, and the two live previews carry four tab buttons between them. |

## Deltas from ticket

**This PR was three times its current size and every added line has been removed. That is the delta worth recording.**

1. The first replacement asserted a mechanism — an authored zone `id` becomes a component id, so a second workspace on the page collides. @neo-opus-vega measured it false: `LayoutAdapter` carries the authored key as `dockNodeId` and derives exactly one id, `stackHandleDomId(itemId)`, from an **item**; `Authoring` stores the authored id as `node.id` on the document against a per-pass set. @tobiu had given me that claim as a **conditional** — *"if the id does get passed to a component"* — and I shipped it as settled fact.
2. The second attempt replaced it with three paragraphs about not naming things, and a Where-to-go-next pointer that declined to name the field it pointed at.
3. @tobiu on the PR: prose-theater, and *"not naming id for… what exactly?"* Both right, and the second objection is the substantive one. **The prose wrote as though addressing a thing later were an open question the reader had to go answer.** It is not. Neo has names and references — and this tutorial had already said so a hundred lines earlier: *"`editor` and `preview` are the panes' identities, and they are how you refer to them everywhere else — in zones, in later operations, in a saved layout."* I invented a mystery the document had already solved, in the section immediately after the one that solved it.

The ticket said the section's own argument needs no counter-example. It needed no replacement either.

## Test Evidence

All coverage runs in CI, apart from the render receipt in AC Evidence above.

One note on that receipt, because it nearly went the other way: my first render check at this head reported the removed prose as still present. Disk and `curl http://localhost:8080/learn/tutorials/DockLayoutsFirstLayout.md` were both clean, so it was a cached page — the re-check ran on a cache-busted boot. The probe had also been written with an inverted variable name (`addedProseGone` returning `true` when the prose was *present*), which is how a stale render nearly read as a pass. Re-run with the assertions named for what they test.

## Post-Merge Validation

- [ ] The mermaid diagram below the edited section does not render in the local portal, so the render receipt covers prose and live previews only. That is #18548's gap, and #18565 (`Resolves #18564`, Monaco's AMD loader swallowing mermaid's UMD `define`) is the fix in flight. Re-running the receipt after it lands is the cheap confirmation; nothing in this diff depends on it.

## Commits

- `7c11510c60` — remove the block.
- `8f4d3ad95c` — remove a mechanism the tutorial never measured (@neo-opus-vega's RA-1).
- `8fa0f5b057` — a routing pointer, since retracted.
- `353a1fac3f` — remove the replacement prose entirely; the deletion was the change.

Authored by Grace (Opus 5, Claude Code). Session c4dc8abc-31fa-4ecd-9aef-5209ccfd16c0.
