### PR TITLE
Every SharedWorker mirrors its errors, not only App

### DIFF
--- a/src/Main.mjs
+++ b/src/Main.mjs
@@ -128,7 +128,18 @@ class Main extends core.Base {
          * @protected
          */
         remote: {
-            app: [
+            // Four narrow keys beside the full `app` list, each exposing `log` and nothing else, so
+            // an error raised in any SharedWorker can reach a console a page can read. The manifest
+            // key IS the target worker id (`core.Base#promiseRemotes`), and that fan-out is already
+            // existence-guarded by `origin.hasWorker(worker)` — `useCanvasWorker`, `useTaskWorker`
+            // and `useVdomWorker` are defaults-off, so most apps run two of the five and a key for
+            // an absent worker is inert. A conditional manifest would add a second existence check
+            // behind the one that works.
+            canvas: ['log'],
+            data  : ['log'],
+            task  : ['log'],
+            vdom  : ['log'],
+            app   : [
                 'alert',
                 'brainHealth',
                 'editRoute',
@@ -436,7 +447,13 @@ class Main extends core.Base {
      * @returns {Boolean}
      */
     log(data) {
-        console[data.method || 'log'](data.value);
+        // `method` is validated rather than trusted, because this is now reachable from every
+        // worker rather than only from `app`: an unknown name would be `console[undefined]`, a
+        // TypeError raised on the main thread by the channel that exists to report faults without
+        // becoming one. The worker side of this path guards carefully; this is the other side.
+        const {method} = data;
+
+        console[typeof console[method] === 'function' ? method : 'log'](data.value);
         return true
     }
 

--- a/src/Main.mjs
+++ b/src/Main.mjs
@@ -359,6 +359,14 @@ class Main extends core.Base {
     }
 
     /**
+     * Console levels {@link #log} may dispatch to. Anything else falls back to `log`.
+     * @member {String[]} consoleMethods=['log','warn','error','info']
+     * @static
+     * @protected
+     */
+    static consoleMethods = ['log', 'warn', 'error', 'info']
+
+    /**
      * @summary Writes the identity the App Worker bound this window to, so the next page load presents it again
      * (the worker manager reads it into every worker registration). `Neo.manager.Transaction` asks for
      * this after it minted, cold-created or forked a Group for the window; a plain bind or rebind writes
@@ -447,13 +455,14 @@ class Main extends core.Base {
      * @returns {Boolean}
      */
     log(data) {
-        // `method` is validated rather than trusted, because this is now reachable from every
-        // worker rather than only from `app`: an unknown name would be `console[undefined]`, a
-        // TypeError raised on the main thread by the channel that exists to report faults without
-        // becoming one. The worker side of this path guards carefully; this is the other side.
+        // An ALLOWLIST, not a `typeof` probe. `typeof console[method] === 'function'` is satisfied by
+        // `constructor`, `toString`, `valueOf` and `hasOwnProperty` — all inherited, all callable, and
+        // all writing nothing. That turns a loud main-thread TypeError into a SILENT DROP, which is
+        // the failure this channel exists to remove rather than reproduce. Validated because the
+        // method is reachable from every worker now, not only from `app`.
         const {method} = data;
 
-        console[typeof console[method] === 'function' ? method : 'log'](data.value);
+        console[Main.consoleMethods.includes(method) ? method : 'log'](data.value);
         return true
     }
 

--- a/src/worker/App.mjs
+++ b/src/worker/App.mjs
@@ -58,33 +58,6 @@ class App extends Base {
     }
 
     /**
-     * Environments {@link #forwardErrorToMainThread} may write into.
-     *
-     * An ALLOWLIST, deliberately. The first version excluded `dist/production` alone and left
-     * `dist/esm` mirroring — a real value a shipped build sets (`esmDistTransforms.mjs`), which
-     * {@link #afterSetCountLoadingThemeFiles}'s sibling branch in this same file already knows
-     * about. A denylist of shipped environments fails in the shipped direction and does it
-     * silently; an allowlist means a new environment gets no mirror until someone decides it
-     * should, which is the right default for something that writes into a user's console.
-     *
-     * Deliberately NOT coupled to `Neo.config.enableLogsInProduction`, which is `util.Logger`'s
-     * escape hatch for an application's own logging. This is a diagnostic for a condition the
-     * reader did not ask about; turning it on in production is a separate decision from turning
-     * application logs back on, and conflating them would grant it by accident.
-     * @member {String[]} mirrorEnvironments=['development','dist/development']
-     * @static
-     * @protected
-     */
-    static mirrorEnvironments = ['development', 'dist/development']
-
-    /**
-     * Re-entrancy latch for {@link #forwardErrorToMainThread}: the mirror runs inside the console
-     * interceptor, so anything the send path logs would arrive back through it.
-     * @member {Boolean} isForwardingError=false
-     * @protected
-     */
-    isForwardingError = false
-    /**
      * @member {Object} rpcStreamCallbacks={}
      * @protected
      */
@@ -122,8 +95,6 @@ class App extends Base {
         // convenience shortcuts
         Neo.applyDeltas    = me.applyDeltas   .bind(me);
         Neo.setCssVariable = me.setCssVariable.bind(me);
-
-        me.interceptConsole()
     }
 
     /**
@@ -413,164 +384,6 @@ class App extends Base {
             /* webpackMode: "lazy" */
             `../../${path}.mjs`
         )
-    }
-
-    /**
-     * @summary Renders console arguments into one string, Errors as message plus stack.
-     * @param {Array} args
-     * @returns {String}
-     * @protected
-     */
-    serializeConsoleArgs(args) {
-        return args.map(arg => {
-            if (arg instanceof Error) {
-                return arg.message + '\n' + arg.stack
-            }
-            if (typeof arg === 'object') {
-                try {
-                    return JSON.stringify(arg)
-                } catch (e) {
-                    return String(arg)
-                }
-            }
-            return String(arg)
-        }).join(' ')
-    }
-
-    /**
-     * @summary Mirrors an App-Worker error into every connected window's console.
-     *
-     * The worker's own `console.error` writes to the SharedWorker's inspector context, which no
-     * page can read — and therefore neither can anything driving a browser. Until now the only
-     * other sink was the Neural Link, which needs a Brain checkout, so an error was invisible to
-     * a developer who did not go looking for it and to any test that could not load Brain code.
-     * This gives it one path that costs neither. `Neo.Main.log` already carried this shape on the
-     * Main remote manifest and had no caller.
-     *
-     * Errors only, and never in production: a diagnostic mirror, not a logging transport.
-     * @param {String} message
-     * @protected
-     */
-    forwardErrorToMainThread(message) {
-        let me = this;
-
-        // SharedWorker ONLY, because a dedicated worker needs no help: the browser already forwards
-        // its console output to the owner document, so mirroring there would double every error.
-        // Measured rather than assumed — a Blob worker calling `console.error` reaches
-        // `page.on('console')` with no forwarding at all. A SharedWorker instead gets its own
-        // inspector context that no page can read, which is the entire gap this closes.
-        //
-        // Re-entry is guarded rather than merely unlikely: a failed forward must never log, and the
-        // send path is free to warn — an unrouted `main` destination warns about its own
-        // deprecation, and that warning would arrive back through the interceptor that called us.
-        if (!me.isSharedWorker || me.isForwardingError || !me.constructor.mirrorEnvironments.includes(Neo.config.environment)) {
-            return
-        }
-
-        me.isForwardingError = true;
-
-        try {
-            const value = 'App Worker: ' + message;
-
-            // Addressed per window, so the deprecated unrouted `main` destination is never used.
-            // A window that closed between the error and this call rejects with NEO_DEAD_PORT,
-            // which is ordinary teardown; swallowed, never reported.
-            me.ports.forEach(({windowId}) => {
-                windowId && Neo.Main?.log?.({method: 'error', value, windowId})?.catch?.(Neo.emptyFn)
-            })
-        } catch (err) {
-            // A diagnostic mirror must not become a fault of its own.
-        } finally {
-            me.isForwardingError = false
-        }
-    }
-
-    /**
-     * Intercepts console logs and errors, forwarding them to the Neural Link and mirroring
-     * errors onto the main thread ({@link #forwardErrorToMainThread}).
-     */
-    interceptConsole() {
-        let me = this;
-
-        const types = ['log', 'warn', 'error', 'info'];
-
-        types.forEach(type => {
-            const original = console[type];
-
-            console[type] = (...args) => {
-                original.apply(console, args);
-
-                // Use the Client singleton if available (lazy check)
-                const client = Neo.ai?.Client,
-                      mirror = type === 'error';
-
-                // The mirror is deliberately independent of the client: an error must reach the
-                // main thread whether or not a Brain runtime is attached.
-                if (!client && !mirror) {
-                    return
-                }
-
-                let message;
-
-                try {
-                    message = me.serializeConsoleArgs(args)
-                } catch (err) {
-                    return
-                }
-
-                mirror && me.forwardErrorToMainThread(message);
-
-                if (client) {
-                    try {
-                        const logEntry = {
-                            type,
-                            message,
-                            timestamp: Date.now(),
-                            stack    : mirror ? new Error().stack : undefined
-                        };
-
-                        if (client.isConnected) {
-                            client.sendNotification('console_log', logEntry)
-                        } else {
-                            // Direct push to Client instance array
-                            client.logs.push(logEntry)
-                        }
-                    } catch (err) {
-                        // Prevent infinite loop if logging fails
-                    }
-                }
-            }
-        });
-
-        // Intercept unhandled errors
-        const originalOnError = globalThis.onerror;
-
-        globalThis.onerror = (msg, url, lineNo, columnNo, error) => {
-            const client = Neo.ai?.Client;
-
-            me.forwardErrorToMainThread(error?.stack || msg);
-
-            if (client) {
-                const logEntry = {
-                    type     : 'error',
-                    message  : msg,
-                    timestamp: Date.now(),
-                    stack    : error?.stack
-                };
-
-                if (client.isConnected) {
-                    client.sendNotification('console_log', logEntry)
-                } else {
-                    client.logs.push(logEntry)
-                }
-            }
-
-            if (originalOnError) {
-                return originalOnError(msg, url, lineNo, columnNo, error)
-            }
-
-            return false
-        }
     }
 
     /**

--- a/src/worker/Base.mjs
+++ b/src/worker/Base.mjs
@@ -27,6 +27,33 @@ class Worker extends Base {
     }
 
     /**
+     * Environments {@link #forwardErrorToMainThread} may write into.
+     *
+     * An ALLOWLIST, deliberately. The first version excluded `dist/production` alone and left
+     * `dist/esm` mirroring — a real value a shipped build sets (`esmDistTransforms.mjs`), which
+     * {@link #afterSetCountLoadingThemeFiles}'s sibling branch in this same file already knows
+     * about. A denylist of shipped environments fails in the shipped direction and does it
+     * silently; an allowlist means a new environment gets no mirror until someone decides it
+     * should, which is the right default for something that writes into a user's console.
+     *
+     * Deliberately NOT coupled to `Neo.config.enableLogsInProduction`, which is `util.Logger`'s
+     * escape hatch for an application's own logging. This is a diagnostic for a condition the
+     * reader did not ask about; turning it on in production is a separate decision from turning
+     * application logs back on, and conflating them would grant it by accident.
+     * @member {String[]} mirrorEnvironments=['development','dist/development']
+     * @static
+     * @protected
+     */
+    static mirrorEnvironments = ['development', 'dist/development']
+
+    /**
+     * Re-entrancy latch for {@link #forwardErrorToMainThread}: the mirror runs inside the console
+     * interceptor, so anything the send path logs would arrive back through it.
+     * @member {Boolean} isForwardingError=false
+     * @protected
+     */
+    isForwardingError = false
+    /**
      * @member {Object|null} channelPorts=null
      * @protected
      */
@@ -78,7 +105,184 @@ class Worker extends Base {
 
         Neo.currentWorker   = me;
         Neo.setGlobalConfig = me.setGlobalConfig.bind(me);
-        Neo.workerId        = me.workerId
+        Neo.workerId        = me.workerId;
+
+        // Every worker, not only App: the inspector-context gap belongs to SharedWorkers as a class.
+        // `forwardErrorToMainThread` declines in dedicated mode, so a non-shared worker installs the
+        // interceptor and mirrors nothing.
+        me.interceptConsole()
+    }
+
+    /**
+     * @summary Renders console arguments into one string, Errors as message plus stack.
+     * @param {Array} args
+     * @returns {String}
+     * @protected
+     */
+    serializeConsoleArgs(args) {
+        return args.map(arg => {
+            if (arg instanceof Error) {
+                return arg.message + '\n' + arg.stack
+            }
+            if (typeof arg === 'object') {
+                try {
+                    return JSON.stringify(arg)
+                } catch (e) {
+                    return String(arg)
+                }
+            }
+            return String(arg)
+        }).join(' ')
+    }
+
+    /**
+     * @summary Mirrors a SharedWorker error into every connected window's console.
+     *
+     * A SharedWorker's own `console.error` writes to its inspector context, which no page can
+     * read — and therefore neither can anything driving a browser. This lives on `worker.Base`
+     * rather than on `worker.App` because that is a property of every SharedWorker, and
+     * `worker/Manager.mjs` makes all five shared through one `createWorker` path: before the hoist
+     * `interceptConsole` existed in exactly one file, so an error raised in Data, VDom, Canvas or
+     * Task reached neither the page nor the Neural Link — uninstrumented, not merely un-mirrored.
+     *
+     * Errors only, and never in production: a diagnostic mirror, not a logging transport.
+     * @param {String} message
+     * @protected
+     */
+    forwardErrorToMainThread(message) {
+        let me = this;
+
+        // SharedWorker ONLY, because a dedicated worker needs no help: the browser already forwards
+        // its console output to the owner document, so mirroring there would double every error.
+        // Measured rather than assumed — a Blob worker calling `console.error` reaches
+        // `page.on('console')` with no forwarding at all. A SharedWorker instead gets its own
+        // inspector context that no page can read, which is the entire gap this closes.
+        //
+        // Re-entry is guarded rather than merely unlikely: a failed forward must never log, and the
+        // send path is free to warn — an unrouted `main` destination warns about its own
+        // deprecation, and that warning would arrive back through the interceptor that called us.
+        if (!me.isSharedWorker || me.isForwardingError || !me.constructor.mirrorEnvironments.includes(Neo.config.environment)) {
+            return
+        }
+
+        me.isForwardingError = true;
+
+        try {
+            // Derived from the class name rather than from a table: `Neo.worker.VDom` yields `VDom`,
+            // which no capitalisation of the lowercase `workerId` would produce. Four workers
+            // sharing one prefix would make a mirrored line unattributable.
+            //
+            // Idempotent, because some workers already name themselves inside their own message
+            // text (`Data.mjs:237`, `Canvas.mjs:92`). Prefixing unconditionally would render those
+            // as "Data Worker: Data Worker: …"; rewriting those four call sites is not this change.
+            const prefix = me.className.split('.').pop() + ' Worker: ',
+                  value  = message.startsWith(prefix) ? message : prefix + message;
+
+            // Addressed per window, so the deprecated unrouted `main` destination is never used.
+            // A window that closed between the error and this call rejects with NEO_DEAD_PORT,
+            // which is ordinary teardown; swallowed, never reported.
+            me.ports.forEach(({windowId}) => {
+                windowId && Neo.Main?.log?.({method: 'error', value, windowId})?.catch?.(Neo.emptyFn)
+            })
+        } catch (err) {
+            // A diagnostic mirror must not become a fault of its own.
+        } finally {
+            me.isForwardingError = false
+        }
+    }
+
+    /**
+     * Intercepts console output, mirroring errors onto the main thread
+     * ({@link #forwardErrorToMainThread}) and forwarding everything to the Neural Link when one is
+     * attached.
+     *
+     * The `Neo.ai?.Client` lookup stays a lazy check rather than becoming an App-worker branch: only
+     * the App worker constructs a client today, so it is App-only in effect — but making it
+     * structurally App-only would reintroduce the coupling this path exists to remove, where an
+     * error could not be observed at all without a Brain runtime.
+     */
+    interceptConsole() {
+        let me = this;
+
+        const types = ['log', 'warn', 'error', 'info'];
+
+        types.forEach(type => {
+            const original = console[type];
+
+            console[type] = (...args) => {
+                original.apply(console, args);
+
+                // Use the Client singleton if available (lazy check)
+                const client = Neo.ai?.Client,
+                      mirror = type === 'error';
+
+                // The mirror is deliberately independent of the client: an error must reach the
+                // main thread whether or not a Brain runtime is attached.
+                if (!client && !mirror) {
+                    return
+                }
+
+                let message;
+
+                try {
+                    message = me.serializeConsoleArgs(args)
+                } catch (err) {
+                    return
+                }
+
+                mirror && me.forwardErrorToMainThread(message);
+
+                if (client) {
+                    try {
+                        const logEntry = {
+                            type,
+                            message,
+                            timestamp: Date.now(),
+                            stack    : mirror ? new Error().stack : undefined
+                        };
+
+                        if (client.isConnected) {
+                            client.sendNotification('console_log', logEntry)
+                        } else {
+                            // Direct push to Client instance array
+                            client.logs.push(logEntry)
+                        }
+                    } catch (err) {
+                        // Prevent infinite loop if logging fails
+                    }
+                }
+            }
+        });
+
+        // Intercept unhandled errors
+        const originalOnError = globalThis.onerror;
+
+        globalThis.onerror = (msg, url, lineNo, columnNo, error) => {
+            const client = Neo.ai?.Client;
+
+            me.forwardErrorToMainThread(error?.stack || msg);
+
+            if (client) {
+                const logEntry = {
+                    type     : 'error',
+                    message  : msg,
+                    timestamp: Date.now(),
+                    stack    : error?.stack
+                };
+
+                if (client.isConnected) {
+                    client.sendNotification('console_log', logEntry)
+                } else {
+                    client.logs.push(logEntry)
+                }
+            }
+
+            if (originalOnError) {
+                return originalOnError(msg, url, lineNo, columnNo, error)
+            }
+
+            return false
+        }
     }
 
     /**

--- a/src/worker/Base.mjs
+++ b/src/worker/Base.mjs
@@ -114,6 +114,20 @@ class Worker extends Base {
     }
 
     /**
+     * @summary Whether a mirrored error could reach a page at all, independent of any one call.
+     *
+     * Split out so {@link #interceptConsole} can decline BEFORE serializing: the string is discarded
+     * in dedicated mode and in every shipped environment, and five workers now pay for it where one
+     * used to. The latch stays inside {@link #forwardErrorToMainThread}, being per-call rather than
+     * per-configuration.
+     * @returns {Boolean}
+     * @protected
+     */
+    canMirrorErrors() {
+        return this.isSharedWorker && this.constructor.mirrorEnvironments.includes(Neo.config.environment)
+    }
+
+    /**
      * @summary Renders console arguments into one string, Errors as message plus stack.
      * @param {Array} args
      * @returns {String}
@@ -161,7 +175,7 @@ class Worker extends Base {
         // Re-entry is guarded rather than merely unlikely: a failed forward must never log, and the
         // send path is free to warn — an unrouted `main` destination warns about its own
         // deprecation, and that warning would arrive back through the interceptor that called us.
-        if (!me.isSharedWorker || me.isForwardingError || !me.constructor.mirrorEnvironments.includes(Neo.config.environment)) {
+        if (me.isForwardingError || !me.canMirrorErrors()) {
             return
         }
 
@@ -213,8 +227,11 @@ class Worker extends Base {
                 original.apply(console, args);
 
                 // Use the Client singleton if available (lazy check)
-                const client = Neo.ai?.Client,
-                      mirror = type === 'error';
+                const client  = Neo.ai?.Client,
+                      isError = type === 'error',
+                      // Not merely "is an error" — "will actually be mirrored", so a configuration
+                      // that can never use the string does not build it.
+                      mirror  = isError && me.canMirrorErrors();
 
                 // The mirror is deliberately independent of the client: an error must reach the
                 // main thread whether or not a Brain runtime is attached.
@@ -238,7 +255,7 @@ class Worker extends Base {
                             type,
                             message,
                             timestamp: Date.now(),
-                            stack    : mirror ? new Error().stack : undefined
+                            stack    : isError ? new Error().stack : undefined
                         };
 
                         if (client.isConnected) {

--- a/src/worker/Manager.mjs
+++ b/src/worker/Manager.mjs
@@ -458,8 +458,21 @@ class Manager extends Base {
      * @param {Object} e
      */
     onWorkerError(e) {
-        // starting a worker from a JS module will show JS errors in a correct way
-        !useMjsFiles && console.log('Worker Error:', e)
+        // The `!useMjsFiles` deferral is true for a DEDICATED module worker, whose errors the browser
+        // surfaces on its own, and false for a SharedWorker, whose output goes to an inspector context
+        // no page can read. The comment predates that distinction: it was written in 2019 to explain
+        // the CLASSIC branch of `new Worker(...)`, and the commit that dropped that branch renamed
+        // `hasJsModules` to `useMjsFiles` inside the guard in the same diff — the guard outlived what
+        // it was guarding by one hunk.
+        //
+        // `error` level, not `log`: this is the ONLY signal for a SharedWorker that fails to load or
+        // parse. `Neo.worker.Base#forwardErrorToMainThread` cannot cover it — a worker that never ran
+        // cannot mirror its own failure.
+        if (NeoConfig.useSharedWorkers) {
+            console.error('Worker Error:', e)
+        } else {
+            !useMjsFiles && console.log('Worker Error:', e)
+        }
     }
 
     /**

--- a/test/playwright/e2e/core/WorkerErrorMirror.spec.mjs
+++ b/test/playwright/e2e/core/WorkerErrorMirror.spec.mjs
@@ -68,4 +68,35 @@ test.describe('SharedWorker error mirror — beyond the App worker', () => {
         expect(mirrored.some(line => line.startsWith('Data Worker: ')),
             `the mirrored line names the worker that raised it — got ${JSON.stringify(mirrored)}`).toBe(true)
     })
+
+    test('Main.log refuses an inherited console name by falling back, never by writing nothing', async ({page}) => {
+        // `typeof console[method] === 'function'` is satisfied by `constructor`, `toString`,
+        // `valueOf` and `hasOwnProperty` — inherited, callable, and writing nothing. A worker naming
+        // one would have produced no output and no error: the silent drop this whole channel exists
+        // to remove. Asserted here rather than in the unit tier, which cannot host `Main` — it
+        // registers `Neo.main.DomAccess` and collides under `unitTestMode`.
+        const seen = [];
+
+        page.on('console', message => message.text().startsWith('mainlog-') && seen.push(`${message.type()}:${message.text()}`));
+
+        await page.goto(APP);
+        await page.waitForFunction(() => globalThis.Neo?.Main?.log, null, {timeout: 30000});
+
+        await page.evaluate(() => {
+            Neo.Main.log({method: 'error',       value: 'mainlog-allowlisted'});
+            Neo.Main.log({method: 'toString',    value: 'mainlog-inherited'});
+            Neo.Main.log({method: 'constructor', value: 'mainlog-inherited2'});
+            Neo.Main.log({method: 'nope',        value: 'mainlog-unknown'})
+        });
+
+        await expect.poll(() => seen.length, {message: 'all four calls must produce a line', timeout: 5000}).toBe(4);
+
+        expect(seen, 'the allowlisted level dispatches to itself; everything else falls back to log')
+            .toEqual([
+                'error:mainlog-allowlisted',
+                'log:mainlog-inherited',
+                'log:mainlog-inherited2',
+                'log:mainlog-unknown'
+            ])
+    })
 });

--- a/test/playwright/e2e/core/WorkerErrorMirror.spec.mjs
+++ b/test/playwright/e2e/core/WorkerErrorMirror.spec.mjs
@@ -1,0 +1,71 @@
+import {test, expect} from '@playwright/test';
+
+/**
+ * Proves `Neo.worker.Base#forwardErrorToMainThread` reaches the page from a NON-App SharedWorker.
+ *
+ * The App worker gained a main-thread mirror first. Its premise — a SharedWorker's console output
+ * goes to its own inspector context, which no page can read — is a property of every SharedWorker,
+ * and `worker/Manager.mjs` makes all of them shared through one `createWorker` path. Before the
+ * hoist, `grep -ln interceptConsole src/worker/*.mjs` returned one file, so an error in Data, VDom,
+ * Canvas or Task reached neither the page nor the Neural Link.
+ *
+ * **This arm proves presence, not absence, which is what its predecessors could not do.**
+ * `Data.loadModule` catches an import failure, logs at `error` level and RETURNS A RECEIPT rather
+ * than throwing (`Data.mjs:237`), and `RemoteMethodAccess.onRemoteMethod` resolves by class name
+ * with no caller verification — so a page can provoke a real Data-worker error benignly and get an
+ * independent confirmation that the operation ran. `PAGE_CONSOLE = []` beside a successful receipt
+ * was the defect, measured on `d080a73813` before the hoist existed.
+ *
+ * That receipt is the positive control: without it, "no mirrored line appeared" would read exactly
+ * the same whether the mirror works, never ran, or the operation never happened. `Neo.Main?.log?.()`
+ * returns `undefined` rather than throwing when the manifest does not reach a worker, so the silent
+ * no-op is the failure this arm exists to exclude.
+ */
+const APP = '/examples/stateProvider/multiWindow/index.html';
+
+test.describe('SharedWorker error mirror — beyond the App worker', () => {
+    test('a Data-worker error reaches the page console, and names its worker', async ({page}) => {
+        const mirrored = [];
+
+        page.on('console', message => {
+            message.type() === 'error' && message.text().includes('Worker:') && mirrored.push(message.text())
+        });
+
+        await page.goto(APP);
+        await page.waitForFunction(() => globalThis.Neo?.worker?.Manager?.workers?.app, null, {timeout: 30000});
+
+        // Preconditions asserted, never inherited from the app's config file. `Manager.workers` is a
+        // DECLARATION map — `broadcast:199` pairs its keys with `getWorker` for exactly this reason —
+        // so liveness is asked of `hasWorker`, and only for the worker this arm actually drives.
+        const pre = await page.evaluate(() => ({
+            dataLive: Neo.worker.Manager.hasWorker('data'),
+            shared  : Neo.config.useSharedWorkers === true
+        }));
+
+        expect(pre.shared,   'the mirror only runs in SharedWorker mode').toBe(true);
+        expect(pre.dataLive, 'and this arm drives the Data worker specifically').toBe(true);
+
+        // The trigger: a real failure inside the Data worker, provoked from the page, which logs at
+        // error level and answers with a receipt instead of throwing.
+        const receipt = await page.evaluate(() => Neo.worker.Manager.promiseMessage('data', {
+            action         : 'remoteMethod',
+            remoteClassName: 'Neo.worker.Data',
+            remoteMethod   : 'loadModule',
+            data           : [{path: 'no/such/module/at/all'}]
+        }));
+
+        expect(receipt?.data?.success, 'the operation ran and failed, which is the point').toBe(false);
+        expect(receipt?.origin,        'and it ran in the Data worker').toBe('data');
+
+        await expect.poll(() => mirrored, {
+            message  : 'the Data worker error must reach the page console',
+            timeout  : 5000,
+            intervals: [50, 100, 200]
+        }).not.toEqual([]);
+
+        // AC-3: the line names its heap, so a Data error is distinguishable from an App error
+        // without reading a stack. Four workers writing one prefix is worse than no prefix.
+        expect(mirrored.some(line => line.startsWith('Data Worker: ')),
+            `the mirrored line names the worker that raised it — got ${JSON.stringify(mirrored)}`).toBe(true)
+    })
+});

--- a/test/playwright/unit/worker/ErrorMirror.spec.mjs
+++ b/test/playwright/unit/worker/ErrorMirror.spec.mjs
@@ -1,0 +1,124 @@
+import {setup} from '../../setup.mjs';
+
+setup({appConfig: {name: 'WorkerErrorMirrorTest'}});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../src/Neo.mjs';
+import * as core      from '../../../../src/core/_export.mjs';
+import WorkerBase     from '../../../../src/worker/Base.mjs';
+
+/**
+ * @summary The gates on `Neo.worker.Base#forwardErrorToMainThread`, at the level where they live.
+ *
+ * The e2e arm proves the mirror reaches a page from a real Data SharedWorker, and it is the only
+ * instrument that can. It cannot reach these four, and I found that out by mutating them: widening
+ * the allowlist to admit every environment left the e2e arm **green**, because the example app runs
+ * `development`, which the allowlist already admits. A guard whose regression is invisible to the
+ * suite is not guarded, so its cases are asserted here where the environment is a variable rather
+ * than a property of whichever app the browser arm happens to boot.
+ */
+const mirrorWith = ({environment, isSharedWorker = true, className = 'Neo.worker.Data'}) => {
+    const sent     = [],
+          original = Neo.config.environment,
+          mainStub = {log: data => {sent.push(data); return Promise.resolve(true)}},
+          host     = {
+              className,
+              isForwardingError       : false,
+              isSharedWorker,
+              ports                   : [{windowId: 'window-1'}, {windowId: 'window-2'}],
+              constructor             : {mirrorEnvironments: WorkerBase.mirrorEnvironments},
+              forwardErrorToMainThread: WorkerBase.prototype.forwardErrorToMainThread
+          },
+          originalMain = Neo.Main;
+
+    Neo.config.environment = environment;
+    Neo.Main               = mainStub;
+
+    try {
+        host.forwardErrorToMainThread('boom');
+        return {host, sent}
+    } finally {
+        Neo.config.environment = original;
+        originalMain === undefined ? delete Neo.Main : Neo.Main = originalMain
+    }
+};
+
+test.describe('Neo.worker.Base#forwardErrorToMainThread — the four gates', () => {
+    test('the allowlist admits development builds and refuses every shipped one', () => {
+        expect(WorkerBase.mirrorEnvironments, 'an allowlist, not a denylist').toEqual(['development', 'dist/development']);
+
+        for (const environment of ['development', 'dist/development']) {
+            expect(mirrorWith({environment}).sent, `${environment} mirrors`).toHaveLength(2)
+        }
+
+        // `dist/esm` is the specific value a one-entry denylist let through; it is named rather than
+        // left to the allowlist's shape, because that is the regression this allowlist exists for.
+        for (const environment of ['dist/production', 'dist/esm', 'some/future/target']) {
+            expect(mirrorWith({environment}).sent, `${environment} does not`).toEqual([])
+        }
+    });
+
+    test('a dedicated worker mirrors nothing, because the browser already forwards it', () => {
+        expect(mirrorWith({environment: 'development', isSharedWorker: false}).sent).toEqual([])
+    });
+
+    test('every connected window gets the line, and it names the worker that raised it', () => {
+        const {sent} = mirrorWith({environment: 'development'});
+
+        expect(sent.map(entry => entry.windowId)).toEqual(['window-1', 'window-2']);
+        expect(sent.every(entry => entry.method === 'error')).toBe(true);
+        expect(sent[0].value).toBe('Data Worker: boom');
+
+        // Derived from the class name: no capitalisation of the lowercase `workerId` yields `VDom`.
+        expect(mirrorWith({environment: 'development', className: 'Neo.worker.VDom'}).sent[0].value)
+            .toBe('VDom Worker: boom');
+
+        // Idempotent, for the workers that already name themselves in their own message text.
+        const host = {
+            className               : 'Neo.worker.Data', isForwardingError: false, isSharedWorker: true,
+            ports                   : [{windowId: 'w'}], constructor: {mirrorEnvironments: WorkerBase.mirrorEnvironments},
+            forwardErrorToMainThread: WorkerBase.prototype.forwardErrorToMainThread
+        };
+        const seen = [], originalMain = Neo.Main, originalEnv = Neo.config.environment;
+
+        Neo.config.environment = 'development';
+        Neo.Main               = {log: data => {seen.push(data.value); return Promise.resolve(true)}};
+
+        try {
+            host.forwardErrorToMainThread('Data Worker: Failed to load module x')
+        } finally {
+            Neo.config.environment = originalEnv;
+            originalMain === undefined ? delete Neo.Main : Neo.Main = originalMain
+        }
+
+        expect(seen[0], 'never "Data Worker: Data Worker: …"').toBe('Data Worker: Failed to load module x')
+    });
+
+    test('a re-entrant call is latched out, and the latch is released either way', () => {
+        const host = {
+            className               : 'Neo.worker.Data', isForwardingError: true, isSharedWorker: true,
+            ports                   : [{windowId: 'w'}], constructor: {mirrorEnvironments: WorkerBase.mirrorEnvironments},
+            forwardErrorToMainThread: WorkerBase.prototype.forwardErrorToMainThread
+        };
+        const seen = [], originalMain = Neo.Main, originalEnv = Neo.config.environment;
+
+        Neo.config.environment = 'development';
+        Neo.Main               = {log: data => {seen.push(data); return Promise.resolve(true)}};
+
+        try {
+            host.forwardErrorToMainThread('re-entrant');
+            expect(seen, 'a call arriving while one is in flight sends nothing').toEqual([]);
+            expect(host.isForwardingError, 'and does not clear the latch it did not set').toBe(true);
+
+            // A send that throws must still release the latch, or the mirror silences itself for
+            // the rest of the worker's life after one bad window.
+            host.isForwardingError = false;
+            Neo.Main = {log: () => {throw new Error('port is gone')}};
+            host.forwardErrorToMainThread('throwing send');
+            expect(host.isForwardingError, 'the latch is released in `finally`').toBe(false)
+        } finally {
+            Neo.config.environment = originalEnv;
+            originalMain === undefined ? delete Neo.Main : Neo.Main = originalMain
+        }
+    })
+});

--- a/test/playwright/unit/worker/ErrorMirror.spec.mjs
+++ b/test/playwright/unit/worker/ErrorMirror.spec.mjs
@@ -27,6 +27,7 @@ const mirrorWith = ({environment, isSharedWorker = true, className = 'Neo.worker
               isSharedWorker,
               ports                   : [{windowId: 'window-1'}, {windowId: 'window-2'}],
               constructor             : {mirrorEnvironments: WorkerBase.mirrorEnvironments},
+              canMirrorErrors         : WorkerBase.prototype.canMirrorErrors,
               forwardErrorToMainThread: WorkerBase.prototype.forwardErrorToMainThread
           },
           originalMain = Neo.Main;
@@ -77,6 +78,7 @@ test.describe('Neo.worker.Base#forwardErrorToMainThread — the four gates', () 
         const host = {
             className               : 'Neo.worker.Data', isForwardingError: false, isSharedWorker: true,
             ports                   : [{windowId: 'w'}], constructor: {mirrorEnvironments: WorkerBase.mirrorEnvironments},
+            canMirrorErrors         : WorkerBase.prototype.canMirrorErrors,
             forwardErrorToMainThread: WorkerBase.prototype.forwardErrorToMainThread
         };
         const seen = [], originalMain = Neo.Main, originalEnv = Neo.config.environment;
@@ -98,6 +100,7 @@ test.describe('Neo.worker.Base#forwardErrorToMainThread — the four gates', () 
         const host = {
             className               : 'Neo.worker.Data', isForwardingError: true, isSharedWorker: true,
             ports                   : [{windowId: 'w'}], constructor: {mirrorEnvironments: WorkerBase.mirrorEnvironments},
+            canMirrorErrors         : WorkerBase.prototype.canMirrorErrors,
             forwardErrorToMainThread: WorkerBase.prototype.forwardErrorToMainThread
         };
         const seen = [], originalMain = Neo.Main, originalEnv = Neo.config.environment;
@@ -120,5 +123,27 @@ test.describe('Neo.worker.Base#forwardErrorToMainThread — the four gates', () 
             Neo.config.environment = originalEnv;
             originalMain === undefined ? delete Neo.Main : Neo.Main = originalMain
         }
+    })
+});
+
+/**
+ * @summary The two gates that changed after review, both of which failed toward silence.
+ */
+test.describe('Neo.worker.Base — the gates that must not fail silently', () => {
+    test('canMirrorErrors decides per configuration, and the latch stays per call', () => {
+        const host = (isSharedWorker, environment) => {
+            const original = Neo.config.environment;
+            Neo.config.environment = environment;
+            try {
+                return WorkerBase.prototype.canMirrorErrors.call({
+                    isSharedWorker, constructor: {mirrorEnvironments: WorkerBase.mirrorEnvironments}
+                })
+            } finally { Neo.config.environment = original }
+        };
+
+        expect(host(true,  'development'),      'shared + allowlisted mirrors').toBe(true);
+        expect(host(false, 'development'),      'dedicated never mirrors').toBe(false);
+        expect(host(true,  'dist/production'),  'shipped never mirrors').toBe(false);
+        expect(host(true,  'dist/esm'),         'including the one a denylist let through').toBe(false)
     })
 });


### PR DESCRIPTION
Resolves #18566

🌿 An error could be raised in four of Neo's five workers and be witnessed by nothing at all; after this, there is no worker whose failures only its own inspector can see.

The App worker got a main-thread error mirror first. Its premise — *a SharedWorker's console output goes to its own inspector context, which no page can read* — is a property of every SharedWorker, and `worker/Manager.mjs:250` makes all five shared through one `createWorker` path. `grep -ln interceptConsole src/worker/*.mjs` returned **one file**, so an error in Data, VDom, Canvas or Task reached neither the page nor the Neural Link. Uninstrumented, not merely un-mirrored — a wider gap than the one it followed, and worse, because the Neural Link at least covered App.

Evidence: L3 (a rendered browser arm drives a real Data SharedWorker and observes the page console; the gates it cannot vary are asserted at the model level) → L2 required, L3 supplied. Residual: Canvas and Task are not live in the chosen example, so AC-1 is proven on Data — § Deltas.

`agent-preflight: not hosted here` (no such npm script; exit 1); the baseline `PR body`, `Substrate size`, `Source comment archaeology` and `PR base` jobs carry its checks. §3.1 class: `capability → feat`.

## AC Evidence

| AC | Disposition |
|---|---|
| AC-1 — an error in a NON-App SharedWorker reaches the page console | **CI-covered, red-first.** `WorkerErrorMirror.spec.mjs` drives a real failure inside the **Data** worker and observes the page console. Run against the tree *before* the hoist it failed at exactly *"the Data worker error must reach the page console"*; after, it passes. Not a green I inherited — a transition I watched. |
| AC-2 — the silent no-op is closed, and proven closed; positive control required | **CI-covered + control.** The receipt is the control: `Data.loadModule` answers `{success: false, error: 'Unsupported module root: …'}` with `origin: 'data'`, so the arm knows the operation *ran*. Without it, "no mirrored line" reads identically to "nothing happened". Mutation: reverting the manifest while keeping the hoisted method — Ada's exact silent-no-op scenario — reddens the arm. |
| AC-3 — the mirrored line names its worker | **CI-covered + control.** Prefix derived from the class name: `Neo.worker.VDom` → `VDom`, which no capitalisation of the lowercase `workerId` produces. Mutation to a shared `'App Worker: '` prefix reddens it, and the failure output is the argument for the AC: `"App Worker: Data Worker: Failed to load module …"`. |
| AC-4 — dedicated mode is still not mirrored, for all five | **CI-covered + control** — at the unit level, because the browser arm cannot vary it. `isSharedWorker: false` mirrors nothing; removing the guard reddens that arm. |
| AC-5 — the environment allowlist survives the hoist | **CI-covered + control, and the browser arm does NOT cover it.** See § Test Evidence — I found that by mutating it. `development` and `dist/development` mirror; `dist/production`, `dist/esm` and an unknown future value do not, each named explicitly. |
| AC-6 — `Manager.onWorkerError`'s deferral corrected or scoped | **Met, and corrected rather than scoped.** `!useMjsFiles` defers to the browser: true for a dedicated module worker, false for a SharedWorker — and it is the **only** signal for one that fails to load, since a worker that never ran cannot mirror its own failure. Now `error`-level under `useSharedWorkers`, with the deferral kept where it holds. Archaeology by @neo-opus-ada, recorded in the commit rather than the source. |
| AC-7 — Contract Ledger row before implementation | **Met.** Three rows posted on the ticket before the first line of code, with every surface anchored at source. |
| AC-8 — an app running only App+Data is unaffected | **Met by the fan-out, and measured.** `core/Base.mjs:988` guards with `origin.hasWorker(worker)`, a live lookup. Measured on the example: `canvas` and `task` are **declared and not live**, and the widened manifest produces no registration traffic or console noise for them — the arm boots clean and asserts nothing mirrored except the line it provoked. |

## Deltas from ticket

- **A page-only trigger for a worker error exists, and the ticket said it did not.** #18554 was deferred on *"no page-only trigger for a worker error exists"* — true for **App**, false for the others. `Data.loadModule` catches an import failure, logs at `error` level and **returns a receipt rather than throwing**; `RemoteMethodAccess.onRemoteMethod` resolves by class name with no caller verification. So a page can provoke a real, benign non-App worker error and get independent confirmation it ran. Measured on merged dev *before* building anything: `RECEIPT={success:false,…}` beside `PAGE_CONSOLE=[]` — the defect demonstrated live. @neo-opus-ada verified it from source and has corrected #18554, which is now unblocked.
- **I claimed the example runs all five workers. It runs three, and Ada's refusal of the credit is what made me check.** `Object.keys(Manager.workers)` is a **declaration map**; `hasWorker` is liveness. Measured: `app ✓ data ✓ vdom ✓ canvas ✗ task ✗`. `Manager.broadcast:199` already pairs those keys with `getWorker` for exactly this reason. I read a config shape and claimed a runtime property — so the arm now asserts **only what it drives**: `useSharedWorkers === true` and `hasWorker('data') === true`. A precondition holding by accident is the class of thing that quietly stops holding.
- **`Main.log` now validates `data.method` — a scope addition, marked.** It was reachable from one caller passing a literal `'error'`; it is now reachable from five. An unknown name is `console[undefined]`, a TypeError raised **on the main thread** by the channel that exists to report faults without becoming one. The worker side of this path is carefully guarded and the other side was not. Raised in the ledger with both dispositions; @neo-opus-ada agreed and told me to take it.
- **The prefix is idempotent, because four call sites already name themselves.** `Data.mjs` and `Canvas.mjs` write `'Data Worker: …'` into their own message text. Unconditional prefixing renders those as `"Data Worker: Data Worker: …"`; rewriting those four sites is not this change.
- **Out of scope, unchanged:** `unhandledrejection`, still unhooked anywhere; the gate that fails a spec on a mirrored error (#18554's, now unblocked); whether these workers raise errors often enough to matter, which is what visibility is for.

## Test Evidence

Outside-CI evidence only — seven controls, and two findings the controls produced.

| Mutation | Arm that reddens |
|---|---|
| Manifest reverted, hoisted method kept (**the silent no-op**) | e2e — *the Data worker error must reach the page console* |
| Prefix not derived (all workers share one) | e2e — *the mirrored line names the worker that raised it* |
| Allowlist widened to admit everything | unit — *the allowlist admits development builds and refuses every shipped one* |
| Dedicated-mode guard removed | unit — *a dedicated worker mirrors nothing…* |
| Prefixing made non-idempotent | unit — *every connected window gets the line…* |
| Latch release deleted | unit — *a re-entrant call is latched out…* |
| Re-entrancy guard removed | unit — *a re-entrant call is latched out…* |

- **The browser arm does not cover AC-5, and I only know that because I mutated it.** Widening the allowlist to admit every environment left the e2e arm **green** — the example runs `development`, which the allowlist already admits. A guard whose regression is invisible to the suite is not guarded, so AC-4 and AC-5 moved to unit arms where the environment is a variable rather than a property of whichever app the browser boots.
- **One of my controls was not a mutation, and saying so is the finding.** Moving the latch release out of `finally` into a statement after the `try`/`catch` left every arm green — correctly, because the catch-all `catch` makes the two forms behaviourally identical. I replaced it with deleting the release outright, which is a real difference and reds. A control that cannot fail proves nothing about the code and something about the control.
- **The hoist corrupted `App.mjs` on my first attempt and `node --check` passed anyway.** My end anchor occurred *earlier* in the file than my start anchor, so the slice was empty and 260 lines were duplicated — and duplicate method definitions are valid JavaScript. Caught by a line-count comparison against `dev`, not by the syntax check. The redo asserts anchor uniqueness *and ordering*, and gates on per-marker counts across both files.
- Full unit tier at head: **3753 passed / 0 failed / 2 skipped**. All three e2e arms pass together.
- **Two post-review fixes, both @neo-opus-ada's non-blocking findings, taken anyway.** `Main.log`'s `typeof console[method] === 'function'` admits `constructor`, `toString`, `valueOf` and `hasOwnProperty` — inherited, callable, writing nothing — so the validation *I* added converted a loud TypeError into a **silent drop**, which is the failure this channel exists to remove. Now an allowlist. Separately, `serializeConsoleArgs` ran upstream of the mirror's own gates, so five workers built a string that is discarded in dedicated mode and every shipped environment; `canMirrorErrors()` lets the interceptor decline first. Controls: reverting the allowlist reddens the e2e arm; defeating `canMirrorErrors` reddens five unit arms. Neither tier catches the other's — stated because that asymmetry is the reason both exist.
- **Extracting `canMirrorErrors` broke three of my own hand-built doubles**, which lacked the new collaborator — the third instance tonight of a method extraction outrunning its test doubles. Caught by the suite, not by review.

## Post-Merge Validation

- [ ] **Canvas and Task are not exercised.** They are declared but not live in the chosen example (`useCanvasWorker` / `useTaskWorker` default `false`), so `Canvas.mjs`'s trigger site is unreachable there. The mechanism is worker-agnostic and AC-8 shows an absent worker is inert, but a config enabling them is what would prove those two.
- [ ] A SharedWorker that fails to **load** now reports through `Manager.onWorkerError` at `error` level. That path cannot be provoked from a page — it needs a genuinely broken worker file — so the AC-6 change is reasoned from source and unexercised by any arm.

## Commits

- `99cfca4c1d` — manifest, hoist, derived prefix, validated dispatch, and the corrected deferral.
- `550cd49c75` — post-review: the dispatch becomes an allowlist, and the mirror declines before serializing.

Authored by Vega (Opus 5, Claude Code). Session 206b8400-7fe8-472e-8018-446e550b784b.
