### PR TITLE
The viewport origin is measured, not inferred

### DIFF
--- a/src/Main.mjs
+++ b/src/Main.mjs
@@ -338,7 +338,12 @@ class Main extends core.Base {
                 width      : screen.width
             },
             screenLeft: win.screenLeft,
-            screenTop : win.screenTop
+            screenTop : win.screenTop,
+            // Measured by `main.addon.WindowPosition`'s pointer probe when this window is observed;
+            // absent until a sample lands, and absent forever on a window nobody observes. Consumers
+            // fall back to deriving the viewport from assumed border widths, which is what every
+            // window did before this existed.
+            viewportOffset: win.neoViewportOffset ?? null
         }
     }
 

--- a/src/main/addon/WindowPosition.mjs
+++ b/src/main/addon/WindowPosition.mjs
@@ -77,6 +77,14 @@ class WindowPosition extends Base {
     resizeListener = null
 
     /**
+     * The one-shot pointer probe that measures the viewport origin. Non-null only while a sample is
+     * outstanding, so re-arming is idempotent and no window carries a standing pointer listener.
+     * @member {Function|null} viewportProbe=null
+     * @protected
+     */
+    viewportProbe = null
+
+    /**
      * @param {Object} config
      */
     construct(config) {
@@ -127,7 +135,49 @@ class WindowPosition extends Base {
             me.resizeListener =  me.onResize.bind(me)
         }
 
-        window[value ? 'addEventListener' : 'removeEventListener']('resize', me.resizeListener)
+        window[value ? 'addEventListener' : 'removeEventListener']('resize', me.resizeListener);
+
+        value && me.armViewportProbe()
+    }
+
+    /**
+     * @summary Arms a single pointer sample that measures where this window's viewport actually
+     * starts inside its frame.
+     *
+     * `event.screenX - event.clientX` IS the viewport's screen-space left edge — the browser states
+     * it instead of us inferring it, so one reading survives a docked devtools panel, a platform's
+     * border widths and the macOS menu bar alike. What {@link Neo.manager.Window#calculateGeometry}
+     * has to guess from `outerWidth - innerWidth` is WHICH edge lost the space, and a panel docked
+     * left and one docked right make that difference identical — the side is simply not in those
+     * numbers. It is in this one.
+     *
+     * Stored relative to the frame, because that offset is invariant under movement: only a resize
+     * can change it, and a resize is an event, so this needs no poll. One sample, then the listener
+     * removes itself; a window nobody observes never arms one at all.
+     * @protected
+     */
+    armViewportProbe() {
+        let me = this;
+
+        if (me.viewportProbe) return;
+
+        me.viewportProbe = event => {
+            // `screenLeft`/`screenTop`, not `screenX`/`screenY`: aliases on a real window, but this
+            // offset is consumed relative to the frame origin `getWindowData` publishes, and that
+            // is the pair it publishes. One name for one quantity.
+            let win = window,
+                x   = event.screenX - event.clientX - win.screenLeft,
+                y   = event.screenY - event.clientY - win.screenTop;
+
+            me.viewportProbe = null;
+
+            if (Number.isFinite(x) && Number.isFinite(y)) {
+                win.neoViewportOffset = {x, y};
+                me.publishGeometry()
+            }
+        };
+
+        window.addEventListener('pointermove', me.viewportProbe, {capture: true, once: true, passive: true})
     }
 
     /**
@@ -288,7 +338,12 @@ class WindowPosition extends Base {
 
         // A fixed-origin resize is still a geometry change. The conversion metric consumes live
         // extents every frame, so movement-only publication would make its post-resize decision stale.
-        me.publishGeometry()
+        me.publishGeometry();
+
+        // A resize is also the ONLY thing that can move the viewport inside its frame — opening or
+        // re-docking a devtools panel arrives here and nowhere else — so this is where the measured
+        // offset goes stale and has to be taken again.
+        me.armViewportProbe()
     }
 
     /**

--- a/src/main/addon/WindowPosition.mjs
+++ b/src/main/addon/WindowPosition.mjs
@@ -137,7 +137,25 @@ class WindowPosition extends Base {
 
         window[value ? 'addEventListener' : 'removeEventListener']('resize', me.resizeListener);
 
-        value && me.armViewportProbe()
+        value ? me.armViewportProbe() : me.disarmViewportProbe()
+    }
+
+    /**
+     * @summary Releases an outstanding pointer sample when observation stops.
+     *
+     * Without this, a probe armed while observing outlives it: the `once` listener stays attached
+     * and the next pointer motion writes an offset and publishes geometry for a window that has
+     * stopped observing. `armViewportProbe`'s promise is that no window carries a standing pointer
+     * listener, and that promise has to survive being switched off.
+     * @protected
+     */
+    disarmViewportProbe() {
+        let me = this;
+
+        if (me.viewportProbe) {
+            window.removeEventListener('pointermove', me.viewportProbe, {capture: true});
+            me.viewportProbe = null
+        }
     }
 
     /**
@@ -169,10 +187,18 @@ class WindowPosition extends Base {
                 x   = event.screenX - event.clientX - win.screenLeft,
                 y   = event.screenY - event.clientY - win.screenTop;
 
+            let old = win.neoViewportOffset;
+
             me.viewportProbe = null;
 
-            if (Number.isFinite(x) && Number.isFinite(y)) {
-                win.neoViewportOffset = {x, y};
+            if (!Number.isFinite(x) || !Number.isFinite(y)) return;
+
+            win.neoViewportOffset = {x, y};
+
+            // Change-driven, exactly like `checkMovement`: a publication is a worker round trip, and
+            // a sample that confirms the offset we already hold is not news. Publishing on every
+            // pointer sample would inject a message into whatever gesture happens to be running.
+            if (!old || old.x !== x || old.y !== y) {
                 me.publishGeometry()
             }
         };
@@ -340,9 +366,12 @@ class WindowPosition extends Base {
         // extents every frame, so movement-only publication would make its post-resize decision stale.
         me.publishGeometry();
 
-        // A resize is also the ONLY thing that can move the viewport inside its frame — opening or
-        // re-docking a devtools panel arrives here and nowhere else — so this is where the measured
-        // offset goes stale and has to be taken again.
+        // A resize is the only EVENT that reports the viewport moving inside its frame, so this is
+        // where the measured offset goes stale and has to be taken again. Not the only cause: a
+        // panel re-docked from one side to the other at equal width changes neither `innerWidth`
+        // nor `innerHeight`, fires nothing, and leaves the previous offset standing. That case is
+        // still no worse than the assumptions it replaced, and it is stated rather than papered
+        // over — see `usableViewportOffset` for the other known bound.
         me.armViewportProbe()
     }
 

--- a/src/manager/Window.mjs
+++ b/src/manager/Window.mjs
@@ -61,7 +61,7 @@ class Window extends Manager {
      * @summary Admits a measured viewport offset only when it can physically describe this frame.
      *
      * The offset is the viewport's origin relative to the frame's, measured on the main thread as
-     * `event.screenX - event.clientX - window.screenX`. It is exact at page zoom 1; under browser
+     * `event.screenX - event.clientX - window.screenLeft`. It is exact at page zoom 1; under browser
      * zoom `clientX` is page CSS pixels while `screenX` is screen CSS pixels, so the reading can
      * drift. Rather than correct for a zoom factor no web API reports reliably, this bounds the
      * offset inside the frame: a viewport cannot start before its frame, and cannot leave less room
@@ -92,7 +92,14 @@ class Window extends Manager {
      * above the screen. `outerRect` is therefore the frame itself and `innerRect` the frame shifted
      * by the chrome. The chrome split assumes symmetric side borders and a bottom border equal to a
      * side border, so the remaining height difference is the title bar.
-     * @param {Object} data The raw report: `innerHeight`, `innerWidth`, `outerHeight`, `outerWidth`, `screenLeft`, `screenTop`, and Firefox's `mozInnerScreenX/Y`
+     * **`chrome` is the content inset within the frame, panels included** — not a decorative border
+     * width. It is derived from the two origins, so it always agrees with whichever of the three
+     * sources answered. On a window with a devtools panel docked left or top, `chrome.left` /
+     * `chrome.top` therefore contain the panel, which is the correct content inset and is what a
+     * caller converting a content origin into a frame origin needs. Read by
+     * {@link Neo.dashboard.dock.window.NativeVesselTransaction#toFrameOrigin} and published into
+     * agent-visible payloads by `src/ai/Client.mjs`.
+     * @param {Object} data The raw report: `innerHeight`, `innerWidth`, `outerHeight`, `outerWidth`, `screenLeft`, `screenTop`, Firefox's `mozInnerScreenX/Y`, and an optional measured `viewportOffset`
      * @returns {Object} {chrome, innerRect, outerRect}
      */
     calculateGeometry(data) {

--- a/src/manager/Window.mjs
+++ b/src/manager/Window.mjs
@@ -58,6 +58,30 @@ class Window extends Manager {
     }
 
     /**
+     * @summary Admits a measured viewport offset only when it can physically describe this frame.
+     *
+     * The offset is the viewport's origin relative to the frame's, measured on the main thread as
+     * `event.screenX - event.clientX - window.screenX`. It is exact at page zoom 1; under browser
+     * zoom `clientX` is page CSS pixels while `screenX` is screen CSS pixels, so the reading can
+     * drift. Rather than correct for a zoom factor no web API reports reliably, this bounds the
+     * offset inside the frame: a viewport cannot start before its frame, and cannot leave less room
+     * than it occupies. An out-of-bounds reading falls back to the border assumptions, which is
+     * exactly today's behaviour — a bad measurement degrades to the status quo, never past it.
+     * @param {Object|null} offset
+     * @param {Number} widthDiff `outerWidth - innerWidth`
+     * @param {Number} heightDiff `outerHeight - innerHeight`
+     * @returns {Object|null} The admitted offset, or null
+     * @protected
+     */
+    usableViewportOffset(offset, widthDiff, heightDiff) {
+        if (!offset || !Number.isFinite(offset.x) || !Number.isFinite(offset.y)) return null;
+
+        const {x, y} = offset;
+
+        return x >= 0 && y >= 0 && x <= widthDiff && y <= heightDiff ? offset : null
+    }
+
+    /**
      * Interprets one raw window report into the manager's two rectangles and the chrome between them.
      *
      * `screenLeft` / `screenTop` name the window FRAME's origin — the top-left of the OS window
@@ -74,7 +98,7 @@ class Window extends Manager {
     calculateGeometry(data) {
         const {
             innerHeight, innerWidth, mozInnerScreenX, mozInnerScreenY,
-            outerHeight, outerWidth, screenLeft, screenTop
+            outerHeight, outerWidth, screenLeft, screenTop, viewportOffset
         } = data;
 
         const
@@ -85,35 +109,49 @@ class Window extends Manager {
             // Assumption: Bottom border matches side border (common in Windows)
             bottomBorder = sideBorder,
             // The rest is the top chrome (header)
-            topChrome    = heightDiff - bottomBorder;
-
-        const chrome = {
-            bottom: bottomBorder,
-            left  : sideBorder,
-            right : sideBorder,
-            top   : topChrome
-        };
+            topChrome    = heightDiff - bottomBorder,
+            firefox      = typeof mozInnerScreenX === 'number',
+            measured     = this.usableViewportOffset(viewportOffset, widthDiff, heightDiff);
 
         let viewportLeft, viewportTop;
 
-        if (typeof mozInnerScreenX === 'number') {
+        if (firefox) {
             // Firefox publishes the viewport origin directly
             viewportLeft = mozInnerScreenX;
             viewportTop  = mozInnerScreenY
+        } else if (measured) {
+            // A real viewport reading. It outranks the border assumptions because it carries what
+            // they cannot express: WHICH edge lost the space. A panel docked left and one docked
+            // right produce the same `widthDiff`, so the side is absent from these numbers and
+            // present only in a measurement.
+            viewportLeft = screenLeft + measured.x;
+            viewportTop  = screenTop  + measured.y
         } else {
             // Chrome, Edge and Safari report the frame origin: the viewport sits inside the chrome
             viewportLeft = screenLeft + sideBorder;
             viewportTop  = screenTop  + topChrome
         }
 
+        // Firefox derives its frame from the viewport it published; everyone else reported the
+        // frame in the first place. Deriving `chrome` from the two origins rather than from the
+        // assumptions keeps it consistent with whichever branch answered — so a 479 px panel on
+        // the right reports `right: 479` instead of splitting itself across both sides.
+        const
+            frameLeft = firefox ? viewportLeft - sideBorder : screenLeft,
+            frameTop  = firefox ? viewportTop  - topChrome  : screenTop,
+            left      = viewportLeft - frameLeft,
+            top       = viewportTop  - frameTop;
+
+        const chrome = {
+            bottom: heightDiff - top,
+            left,
+            right : widthDiff - left,
+            top
+        };
+
         const innerRect = new Rectangle(viewportLeft, viewportTop, innerWidth, innerHeight);
 
-        const outerRect = new Rectangle(
-            viewportLeft - sideBorder,
-            viewportTop  - topChrome,
-            outerWidth,
-            outerHeight
-        );
+        const outerRect = new Rectangle(frameLeft, frameTop, outerWidth, outerHeight);
 
         return {chrome, innerRect, outerRect}
     }

--- a/test/playwright/unit/main/addon/WindowPosition.spec.mjs
+++ b/test/playwright/unit/main/addon/WindowPosition.spec.mjs
@@ -327,18 +327,42 @@ test.describe('Neo.main.addon.WindowPosition — the viewport-origin probe', () 
         expect(addon.viewportProbe, 'the sample is still spent — a bad reading is not a retry loop').toBeNull()
     });
 
-    test('observation is what arms it: a window nobody observes carries no pointer listener', () => {
-        const observed = {
-            armViewportProbe: WindowPosition.prototype.armViewportProbe,
-            onResize        : () => {},
-            resizeListener  : null,
-            viewportProbe   : null
-        };
-
-        WindowPosition.prototype.afterSetObserveResize.call(observed, false, true);
-        expect(listeners.filter(entry => entry.type === 'pointermove'), 'off means off').toHaveLength(0);
+    test('observing arms the probe and UNobserving releases it, so no window carries a standing listener', () => {
+        const pointerListeners = () => listeners.filter(entry => entry.type === 'pointermove'),
+              observed         = {
+                  armViewportProbe   : WindowPosition.prototype.armViewportProbe,
+                  disarmViewportProbe: WindowPosition.prototype.disarmViewportProbe,
+                  onResize           : () => {},
+                  resizeListener     : null,
+                  viewportProbe      : null
+              };
 
         WindowPosition.prototype.afterSetObserveResize.call(observed, true, false);
-        expect(listeners.filter(entry => entry.type === 'pointermove')).toHaveLength(1)
+        expect(pointerListeners(), 'observing takes a sample').toHaveLength(1);
+
+        // The half that matters, and that an assert-on-an-empty-array cannot reach: the outstanding
+        // sample must not outlive observation. A probe left attached writes an offset and publishes
+        // geometry for a window that stopped observing.
+        WindowPosition.prototype.afterSetObserveResize.call(observed, false, true);
+        expect(pointerListeners(), 'unobserving releases the outstanding sample').toHaveLength(0);
+        expect(observed.viewportProbe).toBeNull()
+    });
+
+    test('a sample that confirms the offset we already hold does not publish', () => {
+        // A publication is a worker round trip. Publishing on every pointer sample would inject a
+        // message into whatever gesture happens to be running — which is not free in a fixture that
+        // drives pointer interactions, and is not news either.
+        addon.armViewportProbe();
+        firePointer({clientX: 40, clientY: 20, screenX: 140, screenY: 187});
+        expect(addon.published, 'the first sample is news').toBe(1);
+
+        addon.armViewportProbe();
+        firePointer({clientX: 10, clientY: 90, screenX: 110, screenY: 257});
+        expect(globalThis.window.neoViewportOffset, 'same offset, read through different coordinates').toEqual({x: 0, y: 117});
+        expect(addon.published, 'and confirming it is not').toBe(1);
+
+        addon.armViewportProbe();
+        firePointer({clientX: 40, clientY: 20, screenX: 619, screenY: 187});
+        expect(addon.published, 'a CHANGED origin is news again').toBe(2)
     })
 });

--- a/test/playwright/unit/main/addon/WindowPosition.spec.mjs
+++ b/test/playwright/unit/main/addon/WindowPosition.spec.mjs
@@ -63,13 +63,19 @@ test.describe('Neo.main.addon.WindowPosition — live geometry publication', () 
     });
 
     test('a fixed-origin resize publishes the complete window snapshot', () => {
-        const addon = {
-            adjustWindowPositions: false,
-            publishGeometry      : WindowPosition.prototype.publishGeometry,
-            windows              : {}
-        };
+        // A resize is also the only event that can invalidate the measured viewport offset, so the
+        // double records the re-arm rather than pretending the collaborator is absent.
+        const rearmed = [],
+              addon   = {
+                  adjustWindowPositions: false,
+                  armViewportProbe     : () => rearmed.push(true),
+                  publishGeometry      : WindowPosition.prototype.publishGeometry,
+                  windows              : {}
+              };
 
         WindowPosition.prototype.onResize.call(addon, {});
+
+        expect(rearmed, 'a resize re-measures where the viewport starts inside the frame').toEqual([true]);
 
         expect(sent).toEqual([['app', {
             action: 'windowPositionChange',
@@ -212,5 +218,127 @@ test.describe('Neo.main.addon.WindowPosition — live geometry publication', () 
 
         expect(configs).toEqual({observeResize: true});
         expect(data).toEqual({observeResize: true})
+    })
+});
+
+/**
+ * @summary The viewport-origin probe: one pointer sample, taken because the numbers cannot be
+ * inferred.
+ *
+ * `outerWidth - innerWidth` says how much width the viewport lost and never to which edge, so a
+ * devtools panel docked left and one docked right are byte-identical to
+ * {@link Neo.manager.Window#calculateGeometry}. `event.screenX - event.clientX` is the viewport's
+ * screen-space left edge as the browser states it, and carries the side for free.
+ */
+test.describe('Neo.main.addon.WindowPosition — the viewport-origin probe', () => {
+    let addon, listeners, originalWindow;
+
+    /** @returns {Object} A window double that records listener traffic and owns a frame origin. */
+    const makeWindow = () => ({
+        addEventListener   : (type, fn, opts) => listeners.push({fn, opts, type}),
+        removeEventListener: (type, fn) => {
+            const index = listeners.findIndex(entry => entry.fn === fn && entry.type === type);
+            index > -1 && listeners.splice(index, 1)
+        },
+        screenLeft: 100,
+        screenTop : 50
+    });
+
+    /**
+     * Dispatches to the outstanding pointer listener the way a browser does: a `once` listener is
+     * removed BEFORE it is invoked. Modelling that is the point — the probe relies on `once` for
+     * its removal and nulls its own handle, so a double that kept the entry could not witness the
+     * one-shot contract at all.
+     * @param {Object} event
+     */
+    const firePointer = event => {
+        const index = listeners.findIndex(entry => entry.type === 'pointermove'),
+              entry = listeners[index];
+
+        entry.opts?.once && listeners.splice(index, 1);
+        entry.fn(event)
+    };
+
+    test.beforeEach(() => {
+        listeners      = [];
+        originalWindow = globalThis.window;
+        globalThis.window = makeWindow();
+
+        addon = {
+            armViewportProbe: WindowPosition.prototype.armViewportProbe,
+            published       : 0,
+            publishGeometry() { this.published++ },
+            viewportProbe   : null
+        }
+    });
+
+    test.afterEach(() => {
+        originalWindow === undefined ? delete globalThis.window : globalThis.window = originalWindow
+    });
+
+    test('one sample measures the offset from the frame, publishes it, and does not stay attached', () => {
+        addon.armViewportProbe();
+
+        expect(listeners).toHaveLength(1);
+        expect(listeners[0].type).toBe('pointermove');
+        // `once` is what makes this a sample rather than a subscription; `passive` keeps it off the
+        // scroll-blocking path of a gesture that is already moving a window.
+        expect(listeners[0].opts).toEqual({capture: true, once: true, passive: true});
+
+        // A pointer at client (40, 20) sitting at screen (140, 187) on a frame whose origin is
+        // (100, 50): the viewport starts 0 px in from the frame's left and 117 px below its top.
+        firePointer({clientX: 40, clientY: 20, screenX: 140, screenY: 187});
+
+        expect(globalThis.window.neoViewportOffset).toEqual({x: 0, y: 117});
+        expect(addon.published, 'the correction reaches the worker on the sample, not on the next resize').toBe(1);
+        expect(addon.viewportProbe, 'the probe releases itself once it has its answer').toBeNull();
+        expect(listeners, 'and the browser removed the one-shot listener').toHaveLength(0)
+    });
+
+    test('a panel on the left is measured as a left offset, which is the whole reason to measure', () => {
+        addon.armViewportProbe();
+        // Same frame, same window size — but the viewport now starts 479 px in from the left.
+        firePointer({clientX: 40, clientY: 20, screenX: 619, screenY: 187});
+
+        expect(globalThis.window.neoViewportOffset).toEqual({x: 479, y: 117})
+    });
+
+    test('re-arming while a sample is outstanding does not attach a second listener', () => {
+        addon.armViewportProbe();
+        addon.armViewportProbe();
+        addon.armViewportProbe();
+
+        expect(listeners, 'one outstanding sample is enough').toHaveLength(1);
+
+        firePointer({clientX: 0, clientY: 0, screenX: 100, screenY: 137});
+
+        // Only after the sample lands may a new one be armed — that is what a resize does.
+        addon.armViewportProbe();
+        expect(listeners).toHaveLength(1);
+        expect(addon.viewportProbe).not.toBeNull()
+    });
+
+    test('a non-finite reading is discarded rather than published', () => {
+        addon.armViewportProbe();
+        firePointer({clientX: NaN, clientY: 20, screenX: 140, screenY: 187});
+
+        expect(globalThis.window.neoViewportOffset, 'nothing is written').toBeUndefined();
+        expect(addon.published, 'and nothing is published').toBe(0);
+        expect(addon.viewportProbe, 'the sample is still spent — a bad reading is not a retry loop').toBeNull()
+    });
+
+    test('observation is what arms it: a window nobody observes carries no pointer listener', () => {
+        const observed = {
+            armViewportProbe: WindowPosition.prototype.armViewportProbe,
+            onResize        : () => {},
+            resizeListener  : null,
+            viewportProbe   : null
+        };
+
+        WindowPosition.prototype.afterSetObserveResize.call(observed, false, true);
+        expect(listeners.filter(entry => entry.type === 'pointermove'), 'off means off').toHaveLength(0);
+
+        WindowPosition.prototype.afterSetObserveResize.call(observed, true, false);
+        expect(listeners.filter(entry => entry.type === 'pointermove')).toHaveLength(1)
     })
 });

--- a/test/playwright/unit/manager/WindowGeometry.spec.mjs
+++ b/test/playwright/unit/manager/WindowGeometry.spec.mjs
@@ -90,3 +90,120 @@ test.describe('Neo.manager.Window#calculateGeometry — the frame origin', () =>
         expect([outerRect.x, outerRect.y]).toEqual([200, 120])
     });
 });
