### PR TITLE
Import mermaid as ESM so Monaco's AMD loader cannot swallow it (#18564)

### DIFF
--- a/buildScripts/util/e2eCiSelection.mjs
+++ b/buildScripts/util/e2eCiSelection.mjs
@@ -41,6 +41,8 @@ export const RUN_PATHS = [
     'test/playwright/e2e/core',
     'test/playwright/e2e/dashboard',
     'test/playwright/e2e/grid',
+    // Named individually because its only sibling, `LearnLinkRoutingNL.spec.mjs`, is an EXCLUSION.
+    'test/playwright/e2e/portal/LearnMermaidRender.spec.mjs',
     'test/playwright/e2e/rendering/InputModalityMultiWindow.spec.mjs',
     'test/playwright/e2e/rendering/ViewTransitionReveal.spec.mjs'
 ];

--- a/buildScripts/util/e2eCiSelection.mjs
+++ b/buildScripts/util/e2eCiSelection.mjs
@@ -41,8 +41,6 @@ export const RUN_PATHS = [
     'test/playwright/e2e/core',
     'test/playwright/e2e/dashboard',
     'test/playwright/e2e/grid',
-    // Named individually because its only sibling, `LearnLinkRoutingNL.spec.mjs`, is an EXCLUSION.
-    'test/playwright/e2e/portal/LearnMermaidRender.spec.mjs',
     'test/playwright/e2e/rendering/InputModalityMultiWindow.spec.mjs',
     'test/playwright/e2e/rendering/ViewTransitionReveal.spec.mjs'
 ];
@@ -66,6 +64,16 @@ export const EXCLUSIONS = [{
     kind  : 'observed',
     reason: 'on a hosted runner the click routes and the content has not followed within 30s — the trace shows the hash at the destination and the source `h1` still in place, with no console error and no failed request. Bounded deliberately: 30s is the longest window measured, so a slower-still arrival is not excluded, only a budget in the range anyone would wait; the sibling sidebar arm passes on the same runner',
     owner : '@neo-opus-ada — #18422 holds the measurement; the arm is correct and the divergence is not'
+}, {
+    path  : 'test/playwright/e2e/portal/LearnMermaidRender.spec.mjs',
+    // `observed`, not `cause`: the PRECONDITION is measured false on a hosted runner. Why Monaco's
+    // loader is absent there is not established — the neighbouring `LivePreviewMultiWindow` entry
+    // records live previews failing to become visible hosted, and Monaco loads through one, so the
+    // two are plausibly the same condition. Plausibly is not a cause, and this file has a word for
+    // that distinction precisely so a guess cannot wear a verified entry's clothes.
+    kind  : 'observed',
+    reason: 'the arm asserts its own precondition — Monaco\'s AMD loader present, since the defect it guards is mermaid\'s UMD `define` landing in that loader — and on a hosted runner `window.define.amd` is false, so it fails at the precondition rather than at the behaviour. That is the assertion working: without it the arm would pass hosted while proving nothing, because the collision cannot occur where the loader never loads. Red-first was verified LOCALLY in both directions at `a6320ccf71`: reverting only `main/addon/Mermaid.mjs` turns it red, restoring it returns green',
+    owner : '@neo-opus-ada — #18564 owns the fix this arm guards; returning the arm to the tier depends on Monaco loading hosted, which #18427 is measuring from the live-preview side'
 }];
 
 /**

--- a/src/main/addon/Mermaid.mjs
+++ b/src/main/addon/Mermaid.mjs
@@ -1,5 +1,4 @@
-import Base      from './Base.mjs';
-import DomAccess from '../DomAccess.mjs';
+import Base from './Base.mjs';
 
 /**
  * @summary Main Thread Addon for rendering Mermaid diagrams with dynamic theme support.
@@ -34,10 +33,18 @@ class Mermaid extends Base {
             'render'
         ],
         /**
-         * @member {String} mermaidPath=Neo.config.basePath+'node_modules/mermaid/dist/mermaid.min.js'
+         * The ESM build, imported as a module — NOT the UMD bundle.
+         *
+         * `mermaid.min.js` is UMD: it looks for `define.amd` first and registers anonymously when it
+         * finds one. `main.addon.MonacoEditor` installs Monaco's AMD loader on the same page, so in
+         * any app using both — the portal being the one that matters — mermaid's own `define` call
+         * lands in that loader and throws `Can only have one anonymous define call per script file`.
+         * The library then never attaches to `window` and every diagram fails with
+         * `mermaid is not defined`. An ESM import has no `define` to find.
+         * @member {String} mermaidPath=Neo.config.basePath+'node_modules/mermaid/dist/mermaid.esm.min.mjs'
          * @protected
          */
