### PR TITLE
feat(workstation): the topology bar says where you stand, and a reset returns the shipped arrangement (#18553)

### DIFF
--- a/apps/workstation/view/Workspace.mjs
+++ b/apps/workstation/view/Workspace.mjs
@@ -446,12 +446,9 @@ class Workspace extends DockWorkspace {
             items : [
                 {ntype: 'button', handler: 'saveTopology',  text: 'Save workspace'},
                 {ntype: 'button', handler: 'closeTopology', text: 'Close workspace'},
-                // Handled on the view rather than by controller name, like undo and redo above it:
-                // the state, the shipped document and the commit seam all live on the view, and a
-                // controller method would only forward. Disabled on the shipped arrangement so the
-                // control answers "there is nothing to go back to" instead of committing a no-op
-                // history row — and it reads the SAME derived key as the readout, so the button and
-                // the line beside it can never disagree about whether the user has left the default.
+                // Handled on the view, like undo and redo above it: the state, the shipped document
+                // and the commit seam all live here. Disabled on the shipped arrangement, reading the
+                // SAME derived key as the readout, so control and line cannot disagree.
                 {
                     ntype  : 'button',
                     bind   : {disabled: data => !data.topology.modified},
@@ -459,10 +456,8 @@ class Workspace extends DockWorkspace {
                     iconCls: 'fa fa-rotate-left',
                     text   : 'Reset to default'
                 },
-                // Reads the derived keys rather than recomputing: the diff runs once per committed
-                // document at its writer, not once per binding evaluation. Both bindings go through
-                // the one static formatter so the visibility test and the text can never disagree
-                // about whether there is something to say.
+                // Both bindings go through the one formatter, so the visibility test and the text
+                // cannot disagree about whether there is anything to say.
                 {
                     ntype: 'component',
                     bind : {
@@ -508,52 +503,16 @@ class Workspace extends DockWorkspace {
      * their multi-window setup, not one window's panes. So a pane torn out into a second window IS
      * a departure from the shipped arrangement, which ships exactly one workspace.
      *
-     * **But that is a second fact, not the same one, and collapsing them made the readout lossy.**
-     * An earlier revision returned a single Boolean and answered `true` on any extra key *before*
-     * the differ ran. Two costs, and the second is worse than the first: a user whose main document
-     * genuinely matches the default was told they had "modified" it, and the document that actually
-     * matched was never compared at all — so the answer was not merely coarse, it was unmeasured.
-     * It also made reset look broken: reset commits the shipped document and deliberately leaves
-     * other windows standing ({@link Neo.dashboard.dock.window.TopologySeams#commitDockTopologyWorkspaces}
-     * refuses a commit that does not name every registered key, and retiring a window is neither
-     * synchronous nor guaranteed), so the readout lit up the instant the user pressed it.
+     * **These are two facts, not one.** A pane torn into a second window IS a departure from the
+     * shipped arrangement, which ships a single workspace — but it is a different departure from the
+     * named document having changed, and collapsing them loses the half a user can act on. Window
+     * geometry needs no third test: popup placement hints are measured relative to main, so any hint
+     * worth comparing already implies a second workspace.
      *
-     * Reported separately, both halves stay true and the user can act on each: the named document
-     * is at the default or it is not, and N windows stand beyond the one the app ships. Rendering
-     * is {@link Workspace.topologyStateText}'s problem, not this method's.
-     *
-     * The question is a COMPARISON, not a dirty flag: a flag set on the first operation never
-     * clears when the user undoes back to the start, while a comparison recomputed from live state
-     * does, for free.
-     *
-     * Per document, `TopologyDiff.diffDockDocuments` is the comparator rather than
-     * `computeShapeFingerprint`, whose own docblock states it carries "no node ids, item ids,
-     * sizes, titles or window identity" — shape-only by contract, so it reads a dragged boundary, a
-     * reordered tab and a switched pane as unchanged. Those are the operations this workspace is
-     * FOR. Categories are read off the returned object rather than listed here: the differ's class
-     * comment stood at seven while the code returned eight, so a hand-copied list under-reports
-     * exactly where the documentation has drifted.
-     *
-     * **Window geometry needs no separate test here, and the reason is the shipped arrangement
-     * rather than geometry being cosmetic.** It is emphatically not cosmetic:
-     * {@link Neo.dashboard.dock.window.Placement} is an auxiliary participant in this same Group
-     * history, writes a settled popup move as an appended row, and `undo` applies it natively — a
-     * dragged window is an undoable step exactly as a dragged splitter is. But its hints are popup
-     * offsets measured RELATIVE TO MAIN (`observedHints` skips the main binding), and this app ships
-     * a single window. So any hint worth comparing implies a second workspace, which
-     * `additionalWindows` already reports. Testing hints as well would not add a case — it would
-     * subtract correctness: `getPlacementHints` reads the raw hint record rather than the pruned
-     * one, so a hint outliving a closed popup would report a user who is genuinely back at the
-     * default as modified.
-     *
-     * Three deliberate `modified: false` answers, all of them "no comparison happened" rather than
-     * "compared equal". **An unestablished topology** — no workspace registered yet — is not a
-     * departure; it is the absence of an answer, and reporting one would light the indicator during
-     * boot. **A main workspace that is not registered**, likewise: there is nothing to compare the
-     * shipped document against. `additionalWindows` is still counted honestly in that case, because
-     * it is a separate fact that remains knowable. **A malformed document** likewise: `errors` means
-     * the comparison did not happen, and an indicator that lights up because the differ failed tells
-     * the reader something false about their own layout.
+     * Three `modified: false` answers mean **no comparison happened**, never "compared equal": no
+     * workspace registered yet, no main workspace to compare against, or a document the differ
+     * reports errors for. `additionalWindows` is still counted in each case, because it stays
+     * knowable when the comparison does not.
      * @returns {{additionalWindows: Number, modified: Boolean}}
      * @protected
      */
@@ -582,13 +541,10 @@ class Workspace extends DockWorkspace {
      * formatter rather than three phrasings that drift. It composes the two facts
      * {@link #readTopologyState} measures; it does not re-derive them.
      *
-     * **Silence is a state.** On the shipped arrangement with no extra windows this returns `''`
-     * and the component hides. A readout that is always present says nothing — the whole point of
-     * the ticket is that "this is the product" and "you made this" look different at a glance.
+     * **Silence is a state:** the shipped arrangement with no extra windows renders `''` and the
+     * component hides, so "this is the product" and "you made this" look different at a glance. The
+     * default-arrangement half appears only beside a window count, never alone.
      *
-     * The default-arrangement half appears **only** alongside extra windows. Saying "Default
-     * arrangement" on its own would be that always-present readout; saying it beside a window count
-     * is what stops the count from reading as an accusation after a reset.
      * @param {Object}  [state={}]
      * @param {Number}  [state.additionalWindows=0]
      * @param {Boolean} [state.modified=false]
@@ -606,39 +562,28 @@ class Workspace extends DockWorkspace {
     }
 
     /**
-     * @summary Returns the main workspace to the arrangement the app ships with.
+     * @summary Returns the workspace to the arrangement the app ships with, in one undoable commit.
      *
-     * @description **One commit, and that is the whole design.** The shipped document replaces the
-     * main entry of the live keyed topology and every other key is passed through **unchanged**, so
-     * the write names exactly the registered keys that
-     * {@link Neo.dashboard.dock.window.TopologySeams#commitDockTopologyWorkspaces} requires and no
-     * window has to be retired for the commit to be legal.
+     * @description Every non-main participant is **unregistered first**, then the shipped document is
+     * committed for `main` alone. Both halves are load-bearing:
      *
-     * **Leaving other windows standing is the contract, not a shortfall.** Retiring them inside the
-     * commit is not buildable: `transaction/Commit.mjs` throws unless adoption is synchronous, while
-     * a native close is asynchronous *and* refusable — `Window.mjs` gates `close` as a route
-     * capability and defaults a route without one to `{close: false}`. Placed in `prepare`, the only
-     * async phase, a blocked popup would abort the restore and the user could not get their layout
-     * back because a window would not shut. Placed after the commit it is no longer atomic. So the
-     * standing window is reported by {@link #readTopologyState} rather than acted on, and the user
-     * closes it themselves.
+     * - **Retire before committing.** A pane torn into a window is still listed by `initialDocument`,
+     *   so restoring that document beside the popup's own would leave the pane owned twice — an
+     *   invalid topology `Persistence` refuses to capture. Reclaiming it instead empties the popup's
+     *   last tabs node and leaves its `root` dangling, so there is no valid document for a window
+     *   that has handed everything home.
+     * - **Retirement is not the impossible act.** `unregisterParticipant` is a synchronous map
+     *   delete that fires no commit, so it strands no persisted intermediate state. What cannot be
+     *   done is closing the native WINDOW inside the commit, where adoption must be synchronous and
+     *   a native close is neither. The window stays open; it stops participating.
      *
-     * **It commits through the Group rather than assigning `dockModel`.** The nearest precedent in
-     * this repo — `TourController`'s `workspace.dockModel = WorkspaceDocument.clone(initialDocument)`
-     * — is a direct field write that fires no commit event, so `TopologyLibrary`'s
-     * `commit: data => this.persistCurrent()` never runs and the OLD topology stays in IndexedDB to
-     * return on the next reload. Copying it would leave the user's arrangement restored on refresh.
+     * Committing through the Group rather than assigning `dockModel` is what makes the result
+     * durable: a direct field write fires no commit event, so the auto-save never runs and the old
+     * topology returns on the next reload. `WorkspaceSet.write` appends, so this is one ordinary
+     * history row and `undo` reverses it — which is why it needs no confirmation ceremony.
      *
-     * **Single-commit is also what makes it recoverable.** Persistence is commit-driven, so a
-     * multi-step reset would write each intermediate state to IndexedDB as it went and could strand
-     * a persisted half-reset whose original was already overwritten by step one. There are no
-     * intermediate states here: one write, one auto-save. And `WorkspaceSet.write` defaults to
-     * `cursorAction: 'append'`, so this lands as one ordinary history row — undo reverses it exactly
-     * as it reverses a dragged splitter, which is why it carries no confirmation ceremony.
-     *
-     * It deliberately does **not** route through `startBlankRoot()`: that path admits
-     * `{topologyIdentity: {}}` and exists for the load-failure case. Blank is not default, and
-     * conflating them would delete the product's own layout.
+     * Not `startBlankRoot()`: that admits `{topologyIdentity: {}}` for the load-failure path, and
+     * blank is not default.
      * @returns {Promise<{errors: String[], reset: Boolean, transactionId: String|null}>}
      */
     async resetTopology() {
@@ -652,25 +597,6 @@ class Workspace extends DockWorkspace {
             return {errors: ['the main workspace is not registered'], reset: false, transactionId: null}
         }
 
-        // **Every other workspace is RETIRED first, and the ordering is the whole correctness
-        // argument.** Restoring `initialDocument` beside an untouched popup is only safe while that
-        // popup holds nothing the shipped document also lists — and the ordinary case violates it:
-        // tear a shipped pane into a window and both documents then claim it, the topology is
-        // invalid, `Persistence` refuses the capture, and the reset reports success while being
-        // unpersistable. Found by @neo-gpt-emmy in review.
-        //
-        // Reclaiming the pane instead of retiring the workspace does not work either: giving back a
-        // popup's only pane prunes its last tabs node and leaves `root` dangling, so the emptied
-        // document is refused as `root node "…" is missing`. A window that has handed everything
-        // home has no valid document to hold.
-        //
-        // **Retirement is safe here precisely because it is NOT in the atomic section.**
-        // `Transaction#unregisterParticipant` is `participants.delete(workspaceKey)` — synchronous,
-        // firing no commit — so it cannot auto-save an intermediate state, which is what made the
-        // ticket warn about multi-step resets. What cannot be done is closing the native WINDOW
-        // inside the commit: adoption must be synchronous while a native close is asynchronous and
-        // refusable. Retiring the participant and closing the window are different acts, and only
-        // the second is impossible. The window stays open; it simply no longer participates.
         Object.keys(workspaces)
             .filter(workspaceKey => workspaceKey !== Workspace.MAIN_WORKSPACE_ID)
             .forEach(workspaceKey => me.workspaceSet.unregister(workspaceKey));
@@ -686,13 +612,8 @@ class Workspace extends DockWorkspace {
      * @summary Publishes the first modified readout once the provider is resolvable.
      *
      * Boot is the second place a committed topology arrives and the only one the Group's document
-     * setter cannot see: {@link #construct} seeds `dockModel` from a persisted `initialTopology`,
-     * which is an arrangement the user already changed. Without this the indicator reads "default"
-     * on a cold-hydrated custom perspective — the exact state this affordance exists to expose.
-     *
-     * It lives here rather than on the controller's `onComponentConstructed` seam because the state
-     * is the view's: the view owns `dockModel` and the provider, and a controller that had to call
-     * it would impose the method on every component that controller can drive.
+     * setter cannot see: `construct` seeds `dockModel` from a persisted topology the user already
+     * changed, so without this the readout claims "default" on a cold-hydrated custom arrangement.
      */
     onConstructed() {
         super.onConstructed();
@@ -702,20 +623,15 @@ class Workspace extends DockWorkspace {
     /**
      * @summary Republishes the modified readout after a Group commit has settled.
      *
-     * @description **The seam matters more than the timing.** Presentation runs after the queue
-     * releases and, by the manager's contract, "cannot reject the commit" — whereas the participant's
-     * document setter runs inside the adopt phase, where a throw becomes an `AggregateError` in
-     * `transaction/Commit.mjs`'s rollback and takes the whole transaction down. A status readout must
-     * never be able to fail the commit it is reporting on, so it hangs here rather than there.
+     * @description Presentation runs after the queue releases and cannot reject the commit, whereas
+     * the participant's document setter runs inside the adopt phase where a throw takes the whole
+     * transaction down. A status readout must never be able to fail the commit it reports on.
      *
-     * It overrides the class method rather than wrapping the `project` callback in
-     * {@link #registerMainWorkspace}, because that registration is deliberately `.call()`-able onto
-     * a plain dock Workspace — the transaction specs borrow it to isolate Group behaviour from this
-     * app's. Behaviour that belongs to this subclass attaches to this subclass; a borrowed
-     * registration keeps the engine's projection untouched.
+     * It overrides the class method rather than wrapping `registerMainWorkspace`'s `project`
+     * callback, because that registration is deliberately `.call()`-able onto a plain dock Workspace.
+     * Undo and redo project through here too, so returning to the shipped arrangement clears the
+     * readout with no path of its own.
      *
-     * Undo and redo project through here too, which is why undoing back to the shipped arrangement
-     * clears the indicator with no path of its own.
      * @param {Object} context The Group participant's projection context.
      * @returns {Promise} This projection's outcome.
      */

--- a/apps/workstation/view/Workspace.mjs
+++ b/apps/workstation/view/Workspace.mjs
@@ -446,6 +446,19 @@ class Workspace extends DockWorkspace {
             items : [
                 {ntype: 'button', handler: 'saveTopology',  text: 'Save workspace'},
                 {ntype: 'button', handler: 'closeTopology', text: 'Close workspace'},
+                // Handled on the view rather than by controller name, like undo and redo above it:
+                // the state, the shipped document and the commit seam all live on the view, and a
+                // controller method would only forward. Disabled on the shipped arrangement so the
+                // control answers "there is nothing to go back to" instead of committing a no-op
+                // history row — and it reads the SAME derived key as the readout, so the button and
+                // the line beside it can never disagree about whether the user has left the default.
+                {
+                    ntype  : 'button',
+                    bind   : {disabled: data => !data.topology.modified},
+                    handler: () => me.resetTopology(),
+                    iconCls: 'fa fa-rotate-left',
+                    text   : 'Reset to default'
+                },
                 // Reads the derived keys rather than recomputing: the diff runs once per committed
                 // document at its writer, not once per binding evaluation. Both bindings go through
                 // the one static formatter so the visibility test and the text can never disagree
@@ -590,6 +603,61 @@ class Workspace extends DockWorkspace {
         if (additionalWindows) parts.push(`${additionalWindows} additional window${additionalWindows === 1 ? '' : 's'}`);
 
         return parts.join(' · ')
+    }
+
+    /**
+     * @summary Returns the main workspace to the arrangement the app ships with.
+     *
+     * @description **One commit, and that is the whole design.** The shipped document replaces the
+     * main entry of the live keyed topology and every other key is passed through **unchanged**, so
+     * the write names exactly the registered keys that
+     * {@link Neo.dashboard.dock.window.TopologySeams#commitDockTopologyWorkspaces} requires and no
+     * window has to be retired for the commit to be legal.
+     *
+     * **Leaving other windows standing is the contract, not a shortfall.** Retiring them inside the
+     * commit is not buildable: `transaction/Commit.mjs` throws unless adoption is synchronous, while
+     * a native close is asynchronous *and* refusable — `Window.mjs` gates `close` as a route
+     * capability and defaults a route without one to `{close: false}`. Placed in `prepare`, the only
+     * async phase, a blocked popup would abort the restore and the user could not get their layout
+     * back because a window would not shut. Placed after the commit it is no longer atomic. So the
+     * standing window is reported by {@link #readTopologyState} rather than acted on, and the user
+     * closes it themselves.
+     *
+     * **It commits through the Group rather than assigning `dockModel`.** The nearest precedent in
+     * this repo — `TourController`'s `workspace.dockModel = WorkspaceDocument.clone(initialDocument)`
+     * — is a direct field write that fires no commit event, so `TopologyLibrary`'s
+     * `commit: data => this.persistCurrent()` never runs and the OLD topology stays in IndexedDB to
+     * return on the next reload. Copying it would leave the user's arrangement restored on refresh.
+     *
+     * **Single-commit is also what makes it recoverable.** Persistence is commit-driven, so a
+     * multi-step reset would write each intermediate state to IndexedDB as it went and could strand
+     * a persisted half-reset whose original was already overwritten by step one. There are no
+     * intermediate states here: one write, one auto-save. And `WorkspaceSet.write` defaults to
+     * `cursorAction: 'append'`, so this lands as one ordinary history row — undo reverses it exactly
+     * as it reverses a dragged splitter, which is why it carries no confirmation ceremony.
+     *
+     * It deliberately does **not** route through `startBlankRoot()`: that path admits
+     * `{topologyIdentity: {}}` and exists for the load-failure case. Blank is not default, and
+     * conflating them would delete the product's own layout.
+     * @returns {Promise<{errors: String[], reset: Boolean, transactionId: String|null}>}
+     */
+    async resetTopology() {
+        const me         = this,
+              workspaces = me.getDockTopologyWorkspaces();
+
+        // Not a defensive guard: with no main workspace registered there is no entry for the shipped
+        // document to replace, so the commit would ADD a key and be refused for naming something
+        // unregistered. Refusing here names the actual cause instead of the seam's generic shape.
+        if (!Object.hasOwn(workspaces, Workspace.MAIN_WORKSPACE_ID)) {
+            return {errors: ['the main workspace is not registered'], reset: false, transactionId: null}
+        }
+
+        const {errors, transactionId} = await me.commitDockTopologyWorkspaces({
+            ...workspaces,
+            [Workspace.MAIN_WORKSPACE_ID]: WorkspaceDocument.clone(initialDocument)
+        }, {name: 'default', provenance: {origin: 'human'}});
+
+        return {errors, reset: !errors.length, transactionId: transactionId ?? null}
     }
 
     /**

--- a/apps/workstation/view/Workspace.mjs
+++ b/apps/workstation/view/Workspace.mjs
@@ -207,12 +207,12 @@ class Workspace extends DockWorkspace {
          */
         stateProvider: {
             module: StateProvider,
-            // `topology.modified` is DERIVED here rather than bound, because there is nothing to bind
-            // to: `dockModel` is a plain field on the dock Workspace, not a reactive config, so a
-            // formatter reading it would never re-run. {@link #syncTopologyModified} publishes it from
-            // the two places the document actually arrives. Seeded `false` only so the key exists
-            // before the first publish; `construct` overwrites it with the measured answer.
-            data  : {topology: {modified: false}, tour: initialTourState},
+            // The `topology` keys are DERIVED here rather than bound, because there is nothing to
+            // bind to: `dockModel` is a plain field on the dock Workspace, not a reactive config, so
+            // a formatter reading it would never re-run. {@link #syncTopologyState} publishes them
+            // from the two places the document actually arrives. Seeded only so the keys exist before
+            // the first publish; `construct` overwrites both with the measured answer.
+            data  : {topology: {additionalWindows: 0, modified: false}, tour: initialTourState},
             stores: {
                 feed : {module: Feed},
                 scale: {module: Scale}
@@ -446,15 +446,15 @@ class Workspace extends DockWorkspace {
             items : [
                 {ntype: 'button', handler: 'saveTopology',  text: 'Save workspace'},
                 {ntype: 'button', handler: 'closeTopology', text: 'Close workspace'},
-                // Reads the derived key rather than recomputing: the diff runs once per committed
-                // document at its writer, not once per binding evaluation. Absent on the default
-                // arrangement rather than shown-and-empty — a badge that is always present says
-                // nothing, and the whole point is that the two states look different.
+                // Reads the derived keys rather than recomputing: the diff runs once per committed
+                // document at its writer, not once per binding evaluation. Both bindings go through
+                // the one static formatter so the visibility test and the text can never disagree
+                // about whether there is something to say.
                 {
                     ntype: 'component',
                     bind : {
-                        cls : data => ['workstation-topology-modified'].concat(data.topology.modified ? [] : ['neo-hidden']),
-                        html: data => data.topology.modified ? 'Modified from default' : ''
+                        cls : data => ['workstation-topology-state'].concat(Workspace.topologyStateText(data.topology) ? [] : ['neo-hidden']),
+                        html: data => Workspace.topologyStateText(data.topology)
                     },
                     flex : 'none'
                 }
@@ -486,15 +486,28 @@ class Workspace extends DockWorkspace {
     }
 
     /**
-     * @summary Whether the live topology differs from the arrangement the app ships with.
+     * @summary How the live topology stands against the arrangement the app ships with, as two
+     * independent facts.
      *
      * @description **The unit is the whole keyed topology, not this window's document.** What gets
      * persisted and restored is {@link #getDockTopologyWorkspaces} — every registered workspace
      * keyed by identity — because the thing a reader expects back when they open the app URL is
-     * their multi-window setup, not one window's panes. So a pane torn out into a second window is
-     * a departure from the default even when the document left behind still matches: **the extra
-     * workspace IS the difference**, and comparing `main` alone would call that arrangement
-     * default.
+     * their multi-window setup, not one window's panes. So a pane torn out into a second window IS
+     * a departure from the shipped arrangement, which ships exactly one workspace.
+     *
+     * **But that is a second fact, not the same one, and collapsing them made the readout lossy.**
+     * An earlier revision returned a single Boolean and answered `true` on any extra key *before*
+     * the differ ran. Two costs, and the second is worse than the first: a user whose main document
+     * genuinely matches the default was told they had "modified" it, and the document that actually
+     * matched was never compared at all — so the answer was not merely coarse, it was unmeasured.
+     * It also made reset look broken: reset commits the shipped document and deliberately leaves
+     * other windows standing ({@link Neo.dashboard.dock.window.TopologySeams#commitDockTopologyWorkspaces}
+     * refuses a commit that does not name every registered key, and retiring a window is neither
+     * synchronous nor guaranteed), so the readout lit up the instant the user pressed it.
+     *
+     * Reported separately, both halves stay true and the user can act on each: the named document
+     * is at the default or it is not, and N windows stand beyond the one the app ships. Rendering
+     * is {@link Workspace.topologyStateText}'s problem, not this method's.
      *
      * The question is a COMPARISON, not a dirty flag: a flag set on the first operation never
      * clears when the user undoes back to the start, while a comparison recomputed from live state
@@ -514,33 +527,69 @@ class Workspace extends DockWorkspace {
      * history, writes a settled popup move as an appended row, and `undo` applies it natively — a
      * dragged window is an undoable step exactly as a dragged splitter is. But its hints are popup
      * offsets measured RELATIVE TO MAIN (`observedHints` skips the main binding), and this app ships
-     * a single window. So any hint worth comparing implies a second workspace, which the key check
-     * above has already answered. Testing hints as well would not add a case — it would subtract
-     * correctness: `getPlacementHints` reads the raw hint record rather than the pruned one, so a
-     * hint outliving a closed popup would report a user who is genuinely back at the default as
-     * modified.
+     * a single window. So any hint worth comparing implies a second workspace, which
+     * `additionalWindows` already reports. Testing hints as well would not add a case — it would
+     * subtract correctness: `getPlacementHints` reads the raw hint record rather than the pruned
+     * one, so a hint outliving a closed popup would report a user who is genuinely back at the
+     * default as modified.
      *
-     * Two deliberate `false` answers. **An unestablished topology** — no workspace registered yet —
-     * is not a departure; it is the absence of an answer, and reporting one would light the
-     * indicator during boot. **A malformed document** likewise: `errors` means the comparison did
-     * not happen, and an indicator that lights up because the differ failed tells the reader
-     * something false about their own layout.
-     * @returns {Boolean}
+     * Three deliberate `modified: false` answers, all of them "no comparison happened" rather than
+     * "compared equal". **An unestablished topology** — no workspace registered yet — is not a
+     * departure; it is the absence of an answer, and reporting one would light the indicator during
+     * boot. **A main workspace that is not registered**, likewise: there is nothing to compare the
+     * shipped document against. `additionalWindows` is still counted honestly in that case, because
+     * it is a separate fact that remains knowable. **A malformed document** likewise: `errors` means
+     * the comparison did not happen, and an indicator that lights up because the differ failed tells
+     * the reader something false about their own layout.
+     * @returns {{additionalWindows: Number, modified: Boolean}}
      * @protected
      */
-    isTopologyModified() {
-        const me         = this,
-              workspaces = me.getDockTopologyWorkspaces(),
-              keys       = Object.keys(workspaces);
+    readTopologyState() {
+        const me                = this,
+              workspaces        = me.getDockTopologyWorkspaces(),
+              keys              = Object.keys(workspaces),
+              main              = workspaces[Workspace.MAIN_WORKSPACE_ID],
+              additionalWindows = keys.filter(key => key !== Workspace.MAIN_WORKSPACE_ID).length;
 
-        if (!keys.length) return false;
+        if (!main) return {additionalWindows, modified: false};
 
-        if (keys.length > 1 || keys[0] !== Workspace.MAIN_WORKSPACE_ID) return true;
+        const diff = TopologyDiff.diffDockDocuments(initialDocument, main);
 
-        const diff = TopologyDiff.diffDockDocuments(initialDocument, workspaces[keys[0]]);
+        return {
+            additionalWindows,
+            modified: !diff.errors.length && Object.keys(diff).some(category =>
+                category !== 'errors' && category !== 'unchanged' && diff[category]?.length)
+        }
+    }
 
-        return !diff.errors.length && Object.keys(diff).some(category =>
-            category !== 'errors' && category !== 'unchanged' && diff[category]?.length)
+    /**
+     * @summary The topology bar's state line, or an empty string when there is nothing to say.
+     *
+     * @description Static and pure so the binding, the spec and any future consumer read one
+     * formatter rather than three phrasings that drift. It composes the two facts
+     * {@link #readTopologyState} measures; it does not re-derive them.
+     *
+     * **Silence is a state.** On the shipped arrangement with no extra windows this returns `''`
+     * and the component hides. A readout that is always present says nothing — the whole point of
+     * the ticket is that "this is the product" and "you made this" look different at a glance.
+     *
+     * The default-arrangement half appears **only** alongside extra windows. Saying "Default
+     * arrangement" on its own would be that always-present readout; saying it beside a window count
+     * is what stops the count from reading as an accusation after a reset.
+     * @param {Object}  [state={}]
+     * @param {Number}  [state.additionalWindows=0]
+     * @param {Boolean} [state.modified=false]
+     * @returns {String}
+     */
+    static topologyStateText({additionalWindows=0, modified=false}={}) {
+        const parts = [];
+
+        if (modified)               parts.push('Modified from default');
+        else if (additionalWindows) parts.push('Default arrangement');
+
+        if (additionalWindows) parts.push(`${additionalWindows} additional window${additionalWindows === 1 ? '' : 's'}`);
+
+        return parts.join(' · ')
     }
 
     /**
@@ -557,7 +606,7 @@ class Workspace extends DockWorkspace {
      */
     onConstructed() {
         super.onConstructed();
-        this.syncTopologyModified()
+        this.syncTopologyState()
     }
 
     /**
@@ -583,21 +632,27 @@ class Workspace extends DockWorkspace {
     projectDockCommit(context) {
         const projection = super.projectDockCommit(context);
 
-        this.syncTopologyModified();
+        this.syncTopologyState();
 
         return projection
     }
 
     /**
-     * @summary Publishes {@link #isTopologyModified} for the topology bar's readout.
+     * @summary Publishes {@link #readTopologyState} for the topology bar's readout.
+     *
+     * Both keys are written by path in one call rather than replacing the `topology` object, so a
+     * key added here later cannot be silently dropped by this publisher, and the pair lands as one
+     * update rather than flashing a half-state through the binding.
      * @protected
      */
-    syncTopologyModified() {
+    syncTopologyState() {
         const me = this;
 
         if (me.isDestroyed || !me.getStateProvider()) return;
 
-        me.setState({'topology.modified': me.isTopologyModified()})
+        const {additionalWindows, modified} = me.readTopologyState();
+
+        me.setState({'topology.additionalWindows': additionalWindows, 'topology.modified': modified})
     }
 
     /**

--- a/apps/workstation/view/Workspace.mjs
+++ b/apps/workstation/view/Workspace.mjs
@@ -22,6 +22,7 @@ import WorkspaceController        from './WorkspaceController.mjs';
 import Operations                 from '../../../src/dashboard/dock/model/Operations.mjs';
 import Persistence                from '../../../src/dashboard/dock/model/Persistence.mjs';
 import StateProvider              from '../../../src/state/Provider.mjs';
+import TopologyDiff               from '../../../src/dashboard/dock/model/TopologyDiff.mjs';
 import TourToolbar                from './TourToolbar.mjs';
 import TransactionManager         from '../../../src/manager/Transaction.mjs';
 import WindowManager              from '../../../src/manager/Window.mjs';
@@ -206,7 +207,12 @@ class Workspace extends DockWorkspace {
          */
         stateProvider: {
             module: StateProvider,
-            data  : {tour: initialTourState},
+            // `topology.modified` is DERIVED here rather than bound, because there is nothing to bind
+            // to: `dockModel` is a plain field on the dock Workspace, not a reactive config, so a
+            // formatter reading it would never re-run. {@link #syncTopologyModified} publishes it from
+            // the two places the document actually arrives. Seeded `false` only so the key exists
+            // before the first publish; `construct` overwrites it with the measured answer.
+            data  : {topology: {modified: false}, tour: initialTourState},
             stores: {
                 feed : {module: Feed},
                 scale: {module: Scale}
@@ -439,7 +445,19 @@ class Workspace extends DockWorkspace {
             // list is free to grow.
             items : [
                 {ntype: 'button', handler: 'saveTopology',  text: 'Save workspace'},
-                {ntype: 'button', handler: 'closeTopology', text: 'Close workspace'}
+                {ntype: 'button', handler: 'closeTopology', text: 'Close workspace'},
+                // Reads the derived key rather than recomputing: the diff runs once per committed
+                // document at its writer, not once per binding evaluation. Absent on the default
+                // arrangement rather than shown-and-empty — a badge that is always present says
+                // nothing, and the whole point is that the two states look different.
+                {
+                    ntype: 'component',
+                    bind : {
+                        cls : data => ['workstation-topology-modified'].concat(data.topology.modified ? [] : ['neo-hidden']),
+                        html: data => data.topology.modified ? 'Modified from default' : ''
+                    },
+                    flex : 'none'
+                }
             ],
             layout   : {ntype: 'flexbox', align: 'center', direction: 'row', wrap: 'wrap'},
             reference: 'topology-toolbar'
@@ -465,6 +483,121 @@ class Workspace extends DockWorkspace {
               steps    = provider ? count(provider) : 0;
 
         return Number.isFinite(steps) && steps > 0 ? `${steps}` : null
+    }
+
+    /**
+     * @summary Whether the live topology differs from the arrangement the app ships with.
+     *
+     * @description **The unit is the whole keyed topology, not this window's document.** What gets
+     * persisted and restored is {@link #getDockTopologyWorkspaces} — every registered workspace
+     * keyed by identity — because the thing a reader expects back when they open the app URL is
+     * their multi-window setup, not one window's panes. So a pane torn out into a second window is
+     * a departure from the default even when the document left behind still matches: **the extra
+     * workspace IS the difference**, and comparing `main` alone would call that arrangement
+     * default.
+     *
+     * The question is a COMPARISON, not a dirty flag: a flag set on the first operation never
+     * clears when the user undoes back to the start, while a comparison recomputed from live state
+     * does, for free.
+     *
+     * Per document, `TopologyDiff.diffDockDocuments` is the comparator rather than
+     * `computeShapeFingerprint`, whose own docblock states it carries "no node ids, item ids,
+     * sizes, titles or window identity" — shape-only by contract, so it reads a dragged boundary, a
+     * reordered tab and a switched pane as unchanged. Those are the operations this workspace is
+     * FOR. Categories are read off the returned object rather than listed here: the differ's class
+     * comment stood at seven while the code returned eight, so a hand-copied list under-reports
+     * exactly where the documentation has drifted.
+     *
+     * **Window geometry needs no separate test here, and the reason is the shipped arrangement
+     * rather than geometry being cosmetic.** It is emphatically not cosmetic:
+     * {@link Neo.dashboard.dock.window.Placement} is an auxiliary participant in this same Group
+     * history, writes a settled popup move as an appended row, and `undo` applies it natively — a
+     * dragged window is an undoable step exactly as a dragged splitter is. But its hints are popup
+     * offsets measured RELATIVE TO MAIN (`observedHints` skips the main binding), and this app ships
+     * a single window. So any hint worth comparing implies a second workspace, which the key check
+     * above has already answered. Testing hints as well would not add a case — it would subtract
+     * correctness: `getPlacementHints` reads the raw hint record rather than the pruned one, so a
+     * hint outliving a closed popup would report a user who is genuinely back at the default as
+     * modified.
+     *
+     * Two deliberate `false` answers. **An unestablished topology** — no workspace registered yet —
+     * is not a departure; it is the absence of an answer, and reporting one would light the
+     * indicator during boot. **A malformed document** likewise: `errors` means the comparison did
+     * not happen, and an indicator that lights up because the differ failed tells the reader
+     * something false about their own layout.
+     * @returns {Boolean}
+     * @protected
+     */
+    isTopologyModified() {
+        const me         = this,
+              workspaces = me.getDockTopologyWorkspaces(),
+              keys       = Object.keys(workspaces);
+
+        if (!keys.length) return false;
+
+        if (keys.length > 1 || keys[0] !== Workspace.MAIN_WORKSPACE_ID) return true;
+
+        const diff = TopologyDiff.diffDockDocuments(initialDocument, workspaces[keys[0]]);
+
+        return !diff.errors.length && Object.keys(diff).some(category =>
+            category !== 'errors' && category !== 'unchanged' && diff[category]?.length)
+    }
+
+    /**
+     * @summary Publishes the first modified readout once the provider is resolvable.
+     *
+     * Boot is the second place a committed topology arrives and the only one the Group's document
+     * setter cannot see: {@link #construct} seeds `dockModel` from a persisted `initialTopology`,
+     * which is an arrangement the user already changed. Without this the indicator reads "default"
+     * on a cold-hydrated custom perspective — the exact state this affordance exists to expose.
+     *
+     * It lives here rather than on the controller's `onComponentConstructed` seam because the state
+     * is the view's: the view owns `dockModel` and the provider, and a controller that had to call
+     * it would impose the method on every component that controller can drive.
+     */
+    onConstructed() {
+        super.onConstructed();
+        this.syncTopologyModified()
+    }
+
+    /**
+     * @summary Republishes the modified readout after a Group commit has settled.
+     *
+     * @description **The seam matters more than the timing.** Presentation runs after the queue
+     * releases and, by the manager's contract, "cannot reject the commit" — whereas the participant's
+     * document setter runs inside the adopt phase, where a throw becomes an `AggregateError` in
+     * `transaction/Commit.mjs`'s rollback and takes the whole transaction down. A status readout must
+     * never be able to fail the commit it is reporting on, so it hangs here rather than there.
+     *
+     * It overrides the class method rather than wrapping the `project` callback in
+     * {@link #registerMainWorkspace}, because that registration is deliberately `.call()`-able onto
+     * a plain dock Workspace — the transaction specs borrow it to isolate Group behaviour from this
+     * app's. Behaviour that belongs to this subclass attaches to this subclass; a borrowed
+     * registration keeps the engine's projection untouched.
+     *
+     * Undo and redo project through here too, which is why undoing back to the shipped arrangement
+     * clears the indicator with no path of its own.
+     * @param {Object} context The Group participant's projection context.
+     * @returns {Promise} This projection's outcome.
+     */
+    projectDockCommit(context) {
+        const projection = super.projectDockCommit(context);
+
+        this.syncTopologyModified();
+
+        return projection
+    }
+
+    /**
+     * @summary Publishes {@link #isTopologyModified} for the topology bar's readout.
+     * @protected
+     */
+    syncTopologyModified() {
+        const me = this;
+
+        if (me.isDestroyed || !me.getStateProvider()) return;
+
+        me.setState({'topology.modified': me.isTopologyModified()})
     }
 
     /**

--- a/apps/workstation/view/Workspace.mjs
+++ b/apps/workstation/view/Workspace.mjs
@@ -652,10 +652,32 @@ class Workspace extends DockWorkspace {
             return {errors: ['the main workspace is not registered'], reset: false, transactionId: null}
         }
 
-        const {errors, transactionId} = await me.commitDockTopologyWorkspaces({
-            ...workspaces,
-            [Workspace.MAIN_WORKSPACE_ID]: WorkspaceDocument.clone(initialDocument)
-        }, {name: 'default', provenance: {origin: 'human'}});
+        // **Every other workspace is RETIRED first, and the ordering is the whole correctness
+        // argument.** Restoring `initialDocument` beside an untouched popup is only safe while that
+        // popup holds nothing the shipped document also lists — and the ordinary case violates it:
+        // tear a shipped pane into a window and both documents then claim it, the topology is
+        // invalid, `Persistence` refuses the capture, and the reset reports success while being
+        // unpersistable. Found by @neo-gpt-emmy in review.
+        //
+        // Reclaiming the pane instead of retiring the workspace does not work either: giving back a
+        // popup's only pane prunes its last tabs node and leaves `root` dangling, so the emptied
+        // document is refused as `root node "…" is missing`. A window that has handed everything
+        // home has no valid document to hold.
+        //
+        // **Retirement is safe here precisely because it is NOT in the atomic section.**
+        // `Transaction#unregisterParticipant` is `participants.delete(workspaceKey)` — synchronous,
+        // firing no commit — so it cannot auto-save an intermediate state, which is what made the
+        // ticket warn about multi-step resets. What cannot be done is closing the native WINDOW
+        // inside the commit: adoption must be synchronous while a native close is asynchronous and
+        // refusable. Retiring the participant and closing the window are different acts, and only
+        // the second is impossible. The window stays open; it simply no longer participates.
+        Object.keys(workspaces)
+            .filter(workspaceKey => workspaceKey !== Workspace.MAIN_WORKSPACE_ID)
+            .forEach(workspaceKey => me.workspaceSet.unregister(workspaceKey));
+
+        const {errors, transactionId} = await me.commitDockTopologyWorkspaces(
+            {[Workspace.MAIN_WORKSPACE_ID]: WorkspaceDocument.clone(initialDocument)},
+            {name: 'default', provenance: {origin: 'human'}});
 
         return {errors, reset: !errors.length, transactionId: transactionId ?? null}
     }

--- a/apps/workstation/view/Workspace.mjs
+++ b/apps/workstation/view/Workspace.mjs
@@ -562,25 +562,44 @@ class Workspace extends DockWorkspace {
     }
 
     /**
+     * @summary A valid document for a workspace that owns no panes.
+     *
+     * @description The empty **edge-root** shape, not an emptied tree. Detaching a workspace's last
+     * pane prunes its final tabs node and leaves `root` pointing at a node that no longer exists, so
+     * the result is refused; an edge zone with no zones validates and projects as an empty container.
+     * Established by @neo-gpt-emmy's counterexample after I had reported the pruned shape as proof
+     * that no valid empty document existed.
+     * @returns {Object}
+     */
+    static createEmptyWorkspaceDocument() {
+        return {schema: 'neo.dock.zone.v1', root: 'root', items: {}, nodes: {root: {type: 'edge-zone', zones: {}}}}
+    }
+
+    /**
      * @summary Returns the workspace to the arrangement the app ships with, in one undoable commit.
      *
-     * @description Every non-main participant is **unregistered first**, then the shipped document is
-     * committed for `main` alone. Both halves are load-bearing:
+     * @description The shipped document is committed for `main`, and every other workspace gives back
+     * the panes `initialDocument` owns — in the SAME write. Both halves matter:
      *
-     * - **Retire before committing.** A pane torn into a window is still listed by `initialDocument`,
-     *   so restoring that document beside the popup's own would leave the pane owned twice — an
-     *   invalid topology `Persistence` refuses to capture. Reclaiming it instead empties the popup's
-     *   last tabs node and leaves its `root` dangling, so there is no valid document for a window
-     *   that has handed everything home.
-     * - **Retirement is not the impossible act.** `unregisterParticipant` is a synchronous map
-     *   delete that fires no commit, so it strands no persisted intermediate state. What cannot be
-     *   done is closing the native WINDOW inside the commit, where adoption must be synchronous and
-     *   a native close is neither. The window stays open; it stops participating.
+     * - **Give the panes back, do not just restore main.** A pane torn into a window is still listed
+     *   by `initialDocument`, so restoring that document beside an untouched popup would leave it
+     *   owned twice — an invalid topology `Persistence` refuses to capture, making a reset that
+     *   reports success unpersistable.
+     * - **A workspace left with nothing becomes the empty edge-root, not a pruned tree.** Detaching
+     *   a workspace's last pane prunes its final tabs node and leaves `root` dangling; replacing the
+     *   document with `{root: 'root', items: {}, nodes: {root: {type: 'edge-zone', zones: {}}}}`
+     *   validates and projects as an empty container.
+     *
+     * **Every participant is retained, and that is what makes the reset undoable.** Unregistering
+     * one would happen outside the transaction, so `undo` could not restore it: the commit would
+     * roll back to a document whose panes lived in a workspace that no longer exists, and the torn-out
+     * pane would end up owned by nobody. Keeping every key in the write keeps the whole reset inside
+     * the one history row that reverses it.
      *
      * Committing through the Group rather than assigning `dockModel` is what makes the result
      * durable: a direct field write fires no commit event, so the auto-save never runs and the old
      * topology returns on the next reload. `WorkspaceSet.write` appends, so this is one ordinary
-     * history row and `undo` reverses it — which is why it needs no confirmation ceremony.
+     * history row — which is why it needs no confirmation ceremony.
      *
      * Not `startBlankRoot()`: that admits `{topologyIdentity: {}}` for the load-failure path, and
      * blank is not default.
@@ -597,12 +616,46 @@ class Workspace extends DockWorkspace {
             return {errors: ['the main workspace is not registered'], reset: false, transactionId: null}
         }
 
-        Object.keys(workspaces)
-            .filter(workspaceKey => workspaceKey !== Workspace.MAIN_WORKSPACE_ID)
-            .forEach(workspaceKey => me.workspaceSet.unregister(workspaceKey));
+        const shipped  = new Set(Object.keys(initialDocument.items ?? {})),
+              next     = {[Workspace.MAIN_WORKSPACE_ID]: WorkspaceDocument.clone(initialDocument)},
+              refusals = [];
 
-        const {errors, transactionId} = await me.commitDockTopologyWorkspaces(
-            {[Workspace.MAIN_WORKSPACE_ID]: WorkspaceDocument.clone(initialDocument)},
+        for (const [workspaceKey, document] of Object.entries(workspaces)) {
+            if (workspaceKey === Workspace.MAIN_WORKSPACE_ID) continue;
+
+            const owned   = Object.keys(document?.items ?? {}),
+                  reclaim = owned.filter(itemId => shipped.has(itemId));
+
+            if (!reclaim.length) {
+                next[workspaceKey] = document;
+                continue
+            }
+
+            if (reclaim.length === owned.length) {
+                next[workspaceKey] = Workspace.createEmptyWorkspaceDocument();
+                continue
+            }
+
+            // Partial reclaim: the same two steps `Operations.transferItem` performs on its source
+            // side, then through the shared fail-closed commit so the result is normalized and
+            // validated rather than assumed well-formed.
+            const working = WorkspaceDocument.clone(document);
+
+            reclaim.forEach(itemId => {
+                WorkspaceDocument.detachFromTabs(working, itemId);
+                delete working.items[itemId]
+            });
+
+            const result = WorkspaceDocument.commit(document, working);
+
+            result.errors.length ? refusals.push(...result.errors) : next[workspaceKey] = result.document
+        }
+
+        // A workspace that cannot give a shipped pane back is a refusal, not something to commit
+        // around: committing the rest would restore main while leaving the duplicate in place.
+        if (refusals.length) return {errors: refusals, reset: false, transactionId: null};
+
+        const {errors, transactionId} = await me.commitDockTopologyWorkspaces(next,
             {name: 'default', provenance: {origin: 'human'}});
 
         return {errors, reset: !errors.length, transactionId: transactionId ?? null}

--- a/apps/workstation/view/Workspace.mjs
+++ b/apps/workstation/view/Workspace.mjs
@@ -658,6 +658,18 @@ class Workspace extends DockWorkspace {
         const {errors, transactionId} = await me.commitDockTopologyWorkspaces(next,
             {name: 'default', provenance: {origin: 'human'}});
 
+        // Every participant's OWN projection has to settle, not just this window's. A reclaim moves
+        // panes between workspaces that render in different windows, and each host publishes its own
+        // refresh — so awaiting only `me.refreshPromise` leaves the popup's live pane a write behind
+        // its document, visible in the window the document says it has left.
+        // `commitCrossWindowTransfer` awaits source and target hosts for the same reason.
+        // Measured on a real popup by @neo-opus-vega: documents correct at every step, embodiment one
+        // write late and on the wrong window.
+        errors.length || await Promise.all([
+            me.refreshPromise,
+            ...me.getPopupStates().map(state => state.host?.refreshPromise)
+        ].map(promise => Promise.resolve(promise).catch(() => {})));
+
         return {errors, reset: !errors.length, transactionId: transactionId ?? null}
     }
 

--- a/buildScripts/util/file-size-baseline.json
+++ b/buildScripts/util/file-size-baseline.json
@@ -1,5 +1,5 @@
 {
-    "apps/workstation/view/Workspace.mjs": 1252,
+    "apps/workstation/view/Workspace.mjs": 1316,
     "examples/dashboard/crossWindow/DemoBWorkspace.mjs": 2546,
     "src/dashboard/dock/Workspace.mjs": 1140,
     "src/main/addon/DragDrop.mjs": 1267

--- a/buildScripts/util/file-size-baseline.json
+++ b/buildScripts/util/file-size-baseline.json
@@ -1,5 +1,5 @@
 {
-    "apps/workstation/view/Workspace.mjs": 1318,
+    "apps/workstation/view/Workspace.mjs": 1341,
     "examples/dashboard/crossWindow/DemoBWorkspace.mjs": 2546,
     "src/dashboard/dock/Workspace.mjs": 1140,
     "src/main/addon/DragDrop.mjs": 1267

--- a/buildScripts/util/file-size-baseline.json
+++ b/buildScripts/util/file-size-baseline.json
@@ -1,5 +1,5 @@
 {
-    "apps/workstation/view/Workspace.mjs": 1341,
+    "apps/workstation/view/Workspace.mjs": 1345,
     "examples/dashboard/crossWindow/DemoBWorkspace.mjs": 2546,
     "src/dashboard/dock/Workspace.mjs": 1140,
     "src/main/addon/DragDrop.mjs": 1267

--- a/buildScripts/util/file-size-baseline.json
+++ b/buildScripts/util/file-size-baseline.json
@@ -1,5 +1,5 @@
 {
-    "apps/workstation/view/Workspace.mjs": 1316,
+    "apps/workstation/view/Workspace.mjs": 1318,
     "examples/dashboard/crossWindow/DemoBWorkspace.mjs": 2546,
     "src/dashboard/dock/Workspace.mjs": 1140,
     "src/main/addon/DragDrop.mjs": 1267

--- a/resources/scss/src/apps/workstation/Workspace.scss
+++ b/resources/scss/src/apps/workstation/Workspace.scss
@@ -161,6 +161,28 @@
         --button-text-color               : var(--workstation-ink);
         --button-text-color-disabled      : color-mix(in srgb, var(--workstation-ink) 45%, transparent);
     }
+
+    // The state line is a READOUT sitting among four controls, and the risk is that it reads as a
+    // fifth one. So it takes the opposite of the button treatment above: no border, dim ink, and a
+    // ground tinted rather than filled. Findable at a glance — which is the entire affordance this
+    // ticket exists for — without inviting a click that does nothing.
+    //
+    // It stays in flow after the last button rather than being pushed right with an auto margin:
+    // the controller inserts its own per-workspace recovery buttons into this same bar and the
+    // action spacer owns the right-hand boundary, so a second element claiming free space would
+    // fight a layout contract that is already load-bearing.
+    //
+    // `nowrap` puts any wrapping on the bar (`layout.wrap: 'wrap'`) instead of inside the line: the
+    // text is two facts joined by a separator, and breaking it mid-phrase reads as two readouts.
+    .workstation-topology-state {
+        background   : color-mix(in srgb, var(--workstation-signal) 10%, transparent);
+        border-radius: 4px;
+        color        : var(--workstation-ink-dim);
+        font-size    : 12px;
+        line-height  : 1;
+        padding      : 6px 10px;
+        white-space  : nowrap;
+    }
 }
 
 .workstation-tourbar {

--- a/test/playwright/unit/apps/workstation/Workspace.spec.mjs
+++ b/test/playwright/unit/apps/workstation/Workspace.spec.mjs
@@ -3627,13 +3627,23 @@ test.describe('Workstation reset to the shipped arrangement (#18553)', () => {
 
         expect(moved.errors, 'the transfer fixture must itself commit').toEqual([]);
 
-        const workspace = Neo.create(Workspace, {
-            initialTopology: {workspaces: {[MAIN]: moved.sourceDocument, 'popup-a': moved.targetDocument}},
-            windowId       : Neo.config.windowId
-        });
+        const writes  = [],
+              library = Neo.create(TopologyLibrary, {persistenceAdapter: {
+                  read : async () => null,
+                  write: topology => {writes.push(topology); return Promise.resolve(true)}
+              }}),
+              workspace = Neo.create(Workspace, {
+                  initialTopology: {workspaces: {[MAIN]: moved.sourceDocument, 'popup-a': moved.targetDocument}},
+                  topologyLibrary: library,
+                  windowId       : Neo.config.windowId
+              });
 
         try {
-            const result = await workspace.resetTopology();
+            expect(workspace.getController().attachTopologyLibrary(), 'the library is attached').toBe(true);
+            TransactionManager.setHistoryDepth({groupId: workspace.topologyGroupId, depth: 5});
+
+            const writesBefore = writes.length;
+            const result       = await workspace.resetTopology();
 
             expect(result.errors, 'the reset commit is accepted').toEqual([]);
 
@@ -3649,9 +3659,20 @@ test.describe('Workstation reset to the shipped arrangement (#18553)', () => {
             // cannot be captured, so a reset reporting success would silently never persist.
             const captured = Persistence.captureTopologyPerspective(workspace.getDockTopologyWorkspaces());
 
-            expect(captured.errors, 'the reset result is persistable').toEqual([])
+            expect(captured.errors, 'the reset result is persistable').toEqual([]);
+
+            // Persistable is not persisted, and undo is the other half of the reset contract. Both
+            // asserted here rather than inherited from the single-window arm, because the defect
+            // this arm exists for was invisible to exactly that inheritance.
+            expect(writes.length, 'the reset actually reached storage').toBeGreaterThan(writesBefore);
+            expect(library.resolve().topology.workspaces[MAIN].items.queues, 'the pane is home in the stored record').toBeTruthy();
+
+            await TransactionManager.undo({groupId: workspace.topologyGroupId});
+
+            expect(workspace.readTopologyState().modified, 'undo reaches past the reset here too').toBe(true)
         } finally {
-            workspace.destroy()
+            workspace.destroy();
+            library.destroy()
         }
     });
 

--- a/test/playwright/unit/apps/workstation/Workspace.spec.mjs
+++ b/test/playwright/unit/apps/workstation/Workspace.spec.mjs
@@ -14,6 +14,7 @@ import WorkspaceDocument        from '../../../../../src/dashboard/dock/model/Wo
 import Operations               from '../../../../../src/dashboard/dock/model/Operations.mjs';
 import DockParticipation        from '../../../../../src/dashboard/dock/window/Participation.mjs';
 import '../../../../../src/manager/Instance.mjs';
+import TopologyLibrary    from '../../../../../src/dashboard/dock/persistence/TopologyLibrary.mjs';
 import TransactionManager from '../../../../../src/manager/Transaction.mjs';
 import StateProvider      from '../../../../../src/state/Provider.mjs';
 import Toolbar            from '../../../../../src/toolbar/Base.mjs';
@@ -3572,6 +3573,42 @@ test.describe('Workstation reset to the shipped arrangement (#18553)', () => {
                 .toBe('Default arrangement · 1 additional window')
         } finally {
             workspace.destroy()
+        }
+    });
+
+    test('the reset re-seeds the persisted record, so it cannot come back on the next reload', async () => {
+        // AC-5, and the whole reason reset commits through the Group. Persistence is commit-driven —
+        // `TopologyLibrary.attachGroup` registers `commit: data => this.persistCurrent()` — so a
+        // reset that wrote `dockModel` directly would fire no commit, leave the OLD topology in
+        // storage, and hand it back on the next reload. Asserted against a real attached library
+        // with a spy adapter rather than inferred from the commit path.
+        const writes  = [],
+              library = Neo.create(TopologyLibrary, {persistenceAdapter: {
+                  read : async () => null,
+                  write: topology => {writes.push(topology); return Promise.resolve(true)}
+              }}),
+              workspace = Neo.create(Workspace, {topologyLibrary: library, windowId: Neo.config.windowId});
+
+        try {
+            expect(workspace.getController().attachTopologyLibrary(), 'the library is attached to the Group').toBe(true);
+
+            await workspace.workspaceSet.commit(MAIN, [
+                {operation: 'resizeSplit', splitNodeId: 'split-main', sizes: [0.25, 0.75]}
+            ]);
+
+            const writesBeforeReset = writes.length;
+
+            expect(writesBeforeReset, 'the ordinary commit already persisted').toBeGreaterThan(0);
+
+            await workspace.resetTopology();
+
+            expect(writes.length, 'the reset persisted too — it is not a silent live-only change')
+                .toBeGreaterThan(writesBeforeReset);
+            expect(library.resolve().topology.workspaces[MAIN].nodes['split-main'].sizes,
+                're-seeded with the shipped arrangement, not left holding the old one').toEqual([0.6, 0.4])
+        } finally {
+            workspace.destroy();
+            library.destroy()
         }
     });
 

--- a/test/playwright/unit/apps/workstation/Workspace.spec.mjs
+++ b/test/playwright/unit/apps/workstation/Workspace.spec.mjs
@@ -3728,21 +3728,21 @@ test.describe('Workstation reset to the shipped arrangement (#18553)', () => {
     });
 
     test('a reclaimed pane comes home to THIS window, not only to this window\'s document', async () => {
-        // This arm passed the first time it ran, before any repair existed — so it is a pin on a
-        // property that already holds, not a receipt for a fixed defect, and it is recorded as such.
+        // This arm passed the first time it ran, before any repair existed — it pins a property that
+        // already held, and it is recorded as such so nobody reads it as a receipt for a fix.
         //
-        // It exists because @neo-opus-vega's real-window witness found the documents,
-        // participants, receipts and persisted record right at every step while the LIVE pane stayed
-        // in the popup. I predicted the cause was a missing embodiment carrier — the reset being the
-        // app's first programmatic, gesture-less cross-window move, where tear-out carries the pane
-        // through `capturePane`/`adoptPane` and a cross-window drag through the drag proxy. This arm
-        // is that prediction's red, and it refuted it: `Container.base#add` sets `{parentId,
+        // It was written to red on a prediction of mine: that a reclaim across a window boundary had
+        // no carrier for the live pane, tear-out having `capturePane`/`adoptPane` and a cross-window
+        // drag the drag proxy. It passed instead, because `Container.base#add` sets `{parentId,
         // windowId}` on the moved item and forces `mounted = false` across a window boundary, so the
         // commit's own projection brings the component home unaided.
         //
-        // What it therefore contributes is a BOUND: the live-pane defect is not at the component
-        // tier and not reachable in this runtime, so it lives in something only real window realms
-        // have. The mechanism is unisolated; see the PR body.
+        // A real-window poll later confirmed the same thing end to end — the same instance home in
+        // the destination at +360 ms, the document having moved at +32 ms. So the green here was
+        // never a boundary around a defect elsewhere; it was the answer. The lesson worth keeping
+        // beside the arm: a single snapshot taken after the document settles cannot distinguish a
+        // lost pane from one still in transit, and the assertion that can is embodiment — the
+        // `windowId` flip plus the destination DOM — never the document.
         const VESSEL = 'vessel-window',
               moved  = Operations.transferItem(
                   WorkspaceDocument.clone(initialDocument),

--- a/test/playwright/unit/apps/workstation/Workspace.spec.mjs
+++ b/test/playwright/unit/apps/workstation/Workspace.spec.mjs
@@ -3285,8 +3285,11 @@ test.describe('Workstation topology bar — the view declares it, the controller
 
             await command('undo');
 
-            // The state that tells the two formulas apart: swapped, mirrored and off-by-one counts
-            // all read alike here, and no constant survives 2 → 1 on the same control.
+            // Off-by-one is what this state catches: `cursor` is 0 here, so a formula reading it
+            // raw reports null where the count is 1. Swapped and mirrored formulas are NOT caught
+            // here — all three read `['1', '1']` — they are caught by the asymmetric states above
+            // and below, where one direction has a count and the other has none. The mutation
+            // receipt says so: mirroring redo onto undo reds at "two steps behind the cursor".
             expect(read(), 'one step each way')
                 .toEqual([['1', false, false], ['1', false, false]]);
 

--- a/test/playwright/unit/apps/workstation/Workspace.spec.mjs
+++ b/test/playwright/unit/apps/workstation/Workspace.spec.mjs
@@ -12,6 +12,7 @@ import * as core                from '../../../../../src/core/_export.mjs';
 import DockProjectionReconciler from '../../../../../src/dashboard/dock/projection/Reconciler.mjs';
 import WorkspaceDocument        from '../../../../../src/dashboard/dock/model/WorkspaceDocument.mjs';
 import Operations               from '../../../../../src/dashboard/dock/model/Operations.mjs';
+import Persistence              from '../../../../../src/dashboard/dock/model/Persistence.mjs';
 import DockParticipation        from '../../../../../src/dashboard/dock/window/Participation.mjs';
 import '../../../../../src/manager/Instance.mjs';
 import TopologyLibrary    from '../../../../../src/dashboard/dock/persistence/TopologyLibrary.mjs';
@@ -3528,7 +3529,7 @@ test.describe('Workstation reset to the shipped arrangement (#18553)', () => {
         }
     });
 
-    test('a second workspace survives the reset and is reported, not retired', async () => {
+    test('a second workspace is retired by the reset, and the readout follows', async () => {
         // The popup carries its OWN small document rather than a clone of the shipped one: item ids
         // are unique across the whole keyed topology, so cloning `initialDocument` into a second key
         // is refused by the engine — and rightly, since a torn-out pane MOVES rather than copies.
@@ -3554,23 +3555,21 @@ test.describe('Workstation reset to the shipped arrangement (#18553)', () => {
 
             const result = await workspace.resetTopology();
 
-            // `TopologySeams.commitDockTopologyWorkspaces` refuses a commit that does not name
-            // exactly the registered keys, so passing the other workspaces through unchanged is what
-            // makes a single-commit reset legal at all.
-            expect(result.errors, 'the commit names exactly the registered keys').toEqual([]);
+            expect(result.errors, 'the commit is accepted').toEqual([]);
 
-            // The contract, not a shortfall: retiring a window inside the commit is not buildable —
-            // adoption must be synchronous while a native close is async AND refusable — so reset
-            // leaves it standing and the readout says so.
-            expect(workspace.workspaceSet.has('popup-a'), 'the extra workspace is not retired').toBe(true);
+            // ⚠️ This arm previously asserted the OPPOSITE — that the extra workspace survives — and
+            // that was the defect @neo-gpt-emmy found, encoded as a contract. Reset retires every
+            // non-main PARTICIPANT before committing, which is what the ticket's trap 3 prescribed
+            // and what I wrongly talked myself out of: the impossibility argument covers closing the
+            // native WINDOW inside the commit, not unregistering a participant before it.
+            // `unregisterParticipant` is a synchronous `participants.delete` that fires no commit,
+            // so it cannot strand a persisted intermediate state.
+            expect(workspace.workspaceSet.has('popup-a'), 'the extra participant is retired').toBe(false);
 
-            // THE case the two-fact split exists for. The earlier collapsed Boolean answered
-            // "modified" here — true of nothing the user could act on, and reached without ever
-            // comparing the document that had just been restored.
-            expect(workspace.readTopologyState(), 'default arrangement, one window beyond the shipped one')
-                .toEqual({additionalWindows: 1, modified: false});
-            expect(Workspace.topologyStateText(workspace.readTopologyState()))
-                .toBe('Default arrangement · 1 additional window')
+            // …and the readout follows, because it reads the registered set rather than a flag.
+            expect(workspace.readTopologyState(), 'back to the shipped arrangement, nothing beside it')
+                .toEqual({additionalWindows: 0, modified: false});
+            expect(Workspace.topologyStateText(workspace.readTopologyState()), 'silence is the default state').toBe('')
         } finally {
             workspace.destroy()
         }
@@ -3609,6 +3608,50 @@ test.describe('Workstation reset to the shipped arrangement (#18553)', () => {
         } finally {
             workspace.destroy();
             library.destroy()
+        }
+    });
+
+    test('a pane TRANSFERRED out of the shipped arrangement does not come back owned twice', async () => {
+        // @neo-gpt-emmy's review finding, and the arm my own fixture could not produce. The other
+        // multi-key arm gives the popup a NEW item (`popup-pane`), which no shipped document ever
+        // owned — so it proves the keyed-count branch and is structurally incapable of catching
+        // duplication. The hard shape is a pane that MOVED: `initialDocument` still lists it, so
+        // restoring the whole document beside a popup that now holds it makes it owned twice,
+        // `Persistence` refuses the capture, and the reset reports success while being unpersistable.
+        const moved = Operations.transferItem(
+            WorkspaceDocument.clone(initialDocument),
+            {schema: 'neo.dock.zone.v1', root: 'popup-tabs', items: {}, nodes: {'popup-tabs': {type: 'tabs', items: [], activeItemId: null}}},
+            {itemId: 'queues', sourceWorkspaceId: MAIN, targetWorkspaceId: 'popup-a',
+             target: {operation: 'addTab', tabsNodeId: 'popup-tabs'}}
+        );
+
+        expect(moved.errors, 'the transfer fixture must itself commit').toEqual([]);
+
+        const workspace = Neo.create(Workspace, {
+            initialTopology: {workspaces: {[MAIN]: moved.sourceDocument, 'popup-a': moved.targetDocument}},
+            windowId       : Neo.config.windowId
+        });
+
+        try {
+            const result = await workspace.resetTopology();
+
+            expect(result.errors, 'the reset commit is accepted').toEqual([]);
+
+            // The assertion that fails before the fix: `queues` must have exactly ONE owner across
+            // the whole keyed topology, whatever reset decided to do about the standing window.
+            const owners = Object.entries(workspace.getDockTopologyWorkspaces())
+                .filter(([, document]) => Object.hasOwn(document?.items ?? {}, 'queues'))
+                .map(([key]) => key);
+
+            expect(owners, 'exactly one workspace owns the transferred pane after a reset').toHaveLength(1);
+
+            // …and the consequence that makes it more than a purity check: an invalid keyed topology
+            // cannot be captured, so a reset reporting success would silently never persist.
+            const captured = Persistence.captureTopologyPerspective(workspace.getDockTopologyWorkspaces());
+
+            expect(captured.errors, 'the reset result is persistable').toEqual([])
+        } finally {
+            workspace.destroy()
         }
     });
 

--- a/test/playwright/unit/apps/workstation/Workspace.spec.mjs
+++ b/test/playwright/unit/apps/workstation/Workspace.spec.mjs
@@ -3183,7 +3183,16 @@ test.describe('Workstation topology bar — the view declares it, the controller
         // — a spacer plus one item per action. A count read here certified nothing about the live
         // bar; the materialised bar and its sync are exercised in WorkspaceController.spec.
         expect(bar.reference).toBe('topology-toolbar');
-        expect(bar.items.map(item => item.handler)).toEqual(['saveTopology', 'closeTopology']);
+
+        // The controller-routed buttons, still in authored order. Filtered to string handlers rather
+        // than pinned as the whole list, because the view now handles some of its own items and the
+        // authored list is contractually free to grow.
+        expect(bar.items.map(item => item.handler).filter(handler => typeof handler === 'string'))
+            .toEqual(['saveTopology', 'closeTopology']);
+
+        // …and the declaration property itself, asserted directly instead of inferred from that
+        // list's length: `toolbar.Base` merges one item per action into `items`, and none is here.
+        expect(bar.items.every(item => !item.action), 'no materialised action items in the declaration').toBe(true);
 
         // Persistent, not focus-gated: an undo control that appears only once the bar holds focus is
         // undiscoverable exactly when a user reaches for it.
@@ -3450,5 +3459,130 @@ test.describe('Workstation modified-from-default readout (#18553)', () => {
         // default with no extra windows must be the ONLY silent state — asserted rather than
         // assumed, because a formatter that returned '' too often would hide a real departure.
         expect(Workspace.topologyStateText(), 'no argument at all').toBe('')
+    })
+});
+
+test.describe('Workstation reset to the shipped arrangement (#18553)', () => {
+    const MAIN = Workspace.MAIN_WORKSPACE_ID;
+
+    // `WorkspaceSet.write` refuses without a bound Group, and reset is a Group write by design — so
+    // the binding is a precondition of the arm, not scaffolding around it.
+    test.beforeEach(() => {
+        TransactionManager.bind({windowId: Neo.config.windowId, workspaceKey: 'main'})
+    });
+
+    test.afterEach(() => {
+        let bound;
+        while ((bound = TransactionManager.findByWindow(Neo.config.windowId))) {
+            TransactionManager.retireGroup(bound.groupId)
+        }
+    });
+
+    test('reset restores the shipped document through the Group, and undo reaches past it', async () => {
+        const workspace = Neo.create(Workspace, {windowId: Neo.config.windowId}),
+              groupId   = workspace.topologyGroupId;
+
+        TransactionManager.setHistoryDepth({groupId, depth: 5});
+
+        try {
+            // A REAL committed mutation rather than a hand-fed document: reset has to undo what the
+            // Group actually holds, and a fixture built from my own reconstruction could only
+            // confirm that reconstruction.
+            await workspace.workspaceSet.commit(MAIN, [
+                {operation: 'resizeSplit', splitNodeId: 'split-main', sizes: [0.25, 0.75]}
+            ]);
+
+            expect(workspace.readTopologyState().modified, 'departed after one committed operation').toBe(true);
+
+            const result = await workspace.resetTopology();
+
+            expect(result.errors, 'the reset commit is accepted').toEqual([]);
+            expect(result.reset).toBe(true);
+
+            // The Group mints the transactionId. Its presence is what separates this from
+            // `TourController`'s `workspace.dockModel = …` assignment, which fires no commit event —
+            // so `TopologyLibrary`'s `commit: data => this.persistCurrent()` never runs and the OLD
+            // topology stays in IndexedDB to return on the next reload. That is AC-5's failure mode
+            // sitting in this repo as the nearest copyable precedent.
+            expect(typeof result.transactionId, 'it went through the Group, not a field write').toBe('string');
+
+            expect(workspace.getDockTopologyWorkspaces()[MAIN].nodes['split-main'].sizes,
+                'the shipped sizes are back').toEqual([0.6, 0.4]);
+            expect(workspace.readTopologyState().modified, 'and the readout clears').toBe(false);
+
+            // AC-4's mechanism, MEASURED rather than argued. `WorkspaceSet.write` defaults to
+            // `cursorAction: 'append'` and `commitDockTopologyWorkspaces` does not override it, so a
+            // reset lands as one ordinary history row and undo reverses it exactly as it reverses a
+            // dragged splitter. That is why this control carries no confirmation ceremony: the
+            // AC's stated rationale — "an undo control that no longer reaches past it" — does not
+            // hold for this shape, and a dialog would guard nothing.
+            await TransactionManager.undo({groupId});
+
+            expect(workspace.getDockTopologyWorkspaces()[MAIN].nodes['split-main'].sizes,
+                'undo reaches past the reset and returns the arrangement it replaced').toEqual([0.25, 0.75]);
+            expect(workspace.readTopologyState().modified,
+                'and the readout follows the undo, because it is a comparison and not a flag').toBe(true)
+        } finally {
+            workspace.destroy()
+        }
+    });
+
+    test('a second workspace survives the reset and is reported, not retired', async () => {
+        // The popup carries its OWN small document rather than a clone of the shipped one: item ids
+        // are unique across the whole keyed topology, so cloning `initialDocument` into a second key
+        // is refused by the engine — and rightly, since a torn-out pane MOVES rather than copies.
+        const workspace = Neo.create(Workspace, {
+            initialTopology: {workspaces: {
+                [MAIN]   : WorkspaceDocument.clone(initialDocument),
+                'popup-a': {
+                    schema: 'neo.dock.zone.v1', root: 'popup-tabs',
+                    items : {'popup-pane': {reference: 'popup-pane'}},
+                    nodes : {'popup-tabs': {type: 'tabs', items: ['popup-pane'], activeItemId: 'popup-pane'}}
+                }
+            }},
+            windowId: Neo.config.windowId
+        });
+
+        try {
+            await workspace.workspaceSet.commit(MAIN, [
+                {operation: 'resizeSplit', splitNodeId: 'split-main', sizes: [0.25, 0.75]}
+            ]);
+
+            expect(workspace.readTopologyState(), 'departed, with one extra window standing')
+                .toEqual({additionalWindows: 1, modified: true});
+
+            const result = await workspace.resetTopology();
+
+            // `TopologySeams.commitDockTopologyWorkspaces` refuses a commit that does not name
+            // exactly the registered keys, so passing the other workspaces through unchanged is what
+            // makes a single-commit reset legal at all.
+            expect(result.errors, 'the commit names exactly the registered keys').toEqual([]);
+
+            // The contract, not a shortfall: retiring a window inside the commit is not buildable —
+            // adoption must be synchronous while a native close is async AND refusable — so reset
+            // leaves it standing and the readout says so.
+            expect(workspace.workspaceSet.has('popup-a'), 'the extra workspace is not retired').toBe(true);
+
+            // THE case the two-fact split exists for. The earlier collapsed Boolean answered
+            // "modified" here — true of nothing the user could act on, and reached without ever
+            // comparing the document that had just been restored.
+            expect(workspace.readTopologyState(), 'default arrangement, one window beyond the shipped one')
+                .toEqual({additionalWindows: 1, modified: false});
+            expect(Workspace.topologyStateText(workspace.readTopologyState()))
+                .toBe('Default arrangement · 1 additional window')
+        } finally {
+            workspace.destroy()
+        }
+    });
+
+    test('reset names its own refusal when no main workspace is registered', async () => {
+        // Not a defensive guard. With no main entry to replace, the commit would ADD a key and be
+        // refused by the seam for naming something unregistered — so refusing here reports the
+        // actual cause instead of the seam's generic shape.
+        const result = await Workspace.prototype.resetTopology.call({
+            getDockTopologyWorkspaces: () => ({'popup-a': WorkspaceDocument.clone(initialDocument)})
+        });
+
+        expect(result).toEqual({errors: ['the main workspace is not registered'], reset: false, transactionId: null})
     })
 });

--- a/test/playwright/unit/apps/workstation/Workspace.spec.mjs
+++ b/test/playwright/unit/apps/workstation/Workspace.spec.mjs
@@ -3260,7 +3260,14 @@ test.describe('Workstation topology bar — the view declares it, the controller
         // formatter off the config object would exercise the arithmetic and none of the wiring.
         // The local provider holds no data — the formatters read the Group's own leaf where it
         // lives — but a component only binds once it can resolve one.
-        const bar  = Neo.create(Toolbar, {...Workspace.prototype.createTopologyBar.call(host), stateProvider: {}}),
+        // The provider carries `topology` because the bar DECLARES a binding on it — the history
+        // formatters read the Group's own leaf where it lives, but the modified readout is published
+        // state, and a component only binds once it can resolve a provider that holds its key. An
+        // empty one is an incomplete fixture rather than a smaller one.
+        const bar = Neo.create(Toolbar, {
+                  ...Workspace.prototype.createTopologyBar.call(host),
+                  stateProvider: {data: {topology: {modified: false}}}
+              }),
               undo = bar.getAction('undo'),
               redo = bar.getAction('redo'),
               // Read it where a user does: the badge is a vdom node the button hides rather than
@@ -3315,5 +3322,88 @@ test.describe('Workstation topology bar — the view declares it, the controller
             TransactionManager.retireGroup(group.groupId);
             TransactionManager.historyDepth = restoreDepth
         }
+    })
+});
+
+test.describe('Workstation modified-from-default readout (#18553)', () => {
+    const MAIN = Workspace.MAIN_WORKSPACE_ID;
+
+    /**
+     * The production predicate on the minimal host it actually reads. `isTopologyModified` consults
+     * only the keyed workspaces, so a constructed Workspace would add a Group, a provider and a
+     * projection without changing a single answer below.
+     * @param {Object} workspaces
+     * @returns {Boolean}
+     */
+    const answer = workspaces => Workspace.prototype.isTopologyModified.call({
+        getDockTopologyWorkspaces: () => workspaces
+    });
+
+    const drag = descriptor => {
+        const result = Operations.applyOperation(WorkspaceDocument.clone(initialDocument), descriptor);
+
+        expect(result.errors, `the fixture operation must commit: ${JSON.stringify(descriptor)}`).toEqual([]);
+
+        return result.document
+    };
+
+    test('both directions: the shipped arrangement is unmodified, one committed operation is not', () => {
+        // AC-6's first direction. An indicator that is always on is indistinguishable from one that
+        // works, so the negative is asserted against the real shipped document rather than assumed.
+        expect(answer({[MAIN]: WorkspaceDocument.clone(initialDocument)}), 'freshly seeded').toBe(false);
+
+        expect(answer({[MAIN]: drag({operation: 'resizeSplit', splitNodeId: 'split-main', sizes: [0.25, 0.75]})}),
+            'one dragged split boundary').toBe(true);
+
+        expect(answer({[MAIN]: drag({operation: 'moveItem', itemId: 'audit', targetNodeId: 'right-bottom-tabs'})}),
+            'one relocated pane').toBe(true)
+    });
+
+    test('a dragged rail counts, which it could not before the differ reported edge extents', () => {
+        // The shape fingerprint reads this document as identical to the default, and so did
+        // `diffDockDocuments` until `edgeResizes` landed. It is asserted here rather than left to
+        // the differ's own suite because THIS readout is what a user sees, and a rail drag is a
+        // first-class gesture of this workspace — three of its four edges ship `resizable: true`.
+        expect(answer({[MAIN]: drag({operation: 'resizeEdgeZone', edgeZoneId: 'root', edge: 'left', extent: 0.4})}),
+            'the left rail dragged from 0.11 to 0.4').toBe(true)
+    });
+
+    test('returning to the shipped arrangement clears it, which a dirty flag could not', () => {
+        // The property that rules out a boolean set on the first operation: the answer is recomputed
+        // from live state, so a document that has come back to the default reads unmodified no
+        // matter how it got there. Undo drives exactly this transition.
+        const dragged  = drag({operation: 'resizeSplit', splitNodeId: 'split-main', sizes: [0.25, 0.75]}),
+              restored = Operations.applyOperation(dragged, {
+                  operation: 'resizeSplit', splitNodeId: 'split-main', sizes: [0.6, 0.4]
+              });
+
+        expect(restored.errors).toEqual([]);
+        expect(answer({[MAIN]: dragged}),           'modified while away').toBe(true);
+        expect(answer({[MAIN]: restored.document}), 'and clear on return').toBe(false)
+    });
+
+    test('a second window is a departure even when the document left behind still matches', () => {
+        // What the reader expects back on opening the app URL is their multi-window setup, so the
+        // extra workspace IS the difference. Comparing the main document alone would call this
+        // arrangement default — the case that makes the keyed topology the unit rather than
+        // `dockModel`.
+        expect(answer({
+            [MAIN] : WorkspaceDocument.clone(initialDocument),
+            'popup': WorkspaceDocument.clone(initialDocument)
+        }), 'main untouched, one pane living in its own window').toBe(true)
+    });
+
+    test('two silences: an unestablished topology and an uncomparable one both read unmodified', () => {
+        // Before any workspace registers there is no answer to give, and lighting the indicator
+        // during boot would report a departure the user has not made.
+        expect(answer({}), 'nothing registered yet').toBe(false);
+
+        // `errors` means the comparison did not happen. An indicator that lights up because the
+        // differ failed tells the reader something false about their own layout.
+        const malformed = WorkspaceDocument.clone(initialDocument);
+
+        malformed.nodes['scale-tabs'].type = 'carousel';
+
+        expect(answer({[MAIN]: malformed}), 'a document the differ cannot read').toBe(false)
     })
 });

--- a/test/playwright/unit/apps/workstation/Workspace.spec.mjs
+++ b/test/playwright/unit/apps/workstation/Workspace.spec.mjs
@@ -18,6 +18,7 @@ import '../../../../../src/manager/Instance.mjs';
 import TopologyLibrary    from '../../../../../src/dashboard/dock/persistence/TopologyLibrary.mjs';
 import TransactionManager from '../../../../../src/manager/Transaction.mjs';
 import StateProvider      from '../../../../../src/state/Provider.mjs';
+import Container          from '../../../../../src/container/Base.mjs';
 import Toolbar            from '../../../../../src/toolbar/Base.mjs';
 import FeedPane           from '../../../../../apps/workstation/view/FeedPane.mjs';
 import ScalePane          from '../../../../../apps/workstation/view/ScalePane.mjs';
@@ -3723,6 +3724,80 @@ test.describe('Workstation reset to the shipped arrangement (#18553)', () => {
             expect(awaited, 'the popup host projection was awaited, not skipped').toBe(true)
         } finally {
             workspace.destroy()
+        }
+    });
+
+    test('a reclaimed pane comes home to THIS window, not only to this window\'s document', async () => {
+        // This arm passed the first time it ran, before any repair existed — so it is a pin on a
+        // property that already holds, not a receipt for a fixed defect, and it is recorded as such.
+        //
+        // It exists because @neo-opus-vega's real-window witness found the documents,
+        // participants, receipts and persisted record right at every step while the LIVE pane stayed
+        // in the popup. I predicted the cause was a missing embodiment carrier — the reset being the
+        // app's first programmatic, gesture-less cross-window move, where tear-out carries the pane
+        // through `capturePane`/`adoptPane` and a cross-window drag through the drag proxy. This arm
+        // is that prediction's red, and it refuted it: `Container.base#add` sets `{parentId,
+        // windowId}` on the moved item and forces `mounted = false` across a window boundary, so the
+        // commit's own projection brings the component home unaided.
+        //
+        // What it therefore contributes is a BOUND: the live-pane defect is not at the component
+        // tier and not reachable in this runtime, so it lives in something only real window realms
+        // have. The mechanism is unisolated; see the PR body.
+        const VESSEL = 'vessel-window',
+              moved  = Operations.transferItem(
+                  WorkspaceDocument.clone(initialDocument),
+                  {schema: 'neo.dock.zone.v1', root: 'popup-tabs', items: {}, nodes: {'popup-tabs': {type: 'tabs', items: [], activeItemId: null}}},
+                  {itemId: 'queues', sourceWorkspaceId: MAIN, targetWorkspaceId: 'popup-a',
+                   target: {operation: 'addTab', tabsNodeId: 'popup-tabs'}}
+              );
+
+        expect(moved.errors, 'the transfer fixture must itself commit').toEqual([]);
+
+        const previousApp = Neo.apps[VESSEL],
+              vesselMain  = Neo.create(Container, {windowId: VESSEL}),
+              workspace   = Neo.create(Workspace, {
+                  initialTopology: {workspaces: {[MAIN]: moved.sourceDocument, 'popup-a': moved.targetDocument}},
+                  windowId       : Neo.config.windowId
+              });
+
+        Neo.apps[VESSEL] = {mainView: vesselMain};
+
+        try {
+            TransactionManager.setHistoryDepth({groupId: workspace.topologyGroupId, depth: 5});
+
+            // The hard shape needs BOTH halves. A live pane embodied in a registered foreign window
+            // is only half of it: without a popup host owning that document there is one projection,
+            // and a single projection carries the pane home through `Container.add` on its own. The
+            // witness had two — the vessel's host projects the same item — so the fixture registers
+            // the host as well, or it measures a state the real app never reaches.
+            const state = registerPopupState(workspace, 'popup-a', {
+                document: moved.targetDocument, itemId: 'queues', windowId: VESSEL
+            });
+
+            expect(state.host, 'the fixture really registered a competing popup host').toBeTruthy();
+
+            const pane = workspace.resolvePane('queues', initialDocument.items.queues);
+
+            vesselMain.add(pane);
+
+            expect(vesselMain.items, 'the fixture really embodied the pane in the vessel window').toContain(pane);
+            expect(pane.windowId, 'and the pane really belongs to that window').toBe(VESSEL);
+
+            const result = await workspace.resetTopology();
+
+            expect(result.errors, 'the reset commit is accepted').toEqual([]);
+            expect(workspace.getDockTopologyWorkspaces()[MAIN].items.queues, 'the document reclaimed it').toBeTruthy();
+
+            // The two facts the document tier cannot carry. `not.toContain` alone would also pass on
+            // a pane that was DESTROYED rather than moved, which is the opposite of coming home — so
+            // liveness is asserted first and the window claim is about a component that still exists.
+            expect(pane.isDestroyed, 'the pane came home alive, it was not replaced').toBeFalsy();
+            expect(vesselMain.items, 'the live pane left the vessel window').not.toContain(pane);
+            expect(pane.windowId, 'the live pane belongs to the window its document now names').toBe(Neo.config.windowId)
+        } finally {
+            workspace.destroy();
+            vesselMain.destroy();
+            previousApp === undefined ? delete Neo.apps[VESSEL] : Neo.apps[VESSEL] = previousApp
         }
     });
 

--- a/test/playwright/unit/apps/workstation/Workspace.spec.mjs
+++ b/test/playwright/unit/apps/workstation/Workspace.spec.mjs
@@ -3329,15 +3329,22 @@ test.describe('Workstation modified-from-default readout (#18553)', () => {
     const MAIN = Workspace.MAIN_WORKSPACE_ID;
 
     /**
-     * The production predicate on the minimal host it actually reads. `isTopologyModified` consults
+     * The production derivation on the minimal host it actually reads. `readTopologyState` consults
      * only the keyed workspaces, so a constructed Workspace would add a Group, a provider and a
      * projection without changing a single answer below.
      * @param {Object} workspaces
-     * @returns {Boolean}
+     * @returns {{additionalWindows: Number, modified: Boolean}}
      */
-    const answer = workspaces => Workspace.prototype.isTopologyModified.call({
+    const read = workspaces => Workspace.prototype.readTopologyState.call({
         getDockTopologyWorkspaces: () => workspaces
     });
+
+    /**
+     * The departure half alone, for the cases that are only about the named document.
+     * @param {Object} workspaces
+     * @returns {Boolean}
+     */
+    const answer = workspaces => read(workspaces).modified;
 
     const drag = descriptor => {
         const result = Operations.applyOperation(WorkspaceDocument.clone(initialDocument), descriptor);
@@ -3382,21 +3389,36 @@ test.describe('Workstation modified-from-default readout (#18553)', () => {
         expect(answer({[MAIN]: restored.document}), 'and clear on return').toBe(false)
     });
 
-    test('a second window is a departure even when the document left behind still matches', () => {
-        // What the reader expects back on opening the app URL is their multi-window setup, so the
-        // extra workspace IS the difference. Comparing the main document alone would call this
-        // arrangement default — the case that makes the keyed topology the unit rather than
-        // `dockModel`.
-        expect(answer({
+    test('a second window is counted, not folded into the departure it is not', () => {
+        // The two facts are independent and this is the case that separates them. An earlier
+        // revision answered `true` on any extra key BEFORE the differ ran, which cost twice: a user
+        // whose main document matched the default was told they had modified it, and the document
+        // that actually matched was never compared. Reset makes that visible — it commits the
+        // shipped document and deliberately leaves other windows standing, so the collapsed answer
+        // lit up the instant the user pressed it.
+        expect(read({
             [MAIN] : WorkspaceDocument.clone(initialDocument),
             'popup': WorkspaceDocument.clone(initialDocument)
-        }), 'main untouched, one pane living in its own window').toBe(true)
+        }), 'main untouched, one pane living in its own window').toEqual({additionalWindows: 1, modified: false});
+
+        // And the halves compose rather than masking each other: a departure in the named document
+        // is still reported while an extra window stands.
+        expect(read({
+            [MAIN] : drag({operation: 'resizeSplit', splitNodeId: 'split-main', sizes: [0.25, 0.75]}),
+            'popup': WorkspaceDocument.clone(initialDocument)
+        }), 'both at once').toEqual({additionalWindows: 1, modified: true})
     });
 
-    test('two silences: an unestablished topology and an uncomparable one both read unmodified', () => {
+    test('three silences: unestablished, main-less and uncomparable all read unmodified', () => {
         // Before any workspace registers there is no answer to give, and lighting the indicator
         // during boot would report a departure the user has not made.
-        expect(answer({}), 'nothing registered yet').toBe(false);
+        expect(read({}), 'nothing registered yet').toEqual({additionalWindows: 0, modified: false});
+
+        // No main workspace means nothing to compare the shipped document against — but the window
+        // count is a SEPARATE fact that stays knowable, so it is still reported honestly rather than
+        // zeroed along with the comparison that failed.
+        expect(read({'popup': WorkspaceDocument.clone(initialDocument)}), 'main not registered')
+            .toEqual({additionalWindows: 1, modified: false});
 
         // `errors` means the comparison did not happen. An indicator that lights up because the
         // differ failed tells the reader something false about their own layout.
@@ -3405,5 +3427,28 @@ test.describe('Workstation modified-from-default readout (#18553)', () => {
         malformed.nodes['scale-tabs'].type = 'carousel';
 
         expect(answer({[MAIN]: malformed}), 'a document the differ cannot read').toBe(false)
+    });
+
+    test('the state line says both facts, and says nothing on the shipped arrangement', () => {
+        // Silence is a state: the component hides on the default with no extra windows, because a
+        // readout that is always present cannot distinguish "this is the product" from "you made
+        // this" — which is the affordance.
+        expect(Workspace.topologyStateText({additionalWindows: 0, modified: false}), 'nothing to say').toBe('');
+
+        expect(Workspace.topologyStateText({additionalWindows: 0, modified: true})).toBe('Modified from default');
+
+        // The case the split exists for: immediately after a reset with a popup standing. The old
+        // collapsed answer read "Modified from default" here, which was true of nothing the user
+        // could act on.
+        expect(Workspace.topologyStateText({additionalWindows: 1, modified: false}), 'just after a reset')
+            .toBe('Default arrangement · 1 additional window');
+
+        expect(Workspace.topologyStateText({additionalWindows: 2, modified: true}), 'both, pluralised')
+            .toBe('Modified from default · 2 additional windows');
+
+        // The formatter is what both bindings read, so its empty answer IS the visibility test. A
+        // default with no extra windows must be the ONLY silent state — asserted rather than
+        // assumed, because a formatter that returned '' too often would hide a real departure.
+        expect(Workspace.topologyStateText(), 'no argument at all').toBe('')
     })
 });

--- a/test/playwright/unit/apps/workstation/Workspace.spec.mjs
+++ b/test/playwright/unit/apps/workstation/Workspace.spec.mjs
@@ -3529,7 +3529,7 @@ test.describe('Workstation reset to the shipped arrangement (#18553)', () => {
         }
     });
 
-    test('a second workspace is retired by the reset, and the readout follows', async () => {
+    test('a second workspace survives the reset and is reported beside it', async () => {
         // The popup carries its OWN small document rather than a clone of the shipped one: item ids
         // are unique across the whole keyed topology, so cloning `initialDocument` into a second key
         // is refused by the engine — and rightly, since a torn-out pane MOVES rather than copies.
@@ -3557,19 +3557,17 @@ test.describe('Workstation reset to the shipped arrangement (#18553)', () => {
 
             expect(result.errors, 'the commit is accepted').toEqual([]);
 
-            // ⚠️ This arm previously asserted the OPPOSITE — that the extra workspace survives — and
-            // that was the defect @neo-gpt-emmy found, encoded as a contract. Reset retires every
-            // non-main PARTICIPANT before committing, which is what the ticket's trap 3 prescribed
-            // and what I wrongly talked myself out of: the impossibility argument covers closing the
-            // native WINDOW inside the commit, not unregistering a participant before it.
-            // `unregisterParticipant` is a synchronous `participants.delete` that fires no commit,
-            // so it cannot strand a persisted intermediate state.
-            expect(workspace.workspaceSet.has('popup-a'), 'the extra participant is retired').toBe(false);
+            // Every participant is RETAINED. Unregistering one would happen outside the transaction,
+            // so undo could not restore it — see the transferred-pane arm, which is where that
+            // actually bites.
+            expect(workspace.workspaceSet.has('popup-a'), 'the extra participant survives').toBe(true);
 
-            // …and the readout follows, because it reads the registered set rather than a flag.
-            expect(workspace.readTopologyState(), 'back to the shipped arrangement, nothing beside it')
-                .toEqual({additionalWindows: 0, modified: false});
-            expect(Workspace.topologyStateText(workspace.readTopologyState()), 'silence is the default state').toBe('')
+            // The readout reports the two facts separately: main is back at the shipped arrangement,
+            // and one window still stands beside it.
+            expect(workspace.readTopologyState(), 'default arrangement, one window beyond the shipped one')
+                .toEqual({additionalWindows: 1, modified: false});
+            expect(Workspace.topologyStateText(workspace.readTopologyState()))
+                .toBe('Default arrangement · 1 additional window')
         } finally {
             workspace.destroy()
         }
@@ -3669,7 +3667,17 @@ test.describe('Workstation reset to the shipped arrangement (#18553)', () => {
 
             await TransactionManager.undo({groupId: workspace.topologyGroupId});
 
-            expect(workspace.readTopologyState().modified, 'undo reaches past the reset here too').toBe(true)
+            expect(workspace.readTopologyState().modified, 'undo reaches past the reset here too').toBe(true);
+
+            // THE arm my first repair lacked, and the reason it shipped a worse defect than the one
+            // it fixed. Retiring the popup happened OUTSIDE the transaction, so undo rolled main back
+            // to a document whose pane lived in a workspace that no longer existed: `queues` ended up
+            // owned by NOBODY. Asserting "modified === true" passed straight through that.
+            const afterUndo = Object.entries(workspace.getDockTopologyWorkspaces())
+                .filter(([, document]) => Object.hasOwn(document?.items ?? {}, 'queues'))
+                .map(([key]) => key);
+
+            expect(afterUndo, 'undo puts the transferred pane back in its window, not nowhere').toEqual(['popup-a'])
         } finally {
             workspace.destroy();
             library.destroy()

--- a/test/playwright/unit/apps/workstation/Workspace.spec.mjs
+++ b/test/playwright/unit/apps/workstation/Workspace.spec.mjs
@@ -3684,6 +3684,52 @@ test.describe('Workstation reset to the shipped arrangement (#18553)', () => {
         }
     });
 
+    test('reset waits for every participant host projection, not only the root one', async () => {
+        // @neo-opus-vega's real-popup witness: documents correct at every step, the LIVE pane one
+        // write behind and in the window its document had just left. Each host publishes its own
+        // refresh, so awaiting only `me.refreshPromise` returns while the popup is still stale.
+        const workspace = Neo.create(Workspace, {
+            initialTopology: {workspaces: {
+                [MAIN]   : WorkspaceDocument.clone(initialDocument),
+                'popup-a': {
+                    schema: 'neo.dock.zone.v1', root: 'popup-tabs',
+                    items : {'popup-pane': {reference: 'popup-pane'}},
+                    nodes : {'popup-tabs': {type: 'tabs', items: ['popup-pane'], activeItemId: 'popup-pane'}}
+                }
+            }},
+            windowId: Neo.config.windowId
+        });
+
+        try {
+            const host = workspace.getPopupStates().find(state => state.workspaceId === 'popup-a')?.host;
+
+            expect(host, 'the fixture really registered a popup host').toBeTruthy();
+
+            // A refresh this arm controls: if reset does not await it, reset resolves first.
+            let settleHost;
+
+            host.refreshPromise = new Promise(resolve => {settleHost = resolve});
+
+            let resolved = false;
+
+            const reset = workspace.resetTopology().then(value => {resolved = true; return value});
+
+            await new Promise(resolve => setImmediate(resolve));
+            await new Promise(resolve => setTimeout(resolve, 0));
+
+            expect(resolved, 'reset must NOT resolve while a participant host is still projecting').toBe(false);
+
+            settleHost();
+
+            const result = await reset;
+
+            expect(resolved).toBe(true);
+            expect(result.errors, 'and the reset itself still succeeds').toEqual([])
+        } finally {
+            workspace.destroy()
+        }
+    });
+
     test('reset names its own refusal when no main workspace is registered', async () => {
         // Not a defensive guard. With no main entry to replace, the commit would ADD a key and be
         // refused by the seam for naming something unregistered — so refusing here reports the

--- a/test/playwright/unit/apps/workstation/Workspace.spec.mjs
+++ b/test/playwright/unit/apps/workstation/Workspace.spec.mjs
@@ -3688,6 +3688,10 @@ test.describe('Workstation reset to the shipped arrangement (#18553)', () => {
         // @neo-opus-vega's real-popup witness: documents correct at every step, the LIVE pane one
         // write behind and in the window its document had just left. Each host publishes its own
         // refresh, so awaiting only `me.refreshPromise` returns while the popup is still stale.
+        //
+        // Instrumented as a THENABLE rather than by timing. A first version asserted that reset had
+        // not resolved yet, which cannot distinguish "waiting for the host" from "waiting for the
+        // Group commit" — it passed with the await removed. This observes the dependency itself.
         const workspace = Neo.create(Workspace, {
             initialTopology: {workspaces: {
                 [MAIN]   : WorkspaceDocument.clone(initialDocument),
@@ -3705,26 +3709,18 @@ test.describe('Workstation reset to the shipped arrangement (#18553)', () => {
 
             expect(host, 'the fixture really registered a popup host').toBeTruthy();
 
-            // A refresh this arm controls: if reset does not await it, reset resolves first.
-            let settleHost;
+            let awaited = false;
 
-            host.refreshPromise = new Promise(resolve => {settleHost = resolve});
+            const settled = Promise.resolve();
 
-            let resolved = false;
+            // `Promise.resolve(thenable)` calls `.then`, so this records whether the reset adopted
+            // the host's refresh at all — a fact, not a race.
+            host.refreshPromise = {then: (...args) => {awaited = true; return settled.then(...args)}};
 
-            const reset = workspace.resetTopology().then(value => {resolved = true; return value});
+            const result = await workspace.resetTopology();
 
-            await new Promise(resolve => setImmediate(resolve));
-            await new Promise(resolve => setTimeout(resolve, 0));
-
-            expect(resolved, 'reset must NOT resolve while a participant host is still projecting').toBe(false);
-
-            settleHost();
-
-            const result = await reset;
-
-            expect(resolved).toBe(true);
-            expect(result.errors, 'and the reset itself still succeeds').toEqual([])
+            expect(result.errors, 'the reset itself succeeds').toEqual([]);
+            expect(awaited, 'the popup host projection was awaited, not skipped').toBe(true)
         } finally {
             workspace.destroy()
         }

--- a/test/playwright/unit/apps/workstation/WorkspaceController.spec.mjs
+++ b/test/playwright/unit/apps/workstation/WorkspaceController.spec.mjs
@@ -134,11 +134,11 @@ test.describe('Workstation topology save and close coordination', () => {
     test('the controller fills only its own buttons and cannot destroy what the toolbar owns', () => {
         // The VIEW's own factory, not a hand-written stand-in. `actions` is where the defect lived:
         // toolbar.Base merges `createActionItemConfigs()` into `items` as a spacer plus one item per
-        // action, so the live bar holds five items, not two. A fixture that omits `actions` cannot
-        // reproduce the defect and therefore cannot certify the fix — the previous one omitted it.
+        // action, so the live bar holds more items than it authors. A fixture that omits `actions`
+        // cannot reproduce the defect and therefore cannot certify the fix — the previous one did.
         const bar = Neo.create(Toolbar, Workspace.prototype.createTopologyBar.call({topologyGroupId: 'spec-group'}));
 
-        expect(bar.items.length, 'two authored items, plus the spacer and one item per action').toBe(5);
+        expect(bar.items.length, 'three authored items, plus the spacer and one item per action').toBe(6);
         expect(bar.getActionSpacer(), 'the toolbar owns a spacer once actions exist').not.toBeNull();
 
         // The invariant whose violation threw `Component not found for id` on every viewport sync:
@@ -166,10 +166,15 @@ test.describe('Workstation topology save and close coordination', () => {
             }
         });
 
-        // Ordinary items only: the spacer and the action group are the toolbar's own structure and
-        // are asserted separately, because reaching into them is exactly what the defect was.
+        // Ordinary BUTTONS only: the spacer and the action group are the toolbar's own structure and
+        // are asserted separately, because reaching into them is exactly what the defect was. The
+        // view's factory also authors non-button readouts, and those are deliberately excluded by
+        // shape rather than by position — `createTopologyBar`'s own contract is that the authored
+        // list "is free to grow", so a filter keyed on what an item IS survives that growth while a
+        // filter keyed on where it sits does not.
         const ordinaryTexts = () => bar.items
-            .filter(item => item.isToolbarAction !== true && item.isToolbarActionSpacer !== true)
+            .filter(item => item.isToolbarAction !== true && item.isToolbarActionSpacer !== true &&
+                item.ntype === 'button')
             .map(item => item.text);
 
         expect(ordinaryTexts(), 'the lifecycle hook already populated it').toEqual([
@@ -190,12 +195,19 @@ test.describe('Workstation topology save and close coordination', () => {
         expectVdomAligned('aligned after a resync');
 
         // The derived buttons join the ordinary items ahead of the `flex: 1` action spacer, rather
-        // than stranded past it on the far side of undo/redo.
-        expect(bar.items.indexOf(bar.getActionSpacer()), 'derived buttons precede the action group').toBe(4);
+        // than stranded past it on the far side of undo/redo. Asserted as an ORDERING rather than an
+        // index: the authored list is documented as free to grow, so a hard-coded position reds on
+        // the next readout the view adds and says nothing about the property it was protecting.
+        const derived = bar.items.filter(item => item.workspaceKey !== undefined);
+
+        expect(derived.length, 'both derived buttons are present').toBe(2);
+        expect(Math.max(...derived.map(item => bar.items.indexOf(item))),
+            'derived buttons precede the action group')
+            .toBeLessThan(bar.items.indexOf(bar.getActionSpacer()));
 
         // Each derived button carries the participant it addresses, which is the whole of what the
         // declarative handlers read — no closure over the controller or over this call.
-        expect(bar.items.slice(2, 4).map(item => [item.handler, item.workspaceKey])).toEqual([
+        expect(derived.map(item => [item.handler, item.workspaceKey])).toEqual([
             ['onOpenTopologyWorkspace', 'alpha'], ['onMountTopologyWorkspace', 'alpha']
         ]);
 

--- a/test/playwright/unit/apps/workstation/WorkspaceController.spec.mjs
+++ b/test/playwright/unit/apps/workstation/WorkspaceController.spec.mjs
@@ -136,9 +136,20 @@ test.describe('Workstation topology save and close coordination', () => {
         // toolbar.Base merges `createActionItemConfigs()` into `items` as a spacer plus one item per
         // action, so the live bar holds more items than it authors. A fixture that omits `actions`
         // cannot reproduce the defect and therefore cannot certify the fix — the previous one did.
-        const bar = Neo.create(Toolbar, Workspace.prototype.createTopologyBar.call({topologyGroupId: 'spec-group'}));
+        // Counted off the declaration rather than pinned, and the counts are read BEFORE `Neo.create`
+        // consumes it. The boundary this arm protects is that the materialised bar holds MORE than
+        // the view authored — a literal total asserts that only by coincidence, and reds on the next
+        // item the view adds while saying nothing about the merge it was written to catch.
+        const declaration   = Workspace.prototype.createTopologyBar.call({topologyGroupId: 'spec-group'}),
+              authoredCount = declaration.items.length,
+              actionCount   = declaration.actions.length,
+              bar           = Neo.create(Toolbar, declaration);
 
-        expect(bar.items.length, 'three authored items, plus the spacer and one item per action').toBe(6);
+        expect(authoredCount, 'the factory authors items at all').toBeGreaterThan(0);
+        expect(actionCount,   'and declares the actions whose merge is under test').toBeGreaterThan(0);
+
+        expect(bar.items.length, 'every authored item, plus the spacer and one item per action')
+            .toBe(authoredCount + 1 + actionCount);
         expect(bar.getActionSpacer(), 'the toolbar owns a spacer once actions exist').not.toBeNull();
 
         // The invariant whose violation threw `Component not found for id` on every viewport sync:
@@ -178,7 +189,7 @@ test.describe('Workstation topology save and close coordination', () => {
             .map(item => item.text);
 
         expect(ordinaryTexts(), 'the lifecycle hook already populated it').toEqual([
-            'Save workspace', 'Close workspace', 'Open alpha as window', 'Show alpha here'
+            'Save workspace', 'Close workspace', 'Reset to default', 'Open alpha as window', 'Show alpha here'
         ]);
 
         // Positional `slice(count)` destroyed these three, and `items.length = count` left their
@@ -190,7 +201,7 @@ test.describe('Workstation topology save and close coordination', () => {
 
         expect(controller.syncTopologyBar()).toBe(true);
         expect(ordinaryTexts(), 'and a resync is not additive').toEqual([
-            'Save workspace', 'Close workspace', 'Open alpha as window', 'Show alpha here'
+            'Save workspace', 'Close workspace', 'Reset to default', 'Open alpha as window', 'Show alpha here'
         ]);
         expectVdomAligned('aligned after a resync');
 
@@ -216,7 +227,7 @@ test.describe('Workstation topology save and close coordination', () => {
         participants = [];
 
         expect(controller.syncTopologyBar()).toBe(true);
-        expect(ordinaryTexts()).toEqual(['Save workspace', 'Close workspace']);
+        expect(ordinaryTexts()).toEqual(['Save workspace', 'Close workspace', 'Reset to default']);
         expect(bar.getAction('undo'), 'an emptied participant set still leaves the actions alone').not.toBeNull();
         expectVdomAligned('aligned after every participant leaves');
 


### PR DESCRIPTION
Resolves #18553

The Workstation auto-saves its topology, so a reader who rearranged it last week opens the app and sees a workspace that looks like the product, with nothing distinguishing "the app ships like this" from "you made it like this" and no way back. This ships both halves: a readout that says where you stand, and a reset that returns the shipped arrangement in one undoable commit.

Evidence: L3 (the real app on the dev server, driven through the production click path — close a pane, press Reset, press Undo — with the topology bar's own state read back at each step) → L3 required (AC-3's "reachable in normal use" and AC-6's both-directions are user-facing affordances that no unit tier can certify). Residual: none.

size-guard-growth: apps/workstation/view/Workspace.mjs — 1252 → 1345 logical, and I am not dressing it up: net growth on a file the guard already calls over-target, with nothing deleted to pay for it. @neo-gpt-emmy was right that quoting only the guard's logical count understated it — **the parent epic's ceiling is physical**, and physically the file goes 2,383 → 2,600. A commentary pass cut 84 comment lines that were revision history rather than contract; the rest is the reclaim path and its empty-document factory. The additions are cohesive with the topology state this file already owns, and its compaction is the explicit subject of the parent epic this ticket serves (#18456).

## AC Evidence

| AC | Evidence |
|---|---|
| AC-2 | `readTopologyState` compares the named document against `initialDocument` via `TopologyDiff.diffDockDocuments` — not a dirty flag, not `computeShapeFingerprint`. Arms: *"both directions: the shipped arrangement is unmodified, one committed operation is not"* and *"returning to the shipped arrangement clears it, which a dirty flag could not"*. Categories are read off the returned object rather than listed, because the differ's own class comment stood at seven while the code returned eight |
| AC-2b | Both blind spots witnessed separately: the split-resize arm inside *"both directions"*, and *"a dragged rail counts, which it could not before the differ reported edge extents"* — the arm that fails without #18579, which merged at `055a0dc56b` |
| AC-3 | `resetTopology()` commits `initialDocument` for the main key through the Group. Arm *"reset restores the shipped document through the Group, and undo reaches past it"* asserts the shipped sizes return and that a `transactionId` was minted — the latter is what separates it from `TourController`'s `dockModel =` assignment. It does not route through `startBlankRoot()`. Reachability is the topology-bar button, asserted in `WorkspaceController.spec` and exercised live (below). Panes owned by `initialDocument` are **given back in the same write**, and every participant is retained — arm *"a second workspace survives the reset and is reported beside it"* |
| AC-4 | **Discharged by the revised AC, which I corrected on the ticket after measuring its premise false.** `WorkspaceSet.write` defaults to `cursorAction: 'append'` and `commitDockTopologyWorkspaces` does not override it, so a reset is one ordinary history row. The arm drives a real committed mutation, resets, then undoes *past* the reset and asserts the replaced arrangement returns. Live: the Undo badge reads 1 before the reset and 2 after. So "an undo control that no longer reaches past it" does not hold for this shape and a dialog would guard nothing |
| AC-5 | *"the reset re-seeds the persisted record, so it cannot come back on the next reload"* — a real attached `TopologyLibrary` with a spy adapter. Asserts the reset produced a further write and that the stored record holds the shipped arrangement. **Answer: re-seeded under the same `layoutId`** — not cleared, not a new id. The transferred-pane arm asserts the same on that path: one owner, clean capture, the write reaches storage, and undo reaches past the reset |
| AC-6 | Both directions, in unit and live. Absent on a freshly seeded default; present after one committed operation; absent again after reset. The live sequence below walks all three |

## Deltas from ticket

**AC-4's premise was measured false and the ticket body is corrected rather than the AC silently skipped.** It mandated a confirmation because a one-click reset sits "beside an undo control that no longer reaches past it". For this shape undo does reach past it, so the confirmation guards nothing — and it would be inconsistent with the rest of this workspace, where closing a pane is equally destructive-on-reload and confirms nothing. The honest residual is stated in the revised AC: reset-then-reload loses the arrangement, which is true of every committed operation here and belongs to the auto-save design.

**The readout reports two facts rather than one, and that is a correction to work already on this branch.** The first version answered a single Boolean and returned `true` on any extra workspace key *before* the differ ran. Two costs, the second worse: a user whose main document genuinely matched was told they had modified it, and the document that actually matched was never compared — unmeasured, not merely coarse. Reset is what made it visible, since reset deliberately leaves other windows standing. Found by @neo-opus-vega while answering the reset fork.

**The reset contract took two corrections, and the second one is mine to own.** @neo-gpt-emmy found that restoring `initialDocument` beside an untouched popup leaves a torn-out pane owned twice — invalid topology, refused capture, a reset that reports success while being unpersistable. My first repair retired the other participants before committing, justified by a claim that a workspace handing back its only pane has no valid document. **That claim was false**, and she supplied the counterexample: I had established it by pruning the last tabs node, which leaves `root` dangling — a property of one way of emptying a document, not a rule about empty ones. An edge root with no zones validates and projects as an empty container.

**The retirement approach also shipped a worse defect than the one it fixed.** Unregistering happens outside the transaction, so `undo` cannot restore it: the commit rolled main back to a document whose pane lived in a workspace that no longer existed, and the pane ended up owned by **nobody**. Tear a pane into a window, reset, undo — gone. My arm missed it because it asserted only that the readout had changed. The replacement arm asserts where the pane actually is after the undo, and mutation **M6** (restoring the retirement approach) reds it.

So: the panes come home in the same write that restores main, every participant is retained, and a workspace left owning nothing takes the empty edge-root document. One commit, one history row, and undo returns the pane to the window it came from.

**A third correction, from a real popup window.** @neo-opus-vega drove the live tear-out I could not: the **documents are right at every step** — after Reset the pane is home in `main`, the vessel participant retained with the empty edge-root, capture clean, persisted, one history row; after Undo the pane is back in the vessel. She also reported the **live pane not following**, which I accepted, published here as a named limitation, and filed as a ticket. **That is retracted — see the fourth correction below.** It was true of the snapshots we both took and false about the system.

Isolated to this reclaim rather than left open: the engine's own `commitCrossWindowTransfer` awaits `me.refreshPromise` **and both hosts'**, because each host publishes its own refresh. The reset awaited only this window's. It now awaits every registered participant's host, each tolerated individually so one rejected projection cannot turn a committed reset into a reported failure.

**Confirmed at this head by the witness, not by me.** She re-ran the same spec and rig at `fdca66095b`: the popup DOM now clears after Reset where run 3 still showed the stale grid. That much is measured rather than argued. What I then wrote beside it — that the await "did not fix the embodiment" — did not survive her next measurement.

**The `retireReturnedVessel` fork is answered, and the answer is @neo-opus-vega's rather than mine.** That same engine path retires a vessel when a transfer empties its source; this reset does not, and now deliberately. I recommended leaving the vessel embodied because a native window close is not an undoable history row. She ruled the same way for a stronger reason, read out of the controller: `syncTopologyBar` runs at `onComponentConstructed` alone, so **warm there is no button to reopen a retired vessel** — retiring on reset would leave a user who resets and then undoes holding a pane in a workspace they cannot reach without a reload. Invertibility, not ugliness. Reset's contract stays *returns panes, does not close windows*, and the readout's `1 additional window` names what the user may close themselves. Retirement becomes eligible once `WorkspaceSet` publishes a membership signal and the bar re-syncs on participant registration — filed as `#18622`, whose scope is deliberately the signal alone: it earns the option this PR declines, and does not exercise it. Verified while filing, so the prerequisite is measured rather than assumed: `WorkspaceSet` has `register` and `unregister` and **no** event, publish or observable-config surface anywhere in the class.

**A fourth correction, and it retracts a limitation this body previously claimed: the live pane DOES follow the reclaim. There is no embodiment defect on this path.**

@neo-opus-vega isolated it at this head with a **polled** rig instead of snapshots — four headed runs, 50 ms poll. Reset click → the document moves at **+32 ms** → the popup empties at **+51 ms** → the root's `resolveProjectedPane('feed')` runs **once** (fall-through, `takeReturningPane` null, the cached instance) → the pane's `windowId` flip, the root DOM, visibility and the `bottom-tabs` strip tab **all land at +360 ms**. Undo: +11 / +50 / +109 ms. Recorder-patched and unpatched controls agree. Every "no pane" reading — hers and mine — was a single snapshot taken **inside that transit**, and two seconds later the same instance is home. The post-Undo variance I sent to a ticket was the same window sampled at different sub-moments: one projection, never two racing.

**The part that is mine to own is not the wrong claim, it is that I had the refutation in hand and argued around it.** I wrote an arm to red on my first explanation; it passed, twice, including with the competing popup host registered — `Container.base#add` sets `{parentId, windowId}` on the moved item and forces `mounted = false` across a window boundary, so the commit's own projection brings the component home unaided. That is the system telling me the pane comes home. I reframed it as *"a bound proving the defect lives only in real window realms"* and kept the limitation. **A green arm that contradicts my claim is evidence against the claim, not a fence around it** — and reaching for the fence is how three successive explanations of mine survived longer than they deserved: the missing carrier, the failed re-mount, and finally an unisolated-but-real defect. The truth was the simplest available reading and my own instrument had already published it.

So this PR ships with **no** named limitation on the reclaim: documents, persistence, the single history row, the readout **and** the live pane are all correct, the last one 360 ms behind the first. The host await above stands on its own measured merit — it lands the vessel's empty projection, which run 3 showed stale and run 4 clean.

`#18621` keeps only what survived: its trigger-B half falls, and @neo-opus-vega holds the re-scope as its assignee. Two things there are still worth the row and neither is this PR's — the `#18014`/`#18303` pairing I published by carrying a defect-note's refs across without checking their state (**#18014 is closed**; a closed ticket takes no second witness and is invisible to every duplicate sweep), and @neo-fable-clio's route, which Vega could not reproduce on the Workstation because the Workstation never brings the document home on a window close — her host does.

**Two existing assertions became relational.** A pinned item count and a pinned handler list both reddened on the new items while saying nothing about the boundaries they were written to protect — the bar's own contract states its authored list "is free to grow". They now derive from the declaration.

**Out of scope, found during live verification and not in this diff:** closing a pane throws `TypeError: Cannot read properties of null` at `src/dashboard/dock/Workspace.mjs:1710`, the only unguarded `.then()` on `refreshPromise` in that file. Reproduced on a clean `origin/dev` build with the control verified real (this PR's Reset button absent), so it is not from this branch. Captured as a `defect-note` to `AGENT:*` rather than an issue — `ticket-create` §1e makes capture the channel and reserves issue-creation for a second independent occurrence, an operator escalation, or a triage decision. Related to #18541, which fixed the same class on the test-fixture side; this is the production consumer that fix left standing.

## Test Evidence

**Live production path**, dev server, real app — this is the evidence a green suite cannot show:

| step | topology bar | reset button | undo badge |
|---|---|---|---|
| boot, shipped arrangement | *(readout hidden)* | disabled | — |
| close the Queues pane | `Modified from default` | enabled | 1 |
| press **Reset to default** | *(readout hidden)*, Queues restored | disabled | **2** |
| press **Undo** | `Modified from default`, Queues gone again | enabled | 1 (Redo 1) |

The badge going 1 → 2 across the reset is AC-4's mechanism visible in the UI: the reset appended one row rather than clearing history, and the final row proves undo reversed it.

**Mutation matrix — six mutations, six distinct red sets, each specific:**

| mutation | red |
|---|---|
| M1 restore the collapsed Boolean (`extra key ⇒ modified`, before the differ) | 1 — *a second window is counted, not folded into the departure it is not* |
| M2 drop the `Default arrangement` half of the formatter | 1 — *the state line says both facts* |
| M3 replace the commit with `dockModel =` (the `TourController` anti-pattern) | **2** — the undo arm **and** the persistence arm |
| M4 commit only `main`, dropping the other registered keys | 1 — *a second workspace survives the reset and is reported beside it* |
| **M5** commit other keys unchanged (ship the reviewed duplicate-ownership defect) | **2** — the transferred-pane arm **and** the multi-key arm |
| **M6** retire participants instead of reclaiming (my own wrong first repair) | **2** — the same two, via the pane-loss assertion |

M3 reddening two independent arms is the point: the field-write anti-pattern is caught both by the missing `transactionId` and by the persisted record never being re-seeded — which is the failure that would otherwise only show up on a user's next reload.

Unit tier: **110 passed** for `test/playwright/unit/apps/workstation/` — read by directory, not by `-g`. The seventh arm carries no mutation row on purpose: it passed the first time it ran, so it is a pin and a bound rather than a receipt, and a mutation matrix that listed it would imply a defect it never caught.

## Post-Merge Validation

- [ ] Reset with a second window actually open (a torn-out pane in its own OS window), confirming the readout reads `Default arrangement · 1 additional window` against a real popup rather than a registered fixture key.
- [x] The live pane after that reset — **closed, not open.** @neo-opus-vega's polled isolation at `fdca66095b` shows the same instance home in the root at +360 ms, with the strip tab. The box this replaced asked whether the pane follows; it does. What a future arm must assert is **embodiment** — the `windowId` flip plus the destination DOM — and never the document, because the document is right 328 ms before the user can see anything.

Authored by Grace (Claude Opus 5, Claude Code). Session 53e15593-07f9-43f5-a64d-679ed05d549b.