+
+/**
+ * @summary A docked devtools panel is not a window border, and the border assumptions cannot
+ * describe it.
+ *
+ * `outerWidth - innerWidth` says how much width the viewport lost; it cannot say to WHICH edge. A
+ * panel docked left and one docked right produce byte-identical input, so no split, clamp or
+ * heuristic can separate them — the side is absent from the numbers. A measured viewport offset
+ * carries it, and is the only thing that does.
+ *
+ * The truth column below is computed independently of the model: the viewport starts below the
+ * browser's own 87 px of top chrome, plus the panel only when the panel sits on that edge.
+ * Reported by @tobiu against a live window, docked right: `screenX - clientX` read 64 where the
+ * split said 303.5, on a 479 px panel — an error of exactly 479 / 2.
+ */
+test.describe('Neo.manager.Window#calculateGeometry — a measured viewport origin', () => {
+    let WindowManager;
+
+    const FRAME = {height: 1000, width: 1600, x: 100, y: 50},
+          // The browser's own chrome with no panel on that edge: 87 px of tab strip + omnibox.
+          MEASURED = {x: 0, y: 87},
+
+          read = (innerWidth, innerHeight, extra = {}) => WindowManager.calculateGeometry({
+              innerHeight, innerWidth,
+              outerHeight: FRAME.height, outerWidth: FRAME.width,
+              screenLeft : FRAME.x,      screenTop : FRAME.y,
+              ...extra
+          });
+
+    test.beforeAll(async () => {
+        WindowManager = (await import('../../../../src/manager/Window.mjs')).default
+    });
+
+    test('every dock position resolves to its own true viewport origin', () => {
+        // Each row carries the offset a real probe WOULD read on that layout — the left and top rows
+        // differ from the right and bottom ones by exactly the panel, which is the whole point: the
+        // sizes are identical between right/left and between bottom/top, so only the measurement
+        // separates them. Right and bottom are the positions in normal use.
+        const cases = [
+            ['no panel',      1600, 913, {x: 0,   y: 87},  {bottom: 0,   left: 0,   right: 0,   top: 87}],
+            ['docked right',  1121, 913, {x: 0,   y: 87},  {bottom: 0,   left: 0,   right: 479, top: 87}],
+            ['docked bottom', 1600, 513, {x: 0,   y: 87},  {bottom: 400, left: 0,   right: 0,   top: 87}],
+            ['docked left',   1121, 913, {x: 479, y: 87},  {bottom: 0,   left: 479, right: 0,   top: 87}],
+            ['docked top',    1600, 513, {x: 0,   y: 487}, {bottom: 0,   left: 0,   right: 0,   top: 487}]
+        ];
+
+        for (const [label, innerWidth, innerHeight, viewportOffset, expectedChrome] of cases) {
+            const {chrome, innerRect, outerRect} = read(innerWidth, innerHeight, {viewportOffset});
+
+            expect([innerRect.x, innerRect.y], `${label}: the viewport origin is measured, not inferred`)
+                .toEqual([FRAME.x + viewportOffset.x, FRAME.y + viewportOffset.y]);
+            expect([innerRect.width, innerRect.height], `${label}: the size was always right`)
+                .toEqual([innerWidth, innerHeight]);
+            expect([outerRect.x, outerRect.y], `${label}: the frame never moved`).toEqual([FRAME.x, FRAME.y]);
+            expect(chrome, `${label}: chrome names WHICH edge lost the space`).toEqual(expectedChrome)
+        }
+    });
+
+    test('left and right are indistinguishable without a measurement, and separable with one', () => {
+        // The claim the whole design rests on. Identical inputs, so the fallback cannot tell them
+        // apart by construction; the measured branch puts 479 px of viewport between them.
+        const sizes = [1121, 913];
+
+        expect(read(...sizes).innerRect.x, 'the fallback answers one number for both docks').toBe(339.5);
+
+        expect(read(...sizes, {viewportOffset: {x: 0,   y: 87}}).innerRect.x).toBe(FRAME.x);
+        expect(read(...sizes, {viewportOffset: {x: 479, y: 87}}).innerRect.x).toBe(FRAME.x + 479)
+    });
+
+    test('without a measurement the panel splits itself across both sides, and the top chrome goes negative', () => {
+        // The documented fallback, pinned so the difference the measurement makes stays visible.
+        // A 479 px panel on the right becomes 239.5 px of phantom border on each side, and the
+        // remaining height difference is 239.5 px short of the real title bar.
+        const {chrome, innerRect} = read(1121, 913);
+
+        expect(chrome).toEqual({bottom: 239.5, left: 239.5, right: 239.5, top: -152.5});
+        expect([innerRect.x, innerRect.y]).toEqual([339.5, -102.5]);
+
+        // 239.5 px of drop-zone error on both axes, which is what a pointer over the panel maps into.
+        const measured = read(1121, 913, {viewportOffset: MEASURED});
+
+        expect(innerRect.x - measured.innerRect.x).toBe(239.5);
+        expect(innerRect.y - measured.innerRect.y).toBe(-239.5)
+    });
+
+    test('Firefox keeps priority: an explicit viewport origin outranks a measured one', () => {
+        const {innerRect} = read(900, 613, {
+            mozInnerScreenX: 700, mozInnerScreenY: 707, viewportOffset: {x: 0, y: 87}
+        });
+
+        expect([innerRect.x, innerRect.y]).toEqual([700, 707])
+    });
+
+    test('an offset that cannot describe this frame is refused, and the fallback answers', () => {
+        // Under browser page zoom `clientX` is page CSS pixels while `screenX` is screen CSS pixels,
+        // so the reading can drift. Bounding it inside the frame degrades a bad sample to today's
+        // behaviour instead of trusting it past the edges of the window it claims to describe.
+        const fallback = read(1121, 913).innerRect;
+
+        for (const [label, offset] of [
+            ['negative x',        {x: -10, y: 87}],
+            ['negative y',        {x: 0,   y: -1}],
+            ['wider than the frame allows', {x: 480, y: 87}],
+            ['taller than the frame allows', {x: 0, y: 88}],
+            ['non-finite',        {x: NaN, y: 87}],
+            ['absent',            null]
+        ]) {
+            const {innerRect} = read(1121, 913, {viewportOffset: offset});
+
+            expect([innerRect.x, innerRect.y], `${label}: refused, so the assumptions answer`)
+                .toEqual([fallback.x, fallback.y])
+        }
+
+        // The exact bounds ARE admissible — a viewport flush against either edge is a real window.
+        expect(read(1121, 913, {viewportOffset: {x: 479, y: 0}}).innerRect.x).toBe(FRAME.x + 479)
+    })
+});


