### PR TITLE
test(grid): the blank-frame assertion reports which branch blanked, not just how many (#18587)

### DIFF
--- a/test/playwright/e2e/grid/ThumbDragPause.spec.mjs
+++ b/test/playwright/e2e/grid/ThumbDragPause.spec.mjs
@@ -219,6 +219,23 @@ test.describe('Desktop (1920x1080): BigData Grid Paused Thumb Drag Pinning', () 
         // pushed clean out of the viewport while the worker chases a jump nothing is holding.
         const blankFrames = [...pauseSamples, ...postSamples].filter(sample => !sample.painted);
 
-        expect(blankFrames.length, 'no frame blanked during or after the pause').toBe(0)
+        // `painted` is false through two structurally different branches — `rowCount === 0`, meaning
+        // no rows in the DOM at all, versus rows present but outside the wrapper band, the pooled
+        // case above. They predict different relationships to machine speed, so a bare count cannot
+        // tell a repeat of one from a repeat of the other, and the sampler already collects the
+        // field that separates them. `RowPinning.spec.mjs` logs its blank detail to stdout; putting
+        // it on the assertion instead prints it in the failure block rather than burying it.
+        const blankDetail = () => {
+            const byRowCount = {},
+                  times      = blankFrames.map(sample => sample.t);
+
+            blankFrames.forEach(sample => {
+                byRowCount[sample.rowCount] = (byRowCount[sample.rowCount] || 0) + 1
+            });
+
+            return ` — rowCount→frames ${JSON.stringify(byRowCount)}, spanning ${Math.round(Math.max(...times) - Math.min(...times))}ms`
+        };
+
+        expect(blankFrames.length, `no frame blanked during or after the pause${blankFrames.length ? blankDetail() : ''}`).toBe(0)
     })
 });


### PR DESCRIPTION
Resolves #18587

`grid/ThumbDragPause.spec.mjs` has failed twice in CI and reported `Received: 10` both times, and the repeat has been unreadable — not because the phenomenon is mysterious, but because the assertion collapsed two structurally different failure branches into one integer and discarded the field that separates them. The sampler was already collecting it. A failure now names the `rowCount` distribution of the blank frames and their `t` span.

Evidence: L3 (the arm executed against the live BigData grid, with the reporting path exercised under a deliberately inverted predicate) → L3 required (AC-5 asks that the message render with real values; no AC needs cross-browser or operator-gated verification). No residuals.

`agent-preflight: not hosted here` — this checkout has no `ai/` tree and `npm run agent-preflight` exits `Missing script` (verified without `--silent`, which hides it); baseline pre-commit jobs ran green. Change class per §3.1: **`test`** — zero-delta. The predicate, threshold, and pass/fail set are unchanged; only what a failure says about itself moves.

Micro-review eligible: no — the diff is small, but the concept-bearing surface is *which* discriminator survives into a failure, which is the whole point of the change.

## AC Evidence

| AC | Evidence |
|---|---|
| AC-1 a failure names the `rowCount` distribution and `t` span | Outside-CI: see Test Evidence — rendered message captured under a forced failure |
| AC-2 `rowCount: 0` vs `rowCount > 0` distinguishable from the message alone | `rowCount→frames {"42":177}` names the branch directly; a branch-(a) failure renders `{"0":N}`. The two are the two possible shapes of the same field |
| AC-3 a passing run's message is unchanged | The detail is behind `blankFrames.length ? … : ''`, so an empty set appends the empty string. Arm green post-change with the original message path |
| AC-4 predicate and threshold unchanged | The diff touches no filter and no `toBe(0)`; `git diff` is the assertion message plus one helper |
| AC-5 ⚠️ the reporting path is proven to execute | Outside-CI: see Test Evidence — this is the AC the file's own history demanded |

## Deltas from ticket

**None substantive.** The ticket prescribed the distribution plus the span on the assertion message; that is what shipped.

One judgement made inside that scope: the detail renders as `rowCount→frames {"42":177}, spanning 2939ms` rather than a per-sample dump. A 10-frame failure would print 10 objects and a 177-frame one would flood the log — the distribution is the smallest thing that answers the branch question, which is the trade the ticket's Avoided Traps names.

## Test Evidence

**AC-5's receipt, and it is the one that mattered.** An instrument that reports nothing on failure is worse than none, so I did not take the message on faith. Inverting the filter to `sample.painted` — selecting painted frames, guaranteeing a non-empty set — forced the arm to fail and rendered:

```
Error: no frame blanked during or after the pause — rowCount→frames {"42":177}, spanning 2939ms
Expected: 0
Received: 177
```

That is the branch-(b) shape with real values: 177 frames all carrying 42 rows, spread over 2.9s. A branch-(a) failure renders `{"0":N}` from the same code path, since `rowCount` is read from the same field. Filter restored, arm green, tree clean.

**Local runs**, all on `36cbf5d4b3` off `dev@454c27e5c8`: the arm alone green; earlier on the parent tree the same arm was green 3/3 alone, the whole `e2e/grid` directory green 2/2, and the full CI tier path (`colors core dashboard grid rendering/…`) green at 38 passed / 3 skipped. Those exclusion runs belong to #18439's investigation rather than to this diff, and are cited here only because they are the reason this ticket exists.

## Post-Merge Validation

- [ ] The next `ThumbDragPause` sighting in CI names its `rowCount` distribution. That is the change's entire purpose and it cannot be verified before a failure occurs — the arm is green on demand and red only under conditions this branch cannot reproduce. If the next sighting renders `{"0":N}`, #18439's `Received: 10` repeat is structural; `{"N>0":…}` makes it a viewport-band case. Either reading closes a question that two prior sightings could not.

## Commits

- `36cbf5d4b3` — the discriminator on the assertion message, and the receipt that it renders.

Related: #18439 — the intermittency this makes readable. It stays **open**; this PR fixes an instrument, not a defect, and closes nothing there.

Authored by Ada (Opus 5, Claude Code). Session 0478b26b-cf8d-45c8-98d1-7c974776d895.
