### PR TITLE
feat(dock): a consumer vetoes a header action without taking it over (#18574)

### DIFF
--- a/src/dashboard/dock/projection/HeaderActionPolicy.mjs
+++ b/src/dashboard/dock/projection/HeaderActionPolicy.mjs
@@ -206,6 +206,12 @@ class HeaderActionPolicy extends Base {
      * MERGES: present keys update and omitted keys persist, so `{close: true}` meant as "close
      * allowed, everything else default" keeps every other veto the consumer believed it had just
      * dropped. `setData('dockActionPolicy.<action>', null)` is the way to lift one.
+     *
+     * `dockActionPolicy.<action>` is a BOOLEAN and must stay one. The policy is workspace-wide; a
+     * future per-node policy belongs on a sibling path (`dockActionPolicy.nodes.<nodeId>.<action>`,
+     * node-specific winning over workspace-wide over per-item), because widening this key into a
+     * record keyed by node id would turn every existing consumer's boolean read into a
+     * type-ambiguous one — an additive extension either way, or a migration if the type moves.
      * @param {String} nodeId The tabs node
      * @returns {Object} `{close, lock, maximize, pin, 'pop-out', reload}` → `{configKey: formatter}`
      */

--- a/src/dashboard/dock/projection/HeaderActionPolicy.mjs
+++ b/src/dashboard/dock/projection/HeaderActionPolicy.mjs
@@ -201,6 +201,11 @@ class HeaderActionPolicy extends Base {
      * only the owner provider's bindings when a new key appears. A late key is therefore latent
      * rather than rejected: it applies at the next evaluation some other leaf triggers. The same
      * hazard is why {@link #publishDocument} seeds the leaves a formatter reads before its first run.
+     *
+     * ⚠️ Clear a veto per LEAF, never by re-assigning the namespace object. Writing a partial object
+     * MERGES: present keys update and omitted keys persist, so `{close: true}` meant as "close
+     * allowed, everything else default" keeps every other veto the consumer believed it had just
+     * dropped. `setData('dockActionPolicy.<action>', null)` is the way to lift one.
      * @param {String} nodeId The tabs node
      * @returns {Object} `{close, lock, maximize, pin, 'pop-out', reload}` → `{configKey: formatter}`
      */

--- a/src/dashboard/dock/projection/HeaderActionPolicy.mjs
+++ b/src/dashboard/dock/projection/HeaderActionPolicy.mjs
@@ -179,26 +179,51 @@ class HeaderActionPolicy extends Base {
      * — no `dockReload()` contract and no recreate fallback — and disables while the item has a
      * flight. Each is the expression its projection constant and its former sync computed, in one
      * place.
+     *
+     * **The consumer's veto rides the same formulas, from a namespace this class never writes.**
+     * `dockActionPolicy.<action> === false` hides an engine action that the engine would otherwise
+     * show, and nothing else about it changes: the engine keeps the action's NAME and its behaviour.
+     * That separation is the point — `enableDock*Action` decides who OWNS an action (opting out
+     * frees the name for a host and stops `Workspace#onDockHeaderAction` routing the intent), which
+     * has to stay construction-time, while availability is runtime policy and belongs here. Without
+     * this read a consumer had one choice: accept the engine's per-item policy, or re-implement the
+     * action's whole behaviour to change one boolean.
+     *
+     * Reached through the hierarchy, not published here: `getData` resolves a key through
+     * {@link Neo.state.Provider#getOwnerOfDataProperty}, so an app declaring `dockActionPolicy` on
+     * its OWN provider reaches every workspace beneath it, and an unowned key reads `undefined`
+     * with the engine's policy left in charge. The `dock` namespace could not serve this —
+     * {@link #publishDocument} rewrites it from the committed document on every commit, so a
+     * consumer write there would survive until the next commit and then vanish.
+     *
+     * ⚠️ The key must be DECLARED, not assigned later. An `Effect` reading an absent key touches no
+     * `Config` and so registers no dependency on it, and `state.Provider#setConfigValue` re-runs
+     * only the owner provider's bindings when a new key appears. A late key is therefore latent
+     * rather than rejected: it applies at the next evaluation some other leaf triggers. The same
+     * hazard is why {@link #publishDocument} seeds the leaves a formatter reads before its first run.
      * @param {String} nodeId The tabs node
-     * @returns {Object} `{close, lock, pin, 'pop-out', reload}` → `{configKey: formatter}`
+     * @returns {Object} `{close, lock, maximize, pin, 'pop-out', reload}` → `{configKey: formatter}`
      */
     createActionBindings(nodeId) {
         const active = provider => provider.getData(`dock.nodes.${nodeId}.activeItemId`) || null,
-              field  = (provider, itemId, key) => provider.getData(`dock.items.${itemId}.${key}`);
+              field  = (provider, itemId, key) => provider.getData(`dock.items.${itemId}.${key}`),
+              // Strict `=== false`: absent, null and every other value leave the engine's own policy
+              // deciding, so a consumer publishing nothing sees byte-identical headers.
+              vetoed = (provider, action) => provider.getData(`dockActionPolicy.${action}`) === false;
 
         return {
             close: {
                 hidden() {
                     const itemId = active(this);
 
-                    return !itemId || field(this, itemId, 'closable') === false || field(this, itemId, 'locked') === true
+                    return vetoed(this, 'close') || !itemId || field(this, itemId, 'closable') === false || field(this, itemId, 'locked') === true
                 }
             },
             lock: {
                 hidden() {
                     const itemId = active(this);
 
-                    return !itemId || field(this, itemId, 'lockable') === false
+                    return vetoed(this, 'lock') || !itemId || field(this, itemId, 'lockable') === false
                 },
                 pressed() {
                     const itemId = active(this);
@@ -206,16 +231,24 @@ class HeaderActionPolicy extends Base {
                     return !!itemId && field(this, itemId, 'locked') === true
                 }
             },
+            // Visibility only. The plugin owns maximization itself (`plugin.Maximize#maximizedNodeId`),
+            // which is why this action projects no `pressed` formula and no active-item gate: every
+            // docked node can maximize, so the veto is the only thing that can hide it.
+            maximize: {
+                hidden() {
+                    return vetoed(this, 'maximize')
+                }
+            },
             pin: {
                 hidden() {
                     const itemId = active(this);
 
-                    return !itemId || field(this, itemId, 'pinnable') === false || !field(this, itemId, 'edge')
+                    return vetoed(this, 'pin') || !itemId || field(this, itemId, 'pinnable') === false || !field(this, itemId, 'edge')
                 }
             },
             'pop-out': {
                 hidden() {
-                    return !active(this) || this.getData('dock.popOutAvailable') !== true
+                    return vetoed(this, 'pop-out') || !active(this) || this.getData('dock.popOutAvailable') !== true
                 }
             },
             reload: {
@@ -227,7 +260,7 @@ class HeaderActionPolicy extends Base {
                 hidden() {
                     const itemId = active(this);
 
-                    return !itemId || (field(this, itemId, 'reloadable') !== true && this.getData('dock.recreateFallback') !== true)
+                    return vetoed(this, 'reload') || !itemId || (field(this, itemId, 'reloadable') !== true && this.getData('dock.recreateFallback') !== true)
                 }
             }
         }

--- a/src/dashboard/dock/projection/LayoutAdapter.mjs
+++ b/src/dashboard/dock/projection/LayoutAdapter.mjs
@@ -1231,9 +1231,13 @@ class LayoutAdapter extends Base {
             // maximization is runtime view state (`plugin.Maximize#maximizedNodeId`), never
             // persisted topology, so a projection cannot answer it and a boot config that claimed
             // to would be inventing one. The plugin writes the flag; the mapping is already here.
+            //
+            // `bind` carries the consumer veto and nothing else: this action has no per-item policy
+            // to compute, so its formatter is `dockActionPolicy.maximize` alone.
             ...(context.enableDockMaximizeAction ? [{
                 action            : 'maximize',
                 actionLabel       : 'maximize',
+                bind              : bindings.maximize,
                 iconCls           : context.dockMaximizeIconCls,
                 ntype             : 'toolbar-action-button',
                 pressedActionLabel: 'restore',

--- a/test/playwright/unit/dashboard/DockHeaderState.spec.mjs
+++ b/test/playwright/unit/dashboard/DockHeaderState.spec.mjs
@@ -577,9 +577,9 @@ test.describe('Neo.dashboard.dock.Workspace — the consumer\'s header-action ve
             expect(hiddenOf(), 'each one hides under its own veto').toEqual(ACTIONS);
 
             // The control that makes the assertion above mean something. Lifted per LEAF, because
-            // re-assigning the parent object (`setData('dockActionPolicy', {})`) does NOT clear the
-            // leaf paths already stored for it — measured here, and a consumer replacing its whole
-            // policy object would keep every earlier veto.
+            // assigning the namespace object MERGES rather than replaces: present keys update and
+            // omitted keys persist, so `{close: true}` leaves every other veto standing. Measured
+            // on both shapes — `{}` changes nothing, `{close: true}` updates close alone.
             ACTIONS.forEach(action => parent.setData(`dockActionPolicy.${action}`, null));
             expect(hiddenOf(), 'and with every veto lifted, not one of them hides').toEqual([])
         } finally {

--- a/test/playwright/unit/dashboard/DockHeaderState.spec.mjs
+++ b/test/playwright/unit/dashboard/DockHeaderState.spec.mjs
@@ -123,9 +123,14 @@ const createDocument = () => ({
     }
 });
 
-const ENGINE_KEYS = ['close.hidden', 'lock.hidden', 'lock.pressed', 'pin.hidden', 'pop-out.hidden', 'reload.disabled', 'reload.hidden'],
-      // The engine actions' seven formatters plus the node container's own lock binding.
-      NODE_KEYS   = [...ENGINE_KEYS, 'dockLockedItemIds'];
+const ENGINE_KEYS = ['close.hidden', 'lock.hidden', 'lock.pressed', 'maximize.hidden', 'pin.hidden', 'pop-out.hidden', 'reload.disabled', 'reload.hidden'],
+      // The engine actions' eight formatters plus the node container's own lock binding. `maximize`
+      // carries only the consumer veto: the plugin owns the toggle's own state.
+      NODE_KEYS   = [...ENGINE_KEYS, 'dockLockedItemIds'],
+      // The formatters that read the presented item. `maximize.hidden` is deliberately absent: it
+      // reads `dockActionPolicy.maximize` and nothing else, so an activation cannot re-run it —
+      // which is the dependency precision the counting instrument exists to prove.
+      ACTIVE_ITEM_KEYS = ENGINE_KEYS.filter(key => key !== 'maximize.hidden');
 
 const commit = (workspace, descriptor) => {
     const result = workspace.applyDockZoneOperation(descriptor);
@@ -160,7 +165,7 @@ test.describe('Neo.dashboard.dock.Workspace — header state as bound data', () 
 
         const expected = ['center-tabs', 'side-tabs'].flatMap(nodeId => NODE_KEYS.map(key => `${nodeId}:${key}`)).sort();
 
-        expect(evaluationsOf(workspace), 'eight formatters per node, each run once on creation').toEqual(expected);
+        expect(evaluationsOf(workspace), 'nine formatters per node, each run once on creation').toEqual(expected);
 
         const tabs   = Reconciler.collectProjectedTabs(workspace.items[0]),
               center = tabs.get('center-tabs');
@@ -225,7 +230,7 @@ test.describe('Neo.dashboard.dock.Workspace — header state as bound data', () 
         await center.set({activeIndex: 1});
 
         expect(evaluationsOf(workspace), 'every formatter of the switched header reads its active item')
-            .toEqual(ENGINE_KEYS.map(key => `center-tabs:${key}`).sort());
+            .toEqual(ACTIVE_ITEM_KEYS.map(key => `center-tabs:${key}`).sort());
         expect(close.hidden, 'beta is not closable').toBe(true);
         expect(reload.hidden, 'beta has no contract, but the engine recreate default serves it').toBe(false);
 
@@ -472,5 +477,134 @@ test.describe('Neo.dashboard.dock.Workspace — header state as bound data', () 
         expect(Object.hasOwn(pane.vdom, 'inert'), 'exact restore: the pane never owned inert').toBe(false);
         expect(pane.cls).not.toContain('neo-dock-pane-locked');
         expect(button.wrapperCls, 'unlock restores the drag token').toContain('neo-draggable')
+    })
+});
+
+const ACTIONS = ['close', 'lock', 'maximize', 'pin', 'pop-out', 'reload'];
+
+/**
+ * The consumer's veto. `dockActionPolicy.<action> === false` hides an engine action the
+ * engine would otherwise show, and changes NOTHING else: the name stays reserved and the intent
+ * still routes to the engine. The app declares the namespace on its OWN provider and the engine
+ * reads it through the ordinary hierarchy, so no engine config carries consumer policy.
+ *
+ * Before this, a consumer had two choices and the one it wanted was neither: accept the engine's
+ * per-item policy, or set `enableDock*Action: false` — which frees the action's NAME for a host
+ * and stops `onDockHeaderAction` routing the intent, so changing one boolean meant re-implementing
+ * the action's whole behaviour.
+ */
+test.describe('Neo.dashboard.dock.Workspace — the consumer\'s header-action veto (#18574)', () => {
+    let host, workspace;
+
+    /** The app's provider above the workspace's own, exactly where a consumer would declare policy. */
+    const hostWith = dockActionPolicy => {
+        host = Neo.create(Container, {
+            appName      : 'NeoDashboardDockHeaderStateTest',
+            stateProvider: {data: {dockActionPolicy}},
+            items        : [{module: HeaderStateWorkspace, dockModel: createDocument()}]
+        });
+
+        workspace = host.items[0];
+
+        return Reconciler.collectProjectedTabs(workspace.items[0]).get('center-tabs')
+    };
+
+    test.afterEach(() => {
+        host?.destroy();
+        host = workspace = null
+    });
+
+    test('a declared veto hides the engine action at first paint, with no commit and no re-projection', () => {
+        const center = hostWith({close: false});
+
+        expect(center.getAction('close').hidden, 'the veto hid close on the first run of its formatter').toBe(true);
+        expect(center.getAction('reload').hidden, 'an un-vetoed action is untouched').toBe(false);
+        expect(center.getAction('lock').hidden, 'so is lock').toBe(false);
+
+        // Ownership is unchanged — the whole point of not making the gate reactive. A vetoed action
+        // is hidden, not disowned: the engine still reserves the name and still routes the intent.
+        expect(workspace.enableDockCloseAction, 'the gate was never touched').toBe(true);
+        expect(workspace.onDockHeaderAction({action: 'close', dockNodeId: 'center-tabs', tabContainer: center})?.errors,
+            'the engine still owns the close intent while hiding the control').toEqual([])
+    });
+
+    test('the veto is a live datum: both directions land, and only the vetoed action moves', async () => {
+        const center   = hostWith({close: false, reload: true}),
+              close    = center.getAction('close'),
+              reload   = center.getAction('reload'),
+              provider = host.stateProvider;
+
+        expect(close.hidden, 'starts vetoed').toBe(true);
+
+        provider.setData('dockActionPolicy.close', true);
+        expect(close.hidden, 'lifting the veto restores the action').toBe(false);
+        expect(reload.hidden, 'and reaches no other action').toBe(false);
+
+        // Both halves visited: an arm that only turns policy off is testing its beforeEach.
+        provider.setData('dockActionPolicy.close', false);
+        expect(close.hidden, 'and it hides again').toBe(true);
+
+        // The per-item policy still owns its own axis underneath the veto.
+        provider.setData('dockActionPolicy.close', null);
+        expect(close.hidden, 'a null veto is not a veto — alpha is closable').toBe(false);
+
+        await center.set({activeIndex: 1});
+        expect(close.hidden, 'beta declares closable:false, which the veto never touched').toBe(true)
+    });
+
+    test('every engine action accepts the veto, and none of them hides without one', () => {
+        const parent = Neo.create(Provider, {data: {dockActionPolicy: Object.fromEntries(ACTIONS.map(action => [action, false]))}}),
+              // Seeded so that NO other leg of any formula can hide the action: an enumeration arm
+              // whose actions are hidden by a missing active item would pass with the veto deleted.
+              child  = Neo.create(Provider, {
+                  parent,
+                  data: {
+                      dock: {
+                          items           : {alpha: {closable: true, lockable: true, pinnable: true, edge: 'right', reloadable: true}},
+                          nodes           : {n: {activeItemId: 'alpha'}},
+                          popOutAvailable : true,
+                          recreateFallback: true
+                      }
+                  }
+              }),
+              policy = Neo.create(HeaderActionPolicy, {workspace: {stateProvider: child}});
+
+        try {
+            const bindings = policy.createActionBindings('n'),
+                  hiddenOf = () => ACTIONS.filter(action => bindings[action].hidden.call(child));
+
+            expect(Object.keys(bindings).sort(), 'all six actions carry a formatter').toEqual([...ACTIONS].sort());
+            expect(hiddenOf(), 'each one hides under its own veto').toEqual(ACTIONS);
+
+            // The control that makes the assertion above mean something. Lifted per LEAF, because
+            // re-assigning the parent object (`setData('dockActionPolicy', {})`) does NOT clear the
+            // leaf paths already stored for it — measured here, and a consumer replacing its whole
+            // policy object would keep every earlier veto.
+            ACTIONS.forEach(action => parent.setData(`dockActionPolicy.${action}`, null));
+            expect(hiddenOf(), 'and with every veto lifted, not one of them hides').toEqual([])
+        } finally {
+            policy.destroy();
+            child.destroy();
+            parent.destroy()
+        }
+    });
+
+    test('⚠️ a veto published AFTER the first run does not land, and lands silently on the next unrelated re-evaluation', async () => {
+        // The documented limitation, asserted rather than described. An Effect reading an ABSENT key
+        // touches no Config and so registers no dependency on it, and `setConfigValue` re-runs only
+        // the OWNER provider's bindings when a new key appears, so the veto is latent, not rejected.
+        const center = hostWith({}),
+              close  = center.getAction('close');
+
+        expect(close.hidden, 'alpha is closable and nothing is vetoed').toBe(false);
+
+        host.stateProvider.setData('dockActionPolicy.close', false);
+        expect(close.hidden, 'the late key is invisible to a formatter that never depended on it').toBe(false);
+
+        // Worse than inert, and the reason the declared path is the contract: the veto is not
+        // rejected, it is LATENT. Any later change to a leaf the formula does depend on applies it.
+        await center.set({activeIndex: 1});
+        await center.set({activeIndex: 0});
+        expect(close.hidden, 'an unrelated re-evaluation now applies a veto set two steps ago').toBe(true)
     })
 });

--- a/test/playwright/unit/dashboard/DockHeaderState.spec.mjs
+++ b/test/playwright/unit/dashboard/DockHeaderState.spec.mjs
@@ -603,6 +603,11 @@ test.describe('Neo.dashboard.dock.Workspace — the consumer\'s header-action ve
 
         // Worse than inert, and the reason the declared path is the contract: the veto is not
         // rejected, it is LATENT. Any later change to a leaf the formula does depend on applies it.
+        //
+        // The RETURN to index 0 is load-bearing and the arm is theatre without it: beta declares
+        // `closable: false`, so a `close.hidden` of true there proves nothing — the per-item policy
+        // produces it whether or not the veto works. Alpha IS closable, so only a working veto can
+        // hide close on it.
         await center.set({activeIndex: 1});
         await center.set({activeIndex: 0});
         expect(close.hidden, 'an unrelated re-evaluation now applies a veto set two steps ago').toBe(true)


### PR DESCRIPTION
Resolves #18574

🌿 A dock consumer can no longer be told that hiding one button costs owning its behaviour.

`dockActionPolicy.<action> === false` hides an engine header action, and nothing else about it changes. The engine keeps the action's name and `onDockHeaderAction` still routes the intent, so the app that wants *"the engine's close, hidden while this session is read-only"* stops having to re-implement `handleDockCloseAction` to express it. `HeaderActionPolicy` only ever **reads** the namespace: `state/Provider#getData` resolves up the hierarchy, so an app declares the policy on its own provider and every workspace beneath it follows. The `dock` namespace could not carry this — `publishDocument` rewrites it from the committed document each commit, so a consumer write there would survive until the next one and then vanish.

Evidence: L2 (unit tier — every veto AC is an assertion about a formatter's returned value and the `hidden` config it writes, both reachable in the single-thread harness) → L2 required (no close-target AC names a rendered pixel or a host handoff). AC-6's no-regression half is L3: the dock component tier in a real browser, 135/135 with those specs unmodified. Residual: none.

Micro-review eligible: no — it adds a public consumer contract to a shared projection class, and the ticket's original prescription was falsified before implementation.

`agent-preflight: not hosted here; baseline pr-body + substrate-size run in CI` — this checkout answers `npm error Missing script: "agent-preflight"` (it is Brain-hosted), so the §3.1 class declaration stands unverified rather than skipped: the class is **`feat`**, first match on the ladder, because the delta adds a reusable consumer-operable path that no bug motivated.

## AC Evidence

| AC | Evidence |
|---|---|
| AC-1 a declared veto hides a live projected action, no re-projection | CI-covered: `DockHeaderState.spec.mjs` — *a declared veto hides the engine action at first paint, with no commit and no re-projection*. The host declares `{close: false}` on its own provider; `close.hidden` is true with no commit, while `reload` and `lock` are untouched. Red on `dev`: the namespace is ignored there. |
| AC-2 the inverse arm restores it | CI-covered: *the veto is a live datum: both directions land, and only the vetoed action moves* — `false → true → false`, plus `null` (not a veto) and a per-item leg proving `closable: false` still owns its own axis underneath. |
| AC-3 the action still behaves as the engine's | CI-covered in AC-1's arm: `enableDockCloseAction` is still `true` and `onDockHeaderAction({action: 'close', …})` returns `errors: []` **while the action is vetoed** — the intent executes through `handleDockCloseAction`, so a veto is presentational, not a disownment. Stronger than the AC asked: it holds during the veto, not only after lifting it. |
| AC-4 a late-published key is covered by an arm | CI-covered: *⚠️ a veto published AFTER the first run does not land, and lands silently on the next unrelated re-evaluation*. Measured, not described — and the measurement made the limitation worse than the ticket predicted: the late veto is **latent**, not rejected. Two `activeIndex` changes later it applies. Asserted in both states. |
| AC-5 all six accept the namespace, by enumeration | CI-covered: *every engine action accepts the veto, and none of them hides without one*. All six vetoed → all six hide; then every veto lifted per leaf → **not one** hides. The provider is seeded (`activeItemId`, per-item fields, `popOutAvailable`, `recreateFallback`) precisely so no other leg of any formula can hide an action — without that seeding the arm would pass with the veto deleted. |
| AC-6 no policy ⇒ byte-identical headers; the named specs green unmodified | `DockLayoutAdapter.spec.mjs`, `DockLockAction.spec.mjs`, `DockWorkspace.spec.mjs` and the `dock-hostreload` component app are **untouched** by this diff (`git diff --stat`: one test file, `DockHeaderState.spec.mjs`) and green — unit 3772/3775, dock component tier 135/135. |
| AC-7 `Workspace.mjs` line count unchanged | `git diff --stat origin/dev` lists three files; `src/dashboard/dock/Workspace.mjs` is not among them. Zero lines, no configs, no methods — PR #18213's standing directive holds. |

## Deltas from ticket

**The ticket's prescription was falsified before a line was written, and the body was replaced.** I filed #18574 claiming pop-out was the shipped precedent for a reactive action gate, and prescribed making all six `enableDock*Action` configs reactive while deleting five `LayoutAdapter` branches. Three measurements killed it: `dockPopOutActionActive` is a **capability** predicate (`tearOutHandlers` + realm) and `LayoutAdapter:1220` still gates pop-out's existence on the plain config, so its opt-in is construction-time like the rest; the gate transfers ownership of the action **name** (`LayoutAdapter:1115`, throw at `:1139`), asserted by `DockLayoutAdapter.spec.mjs:266`, `:332-340` and a whole component app — so the deletion would have reddened them; and the consumer gap I asserted was overstated, because a host can already own the name and project its own action. The surviving gap is narrower and sharper: ownership and availability are one config, and only one of them should be construction-time. The full falsification is in the issue body, whose edit history holds the original text.

**`maximize` gained the only new `bind` key in `LayoutAdapter`.** It was the one engine action projecting no formatter at all, so a veto covering the other five would have recreated the exact asymmetry this closes. Its formatter is the veto alone — no `pressed`, no active-item gate — because `plugin.Maximize` owns maximization itself.

**Two existing evaluation-count arms moved, and one of them got sharper.** The counting instrument in `DockHeaderState.spec.mjs` enumerates formatters, so an eighth one is a real change to its census. The interesting half is the second arm: `maximize.hidden` was expected on an activation and **did not run**, because it reads only `dockActionPolicy.maximize`. That is dependency precision, so the arm now expects `ACTIVE_ITEM_KEYS` (the formatters that read the presented item) and the omission is documented rather than papered over. No arm's guarantee was weakened to fit the diff.

**A Provider semantic worth knowing, out of scope, noted in defect-note.** Re-assigning the parent object (`setData('dockActionPolicy', {})`) does **not** clear the leaf paths already stored beneath it — a consumer replacing its whole policy object keeps every earlier veto. Measured while building AC-5's control (which is why that control lifts vetoes per leaf). It is a `state.Provider` question, not this diff's, so it is a comment at the measurement site and a defect-note, not a ticket I invented.

## Test Evidence

All coverage runs in CI.

One honest bound on the full-suite run: `vdom/UpdateWedge.spec.mjs:291` (a watchdog-timeout arm) failed once in the 3775-test unit sweep and passed **3/3 in isolation**. This diff touches three files, none in `vdom/`, and the arm is a timing watchdog under suite load. Reported as a sighting rather than filed on n=1, matching how #18487's flake rate was handled.

## Post-Merge Validation

- [ ] A consumer app declaring `dockActionPolicy` on its own provider — the documented path is a **declared** key, since a late one is latent. Worth one line in #18036 when that guide lands.
- [ ] Whether the per-node axis is wanted: the namespace is per-workspace today. A consumer needing *"hide close on the inspector node only"* has no expression for it; raised with peers rather than pre-built.

## Commits

- `a7c068a302` — the veto read, the maximize binding, and the four arms.

## Evolution

The pivot is the whole story of this lane and it happened at the drift probe, not during implementation: the operator named #18574 as a high-ROI opener, and re-measuring my own ticket against `dev@d94be7d48d` showed its mechanism contradicted three guarded specs. Rewriting the ticket cost one turn; implementing the original would have cost a day and a reverted PR. The reusable lesson is the one @neo-opus-grace wrote the night before — *reading a sibling for the shape you came for is not auditing the sibling* — and F1 is that failure with my own name on it: I cited `popOutAvailable` as reactive-gate prior art inside the census that was supposed to be its audit.

Authored by Vega (Opus 5, Claude Code). Session f0184d21-3900-4091-87c0-c3aa4fde95ce.
