### PR TITLE
fix(main): the mermaid addon awaits its render, so a parse error reaches the author (#18548)

### DIFF
--- a/src/main/addon/Mermaid.mjs
+++ b/src/main/addon/Mermaid.mjs
@@ -131,7 +131,13 @@ class Mermaid extends Base {
                     element.textContent = data.code
                 }
 
-                this.mermaid.run({
+                // AWAITED, and that is the whole point. `mermaid.run` is `(options?) => Promise<void>`
+                // and it REJECTS on a parse error — measured: `Parse error on line 2 … Expecting
+                // 'SEMI', 'NEWLINE'`. Un-awaited inside this `try`, the rejection was unhandled, so
+                // the `catch` below could not fire, the error message never reached the page, and
+                // this `async` method resolved before rendering had finished. The guarantee was
+                // written in code that could not execute.
+                await this.mermaid.run({
                     nodes: [element]
                 })
             } catch (e) {

--- a/test/playwright/e2e/portal/LearnMermaidRender.spec.mjs
+++ b/test/playwright/e2e/portal/LearnMermaidRender.spec.mjs
@@ -44,6 +44,25 @@ import {test, expect} from '@playwright/test';
  */
 const MONACO_EDITOR = '.neo-monaco-editor';
 
+/**
+ * A diagram that actually RENDERED — not mermaid's own error graphic.
+ *
+ * ⚠️ A plain `.neo-mermaid svg` count cannot tell the two apart, and the previous version of this
+ * arm used one. Measured against `dist/mermaid.mjs` in a browser: a fence with a syntax error makes
+ * `mermaid.run()` reject AND still emits one svg, so counting svgs reports a broken fence as a
+ * rendered one. The arm was not useless — the collision it was built for emitted ZERO svgs, so it
+ * discriminated that — but it could not distinguish a correct render from an error graphic, which
+ * is half of what it claims.
+ *
+ *   good fence  ->  aria-roledescription="flowchart-v2"  class="flowchart"
+ *   bad fence   ->  aria-roledescription="error"         class=null
+ *
+ * `aria-roledescription` is the discriminator because mermaid sets it deliberately. Searching the
+ * text for "error" does NOT work: it matches both, since the svg carries embedded CSS that contains
+ * the word. That false discriminator is what measuring instead of guessing caught.
+ */
+const RENDERED_DIAGRAM = '.neo-mermaid svg:not([aria-roledescription="error"])';
+
 const ROUTES = [{
     editors: true,
     name   : 'a live-preview route — Monaco BUSY, the state the collision needs',
@@ -87,10 +106,84 @@ test.describe('learn guide mermaid rendering', () => {
 
             // Rendering is async and staggered — poll for the settled count rather than sampling it,
             // or a mid-render read reports a partial failure that is not one.
-            await expect.poll(() => page.locator('.neo-mermaid svg').count(), {
+            await expect.poll(() => page.locator(RENDERED_DIAGRAM).count(), {
                 message: `every mermaid fence in ${route.source} must reach the reader as an SVG`,
                 timeout: 30000
             }).toBe(expected)
         })
     }
+});
+
+/**
+ * @summary AC-2's second control: a fence the author got WRONG must fail the check.
+ *
+ * The route arms above assert that every authored fence renders. On their own they cannot separate
+ * "the renderer works" from "the renderer renders nothing" — the condition that shipped once
+ * already — so this drives a deliberate syntax error through the same addon and asserts the check
+ * reports it as unrendered. Without it, `RENDERED_DIAGRAM` is an untested predicate.
+ *
+ * It also covers the author-facing half: `main.addon.Mermaid#render` awaits `mermaid.run`, so a
+ * parse failure reaches its `catch` and the message reaches the page. Un-awaited it did not, and the
+ * `Mermaid Error` div was unreachable code.
+ */
+test.describe('mermaid render verification — both controls', () => {
+    test('a correct fence counts as rendered and a syntax error does NOT', async ({page}) => {
+        // The control route, so the addon has really loaded through its own lazy path rather than
+        // being poked before `loadFiles` ran — `this.mermaid` would be null and BOTH cases would
+        // fail identically, which is a control that cannot fail.
+        await page.goto(ROUTES[1].url);
+        await expect(page.locator('.neo-app-content-component').locator('h1')).toBeVisible();
+        await expect.poll(() => page.locator(RENDERED_DIAGRAM).count()).toBeGreaterThan(0);
+
+        // `RENDERED_DIAGRAM` is passed IN rather than restated. Hardcoding the selector here made
+        // the arm independent of the constant it exists to witness: mutating the constant left this
+        // green, which is the duplicate-predicate trap with the third copy in the test oracle.
+        const outcome = await page.evaluate(async selector => {
+            const addon = Neo.main.addon.Mermaid,
+                  make  = id => {
+                      const el = document.createElement('div');
+
+                      el.className = 'neo-mermaid';
+                      el.id        = id;
+                      document.body.appendChild(el);
+                      return el
+                  },
+                  count = (id, css) => document.getElementById(id).querySelectorAll(css).length;
+
+            make('probe-good');
+            make('probe-bad');
+
+            const raw = make('probe-raw');
+
+            await addon.render({id: 'probe-good', code: 'graph TD;\n  A-->B;'});
+            await addon.render({id: 'probe-bad',  code: 'graph TD;\n  A--@@>>B[[[unclosed'});
+
+            // Straight through the library, BYPASSING the addon's catch, so mermaid's own error
+            // graphic survives in the DOM. That graphic is the only thing that can witness the
+            // selector: once the addon reports the failure as text there is no svg left to exclude.
+            raw.textContent = 'graph TD;\n  A--@@>>B[[[unclosed';
+
+            try {
+                await addon.mermaid.run({nodes: [raw]})
+            } catch (error) {
+                // Expected: the parse error. The DOM it left behind is the measurement.
+            }
+
+            return {
+                good        : count('probe-good', selector),
+                bad         : count('probe-bad',  selector),
+                badReport   : document.getElementById('probe-bad').textContent.includes('Mermaid Error'),
+                rawAnySvg   : count('probe-raw', 'svg'),
+                rawRendered : count('probe-raw', selector)
+            }
+        }, RENDERED_DIAGRAM.replace('.neo-mermaid ', ''));
+
+        expect(outcome.good, 'a correct fence renders').toBe(1);
+        expect(outcome.bad,  'and a syntax error is NOT counted as rendered — the control the route arms lack').toBe(0);
+        expect(outcome.badReport, 'and the author is told why, at the point of authoring').toBe(true);
+
+        // The selector itself, witnessed: mermaid's error graphic IS an svg and must not count.
+        expect(outcome.rawAnySvg,  'mermaid emits an svg even for a parse error').toBe(1);
+        expect(outcome.rawRendered, 'and the selector excludes it — a plain svg count cannot').toBe(0)
+    })
 });


### PR DESCRIPTION
## Problem

Two holes that hid each other.

**The addon could not report a failure.** `main.addon.Mermaid#render` called
`this.mermaid.run({nodes: [element]})` **without awaiting it**, inside a `try`/`catch`. `run` is
`(options?) => Promise<void>` and it **rejects** on a parse error, so the rejection was unhandled:
the `catch` never fired, the `Mermaid Error: …` message it writes never reached the page, and the
`async` method resolved before rendering had finished. A guarantee written in code that could not
execute.

**The check could not fail.** The render arm asserted that `.neo-mermaid svg` count equals the
authored fence count. A fence with a syntax error **still emits one svg**, because mermaid draws its
own error graphic — so the arm reported a broken fence as a rendered one. That is exactly the
condition #18548's AC-2 was written to exclude, in the instrument built to satisfy it.

The arm was not worthless: the AMD collision it was built for emitted **zero** svgs, so it
discriminated that. It simply could not tell a correct render from an error graphic, which is half
of what it claimed.

Measured against `dist/mermaid.mjs` in a real browser:

| | correct fence | syntax-error fence |
|---|---|---|
| `mermaid.run()` | resolves | **rejects** — `Parse error on line 2 … Expecting 'SEMI', 'NEWLINE'` |
| svgs emitted | 1 | **1** |
| `aria-roledescription` | `flowchart-v2` | **`error`** |
| svg `class` | `flowchart` | `null` |
| text contains "error" | **true** | true |

## Change

`await this.mermaid.run(…)`, which makes the `catch` live and puts the parse error in front of the
author at the point of authoring — this ticket's whole premise.

The predicate becomes `svg:not([aria-roledescription="error"])`. **The last table row is why it is
that attribute and not the text:** matching the word "error" passes for **both**, since the svg
carries embedded CSS containing it. That false discriminator is what measuring instead of checking
caught, and it is recorded at the constant so the next reader does not reintroduce it.

Evidence: L2 (e2e + unit tiers, both CI-reachable) → L2 required. No residual.

## AC Evidence

| AC | Disposition |
|---|---|
| **AC-1** — a `learn/` diagram is render-verifiable before merge through a documented path; name which option landed | **Met.** **Option 1** — "make the renderer run in the local dev portal" — landed, and it landed because the diagnosis allowed it: not weight, not a deliberate dev omission, but mermaid's vendored UMD wrappers registering into Monaco's AMD loader (#18565 at load time, #18572 at first render). Option 2 became unnecessary once the portal rendered; option 3 was rejected because it moves verification after merge, which the ticket itself criticises. Evidence: `test/playwright/e2e/portal/LearnMermaidRender.spec.mjs`, green in the e2e tier. |
| **AC-2** — **both** controls: a deliberate syntax error must fail, a correct fence must pass | **Met, and it caught my own arm first.** The positive half already held. The negative half did not: see the table above. Evidence: the new `both controls` arm asserts a correct fence renders (`1`), a syntax error is **not** counted as rendered (`0`), and the author is told why (`Mermaid Error` present). Both new assertions are red-proved below. |
| **AC-3** — `guide-authoring` §3 points at that path; its "no headless renderer locally" line corrected or retired | **Transferred to neo-agent-skills#66 — structurally, not by preference.** This repo consumes that file through a symlink (`.agents/skills -> ../node_modules/neo-agent-skills/.agents/skills`), so an edit here lands in `node_modules` and is overwritten on install. No commit in this repo can satisfy it. Carried verbatim. |
| **AC-4** — the route form documented where an author meets it, with the silent-empty-pane failure named | **Transferred to neo-agent-skills#66**, same file, same reason. |

The transfer was recorded **on the ticket before this PR** (issue comment), so the scope is narrowed
by a visible decision rather than by a `Resolves` line quietly covering less than the body asks. If
the preference is to hold #18548 open until #66 lands, this becomes `Refs` with one edit and the
delivered work is unchanged.

## Test Evidence

| mutation | arm that reddens |
|---|---|
| `await` removed from `mermaid.run` | e2e — *and the author is told why, at the point of authoring*, `Expected: true / Received: false` |
| predicate widened to any `svg` | e2e — *and the selector excludes it — a plain svg count cannot*, `Expected: 0 / Received: 1` |

**The first version of that arm was a control that cannot fail, and I only found it by mutating.**
It restated the selector inside `page.evaluate` instead of using the constant, so widening the
constant left it green — the duplicate-predicate trap with the third copy in the test oracle. The
predicate is passed in now, one copy.

The third assertion drives `mermaid.run` **directly, bypassing the addon's catch**, on purpose:
once the addon reports the failure as text there is no svg left for the selector to exclude, so
without that path the selector would be unwitnessed. The arm also loads the addon through its real
lazy path first — poking `render` before `loadFiles` would leave `this.mermaid` null and fail both
cases identically, which is a control that cannot fail in the other direction.

Evidence: e2e **63 passed / 3 skipped / 0 failed** (+1, the new arm); unit **3754 passed / 2
skipped / 0 failed**. All nine pre-commit guards green.

## Deltas

- **The negative control changed my verdict on my own merged work.** I was about to close #18548 on
  the strength of #18565 and #18572 — the symptom was gone and both had merged. Its AC-2 is the
  only reason I did not, and re-reading the ticket instead of the symptom is the reusable part.
- `check-ticket-archaeology` rejected a `#18548` reference in a docblock — the second time this
  session. Archaeology belongs in the commit; the guard is right and the habit is mine.

## Post-Merge Validation

- [ ] neo-agent-skills#66 lands, so `guide-authoring` §3 stops telling authors there is no local
      headless renderer and documents the `#/learn/<section>/<Slug>` route form. Until then an
      author following the bar still routes the check to a peer, which is the cost this ticket named.
- [ ] The `await` makes `render` genuinely await mermaid, so a page with many diagrams now serialises
      them where it previously fired and forgot. The portal's guide routes carry 1–4 fences and show
      no change in the tier, but a future page with many more is where that would first show.

Resolves #18548

Authored by ⚖️ **Ada** · `@neo-opus-ada` · Claude Opus 5 · Claude Code
