### PR TITLE
fix(component): a mermaid diagram resolves its theme through the component chain (#18580)

### DIFF
--- a/src/component/wrapper/Mermaid.mjs
+++ b/src/component/wrapper/Mermaid.mjs
@@ -129,9 +129,7 @@ class Mermaid extends Component {
         if (me.mounted && me.value) {
             await me.ready();
 
-            const
-                theme = me.mermaidTheme || me.themeMap[me.theme] || 'default',
-                code  = `---\nconfig:\n  theme: ${theme}\n---\n${me.value}`;
+            const code = `---\nconfig:\n  theme: ${me.resolveTheme()}\n---\n${me.value}`;
 
             await me.addon.render({
                 code,
@@ -139,6 +137,21 @@ class Mermaid extends Component {
                 windowId: me.windowId
             })
         }
+    }
+
+    /**
+     * @summary Maps this component's resolved theme onto one of mermaid's own theme names.
+     *
+     * Resolution goes through {@link Neo.component.Base#getTheme}, never the `theme` config, which is
+     * `null` for precisely the components that inherit a theme — reading it rendered mermaid's light
+     * `'default'` in a dark app on every path except a toggle. Shape:
+     * {@link Neo.component.wrapper.MonacoEditor#resolveEditorTheme}.
+     * @returns {String}
+     */
+    resolveTheme() {
+        let me = this;
+
+        return me.mermaidTheme || me.themeMap[me.getTheme()] || 'default'
     }
 }
 

--- a/src/component/wrapper/Mermaid.mjs
+++ b/src/component/wrapper/Mermaid.mjs
@@ -147,6 +147,7 @@ class Mermaid extends Component {
      * `'default'` in a dark app on every path except a toggle. Shape:
      * {@link Neo.component.wrapper.MonacoEditor#resolveEditorTheme}.
      * @returns {String}
+     * @protected
      */
     resolveTheme() {
         let me = this;

--- a/test/playwright/unit/component/MermaidTheme.spec.mjs
+++ b/test/playwright/unit/component/MermaidTheme.spec.mjs
@@ -111,6 +111,21 @@ test.describe('Neo.component.wrapper.Mermaid#resolveTheme', () => {
 
         expect(mermaid.getTheme(), 'the scope is dark').toBe('neo-theme-neo-dark');
         expect(mermaid.resolveTheme(), 'and the explicit value still wins').toBe('forest')
+    });
+
+    // The override is guarded by `||`, not `??`, and the empty string is the one value where those
+    // two disagree — so the choice is pinned here rather than left to whoever edits the line next.
+    // `??` would let `''` win and emit `theme: ` into the front matter, which is not a mermaid theme
+    // and renders nothing; falling through yields a diagram. The sibling resolvers use `??`, but on
+    // their FALLBACK rather than an override — neither declares a value-override config, and on the
+    // fallback the two operators cannot be told apart, because every map value is a non-empty string.
+    test('an empty mermaidTheme is not an override, and falls through to the resolved theme', () => {
+        instance = Neo.create(ThemedScope, {
+            appName,
+            items: [{module: Mermaid, mermaidTheme: '', reference: 'mermaid'}]
+        });
+
+        expect(instance.getReference('mermaid').resolveTheme()).toBe('dark')
     })
 });
 

--- a/test/playwright/unit/component/MermaidTheme.spec.mjs
+++ b/test/playwright/unit/component/MermaidTheme.spec.mjs
@@ -1,0 +1,195 @@
+/**
+ * @file test/playwright/unit/component/MermaidTheme.spec.mjs
+ * @summary Pins how a mermaid diagram answers which theme to draw in: through the component chain,
+ * from its declared map, and into the front matter the addon actually receives.
+ */
+
+import {setup} from '../../setup.mjs';
+
+setup({appConfig: {name: 'MermaidThemeTest'}});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../src/Neo.mjs';
+import * as core      from '../../../../src/core/_export.mjs';
+import Container      from '../../../../src/container/Base.mjs';
+import Mermaid        from '../../../../src/component/wrapper/Mermaid.mjs';
+
+// Imported for its side effect and named by nothing below: `manager/Instance.mjs:37` assigns
+// `Neo.get`, which `component/Abstract.mjs:369` needs to walk to a parent — and container teardown
+// walks it. Without this line every arm that nests a diagram in a scope passes and then throws in
+// `afterEach`, which reads as the arm's failure rather than the rig's.
+import '../../../../src/manager/Instance.mjs';
+
+const appName = 'MermaidThemeTest';
+
+/**
+ * @summary A container whose class default names a theme, so children inherit it through the
+ * class-default rung of item creation and carry no theme of their own — the shape the defect lived in.
+ */
+class ThemedScope extends Container {
+    static config = {
+        className: 'Neo.test.component.MermaidTheme.ThemedScope',
+        theme    : 'neo-theme-neo-dark'
+    }
+}
+
+ThemedScope = Neo.setupClass(ThemedScope);
+
+/**
+ * The mermaid theme each shipped Neo theme declares in `Mermaid#themeMap`. `neo-theme-cyberpunk` is
+ * the row that matters most: it is dark, and its name says nothing that a substring test could read.
+ * Note mermaid's light theme is named `default`, which is also the unmapped fallback — so the light
+ * rows and the fallback are asserted separately below rather than being read off one another.
+ */
+const SHIPPED_THEMES = [
+    ['neo-theme-cyberpunk', 'dark'],
+    ['neo-theme-dark',      'dark'],
+    ['neo-theme-light',     'default'],
+    ['neo-theme-neo-dark',  'dark'],
+    ['neo-theme-neo-light', 'default']
+];
+
+test.describe('Neo.component.wrapper.Mermaid#resolveTheme', () => {
+    let instance = null;
+
+    test.afterEach(() => {
+        instance?.destroy();
+        instance = null
+    });
+
+    SHIPPED_THEMES.forEach(([theme, mermaidTheme]) => {
+        test(`${theme} resolves ${mermaidTheme}`, () => {
+            instance = Neo.create(Mermaid, {appName, theme});
+
+            expect(instance.resolveTheme()).toBe(mermaidTheme)
+        })
+    });
+
+    test('a theme the map does not carry keeps the default, so shipping one cannot repaint a diagram', () => {
+        instance = Neo.create(Mermaid, {appName, theme: 'neo-theme-not-shipped-by-neo'});
+
+        expect(instance.resolveTheme()).toBe('default')
+    });
+
+    test('a diagram inside a themed scope answers the scope, while declaring no theme of its own', () => {
+        instance = Neo.create(ThemedScope, {
+            appName,
+            items: [{module: Mermaid, reference: 'mermaid'}]
+        });
+
+        const mermaid = instance.getReference('mermaid');
+
+        expect(mermaid.resolveTheme(), 'the scope decides').toBe('dark');
+
+        // Then the defect's own shape. `container.Base#afterSetTheme` stamps live items on a CHANGE
+        // and leaves construction to `createItem`, so on the paths where the config never lands it
+        // stays empty while the chain still knows the answer. Emptied explicitly because this tier
+        // has no markdown -> tab -> wrapper chain to build, and without it the arm witnesses only
+        // the mapping — the same trap `CanvasColorScheme.spec.mjs` records for the canvas family.
+        mermaid.theme = null;
+
+        expect(mermaid.theme, 'the config a diagram used to read is empty').toBeNull();
+        expect(mermaid.resolveTheme(), 'and the answer is unchanged').toBe('dark')
+    });
+
+    test('a diagram declaring its own theme is not overruled by the scope it sits in', () => {
+        instance = Neo.create(ThemedScope, {
+            appName,
+            items: [{module: Mermaid, reference: 'mermaid', theme: 'neo-theme-neo-light'}]
+        });
+
+        expect(instance.getReference('mermaid').resolveTheme()).toBe('default')
+    });
+
+    test('an explicit mermaidTheme wins over the resolved one, including a mermaid theme Neo never maps', () => {
+        instance = Neo.create(ThemedScope, {
+            appName,
+            items: [{module: Mermaid, mermaidTheme: 'forest', reference: 'mermaid'}]
+        });
+
+        const mermaid = instance.getReference('mermaid');
+
+        expect(mermaid.getTheme(), 'the scope is dark').toBe('neo-theme-neo-dark');
+        expect(mermaid.resolveTheme(), 'and the explicit value still wins').toBe('forest')
+    })
+});
+
+test.describe('a diagram hands the resolved theme to its addon', () => {
+    /**
+     * The rendered SVG is not reachable from here — mermaid draws it in the Main thread addon — so
+     * the front matter this component emits is the assertion boundary, and it is the value that was
+     * wrong. Reading the theme back out by pattern rather than `toContain`, because a substring test
+     * is how the sibling editor arm went green against a wrong value: `'vs-dark'.includes('vs')` is
+     * true, so the poll returned on its first evaluation while the editor was still dark.
+     * @param {String} code
+     * @returns {String|undefined}
+     */
+    const frontMatterTheme = code => code.match(/^---\nconfig:\n {2}theme: (.+)\n---\n/)?.[1];
+
+    let calls    = [],
+        instance = null;
+
+    test.beforeEach(() => {
+        calls = []
+    });
+
+    test.afterEach(() => {
+        instance?.destroy();
+        instance = null
+    });
+
+    /**
+     * Mounts one diagram inside a themed scope and returns the front matter of its FIRST render.
+     * @param {String} theme
+     * @returns {Promise<String|undefined>}
+     */
+    async function firstRenderTheme(theme) {
+        class Scope extends ThemedScope {
+            static config = {
+                className: `Neo.test.component.MermaidTheme.Scope.${theme}`,
+                theme
+            }
+        }
+
+        Neo.setupClass(Scope);
+
+        instance = Neo.create(Scope, {
+            appName,
+            items: [{module: Mermaid, reference: 'mermaid', value: 'graph TD;\n  A-->B;'}]
+        });
+
+        const mermaid = instance.getReference('mermaid');
+
+        // `initAsync` assigns the addon, so the double has to replace it afterwards or it is
+        // overwritten the moment the instance becomes ready.
+        await mermaid.ready();
+
+        // Empty the config FIRST, or this arm cannot fail on the resolution axis.
+        mermaid.theme = null;
+        mermaid.addon = {render: async data => {calls.push(data)}};
+
+        // Mounting is the first-render trigger, and the one path the theme config never reaches:
+        // `afterSetTheme` is the only trigger that carries a value, because it IS the new value.
+        mermaid.mounted = true;
+        await mermaid.timeout(1);
+
+        return frontMatterTheme(calls.at(-1)?.code)
+    }
+
+    test('the first render inside a dark scope is already dark, with no theme change in between', async () => {
+        expect(await firstRenderTheme('neo-theme-neo-dark')).toBe('dark')
+    });
+
+    // The mirror, and it is worth being exact about what it can and cannot catch. It separates a
+    // resolver from a constant `dark`, which the arm above cannot. It does NOT witness the
+    // resolution axis: under the defect `themeMap[null]` is `undefined` and the `||` answers
+    // `'default'` — the same value a correct light resolution returns — so this arm stays green
+    // against the very bug this file exists for. The dark arms are the discriminating ones.
+    test('and the first render inside a light scope is default', async () => {
+        expect(await firstRenderTheme('neo-theme-neo-light')).toBe('default')
+    });
+
+    test('a dark scope whose name says nothing still renders dark', async () => {
+        expect(await firstRenderTheme('neo-theme-cyberpunk')).toBe('dark')
+    })
+});


### PR DESCRIPTION
Resolves #18580

A mermaid diagram in a dark app now comes up dark. `render()` resolved its theme from the raw `theme` config, which is `null` for precisely the components that inherit one, so `themeMap[null]` fell through to `'default'` — mermaid's light palette. Resolution moves into `resolveTheme()` and goes through `getTheme()`, matching `MonacoEditor#resolveEditorTheme` and `Canvas#resolveColorScheme`; this was the fourth component with the defect and the only one left reading the config.

Evidence: L3 (rendered computed styles on the live dark portal tutorial route, local Chromium, with a paired pre-fix control on the same rig) → L3 required (AC-7's boundary is the emitted front matter; no AC requires cross-browser or operator-gated verification). No residuals.

`agent-preflight: not hosted here` — this checkout has no `ai/` tree and `npm run agent-preflight` exits `Missing script`; baseline pre-commit jobs ran (10/10 green, including `check-ticket-archaeology`, `check-jsdoc-types`, `check-parse`). Change class declared per §3.1: **`fix`** — restoration, not capability. `resolveTheme()` is a named extraction of logic that already ran inline in `render()`; it adds no path a consumer could not already reach.

Micro-review eligible: no — the diff is one token of behaviour, but the concept-bearing surface is a new `@protected` resolver plus the reasoning about which arms can fail.

## AC Evidence

| AC | Evidence |
|---|---|
| AC-1 resolves through `getTheme()`, never the config | CI-covered: `test/playwright/unit/component/MermaidTheme.spec.mjs` — the scope arms, plus AC-8's mutation which reds them |
| AC-2 five shipped themes map correctly | CI-covered: same file, five parameterized `<theme> resolves <mermaidTheme>` arms |
| AC-3 themed scope, own config emptied, still resolves | CI-covered: `a diagram inside a themed scope answers the scope, while declaring no theme of its own` |
| AC-4 own theme not overruled by scope | CI-covered: `a diagram declaring its own theme is not overruled by the scope it sits in` |
| AC-5 explicit `mermaidTheme` still wins | CI-covered: `an explicit mermaidTheme wins over the resolved one, including a mermaid theme Neo never maps` |
| AC-6 unmapped theme falls back to `default` | CI-covered: `a theme the map does not carry keeps the default, so shipping one cannot repaint a diagram` |
| AC-7 front matter carries the theme on FIRST render | CI-covered: `the first render inside a dark scope is already dark, with no theme change in between` + the cyberpunk arm |
| AC-8 mutation receipt, byte-identical restore | Outside-CI: see Test Evidence |

## Deltas from ticket

**One AC-7 arm cannot fail on the axis the ticket assumed, and the spec now says so in place.** The light-scope first-render arm stays GREEN under the mutant: under the defect `themeMap[null]` answers `'default'`, which is also what a correct light resolution returns. So that arm separates a resolver from a hardcoded `dark` and nothing more — it cannot witness the resolution axis at all. The dark arms are the discriminating ones. Recorded next to the arm rather than left for a future reader to count as coverage it does not provide.

**Evidence went past the ticket's plan.** #18580 specified unit arms and a mutation receipt. Because the mechanism claim ("mermaid honours the front matter") was still composed rather than measured, this branch also took a live paired control on the production route — see Test Evidence. That independently reproduces @neo-opus-grace's pre-fix numbers on a different rig before showing the resolution.

**A contract decision rides in the second commit, and it belongs here rather than only in a spec comment.** `resolveTheme()` guards the override with `||`, not `??`, and the empty string is the one value where those disagree: under `??` a `mermaidTheme: ''` **wins** and emits `theme: ` into the front matter — not a mermaid theme, renders nothing. Under `||` it falls through to the resolved theme and yields a diagram. `||` was pre-existing and is preserved deliberately; `8e0b33b4b3` makes that choice load-bearing with an arm rather than incidental. The sibling resolvers use `??`, but on their **fallback** link — neither declares a value-override config, and on a fallback the two operators are indistinguishable because every map value is a non-empty string. Surfaced by @neo-opus-vega in review.

**The resolver is `@protected`, matching both precedents its docblock cites.** `MonacoEditor#resolveEditorTheme:383` and `Canvas#resolveColorScheme:182` are both `@protected`, and nothing outside the class calls `resolveTheme()` — the spec calls it directly, but so does `CanvasColorScheme.spec.mjs` for its `@protected` sibling, so that is not a reason for public API. #18580's Contract Ledger row is corrected accordingly. Raised by @neo-opus-grace in review; there was no consumer in mind, so the family convention decided it.

**One import exists for a side effect and is named by nothing.** `manager/Instance.mjs` assigns `Neo.get` at `:37`, which `component/Abstract.mjs:369` needs for the parent walk that container teardown performs. I dropped it from the lifted spec as unused and every nested arm passed and then threw in `afterEach`, reading as the arm's failure rather than the rig's. It is back, with a comment saying why, so the next reader does not remove it the same way.

## Test Evidence

**Live paired control**, both legs on this rig, same route (`#/learn/tutorials/DockLayoutsFirstLayout`), `document.body` = `neo-theme-neo-dark` in both:

| | resolver reads `me.theme` (defect) | resolver reads `getTheme()` (this PR) |
|---|---|---|
| rendered node fill | `rgb(236, 236, 255)` | **`rgb(31, 32, 32)`** |
| label colour | `rgb(51, 51, 51)` | **`rgb(204, 204, 204)`** |
| generated style block carries `fill:#333` | `true` | **`false`** |

The left column reproduces @neo-opus-grace's `dev` measurement value-for-value, independently, before the fix was applied — so the two legs differ only in the resolver. Taken with a throwaway probe against the e2e harness, deleted after the receipt; the Browser pane cannot boot this app at all (worker scripts fail to fetch), which @neo-opus-vega had already recorded.

**Mutation receipt (AC-8), re-taken at the current head rather than carried forward.** Reverting the resolver to `me.themeMap[me.theme]` reds **3 of 13** arms — scope resolution, the dark first-render payload, and the cyberpunk first render. Restored byte-identically, `sha256 c1538dafe4ecd708273f36d4ed392eac4e5658004317ff9657b5e8a81025eaaf` before and after, tree verified clean. Done through the `replace` tool, not `sed -i`.

**Second receipt, for the operator choice:** flipping both `||` to `??` reds the empty-`mermaidTheme` arm and **only** that arm, 12/13.

Unit tier, full: **0 failed**, 2 skipped, at `64b7ad0536`. Static enumeration is `Total: 3800 tests in 356 files`, so 3798 passed accounts for every one; @neo-opus-grace measured 3798 twice independently.

*I first reported 3797 here, and it was wrong rather than differently-conditioned — one test unaccounted for against the enumeration. I cannot reconstruct which, because I read that run with `tail -3` and the evidence is gone. That is the sharper version of the lesson: this receipt **did** name its head and still went off, so a SHA is necessary and not sufficient. An absolute pass-count is a property of the whole tree and of the window the reader took, and neither is fixed by the branch head. Hence the mutant results above are stated as `3 of 13` and `1 of 13` with the arms named — re-derivable by anyone, unlike a total that is only checkable by someone standing exactly where I stood.*

## Post-Merge Validation

- [ ] Confirm on the published portal that the dark route renders dark. Both legs above ran against the dev server's source modules; mermaid ships as a bundle, and while the front matter is emitted component-side and is build-independent, that composition is the one step here still argued rather than measured.

## Commits

- `40edb12e71` — the resolver, the spec, and the archaeology.
- `8e0b33b4b3` — pins the override operator, since the empty string is where `||` and `??` part.
- `64b7ad0536` — the resolver is `@protected`, matching both precedents it cites.

Rebased onto `dev@1c1ac5769e` before re-requesting review, so the head under review is current rather than churned mid-review. Pre-rebase SHAs were `4dd3419b84` / `f5ab46f1e4` / `913967d797`.

Out of scope, and noted rather than silently left: the five theme rows are now declared in three places — `component/Canvas.mjs:50`, `wrapper/Mermaid.mjs:40`, `wrapper/MonacoEditor.mjs:134` — across four consumer classes. That is an architectural change on another maintainer's surface, routed to @neo-opus-vega with the sizing and her own stated shape; a one-token defect fix should not wait behind a three-file refactor. Also settled twice and deliberately not revisited: exposing `--neo-color-scheme` to the App Worker. `Main#resolveThemeColorScheme:1211` is `getComputedStyle()`, main-thread only and off the `app` remote manifest, and #18432 superseded that prescription before it was implemented.

Authored by Ada (Opus 5, Claude Code). Session 0478b26b-cf8d-45c8-98d1-7c974776d895.
