### PR TITLE
The topology bar's undo and redo show how far they reach (#18558)

### DIFF
--- a/apps/workstation/view/Workspace.mjs
+++ b/apps/workstation/view/Workspace.mjs
@@ -461,13 +461,8 @@ class Workspace extends DockWorkspace {
      * @protected
      */
     historyStepBadge(count) {
-        const provider = TransactionManager.getProvider(this.topologyGroupId);
-
-        if (!provider) {
-            return null
-        }
-
-        const steps = count(provider);
+        const provider = TransactionManager.getProvider(this.topologyGroupId),
+              steps    = provider ? count(provider) : 0;
 
         return Number.isFinite(steps) && steps > 0 ? `${steps}` : null
     }

--- a/apps/workstation/view/Workspace.mjs
+++ b/apps/workstation/view/Workspace.mjs
@@ -403,16 +403,30 @@ class Workspace extends DockWorkspace {
             // no mirror to keep in step with `setHistoryDepth`, which publishes without a commit.
             // A retired or unknown Group resolves to nothing and reads disabled, so the control
             // fails closed on the same expression rather than through a separate teardown.
+            // Same leaf for the depth badges: `historyCursor` and `historyLength` are published
+            // alongside the flags above, so they add no second publication path. `historyDepth` is
+            // deliberately unused — it is the Group's configured CAP, and would read as a constant.
             actions: [{
-                action     : 'undo',
-                bind       : {disabled: () => TransactionManager.getProvider(me.topologyGroupId)?.getData('canUndo') !== true},
+                action: 'undo',
+                bind  : {
+                    // `cursor` starts at -1 and `canUndo` is `cursor > -1`, so the steps behind the
+                    // cursor are `cursor + 1`.
+                    badgeText: () => me.historyStepBadge(provider => provider.getData('historyCursor') + 1),
+                    disabled : () => TransactionManager.getProvider(me.topologyGroupId)?.getData('canUndo') !== true
+                },
                 handler    : () => TransactionManager.undo({groupId: me.topologyGroupId}),
                 iconCls    : 'fa fa-rotate-left',
                 showOnFocus: false,
                 text       : 'Undo'
             }, {
-                action     : 'redo',
-                bind       : {disabled: () => TransactionManager.getProvider(me.topologyGroupId)?.getData('canRedo') !== true},
+                action: 'redo',
+                bind  : {
+                    // `canRedo` is `cursor < count - 1`, so the rows ahead of the cursor are
+                    // `count - 1 - cursor`.
+                    badgeText: () => me.historyStepBadge(provider =>
+                        provider.getData('historyLength') - 1 - provider.getData('historyCursor')),
+                    disabled : () => TransactionManager.getProvider(me.topologyGroupId)?.getData('canRedo') !== true
+                },
                 handler    : () => TransactionManager.redo({groupId: me.topologyGroupId}),
                 iconCls    : 'fa fa-rotate-right',
                 showOnFocus: false,
@@ -430,6 +444,32 @@ class Workspace extends DockWorkspace {
             layout   : {ntype: 'flexbox', align: 'center', direction: 'row', wrap: 'wrap'},
             reference: 'topology-toolbar'
         }
+    }
+
+    /**
+     * @summary The step count one history control shows on its badge, or `null` for none.
+     *
+     * Shared by both bindings so the two counts cannot drift into different notions of "available",
+     * and so the missing-Group answer is decided once. A retired or unknown Group has no provider
+     * and yields `null` — the same fail-closed reading its `disabled` bind takes, rather than a
+     * badge surviving on a control that can no longer act.
+     *
+     * Reads inside the callback are the caller's effect dependencies, so a formatter that consults
+     * two keys re-runs on either.
+     * @param {Function} count `(provider) => Number` steps available in that direction
+     * @returns {String|null} The badge text, or `null` when there is nothing to show
+     * @protected
+     */
+    historyStepBadge(count) {
+        const provider = TransactionManager.getProvider(this.topologyGroupId);
+
+        if (!provider) {
+            return null
+        }
+
+        const steps = count(provider);
+
+        return Number.isFinite(steps) && steps > 0 ? `${steps}` : null
     }
 
     /**

--- a/buildScripts/util/file-size-baseline.json
+++ b/buildScripts/util/file-size-baseline.json
@@ -1,5 +1,5 @@
 {
-    "apps/workstation/view/Workspace.mjs": 1240,
+    "apps/workstation/view/Workspace.mjs": 1252,
     "examples/dashboard/crossWindow/DemoBWorkspace.mjs": 2505,
     "src/dashboard/dock/Workspace.mjs": 1100,
     "src/main/addon/DragDrop.mjs": 1267

--- a/resources/scss/src/apps/workstation/Workspace.scss
+++ b/resources/scss/src/apps/workstation/Workspace.scss
@@ -129,17 +129,37 @@
 }
 
 .workstation-topologybar {
+    // `.neo-toolbar` paints its padding from this token, so a plain `padding` here loses the cascade
+    // to it on source order at equal specificity — the declaration this replaces computed to the
+    // shared 5px. Going through the token is also what gives the trailing button's badge room: the
+    // bar is flush right, and at 5px the count overflows the viewport edge.
+    --toolbar-padding: 6px 12px;
+
     background   : var(--workstation-panel);
     border-bottom: 1px solid var(--workstation-line);
     gap          : 6px;
-    padding      : 6px 12px;
 
+    // Every axis the button paints on is named here on purpose. `button/Base.scss` keeps `color`
+    // inheriting at the root so the child glyph and text nodes can own themed colours — which means
+    // a consumer that sets only background and text hands the disabled state to the UA
+    // `button:disabled` cascade, and Chromium paints GrayText. Glyph and disabled tokens are not
+    // polish; they are the half of the contract the engine deliberately leaves to us. Opacity stays
+    // at 1 so the state reads as a colour change rather than a wash over the label.
     .neo-button {
-        --button-background-color      : var(--workstation-panel-2);
-        --button-background-color-hover: color-mix(in srgb, var(--workstation-signal) 12%, var(--workstation-panel-2));
-        --button-border                : 1px solid var(--workstation-line);
-        --button-height                : 32px;
-        --button-text-color            : var(--workstation-ink);
+        --button-background-color         : var(--workstation-panel-2);
+        --button-background-color-disabled: var(--workstation-panel-2);
+        --button-background-color-hover   : color-mix(in srgb, var(--workstation-signal) 12%, var(--workstation-panel-2));
+        --button-badge-background-color   : var(--workstation-signal);
+        --button-badge-color              : var(--workstation-panel);
+        --button-border                   : 1px solid var(--workstation-line);
+        --button-border-disabled          : 1px solid var(--workstation-line);
+        --button-glyph-color              : var(--workstation-ink-dim);
+        --button-glyph-color-disabled     : color-mix(in srgb, var(--workstation-ink-dim) 45%, transparent);
+        --button-glyph-color-hover        : var(--workstation-signal);
+        --button-height                   : 32px;
+        --button-opacity-disabled         : 1;
+        --button-text-color               : var(--workstation-ink);
+        --button-text-color-disabled      : color-mix(in srgb, var(--workstation-ink) 45%, transparent);
     }
 }
 

--- a/test/playwright/unit/apps/workstation/Workspace.spec.mjs
+++ b/test/playwright/unit/apps/workstation/Workspace.spec.mjs
@@ -14,14 +14,16 @@ import WorkspaceDocument        from '../../../../../src/dashboard/dock/model/Wo
 import Operations               from '../../../../../src/dashboard/dock/model/Operations.mjs';
 import DockParticipation        from '../../../../../src/dashboard/dock/window/Participation.mjs';
 import '../../../../../src/manager/Instance.mjs';
-import TransactionManager  from '../../../../../src/manager/Transaction.mjs';
-import FeedPane            from '../../../../../apps/workstation/view/FeedPane.mjs';
-import ScalePane           from '../../../../../apps/workstation/view/ScalePane.mjs';
-import Workspace           from '../../../../../apps/workstation/view/Workspace.mjs';
-import PopupWorkspace      from '../../../../../apps/workstation/view/PopupWorkspace.mjs';
-import GestureDriver       from '../../../../../apps/workstation/tour/GestureDriver.mjs';
-import TourController      from '../../../../../apps/workstation/view/TourController.mjs';
-import DockService         from '../../../../../src/ai/client/DockService.mjs';
+import TransactionManager from '../../../../../src/manager/Transaction.mjs';
+import StateProvider      from '../../../../../src/state/Provider.mjs';
+import Toolbar            from '../../../../../src/toolbar/Base.mjs';
+import FeedPane           from '../../../../../apps/workstation/view/FeedPane.mjs';
+import ScalePane          from '../../../../../apps/workstation/view/ScalePane.mjs';
+import Workspace          from '../../../../../apps/workstation/view/Workspace.mjs';
+import PopupWorkspace     from '../../../../../apps/workstation/view/PopupWorkspace.mjs';
+import GestureDriver      from '../../../../../apps/workstation/tour/GestureDriver.mjs';
+import TourController     from '../../../../../apps/workstation/view/TourController.mjs';
+import DockService        from '../../../../../src/ai/client/DockService.mjs';
 
 import {initialDocument} from '../../../../../apps/workstation/tour/denseWorkstation.mjs';
 
@@ -3227,5 +3229,88 @@ test.describe('Workstation topology bar — the view declares it, the controller
             ['undo', {groupId: 'topology-bar-group'}],
             ['redo', {groupId: 'topology-bar-group'}]
         ])
+    });
+
+    test('the history controls carry the steps they can still take, in both directions (#18558)', async () => {
+        // Real history rather than a hand-published cursor. The badge exists to be trustworthy, and
+        // a formula checked against numbers this arm invented could only confirm the model it was
+        // written from — here `historyCursor` and `historyLength` are the engine's. Depth is
+        // manager-wide and read when the Group is created, so it is raised around this one.
+        const restoreDepth = TransactionManager.historyDepth;
+
+        TransactionManager.historyDepth = 5;
+
+        const group = TransactionManager.bind({windowId: 'topology-badge-window', workspaceKey: 'main'}),
+              owned = {value: {kind: 'initial'}, generation: 1, revision: 0},
+              // The production method on the minimal host it actually reads: the Group id is the
+              // whole of what the factory and the formatter need, and a constructed Workspace would
+              // bind a Group of its own and set the depth this arm is controlling.
+              host  = {historyStepBadge: Workspace.prototype.historyStepBadge, topologyGroupId: group.groupId};
+
+        TransactionManager.registerParticipant({groupId: group.groupId, workspaceKey: 'main', participant: {
+            domain    : 'dock',
+            capture   : () => ({...owned, value: structuredClone(owned.value)}),
+            prepare   : input => input,
+            adopt     : value => {owned.value = structuredClone(value); owned.revision++},
+            compensate: captured => Object.assign(owned, captured, {value: structuredClone(captured.value)})
+        }});
+
+        // A materialised toolbar, not the declaration: the count has to survive `toolbar.Base`
+        // turning `actions` into buttons and the binding effect running the formatter. Calling the
+        // formatter off the config object would exercise the arithmetic and none of the wiring.
+        // The local provider holds no data — the formatters read the Group's own leaf where it
+        // lives — but a component only binds once it can resolve one.
+        const bar  = Neo.create(Toolbar, {...Workspace.prototype.createTopologyBar.call(host), stateProvider: {}}),
+              undo = bar.getAction('undo'),
+              redo = bar.getAction('redo'),
+              // Read it where a user does: the badge is a vdom node the button hides rather than
+              // drops, so "no steps" has to mean an absent node and never the string '0'.
+              read    = () => [undo, redo].map(button => [
+                  button.badgeText, button.badgeNode.removeDom === true, button.disabled
+              ]),
+              command = (method, kind) => TransactionManager[method]({
+                  groupId: group.groupId, cause: `spec-${method}`, provenance: {origin: 'unit'},
+                  ...(kind ? {descriptor: {kind}, changes: [{workspaceKey: 'main', input: {kind}}]} : {})
+              });
+
+        try {
+            expect(read(), 'an empty history shows no depth either way')
+                .toEqual([[null, true, true], [null, true, true]]);
+
+            await command('write', 'a');
+            await command('write', 'b');
+
+            expect(read(), 'two steps behind the cursor, none ahead')
+                .toEqual([['2', false, false], [null, true, true]]);
+
+            await command('undo');
+
+            // The state that tells the two formulas apart: swapped, mirrored and off-by-one counts
+            // all read alike here, and no constant survives 2 → 1 on the same control.
+            expect(read(), 'one step each way')
+                .toEqual([['1', false, false], ['1', false, false]]);
+
+            await command('undo');
+
+            expect(read(), 'nothing behind the cursor, two ahead')
+                .toEqual([[null, true, true], ['2', false, false]]);
+
+            await command('redo');
+
+            expect(read(), 'redo walks the cursor back up')
+                .toEqual([['1', false, false], ['1', false, false]]);
+
+            // Fails closed on the same read as `disabled`. Asked through the helper, because a
+            // retired Group's provider publishes nothing for a binding effect to re-run on — and
+            // the formatter returning a number proves the `null` comes from the missing provider
+            // rather than from the arithmetic.
+            TransactionManager.retireGroup(group.groupId);
+
+            expect(host.historyStepBadge(() => 99), 'a retired Group has no depth to show').toBe(null)
+        } finally {
+            bar.destroy();
+            TransactionManager.retireGroup(group.groupId);
+            TransactionManager.historyDepth = restoreDepth
+        }
     })
 });


### PR DESCRIPTION
Resolves #18558

Undo and redo now say how far they reach, and the bar finally paints them. The depth is another bind on data the Group already publishes to every bound window — `historyCursor` and `historyLength`, read where they live, with no mirror and no new publisher. The paint half is the other complaint on the same two controls, and it was one omission: the bar named five `--button-*` tokens and left the glyph and disabled families unset, so the icons carried no themed colour and Chromium filled the disabled gap with `GrayText`.

Evidence: L3 (live probe — the running app at this head, computed cascade read from the browser in both themes, real `Transaction` writes driving the cursor) → L3 required (no AC needs an operator-gated handoff). No residuals.

size-guard-growth: apps/workstation/view/Workspace.mjs — the two `badgeText` binds and the one helper both counts share; the helper was cut from nine lines to four after the ratchet flagged it, and #18304 is the lane that shrinks this file structurally.

## AC Evidence

| AC | Evidence |
|---|---|
| AC-1 remaining depth, bound from published data, no mirror | CI-covered: `test/playwright/unit/apps/workstation/Workspace.spec.mjs` — *"the history controls carry the steps they can still take, in both directions (#18558)"*. Drives real `Transaction.write` / `undo` / `redo` against a registered participant, so `historyCursor` / `historyLength` are the engine's, not the arm's. |
| AC-2 `historyDepth` not used as the count | CI-covered: same arm — the counts survive a Group whose `historyDepth` is 5 while the badges read 2, 1 and 1. Source: neither formatter names `historyDepth`; the code comment records why. |
| AC-3 zero and no-Group both show nothing | CI-covered: same arm asserts `badgeText === null` **and** `badgeNode.removeDom === true` on the empty history and on the exhausted direction, and `historyStepBadge(() => 99)` returns `null` after `retireGroup` — a formatter that returns a number, so the `null` comes from the missing provider and not from the arithmetic. |
| AC-4 both directions witnessed where they differ | CI-covered: same arm, the `['1', …], ['1', …]` state after one undo of two writes. Mutation-verified below. |
| AC-5 themed in both themes, three states | Outside-CI, live probe — receipts below. |
| AC-6 trailing badge inside the viewport | Outside-CI, live probe at 900 / 1280 / 1440 px — receipts below. |

## Deltas from ticket

**One defect found while verifying, fixed here because the badge cannot ship without it.** `.neo-toolbar` paints its padding from `--toolbar-padding`; `.workstation-topologybar` declared a plain `padding: 6px 12px`, which loses to it at equal specificity on source order. The declaration was dead — the bar computed to the shared `5px` — and at 5px the trailing badge, offset `-10px` outward, landed 4px past the window edge. Routing the same values through the token makes the declaration live and gives the badge room. It is a one-line change to a line this diff already touches; the ticket's AC-6 is written from it.

**The size ratchet red was a fair signal and I answered it twice.** `apps/workstation/view/Workspace.mjs` is the subject of #18304 — *"Workspace still owns 110 methods across five concerns"* — so growing it needs an argument that the growth is as small as it can be, not just a declaration. `historyStepBadge` went from an early return plus a second `const` to `provider ? count(provider) : 0`: nine code lines to four, same behaviour, and the callback is still not invoked when the Group resolves to nothing. What remains is 1240 → 1252, declared above and baselined. `check-file-sizes` passes vacuously in the pre-commit hook, which scopes to the committed diff — the honest local run is `npm run check-file-sizes -- --base origin/dev`, and I owed it before pushing.

**`.workstation-tourbar` has the same dead `padding` and is not fixed here.** It declares `8px 14px` and computes to `5px`. Nothing in this lane depends on it and fixing it changes that bar's rendered spacing, which belongs to whoever owns that surface. Filed as an A2A defect-note rather than smuggled in.

## Test Evidence

**Mutation receipts** — three mutants, each red at the assertion that names its defect, each restored byte-identically (`md5` match against a pre-mutation copy, zero `MUTANT` markers left):

| Mutant | Reds at |
|---|---|
| redo's formatter mirrored to undo's (`cursor + 1`) | *"two steps behind the cursor, none ahead"* |
| `steps > 0` guard dropped from `historyStepBadge` | *"an empty history shows no depth either way"* |
| `badgeText` bind deleted from the undo action | *"two steps behind the cursor, none ahead"* |

The third is the one worth naming: it is the wiring, not the arithmetic. The arm materialises the bar (`Neo.create(Toolbar, {...createTopologyBar(), stateProvider: {}})`) and reads `badgeText` off the live `getAction('undo')` button, so a count that never reaches a button reds. Calling the formatter off `createTopologyBar()`'s return value would have exercised the arithmetic and none of the wiring — the shape that let #18551 ship past two reviews.

**Live probe, dark and light** — the running app, computed values read from the browser, not from the emitted CSS:

| | dark | light |
|---|---|---|
| glyph, enabled | `rgb(139, 151, 168)` | `rgb(90, 107, 128)` — 5.17:1 on the button |
| glyph, hover | `rgb(94, 234, 212)` | `rgb(15, 118, 110)` |
| glyph, disabled | ink-dim at 45% — **not** `GrayText`, and `--button-opacity-disabled: 1` so the label is not washed | same, light ink-dim |
| badge | `rgb(94, 234, 212)` on `rgb(20, 26, 35)` text | `rgb(15, 118, 110)` with `#fff` — 5.47:1 |

**Live probe, the full cursor walk** — one pane closed twice, then undone, on the real bar:

| state | undo | redo |
|---|---|---|
| fresh boot | no badge, disabled | no badge, disabled |
| after 1 operation | `1` | no badge, disabled |
| after 2 operations | `2` | no badge, disabled |
| after 1 undo | `1` | `1` |
| after 2 undos | no badge, disabled | `2` |

**Live probe, AC-6** — trailing badge right edge vs viewport: 2px clear at 900px, 3px at 1280px, 2px at 1440px, bar on one row at each. Before the `--toolbar-padding` fix it measured 1284 against a 1280px viewport.

**Full local tiers at this head:** `unit` 3738 passed / 2 skipped. `components` 267 passed / **1 failed** — `DockMaximize.spec.mjs:504`, which then passed 20/20 running that file alone and 135/135 running the whole `component/dashboard/` directory. Nothing in this diff is loaded by that spec, and the two component specs that *do* consume `apps/workstation` SCSS (`DockRailTabPaint`, `DockSplitterPaint`) passed in every run.

**CI ran the falsifier and both reds were intermittents, on two different tiers.** `gh pr checks` now exits 0. Across three full-tier CI runs of this branch, `components` went pass → fail (`DockMaximize.spec.mjs:741`, a *different* arm from the local one) → pass, and `e2e-engine` went fail (`TreeBigData.spec.mjs:64`, the BigData grid arms of #18439) → pass. Neither is reachable from this diff: `test/playwright/component/apps/dock-maximize/app.mjs` imports only `src/dashboard/dock/*`, `src/manager/Transaction.mjs`, `src/container/Viewport.mjs` and `src/component/Base.mjs` and never instantiates the workstation view, so its per-class stylesheet is never requested; `TreeBigData.spec.mjs` imports only Playwright and drives the grid. Rotating casualty across unrelated branches is #18439's signature, and `DockMaximize`'s two arms now have sightings on three branches today — recorded in Post-Merge Validation rather than filtered out of the evidence.

## Post-Merge Validation

- [x] **Discharged before merge, and it answered the other way than I expected.** `components` is green here, but only after a rerun, and the arm that red was `:741` rather than the `:504` I saw locally. Two arms of one spec file, rotating, on a branch that cannot reach either. Sightings today across three branches (this one, #18559 pre-fix, and my local full run) — enough for #18439 to own the file rather than a single arm.
- [ ] `e2e-engine`'s `TreeBigData.spec.mjs:64` red-then-green here is a fresh sighting for #18439's BigData arms, on a diff with no grid surface. It belongs on that ticket's evidence, not on this one.
- [ ] The badge reads correctly against a Group whose history is deeper than a single session's — the arm caps at two steps, and the formatters are linear, but a long-lived workspace is the first place a cap or a truncation would show.

Related: #18553 — the parent this is AC-1 of. Refs #18456.

Authored by Grace (Opus 5, Claude Code). Session c4dc8abc-31fa-4ecd-9aef-5209ccfd16c0.
