### PR TITLE
The topology bar's sync removes only what it added (#18551)

### DIFF
--- a/apps/workstation/view/Workspace.mjs
+++ b/apps/workstation/view/Workspace.mjs
@@ -420,8 +420,9 @@ class Workspace extends DockWorkspace {
             }],
             cls : ['workstation-topologybar'],
             flex: 'none',
-            // Exactly `WorkspaceController.authoredTopologyButtonCount` items: the controller
-            // replaces everything after them and must not be able to destroy these.
+            // Ordinary items. The controller adds its per-workspace recovery buttons beside them
+            // and removes only the ones it flagged, so neither side counts the other's and this
+            // list is free to grow.
             items : [
                 {ntype: 'button', handler: 'saveTopology',  text: 'Save workspace'},
                 {ntype: 'button', handler: 'closeTopology', text: 'Close workspace'}

--- a/apps/workstation/view/WorkspaceController.mjs
+++ b/apps/workstation/view/WorkspaceController.mjs
@@ -13,15 +13,6 @@ class WorkspaceController extends Controller {
         className: 'Workstation.view.WorkspaceController'
     }
 
-    /**
-     * How many topology-bar buttons the VIEW authors. `syncTopologyBar` replaces everything after
-     * them, so this is the one number both sides must agree on — named here rather than repeated as
-     * a literal on each side, which is how the two would drift.
-     * @member {Number} authoredTopologyButtonCount=2
-     * @static
-     */
-    static authoredTopologyButtonCount = 2
-
     /** @member {Promise|null} tourControllerPromise=null */
     tourControllerPromise = null
 
@@ -141,14 +132,30 @@ class WorkspaceController extends Controller {
         const recovery = me.component.getPopupStates().flatMap(({workspaceId}) => [
             {handler: 'onOpenTopologyWorkspace', text: `Open ${workspaceId} as window`, workspaceKey: workspaceId},
             {handler: 'onMountTopologyWorkspace', text: `Show ${workspaceId} here`,      workspaceKey: workspaceId}
-        ]).map(config => ({ntype: 'button', ...config}));
+        ]).map(config => ({ntype: 'button', isTopologyRecoveryButton: true, ...config}));
 
-        // The two authored buttons are the view's and stay; only the derived tail is replaced, so
-        // a resync cannot destroy structure the view declared.
-        bar.items.slice(me.constructor.authoredTopologyButtonCount).forEach(item => item.destroy());
-        bar.items.length = me.constructor.authoredTopologyButtonCount;
+        // Identity, never position. `items` also carries what the toolbar materialises from the
+        // view's `actions` — a spacer plus one item per action — so ANY index into it addresses
+        // engine-owned structure. Flagging our own is the same device the toolbar uses for
+        // its (`isToolbarAction`, `isToolbarActionSpacer`), and it cannot drift against the view.
+        const stale = bar.items.filter(item => item.isTopologyRecoveryButton === true);
 
-        recovery.length && bar.add(recovery);
+        // `remove` routes through `removeAt`, the one path that splices `items` AND
+        // `getVdomItemsRoot().cn`. A bare `destroy()` defaults `updateParentVdom` to false and
+        // leaves a `{componentId}` placeholder resolving to nothing, which throws on the next
+        // viewport vdom sync rather than here.
+        stale.forEach(item => bar.remove(item, true, true));
+
+        if (recovery.length > 0) {
+            // Ahead of the action spacer, so these join the ordinary items instead of stranding
+            // past a `flex: 1` gap on the far side of undo/redo.
+            const spacer = bar.getActionSpacer();
+
+            bar.insert(spacer ? bar.items.indexOf(spacer) : bar.items.length, recovery)
+        } else if (stale.length > 0) {
+            bar.updateDepth = -1;
+            bar.update()
+        }
 
         return true
     }

--- a/test/playwright/unit/apps/workstation/Workspace.spec.mjs
+++ b/test/playwright/unit/apps/workstation/Workspace.spec.mjs
@@ -22,7 +22,6 @@ import PopupWorkspace      from '../../../../../apps/workstation/view/PopupWorks
 import GestureDriver       from '../../../../../apps/workstation/tour/GestureDriver.mjs';
 import TourController      from '../../../../../apps/workstation/view/TourController.mjs';
 import DockService         from '../../../../../src/ai/client/DockService.mjs';
-import WorkspaceController from '../../../../../apps/workstation/view/WorkspaceController.mjs';
 
 import {initialDocument} from '../../../../../apps/workstation/tour/denseWorkstation.mjs';
 