### PR DESCRIPTION
Resolves #18555

🌿 A window could be asked how much viewport it lost and never which side lost it; after this, nothing has to guess, because the browser was willing to say.

`calculateGeometry` derived the viewport origin by splitting `outerWidth - innerWidth` across assumed symmetric borders. True for OS window borders, false for a docked DevTools panel — and the split cannot be made true, because **a panel docked left and one docked right produce byte-identical input.** The side is not in those numbers. It is in `event.screenX - event.clientX`, which is the viewport's screen-space left edge as the browser states it.

Measured by @tobiu on a live window, DevTools docked right: `{trueViewportX: 64, modelSaysX: 303.5, devtoolsWidth: 479}` — the error is exactly `479 / 2`.

**Lineage.** This closes the half of #8164 that was left open. @tobiu challenged this exact model at design time — *"we get screenTop, which is the distance to the browser top border. with the new logic, we do not know at which position the innerRect of the window starts."* — and the answer was that the main thread reports raw sensors and the worker interprets. Firefox got `mozInnerScreenX`; Chromium got the split. This adds the sensor Chromium was missing, in the division of labour #8164 already established. (Found by @neo-opus-grace in review; I had not cited it.)

**Why the fallback is safe, with the arithmetic rather than the assertion.** `chrome` is now derived from the frame and viewport origins, so it has to be shown equal to the old field-by-field construction, not merely tested:
- Firefox: `frameLeft = viewportLeft - sideBorder` ⇒ `left = sideBorder`, `top = topChrome`, `bottom = heightDiff - topChrome = sideBorder` (= the old `bottomBorder`), `right = widthDiff - sideBorder = sideBorder`.
- Fallback: `viewportLeft = screenLeft + sideBorder` and `frameLeft = screenLeft` ⇒ the same four identities; `outerRect.x` was `(screenLeft + sideBorder) - sideBorder` and is now `screenLeft`.

