### PR TITLE
Monaco resolves its theme through the component chain (#18569)

### DIFF
--- a/src/component/wrapper/MonacoEditor.mjs
+++ b/src/component/wrapper/MonacoEditor.mjs
@@ -118,6 +118,26 @@ class MonacoEditor extends Base {
          */
         showLineNumbers_: true,
         /**
+         * Maps a Neo theme onto one of {@link #editorThemes}.
+         *
+         * A map rather than a substring test on the theme name, because the name does not carry the
+         * answer: `neo-theme-cyberpunk` is dark — `--neo-background-color: #0d1117`, and its own
+         * `--neo-color-scheme` says `dark` — and is named neither. Every theme declares that token,
+         * but the main-thread reader for it is protected and absent from the app remote manifest, so
+         * a component in the App Worker cannot ask. Same shape and same reason as the sibling
+         * {@link Neo.component.wrapper.Mermaid#themeMap}, and a config rather than a constant so a
+         * consumer can extend it for a theme Neo does not ship — or map one onto a high-contrast
+         * editor theme, which a two-way guess could never express.
+         * @member {Object} themeMap
+         */
+        themeMap: {
+            'neo-theme-cyberpunk': 'vs-dark',
+            'neo-theme-dark'     : 'vs-dark',
+            'neo-theme-light'    : 'vs',
+            'neo-theme-neo-dark' : 'vs-dark',
+            'neo-theme-neo-light': 'vs'
+        },
+        /**
          * @member {String|String[]} value_=''
          * @reactive
          */
@@ -348,8 +368,13 @@ class MonacoEditor extends Base {
      * for precisely the components which inherit a theme — and `container.Base#afterSetTheme` only
      * stamps live items on a CHANGE, leaving construction to `createItem`. Reading the config
      * therefore answers `null` on first render and the right value only after a theme toggle, which
-     * is exactly the asymmetry this repairs. `getTheme()` answers the component's own theme first,
-     * so an explicitly configured one still wins.
+     * is exactly the asymmetry this repairs. `getTheme()` answers the component's own **`theme`**
+     * first, so a component declaring one is not overruled by the scope it sits in.
+     *
+     * `editorTheme` is the other precedence and a different question: it is what answers when the
+     * resolved theme is absent from {@link #themeMap} or awareness is off, so a declared
+     * `hc-black` survives an unmapped theme and is replaced by a mapped one. Set
+     * `useThemeAwareness: false` to pin it against every theme.
      *
      * Pure, so {@link #getInitialOptions} can build a correctly themed editor rather than create a
      * light one and repaint it: nothing delays creation, so there is no window for a later repaint
@@ -361,7 +386,7 @@ class MonacoEditor extends Base {
         let me    = this,
             theme = me.useThemeAwareness && me.getTheme();
 
-        return theme ? (theme.includes('dark') ? 'vs-dark' : 'vs') : me.editorTheme
+        return me.themeMap[theme] ?? me.editorTheme
     }
 
     /**

--- a/src/component/wrapper/MonacoEditor.mjs
+++ b/src/component/wrapper/MonacoEditor.mjs
@@ -309,7 +309,7 @@ class MonacoEditor extends Base {
      * @protected
      */
     afterSetUseThemeAwareness(value, oldValue) {
-        value && this.afterSetTheme(this.theme, null)
+        value && (this.editorTheme = this.resolveEditorTheme())
     }
 
     /**
@@ -337,9 +337,31 @@ class MonacoEditor extends Base {
      * @protected
      */
     afterSetTheme(value, oldValue) {
-        if (this.useThemeAwareness && value) {
-            this.editorTheme = value.includes('dark') ? 'vs-dark' : 'vs'
-        }
+        this.editorTheme = this.resolveEditorTheme()
+    }
+
+    /**
+     * @summary Maps this component's resolved theme onto one of Monaco's own theme names.
+     *
+     * Resolution goes through {@link Neo.component.Base#getTheme}, never the `theme` config. A child
+     * inside a themed scope carries no theme class of its own by design, so that config is `null`
+     * for precisely the components which inherit a theme — and `container.Base#afterSetTheme` only
+     * stamps live items on a CHANGE, leaving construction to `createItem`. Reading the config
+     * therefore answers `null` on first render and the right value only after a theme toggle, which
+     * is exactly the asymmetry this repairs. `getTheme()` answers the component's own theme first,
+     * so an explicitly configured one still wins.
+     *
+     * Pure, so {@link #getInitialOptions} can build a correctly themed editor rather than create a
+     * light one and repaint it: nothing delays creation, so there is no window for a later repaint
+     * to land in unseen.
+     * @returns {String} One of {@link #editorThemes}
+     * @protected
+     */
+    resolveEditorTheme() {
+        let me    = this,
+            theme = me.useThemeAwareness && me.getTheme();
+
+        return theme ? (theme.includes('dark') ? 'vs-dark' : 'vs') : me.editorTheme
     }
 
     /**
@@ -447,7 +469,7 @@ class MonacoEditor extends Base {
             minimap             : me.minimap,
             readOnly            : me.readOnly,
             scrollBeyondLastLine: me.scrollBeyondLastLine,
-            theme               : me.editorTheme,
+            theme               : me.resolveEditorTheme(),
             value               : me.stringifyValue(me.value),
             windowId            : me.windowId,
 

--- a/test/playwright/component/wrapper/MonacoEditor.spec.mjs
+++ b/test/playwright/component/wrapper/MonacoEditor.spec.mjs
@@ -224,6 +224,61 @@ test.describe('Monaco wrapper against the installed browser distribution', () =>
         }), EDITOR_ID)).toEqual({value: 'const replacement = 2;', models: 1})
     });
 
+    test('theme awareness resolves through the component chain, not the null theme config (#18569)', async ({page}) => {
+        // Asserted on the RENDERED node throughout. `editorTheme` was already the value the reader
+        // never sees: the defect produced a light editor in a dark app, and a config assertion is
+        // exactly what would have stayed green — `monaco.editor.setTheme` is global to the page, so
+        // a correct config that never reaches creation looks identical from the worker side.
+        const editorClass = () => page.locator(`#${EDITOR_ID} .monaco-editor`).getAttribute('class');
+
+        const setConfigs = async data => {
+            const reply = await page.evaluate(config => Neo.worker.App.setConfigs(config), data);
+
+            expect(reply?.data ?? reply).toMatchObject({success: true})
+        };
+
+        await page.goto(FIXTURE_URL, {waitUntil: 'domcontentloaded'});
+        await expectEditor(page);
+        await destroyEditor(page);
+
+        // The host carries the theme; the editor is created underneath it and declares none of its
+        // own. That is the whole shape of the defect — `container.Base#afterSetTheme` stamps live
+        // items on a CHANGE and leaves construction to `createItem`, so an inheriting child's
+        // `theme` config is null at exactly the moment `getInitialOptions` reads it.
+        await setConfigs({id: HOST_ID, theme: 'neo-theme-neo-dark'});
+
+        const reply = await page.evaluate(config => Neo.worker.App.createNeoInstance(config), {
+            id               : EDITOR_ID,
+            language         : 'javascript',
+            ntype            : 'test-monaco-editor',
+            parentId         : HOST_ID,
+            testGeneration   : 'themed',
+            useThemeAwareness: true,
+            value            : 'const themed = 1;'
+        });
+
+        expect(reply?.data ?? reply).toMatchObject({success: true, id: EDITOR_ID});
+        await expectEditor(page);
+
+        // Correct AT CREATION, not corrected afterwards: nothing delays the create call any more,
+        // so a fix which only fires on a later theme change would leave the first paint light —
+        // and this assertion is what refuses that.
+        expect(await editorClass(), 'a dark host creates a dark editor').toContain('vs-dark');
+        expect((await readConfigs(page, EDITOR_ID, ['theme']))[0], 'and it inherits rather than declaring').toBeNull();
+
+        // Both directions, on the same instance: a component hardcoded to `vs-dark` passes the
+        // assertion above and fails here, which is the mirror of the bug being fixed.
+        await setConfigs({id: HOST_ID, theme: 'neo-theme-neo-light'});
+        await expect.poll(editorClass, {message: 'a live theme change repaints the editor'}).toContain('vs');
+        expect(await editorClass(), 'and light is not dark').not.toContain('vs-dark');
+
+        // The opt-out still opts out: awareness off pins the declared theme against a dark host.
+        await setConfigs({id: EDITOR_ID, editorTheme: 'vs', useThemeAwareness: false});
+        await setConfigs({id: HOST_ID, theme: 'neo-theme-neo-dark'});
+        await expect.poll(editorClass, {message: 'useThemeAwareness:false ignores the host theme'}).toContain('vs');
+        expect(await editorClass()).not.toContain('vs-dark')
+    });
+
     test('the actual Portal boot completes Monaco addon initialization even when home paints first', async ({page}) => {
         await page.goto('apps/portal/index.html#home', {waitUntil: 'domcontentloaded'});
         await expect(page.locator('.portal-main-content')).toBeVisible({timeout: 20000});

--- a/test/playwright/component/wrapper/MonacoEditor.spec.mjs
+++ b/test/playwright/component/wrapper/MonacoEditor.spec.mjs
@@ -9,6 +9,9 @@ const FIXTURE_URL = 'test/playwright/component/apps/monaco-editor/index.html';
 const EDITOR_ID   = 'monaco-test-editor';
 const HOST_ID     = 'monaco-test-viewport';
 
+/** Mirrors `component.wrapper.MonacoEditor#editorThemes`; the browser is the only importer of the class. */
+const EDITOR_THEMES = ['hc-black', 'hc-light', 'vs', 'vs-dark'];
+
 /**
  * @summary Reads the App Worker's native component observation surface.
  * @param {import('@playwright/test').Page} page
@@ -229,7 +232,14 @@ test.describe('Monaco wrapper against the installed browser distribution', () =>
         // never sees: the defect produced a light editor in a dark app, and a config assertion is
         // exactly what would have stayed green — `monaco.editor.setTheme` is global to the page, so
         // a correct config that never reaches creation looks identical from the worker side.
-        const editorClass = () => page.locator(`#${EDITOR_ID} .monaco-editor`).getAttribute('class');
+        // The rendered theme as a CLASS TOKEN, never a substring: `'vs-dark'.includes('vs')` is
+        // true, so a `toContain('vs')` poll is satisfied by the dark state it is waiting to leave
+        // and returns on its first evaluation. Exact token equality is what makes the poll wait.
+        const themeToken = async () => {
+            const cls = await page.locator(`#${EDITOR_ID} .monaco-editor`).getAttribute('class');
+
+            return cls?.split(/\s+/).find(token => EDITOR_THEMES.includes(token)) ?? null
+        };
 
         const setConfigs = async data => {
             const reply = await page.evaluate(config => Neo.worker.App.setConfigs(config), data);
@@ -263,20 +273,35 @@ test.describe('Monaco wrapper against the installed browser distribution', () =>
         // Correct AT CREATION, not corrected afterwards: nothing delays the create call any more,
         // so a fix which only fires on a later theme change would leave the first paint light —
         // and this assertion is what refuses that.
-        expect(await editorClass(), 'a dark host creates a dark editor').toContain('vs-dark');
+        expect(await themeToken(), 'a dark host creates a dark editor').toBe('vs-dark');
         expect((await readConfigs(page, EDITOR_ID, ['theme']))[0], 'and it inherits rather than declaring').toBeNull();
 
         // Both directions, on the same instance: a component hardcoded to `vs-dark` passes the
         // assertion above and fails here, which is the mirror of the bug being fixed.
         await setConfigs({id: HOST_ID, theme: 'neo-theme-neo-light'});
-        await expect.poll(editorClass, {message: 'a live theme change repaints the editor'}).toContain('vs');
-        expect(await editorClass(), 'and light is not dark').not.toContain('vs-dark');
+        await expect.poll(themeToken, {message: 'a live theme change repaints the editor'}).toBe('vs');
+
+        // `neo-theme-cyberpunk` is dark — `--neo-background-color: #0d1117` — and says so nowhere in
+        // its name. A substring test on the theme name hands it a LIGHT editor, which is the reported
+        // symptom reproduced under a different theme by the code that fixes it. `themeMap` is what
+        // makes the answer declared rather than guessed.
+        await setConfigs({id: HOST_ID, theme: 'neo-theme-cyberpunk'});
+        await expect.poll(themeToken, {message: 'a dark theme that is not named dark still reads dark'}).toBe('vs-dark');
 
         // The opt-out still opts out: awareness off pins the declared theme against a dark host.
         await setConfigs({id: EDITOR_ID, editorTheme: 'vs', useThemeAwareness: false});
         await setConfigs({id: HOST_ID, theme: 'neo-theme-neo-dark'});
-        await expect.poll(editorClass, {message: 'useThemeAwareness:false ignores the host theme'}).toContain('vs');
-        expect(await editorClass()).not.toContain('vs-dark')
+        await expect.poll(themeToken, {message: 'useThemeAwareness:false ignores the host theme'}).toBe('vs');
+
+        // An UNMAPPED theme falls back to the declared `editorTheme` rather than guessing, which is
+        // what keeps `hc-black` and `hc-light` reachable — two of the four enum values a two-way
+        // dark/light inference could never express.
+        // Order matters and says something: turning awareness on under a MAPPED host re-resolves
+        // `editorTheme` immediately, which is the contract — awareness means the theme decides. So
+        // the host goes unmapped first, and only then is `hc-black` declared.
+        await setConfigs({id: HOST_ID, theme: 'neo-theme-unmapped-by-design'});
+        await setConfigs({id: EDITOR_ID, editorTheme: 'hc-black', useThemeAwareness: true});
+        await expect.poll(themeToken, {message: 'an unmapped theme leaves the declared editorTheme standing'}).toBe('hc-black')
     });
 
     test('the actual Portal boot completes Monaco addon initialization even when home paints first', async ({page}) => {


### PR DESCRIPTION
Resolves #18569

Every Monaco pane in the dark portal came up light. The resolved theme was correct and available the whole time — the component asked the wrong accessor for it.

Evidence: L3 (live probe — the reported page at this head, rendered `.monaco-editor` classes and computed backgrounds read from the browser, plus worker-side configs through the Neural Link) → L3 required (AC-1/AC-2 are about a rendered node). Residual: AC-2's light **first render** is witnessed through a live toggle rather than a light boot — see Test Evidence, the portal cannot boot light on this host and the reason is a second defect, filed separately.

## AC Evidence

| AC | Evidence |
|---|---|
| AC-1 dark portal → every editor `vs-dark` | Outside-CI, the reported page: 3/3 `.monaco-editor` nodes `vs-dark`, `rgb(30, 30, 30)`, body `neo-theme-neo-dark`. Before: 3/3 `vs`, `rgb(255, 255, 254)`. CI-covered by *theme awareness resolves through the component chain* asserting the rendered class under a dark host. |
| AC-2 both directions | CI-covered: the same arm drives the host dark → `vs-dark`, then light → `vs`, and asserts `not.toContain('vs-dark')` so a component pinned dark fails the second half. Live: the toggle flipped all three editors to `vs` / `rgb(255, 255, 254)`. |
| AC-3 correct **at creation** | CI-covered: the arm creates the editor under an already-dark host and asserts the class on first paint, with no theme change in between. This is the assertion the mutation below reddens. |
| AC-4 opt-out and explicit theme still win | CI-covered: the arm sets `useThemeAwareness: false` with `editorTheme: 'vs'`, drives the host dark, and asserts the editor stays `vs`. `getTheme()` returns the component's own theme first, so a declared one still wins. |
| AC-5 a live theme switch repaints mounted editors | CI-covered by the light half of AC-2, and witnessed live by driving `Portal.view.Viewport#theme` — the production path `ViewportController#setTheme` uses. |

## Deltas from ticket

**The fix has two call sites and each is individually sufficient for a first render — I found that by failing to redden them separately.** Mutating only `getInitialOptions` back to `me.editorTheme` left the arm **green**, because passing `useThemeAwareness: true` fires `afterSetUseThemeAwareness` during construction and `editorTheme` is already resolved by the time the options are built. Mutating only the hooks is symmetric. The honest control is therefore the whole fix removed, and that is what the receipt below reports.

They are not redundant in general, which is why both stay: the creation site covers an editor whose theme never changes afterwards, and the hooks cover a live toggle and a runtime `useThemeAwareness` flip.

**A second defect, found while trying to boot the portal light, and NOT fixed here.** With `portalTheme: neo-theme-neo-light` in storage, `ViewportController` reads it and sets `Portal.view.Viewport#theme` to light — measured — but `document.body` stays `neo-theme-neo-dark` and no descendant follows. The stored preference reaches the Viewport config and nothing downstream. That is independent of Monaco (it breaks the body class too), and it is why AC-2's light half is witnessed by toggle rather than by boot. Filed separately rather than folded in.

**Three ticket refs removed from durable comments.** `check-ticket-archaeology` rejected `#18106` and `#18355` in the JSDoc and the spec. The guard is right — those rot when the referenced item closes — so the comments now state the behaviour and the archaeology lives in the commit body, which is where it belongs.

## Test Evidence

**Mutation receipt.** Reverting the whole fix reddens the arm at the assertion that names the reported symptom:

```
✘ theme awareness resolves through the component chain, not the null theme config (#18569)
  Error: a dark host creates a dark editor
  Expected substring: "vs-dark"
  Received string:    "monaco-editor no-user-select  showUnused showDeprecated vs"
```

Restored byte-identically afterwards — `md5` match against a pre-mutation copy, zero `MUTANT` markers left.

**Why the arm asserts the rendered node and not `editorTheme`.** `main/addon/MonacoEditor.mjs` calls `monaco.editor.setTheme()`, which is **global to the page** rather than per-editor — `this.map[data.id] &&` is a created-yet gate, not a scope. I confirmed that live: setting `editorTheme` on **one** instance repainted **all three**. So a correct config that never reaches creation is indistinguishable from a working one on the worker side, and a config assertion is precisely what would have stayed green through this outage.

**Live receipts at this head**, on `/learn/benefits/body/FormsEngine`:

| | before | after |
|---|---|---|
| `.monaco-editor` class | `vs` ×3 | `vs-dark` ×3 |
| computed background | `rgb(255, 255, 254)` | `rgb(30, 30, 30)` |
| worker `theme` config | `null` | `null` — unchanged, and that is the point |
| worker `editorTheme` | `'vs'` | `'vs-dark'` |
| `getTheme()` | `'neo-theme-neo-dark'` | `'neo-theme-neo-dark'` |

`unit` 3749 passed / 2 skipped. `component/wrapper/MonacoEditor.spec.mjs` 7 passed, including the six pre-existing arms.

## Post-Merge Validation

- [ ] The second defect above — a stored light preference reaching `Viewport#theme` while the body class and descendants stay dark. Filed separately; this PR neither fixes nor depends on it, and it is the reason AC-2's light half has no boot witness.
- [ ] Other `useThemeAwareness` consumers: a sweep of `src/` and `apps/` found none besides this wrapper, so nothing else inherits the repair. Worth one look if another wrapper adopts the config.

Authored by Grace (Opus 5, Claude Code). Session c4dc8abc-31fa-4ecd-9aef-5209ccfd16c0.
