### PR TITLE
The component is the surface, not its controller

### DIFF
--- a/apps/workstation/README.md
+++ b/apps/workstation/README.md
@@ -29,11 +29,18 @@ Pane, store, component, and relevant DOM identities remain stable while the layo
 The data-only screenplay lives in `apps/workstation/tour/denseWorkstation.mjs`; the mounted
 whitebox journey is the runtime and visual falsifier.
 
-For programmatic playback, resolve the optional owner with
-`await workspace.getController().getTourController()`, then call its `startTour()`,
-`runTourSpec()` or `getTourReceipt()`. `cancelTour()` retires that playback controller and waits
-for its started cue work; a later Start creates a fresh controller. The workspace and its stores
+Playback is owned by `WorkspaceController`, which activates the optional runner on first use:
+`getTourController()` resolves it, and `startTour()`, `runTourSpec()`, `getTourReceipt()` and
+`cancelTour()` live on the runner it returns. `cancelTour()` retires that playback controller and
+waits for its started cue work; a later Start creates a fresh one. The workspace and its stores
 remain owned by the ordinary application.
+
+Those are reachable from code running inside the app realm, and **not** from an agent: the Neural
+Link addresses components — `app.callMethod` takes a component id and a method name, with no way
+to express a controller hop — and the workspace deliberately publishes no tour entry point. Driving
+the tour from outside means the **Start dense tour** button or the declarative `onStartTour`
+handler. If a programmatic entry point is ever wanted, it belongs on the component for the same
+reason `saveTopology` does.
 
 ## Save and reopen a workspace
 

--- a/apps/workstation/view/Viewport.mjs
+++ b/apps/workstation/view/Viewport.mjs
@@ -56,7 +56,7 @@ class Viewport extends BaseViewport {
             const participant = binding && Transaction.getParticipant(binding.groupId, binding.workspaceKey);
             const workspace = participant?.componentId && Neo.getComponent(participant.componentId);
             if (workspace?.rootWorkspace) {
-                await workspace.rootWorkspace.getController().mountTopologyWorkspace(binding.workspaceKey, me)
+                await workspace.rootWorkspace.mountTopologyWorkspace(binding.workspaceKey, me)
             }
             return
         }
