### PR TITLE
refactor(workstation): the root adopts the windows bound into its Group, and the Viewport reaches into nothing (#18562)

### DIFF
--- a/apps/workstation/BootIntent.mjs
+++ b/apps/workstation/BootIntent.mjs
@@ -1,0 +1,22 @@
+/**
+ * @summary Reads one Workstation window's boot intent from the URL the main thread registered for it.
+ *
+ * Both sides of window adoption read this — the arriving window's controller, to decide whether it refuses
+ * or creates a root, and the owning root's controller, to decide whether an arrival is its to adopt — so the
+ * intent is resolved in one place, by one rule: the MODE is the presence of a parameter, the KEY is its
+ * value. `?workspace=` with an empty value is therefore a saved-window intent with no key — refused by the
+ * arriving side, ignored by the owner — and never a default boot to one side and a refusal to the other.
+ *
+ * A leaf by design: it imports nothing, so the controllers can import it without loading the application
+ * entry point, whose composition loads the controllers again.
+ *
+ * @param {String} windowId
+ * @returns {{mode: 'default'|'popout'|'workspace', key: String|null, params: URLSearchParams}}
+ */
+export function resolveBootIntent(windowId) {
+    const config = Neo.windowConfigs?.[windowId] || Neo.config,
+          params = new URLSearchParams(config.url?.search ?? ''),
+          mode   = params.has('popout') ? 'popout' : params.has('workspace') ? 'workspace' : 'default';
+
+    return {mode, key: mode === 'default' ? null : params.get(mode), params}
+}

--- a/apps/workstation/app.mjs
+++ b/apps/workstation/app.mjs
@@ -1,5 +1,6 @@
-import Viewport    from './view/Viewport.mjs';
-import Transaction from '../../src/manager/Transaction.mjs';
+import Viewport            from './view/Viewport.mjs';
+import Transaction         from '../../src/manager/Transaction.mjs';
+import {resolveBootIntent} from './BootIntent.mjs';
 
 /**
  * @summary Resolves one Workstation window's carried Neo theme against that window's configured themes.
@@ -15,21 +16,6 @@ export function resolveBootstrapTheme({search='', themes=[]} = {}) {
 }
 
 /**
- * @summary Reads the search params one Workstation window booted with.
- *
- * The main thread registers each window's URL alongside its config, so the App worker can read a window's
- * boot intent synchronously — no round-trip to the realm that owns the document. Both view controllers
- * read it here so that the entry point and the views agree on where that truth lives.
- * @param {String} windowId
- * @returns {URLSearchParams}
- */
-export function resolveBootParams(windowId) {
-    const config = Neo.windowConfigs?.[windowId] || Neo.config;
-
-    return new URLSearchParams(config.url?.search ?? '')
-}
-
-/**
  * @summary Starts each Workstation window with its carried theme on the first viewport instance.
  * @returns {Neo.controller.Application}
  */
@@ -40,12 +26,11 @@ export const onStart = () => {
         theme    = resolveBootstrapTheme({
             search: config.url?.search,
             themes: config.themes
-        });
+        }),
+        carried  = config.topologyIdentity;
 
-    const params  = resolveBootParams(windowId),
-          carried = config.topologyIdentity;
     // A popup cannot cold-create its absent root before that root selects durable truth.
-    if ((params.has('popout') || params.has('workspace')) && carried?.groupId && !Transaction.get(carried.groupId)) {
+    if (resolveBootIntent(windowId).mode !== 'default' && carried?.groupId && !Transaction.get(carried.groupId)) {
         config.topologyIdentity = {}
     }
 

--- a/apps/workstation/app.mjs
+++ b/apps/workstation/app.mjs
@@ -15,6 +15,21 @@ export function resolveBootstrapTheme({search='', themes=[]} = {}) {
 }
 
 /**
+ * @summary Reads the search params one Workstation window booted with.
+ *
+ * The main thread registers each window's URL alongside its config, so the App worker can read a window's
+ * boot intent synchronously — no round-trip to the realm that owns the document. Both view controllers
+ * read it here so that the entry point and the views agree on where that truth lives.
+ * @param {String} windowId
+ * @returns {URLSearchParams}
+ */
+export function resolveBootParams(windowId) {
+    const config = Neo.windowConfigs?.[windowId] || Neo.config;
+
+    return new URLSearchParams(config.url?.search ?? '')
+}
+
+/**
  * @summary Starts each Workstation window with its carried theme on the first viewport instance.
  * @returns {Neo.controller.Application}
  */
@@ -27,7 +42,7 @@ export const onStart = () => {
             themes: config.themes
         });
 
-    const params  = new URLSearchParams(config.url?.search ?? ''),
+    const params  = resolveBootParams(windowId),
           carried = config.topologyIdentity;
     // A popup cannot cold-create its absent root before that root selects durable truth.
     if ((params.has('popout') || params.has('workspace')) && carried?.groupId && !Transaction.get(carried.groupId)) {

--- a/apps/workstation/view/Viewport.mjs
+++ b/apps/workstation/view/Viewport.mjs
@@ -1,6 +1,5 @@
-import BaseViewport from '../../../src/container/Viewport.mjs';
-import Transaction  from '../../../src/manager/Transaction.mjs';
-import Workspace    from './Workspace.mjs';
+import BaseViewport       from '../../../src/container/Viewport.mjs';
+import ViewportController from './ViewportController.mjs';
 
 /**
  * @summary Standalone viewport for the living-data Workstation flagship.
@@ -8,14 +7,17 @@ import Workspace    from './Workspace.mjs';
  * The viewport owns only the render root. Workstation owns the state provider, dock document,
  * stores, pane cache, and deterministic tour so the application remains independently bootable.
  *
- * Two boot modes, resolved from the window's own search params (async — the worker reads the
- * URL through the main-thread seam, so the workspace mounts in `onConstructed`):
+ * Three boot modes, read from the window's own search params:
  *
  * - default         → the dense living-data workspace (`Workspace`)
  * - `?popout=<id>`  → an EMPTY pop-out host: this window carries no workspace of its own; the
  *   opener's workspace reparents the live pane into this viewport (the shared-heap contract —
  *   one App Worker, two render targets; the dockdemo vessel-shell sibling pattern).
  * - `?workspace=<key>` → a render target for an already hydrated keyed document.
+ *
+ * Which mode applies — and whether this window creates a root or is adopted by the root that already
+ * owns its Group — is its controller's decision. The view declares its class, its layout and that
+ * controller, and reaches into nothing.
  *
  * @class Workstation.view.Viewport
  * @extends Neo.container.Viewport
@@ -32,153 +34,14 @@ class Viewport extends BaseViewport {
          */
         cls: ['workstation-viewport'],
         /**
+         * @member {Neo.controller.Component} controller=ViewportController
+         * @reactive
+         */
+        controller: ViewportController,
+        /**
          * @member {Object} layout
          */
         layout: {ntype: 'vbox', align: 'stretch'}
-    }
-
-    /**
-     * @summary Resolves the boot mode and mounts the Group's retained Workspace on a warm rebind. A fresh
-     * root creates its Workspace; a pop-out vessel waits for its live pane instead.
-     */
-    async onConstructed() {
-        super.onConstructed();
-
-        let me     = this,
-            url    = await Neo.Main.getByPath({path: 'document.URL', windowId: me.windowId}),
-            params = new URL(url).searchParams;
-
-        if (me.isDestroyed) return;
-
-        if (params.get('popout')) {
-            me.addCls('workstation-popout-host');
-            const binding = Transaction.findByWindow(me.windowId);
-            const participant = binding && Transaction.getParticipant(binding.groupId, binding.workspaceKey);
-            const workspace = participant?.componentId && Neo.getComponent(participant.componentId);
-            if (workspace?.rootWorkspace) {
-                await workspace.rootWorkspace.getController().mountTopologyWorkspace(binding.workspaceKey, me)
-            }
-            return
-        }
-
-        if (params.has('workspace')) {
-            const binding = Transaction.findByWindow(me.windowId),
-                  owner   = binding && Transaction.getParticipant(binding.groupId, binding.workspaceKey),
-                  workspace = owner?.componentId && Neo.getComponent(owner.componentId),
-                  root = workspace?.rootWorkspace ?? workspace;
-            if (root && binding.workspaceKey === params.get('workspace')) {
-                await root.getController().mountTopologyWorkspace(binding.workspaceKey, me)
-            } else {
-                me.add({ntype: 'component', html: 'This saved window is waiting for its original workspace.'})
-            }
-            return
-        }
-
-        const binding     = Transaction.findByWindow(me.windowId),
-              participant = binding && Transaction.getParticipant(binding.groupId, Workspace.MAIN_WORKSPACE_ID),
-              workspace   = participant?.componentId && Neo.getComponent(participant.componentId);
-
-        if (workspace) {
-            // The old render target is gone; detach silently before the ordinary cross-window add.
-            workspace.parent?.remove(workspace, false, true);
-            me.add(workspace)
-        } else {
-            await me.createRoot(binding, params.get('layout') ?? undefined)
-        }
-    }
-
-    /**
-     * @summary Hydrates one explicitly selected topology before mounting its root render target.
-     * @description Only a root binding can read storage. Popup carriers never select saved roots.
-     * The library is reused with the Workspace on warm F5; this path runs only for a new heap owner.
-     * @param {Object} binding The admitted Group binding.
-     * @param {String} [layoutId] Omission uses only the persisted activeLayoutId.
-     * @returns {Promise<void>}
-     */
-    async createRoot(binding, layoutId) {
-        const me = this;
-        if (!binding || binding.workspaceKey !== 'main') {
-            me.add({ntype: 'component', html: 'This window is waiting for its original workspace.'});
-            return
-        }
-
-        const {default: TopologyLibrary} = await import('../../../src/dashboard/dock/persistence/TopologyLibrary.mjs'),
-              library                    = Neo.create(TopologyLibrary, {
-                  persistenceAdapter: TopologyLibrary.createIndexedDBAdapter(binding.groupId)
-              }),
-              loaded = await library.hydrate();
-
-        let selection = {topology: null, errors: []}, workspace;
-        if (loaded.hydrated || layoutId !== undefined) selection = library.prepareSelection(layoutId);
-
-        const errors = [...loaded.errors, ...selection.errors];
-        if (selection.topology && !selection.topology.workspaces[Workspace.MAIN_WORKSPACE_ID]) {
-            errors.push('saved topology has no Workstation root')
-        }
-
-        if (me.isDestroyed || errors.length) {
-            library.destroy();
-            if (!me.isDestroyed) me.showRootFailure();
-            return
-        }
-
-        try {
-            workspace = Neo.create(Workspace, {
-                flex           : 1,
-                initialTopology: selection.topology,
-                topologyGroupId: binding.groupId,
-                topologyLibrary: library,
-                windowId       : me.windowId
-            });
-
-            if (selection.topology) {
-                await Transaction.write({
-                    cause       : 'cold-hydrate',
-                    changes     : Object.entries(selection.topology.workspaces).map(([workspaceKey, document]) => ({workspaceKey, input: document})),
-                    cursorAction: 'preserve',
-                    descriptor  : {operation: 'hydrateTopology', layoutId: selection.topology.layoutId},
-                    groupId     : binding.groupId,
-                    provenance  : {source: 'cold-hydrate'}
-                });
-                library.adoptCollection(selection.collection, {expectedVersion: selection.version})
-            }
-
-            if (me.isDestroyed) {
-                workspace.destroy();
-                return
-            }
-
-            workspace.getController().attachTopologyLibrary();
-            me.add(workspace);
-            if (!selection.topology) await workspace.saveTopology()
-        } catch (error) {
-            workspace?.destroy();
-            library.destroy();
-            if (!me.isDestroyed) me.showRootFailure();
-            throw error
-        }
-    }
-
-    /**
-     * @summary Offers an explicit fresh root when a persisted selection cannot be used.
-     */
-    showRootFailure() {
-        this.add([
-            {ntype: 'component', html: 'The saved workspace could not be loaded.'},
-            {ntype: 'button', text: 'Start a new workspace', handler: () => this.startBlankRoot()}
-        ])
-    }
-
-    /**
-     * @summary Starts a new logical root without replacing the refused saved collection.
-     * @returns {Promise<void>}
-     */
-    async startBlankRoot() {
-        Transaction.release(this.windowId);
-        const binding = await Transaction.admit({topologyIdentity: {}, windowId: this.windowId});
-        if (binding.outcome === 'refused' || this.isDestroyed) return;
-        this.removeAll();
-        await this.createRoot(binding)
     }
 }
 