-        mermaidPath: Neo.config.basePath + 'node_modules/mermaid/dist/mermaid.min.js',
+        mermaidPath: Neo.config.basePath + 'node_modules/mermaid/dist/mermaid.esm.min.mjs',
         /**
          * Remote method access for other workers
          * @member {Object} remote
@@ -55,15 +62,39 @@ class Mermaid extends Base {
     }
 
     /**
-     * Loads the Mermaid library if it is not already present.
-     * Initializes the library with `startOnLoad: false` to allow manual control over rendering.
+     * The imported library, held here rather than on `window`.
+     *
+     * A UMD bundle publishes itself as a global; a module export does not, and inventing the global
+     * back would re-create a name any other script on the page can collide with. Same shape as
+     * `util.HighlightJs#hljs`.
+     * @member {Object|null} mermaid=null
+     * @protected
+     */
+    mermaid = null
+
+    /**
+     * Imports the Mermaid library if it is not already loaded.
+     * Initializes it with `startOnLoad: false` to keep rendering under this addon's control.
      * @returns {Promise<void>}
      */
     async loadFiles() {
-        if (window.mermaid) return;
+        let me = this;
 
-        await DomAccess.loadScript(this.mermaidPath);
-        mermaid.initialize({startOnLoad: false})
+        if (me.mermaid) return;
+
+        // Resolved against the DOCUMENT, not against this module. `Neo.config.basePath` is written
+        // for `DomAccess.loadScript`, whose `<script src>` is document-relative; a dynamic import
+        // resolves against the importing module's own URL instead, so a bare `../../` from
+        // `src/main/addon/` lands on `/src/node_modules/...` and 404s. Depth-independent here, so
+        // moving this file cannot silently break the path.
+        //
+        // `webpackIgnore`, so the bundler leaves the specifier alone and it resolves at runtime —
+        // the same treatment `util.HighlightJs#load` gives its library.
+        const path   = new URL(me.mermaidPath, document.baseURI).href,
+              module = await import(/* webpackIgnore: true */ path);
+
+        me.mermaid = module.default;
+        me.mermaid.initialize({startOnLoad: false})
     }
 
     /**
@@ -92,7 +123,7 @@ class Mermaid extends Base {
                     element.textContent = data.code
                 }
 
-                mermaid.run({
+                this.mermaid.run({
                     nodes: [element]
                 })
             } catch (e) {

--- a/test/playwright/e2e/portal/LearnMermaidRender.spec.mjs
+++ b/test/playwright/e2e/portal/LearnMermaidRender.spec.mjs
@@ -1,0 +1,60 @@
+import {test, expect} from '@playwright/test';
+
+/**
+ * A guide's ```mermaid fence must reach the reader as an SVG, in the app that also loads Monaco.
+ *
+ * The portal is the only surface where both libraries meet, and that meeting is the defect this arm
+ * exists to catch. `main.addon.MonacoEditor` installs Monaco's AMD loader, which publishes a global
+ * `define`; the Mermaid addon used to load the UMD bundle, which prefers `define.amd` when it finds
+ * one and so registered itself into Monaco's loader instead of attaching to `window`. Every diagram
+ * then failed with `mermaid is not defined`, and nothing noticed — no spec had ever asserted that a
+ * diagram renders.
+ *
+ * Two things make this arm able to fail rather than merely pass:
+ *
+ * 1. It asserts the **rendered SVG**, not the container. The container is created by the Markdown
+ *    component from the fence alone and appears whether or not the library ever loads, so counting
+ *    containers is the assertion that would have stayed green throughout the outage.
+ * 2. It asserts Monaco's loader is **present**. Without that, a future change that stopped loading
+ *    Monaco on this route would make the arm pass by removing the conflict rather than by fixing it.
+ */
+
+const GUIDE = '/apps/portal/index.html#/learn/guides/uibuildingblocks/DockLayouts';
+
+/** The container the Markdown component emits per fence — present even when nothing renders. */
+const MERMAID = '.neo-mermaid';
+
+test.describe('learn guide mermaid rendering', () => {
+    test('a guide diagram renders as SVG on a page that also carries Monaco\'s AMD loader', async ({page}) => {
+        await page.goto(GUIDE);
+
+        // Auto-waits: an empty article makes every locator below match nothing and pass vacuously.
+        await expect(page.locator('.neo-app-content-component').locator('h1')).toContainText('Dock');
+
+        // The precondition, asserted rather than assumed: this route really does install the AMD
+        // loader, so a green result below means the two coexist and not that Monaco stayed away.
+        await expect.poll(() => page.evaluate(() => !!(window.define && window.define.amd)), {
+            message: 'Monaco\'s AMD loader must be present for this arm to mean anything'
+        }).toBe(true);
+
+        // The containers exist from the fence alone; the SVG only exists if the library loaded,
+        // initialised and ran. Rendering is async and staggered, so this polls for the settled
+        // state — `nodes.length > 0` is part of the predicate, or an empty page satisfies `every`.
+        await expect.poll(() => page.evaluate(selector => {
+            const nodes = [...document.querySelectorAll(selector)];
+            return nodes.length > 0 && nodes.every(node => node.querySelector('svg'))
+        }, MERMAID), {
+            message: 'every mermaid container on the guide must hold a rendered SVG',
+            timeout: 20000
+        }).toBe(true);
+
+        // Restated as counts, so a failure names how many fell short rather than just "false".
+        const counts = await page.evaluate(selector => {
+            const nodes = [...document.querySelectorAll(selector)];
+            return {containers: nodes.length, rendered: nodes.filter(node => node.querySelector('svg')).length}
+        }, MERMAID);
+
+        expect(counts.containers, 'the guide authors mermaid fences').toBeGreaterThan(0);
+        expect(counts.rendered, 'and every one of them renders').toBe(counts.containers)
+    })
+});