Identical on every field, including the two the pre-existing arms do not assert.

Evidence: L2 (every AC is model-level derivation logic, fully covered by the unit tier at exact head; the browser-side reading is one expression whose value the operator measured directly) → L2 required. Residual: the rendered confirmation that drop zones stop activating over the panel needs a real window with DevTools open, which no automated tier here can produce — § Post-Merge Validation.

`agent-preflight: not hosted here` (no such npm script; exit 1); the baseline `PR body`, `Substrate size`, `Source comment archaeology` and `PR base` jobs carry its checks. §3.1 class: `capability → feat`.

## AC Evidence

| AC | Disposition |
|---|---|
| AC-1 — a measured origin is used verbatim; asserted across all five dock rows incl. the `topChrome` sign and the bottom-dock full-height error; right and bottom required | **CI-covered.** One arm walks all five rows, each carrying the offset a real probe *would* read on that layout. `chrome` now names the edge that lost the space: a right dock reports `right: 479`, a bottom dock `bottom: 400`. Left and top fall out of the same measurement with no case of their own — which is the argument for measuring rather than branching. |
| AC-2 — with no measurement, output is byte-identical to `dev` | **CI-covered.** The four pre-existing `WindowGeometry` arms pass unchanged, including the symmetric-split and Firefox rows, and `unit/manager/` is 205/205. A new arm pins the documented fallback explicitly (`{bottom: 239.5, left: 239.5, right: 239.5, top: -152.5}`) so the difference the measurement makes stays visible rather than implied. |
| AC-3 — Firefox's `mozInnerScreenX` keeps priority over a measured origin | **CI-covered + control.** An arm supplies both and asserts Firefox wins; moving the measured branch ahead of it reddens exactly that arm. |
| AC-4 — one-shot per resize; a permanent `pointermove` on every window is a rejected shape | **CI-covered + 4 controls.** `{capture, once, passive}` asserted literally; re-arming while a sample is outstanding attaches nothing; `onResize` re-arms; `afterSetObserveResize(false)` arms nothing, so a window nobody observes carries no pointer listener. |
| AC-5 — the screen→local conversion is proven at the model level, mutation-proven | **Met at the derivation, not at `DragCoordinator`.** `DragCoordinator:1104` computes `localX = screenX - innerRect.x` and is correct given a correct `innerRect`; the defect was entirely upstream. The arm that carries this is *left and right are indistinguishable without a measurement, and separable with one* — 479 px of viewport between two identical inputs. Deliberately **not** asserted through `DragCoordinator`, which would test this change through an unrelated collaborator. § Deltas. |
| AC-6 — the browser-zoom bound is stated, not implied | **Met.** `usableViewportOffset` bounds the offset inside the frame and its docblock says why: under page zoom `clientX` is page CSS px and `screenX` screen CSS px, so a reading can drift; an out-of-bounds sample degrades to today's behaviour rather than past it. Six refusal cases witnessed, plus both exact bounds admitted. |

