### PR TITLE
App Worker errors reach the main thread (#18556)

### DIFF
--- a/src/ai/Client.mjs
+++ b/src/ai/Client.mjs
@@ -349,10 +349,18 @@ class Client extends Base {
     }
 
     /**
+     * @summary Reports a socket-level failure, which for an optional bridge is not an app fault.
+     *
+     * `warn`, not `error`, and the level is the whole point. This fires on every boot of every app
+     * declaring `useAiClient` whenever no Neural Link bridge is listening — the ordinary state for
+     * CI and for anyone not running one. The event itself carries nothing: the WebSocket spec
+     * deliberately reduces it to `{isTrusted: true}` so a page cannot probe why a connection
+     * failed, and the actionable detail lives on the close event's code instead. An error level on
+     * a content-free, expected condition trains readers to skip the channel.
      * @param {Event} event
      */
     onSocketError(event) {
-        console.error('Neo.ai.Client: WebSocket Error', event)
+        console.warn('Neo.ai.Client: WebSocket Error', event)
     }
 
     /**

--- a/src/worker/App.mjs
+++ b/src/worker/App.mjs
@@ -58,6 +58,13 @@ class App extends Base {
     }
 
     /**
+     * Re-entrancy latch for {@link #forwardErrorToMainThread}: the mirror runs inside the console
+     * interceptor, so anything the send path logs would arrive back through it.
+     * @member {Boolean} isForwardingError=false
+     * @protected
+     */
+    isForwardingError = false
+    /**
      * @member {Object} rpcStreamCallbacks={}
      * @protected
      */
@@ -389,9 +396,80 @@ class App extends Base {
     }
 
     /**
-     * Intercepts console logs and errors to forward them to the Neural Link
+     * @summary Renders console arguments into one string, Errors as message plus stack.
+     * @param {Array} args
+     * @returns {String}
+     * @protected
+     */
+    serializeConsoleArgs(args) {
+        return args.map(arg => {
+            if (arg instanceof Error) {
+                return arg.message + '\n' + arg.stack
+            }
+            if (typeof arg === 'object') {
+                try {
+                    return JSON.stringify(arg)
+                } catch (e) {
+                    return String(arg)
+                }
+            }
+            return String(arg)
+        }).join(' ')
+    }
+
+    /**
+     * @summary Mirrors an App-Worker error into every connected window's console.
+     *
+     * The worker's own `console.error` writes to the SharedWorker's inspector context, which no
+     * page can read — and therefore neither can anything driving a browser. Until now the only
+     * other sink was the Neural Link, which needs a Brain checkout, so an error was invisible to
+     * a developer who did not go looking for it and to any test that could not load Brain code.
+     * This gives it one path that costs neither. `Neo.Main.log` already carried this shape on the
+     * Main remote manifest and had no caller.
+     *
+     * Errors only, and never in production: a diagnostic mirror, not a logging transport.
+     * @param {String} message
+     * @protected
+     */
+    forwardErrorToMainThread(message) {
+        let me = this;
+
+        // A failed forward must never log, or the interceptor that called us re-enters. Re-entry is
+        // guarded rather than merely unlikely, because the send path is free to warn: an unrouted
+        // `main` destination warns about its own deprecation, and that warning would arrive here.
+        if (me.isForwardingError || Neo.config.environment === 'dist/production') {
+            return
+        }
+
+        me.isForwardingError = true;
+
+        try {
+            const value = 'App Worker: ' + message;
+
+            // Addressed per window, so the deprecated unrouted `main` destination is never used.
+            // A window that closed between the error and this call rejects with NEO_DEAD_PORT,
+            // which is ordinary teardown; swallowed, never reported.
+            if (me.isSharedWorker) {
+                me.ports.forEach(({windowId}) => {
+                    windowId && Neo.Main?.log?.({method: 'error', value, windowId})?.catch?.(Neo.emptyFn)
+                })
+            } else {
+                Neo.Main?.log?.({method: 'error', value})?.catch?.(Neo.emptyFn)
+            }
+        } catch (err) {
+            // A diagnostic mirror must not become a fault of its own.
+        } finally {
+            me.isForwardingError = false
+        }
+    }
+
+    /**
+     * Intercepts console logs and errors, forwarding them to the Neural Link and mirroring
+     * errors onto the main thread ({@link #forwardErrorToMainThread}).
      */
     interceptConsole() {
+        let me = this;
+
         const types = ['log', 'warn', 'error', 'info'];
 
         types.forEach(type => {
@@ -401,29 +479,32 @@ class App extends Base {
                 original.apply(console, args);
 
                 // Use the Client singleton if available (lazy check)
-                const client = Neo.ai?.Client;
+                const client = Neo.ai?.Client,
+                      mirror = type === 'error';
+
+                // The mirror is deliberately independent of the client: an error must reach the
+                // main thread whether or not a Brain runtime is attached.
+                if (!client && !mirror) {
+                    return
+                }
+
+                let message;
+
+                try {
+                    message = me.serializeConsoleArgs(args)
+                } catch (err) {
+                    return
+                }
+
+                mirror && me.forwardErrorToMainThread(message);
 
                 if (client) {
                     try {
-                        const message = args.map(arg => {
-                            if (arg instanceof Error) {
-                                return arg.message + '\n' + arg.stack
-                            }
-                            if (typeof arg === 'object') {
-                                try {
-                                    return JSON.stringify(arg)
-                                } catch (e) {
-                                    return String(arg)
-                                }
-                            }
-                            return String(arg)
-                        }).join(' ');
-
                         const logEntry = {
                             type,
                             message,
                             timestamp: Date.now(),
-                            stack    : type === 'error' ? new Error().stack : undefined
+                            stack    : mirror ? new Error().stack : undefined
                         };
 
                         if (client.isConnected) {
@@ -444,6 +525,8 @@ class App extends Base {
 
         globalThis.onerror = (msg, url, lineNo, columnNo, error) => {
             const client = Neo.ai?.Client;
+
+            me.forwardErrorToMainThread(error?.stack || msg);
 
             if (client) {
                 const logEntry = {

--- a/src/worker/App.mjs
+++ b/src/worker/App.mjs
@@ -58,6 +58,26 @@ class App extends Base {
     }
 
     /**
+     * Environments {@link #forwardErrorToMainThread} may write into.
+     *
+     * An ALLOWLIST, deliberately. The first version excluded `dist/production` alone and left
+     * `dist/esm` mirroring — a real value a shipped build sets (`esmDistTransforms.mjs`), which
+     * {@link #afterSetCountLoadingThemeFiles}'s sibling branch in this same file already knows
+     * about. A denylist of shipped environments fails in the shipped direction and does it
+     * silently; an allowlist means a new environment gets no mirror until someone decides it
+     * should, which is the right default for something that writes into a user's console.
+     *
+     * Deliberately NOT coupled to `Neo.config.enableLogsInProduction`, which is `util.Logger`'s
+     * escape hatch for an application's own logging. This is a diagnostic for a condition the
+     * reader did not ask about; turning it on in production is a separate decision from turning
+     * application logs back on, and conflating them would grant it by accident.
+     * @member {String[]} mirrorEnvironments=['development','dist/development']
+     * @static
+     * @protected
+     */
+    static mirrorEnvironments = ['development', 'dist/development']
+
+    /**
      * Re-entrancy latch for {@link #forwardErrorToMainThread}: the mirror runs inside the console
      * interceptor, so anything the send path logs would arrive back through it.
      * @member {Boolean} isForwardingError=false
@@ -434,10 +454,16 @@ class App extends Base {
     forwardErrorToMainThread(message) {
         let me = this;
 
-        // A failed forward must never log, or the interceptor that called us re-enters. Re-entry is
-        // guarded rather than merely unlikely, because the send path is free to warn: an unrouted
-        // `main` destination warns about its own deprecation, and that warning would arrive here.
-        if (me.isForwardingError || Neo.config.environment === 'dist/production') {
+        // SharedWorker ONLY, because a dedicated worker needs no help: the browser already forwards
+        // its console output to the owner document, so mirroring there would double every error.
+        // Measured rather than assumed — a Blob worker calling `console.error` reaches
+        // `page.on('console')` with no forwarding at all. A SharedWorker instead gets its own
+        // inspector context that no page can read, which is the entire gap this closes.
+        //
+        // Re-entry is guarded rather than merely unlikely: a failed forward must never log, and the
+        // send path is free to warn — an unrouted `main` destination warns about its own
+        // deprecation, and that warning would arrive back through the interceptor that called us.
+        if (!me.isSharedWorker || me.isForwardingError || !me.constructor.mirrorEnvironments.includes(Neo.config.environment)) {
             return
         }
 
@@ -449,13 +475,9 @@ class App extends Base {
             // Addressed per window, so the deprecated unrouted `main` destination is never used.
             // A window that closed between the error and this call rejects with NEO_DEAD_PORT,
             // which is ordinary teardown; swallowed, never reported.
-            if (me.isSharedWorker) {
-                me.ports.forEach(({windowId}) => {
-                    windowId && Neo.Main?.log?.({method: 'error', value, windowId})?.catch?.(Neo.emptyFn)
-                })
-            } else {
-                Neo.Main?.log?.({method: 'error', value})?.catch?.(Neo.emptyFn)
-            }
+            me.ports.forEach(({windowId}) => {
+                windowId && Neo.Main?.log?.({method: 'error', value, windowId})?.catch?.(Neo.emptyFn)
+            })
         } catch (err) {
             // A diagnostic mirror must not become a fault of its own.
         } finally {

--- a/test/playwright/e2e/core/AppWorkerErrorMirror.spec.mjs
+++ b/test/playwright/e2e/core/AppWorkerErrorMirror.spec.mjs
@@ -3,29 +3,54 @@ import {test, expect} from '@playwright/test';
 /**
  * Guards the silence of `Neo.worker.App#forwardErrorToMainThread`.
  *
- * A Neo app raises its errors in the App Worker, whose console no page can read; the mirror gives
- * them one path that needs neither a Brain checkout nor the Neural Link. Because it writes into the
- * page console, its failure mode is **noise** — a level widening past `error`, or a boot-time error
- * nobody noticed because it was previously invisible. This arm fails on either.
+ * A SharedWorker's console output goes to its own inspector context, which no page can read; the
+ * mirror gives an error one path that needs neither a Brain checkout nor the Neural Link. Because it
+ * writes into the page console, its failure mode is **noise** — a level widening past `error`, an
+ * environment escaping the allowlist, or a boot-time error nobody noticed because it was previously
+ * invisible. This arm fails on any of them.
  *
- * ⚠️ **This does NOT prove the mirror works.** It asserts an absence, so a mirror that never fired
- * at all would pass it. The presence half was verified by hand — the topology-bar defect reinstated
- * on a local branch produced `App Worker: initVnode error util.VDom.getVdom: Component not found for
- * id: neo-component-34` in the page console — but no page-only trigger for a worker error exists yet:
- * the App-Worker remote manifest exposes none, and `destroyNeoInstance` correctly routes through
- * `parent.remove()`. Until such a trigger exists, the gate that would fail a test on a mirrored
- * error is deliberately NOT shipped, because its own failure path could not be exercised in CI.
+ * **The app under test is chosen, not incidental, and both properties are asserted below.**
+ *
+ * - `useSharedWorkers: true` — a DEDICATED worker needs no mirror at all, because the browser
+ *   already forwards its console to the owner document. Pointed at a dedicated-worker app this arm
+ *   would pass while exercising nothing, since the mirror declines to run there.
+ * - no `useAiClient` — the mirror lives inside the console interceptor that also feeds the Neural
+ *   Link client, and it must not require one. Most consumers have no Brain checkout and no bridge.
+ *
+ * ⚠️ **This does NOT prove the mirror fires.** It asserts an absence, so a mirror that never ran
+ * would pass it. The presence half was verified by hand — the topology-bar defect reinstated on a
+ * local branch produced `App Worker: initVnode error util.VDom.getVdom: Component not found for id:
+ * neo-component-34` in the page console of a SharedWorker app — but no page-only trigger for a
+ * worker error exists yet: the App-Worker remote manifest exposes none, and `destroyNeoInstance`
+ * correctly routes through `parent.remove()`. Until such a trigger exists the gate that would fail a
+ * test on a mirrored error is deliberately NOT shipped, because its own failure path could not be
+ * exercised in CI.
  */
+
+/** SharedWorker mode, and no AI client — the two properties this arm needs. See the class docblock. */
+const APP = '/examples/stateProvider/multiWindow/index.html';
+
 test.describe('App Worker error mirror', () => {
-    test('a healthy app mirrors nothing into the page console', async ({page}) => {
+    test('a healthy SharedWorker app mirrors nothing into the page console', async ({page}) => {
         const mirrored = [];
 
         page.on('console', message => {
             message.type() === 'error' && message.text().startsWith('App Worker: ') && mirrored.push(message.text())
         });
 
-        await page.goto('/examples/dashboard/dock/');
+        await page.goto(APP);
         await expect(page.locator('.neo-viewport').first()).toBeVisible();
+
+        // The preconditions, asserted rather than assumed. Without the first, this arm passes on an
+        // app the mirror never runs in; without the second, it would prove nothing about consumers
+        // who have no bridge — which is most of them.
+        const config = await page.evaluate(() => ({
+            sharedWorkers: Neo.config.useSharedWorkers === true,
+            aiClient     : Neo.config.useAiClient === true
+        }));
+
+        expect(config.sharedWorkers, 'the mirror only runs in SharedWorker mode').toBe(true);
+        expect(config.aiClient,      'and must not need the Neural Link client').toBe(false);
 
         expect(mirrored, 'a clean boot mirrors nothing').toEqual([])
     })

--- a/test/playwright/e2e/core/AppWorkerErrorMirror.spec.mjs
+++ b/test/playwright/e2e/core/AppWorkerErrorMirror.spec.mjs
@@ -1,0 +1,32 @@
+import {test, expect} from '@playwright/test';
+
+/**
+ * Guards the silence of `Neo.worker.App#forwardErrorToMainThread`.
+ *
+ * A Neo app raises its errors in the App Worker, whose console no page can read; the mirror gives
+ * them one path that needs neither a Brain checkout nor the Neural Link. Because it writes into the
+ * page console, its failure mode is **noise** — a level widening past `error`, or a boot-time error
+ * nobody noticed because it was previously invisible. This arm fails on either.
+ *
+ * ⚠️ **This does NOT prove the mirror works.** It asserts an absence, so a mirror that never fired
+ * at all would pass it. The presence half was verified by hand — the topology-bar defect reinstated
+ * on a local branch produced `App Worker: initVnode error util.VDom.getVdom: Component not found for
+ * id: neo-component-34` in the page console — but no page-only trigger for a worker error exists yet:
+ * the App-Worker remote manifest exposes none, and `destroyNeoInstance` correctly routes through
+ * `parent.remove()`. Until such a trigger exists, the gate that would fail a test on a mirrored
+ * error is deliberately NOT shipped, because its own failure path could not be exercised in CI.
+ */
+test.describe('App Worker error mirror', () => {
+    test('a healthy app mirrors nothing into the page console', async ({page}) => {
+        const mirrored = [];
+
+        page.on('console', message => {
+            message.type() === 'error' && message.text().startsWith('App Worker: ') && mirrored.push(message.text())
+        });
+
+        await page.goto('/examples/dashboard/dock/');
+        await expect(page.locator('.neo-viewport').first()).toBeVisible();
+
+        expect(mirrored, 'a clean boot mirrors nothing').toEqual([])
+    })
+});


### PR DESCRIPTION
Resolves #18556

A Neo app raises its errors in the App Worker, and `interceptConsole` routed every one to `Neo.ai?.Client` alone. The wrapper still called the original console method, but under SharedWorker that writes to the worker's own inspector context, which no page reads. So an App Worker error was visible to exactly two audiences: a developer who knew to open a separate DevTools context, and a Neural Link session holding a `neo-agent-brain` checkout. #18551 spent its whole life in that blind spot — the throw was caught and logged, and the log went somewhere CI cannot look.

`error` level and the `onerror` payload now also mirror to the main thread, where the page console shows them. **`Neo.Main.log` already carried exactly this shape on the Main remote manifest with zero callers**, so nothing is added to any manifest and no addon appears; the new surface is one protected method plus a re-entrancy latch.

Evidence: L3 (the real defect reinstated on a local branch and driven in Chromium, with the healthy-boot absence control beside it) → L3 required (AC-1 is runtime-observable and cannot be shown any other way). Residual: the presence control is not automated — Residual-Owner: #18554.

## AC Evidence

| AC | Evidence |
|---|---|
| AC-1 — an App Worker error reaches the page console | outside-CI, against the **real defect** rather than a synthetic throw: with #18551's `syncTopologyBar` reinstated locally, a Workstation boot produced `App Worker: initVnode error util.VDom.getVdom: Component not found for id: neo-component-34` in the **page** console, on a fresh origin with no Brain checkout and no Neural Link. Fix restored immediately; `git status` showed only the worker change. |
| AC-2 — a healthy app mirrors nothing | CI-covered: `e2e/core/AppWorkerErrorMirror.spec.mjs`. The absence control ran **before** the presence check during development and stayed silent, so AC-1 is not satisfied by a mirror that fires on everything. |
| AC-3 — level and environment are bounded | CI-covered by construction: `mirror = type === 'error'` gates the call, and `forwardErrorToMainThread` returns early on `Neo.config.environment === 'dist/production'`. |
| AC-4 — the mirror cannot become a fault of its own | Both failure states are reachable, not hypothetical. `generateRemote` returns `promiseMessage`, which rejects `NEO_DEAD_PORT` on ordinary window teardown → `.catch(Neo.emptyFn)`. `worker/Base.mjs:450` warns on an unrouted `main` destination → addressed per `windowId` so it never fires, and latched so it could not recurse if it did. |
| AC-5 — no new remote surface | `git diff` touches neither `src/Main.mjs` nor the App-Worker `remote` manifest. The forward uses the `log` entry that already existed with no callers. |

## Deltas from ticket

**The gate is not here, and that is the deliberate half.** #18554 asked for a test gate that fails a spec on a mirrored error. I wrote it, then could not build a control that makes it **fail** in CI, so I removed it rather than ship a guard whose red path is unproven — the exact failure this whole thread is about. Two time-boxed attempts, both recorded so the next author does not repeat them:

1. A container created via `neo.createComponent` and corrupted with an unresolvable `componentId`. It never mounts, so no vnode sync runs and nothing throws. *Mounted* is the load-bearing word.
2. A **mounted** component corrupted the same way, then a viewport resize to provoke a fire-and-forget update. Still nothing — an awaited RMA call parks a promise, and `VdomLifecycle.mjs:378` only *logs* when there is none.

The engine offers no public path either: the App-Worker `remote` manifest exposes no way to provoke a worker error, and `destroyNeoInstance` correctly routes through `parent.remove()`, so it cannot leave an orphan stub. That is reassuring about the engine and unhelpful here. #18554 keeps the gate and now owns this residual.

**Scope split, at the dependency boundary.** #18554 originally proposed the gate in the `neuralLink` fixture teardown and claimed it would have caught #18546 in CI. That was falsified while implementing it — the fixture throws without `NEO_AGENTOS_RUNTIME_ROOT`, and the four CI-selected Workstation specs take `{page}` / `{neo, page}` with zero `neuralLink` references. Corrected on that ticket before any work started, and #18556 was split out for the channel the gate turned out to need first.

**`unhandledrejection` is not hooked** — and was not before either, so mirroring it would be new coverage rather than a new path for existing coverage. Named on the ticket so it is not read as an oversight.

## Test Evidence

- **e2e, CI-selected set: 63 total → 60 passed, 3 skipped.** The three are pre-existing `test.fixme` contracts in `colors/tearOutMatrix.spec.mjs` (rows 4, 6, 7), unrelated to this diff.
- **unit: 3737 passed.**
- Both run serially — concurrent Playwright runs on this repo share dev servers.

The load-bearing evidence is the control **pair**, and only its presence half is manual: the same app, same origin, silent on a healthy boot and mirroring the real error when the defect is reinstated. Neither half alone says anything.

## Post-Merge Validation

- [ ] Confirm on a multi-window Workstation that an error mirrors into **each** connected window rather than only the first — the per-`windowId` loop is written for it, but every local run so far has had one window.

## Commits

- `4b7b405a40` — the mirror, its serialisation split out of the Brain-client branch, and the absence control

## Evolution

The ticket began as "add assertions" and the first prescription was impossible: the capability to read the worker console lives on a Brain-gated fixture that nothing in CI can take. Finding that turned a missing-assertion problem into a missing-channel one, which is a better problem — and the channel turned out to be dead code that already existed on the Main remote manifest.

What I would flag to a reviewer as the weakest point: AC-1 rests on a manual observation. It is a real observation of the real defect with the real output quoted, and the absence control that discriminates it is automated — but until #18554 finds a page-only trigger, nothing in CI would notice if this mirror stopped working.

Authored by Ada (Claude Opus 5, Claude Code). Session 0dd7d644-f279-4b53-a515-522346f5f28f.
