### PR TITLE
fix(dashboard): a restore skips steps the executor would refuse, so one bad value cannot strand the plan (#18585)

### DIFF
--- a/src/dashboard/dock/persistence/RestorePlanner.mjs
+++ b/src/dashboard/dock/persistence/RestorePlanner.mjs
@@ -146,6 +146,10 @@ class RestorePlanner extends Base {
         //     accepts `pinnable: false` beside `autoHidden: true` (it checks the type only), while
         //     `normalizeSplitSizes` and `setItemAutoHidden` refuse both.
         //
+        // So NEITHER the shape gate nor `validate` predicts what the executor takes, and a
+        // validate-on-load boundary would leave the second reason untouched. The reducers' own
+        // predicates are the only honest source, which is what these filters mirror.
+        //
         // These predicates deliberately MIRROR the executor's rather than sharing them: keeping
         // `planRestore` a pure fold — no executor round-trip to decide what to plan — is worth the
         // duplication. But the duplication is real and unlinked. A refusal added to any of the three

--- a/src/dashboard/dock/persistence/RestorePlanner.mjs
+++ b/src/dashboard/dock/persistence/RestorePlanner.mjs
@@ -43,9 +43,11 @@ class RestorePlanner extends Base {
      * split resizes → edge-zone resizes → auto-hide flips; `adds` lead when present). `removes` are NOT
      * destroyed — restore never deletes — they surface as a `surplus` list the cross-topology dual consumes.
      *
-     * Not every reported change becomes a step: `edgeResizes` is filtered to what the executor accepts,
-     * so a zone the app has since made non-resizable is reported by the differ and skipped here rather
-     * than planned into a step that would fail the whole application.
+     * Not every reported change becomes a step: each value-bearing category is filtered to what the
+     * executor accepts, so a zone the app has since made non-resizable, a split size outside the
+     * reducer's domain, or an auto-hide of an unpinnable pane is reported by the differ and skipped
+     * here rather than planned into a step that would fail the whole application. A skipped step is
+     * never an error — the differ reports document truth, this planner emits only what can run.
      * @param {Object} current  The live committed document.
      * @param {Object} captured The captured layout document to restore toward.
      * @returns {{deferred: Boolean, reason: (String|null), plan: Object[], surplus: Object[], errors: String[]}}
@@ -126,29 +128,41 @@ class RestorePlanner extends Base {
         diff.activeItemChanges.forEach(({nodeId, to}) =>
             plan.push({operation: 'setActiveItem', tabsNodeId: nodeId, itemId: to}));
 
-        diff.resizes.forEach(({nodeId, toSizes}) =>
-            plan.push({operation: 'resizeSplit', splitNodeId: nodeId, sizes: [...toSizes]}));
+        // The three value-bearing categories emit only what the executor will accept, and the rule
+        // for each is the same: cover the refusals the shape gate upstream does not. Predicates read
+        // `current`, never the capture, because the live document is the one the executor validates —
+        // reading the capture's would emit a step it then rejects, and suppress one it would accept.
+        //
+        // Why a filter and not a best effort: `applyRestorePlan` is fail-closed on the first error,
+        // so ONE unusable step strands every later one, including steps with no relationship to it.
+        // The failure is not "the rail does not move" but "the restore silently did almost nothing".
+        //
+        // A value gets here unusable for two different reasons, and both are measured:
+        //   - contract-ILLEGAL and unchecked — nothing in the persistence tier calls
+        //     `WorkspaceDocument.validate`, so an out-of-range extent from another writer
+        //     (hand-authored, an older schema, edited storage) arrives intact.
+        //   - contract-LEGAL and refused anyway — the contract and the reducers are different sets.
+        //     `validate` accepts a split `sizes: [0, 1]` (it checks the sum, not the elements) and
+        //     accepts `pinnable: false` beside `autoHidden: true` (it checks the type only), while
+        //     `normalizeSplitSizes` and `setItemAutoHidden` refuse both.
+        //
+        // These predicates deliberately MIRROR the executor's rather than sharing them: keeping
+        // `planRestore` a pure fold — no executor round-trip to decide what to plan — is worth the
+        // duplication. But the duplication is real and unlinked. A refusal added to any of the three
+        // reducers will not surface here, and the arms in `DockRestorePlanner.spec.mjs` are the only
+        // thing that would catch it.
 
-        // Only the steps the executor will accept. `Operations.resizeEdgeZone` has four refusals;
-        // the shape gate upstream already rejects one of them (an unresolvable descriptor fails
-        // `computeShapeFingerprint`, so no plan is built at all), and the three below are this
-        // filter's scope: a non-edge `center`, a descriptor that is not exactly `resizable`, and an
-        // `extent` outside the open interval `(0, 1)`. The permission and the edge are read off the
-        // LIVE document because that is the descriptor the executor validates — reading the
-        // capture's would emit a step the executor then rejects, and suppress one it would accept.
-        //
-        // Missing ANY of the three is not "the rail does not move". `applyRestorePlan` is
-        // fail-closed on the first error, so one unusable step strands every later one — a valid
-        // auto-hide flip queued behind an illegal rail simply never runs. The `(0, 1)` clause
-        // matters because nothing in the persistence tier calls `WorkspaceDocument.validate`: a
-        // capture is trusted on shape and never on contract, so a contract-illegal value from
-        // another writer (hand-authored, an older schema, edited storage) reaches here intact.
-        //
-        // This predicate deliberately mirrors the executor's rather than sharing it. Keeping the
-        // planner a PURE fold — no executor round-trip to decide what to plan — is worth the
-        // duplication, but the duplication is real and unlinked: a fifth refusal added to
-        // `Operations.resizeEdgeZone` will not surface here, and the arms in
-        // `DockRestorePlanner.spec.mjs` are what would catch it.
+        // `resizeSplit` rejects a non-finite or non-positive element; every-element-positive also
+        // gives `normalizeSplitSizes` the finite positive total it requires.
+        diff.resizes.forEach(({nodeId, toSizes}) => {
+            if (toSizes.every(size => Number.isFinite(size) && size > 0)) {
+                plan.push({operation: 'resizeSplit', splitNodeId: nodeId, sizes: [...toSizes]})
+            }
+        });
+
+        // `resizeEdgeZone` rejects `center` (not one of the four resizable edges), a descriptor that
+        // is not exactly `resizable`, and an extent outside the open interval `(0, 1)`. Its fourth
+        // refusal — an unresolvable descriptor — is the one the shape gate already catches.
         diff.edgeResizes.forEach(({nodeId, edge, to}) => {
             if (edge !== 'center' && to > 0 && to < 1 &&
                 current.nodes?.[nodeId]?.zones?.[edge]?.resizable === true
@@ -157,8 +171,17 @@ class RestorePlanner extends Base {
             }
         });
 
-        diff.autoHideFlips.forEach(({itemId, to}) =>
-            plan.push({operation: 'setItemAutoHidden', itemId, autoHidden: to}));
+        // `setItemAutoHidden` rejects a non-pinnable item — in BOTH directions, since it gates on
+        // `pinnable` before it looks at the value — and rejects auto-hiding a pinned one. A pane the
+        // app has since unpinned from the rail keeps its live visibility rather than taking the
+        // restore down with it, the same degradation the edge-zone filter above chooses.
+        diff.autoHideFlips.forEach(({itemId, to}) => {
+            const item = current.items?.[itemId];
+
+            if (item && item.pinnable !== false && !(to && item.pinned === true)) {
+                plan.push({operation: 'setItemAutoHidden', itemId, autoHidden: to})
+            }
+        });
 
         // Restore never destroys: an item current holds that the capture doesn't surfaces as surplus, not a delete.
         let surplus = diff.removes.map(({itemId, from}) => ({itemId, from}));

--- a/src/dashboard/dock/persistence/RestorePlanner.mjs
+++ b/src/dashboard/dock/persistence/RestorePlanner.mjs
@@ -128,38 +128,19 @@ class RestorePlanner extends Base {
         diff.activeItemChanges.forEach(({nodeId, to}) =>
             plan.push({operation: 'setActiveItem', tabsNodeId: nodeId, itemId: to}));
 
-        // The three value-bearing categories emit only what the executor will accept, and the rule
-        // for each is the same: cover the refusals the shape gate upstream does not. Predicates read
-        // `current`, never the capture, because the live document is the one the executor validates —
-        // reading the capture's would emit a step it then rejects, and suppress one it would accept.
-        //
-        // Why a filter and not a best effort: `applyRestorePlan` is fail-closed on the first error,
-        // so ONE unusable step strands every later one, including steps with no relationship to it.
-        // The failure is not "the rail does not move" but "the restore silently did almost nothing".
-        //
-        // A value gets here unusable for two different reasons, and both are measured:
-        //   - contract-ILLEGAL and unchecked — nothing in the persistence tier calls
-        //     `WorkspaceDocument.validate`, so an out-of-range extent from another writer
-        //     (hand-authored, an older schema, edited storage) arrives intact.
-        //   - contract-LEGAL and refused anyway — the contract and the reducers are different sets.
-        //     `validate` accepts a split `sizes: [0, 1]` (it checks the sum, not the elements) and
-        //     accepts `pinnable: false` beside `autoHidden: true` (it checks the type only), while
-        //     `normalizeSplitSizes` and `setItemAutoHidden` refuse both.
-        //
-        // So NEITHER the shape gate nor `validate` predicts what the executor takes, and a
-        // validate-on-load boundary would leave the second reason untouched. The reducers' own
-        // predicates are the only honest source, which is what these filters mirror.
-        //
-        // These predicates deliberately MIRROR the executor's rather than sharing them: keeping
-        // `planRestore` a pure fold — no executor round-trip to decide what to plan — is worth the
-        // duplication. But the duplication is real and unlinked. A refusal added to any of the three
-        // reducers will not surface here, and the arms in `DockRestorePlanner.spec.mjs` are the only
-        // thing that would catch it.
+        // Only steps the executor will accept: `applyRestorePlan` is fail-closed, so one refused step
+        // strands every later one, and neither the shape gate nor `WorkspaceDocument.validate` predicts
+        // acceptance — a legal `sizes: [0, 1]`, or `pinnable: false` beside `autoHidden: true`, is
+        // still refused, and nothing in this tier validates a capture at all. Predicates read `current`,
+        // the document the executor validates. `planRestore` stays a pure fold: where a reducer exposes
+        // its acceptance as a pure function it is asked; where it does not, its refusals are restated
+        // here, and the arms in `DockRestorePlanner.spec.mjs` are what would catch a new one.
 
-        // `resizeSplit` rejects a non-finite or non-positive element; every-element-positive also
-        // gives `normalizeSplitSizes` the finite positive total it requires.
+        // `resizeSplit` accepts exactly what `normalizeSplitSizes` accepts, counted against the LIVE split.
         diff.resizes.forEach(({nodeId, toSizes}) => {
-            if (toSizes.every(size => Number.isFinite(size) && size > 0)) {
+            const count = current.nodes?.[nodeId]?.children?.length ?? 0;
+
+            if (!WorkspaceDocument.normalizeSplitSizes(toSizes, count, nodeId).errors.length) {
                 plan.push({operation: 'resizeSplit', splitNodeId: nodeId, sizes: [...toSizes]})
             }
         });
@@ -175,10 +156,8 @@ class RestorePlanner extends Base {
             }
         });
 
-        // `setItemAutoHidden` rejects a non-pinnable item — in BOTH directions, since it gates on
-        // `pinnable` before it looks at the value — and rejects auto-hiding a pinned one. A pane the
-        // app has since unpinned from the rail keeps its live visibility rather than taking the
-        // restore down with it, the same degradation the edge-zone filter above chooses.
+        // `setItemAutoHidden` refuses a non-pinnable item in BOTH directions (it gates on `pinnable`
+        // before the value) and refuses auto-hiding a pinned one; the pane keeps its live visibility.
         diff.autoHideFlips.forEach(({itemId, to}) => {
             const item = current.items?.[itemId];
 

--- a/test/playwright/unit/dashboard/DockRestorePlanner.spec.mjs
+++ b/test/playwright/unit/dashboard/DockRestorePlanner.spec.mjs
@@ -466,6 +466,35 @@ function flagDoc({sizes = [0.6, 0.4], autoHidden = false, pinnable, activeItemId
 }
 
 /**
+ * The unrelated valid step each arm carries, chosen by PLAN POSITION — the planner orders
+ * `activeItems → resizes → edgeResizes → autoHideFlips`, so which survivor is honest depends on
+ * where the refused step sits.
+ */
+const SURVIVOR = {
+    /**
+     * Downstream of `resizes`. This is the step a refused resize actually STRANDS, which is the
+     * harm — an upstream survivor would have applied before the executor ever reached the bad step
+     * and would prove only that the step was filtered, never that nothing was stranded.
+     */
+    afterResizes: {
+        step : {operation: 'setItemAutoHidden', itemId: 'terminal', autoHidden: true},
+        read : document => document.items.terminal.autoHidden,
+        value: true
+    },
+    /**
+     * Upstream. `autoHideFlips` is the LAST category, so a refused flip strands nothing behind it
+     * and no downstream survivor exists to offer; the harm there is the reported error plus the
+     * unapplied flip. Recorded here rather than left as an unexplained difference between the two
+     * arm families.
+     */
+    beforeValues: {
+        step : {operation: 'setActiveItem', tabsNodeId: 'main-tabs', itemId: 'swarm'},
+        read : document => document.nodes['main-tabs'].activeItemId,
+        value: 'swarm'
+    }
+};
+
+/**
  * @summary Asserts an unusable step is skipped WITHOUT taking the rest of the plan with it.
  *
  * The defect these arms exist for is not a wrong value — it is `applied: 0` on a restore that
@@ -475,17 +504,17 @@ function flagDoc({sizes = [0.6, 0.4], autoHidden = false, pinnable, activeItemId
  * only that the unusable field is untouched would pass on a planner that emitted nothing at all.
  * @param {Object} current
  * @param {Object} captured
+ * @param {Object} survivor One of {@link SURVIVOR}
  * @returns {Object} the restore receipt, for per-case assertions
  */
-function expectSkippedButPlanStillRuns(current, captured) {
+function expectSkippedButPlanStillRuns(current, captured, survivor) {
     const receipt = DockRestorePlanner.restoreToward(current, captured);
 
     expect(receipt.deferred).toBe(false);
     expect(receipt.errors, 'a skipped step is never a restore error').toEqual([]);
-    expect(receipt.plan, 'exactly the unrelated valid step — and NOT an empty plan')
-        .toEqual([{operation: 'setActiveItem', tabsNodeId: 'main-tabs', itemId: 'swarm'}]);
+    expect(receipt.plan, 'exactly the unrelated valid step — and NOT an empty plan').toEqual([survivor.step]);
     expect(receipt.applied, 'the valid step still ran').toBe(1);
-    expect(receipt.document.nodes['main-tabs'].activeItemId).toBe('swarm');
+    expect(survivor.read(receipt.document), 'and its effect reached the document').toBe(survivor.value);
 
     return receipt
 }
@@ -495,8 +524,8 @@ test.describe('DockRestorePlanner — steps the executor would refuse (#18585)',
         // `[0, 1]` sums to 1 and matches the children count, so `WorkspaceDocument.validate` accepts
         // it — the document is legal. `normalizeSplitSizes` additionally requires every element > 0,
         // so `resizeSplit` refuses it. The two are different sets and this capture sits between them.
-        const captured = flagDoc({sizes: [0, 1], activeItemId: 'swarm'}),
-              current  = flagDoc({sizes: [0.6, 0.4]});
+        const captured = flagDoc({sizes: [0, 1],     autoHidden: true}),
+              current  = flagDoc({sizes: [0.6, 0.4], autoHidden: false});
 
         expect(WorkspaceDocument.validate(captured),
             'the premise: the document contract accepts this capture').toEqual([]);
@@ -504,18 +533,18 @@ test.describe('DockRestorePlanner — steps the executor would refuse (#18585)',
             'and the differ reports it, because document truth is not reducer acceptance')
             .toEqual([{nodeId: 'root', fromSizes: [0.6, 0.4], toSizes: [0, 1]}]);
 
-        const {document: restored} = expectSkippedButPlanStillRuns(current, captured);
+        const {document: restored} = expectSkippedButPlanStillRuns(current, captured, SURVIVOR.afterResizes);
 
         expect(restored.nodes.root.sizes, 'the live split is left where it was').toEqual([0.6, 0.4])
     });
 
     test('a non-finite split size is skipped on the same axis', () => {
-        const captured = flagDoc({sizes: [Number.NaN, 1], activeItemId: 'swarm'}),
-              current  = flagDoc({sizes: [0.6, 0.4]});
+        const captured = flagDoc({sizes: [Number.NaN, 1], autoHidden: true}),
+              current  = flagDoc({sizes: [0.6, 0.4],       autoHidden: false});
 
         // `NaN` fails the reducer's finiteness check rather than its positivity check, so this pins
         // the other half of one clause — `Number.isFinite(size) && size > 0` needs both.
-        expectSkippedButPlanStillRuns(current, captured);
+        expectSkippedButPlanStillRuns(current, captured, SURVIVOR.afterResizes);
     });
 
     test('an auto-hide the reducer refuses is skipped: unpinnable panes keep their live visibility', () => {
@@ -529,7 +558,7 @@ test.describe('DockRestorePlanner — steps the executor would refuse (#18585)',
         expect(DockTopologyDiff.diffDockDocuments(current, captured).autoHideFlips)
             .toEqual([{itemId: 'terminal', from: false, to: true}]);
 
-        const {document: restored} = expectSkippedButPlanStillRuns(current, captured);
+        const {document: restored} = expectSkippedButPlanStillRuns(current, captured, SURVIVOR.beforeValues);
 
         expect(restored.items.terminal.autoHidden, 'the pane stays visible rather than aborting the restore').toBe(false)
     });
@@ -541,7 +570,7 @@ test.describe('DockRestorePlanner — steps the executor would refuse (#18585)',
         captured.items.terminal.pinned = true;
         current.items.terminal.pinned  = true;
 
-        expectSkippedButPlanStillRuns(current, captured);
+        expectSkippedButPlanStillRuns(current, captured, SURVIVOR.beforeValues);
     });
 
     test('the inverse halves: a legal size and a legal auto-hide still plan and apply', () => {
@@ -572,6 +601,6 @@ test.describe('DockRestorePlanner — steps the executor would refuse (#18585)',
         expect(DockTopologyDiff.diffDockDocuments(current, captured).autoHideFlips)
             .toEqual([{itemId: 'terminal', from: true, to: false}]);
 
-        expectSkippedButPlanStillRuns(current, captured);
+        expectSkippedButPlanStillRuns(current, captured, SURVIVOR.beforeValues);
     })
 });

--- a/test/playwright/unit/dashboard/DockRestorePlanner.spec.mjs
+++ b/test/playwright/unit/dashboard/DockRestorePlanner.spec.mjs
@@ -538,12 +538,34 @@ test.describe('DockRestorePlanner — steps the executor would refuse (#18585)',
         expect(restored.nodes.root.sizes, 'the live split is left where it was').toEqual([0.6, 0.4])
     });
 
-    test('a non-finite split size is skipped on the same axis', () => {
-        const captured = flagDoc({sizes: [Number.NaN, 1], autoHidden: true}),
-              current  = flagDoc({sizes: [0.6, 0.4],       autoHidden: false});
+    test('a non-finite element is skipped, and the arm sees finiteness rather than positivity', () => {
+        // `Infinity > 0` holds, so a planner checking positivity alone would emit this step and the
+        // executor would refuse it. `NaN` cannot make that distinction: it fails `> 0` as well.
+        const captured = flagDoc({sizes: [Number.POSITIVE_INFINITY, 1], autoHidden: true}),
+              current  = flagDoc({sizes: [0.6, 0.4],                    autoHidden: false});
 
-        // `NaN` fails the reducer's finiteness check rather than its positivity check, so this pins
-        // the other half of one clause — `Number.isFinite(size) && size > 0` needs both.
+        expectSkippedButPlanStillRuns(current, captured, SURVIVOR.afterResizes);
+    });
+
+    test('a size count that does not match the live split is skipped', () => {
+        // `[1]` passes every per-element check — finite, positive — and the reducer refuses it on
+        // count against the split's children. The count is read from the LIVE split; the shape gate
+        // upstream is what guarantees it equals the capture's.
+        const captured = flagDoc({sizes: [1],        autoHidden: true}),
+              current  = flagDoc({sizes: [0.6, 0.4], autoHidden: false});
+
+        expect(DockTopologyDiff.diffDockDocuments(current, captured).resizes, 'the differ reports the length change as a resize')
+            .toEqual([{nodeId: 'root', fromSizes: [0.6, 0.4], toSizes: [1]}]);
+
+        expectSkippedButPlanStillRuns(current, captured, SURVIVOR.afterResizes);
+    });
+
+    test('finite positive elements whose total overflows are skipped: the sum is the reducer\'s own clause', () => {
+        // Each element passes finiteness and positivity on its own; their sum is `Infinity`, which
+        // `normalizeSplitSizes` refuses. A mirror of the per-element checks alone emits this step.
+        const captured = flagDoc({sizes: [Number.MAX_VALUE, Number.MAX_VALUE], autoHidden: true}),
+              current  = flagDoc({sizes: [0.6, 0.4],                           autoHidden: false});
+
         expectSkippedButPlanStillRuns(current, captured, SURVIVOR.afterResizes);
     });
 

--- a/test/playwright/unit/dashboard/DockRestorePlanner.spec.mjs
+++ b/test/playwright/unit/dashboard/DockRestorePlanner.spec.mjs
@@ -436,3 +436,142 @@ test.describe('DockRestorePlanner — edge-zone extents (#18579)', () => {
         expect(plan, 'a no-op step is a spurious commit').toEqual([])
     })
 });
+
+/**
+ * A split-rooted document whose side pane can carry the flags and whose split can carry the sizes
+ * these arms need. Separate from `doc()` because that fixture pins sizes and declares no item flags,
+ * and the whole point here is a capture whose VALUES the document contract accepts.
+ * @param {Object} [config]
+ * @returns {Object}
+ */
+function flagDoc({sizes = [0.6, 0.4], autoHidden = false, pinnable, activeItemId = 'strategy'} = {}) {
+    const terminal = {reference: 'terminal', title: 'Terminal', autoHidden};
+
+    if (pinnable !== undefined) { terminal.pinnable = pinnable }
+
+    return {
+        schema: 'neo.dock.zone.v1',
+        root  : 'root',
+        items : {
+            strategy: {reference: 'strategy', title: 'Strategy'},
+            swarm   : {reference: 'swarm',    title: 'Swarm'},
+            terminal
+        },
+        nodes: {
+            root       : {type: 'split', orientation: 'horizontal', children: ['main-tabs', 'side-tabs'], sizes},
+            'main-tabs': {type: 'tabs', items: ['strategy', 'swarm'], activeItemId},
+            'side-tabs': {type: 'tabs', items: ['terminal'], activeItemId: 'terminal'}
+        }
+    }
+}
+
+/**
+ * @summary Asserts an unusable step is skipped WITHOUT taking the rest of the plan with it.
+ *
+ * The defect these arms exist for is not a wrong value — it is `applied: 0` on a restore that
+ * reported no error worth acting on, because `applyRestorePlan` is fail-closed and one refused step
+ * strands every later one. So each case carries a second, unrelated pending change and asserts the
+ * plan is exactly that step: the unusable one absent, the valid one present AND applied. Asserting
+ * only that the unusable field is untouched would pass on a planner that emitted nothing at all.
+ * @param {Object} current
+ * @param {Object} captured
+ * @returns {Object} the restore receipt, for per-case assertions
+ */
+function expectSkippedButPlanStillRuns(current, captured) {
+    const receipt = DockRestorePlanner.restoreToward(current, captured);
+
+    expect(receipt.deferred).toBe(false);
+    expect(receipt.errors, 'a skipped step is never a restore error').toEqual([]);
+    expect(receipt.plan, 'exactly the unrelated valid step — and NOT an empty plan')
+        .toEqual([{operation: 'setActiveItem', tabsNodeId: 'main-tabs', itemId: 'swarm'}]);
+    expect(receipt.applied, 'the valid step still ran').toBe(1);
+    expect(receipt.document.nodes['main-tabs'].activeItemId).toBe('swarm');
+
+    return receipt
+}
+
+test.describe('DockRestorePlanner — steps the executor would refuse (#18585)', () => {
+    test('a split size the CONTRACT accepts and the reducer refuses is skipped, not planned', () => {
+        // `[0, 1]` sums to 1 and matches the children count, so `WorkspaceDocument.validate` accepts
+        // it — the document is legal. `normalizeSplitSizes` additionally requires every element > 0,
+        // so `resizeSplit` refuses it. The two are different sets and this capture sits between them.
+        const captured = flagDoc({sizes: [0, 1], activeItemId: 'swarm'}),
+              current  = flagDoc({sizes: [0.6, 0.4]});
+
+        expect(WorkspaceDocument.validate(captured),
+            'the premise: the document contract accepts this capture').toEqual([]);
+        expect(DockTopologyDiff.diffDockDocuments(current, captured).resizes,
+            'and the differ reports it, because document truth is not reducer acceptance')
+            .toEqual([{nodeId: 'root', fromSizes: [0.6, 0.4], toSizes: [0, 1]}]);
+
+        const {document: restored} = expectSkippedButPlanStillRuns(current, captured);
+
+        expect(restored.nodes.root.sizes, 'the live split is left where it was').toEqual([0.6, 0.4])
+    });
+
+    test('a non-finite split size is skipped on the same axis', () => {
+        const captured = flagDoc({sizes: [Number.NaN, 1], activeItemId: 'swarm'}),
+              current  = flagDoc({sizes: [0.6, 0.4]});
+
+        // `NaN` fails the reducer's finiteness check rather than its positivity check, so this pins
+        // the other half of one clause — `Number.isFinite(size) && size > 0` needs both.
+        expectSkippedButPlanStillRuns(current, captured);
+    });
+
+    test('an auto-hide the reducer refuses is skipped: unpinnable panes keep their live visibility', () => {
+        // `validate` requires `autoHidden` to be a boolean and says nothing about `pinnable`, so a
+        // pane declared `pinnable: false, autoHidden: true` is a legal document. `setItemAutoHidden`
+        // refuses to auto-hide a non-pinnable item, which is the second divergence, not the same one.
+        const captured = flagDoc({autoHidden: true,  pinnable: false, activeItemId: 'swarm'}),
+              current  = flagDoc({autoHidden: false, pinnable: false});
+
+        expect(WorkspaceDocument.validate(captured), 'legal document, refused step').toEqual([]);
+        expect(DockTopologyDiff.diffDockDocuments(current, captured).autoHideFlips)
+            .toEqual([{itemId: 'terminal', from: false, to: true}]);
+
+        const {document: restored} = expectSkippedButPlanStillRuns(current, captured);
+
+        expect(restored.items.terminal.autoHidden, 'the pane stays visible rather than aborting the restore').toBe(false)
+    });
+
+    test('a pinned pane is not auto-hidden either, and that refusal is the reducer\'s own', () => {
+        const captured = flagDoc({autoHidden: true, activeItemId: 'swarm'}),
+              current  = flagDoc({autoHidden: false});
+
+        captured.items.terminal.pinned = true;
+        current.items.terminal.pinned  = true;
+
+        expectSkippedButPlanStillRuns(current, captured);
+    });
+
+    test('the inverse halves: a legal size and a legal auto-hide still plan and apply', () => {
+        // The control that makes every arm above mean something. Same fixtures, values inside both
+        // the contract AND the reducer's domain: the steps must be planned, not filtered.
+        const sized = DockRestorePlanner.restoreToward(flagDoc({sizes: [0.6, 0.4]}), flagDoc({sizes: [0.25, 0.75]}));
+
+        expect(sized.errors).toEqual([]);
+        expect(sized.plan).toEqual([{operation: 'resizeSplit', splitNodeId: 'root', sizes: [0.25, 0.75]}]);
+        expect(sized.applied).toBe(1);
+        expect(sized.document.nodes.root.sizes).toEqual([0.25, 0.75]);
+
+        const hidden = DockRestorePlanner.restoreToward(flagDoc({autoHidden: false}), flagDoc({autoHidden: true}));
+
+        expect(hidden.errors).toEqual([]);
+        expect(hidden.plan).toEqual([{operation: 'setItemAutoHidden', itemId: 'terminal', autoHidden: true}]);
+        expect(hidden.applied).toBe(1);
+        expect(hidden.document.items.terminal.autoHidden).toBe(true)
+    });
+
+    test('un-hiding an unpinnable pane is skipped too: the reducer refuses BOTH directions', () => {
+        // Not symmetry for its own sake — `setItemAutoHidden` gates on `pinnable` before it looks at
+        // the value, so `autoHidden: false` is refused for an unpinnable item exactly as `true` is. A
+        // filter written as `!(to && …)` alone would let this one through and abort the restore.
+        const captured = flagDoc({autoHidden: false, pinnable: false, activeItemId: 'swarm'}),
+              current  = flagDoc({autoHidden: true,  pinnable: false});
+
+        expect(DockTopologyDiff.diffDockDocuments(current, captured).autoHideFlips)
+            .toEqual([{itemId: 'terminal', from: true, to: false}]);
+
+        expectSkippedButPlanStillRuns(current, captured);
+    })
+});


### PR DESCRIPTION
Resolves #18585

🌿 A restore can no longer report one field's problem and quietly abandon everything queued behind it.

`applyRestorePlan` is fail-closed on the first error, so a single step the executor refuses strands every later one — including steps with no relationship to it. The edge-zone category got an acceptance filter with the rail-width fix (#18581); its two siblings never did, and both have a reachable refusal. `resizes` → `resizeSplit` refuses what `normalizeSplitSizes` refuses: a size count that does not match the split's children, a non-finite or non-positive element, a total that is not finite and positive. `autoHideFlips` → `setItemAutoHidden` rejects an unpinnable item in **both** directions and rejects auto-hiding a pinned one. None of the offending values is contract-illegal, which is the part that makes this a pattern rather than a field.

Evidence: L2 (unit tier — every AC is an assertion about the plan the planner emits and the receipt applying it returns, both reachable in the single-thread harness) → L2 required (no AC names a rendered surface or a host effect). Residual: none.

`agent-preflight: not hosted here; baseline pr-body + substrate-size run in CI` — this checkout answers `npm error Missing script: "agent-preflight"`, so the §3.1 class declaration stands unverified rather than skipped: the class is **`fix`**, second on the ladder — it adds no consumer-operable path, it restores defined behaviour.

Micro-review eligible: no — it changes what a public planner emits, on a surface a peer's PR touched an hour before it opened.

## The measurement that changed the ticket

I filed #18585 claiming the substrate was *"a capture is trusted on shape and never on contract — nothing in the persistence tier calls `WorkspaceDocument.validate`"*, and committed to measuring whether `extent` was the only divergent field before writing a line. **`validate` accepts both failing documents.** The boundary I was about to propose would have caught neither.

| plan category | reducer | filter before this PR | divergence | reachable? |
|---|---|---|---|---|
| `resizes` | `resizeSplit` | **none** | contract checks the SUM; `normalizeSplitSizes` additionally wants a size per live child, every element finite and `> 0`, and a finite positive total | **yes — measured**, and the review measured two more members of the same set |
| `autoHideFlips` | `setItemAutoHidden` | **none** | contract checks the TYPE; reducer additionally refuses `pinnable === false` | **yes — measured** |
| `edgeResizes` | `resizeEdgeZone` | 3 conditions (#18581) | contract and reducer agree | no — guarded |
| `activeItemChanges` | `setActiveItem` | differ emits only a listed member | — | no — guarded upstream |
| — | `setItemPinned`, `setItemLocked` | n/a | both refuse `pinnable`/`lockable === false`, which the contract permits | **no — no plan category emits them** |

That last row is why the sweep had to be a measurement rather than a list: two of the five divergences cannot be reached from a restore plan at all, and "fixing" them would have been ceremony.

## AC Evidence

| AC | Evidence |
|---|---|
| AC-1 neither bad value aborts the restore, and a valid queued step still runs | CI-covered: *a split size the CONTRACT accepts and the reducer refuses is skipped, not planned*, its three siblings on the same axis (a non-finite element, a mismatched count, an overflowing total) and *an auto-hide the reducer refuses is skipped: unpinnable panes keep their live visibility*. All go through `expectSkippedButPlanStillRuns`, which asserts the plan is **exactly** the one unrelated valid step, `applied: 1`, and that step's effect present on the restored document. The survivor is chosen by plan position: the split arms use an auto-hide flip, which sits **downstream** of `resizes` and is therefore the step a refused resize actually strands. An arm asserting only that the bad field is untouched passes on a planner that emitted nothing. |
| AC-2 red-first | Round 1: `git checkout origin/dev -- RestorePlanner.mjs` with the spec kept: **5 failed / 18 passed**. Round 2, the three new arms against the round-one filter: **2 failed / 23 passed** — the count arm and the overflow arm, exactly the review's two counterexamples; the `Infinity` arm was already green because the round-one clause caught it. |
| AC-3 legal values still plan and apply | CI-covered: *the inverse halves: a legal size and a legal auto-hide still plan and apply* — a `[0.25, 0.75]` resize and an ordinary auto-hide both reach `applied: 1` with the effect asserted on the document. |
| AC-4 mutation receipt | Round 2 on the repaired head: normalizer not asked (`if (true \|\| …)`) → **4** red, all four resize arms; the capture counts itself (`count = toSizes.length`) → **1** red, the count arm alone. Round 1's auto-hide mutants stand: whole filter → **3** red; only the `pinnable` check → **2** red with the pinned arm green, so the two `setItemAutoHidden` refusals are covered by different arms. |
| AC-5 the chosen shape is stated with its reason | Shape (1), filter at the planner. The comment states the rule (only steps the executor will accept), why (fail-closed application; neither the shape gate nor `validate` predicts acceptance), the live-document authority, and the pure-fold trade-off: where a reducer exposes its acceptance as a pure function it is asked — `resizeSplit` does, through `normalizeSplitSizes`, so that category no longer mirrors anything — and where it does not, the refusals are restated and the spec's arms are what would catch a new one. The ticket's sweep says why shape (2) was rejected: reconciling would teach the contract that `pinnable: false` forbids `autoHidden: true`, a rule no document has had to satisfy. |
| AC-6 both reachable divergences fixed, sweep in the PR body | Both filtered; the sweep is the table above, run before implementation. |
| AC-7 existing arms green unmodified | The spec diff is a pure append plus the two shared helpers; every pre-existing arm including #18581's five is untouched and green. `DockRestorePlanner.spec.mjs` 25/25 at the head; the round-one full unit tier was 3791 passed / 2 skipped / 0 failed, and the round-two delta touches this spec only. |

## Deltas from ticket

**The scope doubled before implementation, because AC-6 was run first.** #18585 was filed on the split-size instance with the item-flag divergences labelled as unmeasured candidates. Running the sweep turned one of them into a second defect with its own control, and turned two others into measured non-reachability. The ticket body carries the sweep and the title changed from one category to *"two of three value-bearing plan categories"*.

**I restructured the comment PR #18581 added rather than adding beside it.** That block was ~20 lines justifying one filter; three filters with that prose tripled would have failed the added-comments-over-added-code test. Round 2 compressed it further, to the durable rule, the live-document authority, the pure-fold trade-off and the drift warning, after the review counted 39 comment lines against 11 code lines; this file's added lines now stand at 13 comment to 17 code.

**My first arm shape proved the wrong thing, and a review note on #18581's helper is what surfaced it.** The note offered #18581's `expectRailVetoedButPlanStillRuns` so the two filters' arms would not drift into different notions of "vetoed". Checking whether they could share it is what made me look at the survivor step — the planner orders `activeItems → resizes → edgeResizes → autoHideFlips`, so my split arms' `setActiveItem` survivor sat **upstream** of the refused step and proved only that the step was filtered, never that nothing was stranded. The survivor is now chosen by plan position, and the asymmetry is stated in the spec: `autoHideFlips` is the last category, so its arms have no downstream survivor to offer and the harm there is the reported error plus the unapplied flip.

**The #18581 comment's reachability explanation is corrected here rather than in a follow-up PR**, because this diff rewrites that block. Its `(0, 1)` justification is sound for the extent case — `validate` does reject `extent: 1.5` — but as an *explanation of reachability* it points the next reader at a validate-on-load boundary that would not catch the sibling case one line above it. The block now states both reasons.

**One arm exists for a filter I did not write.** `setItemAutoHidden` gates on `pinnable` *before* it looks at the value, so `autoHidden: false` is refused for an unpinnable item exactly as `true` is. A filter written as `!(to && item.pinned === true)` alone would let the un-hide through and abort the restore — the `pinnable`-only mutant is that filter, and *un-hiding an unpinnable pane is skipped too* is the arm that catches it.

## Test Evidence

All coverage runs in CI.

The red-first and mutation receipts above are outside CI by construction — they require reverting or mutating source. Each was run at this branch's content with the spec unchanged, and the implementation was restored from the committed head and re-verified green after every mutant.

## Post-Merge Validation

- [ ] Whether `addTab` / `moveItem` have divergences of their own. The sweep covered the value-bearing categories; the membership categories emit ids rather than values, and I did not measure their reducers. Not a gap this PR leaves open — a question it did not ask.
- [ ] Whether the two mirrored predicates that remain (`resizeEdgeZone`, `setItemAutoHidden`) want the treatment `resizeSplit` now has — a pure acceptance function on the reducer's side the planner can ask. A different ticket.

## Commits

- `6f1a7fbf23` — both filters, the hoisted comment, and six arms.
- `e95a94d4fe` — the survivor repointed downstream of the refused step, plus the clause correcting the reachability explanation.
- `e945d189a3` — the resize filter asks `normalizeSplitSizes` instead of mirroring two of its four clauses; three arms replace the `NaN` arm; the comment block compressed.

## Evolution

The pivot is that the ticket's premise was wrong and its own AC caught it. I filed on *"trusted on shape, never on contract"*, and the rule from earlier that day — *a reframing is not a falsifier; name the measurement that changed* — is why AC-6 existed as a blocking sweep rather than a note. Running it before implementation produced a second defect, two measured non-reachabilities, and the argument that settles the fix shape.

Round 2 is the same lesson one layer down. The round-one filter mirrored two of `normalizeSplitSizes`' four clauses and claimed completeness; the review's two counterexamples (`[1]` on a two-child split, `[MAX_VALUE, MAX_VALUE]`) were members of the same set I had enumerated for the auto-hide reducer and not for this one. The repair stops mirroring where a pure acceptance function exists: the planner asks the reducer's own normalizer, so a fifth clause added there reaches the planner without anyone remembering to copy it.

Authored by Vega (Opus 5, Claude Code). Session f0184d21-3900-4091-87c0-c3aa4fde95ce. Round 2 by Vega (Fable 5.1, Claude Code), session c4a95308-109e-4761-a8a0-50f84debf222.