## Deltas from ticket

- **The ticket's first table was wrong about the bottom dock, and I corrected the body before writing code.** I had compared the model against a "truth" I derived *from the model* — circular. Against an independently computed truth (frame top + the browser's own 87 px, plus the panel only when it is on that edge), a bottom dock is wrong by the **full panel height**, not unaffected: the modeled viewport lands exactly where the panel is. Only the no-panel and top-dock rows are correct today, the latter by coincidence. The corrected table is the ticket body; this also retracts a prediction I had given @tobiu that docking to the bottom would make the symptom vanish.
- **AC-5 is met one level up from where it was written.** The ticket asked for the proof at `DragCoordinator`. Reading it, `:897`, `:1008` and `:1104` all consume `innerRect` correctly — as do `DragAffordances#getGeometrySignature` and `Participation#defaultHitTest`, which read its *size*, and the size was never wrong. Routing the assertion through `DragCoordinator` would have tested this change through a collaborator that has no defect. The claim is asserted where it lives.
- **`screenLeft`/`screenTop`, not `screenX`/`screenY`.** Aliases on a real window, but the offset is consumed relative to the frame origin `getWindowData` publishes, and that is the pair it publishes. Changed mid-implementation for that reason, not for style.
- **One existing arm's double gained a collaborator.** `onResize` now re-arms the probe, so *a fixed-origin resize publishes the complete window snapshot* threw `me.armViewportProbe is not a function` on its hand-built double. Confirmed red first, then the double was given the collaborator and an assertion that the re-arm happens — the arm is stronger than before, not merely repaired.
- **`chrome` is now derived from the two origins rather than from the assumptions.** It has to be, or it would contradict whichever branch answered. This is why a right dock can report `right: 479` at all. The Firefox and fallback branches produce identical output to before, which the four pre-existing arms pin.
- **The probe publishes only on a CHANGED origin.** Added after review: a publication is a worker round trip, and the first version published on every sample — injecting a message into whatever gesture happened to be running. Now change-driven, exactly like `checkMovement`, which is this addon's own discipline. This is also the most likely cause of the `components` CI failure discussed under § Test Evidence.
- **`chrome`'s meaning widened, and its consumers are named.** It was an assumed decoration; in the measured branch it is the content inset, panels included. I verified both readers myself: `NativeVesselTransaction#toFrameOrigin` (`:121`) subtracts `chrome.left`/`chrome.top` to place a native window, and `src/ai/Client.mjs:202`/`:311` publish it into agent-visible payloads. On a window with no panel the measurement agrees with the assumptions, so normal use is unchanged; the contract is now stated in `calculateGeometry`'s docblock rather than left to be inferred from a derivation comment.
- **A second known bound, alongside zoom.** Re-docking a panel from one side to the other at **equal width** changes neither `innerWidth` nor `innerHeight`, so no `resize` fires and the previous offset stands — the origin is then wrong by the panel. Still strictly better than the assumptions on every input, and now stated in `onResize` rather than claimed away by an absolute. (@neo-opus-grace constructed this counterexample against my comment.)
- **Out of scope, noted:** the stray `console.log('Window.onWindowConnect', …)` at `src/manager/Window.mjs:146`, sighted while working here and sent as a defect-note rather than folded in.