--- a/apps/workstation/view/ViewportController.mjs
+++ b/apps/workstation/view/ViewportController.mjs
@@ -1,7 +1,7 @@
 import Controller          from '../../../src/controller/Component.mjs';
 import Transaction         from '../../../src/manager/Transaction.mjs';
 import Workspace           from './Workspace.mjs';
-import {resolveBootParams} from '../app.mjs';
+import {resolveBootIntent} from '../BootIntent.mjs';
 
 /**
  * @summary Decides one Workstation window's boot from the registry, and creates a root only where no owner exists.
@@ -69,11 +69,12 @@ class ViewportController extends Controller {
     }
 
     /**
-     * The search params this window booted with, read from the config the main thread registered for it.
-     * @member {URLSearchParams} bootParams
+     * What this window booted FOR, read from the URL the main thread registered for it: the mode by a
+     * parameter's presence, the key by its value — the one reading the owner shares.
+     * @member {{mode: String, key: String|null, params: URLSearchParams}} bootIntent
      */
-    get bootParams() {
-        return resolveBootParams(this.component.windowId)
+    get bootIntent() {
+        return resolveBootIntent(this.component.windowId)
     }
 
     /**
@@ -85,7 +86,7 @@ class ViewportController extends Controller {
     onComponentConstructed() {
         const me = this;
 
-        if (me.bootParams.get('popout')) {
+        if (me.bootIntent.mode === 'popout') {
             me.component.addCls('workstation-popout-host')
         }
 
@@ -133,14 +134,14 @@ class ViewportController extends Controller {
 
         me.#decided = true;
 
-        const params = me.bootParams;
+        const intent = me.bootIntent;
 
-        if (params.get('popout')) return;
+        if (intent.mode === 'popout') return;
 
-        if (params.has('workspace')) {
+        if (intent.mode === 'workspace') {
             const root = binding && ViewportController.rootOf(Transaction.getParticipant(binding.groupId, binding.workspaceKey));
 
-            if (!root || binding.workspaceKey !== params.get('workspace')) {
+            if (!root || binding.workspaceKey !== intent.key) {
                 component.add({ntype: 'component', html: 'This saved window is waiting for its original workspace.'})
             }
 
@@ -151,7 +152,7 @@ class ViewportController extends Controller {
             return
         }
 
-        return me.createRoot(binding, params.get('layout') ?? undefined).catch(error => {
+        return me.createRoot(binding, intent.params.get('layout') ?? undefined).catch(error => {
             console.error('[Workstation] root creation failed', error)
         })
     }

--- a/apps/workstation/view/ViewportController.mjs
+++ b/apps/workstation/view/ViewportController.mjs
@@ -1,0 +1,278 @@
+import Controller          from '../../../src/controller/Component.mjs';
+import Transaction         from '../../../src/manager/Transaction.mjs';
+import Workspace           from './Workspace.mjs';
+import {resolveBootParams} from '../app.mjs';
+
+/**
+ * @summary Decides one Workstation window's boot from the registry, and creates a root only where no owner exists.
+ *
+ * A window's URL says what it is FOR — `?popout=<id>`, `?workspace=<key>`, or the default root — and the
+ * Group registry says what it is BOUND TO. Both are readable synchronously inside the App worker: the URL
+ * from the config the main thread registered for the window, the binding from `Neo.manager.Transaction`,
+ * which the engine admits at app registration. A held identity (a reload, a reserved slot) is bound before
+ * this view constructs; a minted one is bound through the manager's `bind` event once its carrier accepts.
+ * So the decision needs no round-trip to the main thread — which is what let the previous shape fail
+ * silently: an awaited URL read inside an async `onConstructed` turned a boot defect into an unhandled
+ * rejection that nothing listened for.
+ *
+ * The decision is deliberately narrow. A window that has an owner — a live root whose Group this window is
+ * bound into — renders NOTHING here: the owner adopts it when the worker publishes the window's `connect`
+ * (see {@link Workstation.view.WorkspaceController#onWindowConnect}). This controller only refuses what
+ * cannot be adopted and creates a root where none exists. Nothing in it resolves another component's
+ * controller to address that component.
+ *
+ * @class Workstation.view.ViewportController
+ * @extends Neo.controller.Component
+ */
+class ViewportController extends Controller {
+    static config = {
+        /**
+         * @member {String} className='Workstation.view.ViewportController'
+         * @protected
+         */
+        className: 'Workstation.view.ViewportController'
+    }
+
+    /**
+     * Whether this window's boot has been decided. One window, one decision: a `bind` arriving after a held
+     * identity already decided the boot — a blank-root restart re-admits the same window — must not decide it
+     * again.
+     * @member {Boolean} #decided=false
+     * @private
+     */
+    #decided = false
+
+    /**
+     * @param {Object} config
+     */
+    construct(config) {
+        super.construct(config);
+
+        Transaction.on({
+            admissionRefused: this.onAdmissionRefused,
+            bind            : this.onGroupBind,
+            scope           : this
+        })
+    }
+
+    /**
+     * @param {...*} args
+     */
+    destroy(...args) {
+        Transaction.un({
+            admissionRefused: this.onAdmissionRefused,
+            bind            : this.onGroupBind,
+            scope           : this
+        });
+
+        super.destroy(...args)
+    }
+
+    /**
+     * The search params this window booted with, read from the config the main thread registered for it.
+     * @member {URLSearchParams} bootParams
+     */
+    get bootParams() {
+        return resolveBootParams(this.component.windowId)
+    }
+
+    /**
+     * @summary Marks a pop-out host and decides a boot whose binding already settled.
+     *
+     * A held identity binds synchronously at app registration, before the viewport constructs, so its binding
+     * is readable now. A minted identity is still awaiting its carrier; {@link #onGroupBind} decides that one.
+     */
+    onComponentConstructed() {
+        const me = this;
+
+        if (me.bootParams.get('popout')) {
+            me.component.addCls('workstation-popout-host')
+        }
+
+        me.decide(Transaction.findByWindow(me.component.windowId))
+    }
+
+    /**
+     * @summary The carrier refused this window's identity: nothing can own it, so the window says so.
+     * @param {Object} data
+     * @param {String} data.windowId
+     */
+    onAdmissionRefused({windowId}) {
+        windowId === this.component.windowId && this.decide(null, true)
+    }
+
+    /**
+     * @summary A minted identity's carrier accepted: this window's binding exists now.
+     * @param {Object} data
+     * @param {String} data.windowId
+     */
+    onGroupBind({windowId}) {
+        windowId === this.component.windowId && this.decide(Transaction.findByWindow(windowId))
+    }
+
+    /**
+     * @summary Refuses what no owner can adopt, creates a root where none exists, and otherwise renders nothing.
+     *
+     * | URL                 | the binding says                            | this window does                                                   |
+     * |---------------------|---------------------------------------------|--------------------------------------------------------------------|
+     * | `?popout=<id>`      | anything                                    | nothing — the owner's tear-out lifecycle or its `connect` adoption mounts the vessel |
+     * | `?workspace=<key>`  | bound under `key`, with a live root         | nothing — the root adopts on `connect`                             |
+     * | `?workspace=<key>`  | anything else                               | the refusal, fail-closed                                            |
+     * | default             | `main`, and the Group holds a live root     | nothing — the retained root moves in on `connect`                   |
+     * | default             | `main`, no root                             | creates the root                                                   |
+     * | default             | not `main`, or refused                      | the waiting notice {@link #createRoot} renders for a non-root slot  |
+     *
+     * @param {Object|null} binding The window's Group binding, `null` while none exists.
+     * @param {Boolean} [refused=false] Whether the carrier refused the identity, which is final.
+     * @returns {Promise<void>|undefined} The root creation, when this window creates one.
+     */
+    decide(binding, refused=false) {
+        const me = this, {component} = me;
+
+        if (me.#decided || component.isDestroyed || (!binding && !refused)) return;
+
+        me.#decided = true;
+
+        const params = me.bootParams;
+
+        if (params.get('popout')) return;
+
+        if (params.has('workspace')) {
+            const root = binding && ViewportController.rootOf(Transaction.getParticipant(binding.groupId, binding.workspaceKey));
+
+            if (!root || binding.workspaceKey !== params.get('workspace')) {
+                component.add({ntype: 'component', html: 'This saved window is waiting for its original workspace.'})
+            }
+
+            return
+        }
+
+        if (binding?.workspaceKey === 'main' && ViewportController.rootOf(Transaction.getParticipant(binding.groupId, Workspace.MAIN_WORKSPACE_ID))) {
+            return
+        }
+
+        return me.createRoot(binding, params.get('layout') ?? undefined).catch(error => {
+            console.error('[Workstation] root creation failed', error)
+        })
+    }
+
+    /**
+     * The live root a Group participant resolves to: the participant's own component when it is a root, its
+     * `rootWorkspace` when it is a popup owner, `null` when it resolves to nothing live.
+     * @param {Object|null} participant
+     * @returns {Neo.component.Base|null}
+     */
+    static rootOf(participant) {
+        const owner = participant?.componentId && Neo.getComponent(participant.componentId),
+              root  = owner?.rootWorkspace ?? owner;
+
+        return root && !root.isDestroyed ? root : null
+    }
+
+    /**
+     * @summary Hydrates one explicitly selected topology before mounting its root render target.
+     * @description Only a root binding can read storage. Popup carriers never select saved roots.
+     * The library is reused with the Workspace on warm reload; this path runs only for a new heap owner.
+     * @param {Object|null} binding The admitted Group binding, `null` when admission was refused.
+     * @param {String} [layoutId] Omission uses only the persisted activeLayoutId.
+     * @returns {Promise<void>}
+     */
+    async createRoot(binding, layoutId) {
+        const me = this, view = me.component;
+
+        if (!binding || binding.workspaceKey !== 'main') {
+            view.add({ntype: 'component', html: 'This window is waiting for its original workspace.'});
+            return
+        }
+
+        const {default: TopologyLibrary} = await import('../../../src/dashboard/dock/persistence/TopologyLibrary.mjs'),
+              library                    = Neo.create(TopologyLibrary, {
+                  persistenceAdapter: TopologyLibrary.createIndexedDBAdapter(binding.groupId)
+              }),
+              loaded = await library.hydrate();
+
+        let selection = {topology: null, errors: []}, workspace;
+        if (loaded.hydrated || layoutId !== undefined) selection = library.prepareSelection(layoutId);
+
+        const errors = [...loaded.errors, ...selection.errors];
+        if (selection.topology && !selection.topology.workspaces[Workspace.MAIN_WORKSPACE_ID]) {
+            errors.push('saved topology has no Workstation root')
+        }
+
+        if (view.isDestroyed || errors.length) {
+            library.destroy();
+            if (!view.isDestroyed) me.showRootFailure();
+            return
+        }
+
+        try {
+            workspace = Neo.create(Workspace, {
+                flex           : 1,
+                initialTopology: selection.topology,
+                topologyGroupId: binding.groupId,
+                topologyLibrary: library,
+                windowId       : view.windowId
+            });
+
+            if (selection.topology) {
+                await Transaction.write({
+                    cause       : 'cold-hydrate',
+                    changes     : Object.entries(selection.topology.workspaces).map(([workspaceKey, document]) => ({workspaceKey, input: document})),
+                    cursorAction: 'preserve',
+                    descriptor  : {operation: 'hydrateTopology', layoutId: selection.topology.layoutId},
+                    groupId     : binding.groupId,
+                    provenance  : {source: 'cold-hydrate'}
+                });
+                library.adoptCollection(selection.collection, {expectedVersion: selection.version})
+            }
+
+            if (view.isDestroyed) {
+                workspace.destroy();
+                return
+            }
+
+            // The attach must follow the cold-hydrate write, so it stays a step of this boot; moving the
+            // persistence cluster onto its owner is a separate change.
+            workspace.getController().attachTopologyLibrary();
+            view.add(workspace);
+            if (!selection.topology) await workspace.saveTopology()
+        } catch (error) {
+            workspace?.destroy();
+            library.destroy();
+            if (!view.isDestroyed) me.showRootFailure();
+            throw error
+        }
+    }
+
+    /**
+     * @summary Offers an explicit fresh root when a persisted selection cannot be used.
+     */
+    showRootFailure() {
+        this.component.add([
+            {ntype: 'component', html: 'The saved workspace could not be loaded.'},
+            {ntype: 'button', text: 'Start a new workspace', handler: 'onStartBlankRoot'}
+        ])
+    }
+
+    /**
+     * @summary Declarative handler: starts a new logical root without replacing the refused saved collection.
+     *
+     * Re-admission binds this same window again, which the manager publishes as a `bind`; the boot was
+     * decided long before, so that event changes nothing here.
+     * @returns {Promise<void>}
+     */
+    async onStartBlankRoot() {
+        const me = this, view = me.component, {windowId} = view;
+
+        Transaction.release(windowId);
+
+        const binding = await Transaction.admit({topologyIdentity: {}, windowId});
+
+        if (binding.outcome === 'refused' || view.isDestroyed) return;
+
+        view.removeAll();
+        await me.createRoot(binding)
+    }
+}
+
+export default Neo.setupClass(ViewportController);

--- a/apps/workstation/view/WorkspaceController.mjs
+++ b/apps/workstation/view/WorkspaceController.mjs
@@ -1,7 +1,7 @@
 import Controller          from '../../../src/controller/Component.mjs';
 import Persistence         from '../../../src/dashboard/dock/model/Persistence.mjs';
 import TransactionManager  from '../../../src/manager/Transaction.mjs';
-import {resolveBootParams} from '../app.mjs';
+import {resolveBootIntent} from '../BootIntent.mjs';
 
 /**
  * @summary Workstation actions, durable topology, window adoption and optional tour-controller activation.
@@ -41,7 +41,9 @@ class WorkspaceController extends Controller {
      * The worker publishes `connect` once the window's app and main view exist, so the render target is
      * live. The binding says which slot the window took; the window's own URL says what it came FOR, and
      * the two must agree — a non-matching arrival is ignored rather than adopted, the owner's half of the
-     * fail-closed contract whose other half is the arriving viewport's refusal. Three arrivals are adopted:
+     * fail-closed contract whose other half is the arriving viewport's refusal. Both halves read the URL
+     * through `resolveBootIntent`, so neither can call an intent what the other calls none. Three arrivals
+     * are adopted:
      *
      * - the root's own `main` slot (the one {@link Workstation.view.Workspace#registerMainWorkspace} binds
      *   under) rebound to a new window — a reload of the main window while this worker lives — so the root
@@ -68,12 +70,10 @@ class WorkspaceController extends Controller {
 
         if (!target || target.isDestroyed) return false;
 
-        const params   = resolveBootParams(windowId),
-              popout   = params.get('popout'),
-              declared = params.get('workspace') ?? (popout ? root.tearOutWorkspaceKey(popout) : null);
+        const intent = resolveBootIntent(windowId);
 
         if (binding.workspaceKey === 'main') {
-            if (declared) return false;
+            if (intent.mode !== 'default') return false;
 
             // The old render target is gone; detach silently before the ordinary cross-window add.
             root.parent?.remove(root, false, true);
@@ -81,6 +81,9 @@ class WorkspaceController extends Controller {
 
             return true
         }
+
+        const declared = intent.mode === 'workspace' ? intent.key
+            : intent.mode === 'popout' ? root.tearOutWorkspaceKey(intent.key) : null;
 
         if (declared !== binding.workspaceKey) return false;
 

--- a/apps/workstation/view/WorkspaceController.mjs
+++ b/apps/workstation/view/WorkspaceController.mjs
@@ -1,9 +1,10 @@
-import Controller         from '../../../src/controller/Component.mjs';
-import Persistence        from '../../../src/dashboard/dock/model/Persistence.mjs';
-import TransactionManager from '../../../src/manager/Transaction.mjs';
+import Controller          from '../../../src/controller/Component.mjs';
+import Persistence         from '../../../src/dashboard/dock/model/Persistence.mjs';
+import TransactionManager  from '../../../src/manager/Transaction.mjs';
+import {resolveBootParams} from '../app.mjs';
 
 /**
- * @summary Workstation actions, durable topology and optional tour-controller activation.
+ * @summary Workstation actions, durable topology, window adoption and optional tour-controller activation.
  * @class Workstation.view.WorkspaceController
  * @extends Neo.controller.Component
  */
@@ -15,6 +16,82 @@ class WorkspaceController extends Controller {
 
     /** @member {Promise|null} tourControllerPromise=null */
     tourControllerPromise = null
+
+    /**
+     * @param {Object} config
+     */
+    construct(config) {
+        super.construct(config);
+
+        Neo.currentWorker.on({connect: this.onWindowConnect, scope: this})
+    }
+
+    /**
+     * @param {...*} args
+     */
+    destroy(...args) {
+        Neo.currentWorker.un({connect: this.onWindowConnect, scope: this});
+
+        super.destroy(...args)
+    }
+
+    /**
+     * @summary A window bound into this root's Group announced itself: the root adopts it.
+     *
+     * The worker publishes `connect` once the window's app and main view exist, so the render target is
+     * live. The binding says which slot the window took; the window's own URL says what it came FOR, and
+     * the two must agree — a non-matching arrival is ignored rather than adopted, the owner's half of the
+     * fail-closed contract whose other half is the arriving viewport's refusal. Three arrivals are adopted:
+     *
+     * - the root's own `main` slot (the one {@link Workstation.view.Workspace#registerMainWorkspace} binds
+     *   under) rebound to a new window — a reload of the main window while this worker lives — so the root
+     *   moves itself into the new render target;
+     * - a restored `?workspace=<key>` window bound under `key`;
+     * - a reloaded vessel window bound under its item's key.
+     *
+     * A vessel connecting for the first time belongs to the tear-out lifecycle, which registers its target
+     * itself; this handler recognises an already-mounted host and leaves it alone.
+     * @param {Object} data
+     * @param {String} data.windowId
+     * @returns {Promise<Boolean>} Whether this call adopted the window.
+     */
+    async onWindowConnect({windowId}) {
+        const me = this, root = me.component;
+
+        if (!root || root.isDestroyed || windowId === root.windowId) return false;
+
+        const binding = TransactionManager.findByWindow(windowId);
+
+        if (!binding || binding.groupId !== root.topologyGroupId) return false;
+
+        const target = Neo.apps[windowId]?.mainView;
+
+        if (!target || target.isDestroyed) return false;
+
+        const params   = resolveBootParams(windowId),
+              popout   = params.get('popout'),
+              declared = params.get('workspace') ?? (popout ? root.tearOutWorkspaceKey(popout) : null);
+
+        if (binding.workspaceKey === 'main') {
+            if (declared) return false;
+
+            // The old render target is gone; detach silently before the ordinary cross-window add.
+            root.parent?.remove(root, false, true);
+            target.add(root);
+
+            return true
+        }
+
+        if (declared !== binding.workspaceKey) return false;
+
+        const state = root.getPopupState(binding.workspaceKey);
+
+        if (!state || (state.windowId === windowId && state.host?.parent === target && !state.disconnected)) {
+            return false
+        }
+
+        return me.mountTopologyWorkspace(binding.workspaceKey, target)
+    }
 
     /**
      * @summary Installs the optional playback controller on its real toolbar at first activation.

--- a/test/playwright/component/workstation/WorkstationBoot.spec.mjs
+++ b/test/playwright/component/workstation/WorkstationBoot.spec.mjs
@@ -1,16 +1,18 @@
 import {test, expect} from '@playwright/test';
 
 /**
- * @summary Workstation's three boot modes, observed as RENDERED DOM in the real app.
+ * @summary Workstation's three boot modes, and the reload that rebinds one of them, observed as RENDERED DOM in the real app.
  *
  * This tier is the point and it is not interchangeable with the unit witness. `apps/workstation`'s
- * boot orchestration lives in `view/Viewport.mjs#onConstructed`, which `await`s the window's URL
- * through `Neo.Main.getByPath` and then resolves its owning workspace through the Transaction
- * Group. A unit spec cannot reach that: there is no Main thread to answer the URL read, so the
- * branch under test never executes. The failure this file exists to catch was measured — a
+ * boot is decided in `view/ViewportController.mjs#decide` from two synchronous sources — the URL the
+ * main thread registered for the window and the window's Group binding — and a window that already
+ * has an owner is adopted by that owner in `view/WorkspaceController.mjs#onWindowConnect`, on the App
+ * worker's `connect` event. The unit tier drives the decision table and the adoption handler directly;
+ * it never runs the real Viewport in a real window, and nothing in it fires the worker's `connect`.
+ * The failure this file exists to catch was measured against the previous shape of this boot: a
  * refactor took `.workstation-dock-host` from 1 to 0 while the entire workstation unit tier stayed
- * green at 97/97, because an async rejection inside `onConstructed` is an unhandled rejection and
- * nothing hooks `unhandledrejection`.
+ * green at 97/97, because an async rejection inside the then-`onConstructed` was an unhandled
+ * rejection and nothing hooks `unhandledrejection`.
  *
  * Deliberately Brain-free. The sibling coverage in `e2e/workstation/` drives the Neural Link and
  * therefore requires `NEO_AGENTOS_RUNTIME_ROOT` pointing at a Brain checkout; these arms navigate
@@ -24,10 +26,27 @@ const APP = 'apps/workstation/index.html';
 
 /**
  * The default-boot host, set in `apps/workstation/view/Workspace.mjs`. Its presence is the whole
- * assertion: the class is written by the Workspace the Viewport mounts, so it cannot appear unless
- * the boot path resolved an owner AND mounted through it.
+ * assertion: the class is written by the Workspace the window's controller creates or its owner moves
+ * in, so it cannot appear unless the boot path resolved an owner AND mounted through it.
  */
 const DOCK_HOST = '.workstation-dock-host';
+
+/** The arriving side's fail-closed answer to a saved-window URL no owner can adopt. */
+const REFUSAL = 'This saved window is waiting for its original workspace.';
+
+/**
+ * What one Workstation window can say about its own boot, read from the DOM and the main thread: the
+ * identity it carries across its reloads, its window generation, and the ids of its Viewport and dock
+ * host — the App worker's component ids, so they name the instances behind the elements.
+ * @param {import('@playwright/test').Page} page
+ * @returns {Promise<{carrier: Object|null, hostId: String|undefined, viewportId: String|undefined, windowId: String}>}
+ */
+const readBoot = page => page.evaluate(() => ({
+    carrier   : JSON.parse(sessionStorage.getItem(Neo.worker.Manager.topologyIdentityStorageKey) || 'null'),
+    hostId    : document.querySelector('.workstation-dock-host')?.id,
+    viewportId: document.querySelector('.workstation-viewport')?.id,
+    windowId  : Neo.worker.Manager.windowId
+}));
 
 test.describe('workstation boot — the rendered outcome of each URL mode', () => {
     test('default boot mounts the dock host', async ({page}) => {
@@ -57,11 +76,43 @@ test.describe('workstation boot — the rendered outcome of each URL mode', () =
         // must say so rather than mount a host it has no owner for.
         await page.goto(`${APP}?workspace=no-such-workspace-key`);
 
-        await expect(page.getByText('This saved window is waiting for its original workspace.'))
-            .toBeVisible({timeout: 60000});
+        await expect(page.getByText(REFUSAL)).toBeVisible({timeout: 60000});
 
         expect(await page.locator(DOCK_HOST).count(),
             'the refusal branch must not mount a dock host').toBe(0)
+    });
+
+    test('a reload of the root window while the worker lives moves the retained root into the new window', async ({page, context}) => {
+        await page.goto(APP);
+        await page.waitForSelector(DOCK_HOST, {state: 'attached', timeout: 60000});
+
+        const before = await readBoot(page);
+
+        // The App worker is shared, and a SharedWorker ends with its last client — which a reload of the
+        // only window is. A second window keeps the worker, and with it the root, alive across the
+        // reload. Its own boot is the refusal arm above, so it creates no root that could confuse the count.
+        const keeper = await context.newPage();
+
+        await keeper.goto(`${APP}?workspace=no-such-workspace-key`);
+        await expect(keeper.getByText(REFUSAL)).toBeVisible({timeout: 60000});
+
+        await page.reload();
+        await page.waitForSelector(DOCK_HOST, {state: 'attached', timeout: 60000});
+
+        const after = await readBoot(page);
+
+        // Controls first. A reload is a new window generation carrying the same identity, and the new
+        // Viewport's id continues the worker's counter: a worker that restarted would mint the first id
+        // again, and a same-id host below would then prove nothing.
+        expect(after.windowId, 'a reload is a new window generation').not.toBe(before.windowId);
+        expect(after.carrier, 'carrying the identity its slot rebinds under').toEqual(before.carrier);
+        expect(after.viewportId, 'into a worker heap that survived the reload').not.toBe(before.viewportId);
+
+        // The claim: the host the root already owned, moved — not a second one, not a fresh one.
+        expect(await page.locator(DOCK_HOST).count(), 'exactly one dock host').toBe(1);
+        expect(after.hostId, 'the same host instance, adopted into the new window').toBe(before.hostId);
+
+        await keeper.close()
     });
 
     test('a popout URL takes the popout branch and does not mount a default host', async ({page}) => {

--- a/test/playwright/component/workstation/WorkstationBoot.spec.mjs
+++ b/test/playwright/component/workstation/WorkstationBoot.spec.mjs
@@ -1,0 +1,78 @@
+import {test, expect} from '@playwright/test';
+
+/**
+ * @summary Workstation's three boot modes, observed as RENDERED DOM in the real app.
+ *
+ * This tier is the point and it is not interchangeable with the unit witness. `apps/workstation`'s
+ * boot orchestration lives in `view/Viewport.mjs#onConstructed`, which `await`s the window's URL
+ * through `Neo.Main.getByPath` and then resolves its owning workspace through the Transaction
+ * Group. A unit spec cannot reach that: there is no Main thread to answer the URL read, so the
+ * branch under test never executes. The failure this file exists to catch was measured — a
+ * refactor took `.workstation-dock-host` from 1 to 0 while the entire workstation unit tier stayed
+ * green at 97/97, because an async rejection inside `onConstructed` is an unhandled rejection and
+ * nothing hooks `unhandledrejection`.
+ *
+ * Deliberately Brain-free. The sibling coverage in `e2e/workstation/` drives the Neural Link and
+ * therefore requires `NEO_AGENTOS_RUNTIME_ROOT` pointing at a Brain checkout; these arms navigate
+ * and read DOM only, so they run in a tracked-only clone and can gate a boot change on any host.
+ *
+ * Run: NEO_COMPONENT_PORT=8186 npx playwright test workstation/WorkstationBoot -c test/playwright/playwright.config.component.mjs --workers=1
+ */
+
+/** The real app, served from the repo root by the component tier's webServer. */
+const APP = 'apps/workstation/index.html';
+
+/**
+ * The default-boot host, set in `apps/workstation/view/Workspace.mjs`. Its presence is the whole
+ * assertion: the class is written by the Workspace the Viewport mounts, so it cannot appear unless
+ * the boot path resolved an owner AND mounted through it.
+ */
+const DOCK_HOST = '.workstation-dock-host';
+
+test.describe('workstation boot — the rendered outcome of each URL mode', () => {
+    test('default boot mounts the dock host', async ({page}) => {
+        await page.goto(APP);
+        await page.waitForSelector(DOCK_HOST, {state: 'attached', timeout: 60000});
+
+        // Counted rather than presence-checked: the failure mode on the other side of this arm is a
+        // second host mounted by a duplicate boot, which `waitForSelector` alone reports as success.
+        expect(await page.locator(DOCK_HOST).count(), 'exactly one dock host, mounted once').toBe(1);
+
+        // And the host is not an empty shell — a mounted-but-unpopulated host is what a boot that
+        // resolves its owner and then fails to project would leave behind.
+        //
+        // Attached, not visible, and scoped INTO the host: an unscoped visible-wait resolves to the
+        // first of nine tab-header buttons, which is a collapsed rail's `neo-dashboard-dock-reveal-title`
+        // and invisible by design — measured here, so the next author does not re-add the wait that
+        // times out against a correct boot.
+        await expect(page.locator(`${DOCK_HOST} .neo-tab-header-button`).first())
+            .toBeAttached({timeout: 60000});
+        expect(await page.locator(`${DOCK_HOST} .neo-tab-header-button`).count(),
+            'the host carries projected tab chrome').toBeGreaterThan(0)
+    });
+
+    test('a saved window whose workspace is unknown renders the refusal, not an empty page', async ({page}) => {
+        // `?workspace=<key>` with no Group binding for this window is the branch that must FAIL
+        // CLOSED. `Transaction.findByWindow` finds nothing, so the key cannot match and the Viewport
+        // must say so rather than mount a host it has no owner for.
+        await page.goto(`${APP}?workspace=no-such-workspace-key`);
+
+        await expect(page.getByText('This saved window is waiting for its original workspace.'))
+            .toBeVisible({timeout: 60000});
+
+        expect(await page.locator(DOCK_HOST).count(),
+            'the refusal branch must not mount a dock host').toBe(0)
+    });
+
+    test('a popout URL takes the popout branch and does not mount a default host', async ({page}) => {
+        // `?popout=<id>` marks the window as a vessel host. With no live pane to adopt it stays
+        // empty — that is correct, and the discriminator is the class rather than the emptiness:
+        // an empty page proves nothing, while `workstation-popout-host` proves the branch ran.
+        await page.goto(`${APP}?popout=no-such-pane`);
+
+        await page.waitForSelector('.workstation-popout-host', {state: 'attached', timeout: 60000});
+
+        expect(await page.locator(DOCK_HOST).count(),
+            'the popout branch must not also mount the default host').toBe(0)
+    })
+});

--- a/test/playwright/component/workstation/WorkstationBoot.spec.mjs
+++ b/test/playwright/component/workstation/WorkstationBoot.spec.mjs
@@ -34,6 +34,67 @@ const DOCK_HOST = '.workstation-dock-host';
 /** The arriving side's fail-closed answer to a saved-window URL no owner can adopt. */
 const REFUSAL = 'This saved window is waiting for its original workspace.';
 
+/** The shipped pane the adoption arms move: its tab title, its pane class, and the vessel key the app mints for it. */
+const
+    FEED_TITLE = 'Live Event Stream',
+    FEED_PANE  = '.workstation-pane-feed:not(.workstation-placeholder)',
+    FEED_KEY   = 'workstation-vessel:feed';
+
+/**
+ * Reads one Group's persisted topology collection from the page's IndexedDB — the durable record a cold
+ * boot hydrates — through the same database, store and key the library's adapter writes.
+ * @param {import('@playwright/test').Page} page
+ * @param {String} groupId
+ * @returns {Promise<Object|null>}
+ */
+const readPersistedTopology = (page, groupId) => page.evaluate(key => new Promise(resolve => {
+    const request = indexedDB.open('neo-dock-topologies', 1);
+
+    request.onerror   = () => resolve(null);
+    request.onsuccess = () => {
+        const database = request.result;
+
+        try {
+            const read = database.transaction('collections', 'readonly').objectStore('collections').get(key);
+
+            read.onsuccess = () => {database.close(); resolve(read.result ?? null)};
+            read.onerror   = () => {database.close(); resolve(null)}
+        } catch {
+            database.close();
+            resolve(null)
+        }
+    }
+}), groupId);
+
+/**
+ * Tears the shipped feed pane into a REAL popup window through the focus-gated pop-out header action
+ * — the app's own tear-out path — and resolves once the popup shows the live pane.
+ * @param {import('@playwright/test').Page} page The root window.
+ * @returns {Promise<import('@playwright/test').Page>} The vessel window.
+ */
+const tearOutFeed = async page => {
+    const tab = page.locator('.neo-tab-header-button', {hasText: FEED_TITLE}).first();
+
+    await expect(tab).toBeVisible({timeout: 60000});
+    await tab.click();
+
+    const header = page.locator('.neo-tab-header-toolbar').filter({has: page.locator('.neo-tab-header-button', {hasText: FEED_TITLE})}).first(),
+          popOut = header.locator('.neo-button:has([class*="fa-window-restore"])').first();
+
+    await expect(popOut, 'the pop-out action projects on the focused pane').toBeVisible({timeout: 10000});
+
+    const popupPromise = page.waitForEvent('popup', {timeout: 30000});
+
+    await popOut.click();
+
+    const popup = await popupPromise;
+
+    await popup.waitForSelector('.workstation-popout-host', {state: 'attached', timeout: 60000});
+    await expect(popup.locator(FEED_PANE).first(), 'the vessel renders the live pane').toBeVisible({timeout: 60000});
+
+    return popup
+};
+
 /**
  * What one Workstation window can say about its own boot, read from the DOM and the main thread: the
  * identity it carries across its reloads, its window generation, and the ids of its Viewport and dock
@@ -113,6 +174,85 @@ test.describe('workstation boot — the rendered outcome of each URL mode', () =
         expect(after.hostId, 'the same host instance, adopted into the new window').toBe(before.hostId);
 
         await keeper.close()
+    });
+
+    test('a torn-out pane\'s window, reloaded while the worker lives, is re-adopted by the owner with the same live pane', async ({page}) => {
+        await page.goto(APP);
+        await page.waitForSelector(DOCK_HOST, {state: 'attached', timeout: 60000});
+
+        // A real vessel: `?popout=feed`, bound under the app's vessel key, holding the live pane.
+        const popup  = await tearOutFeed(page),
+              before = {...await readBoot(popup), paneId: await popup.locator(FEED_PANE).first().getAttribute('id')};
+
+        // The root window keeps the SharedWorker; reloading the vessel rebinds its slot to a new window
+        // generation, and the owner's `connect` adoption is the only path that puts the pane back.
+        await popup.reload();
+        await popup.waitForSelector('.workstation-popout-host', {state: 'attached', timeout: 60000});
+        await expect(popup.locator(FEED_PANE).first(), 'the reloaded vessel shows the pane again').toBeVisible({timeout: 60000});
+
+        const after = {...await readBoot(popup), paneId: await popup.locator(FEED_PANE).first().getAttribute('id')};
+
+        expect(after.windowId, 'a reload is a new window generation').not.toBe(before.windowId);
+        expect(after.carrier, 'carrying the vessel identity its slot rebinds under').toEqual(before.carrier);
+        expect(after.viewportId, 'into a worker heap that survived').not.toBe(before.viewportId);
+        expect(after.paneId, 'the same live pane instance, adopted into the new window').toBe(before.paneId);
+        expect(await page.locator(FEED_PANE).count(), 'and the root does not also show it').toBe(0);
+
+        await popup.close()
+    });
+
+    test('a keyed workspace a cold boot recovers is adopted by the owner in the window its recovery button opens', async ({page, context}) => {
+        await page.goto(APP);
+        await page.waitForSelector(DOCK_HOST, {state: 'attached', timeout: 60000});
+
+        // Make the two-workspace topology durable under this root's Group identity, then end the worker:
+        // the vessel window first, the root last, and the carrier read before it goes.
+        const popup   = await tearOutFeed(page),
+              carrier = (await readBoot(page)).carrier;
+
+        expect(carrier?.groupId, 'the root carries its Group identity').toBeTruthy();
+
+        await page.getByRole('button', {name: 'Save workspace', exact: true}).click();
+
+        // The teardown may only start once the durable record holds the vessel workspace: read back
+        // the collection the library wrote, under this Group's key, until its active topology lists it.
+        await expect.poll(async () => {
+            const collection = await readPersistedTopology(page, carrier.groupId);
+            return Object.keys(collection?.topologies?.[collection.activeLayoutId]?.workspaces ?? {})
+        }, {message: 'the saved topology carries the vessel workspace', timeout: 30000}).toContain(FEED_KEY);
+
+        await popup.close();
+        await page.close();
+
+        // A cold boot with the same carrier hydrates the saved topology: the vessel workspace is
+        // retained, disconnected, and the bar offers to open it — the `?workspace=<key>` path.
+        const cold = await context.newPage();
+
+        await cold.addInitScript(({key, identity}) => {
+            if (!sessionStorage.getItem(key)) sessionStorage.setItem(key, JSON.stringify(identity))
+        }, {key: 'neo-topology-identity', identity: carrier});
+        await cold.goto(APP);
+        await cold.waitForSelector(DOCK_HOST, {state: 'attached', timeout: 60000});
+
+        const reopen = cold.getByRole('button', {name: `Open ${FEED_KEY} as window`, exact: true});
+
+        await expect(reopen, 'the recovered topology offers the retained vessel workspace').toBeVisible({timeout: 60000});
+        expect(await cold.locator(FEED_PANE).count(), 'the pane is not in the root while its workspace is a window').toBe(0);
+
+        const savedPromise = context.waitForEvent('page', {timeout: 45000});
+
+        await reopen.click();
+
+        const saved = await savedPromise;
+
+        // The arriving window declares `?workspace=<key>`, its binding is under that key, and the owner's
+        // `connect` adoption mounts the retained workspace into it — nothing else renders here.
+        await saved.waitForSelector('.workstation-viewport', {state: 'attached', timeout: 60000});
+        expect(new URL(saved.url()).searchParams.get('workspace'), 'the recovery window is a saved-window URL').toBe(FEED_KEY);
+        await expect(saved.locator(FEED_PANE).first(), 'the owner adopted the window and mounted the pane').toBeVisible({timeout: 60000});
+        await expect(saved.getByText(REFUSAL), 'and the arriving side refused nothing').toHaveCount(0);
+
+        await saved.close()
     });
 
     test('a popout URL takes the popout branch and does not mount a default host', async ({page}) => {

--- a/test/playwright/unit/apps/workstation/ViewportController.spec.mjs
+++ b/test/playwright/unit/apps/workstation/ViewportController.spec.mjs
@@ -12,8 +12,10 @@ import * as core      from '../../../../../src/core/_export.mjs';
 import '../../../../../src/manager/Instance.mjs';
 import Container          from '../../../../../src/container/Base.mjs';
 import Transaction        from '../../../../../src/manager/Transaction.mjs';
-import Workspace          from '../../../../../apps/workstation/view/Workspace.mjs';
+// The controller is the first app module this spec loads, on purpose: a controller that reaches the
+// app entry point through its imports loads its own view before itself, and this order is what fails.
 import ViewportController from '../../../../../apps/workstation/view/ViewportController.mjs';
+import Workspace          from '../../../../../apps/workstation/view/Workspace.mjs';
 
 /**
  * @summary The controller under test with its root creation recorded instead of run.

--- a/test/playwright/unit/apps/workstation/ViewportController.spec.mjs
+++ b/test/playwright/unit/apps/workstation/ViewportController.spec.mjs
@@ -1,0 +1,237 @@
+import {setup} from '../../../setup.mjs';
+
+setup({
+    appConfig: {
+        name: 'WorkstationViewportControllerTest'
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../src/Neo.mjs';
+import * as core      from '../../../../../src/core/_export.mjs';
+import '../../../../../src/manager/Instance.mjs';
+import Container          from '../../../../../src/container/Base.mjs';
+import Transaction        from '../../../../../src/manager/Transaction.mjs';
+import Workspace          from '../../../../../apps/workstation/view/Workspace.mjs';
+import ViewportController from '../../../../../apps/workstation/view/ViewportController.mjs';
+
+/**
+ * @summary The controller under test with its root creation recorded instead of run.
+ *
+ * `createRoot` hydrates storage and constructs the flagship Workspace; the decision table is the subject
+ * here, so these arms observe WHETHER and WITH WHAT it is asked to run. The refusal branches never reach
+ * it and render through the real method, and the refused-admission arm runs the real class.
+ */
+class RecordingController extends ViewportController {
+    static config = {
+        className: 'Test.Workstation.RecordingViewportController'
+    }
+
+    /** @member {Array[]} calls=[] */
+    calls = []
+
+    /**
+     * @param {...*} args
+     * @returns {Promise<void>}
+     */
+    createRoot(...args) {
+        this.calls.push(args);
+        return Promise.resolve()
+    }
+}
+
+Neo.setupClass(RecordingController);
+
+const REFUSAL = 'This saved window is waiting for its original workspace.',
+      WAITING = 'This window is waiting for its original workspace.';
+
+let sequence = 0;
+
+/**
+ * @summary Registers the URL a booting window carries, the way the main thread does before the app loads.
+ * @param {String} [search='']
+ * @returns {String} The window id.
+ */
+function registerWindow(search='') {
+    const windowId = `viewport-controller-${++sequence}`;
+
+    Neo.windowConfigs ??= {};
+    Neo.windowConfigs[windowId] = {url: {search}};
+
+    return windowId
+}
+
+/**
+ * @summary The window's main view, constructed AFTER admission the way `Application#construct` orders it.
+ * @param {String} windowId
+ * @param {Function} [controller=RecordingController]
+ * @returns {Neo.container.Base}
+ */
+function createView(windowId, controller=RecordingController) {
+    return Neo.create(Container, {controller, windowId})
+}
+
+/**
+ * @summary A live component registered as the Group's participant under one key.
+ * @param {String} groupId
+ * @param {String} workspaceKey
+ * @returns {Neo.container.Base}
+ */
+function registerOwner(groupId, workspaceKey) {
+    const owner = Neo.create(Container, {});
+
+    Transaction.registerParticipant({groupId, workspaceKey, participant: {componentId: owner.id}});
+
+    return owner
+}
+
+/**
+ * @param {String} windowId
+ * @param {Object[]} instances
+ * @param {String[]} groupIds
+ */
+function retire(windowId, instances, groupIds) {
+    instances.forEach(instance => instance.destroy());
+    delete Neo.windowConfigs[windowId];
+    Transaction.release(windowId);
+    groupIds.forEach(groupId => Transaction.retireGroup(groupId))
+}
+
+test.describe('Workstation.view.ViewportController — one window, one decision, from the registry', () => {
+    test('a restored window bound under its declared key with a live root renders nothing: the root adopts it', () => {
+        const owner    = Transaction.bind({windowId: `viewport-controller-owner-${++sequence}`}),
+              windowId = registerWindow('?workspace=details');
+
+        Transaction.bind({...Transaction.reserve({groupId: owner.groupId, workspaceKey: 'details'}), windowId});
+
+        const root = registerOwner(owner.groupId, 'details'),
+              view = createView(windowId);
+
+        try {
+            expect(view.items.length, 'no refusal, no placeholder').toBe(0);
+            expect(view.controller.calls, 'and no root of its own').toEqual([])
+        } finally {
+            retire(windowId, [view, root], [owner.groupId])
+        }
+    });
+
+    test('a restored window bound under a different key than its URL declares refuses, fail-closed', () => {
+        const owner    = Transaction.bind({windowId: `viewport-controller-owner-${++sequence}`}),
+              windowId = registerWindow('?workspace=details');
+
+        Transaction.bind({...Transaction.reserve({groupId: owner.groupId, workspaceKey: 'other'}), windowId});
+
+        const root = registerOwner(owner.groupId, 'other'),
+              view = createView(windowId);
+
+        try {
+            expect(view.items.map(item => item.html)).toEqual([REFUSAL]);
+            expect(view.controller.calls).toEqual([])
+        } finally {
+            retire(windowId, [view, root], [owner.groupId])
+        }
+    });
+
+    test('a restored window whose worker never saw its Group is minted a root slot, and refuses once that binding lands', () => {
+        const windowId = registerWindow('?workspace=details'),
+              view     = createView(windowId);
+
+        let groupId;
+
+        try {
+            expect(view.items.length, 'nothing is decided while the carrier answer is pending').toBe(0);
+
+            // The minted identity's carrier accepted: the manager binds the window as a new root, under `main`.
+            ({groupId} = Transaction.bind({windowId}));
+
+            expect(view.items.map(item => item.html), 'a root slot cannot host a saved window').toEqual([REFUSAL]);
+            expect(view.controller.calls).toEqual([])
+        } finally {
+            retire(windowId, [view], groupId ? [groupId] : [])
+        }
+    });
+
+    test('a default window whose Group already holds a live root renders nothing: the retained root moves in', () => {
+        const windowId  = registerWindow(),
+              {groupId} = Transaction.bind({windowId}),
+              root      = registerOwner(groupId, Workspace.MAIN_WORKSPACE_ID),
+              view      = createView(windowId);
+
+        try {
+            expect(view.items.length).toBe(0);
+            expect(view.controller.calls).toEqual([])
+        } finally {
+            retire(windowId, [view, root], [groupId])
+        }
+    });
+
+    test('a default window with a held root binding and no root creates one, carrying the selected layout', () => {
+        const windowId = registerWindow('?layout=layout-a'),
+              binding  = Transaction.bind({windowId}),
+              view     = createView(windowId);
+
+        try {
+            // `findByWindow` describes the slot, not the window: group, key and generation.
+            expect(view.controller.calls).toEqual([[
+                {generation: 1, groupId: binding.groupId, workspaceKey: 'main'},
+                'layout-a'
+            ]]);
+            expect(view.items.length).toBe(0)
+        } finally {
+            retire(windowId, [view], [binding.groupId])
+        }
+    });
+
+    test('a minted root decides on the bind event, exactly once, and a re-admission of the same window decides nothing', () => {
+        const windowId = registerWindow(),
+              view     = createView(windowId);
+
+        let binding;
+
+        try {
+            expect(view.controller.calls, 'no binding yet, no decision yet').toEqual([]);
+
+            binding = Transaction.bind({windowId});
+
+            expect(view.controller.calls.length, 'the accepted carrier decides the boot').toBe(1);
+            expect(view.controller.calls[0][0]).toMatchObject({groupId: binding.groupId, workspaceKey: 'main'});
+
+            // A blank-root restart releases and re-admits the same window; the manager publishes a second bind.
+            Transaction.release(windowId);
+            Transaction.bind({windowId, groupId: binding.groupId, workspaceKey: 'main', generationToken: binding.generationToken});
+
+            expect(view.controller.calls.length, 'one window, one decision').toBe(1)
+        } finally {
+            retire(windowId, [view], binding ? [binding.groupId] : [])
+        }
+    });
+
+    test('a refused admission renders the waiting notice instead of a root', () => {
+        const windowId = registerWindow(),
+              view     = createView(windowId, ViewportController);
+
+        try {
+            expect(view.items.length).toBe(0);
+
+            Transaction.fire('admissionRefused', {windowId, outcome: 'refused', groupId: null, workspaceKey: 'main'});
+
+            expect(view.items.map(item => item.html)).toEqual([WAITING])
+        } finally {
+            retire(windowId, [view], [])
+        }
+    });
+
+    test('a pop-out window marks itself as a vessel host and decides nothing else', () => {
+        const windowId  = registerWindow('?popout=alerts'),
+              {groupId} = Transaction.bind({windowId}),
+              view      = createView(windowId);
+
+        try {
+            expect(view.cls).toContain('workstation-popout-host');
+            expect(view.items.length).toBe(0);
+            expect(view.controller.calls).toEqual([])
+        } finally {
+            retire(windowId, [view], [groupId])
+        }
+    })
+});

--- a/test/playwright/unit/apps/workstation/WorkspaceController.spec.mjs
+++ b/test/playwright/unit/apps/workstation/WorkspaceController.spec.mjs
@@ -9,7 +9,9 @@ import '../../../../../src/manager/Instance.mjs';
 import ComponentManager    from '../../../../../src/manager/Component.mjs';
 import Transaction         from '../../../../../src/manager/Transaction.mjs';
 import TopologyLibrary     from '../../../../../src/dashboard/dock/persistence/TopologyLibrary.mjs';
+import Container           from '../../../../../src/container/Base.mjs';
 import Toolbar             from '../../../../../src/toolbar/Base.mjs';
+import PopupWorkspace      from '../../../../../apps/workstation/view/PopupWorkspace.mjs';
 import Workspace           from '../../../../../apps/workstation/view/Workspace.mjs';
 import WorkspaceController from '../../../../../apps/workstation/view/WorkspaceController.mjs';
 
@@ -207,5 +209,146 @@ test.describe('Workstation topology save and close coordination', () => {
         expect(controller.syncTopologyBar(), 'a destroyed bar is not a synced bar').toBe(false);
 
         controller.destroy()
+    })
+});
+
+/**
+ * @summary A root Workspace whose window is bound into a Group, plus one connected window with a live main view.
+ * @returns {Object}
+ */
+function createAdoptionFixture() {
+    const rootWindowId = `adoption-root-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`,
+          rootBinding  = Transaction.bind({windowId: rootWindowId, workspaceKey: 'main'}),
+          root         = Neo.create(Workspace, {windowId: rootWindowId}),
+          windows      = [];
+
+    Neo.windowConfigs ??= {};
+
+    /**
+     * @param {String} search The URL the arriving window booted with.
+     * @returns {{windowId: String, target: Neo.container.Base}}
+     */
+    const connectWindow = search => {
+        const windowId = `${rootWindowId}-w${windows.length + 1}`,
+              target   = Neo.create(Container, {windowId});
+
+        Neo.windowConfigs[windowId] = {url: {search}};
+        Neo.apps[windowId] = {mainView: target};
+        windows.push({windowId, target});
+
+        return {windowId, target}
+    };
+
+    /**
+     * @param {String} workspaceKey
+     * @returns {Object} The popup owner's runtime state.
+     */
+    const registerPopup = workspaceKey => {
+        const host = Neo.create(PopupWorkspace, {
+            dockModel      : root.createVesselWorkspaceDocument('alerts'), rootWorkspace: root,
+            topologyGroupId: root.topologyGroupId, workspaceKey, workspaceSet: root.workspaceSet
+        });
+
+        host.runtimeState = {
+            committed: true, disconnected: true, host, windowId: null, workspaceId: workspaceKey,
+            get document() { return host.dockModel },
+            set document(value) { host.dockModel = value }
+        };
+
+        return host.runtimeState
+    };
+
+    const destroy = () => {
+        windows.forEach(({windowId, target}) => {
+            delete Neo.apps[windowId];
+            delete Neo.windowConfigs[windowId];
+            target.destroy()
+        });
+        root.destroy();
+        Transaction.retireGroup(rootBinding.groupId)
+    };
+
+    return {connectWindow, destroy, registerPopup, root, rootBinding}
+}
+
+test.describe('Workstation topology adoption on window connect', () => {
+    test('a restored window bound under its declared key is adopted once, and a second connect is a no-op', async () => {
+        const fixture = createAdoptionFixture(), {root} = fixture, key = 'details';
+
+        try {
+            const state = fixture.registerPopup(key);
+
+            Transaction.bind({...Transaction.reserve({groupId: root.topologyGroupId, workspaceKey: key}), windowId: `${root.windowId}-w1`});
+
+            const {windowId, target} = fixture.connectWindow(`?workspace=${key}`);
+
+            expect(await root.controller.onWindowConnect({windowId}), 'the root adopts the arrival').toBe(true);
+            expect(state.host.parent, 'the popup owner renders into the arriving window').toBe(target);
+            expect(state).toMatchObject({disconnected: false, windowId});
+
+            expect(await root.controller.onWindowConnect({windowId}), 'an already-mounted host is left alone').toBe(false);
+            expect(state.host.parent).toBe(target)
+        } finally {
+            fixture.destroy()
+        }
+    });
+
+    test('an arrival whose URL declares a different key than its binding is ignored, not adopted', async () => {
+        const fixture = createAdoptionFixture(), {root} = fixture, key = 'details';
+
+        try {
+            const state = fixture.registerPopup(key);
+
+            Transaction.bind({...Transaction.reserve({groupId: root.topologyGroupId, workspaceKey: key}), windowId: `${root.windowId}-w1`});
+
+            const {windowId, target} = fixture.connectWindow('?workspace=other');
+
+            expect(await root.controller.onWindowConnect({windowId})).toBe(false);
+            expect(state.host.parent, 'a non-matching arrival mounts nothing').not.toBe(target);
+            expect(state).toMatchObject({disconnected: true, windowId: null})
+        } finally {
+            fixture.destroy()
+        }
+    });
+
+    test('a window bound into another Group is not this root\'s to adopt', async () => {
+        const fixture = createAdoptionFixture(), {root} = fixture;
+
+        let foreign;
+
+        try {
+            const {windowId} = fixture.connectWindow('');
+
+            foreign = Transaction.bind({windowId});
+
+            expect(foreign.groupId).not.toBe(root.topologyGroupId);
+            expect(await root.controller.onWindowConnect({windowId})).toBe(false)
+        } finally {
+            fixture.destroy();
+            foreign && Transaction.retireGroup(foreign.groupId)
+        }
+    });
+
+    test('the root\'s own slot rebound to a new window moves the root, unless that window declares another intent', async () => {
+        const fixture = createAdoptionFixture(), {root, rootBinding} = fixture;
+
+        try {
+            const {windowId, target} = fixture.connectWindow('?workspace=details');
+
+            // The main window reloaded while this worker lives: its slot is released, then rebound to the new window.
+            Transaction.release(root.windowId);
+            Transaction.bind({groupId: rootBinding.groupId, workspaceKey: 'main', generationToken: rootBinding.generationToken, windowId});
+
+            expect(await root.controller.onWindowConnect({windowId}), 'a root slot whose window asks for a saved workspace is refused').toBe(false);
+            expect(root.parent, 'and the root stays where it is').toBeNull();
+
+            Neo.windowConfigs[windowId].url.search = '';
+
+            expect(await root.controller.onWindowConnect({windowId}), 'the same slot with no declared intent is the reload').toBe(true);
+            expect(root.parent).toBe(target);
+            expect(root.windowId).toBe(windowId)
+        } finally {
+            fixture.destroy()
+        }
     })
 });

--- a/test/playwright/unit/apps/workstation/WorkspaceController.spec.mjs
+++ b/test/playwright/unit/apps/workstation/WorkspaceController.spec.mjs
@@ -6,14 +6,18 @@ import {test, expect}      from '@playwright/test';
 import Neo                 from '../../../../../src/Neo.mjs';
 import * as core           from '../../../../../src/core/_export.mjs';
 import '../../../../../src/manager/Instance.mjs';
-import ComponentManager    from '../../../../../src/manager/Component.mjs';
-import Transaction         from '../../../../../src/manager/Transaction.mjs';
-import TopologyLibrary     from '../../../../../src/dashboard/dock/persistence/TopologyLibrary.mjs';
-import Container           from '../../../../../src/container/Base.mjs';
-import Toolbar             from '../../../../../src/toolbar/Base.mjs';
+import Base             from '../../../../../src/core/Base.mjs';
+import ComponentManager from '../../../../../src/manager/Component.mjs';
+import Transaction      from '../../../../../src/manager/Transaction.mjs';
+import TopologyLibrary  from '../../../../../src/dashboard/dock/persistence/TopologyLibrary.mjs';
+import Container        from '../../../../../src/container/Base.mjs';
+import Toolbar          from '../../../../../src/toolbar/Base.mjs';
+// The controller loads before the views it serves: an import path from the controller back to the
+// app entry point would evaluate `Workspace` before this binding exists, and this order exposes it.
+import WorkspaceController from '../../../../../apps/workstation/view/WorkspaceController.mjs';
+import ViewportController  from '../../../../../apps/workstation/view/ViewportController.mjs';
 import PopupWorkspace      from '../../../../../apps/workstation/view/PopupWorkspace.mjs';
 import Workspace           from '../../../../../apps/workstation/view/Workspace.mjs';
-import WorkspaceController from '../../../../../apps/workstation/view/WorkspaceController.mjs';
 
 /**
  * @summary An event-driven storage boundary for a write already in flight.
@@ -212,6 +216,22 @@ test.describe('Workstation topology save and close coordination', () => {
     })
 });
 
+/** The arriving side's fail-closed answer to a saved-window URL it cannot be adopted under. */
+const REFUSAL = 'This saved window is waiting for its original workspace.';
+
+/**
+ * @summary A stand-in for the App worker with the engine's own event surface, so `connect` can be FIRED.
+ *
+ * The harness worker stub has `on` and `un` as no-ops and no `fire`; an arm about the subscription itself
+ * needs the real Observable behind those three and nothing else about the worker.
+ */
+class ObservableWorker extends Base {
+    static config = {className: 'Test.Workstation.ObservableWorker'}
+    static observable = true
+}
+
+Neo.setupClass(ObservableWorker);
+
 /**
  * @summary A root Workspace whose window is bound into a Group, plus one connected window with a live main view.
  * @returns {Object}
@@ -226,13 +246,19 @@ function createAdoptionFixture() {
 
     /**
      * @param {String} search The URL the arriving window booted with.
+     * @param {Object} [options]
+     * @param {Function} [options.bind] Binds the window before its main view constructs, as admission precedes the view.
+     * @param {Function} [options.controller] The main view's controller — the real arriving one, when an arm couples both sides.
      * @returns {{windowId: String, target: Neo.container.Base}}
      */
-    const connectWindow = search => {
-        const windowId = `${rootWindowId}-w${windows.length + 1}`,
-              target   = Neo.create(Container, {windowId});
+    const connectWindow = (search, {bind, controller} = {}) => {
+        const windowId = `${rootWindowId}-w${windows.length + 1}`;
 
         Neo.windowConfigs[windowId] = {url: {search}};
+        bind?.(windowId);
+
+        const target = Neo.create(Container, {controller, windowId});
+
         Neo.apps[windowId] = {mainView: target};
         windows.push({windowId, target});
 
@@ -349,6 +375,88 @@ test.describe('Workstation topology adoption on window connect', () => {
             expect(root.windowId).toBe(windowId)
         } finally {
             fixture.destroy()
+        }
+    });
+
+    test('both sides read one intent: a rebound root slot whose URL carries `workspace=` with no key is refused by the arriving controller and not adopted by the owner', async () => {
+        const fixture = createAdoptionFixture(), {root, rootBinding} = fixture;
+
+        // Each row rebinds the root's own slot to a new window whose main view runs the REAL arriving
+        // controller, so the refusal and the adoption decision are read off the same window.
+        let previous = root.windowId;
+
+        const rebind = search => fixture.connectWindow(search, {
+            controller: ViewportController,
+            bind      : windowId => {
+                Transaction.release(previous);
+                Transaction.bind({groupId: rootBinding.groupId, workspaceKey: 'main', generationToken: rootBinding.generationToken, windowId});
+                previous = windowId
+            }
+        });
+
+        try {
+            for (const [search, refused, adopted] of [['', false, true], ['?workspace=details', true, false], ['?workspace=', true, false]]) {
+                const {windowId, target} = rebind(search), label = search || '(no search)';
+
+                expect(target.items.some(item => item.html === REFUSAL), `${label}: the arriving side refuses`).toBe(refused);
+                expect(await root.controller.onWindowConnect({windowId}), `${label}: the owner adopts`).toBe(adopted);
+                expect(root.parent === target, `${label}: the root is in that window`).toBe(adopted)
+            }
+        } finally {
+            fixture.destroy()
+        }
+    });
+
+    test('the owner adopts through the worker\'s own connect event, and stops listening when it is destroyed', () => {
+        const harnessWorker = Neo.currentWorker,
+              worker        = Neo.create(ObservableWorker);
+
+        // Whatever the engine asks a worker for while a Workspace constructs stays the harness stub's answer;
+        // only the event surface is the real one.
+        Object.assign(worker, {
+            getAddon        : harnessWorker.getAddon,
+            insertThemeFiles: harnessWorker.insertThemeFiles,
+            isSharedWorker  : false,
+            promiseMessage  : harnessWorker.promiseMessage,
+            sendMessage     : harnessWorker.sendMessage
+        });
+        Neo.currentWorker = worker;
+
+        const subscribers = () => (worker.toJSON().listeners.connect ?? []).map(({scope}) => scope.id);
+
+        let fixture;
+
+        try {
+            fixture = createAdoptionFixture();
+
+            const {root, rootBinding} = fixture,
+                  controllerId        = root.controller.id;
+
+            expect(subscribers(), 'constructing the root subscribed its controller').toContain(controllerId);
+
+            const {windowId, target} = fixture.connectWindow('', {
+                bind: windowId => {
+                    Transaction.release(root.windowId);
+                    Transaction.bind({groupId: rootBinding.groupId, workspaceKey: 'main', generationToken: rootBinding.generationToken, windowId})
+                }
+            });
+
+            // The payload `Neo.worker.App` publishes, fired the way it fires it — nothing calls the handler.
+            worker.fire('connect', {appName: 'Workstation', windowData: {}, windowId});
+
+            expect(root.parent, 'the event alone moved the root').toBe(target);
+            expect(root.windowId).toBe(windowId);
+
+            const before = subscribers().length;
+
+            root.destroy();
+
+            expect(subscribers(), 'destroying the root unsubscribed its controller').not.toContain(controllerId);
+            expect(subscribers().length, 'and nothing else').toBe(before - 1)
+        } finally {
+            fixture?.destroy();
+            Neo.currentWorker = harnessWorker;
+            worker.destroy()
         }
     })
 });


### PR DESCRIPTION
Resolves #18562

🌿 A booting window can no longer say which controller owns it: the owner adopts what is bound into its Group, and the view names no one.

Workstation's Viewport addressed another component through that component's controller three times, because the arriving window resolved its owner and pushed itself in. Now the root's controller adopts the windows bound into its Group when the worker publishes their `connect`, and the Viewport declares a controller that decides only what no owner can adopt (the refusal) and what no owner exists for (the cold root) — from two synchronous sources, the URL the main thread registered for the window and the Group binding the engine admits at app registration. Both sides read the URL through one leaf module, `apps/workstation/BootIntent.mjs`, by one rule: the mode is a parameter's presence, the key its value. The awaited main-thread URL read is gone, and with it the async `onConstructed` whose rejection nothing listened for, which is how the vetoed attempt broke the boot under a green unit tier.

Evidence: L3 (the Brain-free component-tier witness renders the real `apps/workstation/index.html` in all three URL modes against a live SharedWorker and drives every adoption the owner performs through the worker's real `connect`: the retained root on a root-window reload, a torn-out vessel on its window's reload, and a saved `?workspace=<key>` window a cold boot's recovery button opens) → L3 required (AC-2, AC-3 and AC-5 name rendered outcomes). Residual: none. The Brain-gated `WorkstationTopologyGroupsNL` battery is unchanged here and its standing red, tracked on #17844, is not cited for anything.

## AC Evidence
| AC | Evidence |
|---|---|
| AC-1 | `grep -n 'getController()' apps/workstation/view/*.mjs` at the head: 4 → 2. Remaining: `ViewportController.mjs:237`, inside a controller after the cold-hydrate write, and `Workspace.mjs:827`, the `saveTopology` delegate the Neural Link addresses on the component — dispositioned under AC-4 |
| AC-2 | `test/playwright/component/workstation/WorkstationBoot.spec.mjs`, default arm: exactly one `.workstation-dock-host` carrying projected tab chrome, in the real app, no Brain checkout; CI `components` |
| AC-3 | Rendered, through the real connection path, same spec: the refusal arm (`?workspace=<unknown>` → the refusal text, zero hosts); the popout arm (`?popout=<id>` → the vessel branch, no default host); the reload arm (a keeper window holds the SharedWorker, the root window reloads, and the dock host reappears with the same element id inside a Viewport with a new one); the **vessel arm** (the shipped feed pane torn into a real popup through the focus-gated pop-out action, the popup reloaded, and the same pane element back in it under a new window generation with the vessel carrier unchanged, the root not showing it); the **saved-window arm** (after the tear-out and `Save workspace`, both windows closed, a new page seeded with the root's carrier cold-boots, the recovered topology's bar offers `Open workstation-vessel:feed as window`, the window it opens is a `?workspace=<key>` URL, and the owner mounts the pane into it with no refusal rendered). Handler and subscription, unit tier: `WorkspaceController.spec.mjs` adopts a saved window once and ignores a second connect, ignores a mismatched key and a foreign Group, moves the root on its own slot's rebind, refuses **and** does not adopt `?workspace=` with no key on one rebound window while `''` adopts and `?workspace=details` refuses, and adopts through a real Observable's `connect` event, dropping the subscription on destroy; `ViewportController.spec.mjs` (8 arms) covers held, minted and refused identities across the three modes |
| AC-4 | not fixed here, and said why: `Workspace#saveTopology` delegates because `app.callMethod` addresses components; relocating `captureTopology`, `saveTopology` and `attachTopologyLibrary` changes the ledgered `apps/workstation/view/Workspace.mjs` against #18461's shrink contract, so the residual is dispositioned to #18460's view-interaction row by comment rather than decided inside this leaf |
| AC-5 | three mutants, component tier, each at a committed head with the file restored from it afterwards. Root creation disabled in `ViewportController#decide`: the default arm and the reload arm red on the missing host, the others green. The owner's main-slot adoption disabled: the reload arm red alone. The owner's saved/vessel adoption disabled (`return false` ahead of the key match in `onWindowConnect`): the vessel arm and the saved-window arm red, the four others green, and in the unit tier exactly the saved-window adoption arm red — receipts under Test Evidence |

## Deltas from ticket
- The arriving window decides from `Neo.windowConfigs` plus the Group binding instead of awaiting `Neo.Main.getByPath`. The reader is a leaf, `BootIntent.mjs`, imported by the entry point and both controllers; the review's first round measured why it cannot live in `app.mjs`: a controller importing the entry point loads its own view before itself, and a fresh import of either controller died in the temporal dead zone.
- The owner matches the arrival's declared intent against its binding and ignores a mismatch, the prior art's "a non-matching arrival is ignored". The first round also measured the two sides disagreeing on `?workspace=` with an empty value — refused by the arriving side, adopted by the owner, one window holding both. Intent is one reading now, so neither side can call an intent what the other calls none.
- The decision-table arms run on a plain container rather than the real Viewport; the coupled arm runs the real arriving controller on that container, and every adoption in a real window is what the component-tier witness exercises. The saved-window arm boots cold on purpose: the topology bar's recovery buttons are filled once at construct (`syncTopologyBar` has no membership signal), so a fresh boot after a tear-out offers none — a property of the bar, not of this change, and named in the controller's own docblock.

## Test Evidence
- Boot witness at the head: `npx playwright test workstation/WorkstationBoot -c test/playwright/playwright.config.component.mjs --workers=1` → `Running 6 tests`, 6 passed.
- Mutant A (`return` in place of `me.createRoot(...)` in `ViewportController#decide`): 2 failed / 2 passed of the then four arms — default and reload; refusal and popout green. Mutant B (`return false` at the top of the main-slot branch in `WorkspaceController#onWindowConnect`): witness 1 failed / 3 passed — the reload arm; the two controller specs 3 failed / 15 passed — the slot-rebind arm, the coupled-intent arm and the connect-event arm. Mutant C (`return false` ahead of the key match in the same handler): witness 2 failed / 4 passed — the vessel arm and the saved-window arm; the two controller specs 1 failed / 17 passed — *a restored window bound under its declared key is adopted once*. Each mutant was applied after its commit and the file restored from it, tree clean before the next step.
- Fresh imports, one Node process per module, per the review's recipe (`setup.mjs`, `src/Neo.mjs`, `src/core/_export.mjs`, `setup({appConfig:{name:'ImportReview'}})`, then the controller alone): at the reviewed head 4670a694da, `ViewportController.mjs` and `WorkspaceController.mjs` both `ReferenceError: Cannot access '…' before initialization`; at e6abf702a9, both load. Both specs import their controller before any other app module, so the same back-edge fails at import in CI; the two commits since touch tests only.
- Unit tier, `--workers=1`: the two controller specs 18 passed; the `unit/apps/workstation` folder 110 passed. The full tier was 3810 passed / 2 skipped at 4670a694da; the source delta since touches the three workstation modules only.
- Size guard, CI's base argv: 8 paths evaluated, 0 violations.
- agent-preflight: not hosted here; baseline `PR body`, `Substrate size` and `Source comment archaeology` jobs run in CI.

## Post-Merge Validation
- [ ] On a Brain seat, `WorkstationTopologyGroupsNL`'s reload arms confirm the same adoptions through the Neural Link's readers; the paths themselves are covered above without the Brain.

## Commits
- 080ab3baa1 — the Brain-free boot witness, committed before the change it gates
- 4670a694da — the root adopts the windows bound into its Group; the Viewport declares its controller
- e6abf702a9 — both sides read one intent from a leaf module; the reload arm and the connect-event arm
- 4e7923b8a6 — the vessel arm and the saved-window arm: the owner's saved and vessel adoption through a real window's `connect`

Authored by Vega (Fable 5.1, Claude Code). Session c4a95308-109e-4761-a8a0-50f84debf222.
