### PR TITLE
fix(dashboard): the topology diff reports edge-zone extents, so a restore returns rail widths (#18579)

### DIFF
--- a/src/ai/client/DockService.mjs
+++ b/src/ai/client/DockService.mjs
@@ -234,7 +234,9 @@ class DockService extends Service {
      * @param {Object} params
      * @param {String} params.componentId     The dock workspace / holder component id
      * @param {Object} params.beforeDocument  The earlier dockZone.v1 document to compare against
-     * @param {Number} [params.sizeEpsilon]   Optional resize tolerance on split size fractions
+     * @param {Number} [params.sizeEpsilon]   Optional tolerance on both split size fractions and
+     * edge-zone extents — one knob for both, since they are the same quantity under the same
+     * document contract. Tightening it for splits tightens it for rails.
      * @returns {Object} The {@link Neo.dashboard.dock.model.TopologyDiff#diffDockDocuments} result
      */
     async diffDockTopology({componentId, beforeDocument, sizeEpsilon}) {

--- a/src/dashboard/dock/model/TopologyDiff.mjs
+++ b/src/dashboard/dock/model/TopologyDiff.mjs
@@ -16,12 +16,22 @@ import WorkspaceDocument from './WorkspaceDocument.mjs';
  * - `adds`         — an item entered the tree (catalog-only items are NOT topology adds)
  * - `removes`      — an item left the tree
  * - `resizes`      — a split present in both documents changed its size fractions beyond epsilon
+ * - `edgeResizes`  — an edge-zone descriptor present in both documents changed its `extent`
+ *                    beyond epsilon. The other half of `resizes`: `Operations` classes
+ *                    `resizeSplit` and `resizeEdgeZone` identically as `geometry`, so reporting
+ *                    one and not the other let a rail drag restore as a no-op
  * - `tabReorders`  — an item kept its container but changed its tab index. Index truth is
  *                    reported verbatim: a shift induced by a sibling's departure IS a reorder
  *                    here — assertion consumers filter by `itemId` when they need
  *                    action-attribution rather than positional truth
+ * - `activeItemChanges` — a tabs node present in both documents changed its `activeItemId`
  * - `autoHideFlips`— an item's `autoHidden` flag toggled
  * - `unchanged`    — items present in both trees with none of the above
+ *
+ * This list is the complete return shape and is a maintenance obligation: it stood at seven while
+ * the code returned eight for the whole life of `activeItemChanges`, and a reader who built a
+ * category list from this prose under-reported exactly where it had drifted. Derive categories
+ * from the returned object, never from a comment.
  *
  * The output is JSON-first and snapshot-stable: every category array is sorted by its primary
  * key and the walk order is deterministic, so identical inputs produce byte-identical results.
@@ -96,13 +106,16 @@ class TopologyDiff extends Base {
      * @param {Object} before The earlier committed document
      * @param {Object} after The later committed document
      * @param {Object} [options]
-     * @param {Number} [options.sizeEpsilon=TopologyDiff.SIZE_EPSILON] Resize tolerance on size fractions
-     * @returns {{moves: Object[], adds: Object[], removes: Object[], resizes: Object[], tabReorders: Object[], autoHideFlips: Object[], activeItemChanges: Object[], unchanged: String[], errors: String[]}}
+     * @param {Number} [options.sizeEpsilon=TopologyDiff.SIZE_EPSILON] Tolerance on both size fractions
+     * and edge-zone extents. One knob for both: they are the same quantity — a fraction in the open
+     * interval `(0, 1)` validated by the same document contract — so a second tolerance would be a
+     * surface consumers must reason about with no question behind it.
+     * @returns {{moves: Object[], adds: Object[], removes: Object[], resizes: Object[], edgeResizes: Object[], tabReorders: Object[], autoHideFlips: Object[], activeItemChanges: Object[], unchanged: String[], errors: String[]}}
      * @static
      */
     static diffDockDocuments(before, after, {sizeEpsilon = TopologyDiff.SIZE_EPSILON} = {}) {
         const
-            empty  = () => ({moves: [], adds: [], removes: [], resizes: [], tabReorders: [], autoHideFlips: [], activeItemChanges: [], unchanged: [], errors: []}),
+            empty  = () => ({moves: [], adds: [], removes: [], resizes: [], edgeResizes: [], tabReorders: [], autoHideFlips: [], activeItemChanges: [], unchanged: [], errors: []}),
             result = empty(),
             errors = [];
 
@@ -175,6 +188,39 @@ class TopologyDiff extends Base {
                 if (fromActive !== toActive && toActive != null && (afterNode.items || []).includes(toActive)) {
                     result.activeItemChanges.push({nodeId, from: fromActive, to: toActive})
                 }
+
+                return
+            }
+
+            // An edge zone's size lives on the DESCRIPTOR, not on the node it points at, which is
+            // why the split branch below cannot reach it: `dockZoneDescriptorKeys` owns `extent`
+            // and the node owns only `zones`. Walked in `dockZoneEdgeKeys` order rather than the
+            // record's own key order, so the output stays snapshot-stable like every other
+            // category. `center` is walked too: nothing in the operation vocabulary can resize it,
+            // but a hand-authored document can carry the field, and this differ reports document
+            // truth — the planner is what filters to executable steps.
+            if (beforeNode?.type === 'edge-zone' && afterNode?.type === 'edge-zone') {
+                const
+                    beforeZones = WorkspaceDocument.isJsonRecord(beforeNode.zones) ? beforeNode.zones : {},
+                    afterZones  = WorkspaceDocument.isJsonRecord(afterNode.zones)  ? afterNode.zones  : {};
+
+                [...WorkspaceDocument.dockZoneEdgeKeys].forEach(edge => {
+                    const
+                        from = beforeZones[edge]?.extent,
+                        to   = afterZones[edge]?.extent;
+
+                    // Absence is not a change to zero. A slot that carries no extent on either side
+                    // takes the projection's default on both, so it has not moved; a slot that has
+                    // one on only one side has no comparable pair, and inventing the default here
+                    // would report a resize the user never performed. `resizable` is deliberately
+                    // NOT compared: it is a policy flag, and a geometry category that moved on it
+                    // would make the planner emit a resize for a permission change.
+                    if (!Number.isFinite(from) || !Number.isFinite(to)) return;
+
+                    if (Math.abs(from - to) > sizeEpsilon) {
+                        result.edgeResizes.push({nodeId, edge, from, to})
+                    }
+                });
 
                 return
             }

--- a/src/dashboard/dock/persistence/RestorePlanner.mjs
+++ b/src/dashboard/dock/persistence/RestorePlanner.mjs
@@ -129,14 +129,30 @@ class RestorePlanner extends Base {
         diff.resizes.forEach(({nodeId, toSizes}) =>
             plan.push({operation: 'resizeSplit', splitNodeId: nodeId, sizes: [...toSizes]}));
 
-        // Only the steps the executor will accept. `Operations.resizeEdgeZone` refuses `center` and
-        // refuses any descriptor whose `resizable` is not exactly `true` — and the descriptor it
-        // validates is the LIVE one, so the permission is read off `current`, never off the capture.
-        // Same discipline the active-item emit above takes: the diff reports document truth, the
-        // planner emits only what can run, because a restore must not start failing over a boundary
-        // the app has since made fixed.
+        // Only the steps the executor will accept. `Operations.resizeEdgeZone` has four refusals;
+        // the shape gate upstream already rejects one of them (an unresolvable descriptor fails
+        // `computeShapeFingerprint`, so no plan is built at all), and the three below are this
+        // filter's scope: a non-edge `center`, a descriptor that is not exactly `resizable`, and an
+        // `extent` outside the open interval `(0, 1)`. The permission and the edge are read off the
+        // LIVE document because that is the descriptor the executor validates — reading the
+        // capture's would emit a step the executor then rejects, and suppress one it would accept.
+        //
+        // Missing ANY of the three is not "the rail does not move". `applyRestorePlan` is
+        // fail-closed on the first error, so one unusable step strands every later one — a valid
+        // auto-hide flip queued behind an illegal rail simply never runs. The `(0, 1)` clause
+        // matters because nothing in the persistence tier calls `WorkspaceDocument.validate`: a
+        // capture is trusted on shape and never on contract, so a contract-illegal value from
+        // another writer (hand-authored, an older schema, edited storage) reaches here intact.
+        //
+        // This predicate deliberately mirrors the executor's rather than sharing it. Keeping the
+        // planner a PURE fold — no executor round-trip to decide what to plan — is worth the
+        // duplication, but the duplication is real and unlinked: a fifth refusal added to
+        // `Operations.resizeEdgeZone` will not surface here, and the arms in
+        // `DockRestorePlanner.spec.mjs` are what would catch it.
         diff.edgeResizes.forEach(({nodeId, edge, to}) => {
-            if (edge !== 'center' && current.nodes?.[nodeId]?.zones?.[edge]?.resizable === true) {
+            if (edge !== 'center' && to > 0 && to < 1 &&
+                current.nodes?.[nodeId]?.zones?.[edge]?.resizable === true
+            ) {
                 plan.push({operation: 'resizeEdgeZone', edgeZoneId: nodeId, edge, extent: to})
             }
         });

--- a/src/dashboard/dock/persistence/RestorePlanner.mjs
+++ b/src/dashboard/dock/persistence/RestorePlanner.mjs
@@ -39,9 +39,13 @@ class RestorePlanner extends Base {
      *
      * Fingerprint gate first: a shape mismatch returns a structured deferral (the cross-topology leaf owns
      * that path) with an empty plan — never a silent partial. Otherwise it maps each diff category to its
-     * operation in a deterministic order (moves → tab reorders ascending target index → resizes → auto-hide
-     * flips; `adds` lead when present). `removes` are NOT destroyed — restore never deletes — they surface as
-     * a `surplus` list the cross-topology dual consumes.
+     * operation in a deterministic order (moves → tab reorders ascending target index → active items →
+     * split resizes → edge-zone resizes → auto-hide flips; `adds` lead when present). `removes` are NOT
+     * destroyed — restore never deletes — they surface as a `surplus` list the cross-topology dual consumes.
+     *
+     * Not every reported change becomes a step: `edgeResizes` is filtered to what the executor accepts,
+     * so a zone the app has since made non-resizable is reported by the differ and skipped here rather
+     * than planned into a step that would fail the whole application.
      * @param {Object} current  The live committed document.
      * @param {Object} captured The captured layout document to restore toward.
      * @returns {{deferred: Boolean, reason: (String|null), plan: Object[], surplus: Object[], errors: String[]}}
@@ -106,7 +110,7 @@ class RestorePlanner extends Base {
 
         let plan = [];
 
-        // adds → moves (collapse-safe order) → tabReorders (ascending captured index) → activeItems → resizes → autoHideFlips.
+        // adds → moves (collapse-safe order) → tabReorders (ascending captured index) → activeItems → resizes → edgeResizes → autoHideFlips.
         diff.adds.forEach(({itemId, to}) =>
             plan.push({operation: 'addTab', itemId, tabsNodeId: to.nodeId, index: to.index}));
 
@@ -124,6 +128,18 @@ class RestorePlanner extends Base {
 
         diff.resizes.forEach(({nodeId, toSizes}) =>
             plan.push({operation: 'resizeSplit', splitNodeId: nodeId, sizes: [...toSizes]}));
+
+        // Only the steps the executor will accept. `Operations.resizeEdgeZone` refuses `center` and
+        // refuses any descriptor whose `resizable` is not exactly `true` — and the descriptor it
+        // validates is the LIVE one, so the permission is read off `current`, never off the capture.
+        // Same discipline the active-item emit above takes: the diff reports document truth, the
+        // planner emits only what can run, because a restore must not start failing over a boundary
+        // the app has since made fixed.
+        diff.edgeResizes.forEach(({nodeId, edge, to}) => {
+            if (edge !== 'center' && current.nodes?.[nodeId]?.zones?.[edge]?.resizable === true) {
+                plan.push({operation: 'resizeEdgeZone', edgeZoneId: nodeId, edge, extent: to})
+            }
+        });
 
         diff.autoHideFlips.forEach(({itemId, to}) =>
             plan.push({operation: 'setItemAutoHidden', itemId, autoHidden: to}));

--- a/test/playwright/unit/dashboard/DockRestorePlanner.spec.mjs
+++ b/test/playwright/unit/dashboard/DockRestorePlanner.spec.mjs
@@ -277,26 +277,51 @@ test.describe('DockRestorePlanner — same-topology restore', () => {
  * edge zone carrying extents; these do, which is the only way to exercise the rail-restore path.
  * @returns {Object}
  */
-function railDoc() {
+function railDoc({autoHidden = false, extent = 0.11, resizable = true} = {}) {
     return {
         schema: 'neo.dock.zone.v1',
         root  : 'root',
         items : {
             strategy: {reference: 'strategy', title: 'Strategy'},
-            queues  : {reference: 'queues',   title: 'Queues'}
+            queues  : {reference: 'queues',   title: 'Queues', autoHidden}
         },
         nodes: {
             root       : {
                 type : 'edge-zone',
                 zones: {
                     center: {nodeId: 'main-tabs'},
-                    left  : {nodeId: 'left-tabs', extent: 0.11, resizable: true}
+                    left  : {nodeId: 'left-tabs', extent, resizable}
                 }
             },
             'main-tabs': {type: 'tabs', items: ['strategy'], activeItemId: 'strategy'},
             'left-tabs': {type: 'tabs', items: ['queues'],   activeItemId: 'queues'}
         }
     }
+}
+
+/**
+ * @summary Asserts a vetoed rail step against a plan that is NOT empty.
+ *
+ * `expect(plan).toEqual([])` cannot tell "the rail was filtered" from "the planner emitted nothing
+ * for an unrelated reason" — every veto arm passes on a planner that has stopped working. So each
+ * one here carries a second, unrelated pending change (an auto-hide flip, which the planner orders
+ * after `edgeResizes`) and asserts the plan is exactly that one step: the rail absent, the valid
+ * step present and applied. That distinguishes a filter from a no-op, which an empty plan cannot.
+ * @param {Object} current
+ * @param {Object} captured
+ * @returns {Object} the restore receipt, for further per-case assertions
+ */
+function expectRailVetoedButPlanStillRuns(current, captured) {
+    const receipt = DockRestorePlanner.restoreToward(current, captured);
+
+    expect(receipt.deferred).toBe(false);
+    expect(receipt.errors, 'a vetoed rail must never surface as a restore error').toEqual([]);
+    expect(receipt.plan, 'exactly the unrelated valid step — no resizeEdgeZone, and NOT an empty plan')
+        .toEqual([{operation: 'setItemAutoHidden', itemId: 'queues', autoHidden: false}]);
+    expect(receipt.applied, 'the valid step still ran').toBe(1);
+    expect(receipt.document.items.queues.autoHidden).toBe(false);
+
+    return receipt
 }
 
 test.describe('DockRestorePlanner — edge-zone extents (#18579)', () => {
@@ -328,34 +353,72 @@ test.describe('DockRestorePlanner — edge-zone extents (#18579)', () => {
     });
 
     test('a zone the app has since fixed is reported but never planned', () => {
-        const captured = railDoc(),
-              current  = railDoc();
-
-        current.nodes.root.zones.left.extent    = 0.4;
-        current.nodes.root.zones.left.resizable = false;
+        const captured = railDoc({autoHidden: false}),
+              current  = railDoc({autoHidden: true, extent: 0.4, resizable: false});
 
         // The differ still reports it — document truth does not depend on permission.
         expect(DockTopologyDiff.diffDockDocuments(current, captured).edgeResizes)
             .toEqual([{nodeId: 'root', edge: 'left', from: 0.4, to: 0.11}]);
 
-        const {deferred, errors, plan, document: restored} = DockRestorePlanner.restoreToward(current, captured);
-
         // `Operations.resizeEdgeZone` refuses a non-resizable descriptor, and application is
         // fail-closed on the FIRST error — so an unfiltered emit here would not merely skip the
         // rail, it would abort every step after it. Restore never starts throwing over a boundary
         // the app has made fixed.
-        expect(plan).toEqual([]);
-        expect(deferred).toBe(false);
-        expect(errors).toEqual([]);
+        const {document: restored} = expectRailVetoedButPlanStillRuns(current, captured);
+
         expect(restored.nodes.root.zones.left.extent, 'and the live width is left alone').toBe(0.4)
     });
 
-    test('center is never planned: the executor refuses it, so the planner must not offer it', () => {
-        const captured = railDoc(),
-              current  = railDoc();
+    test('the reverse polarity: a zone the app has since FREED restores its width, not its permission', () => {
+        const captured = railDoc({resizable: false}),
+              current  = railDoc({extent: 0.4, resizable: true});
 
-        current.nodes.root.zones.center.extent    = 0.9;
-        captured.nodes.root.zones.center.extent   = 0.5;
+        const {deferred, errors, plan, applied, document: restored} =
+            DockRestorePlanner.restoreToward(current, captured);
+
+        // The mirror of the arm above, and the one a filter reading the CAPTURED descriptor would
+        // get wrong while still passing that one. The executor validates the descriptor it is
+        // handed — the live one — so this step is acceptable and must be planned.
+        expect(deferred).toBe(false);
+        expect(errors).toEqual([]);
+        expect(plan).toEqual([{operation: 'resizeEdgeZone', edgeZoneId: 'root', edge: 'left', extent: 0.11}]);
+        expect(applied).toBe(1);
+
+        // Geometry restores; policy does not. Returning `resizable: false` here would let a capture
+        // re-fix a boundary the app deliberately freed, which is app state rather than user state —
+        // the same line the differ draws by refusing to treat `resizable` as a geometry change.
+        expect(restored.nodes.root.zones.left.extent).toBe(0.11);
+        expect(restored.nodes.root.zones.left.resizable, 'the live permission survives the restore').toBe(true)
+    });
+
+    test('an out-of-contract captured extent is vetoed, so one illegal value cannot abort the restore', () => {
+        const captured = railDoc({autoHidden: false}),
+              current  = railDoc({autoHidden: true, extent: 0.4});
+
+        // `1.5` is contract-illegal: `extent` is a finite number in the OPEN interval (0, 1). The
+        // shape gate does not catch it — it validates descriptor resolvability, not the value — and
+        // the differ's own bound is `Number.isFinite`, so it is reported truthfully. The executor
+        // refuses it, and because application is fail-closed on the FIRST error an emitted step
+        // here strands every later one: the auto-hide flip below never runs.
+        captured.nodes.root.zones.left.extent = 1.5;
+
+        expect(WorkspaceDocument.computeShapeFingerprint(captured).errors,
+            'the shape gate admits it, which is why the planner has to be the one to refuse').toEqual([]);
+        expect(DockTopologyDiff.diffDockDocuments(current, captured).edgeResizes,
+            'and the differ reports it, because document truth is not contract validity')
+            .toEqual([{nodeId: 'root', edge: 'left', from: 0.4, to: 1.5}]);
+
+        const {document: restored} = expectRailVetoedButPlanStillRuns(current, captured);
+
+        expect(restored.nodes.root.zones.left.extent, 'the live width is untouched by an illegal capture').toBe(0.4)
+    });
+
+    test('center is never planned: the executor refuses it, so the planner must not offer it', () => {
+        const captured = railDoc({autoHidden: false}),
+              current  = railDoc({autoHidden: true});
+
+        current.nodes.root.zones.center.extent  = 0.9;
+        captured.nodes.root.zones.center.extent = 0.5;
         // resizable on center is meaningless to the executor; set it to prove the edge test, not the
         // permission test, is what excludes center.
         current.nodes.root.zones.center.resizable = true;
@@ -363,7 +426,7 @@ test.describe('DockRestorePlanner — edge-zone extents (#18579)', () => {
         expect(DockTopologyDiff.diffDockDocuments(current, captured).edgeResizes,
             'the differ reports document truth').toEqual([{nodeId: 'root', edge: 'center', from: 0.9, to: 0.5}]);
 
-        expect(DockRestorePlanner.restoreToward(current, captured).plan).toEqual([])
+        expectRailVetoedButPlanStillRuns(current, captured)
     });
 
     test('an unchanged rail plans nothing: restore plans stay minimal', () => {

--- a/test/playwright/unit/dashboard/DockRestorePlanner.spec.mjs
+++ b/test/playwright/unit/dashboard/DockRestorePlanner.spec.mjs
@@ -271,3 +271,105 @@ test.describe('DockRestorePlanner — same-topology restore', () => {
         })
     })
 });
+
+/**
+ * A rail-bearing document. The fixture above roots at a `split`, so no arm here plans across an
+ * edge zone carrying extents; these do, which is the only way to exercise the rail-restore path.
+ * @returns {Object}
+ */
+function railDoc() {
+    return {
+        schema: 'neo.dock.zone.v1',
+        root  : 'root',
+        items : {
+            strategy: {reference: 'strategy', title: 'Strategy'},
+            queues  : {reference: 'queues',   title: 'Queues'}
+        },
+        nodes: {
+            root       : {
+                type : 'edge-zone',
+                zones: {
+                    center: {nodeId: 'main-tabs'},
+                    left  : {nodeId: 'left-tabs', extent: 0.11, resizable: true}
+                }
+            },
+            'main-tabs': {type: 'tabs', items: ['strategy'], activeItemId: 'strategy'},
+            'left-tabs': {type: 'tabs', items: ['queues'],   activeItemId: 'queues'}
+        }
+    }
+}
+
+test.describe('DockRestorePlanner — edge-zone extents (#18579)', () => {
+    test('a rail drag plans a step and the round trip returns the captured width', () => {
+        const captured = railDoc(),
+              dragged  = Operations.applyOperation(railDoc(), {
+                  operation: 'resizeEdgeZone', edgeZoneId: 'root', edge: 'left', extent: 0.4
+              });
+
+        expect(dragged.errors, 'the drag itself must commit through the executor').toEqual([]);
+        expect(dragged.document.nodes.root.zones.left.extent).toBe(0.4);
+
+        const {deferred, reason, errors, plan, applied, document: restored} =
+            DockRestorePlanner.restoreToward(dragged.document, captured);
+
+        // The defect this arm exists for was not a wrong answer — it was `deferred: false,
+        // errors: [], plan: []`. Success with nothing to do, on two documents that differ. A
+        // consumer folding that plan concludes the layout is already restored, so asserting the
+        // restored extent ALONE would still pass on a planner that silently gave up: these three
+        // pin that the emptiness is gone, not just that the value happens to be right.
+        expect(deferred).toBe(false);
+        expect(reason).toBe(null);
+        expect(errors).toEqual([]);
+        expect(plan).toEqual([{operation: 'resizeEdgeZone', edgeZoneId: 'root', edge: 'left', extent: 0.11}]);
+        expect(applied).toBe(1);
+
+        expect(restored.nodes.root.zones.left.extent, 'the rail is back where it was captured').toBe(0.11);
+        expect(DockTopologyDiff.diffDockDocuments(restored, captured).edgeResizes).toEqual([])
+    });
+
+    test('a zone the app has since fixed is reported but never planned', () => {
+        const captured = railDoc(),
+              current  = railDoc();
+
+        current.nodes.root.zones.left.extent    = 0.4;
+        current.nodes.root.zones.left.resizable = false;
+
+        // The differ still reports it — document truth does not depend on permission.
+        expect(DockTopologyDiff.diffDockDocuments(current, captured).edgeResizes)
+            .toEqual([{nodeId: 'root', edge: 'left', from: 0.4, to: 0.11}]);
+
+        const {deferred, errors, plan, document: restored} = DockRestorePlanner.restoreToward(current, captured);
+
+        // `Operations.resizeEdgeZone` refuses a non-resizable descriptor, and application is
+        // fail-closed on the FIRST error — so an unfiltered emit here would not merely skip the
+        // rail, it would abort every step after it. Restore never starts throwing over a boundary
+        // the app has made fixed.
+        expect(plan).toEqual([]);
+        expect(deferred).toBe(false);
+        expect(errors).toEqual([]);
+        expect(restored.nodes.root.zones.left.extent, 'and the live width is left alone').toBe(0.4)
+    });
+
+    test('center is never planned: the executor refuses it, so the planner must not offer it', () => {
+        const captured = railDoc(),
+              current  = railDoc();
+
+        current.nodes.root.zones.center.extent    = 0.9;
+        captured.nodes.root.zones.center.extent   = 0.5;
+        // resizable on center is meaningless to the executor; set it to prove the edge test, not the
+        // permission test, is what excludes center.
+        current.nodes.root.zones.center.resizable = true;
+
+        expect(DockTopologyDiff.diffDockDocuments(current, captured).edgeResizes,
+            'the differ reports document truth').toEqual([{nodeId: 'root', edge: 'center', from: 0.9, to: 0.5}]);
+
+        expect(DockRestorePlanner.restoreToward(current, captured).plan).toEqual([])
+    });
+
+    test('an unchanged rail plans nothing: restore plans stay minimal', () => {
+        const {plan, errors} = DockRestorePlanner.restoreToward(railDoc(), railDoc());
+
+        expect(errors).toEqual([]);
+        expect(plan, 'a no-op step is a spurious commit').toEqual([])
+    })
+});

--- a/test/playwright/unit/dashboard/DockTopologyDiff.spec.mjs
+++ b/test/playwright/unit/dashboard/DockTopologyDiff.spec.mjs
@@ -260,3 +260,133 @@ test.describe('Neo.dashboard.dock.model.TopologyDiff (#14650)', () => {
         expect(gate.fingerprint?.shape).toBe('e{}')
     });
 });
+
+/**
+ * A rail-bearing document: the root edge zone carries three resizable edges with extents, plus a
+ * fixed `center`. Separate from `doc()` because that fixture's only zone is the non-resizable
+ * center — the shape this category exists for was absent from the spec's whole fixture surface,
+ * which is one reason the omission survived.
+ * @returns {Object}
+ */
+function railDoc() {
+    return {
+        schema: 'neo.dock.zone.v1',
+        root  : 'root',
+        items : {
+            strategy: {reference: 'strategy', title: 'Strategy'},
+            queues  : {reference: 'queues',   title: 'Queues'},
+            feed    : {reference: 'feed',     title: 'Feed'}
+        },
+        nodes: {
+            root         : {
+                type : 'edge-zone',
+                zones: {
+                    center: {nodeId: 'main-tabs'},
+                    left  : {nodeId: 'left-tabs',   extent: 0.11, resizable: true},
+                    bottom: {nodeId: 'bottom-tabs', extent: 0.17, resizable: true}
+                }
+            },
+            'main-tabs'  : {type: 'tabs', items: ['strategy'], activeItemId: 'strategy'},
+            'left-tabs'  : {type: 'tabs', items: ['queues'],   activeItemId: 'queues'},
+            'bottom-tabs': {type: 'tabs', items: ['feed'],     activeItemId: 'feed'}
+        }
+    }
+}
+
+test.describe('TopologyDiff — edge-zone extents (#18579)', () => {
+    test('a rail drag is a reported change; the shape gate the differ runs on cannot see it', () => {
+        const before = railDoc(),
+              after  = railDoc();
+
+        after.nodes.root.zones.left.extent = 0.4;
+
+        const result = DockTopologyDiff.diffDockDocuments(before, after);
+
+        expect(result.errors).toEqual([]);
+        expect(result.edgeResizes).toEqual([{nodeId: 'root', edge: 'left', from: 0.11, to: 0.4}]);
+
+        // The two documents are structurally identical, so the shape fingerprint — which
+        // `planRestore` uses as its comparability gate — reads them as the same layout. That is the
+        // fingerprint's documented contract, and it is exactly why this category has to exist: the
+        // differ is the only instrument that can see the drag.
+        expect(WorkspaceDocument.computeShapeFingerprint(before).fingerprint.shape)
+            .toBe(WorkspaceDocument.computeShapeFingerprint(after).fingerprint.shape);
+
+        // and nothing else moved
+        expect(result.resizes).toEqual([]);
+        expect(result.moves).toEqual([]);
+        expect(result.tabReorders).toEqual([]);
+        expect(result.activeItemChanges).toEqual([])
+    });
+
+    test('extent epsilon: sub-epsilon drift is no change, and one tolerance governs both resize kinds', () => {
+        const before  = railDoc(),
+              drifted = railDoc();
+
+        drifted.nodes.root.zones.left.extent = 0.1105; // 0.0005 — inside the 0.001 default
+
+        expect(DockTopologyDiff.diffDockDocuments(before, drifted).edgeResizes,
+            'sub-epsilon drift must not plan a restore step').toEqual([]);
+
+        // Same knob, both categories: a caller tightening it for splits tightens it for rails, which
+        // is the property that lets `sizeEpsilon` stay one parameter.
+        expect(DockTopologyDiff.diffDockDocuments(before, drifted, {sizeEpsilon: 0.0001}).edgeResizes)
+            .toEqual([{nodeId: 'root', edge: 'left', from: 0.11, to: 0.1105}])
+    });
+
+    test('an absent extent is not a change to zero, on either side', () => {
+        const before = railDoc(),
+              after  = railDoc();
+
+        delete after.nodes.root.zones.left.extent;
+
+        expect(DockTopologyDiff.diffDockDocuments(before, after).edgeResizes,
+            'a slot that loses its extent takes the projection default; it did not resize').toEqual([]);
+        expect(DockTopologyDiff.diffDockDocuments(after, before).edgeResizes,
+            'and the same holds in the other direction').toEqual([]);
+
+        // `center` carries no extent on either side and must stay silent rather than compare 0 to 0.
+        expect(DockTopologyDiff.diffDockDocuments(railDoc(), railDoc()).edgeResizes).toEqual([])
+    });
+
+    test('resizable is a policy flag, not geometry: flipping it alone reports nothing', () => {
+        const before = railDoc(),
+              after  = railDoc();
+
+        after.nodes.root.zones.left.resizable = false;
+
+        const result = DockTopologyDiff.diffDockDocuments(before, after);
+
+        expect(result.errors).toEqual([]);
+        expect(result.edgeResizes,
+            'a permission change must not become a resize step the planner would then emit').toEqual([])
+    });
+
+    test('multiple rails report in dockZoneEdgeKeys order, and two runs are byte-identical', () => {
+        const before = railDoc(),
+              after  = railDoc();
+
+        after.nodes.root.zones.left.extent   = 0.4;
+        after.nodes.root.zones.bottom.extent = 0.3;
+
+        const one = DockTopologyDiff.diffDockDocuments(before, after),
+              two = DockTopologyDiff.diffDockDocuments(before, after);
+
+        // `dockZoneEdgeKeys` is top → right → bottom → left → center, so bottom precedes left
+        // regardless of the order the zones record happens to enumerate.
+        expect(one.edgeResizes.map(entry => entry.edge)).toEqual(['bottom', 'left']);
+        expect(JSON.stringify(one)).toBe(JSON.stringify(two))
+    });
+
+    test('the returned category set is pinned, because the class docblock drifted from it once', () => {
+        // `activeItemChanges` was added to the return shape and never to the class comment, so for
+        // its whole life the prose said seven and the code returned eight. A reader building a
+        // category list from that comment under-reports precisely where it has drifted — which is
+        // how the edge-zone omission stayed invisible to its own readers. This arm reds on the next
+        // addition, and the docblock note beside the list says what to do about it.
+        expect(Object.keys(DockTopologyDiff.diffDockDocuments(doc(), doc())).sort()).toEqual([
+            'activeItemChanges', 'adds', 'autoHideFlips', 'edgeResizes', 'errors',
+            'moves', 'removes', 'resizes', 'tabReorders', 'unchanged'
+        ])
+    });
+});


### PR DESCRIPTION
Resolves #18579

`TopologyDiff.diffDockDocuments` gains an `edgeResizes` category and `RestorePlanner` emits `resizeEdgeZone` from it, so a saved dock layout restores the rail widths it captured. Before this, the differ's node walk returned before reaching `edge-zone` nodes, and since the planner is a pure fold over that diff, two documents differing only in a rail width planned `deferred: false, errors: [], plan: []` — success with nothing to do. The differ reports document truth (including `center`); the planner filters to what `Operations.resizeEdgeZone` will accept, because it refuses `center` and refuses a non-`resizable` descriptor and application is fail-closed on the first error, so an unfiltered emit would abort every step after it rather than merely skip the rail.

Evidence: L2 (unit tier, pure-JSON model + planner — no runtime, host or rendered surface is involved) → L2 required (every close-target AC is document or plan behaviour). Residual: none.

`agent-preflight: not hosted here; baseline husky pre-commit jobs ran` — no `ai/` tree in this checkout, so the §3.1 class declaration stands unverified. Declared class: **restoration → `fix`** (adds no capability; `resizeEdgeZone` already existed in the operation vocabulary, classed `geometry` beside `resizeSplit` — this makes the defined restore behaviour reach it).

## AC Evidence

| AC | Evidence |
|---|---|
| AC-1 — a rail-only difference is reported | CI-covered: `DockTopologyDiff.spec.mjs` › `a rail drag is a reported change; the shape gate the differ runs on cannot see it`. The same arm asserts the two documents' shape fingerprints are equal, pinning why the differ had to be the instrument. |
| AC-2 — the planner emits a step | CI-covered: `DockRestorePlanner.spec.mjs` › `a rail drag plans a step and the round trip returns the captured width`. Asserts `deferred: false`, `reason: null`, `errors: []` **and** the exact one-step plan — the empty-triple shape is what made the defect silent, so the arm pins its absence rather than only the end value. |
| AC-3 — round trip returns the captured extent | CI-covered: same arm's tail — `restored.nodes.root.zones.left.extent` is `0.11`, and a re-diff against the capture is empty. |
| AC-4 — sub-epsilon drift is no change | CI-covered: `DockTopologyDiff.spec.mjs` › `extent epsilon: sub-epsilon drift is no change, and one tolerance governs both resize kinds`. Also pins that tightening `sizeEpsilon` tightens both categories, which is what keeps it one parameter. |
| AC-5 — an absent extent is not a change to zero | CI-covered: `DockTopologyDiff.spec.mjs` › `an absent extent is not a change to zero, on either side` — asserted in both directions, plus the `center`-has-none case. |
| AC-6 — `resizable` is not extent | CI-covered: `DockTopologyDiff.spec.mjs` › `resizable is a policy flag, not geometry: flipping it alone reports nothing`. |
| AC-7 — every existing arm green, unmodified | CI-covered + mechanical: full unit tier **3781 passed / 2 skipped / 0 failed**. No pre-existing arm was edited to pass; the Round-2 commit edits only arms this PR itself added (the three veto arms, to the stronger non-empty-plan shape). |
| AC-8 — mutation-verified, arms cover different failures | Outside-CI: **5**-mutant matrix in Test Evidence below, each redding a distinct set. |
| AC-9 — the docblock enumerates what the code returns | Reviewable in the diff: the class comment gains `edgeResizes` and the previously-absent `activeItemChanges`, plus a note on why the list is a maintenance obligation. Mechanically backstopped by `DockTopologyDiff.spec.mjs` › `the returned category set is pinned, because the class docblock drifted from it once`, which reds on the next category addition. |

## Deltas from ticket

**One addition the ticket did not anticipate, and it is the reason the planner arms are shaped as they are.** `Operations.resizeEdgeZone` has four refusals — `center`, a descriptor that is not exactly `resizable`, an `extent` outside `(0, 1)`, and an unresolvable descriptor. I found them only by reading the executor's guards to write the emit. The shape gate upstream already rejects the fourth; the planner must mirror the other three, because `applyRestorePlan` is fail-closed on the first error, so an unfiltered emit does not degrade to "the rail does not move" — it aborts every plan step after it. The filter reads the **live** descriptor, not the capture's, since that is the one the executor validates.

**I shipped two of those three in Round 1 and @neo-opus-vega measured the third.** The `(0, 1)` clause was missing, and a contract-illegal captured extent therefore stranded valid later steps. It is reachable because nothing in the persistence tier calls `WorkspaceDocument.validate` — a capture is trusted on shape, never on contract — so a value from another writer survives to the planner intact. None of this is in the ticket's AC list; it is in scope because without it the fix makes restore worse than the defect it repairs.

Nothing else. `setItemLocked` is invisible to the differ too — measured while probing, deliberately left out per the ticket's Out of Scope, and stated there rather than folded in silently.

## Test Evidence

Everything above runs in CI. What a green suite cannot show is whether the arms can fail, so the mutation matrix — five mutants at `3fba9fbd33`:

| mutant | red arms |
|---|---|
| M1 — the diff emit removed (`result.edgeResizes.push(…)` → no-op) | **8**: all 3 `TopologyDiff` extent arms + all 5 `RestorePlanner` extent arms |
| M2 — the planner emit removed (the whole `diff.edgeResizes.forEach` block) | **2**: both positive arms — the round trip and the reverse polarity |
| M3 — the whole executor-acceptance filter removed (`if (true)`) | **3**: all three veto arms |
| M4 — **only** the `(0, 1)` contract clause removed | **1**: `an out-of-contract captured extent is vetoed…` alone |
| M5 — the filter reads the **captured** descriptor instead of the live one | **2**: both polarity arms |

Each mutant reds a distinct set. Three of these are new and each answers a specific hole from the Round-1 review:

- **M4 isolates the RA-1 clause.** One clause out, exactly one arm red — the defect is guarded by an arm that fails for that reason and no other.
- **M5 is why RA-2's arm had to exist.** Before it, this mutant redded a single arm and the surviving one made a wrong-direction filter look correct. Now the pair pins the *direction*, not just the behaviour.
- **M2 went from 1 red to 2** for the same reason.

**The previous limit is closed.** The veto arms no longer assert `plan` is empty — `toEqual([])` cannot tell a working filter from a planner that emitted nothing for an unrelated reason. Each now carries a second, unrelated pending change (an auto-hide flip, which the planner orders after `edgeResizes`) and asserts the plan is **exactly that one step**: the rail absent, the valid step present *and applied*. That shape is @neo-opus-vega's, taken directly from his RA-1 probe.

Red-first was run for RA-1 before the fix: the new arm failed at `2c2c04aa4b` and passes at `3fba9fbd33`. Every mutant was applied to the committed tree and reverted with `git checkout -- src/`, so no mutation could be staged over the fix.

## Post-Merge Validation

- [ ] The Neural Link `diff_dock_topology` tool reports `edgeResizes` against a live workspace after a real rail drag. The tool is a pass-through to this differ with no local shaping, so the unit tier covers the computation; what merge adds is the live wiring.
- [ ] A perspective saved with non-default rails, dragged away from, and restored in the running Workstation returns the rails visually. `initialDocument` ships three resizable edges, so this is reachable in the app without a fixture.

## Commits

- `2c2c04aa4b` — the differ category, the planner emit with its executor-acceptance filter, both specs, and the docblock correction.
- `3fba9fbd33` — Round-1 review response: the `(0, 1)` contract clause on the filter (RA-1), the reverse-polarity arm (RA-2), the `sizeEpsilon` JSDoc on `src/ai/client/DockService.mjs` (RA-3), and the three veto arms rebuilt on the non-empty-plan shape.

---

Authored by Grace (Opus 5, Claude Code). Session e2441cf8-c250-4d78-b8c6-d6fa1624838c.