@@ -67,7 +67,7 @@ class Viewport extends BaseViewport {
                   workspace = owner?.componentId && Neo.getComponent(owner.componentId),
                   root = workspace?.rootWorkspace ?? workspace;
             if (root && binding.workspaceKey === params.get('workspace')) {
-                await root.getController().mountTopologyWorkspace(binding.workspaceKey, me)
+                await root.mountTopologyWorkspace(binding.workspaceKey, me)
             } else {
                 me.add({ntype: 'component', html: 'This saved window is waiting for its original workspace.'})
             }
@@ -148,7 +148,7 @@ class Viewport extends BaseViewport {
                 return
             }
 
-            workspace.getController().attachTopologyLibrary();
+            workspace.attachTopologyLibrary();
             me.add(workspace);
             if (!selection.topology) await workspace.saveTopology()
         } catch (error) {

--- a/apps/workstation/view/Workspace.mjs
+++ b/apps/workstation/view/Workspace.mjs
@@ -828,6 +828,30 @@ class Workspace extends DockWorkspace {
     }
 
     /**
+     * @summary Presents an already hydrated participant in a render target, through the root controller.
+     *
+     * A component's own public surface, not a convenience: `Neo.manager.Transaction` resolves a
+     * Group participant to a **component** id, and the Neural Link addresses components too, so a
+     * caller that has resolved this workspace has resolved the thing it should be talking to. The
+     * orchestration stays on the controller, which owns Group participants and render targets.
+     * @param {String} workspaceKey
+     * @param {Neo.container.Base} target A user-activated window or the root's inline fallback.
+     * @returns {Promise<Boolean>}
+     */
+    mountTopologyWorkspace(workspaceKey, target) {
+        return this.getController().mountTopologyWorkspace(workspaceKey, target)
+    }
+
+    /**
+     * @summary Hands this root's reconnect lease and durable disposal to the Group library, through
+     * the root controller.
+     * @returns {Boolean}
+     */
+    attachTopologyLibrary() {
+        return this.getController().attachTopologyLibrary()
+    }
+
+    /**
      * A headless instance joins its Group when a real render target arrives (see
      * {@link #registerMainWorkspace}); the engine's geometry binding runs on the same signal.
      * @param {String|null} value

--- a/apps/workstation/view/WorkspaceController.mjs
+++ b/apps/workstation/view/WorkspaceController.mjs
@@ -90,7 +90,10 @@ class WorkspaceController extends Controller {
 
     /**
      * @summary Lets the Group library own the reconnect lease and durable disposal of this root.
+     * Reached through {@link Workstation.view.Workspace#attachTopologyLibrary} — the component is
+     * the surface another component addresses.
      * @returns {Boolean}
+     * @protected
      */
     attachTopologyLibrary() {
         return this.component.topologyLibrary.attachGroup({
@@ -178,9 +181,12 @@ class WorkspaceController extends Controller {
 
     /**
      * @summary Presents an already hydrated participant without changing its document or history.
+     * Reached through {@link Workstation.view.Workspace#mountTopologyWorkspace} — the component is
+     * the surface another component addresses.
      * @param {String} workspaceKey
      * @param {Neo.container.Base} target A user-activated window or the root's inline fallback.
      * @returns {Promise<Boolean>}
+     * @protected
      */
     async mountTopologyWorkspace(workspaceKey, target) {
         const state = this.component.getPopupState(workspaceKey);

--- a/buildScripts/util/file-size-baseline.json
+++ b/buildScripts/util/file-size-baseline.json
@@ -1,5 +1,5 @@
 {
-    "apps/workstation/view/Workspace.mjs": 1252,
+    "apps/workstation/view/Workspace.mjs": 1258,
     "examples/dashboard/crossWindow/DemoBWorkspace.mjs": 2505,
     "src/dashboard/dock/Workspace.mjs": 1100,
     "src/main/addon/DragDrop.mjs": 1267

--- a/test/playwright/unit/apps/workstation/Workspace.spec.mjs
+++ b/test/playwright/unit/apps/workstation/Workspace.spec.mjs
@@ -3314,3 +3314,43 @@ test.describe('Workstation topology bar — the view declares it, the controller
         }
     })
 });
+
+/**
+ * @summary The three operations a caller outside this component reaches it through.
+ *
+ * `Neo.manager.Transaction` resolves a Group participant to a **component** id and the Neural Link
+ * addresses components, so anything another component or an agent must reach has to live here.
+ * The controller keeps the orchestration; these three carry arguments and nothing else. They are
+ * asserted together because the value is that they are one pattern — three shapes doing the same
+ * job differently is the state this replaced.
+ */
+test.describe('Workstation.view.Workspace — the component IS the surface (#18562)', () => {
+    test('each entry point delegates to the controller with its arguments unchanged', async () => {
+        const calls      = [],
+              target     = {id: 'render-target', windowId: 'window-7'},
+              controller = {
+                  attachTopologyLibrary : (...args) => {calls.push(['attachTopologyLibrary', args]); return true},
+                  mountTopologyWorkspace: async (...args) => {calls.push(['mountTopologyWorkspace', args]); return true},
+                  saveTopology          : async (...args) => {calls.push(['saveTopology', args]); return {persisted: true}}
+              },
+              host       = {getController: () => controller};
+
+        await Workspace.prototype.saveTopology.call(host, 'layout-b');
+        // `target` is the argument an accidental signature change drops in silence: the controller
+        // returns false on a missing target rather than throwing, so the caller would see a refusal
+        // and no error at all.
+        await Workspace.prototype.mountTopologyWorkspace.call(host, 'vessel-metrics', target);
+        Workspace.prototype.attachTopologyLibrary.call(host);
+
+        expect(calls).toEqual([
+            ['saveTopology',           ['layout-b']],
+            ['mountTopologyWorkspace', ['vessel-metrics', target]],
+            ['attachTopologyLibrary',  []]
+        ]);
+
+        // Each returns what its controller returned — a delegation that swallowed the result would
+        // turn the mount refusal above into an undefined nobody branches on.
+        expect(await Workspace.prototype.mountTopologyWorkspace.call(host, 'vessel-metrics', target)).toBe(true);
+        expect(Workspace.prototype.attachTopologyLibrary.call(host)).toBe(true)
+    })
+});


### PR DESCRIPTION
Resolves #18562
Parent: #18460

🌿 A component could be reached by naming its controller's methods; after this, `Viewport` has no way to say `WorkspaceController` at all.

`Viewport` resolved — through the Transaction Group — which workspace owns its window, then reached **past that component into its controller** at three sites. That is not the shape #18545 fixed: nothing here is a view finishing its own child. It is one component using another's controller as that component's API, which couples `Viewport` to a class it never imports.

**Cross-component `getController()` in `apps/workstation/view/`: 3 → 0.** With #18545, #18460's Ledger row 1 (*View interaction*) is complete: its AC-2 is met, not advanced.

Evidence: L2 (delegation is model-level and fully covered by the unit tier at exact head; both `Viewport` boot modes are exercised by the existing Brain-gated Workstation e2e journeys) → L2 required. Residual: those journeys do not run in CI (#17844 owns that), so the boot-mode coverage is a maintainer-local instrument — § Post-Merge Validation.

`agent-preflight: not hosted here` (no such npm script; exit 1); the baseline `PR body`, `Substrate size`, `Source comment archaeology` and `PR base` jobs carry its checks. §3.1 class: `zero-delta → refactor`.

## AC Evidence

| AC | Disposition |
|---|---|
| AC-1 — zero production `getController()` sites; before/after reported; AC-2 stated complete | **Met, as a measurement.** `apps/workstation/view/Viewport.mjs`: **3 → 0**. The three `getController()` calls that remain in the app are all inside `Workspace.mjs`, where a component delegates to *its own* controller — the sanctioned direction, and the pattern `saveTopology` already used before this PR. #18460's AC-2 is now complete across #18545 and this. |
| AC-2 — the entry points delegate and hold no logic; `target` asserted | **CI-covered + 2 controls.** One arm calls all three on a prototype with a recording controller and asserts the exact call list, including `target` by identity. Dropping `target` reddens it; swallowing a return value reddens it. |
| AC-3 — `saveTopology` unchanged; the three visible as one pattern | **Met.** `saveTopology`'s body is untouched. The three sit adjacent in `Workspace.mjs` with the same one-line shape, and the arm asserts them together for that reason — the value is that they are one pattern, and three shapes doing one job differently is the state this replaced. |
| AC-4 — both boot modes and the refusal branch still work | **Met by construction, and stated as the weakest evidence here.** The change is call-site only: `x.getController().m(a, b)` → `x.m(a, b)`, with argument order and the `await` unchanged at all three sites. The refusal branch (`'This saved window is waiting for its original workspace.'`) is untouched — it sits in the `else` of a key comparison this PR does not enter. The e2e journeys that exercise both modes are Brain-gated and do not run in CI, so I am not claiming them as coverage; § Post-Merge Validation. |
| AC-5 — witnesses green at head; moved arms named | **CI-covered.** Workstation unit **97/97**, full unit tier in § Test Evidence. **No arm moved** — nothing referenced these two operations through `getController()`, so there was nothing to relocate. Stated because the AC asked and the honest answer is "none", not silence. |
| AC-6 — mutation-proven | **Met.** Both controls in § Test Evidence, each named with the arm it reddens. |

## Deltas from ticket

- **The AC-2 wording question was settled in the ticket before implementation, not argued after.** #18460's AC-2 forbids a "new forwarding façade", which read literally also blocks this fix. That clause was written against PR #18473 — a secondary controller plus four delegators whose only justification was the lifetime the extraction introduced. Two public entry points replacing three cross-component reach-throughs, matching this file pair's own executed precedent, is a different thing. The reasoning is in #18562's *The Fix* section so a reviewer can reject the reading rather than reverse-engineer it; the named alternative is an event contract, which is larger and would be its own ticket.
- **`Neo.manager.Transaction` resolves participants to component ids, and the Neural Link addresses components.** That is what makes the component the correct surface rather than a matter of taste: `WorkstationTopologyGroupsNL.spec.mjs:229` reaches `saveTopology` through `app.callMethod`, which cannot address a controller. Anything an agent must reach has to live on the component.
- **The controller methods are now `@protected` and say where they are reached from.** The bodies did not move — putting Group-participant orchestration on a view is the inverse error and worse than the reach-through it would replace.
size-guard-growth: apps/workstation/view/Workspace.mjs — 1252 to 1258 code lines, two three-line delegates that replace three cross-component reach-throughs in `Viewport.mjs`. Rebased onto #18560, which ratcheted the same file to 1252; the baseline is regenerated rather than hand-merged, so the conflict resolved to dev's value and was re-measured from the rebased tree. Not netted away: like the first half of this direction fix, it makes #18460 AC-3's 1,000-line entrypoint ceiling harder rather than easier, and that row's answer is behaviour extraction owned by its other leaves. Third time this file has been grown for a direction fix, and it should not be a fourth without AC-3 moving first.

- **The app's README taught the pattern this PR deletes, and @neo-opus-grace caught it.** `apps/workstation/README.md:33` offered `await workspace.getController().getTourController()` *"For programmatic playback"* — the front door teaching the reach-through. One refinement on her framing, stated rather than swallowed: that line **does** execute for callers inside the app realm, so it was not broken; what it did was teach the removed pattern and quietly promise a path an agent cannot take, since `app.callMethod` carries a component id and a method name with no way to express a controller hop. The paragraph now says both halves — where playback is owned, and that it is deliberately not component-addressable, with the reason a future entry point would belong on the component. **Fixing the README made AC-1's prose true rather than requiring it to be narrowed:** `git grep "getController()" -- apps/workstation/` now returns exactly the three self-directed calls in `Workspace.mjs`.

- **My own control reporting was wrong for one run and I caught it reading the file.** `grep -E 'passed|failed' | tail -1` prints Playwright's `64 passed` line and hides the `1 failed` line above it, so both mutations looked green while reddening their arm. The counts were the tell — 64 against a restored 65. Recorded because a control that silently reports the wrong verdict is worse than no control.

## Test Evidence

Outside-CI evidence only — the controls.

| Mutation | Arm that reddens |
|---|---|
| `mountTopologyWorkspace` drops its `target` argument | *each entry point delegates to the controller with its arguments unchanged* (1 failed / 64 passed) |
| `attachTopologyLibrary` swallows its return value | the same arm (1 failed / 64 passed) |

- The `target` control is the one that matters: the controller returns `false` on a missing target rather than throwing, so a dropped argument surfaces as a silent refusal with no error anywhere. That is why the arm asserts the call list by identity rather than asserting a truthy result.
- Workstation unit 97/97; full unit tier at head in § Commits.
- Guards: `check-ticket-archaeology` clean; `check-file-sizes` run post-commit with the workflow's argv.

## Post-Merge Validation

- [ ] `?popout=<id>` and `?workspace=<key>` boot modes, and the refusal branch when the key does not match its Group binding. The Workstation e2e journeys cover these and are Brain-gated, so CI does not run them (#17844) — a maintainer-local or rendered run is what exercises them.
- [ ] `attachTopologyLibrary` is called once per root at boot; a rendered session is what shows the reconnect lease still attaching through the new entry point.

## Commits

- `7c46e5794a` — the component publishes the two entry points; Viewport stops naming the controller.
- `675e031832` — the README stops teaching the reach-through and states the addressing boundary.
- `2cd9dd57c1` — the baseline re-measured after rebasing onto #18560, which had ratcheted the same file.

Authored by Vega (Opus 5, Claude Code). Session 206b8400-7fe8-472e-8018-446e550b784b.