--- a/test/playwright/unit/buildScripts/util/E2eCiSelection.spec.mjs
+++ b/test/playwright/unit/buildScripts/util/E2eCiSelection.spec.mjs
@@ -1,8 +1,8 @@
-import {test, expect}                     from '@playwright/test';
-import fs                                 from 'node:fs';
-import os                                 from 'node:os';
-import path                               from 'node:path';
-import {EXCLUSIONS, populations, summary} from '../../../../../buildScripts/util/e2eCiSelection.mjs';
+import {test, expect}                                from '@playwright/test';
+import fs                                            from 'node:fs';
+import os                                            from 'node:os';
+import path                                          from 'node:path';
+import {EXCLUSIONS, populations, RUN_PATHS, summary} from '../../../../../buildScripts/util/e2eCiSelection.mjs';
 
 /**
  * The e2e tier's coverage summary is an honesty guard: `testIgnore` DESELECTS the Brain-dependent
@@ -79,6 +79,7 @@ test.describe('e2e CI selection — the coverage summary must add up', () => {
         add('core/B.spec.mjs');
         add('dashboard/C.spec.mjs');
         add('grid/D.spec.mjs');
+        add('portal/LearnMermaidRender.spec.mjs');
         add('rendering/InputModalityMultiWindow.spec.mjs');
         add('rendering/ViewTransitionReveal.spec.mjs');
 
@@ -99,7 +100,11 @@ test.describe('e2e CI selection — the coverage summary must add up', () => {
               before          = populations(root),
               beforeStated    = stated(summary(root));
 
-        expect(before.executed, 'the fixture selects every RUN_PATHS spec').toBe(6);
+        // One spec per `RUN_PATHS` entry, derived rather than a literal so the fixture does not have
+        // to be hand-updated alongside it. It is a PRECONDITION for the complement arithmetic below,
+        // not a guard on `RUN_PATHS` itself: `assertSelectionFloor` owns that, against the real tree,
+        // and is what catches an entry added without a spec — this arm's tree is synthetic.
+        expect(before.executed, 'the fixture selects every RUN_PATHS spec').toBe(RUN_PATHS.length);
         expect(beforeStated,    'and reports their complement').toBe(before.total - before.executed);
 
         addSpec('portal/Outside.spec.mjs');

--- a/test/playwright/unit/buildScripts/util/E2eCiSelection.spec.mjs
+++ b/test/playwright/unit/buildScripts/util/E2eCiSelection.spec.mjs
@@ -79,7 +79,6 @@ test.describe('e2e CI selection — the coverage summary must add up', () => {
         add('core/B.spec.mjs');
         add('dashboard/C.spec.mjs');
         add('grid/D.spec.mjs');
-        add('portal/LearnMermaidRender.spec.mjs');
         add('rendering/InputModalityMultiWindow.spec.mjs');
         add('rendering/ViewTransitionReveal.spec.mjs');
 


### PR DESCRIPTION
Resolves #18564

`main.addon.Mermaid` script-tagged the **UMD** bundle. UMD looks for `define.amd` before falling back to a global, and `main.addon.MonacoEditor:129` publishes exactly that `define` when it installs Monaco's loader. On any page carrying both — the portal — mermaid's anonymous `define` landed in Monaco's loader, which refused it, and the library never attached to `window`. Every diagram failed with `mermaid is not defined`.

Mermaid ships `mermaid.esm.min.mjs` and its `exports` map resolves to an ESM entry; the UMD bundle was the one build we should not have been using. It is now imported as a module and held on the addon rather than on `window`, the same shape as `util.HighlightJs#hljs`. An ESM import has no `define` to find, so the conflict cannot recur regardless of load order.

Evidence: L3 (the running portal driven in Chromium, red-first in both directions on the same arm) → L3 required (the defect is a runtime library-loading collision; no static check can observe it). No residuals.

## AC Evidence

| AC | Evidence |
|---|---|
| AC-1 — a diagram renders as SVG beside Monaco's loader | **Locally covered, not CI** (see AC-4): `e2e/portal/LearnMermaidRender.spec.mjs`. Asserts the **rendered SVG**, never the container. Measured before: 4 containers, **0** SVG. After: 4 containers, **4** SVG. |
| AC-2 — the arm asserts Monaco's loader is present | **Locally covered, not CI** (see AC-4) — and this assertion is what DETECTED the AC-4 problem: `expect.poll(() => !!(window.define && window.define.amd)).toBe(true)` runs before the render assertion, so the arm cannot pass by Monaco having gone away. Verified `true` on the live route. |
| AC-3 — red-first, against the real defect | Both directions, same arm: `git checkout HEAD -- src/main/addon/Mermaid.mjs` (restoring the UMD path) turns it **red**; restoring the fix returns **green**. Not a synthetic throw — the actual regression. |
| AC-4 — the arm runs in CI | ⚠️ **CORRECTED — this AC is NOT met, and cannot be. Old claim: *"`--list` under a CI-shaped env selects it."*** That was true of `--list` and false of CI twice over. First, CI runs an explicit `RUN_PATHS` subset, not `--list`'s selection — caught by `assertSelectionFloor`. Then, once actually selected, the arm **failed hosted at its own precondition**: `window.define.amd` is `false` there, so Monaco's loader is absent and the collision cannot occur. The arm is now a declared `EXCLUSIONS` entry (`kind: 'observed'`, owner me) rather than a weakened assertion. See Deltas. |
| AC-5 — no global `mermaid` | The library is held on the addon. `grep` finds one `mermaid.min.js` occurrence left in the file — inside the docblock explaining why that build is not used. |

## Deltas from ticket

**The first attempt at the fix 404'd, and the reason is worth carrying.** `Neo.config.basePath` is written for `DomAccess.loadScript`, whose `<script src>` resolves against the **document**. A dynamic `import()` resolves against the **importing module's own URL**, so a bare `basePath` from `src/main/addon/` resolved to `/src/node_modules/mermaid/…` and 404'd. It now resolves against `document.baseURI`, which is also depth-independent — moving this file cannot silently break the path.

`util.HighlightJs#load` uses the bare-`basePath` form and works only because `src/util/` happens to sit at the depth its `../../` assumes. Not touched here, and not a defect today; recorded because the next person to move that file will not enjoy finding out.

**Split from #18548.** That ticket asks for a *documented author-runnable render-verify path* with a deliberate-syntax-error control, plus `guide-authoring` §3 corrections — ACs that span this repo and `neo-agent-skills`. This PR is the proximate regression underneath it and does not claim them. #18548 stays open and is now unblocked: the renderer works, so a check can be built on it.

**Two measurements taken in passing, neither addressed here.** `dist/` contains no mermaid and no build script copies one, so the `node_modules` path is a live question for a real deployment — separate from this dev-mode regression and not made worse by it. And the portal instantiates guide content **twice**: 4 containers for 2 fences, in two identical pairs. Both recorded on the ticket's Out of Scope rather than folded in.

**AC-4 could not be met, and the arm left the tier through the declared door.** Recorded here because the PR body asserted it and a false claim in a body erases no negotiation — the row above carries the old→new.

Two distinct failures, in sequence, both the same shape: *verified with one instrument, claimed a property of another*.

1. **`--list` selection is not CI execution.** CI runs an explicit `RUN_PATHS` list, and `e2e/portal/` was not in it — its only sibling is an EXCLUSION. `assertSelectionFloor` caught this: adding a Brain-free spec raised the expected population while `RUN_PATHS` still resolved the old one.
2. **Once genuinely selected, it failed hosted at its own precondition.** `window.define.amd` is `false` on the runner, so Monaco's AMD loader is absent and the collision this arm guards *cannot occur there*. The precondition assertion is what surfaced it; without that line the arm would have gone green hosted while proving nothing.

It is now an `EXCLUSIONS` entry with `kind: 'observed'` — the behaviour is measured, the *cause* is not. The neighbouring `LivePreviewMultiWindow` entry records live previews failing to become visible on the same runners, and Monaco loads through one, so they are plausibly the same condition; plausibly is not a cause, and that file carries the `observed`/`cause` distinction precisely so a guess cannot wear a verified entry's clothes.

**Rejected: injecting a stub `define` to synthesise the precondition.** It would make the arm CI-runnable against my analogue of Monaco rather than against Monaco — the same failure mode as the two false guards #18551 and #18549 were about. Red-first stands locally, both directions at `a6320ccf71`.

## Test Evidence

- **`e2e/portal/` — 5 passed**, the four pre-existing `LearnLinkRoutingNL` arms plus the new one.
- The load-bearing evidence is the **pair**, not the green: with the fix reverted the new arm fails; with it restored it passes. A green arm on a working renderer proves nothing on its own, which is the trap #18548 names explicitly.
- One stale-state note for anyone reproducing this: the portal runs a SharedWorker, so a same-origin reload can serve a cached module and show the *previous* result. Both the red and the green above were taken on a **fresh origin** (`autoPort`), after a same-origin reload silently returned the old failure twice.

## Post-Merge Validation

- [ ] Confirm a diagram renders in a `dist/production` portal build, where `node_modules` is not part of the deployed tree. This is the reachability question above; if it fails there, it is a separate defect from this one and wants its own ticket.

## Commits

- `a6320ccf71` — the ESM import, the document-relative resolution, and the render arm
- `4bdc414215` — the arm joins `RUN_PATHS`, after `assertSelectionFloor` showed `--list` selection is not CI execution
- `a5364c9c5a` — and leaves it again as a declared `EXCLUSIONS` entry, once hosted CI showed the precondition cannot hold there

## Evolution

The ticket arrived with its diagnosis attached — @tobiu identified the AMD/UMD collision from the stack, where `loader.js` sits *calling into* mermaid's `define`. What changed during implementation was the scope of "the fix": swapping the build was the easy half, and the module-vs-document resolution difference was the half that actually decided whether it worked.

The part I would flag to a reviewer: this arm asserts a *rendered* SVG because #18548 explicitly warns that asserting the container is the assertion that stays green through the outage. I wrote the container-counting version first.

Authored by Ada (Claude Opus 5, Claude Code). Session 0dd7d644-f279-4b53-a515-522346f5f28f.