@@ -3177,12 +3176,12 @@ test.describe('Workstation topology bar — the view declares it, the controller
 
         expect(Object.keys(actions).sort()).toEqual(['redo', 'undo']);
 
-        // The authored head is the view's contract with its controller: `syncTopologyBar` replaces
-        // everything after exactly this many items, so the count is asserted against the number the
-        // controller reads rather than against a literal repeated on both sides.
+        // This is the DECLARATION, not a toolbar. `createTopologyBar` returns a plain object, so
+        // `items` is what the view wrote and never what `toolbar.Base` materialises from `actions`
+        // — a spacer plus one item per action. A count read here certified nothing about the live
+        // bar; the materialised bar and its sync are exercised in WorkspaceController.spec.
         expect(bar.reference).toBe('topology-toolbar');
         expect(bar.items.map(item => item.handler)).toEqual(['saveTopology', 'closeTopology']);
-        expect(bar.items).toHaveLength(WorkspaceController.authoredTopologyButtonCount);
 
         // Persistent, not focus-gated: an undo control that appears only once the bar holds focus is
         // undiscoverable exactly when a user reaches for it.

--- a/test/playwright/unit/apps/workstation/WorkspaceController.spec.mjs
+++ b/test/playwright/unit/apps/workstation/WorkspaceController.spec.mjs
@@ -6,9 +6,11 @@ import {test, expect}      from '@playwright/test';
 import Neo                 from '../../../../../src/Neo.mjs';
 import * as core           from '../../../../../src/core/_export.mjs';
 import '../../../../../src/manager/Instance.mjs';
+import ComponentManager    from '../../../../../src/manager/Component.mjs';
 import Transaction         from '../../../../../src/manager/Transaction.mjs';
 import TopologyLibrary     from '../../../../../src/dashboard/dock/persistence/TopologyLibrary.mjs';
 import Toolbar             from '../../../../../src/toolbar/Base.mjs';
+import Workspace           from '../../../../../apps/workstation/view/Workspace.mjs';
 import WorkspaceController from '../../../../../apps/workstation/view/WorkspaceController.mjs';
 
 /**
@@ -123,14 +125,27 @@ test.describe('Workstation topology save and close coordination', () => {
         }
     });
 
-    test('the controller fills only the tail of the view-declared bar and cannot destroy what the view authored', () => {
-        // A real toolbar, so `bar.add` and `item.destroy` are the engine's and not a double's; the
-        // reference is how the controller finds it, exactly as it does in the live view.
-        const bar = Neo.create(Toolbar, {
-            items    : [{ntype: 'button', handler: 'saveTopology', text: 'Save workspace'},
-                        {ntype: 'button', handler: 'closeTopology', text: 'Close workspace'}],
-            reference: 'topology-toolbar'
-        });
+    test('the controller fills only its own buttons and cannot destroy what the toolbar owns', () => {
+        // The VIEW's own factory, not a hand-written stand-in. `actions` is where the defect lived:
+        // toolbar.Base merges `createActionItemConfigs()` into `items` as a spacer plus one item per
+        // action, so the live bar holds five items, not two. A fixture that omits `actions` cannot
+        // reproduce the defect and therefore cannot certify the fix — the previous one omitted it.
+        const bar = Neo.create(Toolbar, Workspace.prototype.createTopologyBar.call({topologyGroupId: 'spec-group'}));
+
+        expect(bar.items.length, 'two authored items, plus the spacer and one item per action').toBe(5);
+        expect(bar.getActionSpacer(), 'the toolbar owns a spacer once actions exist').not.toBeNull();
+
+        // The invariant whose violation threw `Component not found for id` on every viewport sync:
+        // a placeholder in the parent vdom must resolve to a live component. `items.length =` and a
+        // bare `destroy()` each break it silently — nothing reds until a vdom walk reaches the stub.
+        const expectVdomAligned = message => {
+            const ids = bar.getVdomItemsRoot().cn.map(node => node.componentId);
+
+            expect(ids.length, message).toBe(bar.items.length);
+            expect(ids.filter(id => id && !ComponentManager.get(id)), message).toEqual([])
+        };
+
+        expectVdomAligned('aligned before the controller runs');
 
         let participants = ['alpha'];
 
@@ -145,27 +160,47 @@ test.describe('Workstation topology save and close coordination', () => {
             }
         });
 
-        expect(bar.items.map(item => item.text), 'the lifecycle hook already populated it').toEqual([
+        // Ordinary items only: the spacer and the action group are the toolbar's own structure and
+        // are asserted separately, because reaching into them is exactly what the defect was.
+        const ordinaryTexts = () => bar.items
+            .filter(item => item.isToolbarAction !== true && item.isToolbarActionSpacer !== true)
+            .map(item => item.text);
+
+        expect(ordinaryTexts(), 'the lifecycle hook already populated it').toEqual([
             'Save workspace', 'Close workspace', 'Open alpha as window', 'Show alpha here'
         ]);
 
+        // Positional `slice(count)` destroyed these three, and `items.length = count` left their
+        // vdom placeholders pointing at the corpses.
+        expect(bar.getAction('undo'), 'the toolbar keeps its own actions across a sync').not.toBeNull();
+        expect(bar.getAction('redo')).not.toBeNull();
+        expect(bar.getActionSpacer(), 'and its own spacer').not.toBeNull();
+        expectVdomAligned('aligned after the first sync');
+
         expect(controller.syncTopologyBar()).toBe(true);
-        expect(bar.items.map(item => item.text), 'and a resync is not additive').toEqual([
+        expect(ordinaryTexts(), 'and a resync is not additive').toEqual([
             'Save workspace', 'Close workspace', 'Open alpha as window', 'Show alpha here'
         ]);
+        expectVdomAligned('aligned after a resync');
+
+        // The derived buttons join the ordinary items ahead of the `flex: 1` action spacer, rather
+        // than stranded past it on the far side of undo/redo.
+        expect(bar.items.indexOf(bar.getActionSpacer()), 'derived buttons precede the action group').toBe(4);
 
         // Each derived button carries the participant it addresses, which is the whole of what the
         // declarative handlers read — no closure over the controller or over this call.
-        expect(bar.items.slice(2).map(item => [item.handler, item.workspaceKey])).toEqual([
+        expect(bar.items.slice(2, 4).map(item => [item.handler, item.workspaceKey])).toEqual([
             ['onOpenTopologyWorkspace', 'alpha'], ['onMountTopologyWorkspace', 'alpha']
         ]);
 
         // Re-running is not additive, and the authored head survives a resync that removes every
-        // participant — the failure mode of replacing the whole list instead of its tail.
+        // participant — the failure mode of replacing the whole list instead of only its own.
         participants = [];
 
         expect(controller.syncTopologyBar()).toBe(true);
-        expect(bar.items.map(item => item.handler)).toEqual(['saveTopology', 'closeTopology']);
+        expect(ordinaryTexts()).toEqual(['Save workspace', 'Close workspace']);
+        expect(bar.getAction('undo'), 'an emptied participant set still leaves the actions alone').not.toBeNull();
+        expectVdomAligned('aligned after every participant leaves');
 
         // An unreachable bar is reported, never assumed: a destroyed view must not read as synced.
         bar.destroy();


### PR DESCRIPTION
Resolves #18551

The topology bar's items are not the two the view writes. `toolbar.Base` merges what it materialises from `actions` into the same array — a spacer plus one item per action — so the live bar holds five. `syncTopologyBar` indexed that array at `2`, destroyed the toolbar's own spacer and both action buttons, and left their `{componentId}` placeholders in the vdom: `destroy()` defaults `updateParentVdom` to `false`, and `items.length = 2` is a raw truncation that bypasses `removeAt`, the one path that splices `items` and `getVdomItemsRoot().cn` together. Every Workstation viewport vdom sync then threw `util.VDom.getVdom: Component not found for id`. @tobiu saw it as empty grids, absent dock styling, and missing undo/redo.

The controller now flags its own buttons and removes them by identity through `container.Base#remove`, inserting new ones ahead of `getActionSpacer()`. `authoredTopologyButtonCount` is deleted: it existed only to serve the arithmetic being removed.

Evidence: L3 (unit tier plus live-runtime verification in two browsers on two origins, including @tobiu's own instance) → L3 required (AC-6 is runtime-only by construction — the unit tier is what missed this). No residuals.

## AC Evidence

| AC | Evidence |
|---|---|
| AC-1 — the fixture is the view's declaration, not an analogue | CI-covered: `WorkspaceController.spec.mjs:128` builds the bar with `Neo.create(Toolbar, Workspace.prototype.createTopologyBar.call({topologyGroupId: 'spec-group'}))`. **Red-first confirmed**: against the pre-fix controller it fails at `expect(bar.getAction('undo')).not.toBeNull()` → `Received: null`, i.e. it reproduces the destruction rather than the symptom. The arm's own precondition (`bar.items` length 5, spacer present) passed pre-fix, so the fixture is demonstrably the materialised bar. |
| AC-2 — the toolbar's own items survive a sync | CI-covered: `getAction('undo')`, `getAction('redo')` and `getActionSpacer()` all assert non-null after the first sync, after a resync, and after a resync that empties the participant set. |
| AC-3 — `items` and `vdom.cn` stay aligned | CI-covered by `expectVdomAligned()`, asserted at four points. It checks both halves: the lengths match **and** `getVdomItemsRoot().cn.filter(id => id && !ComponentManager.get(id))` is empty. The second half is the invariant that actually broke — a length check alone would pass a swapped-but-dead stub. |
| AC-4 — the authored head still survives | CI-covered, retained from #18545's arm, which was correct about the head: emptying the participant set leaves `['Save workspace', 'Close workspace']`. |
| AC-5 — `authoredTopologyButtonCount` is gone | `git grep -n authoredTopologyButtonCount` → **0**. Positive control: AC-2/AC-3 pass without it, so its removal is demonstrated, not asserted. |
| AC-6 — the operator's symptom is gone at runtime | Verified on two live instances. (a) A fresh origin (`localhost:61855`, fresh SharedWorker): boots with zero worker-console errors, grids populated, dock styling applied, undo/redo rendered right of the spacer. (b) **@tobiu's own instance** (`localhost:8082`, Chrome, worker `83dc86b2`): `query_vdom({id:'neo-toolbar-1'})` = 5 children and `find_instances({parentId:'neo-toolbar-1'})` = **5 live components**, where before it was 5 vs 2. |

## Deltas from ticket

**`neo-component-35` is the action spacer — confirmed, not inferred.** The ticket named it from source reading. The post-fix `find_instances` returns it live with `className: 'Neo.component.Base'`, `cls: ['neo-toolbar-action-spacer']`, `style.flex: '1 1 0%'`. The identification now rests on the instance rather than on the constructor that could have produced it.

**A second false guard was found while removing the first.** `Workspace.spec.mjs:3185` asserted `expect(bar.items).toHaveLength(WorkspaceController.authoredTopologyButtonCount)` — but `createTopologyBar` returns a **plain object**, so `bar.items` there is the declaration `[Save, Close]`, permanently length 2. It compared a declared count against a constant describing materialised items and could not fail for the reason it existed. @neo-opus-grace found this in her own #18546 approval and retracted it: *"calls production code ≠ exercises the runtime object."* The assertion is dropped and the comment records why, so the next author does not restore it.

**A now-dead import removed.** `WorkspaceController` was imported by `Workspace.spec.mjs` solely for that constant. Left in place it would be the inverse of @neo-opus-vega's `defect-note` on unit specs and imports.

**Two findings that were NOT the cause, recorded because they cost real time.** The two dev servers on this machine serve **different clones** — `:8080` → `/Users/Shared/claude/neomjs/neo`, `:8082` → `/Users/Shared/github/neomjs/neo` — and separate origins mean separate SharedWorker and separate IndexedDB. I expected the pre-#18536 `componentRef` topology in IndexedDB (the Post-Merge checkbox I wrote on #18528) to be the cause. It is not: a virgin-IndexedDB pane on the other origin threw the same error. Two origins, two browser engines, empty vs. persisted storage, same defect.

**One correction to my own diagnosis, mid-investigation.** My first runtime reading was of my own Browser pane rather than @tobiu's instance — same error, wrong witness. Caught on the timestamps (the erroring worker connected 30s *after* my healthcheck) and on his correction that he runs `:8082`. The finding survived re-derivation against the right instance; the first version of it was about the wrong one.

## Test Evidence

`test-unit` on `test/playwright/unit/apps/workstation/`: **96 passed**, run after the `check-block-alignment --fix` staging pass so the committed bytes are what was measured.

The red-first control is the load-bearing one here, because the defect's whole character is that a green suite certified nothing: reverting only the controller change turns `WorkspaceController.spec.mjs:128` red at the undo assertion, while the pre-existing fixture stayed green through the entire defect's life.

Out of scope, deliberately: `VDom.syncVdomState:451` maps `getVdom` over every child before filtering `removeDom`, so a `removeDom` placeholder whose component is gone would throw on the `map` even though the next line discards it. Not this defect — the orphans here are not `removeDom` — and the throw is what made this findable. Untouched.

## Post-Merge Validation

- [ ] A Workstation window that was open across the merge needs its SharedWorker replaced, not just a reload: the worker survives a single-tab reload, so a stale one keeps serving pre-fix code. Close every tab on the origin, then reopen.

## Commits

- `855001d690` — identity-based removal, the constant deleted, both spec arms corrected

## Evolution

The ticket was filed from a runtime probe, not from reading the diff: `query_vdom` reporting five vdom children against `find_instances` reporting two live components is the entire defect in one comparison, and it named the mechanism before any source was read. That pairing is the reusable instrument — a container whose vdom child count exceeds its resolvable component count is broken by construction, whatever put it there.

What the ticket did not anticipate is that the same false-guard shape existed twice: once as the constant, once as the assertion that was supposed to protect it. Both were written in the same PR, an hour apart, by two people who each checked the other's half against a fixture that could not fail.

Authored by Ada (Claude Opus 5, Claude Code). Session 0dd7d644-f279-4b53-a515-522346f5f28f.
