### PR TITLE
test(dock): the maximize fixture chains its refresh, so two passes cannot project two shells (#18561)

### DIFF
--- a/test/playwright/component/apps/dock-maximize/app.mjs
+++ b/test/playwright/component/apps/dock-maximize/app.mjs
@@ -474,9 +474,13 @@ class MaximizeFixtureWorkspace extends DockWorkspace {
     settleJson = null
 
     /**
-     * How many {@link #refreshCount}-triggered refreshes have started and not yet settled.
+     * How many {@link #refreshCount}-triggered refreshes are QUEUED or running and not yet settled.
      * Distinguishes "no receipt was published" from "the refresh is stuck" — the two states a
      * hanging settle probe cannot tell apart.
+     *
+     * Queued counts, not only started: the trigger chains onto the settled tail, so a refresh can
+     * be published and waiting. Reporting 0 for that window would tell the probe no receipt exists
+     * when one does, which is the confusion this counter was added to end.
      * @member {Number} refreshInFlight=0
      */
     refreshInFlight = 0
@@ -764,7 +768,14 @@ class MaximizeFixtureWorkspace extends DockWorkspace {
         // makes the probe observe the refresh it is meant to observe.
         this.refreshInFlight++;
 
-        this.refreshPromise = this.refreshDockWorkspace()
+        // Chained onto the settled tail, exactly as `projectDockZoneDocument` does. Assigning
+        // `refreshPromise = this.refreshDockWorkspace()` called it IMMEDIATELY and discarded any
+        // in-flight tail, so this trigger could start a second pass while a commit-driven one was
+        // still pending — and each pass projected its own shell. The duplicate header-only shell
+        // that produced is what the arms were failing on; production cannot reach it, because every
+        // production projection goes through that chain. The fixture was manufacturing concurrency.
+        this.refreshPromise = (this.refreshPromise?.catch(() => {}) || Promise.resolve())
+            .then(() => this.refreshDockWorkspace())
             .finally(() => {this.refreshInFlight--})
     }
 

--- a/test/playwright/unit/dashboard/DockWorkspace.spec.mjs
+++ b/test/playwright/unit/dashboard/DockWorkspace.spec.mjs
@@ -828,7 +828,59 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
         })
     });
 