## Test Evidence

Outside-CI evidence only — the controls, and two findings the controls produced.

| Mutation | Arm that reddens |
|---|---|
| The measured branch removed (always falls back) | 4 arms, incl. *every dock position resolves to its own true viewport origin* |
| The bounds guard always accepts | *an offset that cannot describe this frame is refused, and the fallback answers* |
| The measured branch moved ahead of Firefox | *Firefox keeps priority: an explicit viewport origin outranks a measured one* |
| `once: true` dropped from the listener | *…does not stay attached* **and** *re-arming while a sample is outstanding…* |
| The outstanding-sample guard removed | *re-arming while a sample is outstanding does not attach a second listener* |
| `onResize` no longer re-arms | *a fixed-origin resize publishes the complete window snapshot* |
| The `Number.isFinite` guard removed | *a non-finite reading is discarded rather than published* |
| Unobserving no longer disarms | *observing arms the probe and UNobserving releases it…* |
| Publication made unconditional again | *a sample that confirms the offset we already hold does not publish* |

- **A third fake arm, which I did not catch — @neo-opus-grace did.** `observation is what arms it` asserted zero `pointermove` listeners after `afterSetObserveResize(false, true)`, but `beforeEach` had reset the array and nothing armed anything: an empty array compared to an empty array. Worse, the invariant it claimed to guard was **false** — unobserving removed only the resize listener, so a probe armed while observing kept its `once` listener and would still write an offset and publish for a window that had stopped observing. `disarmViewportProbe` now exists and the arm arms, unobserves, then asserts removal. Three of this species in one diff, two self-caught and one not; the one I missed was the one guarding my own docblock's promise.
- **I called the `components` failure a known flake, and that was premature.** The arm (`DockMaximize.spec.mjs:741`) *is* @neo-opus-ada's documented ~25% flake, and a `--repeat-each=8` control gave 8/8 on my branch against 1/8 on pristine `dev`. But it then failed **2/2 on CI** while `components` was green on three sibling PRs — which is not a flake pattern. The mechanism is mine: `dock-maximize/app.mjs:290` extends `DockWorkspace`, so that fixture arms `observeResize`, which armed a `pointermove` listener whose handler published geometry into a running gesture. An isolated local arm cannot see that; CI's full-tier ordering can. The change-driven publication above is the fix, and CI is the instrument that will confirm or refute it.
- **Two of my own arms were fake and I caught them by asking what they varied, not by running them.** The five-dock arm originally applied one right-dock offset to *all five* rows — so the left and top rows, the two that exist to prove the measurement carries the side, were asserting nothing. Each row now carries the offset a real probe would read on that layout. Separately, my window double did not model `once: true`, so the one-shot arm could not witness the removal it claimed; the double now removes a `once` listener before invoking it, as a browser does. Both were green before the fix.
- Full unit tier at head: see the run in § Commits. `unit/manager/` 205/205, `unit/main/addon/WindowPosition` 12/12.
- Guards: `check-ticket-archaeology` clean on all touched files; `check-file-sizes` with the workflow's full argv; `generate-docs-json` produces no hierarchy diff (no new class).

## Post-Merge Validation

- [ ] The rendered confirmation: with DevTools docked right, drag a native popup in from the right and verify drop zones no longer activate while the pointer is over the panel. No tier here can produce this — an emulated viewport reports window chrome as `0 × 0`, so the defect class is structurally invisible to automation in this repo.
- [ ] The same check with DevTools docked **bottom**, which is wrong today by the full panel height and which I incorrectly predicted was unaffected. It is the second required position.
- [ ] A window that is observed but never receives pointer motion keeps the old behaviour by design. Worth one look that a freshly opened vessel corrects itself on the first drag rather than staying on the fallback.

## Commits

- `40da9d322b` — the measurement, its one-shot probe, and the derivation that prefers it.
- `10b70b2b59` — the probe releases itself on unobserve, and speaks only when the origin changed.

Authored by Vega (Opus 5, Claude Code). Session 206b8400-7fe8-472e-8018-446e550b784b.
