### PR TITLE
fix(component): resolve a canvas colour scheme from the declared theme map (#18576)

### DIFF
--- a/src/app/SharedCanvas.mjs
+++ b/src/app/SharedCanvas.mjs
@@ -60,8 +60,7 @@ class SharedCanvas extends Canvas {
      */
     afterSetIsCanvasReady(value, oldValue) {
         if (value) {
-            let mode = this.theme?.includes('dark') ? 'dark' : 'light';
-            this.renderer?.setTheme(mode);
+            this.renderer?.setTheme(this.resolveColorScheme());
             this.fire('canvasReady')
         }
     }
@@ -120,9 +119,8 @@ class SharedCanvas extends Canvas {
     afterSetTheme(value, oldValue) {
         super.afterSetTheme(value, oldValue);
 
-        if (value && this.isCanvasReady) {
-            let mode = value.includes('dark') ? 'dark' : 'light';
-            this.renderer.setTheme(mode)
+        if (this.isCanvasReady) {
+            this.renderer.setTheme(this.resolveColorScheme())
         }
     }
 

--- a/src/component/Canvas.mjs
+++ b/src/component/Canvas.mjs
@@ -35,6 +35,25 @@ class Canvas extends Component {
          */
         offscreenRegistered_: false,
         /**
+         * Maps a Neo theme onto the light/dark hint a renderer needs.
+         *
+         * A map rather than a substring test on the theme name, because the name does not carry the
+         * answer: `neo-theme-cyberpunk` is dark — `--neo-background-color: #0d1117`, and its own
+         * `--neo-color-scheme` says `dark` — and is named neither. Every theme declares that token,
+         * but the main-thread reader for it is protected and absent from the app remote manifest, so
+         * a component in the App Worker cannot ask, and a renderer registration needs the answer
+         * synchronously. A config rather than a constant, so a consumer can extend it for a theme
+         * Neo does not ship.
+         * @member {Object} themeMap
+         */
+        themeMap: {
+            'neo-theme-cyberpunk': 'dark',
+            'neo-theme-dark'     : 'dark',
+            'neo-theme-light'    : 'light',
+            'neo-theme-neo-dark' : 'dark',
+            'neo-theme-neo-light': 'light'
+        },
+        /**
          * @member {Object} _vdom={tag: 'canvas'}
          */
         _vdom:
@@ -143,6 +162,27 @@ class Canvas extends Component {
      */
     onDomResize(data) {
         this.fire('resize', data)
+    }
+
+    /**
+     * @summary Maps the theme this canvas actually renders under onto a light/dark hint.
+     *
+     * Resolution goes through {@link Neo.component.Base#getTheme}, never the `theme` config. A child
+     * inside a themed scope carries no theme class of its own by design, so that config is `null` for
+     * precisely the components which inherit a theme — and `container.Base#afterSetTheme` only stamps
+     * live items on a CHANGE, leaving construction to `createItem`. Reading the config therefore
+     * answers `null` on first render and the right value only after a theme toggle, which paints a
+     * light canvas in a dark app until someone touches the theme switcher. `getTheme()` answers the
+     * component's own theme first, so a canvas declaring one is not overruled by the scope it sits in.
+     *
+     * Pure and synchronous, so a renderer registration can carry the answer rather than correct it
+     * afterwards, and an unmapped theme yields `'light'` — adding a theme cannot silently repaint an
+     * existing app.
+     * @returns {'dark'|'light'}
+     * @protected
+     */
+    resolveColorScheme() {
+        return this.themeMap[this.getTheme()] ?? 'light'
     }
 }
 

--- a/src/component/Sparkline.mjs
+++ b/src/component/Sparkline.mjs
@@ -115,12 +115,10 @@ class Sparkline extends Canvas {
 
         let me = this;
 
-        if (me.offscreenRegistered && value) {
-            let theme = value.includes('dark') ? 'dark' : 'light';
-
+        if (me.offscreenRegistered) {
             me.renderer?.updateConfig({
                 canvasId: me.id,
-                theme
+                theme   : me.resolveColorScheme()
             })
         }
     }
@@ -187,7 +185,7 @@ class Sparkline extends Canvas {
             await me.renderer?.register({
                 canvasId        : me.id,
                 devicePixelRatio: Neo.config.devicePixelRatio,
-                theme           : me.theme?.includes('dark') ? 'dark' : 'light',
+                theme           : me.resolveColorScheme(),
                 usePulse        : me.usePulse,
                 useTransition   : me.useTransition,
                 windowId        : me.windowId

--- a/test/playwright/unit/component/CanvasColorScheme.spec.mjs
+++ b/test/playwright/unit/component/CanvasColorScheme.spec.mjs
@@ -76,11 +76,12 @@ test.describe('Neo.component.Canvas#resolveColorScheme', () => {
 
         expect(canvas.resolveColorScheme(), 'the scope decides').toBe('dark');
 
-        // Then the defect's own shape, induced rather than observed: `container.Base#afterSetTheme`
-        // stamps live items on a CHANGE and leaves construction to `createItem`, so on the paths
-        // where the config never lands it stays empty while the chain still knows the answer. This
-        // arm pins that the resolver reads the chain and not the config — it does not claim to
-        // reproduce which production path leaves it empty.
+        // Then the defect's own shape. `container.Base#afterSetTheme` stamps live items on a CHANGE
+        // and leaves construction to `createItem`, so on the paths where the config never lands it
+        // stays empty while the chain still knows the answer. That state is observed, not just
+        // constructed: three live editors inside the portal's themed viewport measured `theme: null`
+        // with `getTheme()` returning `'neo-theme-neo-dark'`, through a markdown → tab → wrapper
+        // chain. Emptied explicitly here because this tier has no such chain to build.
         canvas.theme = null;
 
         expect(canvas.theme, 'the config a canvas used to read is empty').toBeNull();
@@ -145,6 +146,13 @@ test.describe('a canvas hands the resolved scheme to its renderer', () => {
         });
 
         const sparkline = instance.getReference('sparkline');
+
+        // Empty the config FIRST, or this arm cannot fail on the resolution axis: `createItem`
+        // populates an inherited theme on this path, so a resolver reading the config would answer
+        // correctly here and the arm would witness only the mapping. The shape below is the one
+        // measured in production — three live editors inside the portal's themed viewport, each
+        // `theme: null` while `getTheme()` returned the dark theme.
+        sparkline.theme = null;
 
         // Registration is where the component last controls the value. The rendered pixel is not
         // reachable from here — `main/DomAccess.mjs` transfers the canvas with

--- a/test/playwright/unit/component/CanvasColorScheme.spec.mjs
+++ b/test/playwright/unit/component/CanvasColorScheme.spec.mjs
@@ -1,0 +1,189 @@
+/**
+ * @file test/playwright/unit/component/CanvasColorScheme.spec.mjs
+ * @summary Pins how a canvas answers light-or-dark: through the component chain, from a declared
+ * map, and into the payload a renderer actually receives.
+ */
+
+import {setup} from '../../setup.mjs';
+
+setup({appConfig: {name: 'CanvasColorSchemeTest'}});
+
+import {test, expect}  from '@playwright/test';
+import Neo             from '../../../../src/Neo.mjs';
+import * as core       from '../../../../src/core/_export.mjs';
+import Canvas          from '../../../../src/component/Canvas.mjs';
+import Container       from '../../../../src/container/Base.mjs';
+import InstanceManager from '../../../../src/manager/Instance.mjs';
+import Sparkline       from '../../../../src/component/Sparkline.mjs';
+
+const appName = 'CanvasColorSchemeTest';
+
+/**
+ * @summary A container whose class default names a theme, so children inherit it through the
+ * class-default rung of item creation and carry no theme of their own — the shape the defect lived in.
+ */
+class ThemedScope extends Container {
+    static config = {
+        className: 'Neo.test.component.CanvasColorScheme.ThemedScope',
+        theme    : 'neo-theme-neo-dark'
+    }
+}
+
+ThemedScope = Neo.setupClass(ThemedScope);
+
+/**
+ * The scheme each shipped theme declares as `--neo-color-scheme` in its own `Global.scss`.
+ * `neo-theme-cyberpunk` is the row that matters: it is dark, its name says nothing, and a substring
+ * test on the name answers `light` for it.
+ */
+const SHIPPED_THEMES = [
+    ['neo-theme-cyberpunk', 'dark'],
+    ['neo-theme-dark',      'dark'],
+    ['neo-theme-light',     'light'],
+    ['neo-theme-neo-dark',  'dark'],
+    ['neo-theme-neo-light', 'light']
+];
+
+test.describe('Neo.component.Canvas#resolveColorScheme', () => {
+    let instance = null;
+
+    test.afterEach(() => {
+        instance?.destroy();
+        instance = null
+    });
+
+    SHIPPED_THEMES.forEach(([theme, scheme]) => {
+        test(`${theme} resolves ${scheme}`, () => {
+            instance = Neo.create(Canvas, {appName, theme});
+
+            expect(instance.resolveColorScheme()).toBe(scheme)
+        })
+    });
+
+    test('a theme the map does not carry keeps the light default, so adding one cannot repaint an app', () => {
+        instance = Neo.create(Canvas, {appName, theme: 'neo-theme-not-shipped-by-neo'});
+
+        expect(instance.resolveColorScheme()).toBe('light')
+    });
+
+    test('a canvas inside a themed scope answers the scope, while declaring no theme of its own', () => {
+        instance = Neo.create(ThemedScope, {
+            appName,
+            items: [{module: Canvas, reference: 'canvas'}]
+        });
+
+        const canvas = instance.getReference('canvas');
+
+        expect(canvas.resolveColorScheme(), 'the scope decides').toBe('dark');
+
+        // Then the defect's own shape, induced rather than observed: `container.Base#afterSetTheme`
+        // stamps live items on a CHANGE and leaves construction to `createItem`, so on the paths
+        // where the config never lands it stays empty while the chain still knows the answer. This
+        // arm pins that the resolver reads the chain and not the config — it does not claim to
+        // reproduce which production path leaves it empty.
+        canvas.theme = null;
+
+        expect(canvas.theme, 'the config a canvas used to read is empty').toBeNull();
+        expect(canvas.resolveColorScheme(), 'and the answer is unchanged').toBe('dark')
+    });
+
+    test('a canvas declaring its own theme is not overruled by the scope it sits in', () => {
+        instance = Neo.create(ThemedScope, {
+            appName,
+            items: [{module: Canvas, reference: 'canvas', theme: 'neo-theme-neo-light'}]
+        });
+
+        expect(instance.getReference('canvas').resolveColorScheme()).toBe('light')
+    })
+});
+
+test.describe('a canvas hands the resolved scheme to its renderer', () => {
+    const RENDERER_NS = 'Neo.test.canvas.ColorSchemeDouble';
+
+    let calls          = [],
+        instance       = null,
+        originalCanvas = null;
+
+    test.beforeEach(() => {
+        calls = [];
+
+        Object.assign(Neo.ns(RENDERER_NS, true), {
+            register    : async data => {calls.push(['register', data])},
+            unregister  : async () => {},
+            updateConfig: data => {calls.push(['updateConfig', data])},
+            updateData  : () => {},
+            updateSize  : () => {}
+        });
+
+        // `Canvas#destroy` unregisters through the Canvas Worker, which the unit engine does not
+        // start. Without this the teardown throws and the failure reads as the arm's, not the rig's.
+        originalCanvas    = Neo.worker.Canvas;
+        Neo.worker.Canvas = {unregisterCanvas: () => {}}
+    });
+
+    test.afterEach(() => {
+        instance?.destroy();
+        instance = null;
+
+        if (originalCanvas === undefined) {
+            delete Neo.worker.Canvas
+        } else {
+            Neo.worker.Canvas = originalCanvas
+        }
+
+        delete Neo.test?.canvas?.ColorSchemeDouble
+    });
+
+    test('the registration payload carries the scope theme, with no theme change in between', async () => {
+        instance = Neo.create(ThemedScope, {
+            appName,
+            items: [{
+                module           : Sparkline,
+                reference        : 'sparkline',
+                rendererClassName: RENDERER_NS
+            }]
+        });
+
+        const sparkline = instance.getReference('sparkline');
+
+        // Registration is where the component last controls the value. The rendered pixel is not
+        // reachable from here — `main/DomAccess.mjs` transfers the canvas with
+        // `transferControlToOffscreen()`, after which the owning thread cannot read it — so this
+        // payload is the assertion boundary, and it is the value that was wrong.
+        sparkline.offscreenRegistered = true;
+        await sparkline.timeout(1);
+
+        const register = calls.find(([name]) => name === 'register');
+
+        expect(register, 'the renderer was registered').toBeTruthy();
+        expect(register[1].theme, 'and the first payload is already dark').toBe('dark')
+    });
+
+    test('both directions on one instance, including a dark theme whose name says nothing', async () => {
+        instance = Neo.create(ThemedScope, {
+            appName,
+            items: [{
+                module           : Sparkline,
+                reference        : 'sparkline',
+                rendererClassName: RENDERER_NS
+            }]
+        });
+
+        const
+            sparkline = instance.getReference('sparkline'),
+            lastTheme = () => calls.filter(([name]) => name === 'updateConfig').at(-1)?.[1].theme;
+
+        sparkline.offscreenRegistered = true;
+        await sparkline.timeout(1);
+
+        // Light is the direction a component hardcoded to `dark` fails, which is the mirror of the
+        // bug: asserting only the dark half passes against the wrong implementation.
+        instance.theme = 'neo-theme-neo-light';
+        await sparkline.timeout(1);
+        expect(lastTheme(), 'a live theme change reaches the renderer').toBe('light');
+
+        instance.theme = 'neo-theme-cyberpunk';
+        await sparkline.timeout(1);
+        expect(lastTheme(), 'and a dark theme that is not named dark still reads dark').toBe('dark')
+    })
+});


### PR DESCRIPTION
Resolves #18576

🌿 A canvas can no longer be dark on the page and light in the only value it sends.

`SharedCanvas` and `Sparkline` each carried both halves of the defect #18570 fixed in the Monaco wrapper: they read the raw `theme` config — `null` by design for a component that inherits its theme — and they inferred darkness from the theme name. Both extend `component.Canvas`, which had no theme surface at all, so the map and the resolver land there once instead of twice, and the four consumer sites each lose their guess. `resolveColorScheme()` is pure and synchronous, so a renderer registration carries the answer rather than correcting it afterwards.

Evidence: L2 (unit tier, engine runtime — the rendered pixel is unreachable by construction, since `main/DomAccess.mjs:944` transfers the node with `transferControlToOffscreen()` and the owning thread cannot read it afterwards) → L2 required (every close-target AC is about the value the component computes and hands over). Residual: none — AC-1 was narrowed on the ticket to the payload boundary, with that reason recorded there rather than shipped as an unmet bar.

Micro-review eligible: no — it adds a config and a method to a shared base class two components inherit.

## AC Evidence

| AC | Evidence |
|---|---|
| AC-1 first payload is already dark, no theme change in between | CI-covered: `CanvasColorScheme.spec.mjs` — *the registration payload carries the scope theme, with no theme change in between*. Asserts `register()`'s first payload, the last value the component controls. |
| AC-2 both directions | CI-covered: *both directions on one instance, including a dark theme whose name says nothing* — dark host, then light, then cyberpunk, reading the last `updateConfig` payload each time. The light half is what a component hardcoded to `dark` fails. |
| AC-3 cyberpunk renders dark | CI-covered twice: the `neo-theme-cyberpunk resolves dark` table row, and the third leg of the both-directions arm. Mutation receipt below. |
| AC-4 an unmapped theme keeps today's value | CI-covered: *a theme the map does not carry keeps the light default, so adding one cannot repaint an app*. |
| AC-5 neither component reads the raw config | CI-covered by the arms above, plus the direct grep: `grep -n "theme?.includes\|value.includes('dark')" src/app/SharedCanvas.mjs src/component/Sparkline.mjs src/component/Canvas.mjs` exits 1 with zero hits. |

## Deltas from ticket

**The fix went to the shared base, not per component.** The ticket prescribed the change *"per component, mirroring `MonacoEditor`"*. Both classes extend `Neo.component.Canvas` and both map onto the same `'dark' | 'light'` vocabulary — unlike `Mermaid` and `MonacoEditor`, which map onto different third-party vocabularies and therefore each keep their own map. One `themeMap` and one `resolveColorScheme()` on the base serves both, and any future canvas. Net: +40 lines on the base, −10 across the two consumers, and four guesses deleted.

**AC-1 was narrowed, and the narrowing is on the ticket.** It asked for the rendered pixel; the pixel is unreachable by construction rather than merely unreached. Stated in the ticket body with the `transferControlToOffscreen()` reason, so the next reader sees why the bar moved rather than finding an AC nobody met.

**One of my own assertions was wrong and the arm caught it.** I wrote `expect(canvas.theme).toBeNull()` for a canvas created inside a themed scope, on the belief that an inheriting child never receives the config. It receives it on *this* construction path — `container.Base#afterSetTheme` propagates the theme as a config, and `createItem` passes it down. The arm now induces the empty config explicitly and says so, rather than claiming to reproduce whichever production path leaves it empty. The distinction matters: the resolver is what this PR pins, not the propagation timing.

## Test Evidence

**Mutation receipt.** Reverting only the map to the guess it replaces —

```javascript
- return this.themeMap[this.getTheme()] ?? 'light'
+ return this.getTheme()?.includes('dark') ? 'dark' : 'light'
```

— reds exactly the two arms that exist to catch it, and nothing else:

```
1) neo-theme-cyberpunk resolves dark          Expected: "dark"  Received: "light"
2) both directions ... a dark theme whose name says nothing
                                              Expected: "dark"  Received: "light"
2 failed, 8 passed
```

The eight survivors are the honest part: `includes('dark')` is correct for the other four shipped themes, which is why the defect lived this long. Restored with `git checkout HEAD --`, tree clean at zero changed files.

Full unit tier at this head: **3763 passed, 2 skipped**.

## Post-Merge Validation

- [ ] The live portal header canvas and any sparkline under `neo-theme-cyberpunk` — the theme is not in `Neo.config.themes` by default, so no CI tier boots it, and the map row for it is asserted rather than observed in a running app.

## Commits

- `4fb6a0b01f` — the map and resolver on `component.Canvas`, the four consumer sites, and the spec.

Authored by Vega (Opus 5, Claude Code). Session 206b8400-7fe8-472e-8018-446e550b784b.