-    test('the holder contract: a config-assigned document is readable before any operation', () => {
+    test('projectDockZoneDocument SERIALIZES: a second projection cannot enter while the first is in flight', async () => {
+    // The invariant every direct caller of `refreshDockWorkspace` leans on, and nothing asserted it.
+    //
+    // `projectDockZoneDocument` chains each pass onto the settled tail of `refreshPromise`, so two
+    // projections issued in one tick run one after the other. A caller that instead assigns
+    // `refreshPromise = this.refreshDockWorkspace()` starts a SECOND pass while the first is still
+    // in flight, and both project a shell — which surfaces as a duplicate header-only shell: tab
+    // headers and close buttons, no panes. A component fixture did exactly that; fixing it removed
+    // the only thing that had ever noticed, so the invariant it now relies on is pinned here.
+    //
+    // ⚠️ The first pass is HELD open on purpose. The obvious version of this arm — fire two real
+    // projections and count overlap — passes with the chaining deleted, because a real refresh
+    // settles inside one macrotask and the second never had the chance to overlap. It witnessed
+    // nothing. Holding the first pass is what makes an unserialized second observable.
+    const workspace = Neo.create(PlainWorkspace, {dockModel: createDocument()});
+
+    let releaseFirst, entered = [];
+
+    const held = new Promise(resolve => {releaseFirst = resolve});
+
+    workspace.refreshDockWorkspace = async function(...args) {
+        const index = entered.length;
+
+        entered.push(index);
+
+        index === 0 && await held;
+
+        return undefined
+    };
+
+    try {
+        const first  = workspace.projectDockZoneDocument(createDocument()),
+              second = workspace.projectDockZoneDocument(createDocument());
+
+        // Cross two macrotask boundaries with the SAME primitive the chain deferred behind, rather
+        // than a wall-clock constant: the unserialized path waits on one `timeout(0)` before it
+        // enters, so two are enough for it to have entered, and a serialized one still has not.
+        await workspace.timeout(0);
+        await workspace.timeout(0);
+
+        expect(entered.length, 'the second projection must NOT have entered while the first is held').toBe(1);
+
+        releaseFirst();
+        await Promise.all([first, second]);
+
+        expect(entered.length, 'and it runs once the first settles — serialized, not dropped').toBe(2)
+    } finally {
+        releaseFirst();
+        workspace.destroy()
+    }
+});
+
+test('the holder contract: a config-assigned document is readable before any operation', () => {
         const document = createDocument();
 
         workspace = Neo.create(PlainWorkspace, {dockModel: document});


### PR DESCRIPTION
## Problem

`test/playwright/component/apps/dock-maximize/app.mjs` — `afterSetRefreshCount` assigned
`refreshPromise = this.refreshDockWorkspace()`, calling it **immediately** and discarding any
in-flight tail. `projectDockZoneDocument` instead chains every projection onto the settled tail and
defers behind a `timeout(0)`, so the fixture's direct call reliably started a **second** pass while
a commit-driven one was still pending, and each pass projected its own shell.

The visible result was a **duplicate header-only dock shell** — tab headers and close buttons, no
panes, no `lock`, no `reload`. The spec's helpers are page-scoped, so `toHaveCount(1)` counted one
`fa-times` from each shell and received `2`, stable across all 14 polls of the 5 s budget. That
stability is why this was never a settle race: nothing was still arriving, the terminal state was
wrong.

The aria snapshot at failure shows both shells as siblings under a workspace that declares exactly
one (`dockShellIndex`, chrome inside its own `items`), which is what rules out the competing reading
that the harness legitimately mounts two workspaces.

## Change

Three lines in the fixture: chain the trigger onto the settled tail, exactly as production does.

Production cannot reach the state the fixture manufactured — `refreshDockWorkspace` has two call
sites in `src/`, both inside that chain or its self-retry. **So fixing the fixture removes the only
thing that had ever noticed**, and the invariant it now relies on is armed rather than assumed:
`unit/dashboard/DockWorkspace.spec.mjs` gains *"projectDockZoneDocument SERIALIZES: a second
projection cannot enter while the first is in flight"*.

Evidence: L2 (component + unit tiers, both local and CI-reachable) → L2 required. No residual.

## AC Evidence

| AC | Disposition |
|---|---|
| **AC-1** — the arm is identified by title, not line | **Met.** Every reference in the ticket, the commit and this body names the `test(...)` title. The sibling arm has been `:384` → `:422` → `:504` across three weeks of receipts, which is the reason for the rule. Evidence: the commit body and the ticket comment both cite titles only. |
| **AC-2** — a red-first instrument exists before any fix | **Met, and it produced the diagnosis.** The received count was captured first (`2`, not `0`), which killed the settle-race reading. A temporary probe then counted overlapping `refreshDockWorkspace` passes and **falsified my own next hypothesis**: overlap was present on PASSING runs too (`maxRefreshDepth=2, nodes=3`), so overlap is necessary-not-sufficient and "the arm went green" would not have witnessed serialization. Evidence: ticket comment with the aria snapshot and the probe table. |
| **AC-3** — the rate is re-measured on the same instrument, N ≥ 24, on `dev` and on the branch, matched | **Met.** Same command, same worker count, same machine, `--repeat-each=24` over both arms: **dev 17 failed / 31 passed of 48**; **branch 0 failed / 48 passed**. At even a 20% base rate a clean 48 is `≈2e-5`. Earlier `N=8` per-arm split, for the record: `6/8` and `3/8`. |
| **AC-4** — the fix is not a sleep, and not a retry | **Met.** The fix is a promise chain; no timeout, no retry, no widened budget. The new arm waits on `workspace.timeout(0)` — the same primitive the production chain defers behind — rather than a wall-clock constant, so it carries no magic number either. |
| **AC-5** — #18487's arm is untouched and still passes | **Met, and deliberately NOT silently.** Its source is untouched; it passes 24/24. The shared fixture fix does also clear it, which is exactly what this AC warns about absorbing quietly — so it is disclosed here, in the commit, and in the retraction on #18573 with the measurement that showed it. Nothing is flattened: the arm keeps its own name, its own assertion and its own rate line above. |

## Test Evidence

The new arm is **deliberately not the obvious one, and the obvious one is the finding.** Firing two
real projections and counting overlap **passes with the tail chaining deleted** — a real refresh
settles inside one macrotask, so the second never gets the chance to overlap and the arm witnesses
nothing. I shipped that version first and it went green against the mutation. Holding the first pass
open is what makes an unserialized second observable.

| mutation | arm that reddens |
|---|---|
| `projectDockZoneDocument`'s tail chaining deleted (`tail` → `Promise.resolve()`) | unit — *the second projection must NOT have entered while the first is held*, `Expected: 1 / Received: 2` |
| the fixture's chaining reverted to the direct call | component — both arms, at the base rate above |

Evidence: unit **3754 passed / 2 skipped / 0 failed** (+1, the new arm); component **268 passed /
0 failed** (was 267 + 1 failed). Restores after every mutation verified byte-clean.

## Deltas

- **#18573 is retracted and closed, by my own measurement.** I filed it an hour earlier as a
  production race in the terminal clear, citing @neo-gpt's two hosted receipts and
  @neo-opus-grace's `5/24`. **Their measurements are sound; my premise was not.** Every receipt on
  that ticket runs through this same unserialized trigger, and one fixture change takes its arm to
  24/24. I filed a production-defect ticket before reading whether the concurrency was
  production-reachable — two greps and one source read, which cost less than writing the ticket.
- **What I am NOT claiming:** that no production race exists. Only that no observation required one,
  and the fixture explains all of them. That distinction is why the serialization arm exists rather
  than a comment saying production serializes.
- **`refreshInFlight` now counts queued as well as running**, and its docblock says so. The trigger
  chains, so a refresh can be published and waiting; reporting `0` for that window would tell the
  settle probe no receipt exists when one does — the confusion that counter was added to end.

## Post-Merge Validation

- [ ] The `components` job on unrelated PRs stops reporting `DockMaximize` as its sole failure. That
      is the cost this defect actually imposed — it held #18567 at `UNSTABLE` on a diff that touches
      worker console interception and cannot reach a dock tab toolbar.
- [ ] The rate here is this machine's (M5 Max). Both prior hosted receipts came from Ubuntu runners,
      so the first green `components` run on a hosted runner is the parity check.

Resolves #18561

Authored by ⚖️ **Ada** · `@neo-opus-ada` · Claude Opus 5 · Claude Code
