### PR TITLE
docs(dock): make pane ownership runnable (#18530)

### DIFF
--- a/learn/guides/uibuildingblocks/DockLayoutsAdoption.md
+++ b/learn/guides/uibuildingblocks/DockLayoutsAdoption.md
@@ -14,6 +14,11 @@ refresh scheduling, reconciliation, motion and cross-zone drops. Both the minima
 that engine class today. The basic path below uses initial declarations; the existing consumers also show the advanced
 extension points for richer application integration.
 
+The snippets in this guide intentionally remain `readonly`: each is a partial application file or fragment with
+app-local modules, storage or surrounding state, so running it alone would teach a false boundary. The
+[ordinary-panes guide](DockLayoutsPanes.md) carries the self-contained live workspace where you can exercise the
+same declarations, data ownership and movement inside the portal.
+
 ## One class, five decisions
 
 ```mermaid

--- a/learn/guides/uibuildingblocks/DockLayoutsPanes.md
+++ b/learn/guides/uibuildingblocks/DockLayoutsPanes.md
@@ -59,6 +59,10 @@ a loading pipeline.
 The following modules share an application directory. Their engine imports assume a location three
 levels below the repository root, as in the dashboard examples; adjust the paths for your application.
 
+These five file-by-file examples stay `readonly` because each fence represents one application module.
+The complete live preview later in this guide folds the same roles into the portal's single-module execution
+envelope, so you can run the ownership journey without confusing that teaching constraint with an app structure.
+
 `QueueModel.mjs` defines the record fields:
 
 ```javascript readonly
@@ -242,6 +246,134 @@ The provider is at the lowest common root of the consumers that need it. It crea
 `QueueStore` class and owns that Store's retirement. The queue pane merely uses it. A provider inside the
 queue would establish a different lifetime and sharing boundary; adding one to every pane would obscure
 the decision this example is making.
+
+## Run the ownership journey
+
+The file-by-file version above is what you would keep in an application. The preview below is the same ownership
+chain compressed into one executable module so the portal can mount it. Open **Preview**, click **Complete next
+task**, then drag the **Work queue** tab into the center group and back to the right. To collapse the right group,
+focus the active **Work queue** tab, choose **unpin**, select the vertical rail tab, then choose **Pin** in the reveal
+overlay. The first record and the summary keep their edited state while the workspace changes only the pane's
+placement. The preview's fullscreen action gives the dock targets more room if the article column feels tight.
+
+```javascript live-preview
+import Button     from '../button/Base.mjs';
+import Component  from '../component/Base.mjs';
+import Container  from '../container/Base.mjs';
+import Controller from '../controller/Component.mjs';
+import Grid        from '../grid/Container.mjs';
+import Model       from '../data/Model.mjs';
+import Provider    from '../state/Provider.mjs';
+import Store       from '../data/Store.mjs';
+import Workspace   from '../dashboard/dock/Workspace.mjs';
+
+class QueueModel extends Model {
+    static config = {
+        className: 'Guides.dockLayoutsPanes.QueueModel',
+        fields: [
+            {name: 'id', type: 'String'},
+            {name: 'title', type: 'String'},
+            {name: 'status', type: 'String'}
+        ]
+    }
+}
+
+QueueModel = Neo.setupClass(QueueModel);
+
+class QueueStore extends Store {
+    static config = {
+        className: 'Guides.dockLayoutsPanes.QueueStore',
+        model: QueueModel,
+        data: [
+            {id: 'design', title: 'Review the design', status: 'Ready'},
+            {id: 'build', title: 'Build the preview', status: 'Ready'},
+            {id: 'check', title: 'Check the result', status: 'Ready'}
+        ]
+    }
+}
+
+QueueStore = Neo.setupClass(QueueStore);
+
+class QueueController extends Controller {
+    static config = {
+        className: 'Guides.dockLayoutsPanes.QueueController'
+    }
+
+    onCompleteNext() {
+        const record = this.getStore('queue').find('status', 'Ready', true);
+
+        if (record) {
+            record.status = 'Done';
+            this.setState({lastAction: `Completed: ${record.title}`})
+        }
+    }
+}
+
+QueueController = Neo.setupClass(QueueController);
+
+class QueueContainer extends Container {
+    static config = {
+        className: 'Guides.dockLayoutsPanes.QueueContainer',
+        controller: QueueController,
+        layout: {ntype: 'vbox', align: 'stretch'},
+        items: [{
+            module: Button,
+            flex: 'none',
+            text: 'Complete next task',
+            handler: 'onCompleteNext'
+        }, {
+            module: Grid,
+            flex: 1,
+            bind: {store: 'stores.queue'},
+            columns: [
+                {dataField: 'title', text: 'Task', flex: 1},
+                {dataField: 'status', text: 'Status', width: 100}
+            ]
+        }]
+    }
+}
+
+QueueContainer = Neo.setupClass(QueueContainer);
+
+class MainView extends Workspace {
+    static config = {
+        className: 'Guides.dockLayoutsPanes.MainView',
+        layout: {ntype: 'vbox', align: 'stretch'},
+        stateProvider: {
+            module: Provider,
+            data: {lastAction: 'Pick a task to complete.'},
+            stores: {queue: QueueStore}
+        },
+        panes: {
+            summary: {
+                module: Component,
+                header: {text: 'Summary'},
+                bind: {text: data => data.lastAction}
+            },
+            notes: {
+                module: Component,
+                header: {text: 'Notes'},
+                text: 'The workspace owns the work queue.'
+            },
+            queue: {
+                module: QueueContainer,
+                header: {text: 'Work queue'}
+            },
+            help: {
+                module: Component,
+                header: {text: 'Help'},
+                text: 'Complete a task, then move the queue.'
+            }
+        },
+        zones: {
+            center: ['summary', 'notes'],
+            right: {items: ['queue', 'help'], extent: 0.55, resizable: true}
+        }
+    }
+}
+
+MainView = Neo.setupClass(MainView);
+```
 
 ## Move the work without rebuilding it
 


### PR DESCRIPTION
Authored by Euclid (`@neo-gpt`, GPT-6 Codex), session `92f5d790-2865-4f69-b25e-150175745a6d`.

Resolves #18530

Turn the ordinary-pane ownership story into something the reader can run. `DockLayoutsPanes.md` now keeps its production-shaped five-file sequence as explained readonly context, then folds the same Model → Store → Provider → Controller → Grid → Workspace chain into one self-contained Portal live preview. The preview exposes the exact payoff: edit a record, move the live pane between groups, collapse it into a rail, reveal it, and pin it back without losing application state.

`DockLayoutsAdoption.md` now records the complementary verdict: its partial, app-local snippets remain readonly because executing them alone would teach a false boundary, and it links to the runnable ordinary-pane workspace.

Evidence: L2 — current-head source/docs validation plus local Portal, Neural Link, and physical drag receipts.

Change class: zero-delta.

Micro-review eligible: docs-only; the whole-guide authoring bar still applies.

Decision Record impact: none — this changes guide execution affordances, not a runtime contract.

agent-preflight: not hosted in the Engine package (`npm run agent-preflight` reports `Missing script`).

## AC Evidence

| AC | Evidence |
|---|---|
| AC-1 | The Portal renders a real `javascript live-preview` editor and mounted dock workspace on the guide route. |
| AC-2 | The live queue completes a task, physically drags center-and-back, unpins to a rail, reveals, and pins back while `Done` and the summary survive. |
| AC-3 | The block uses guide-relative imports, `Guides.dockLayoutsPanes.*` class names, and assignment-form `Neo.setupClass()` tails. |
| AC-4 | `DockLayoutsAdoption.md` states why its app-local fragments stay readonly and routes readers to the self-contained live workspace. |
| AC-5 | The five remaining readonly fences are explicitly identified as separate application modules, distinct from the Portal's single-module preview envelope. |

## Deltas from ticket

None. This uses the ticket's one-payoff-preview option and leaves the reviewed guide narrative intact outside the execution affordance and readonly rationale.

## Test Evidence

- `lint-guides.mjs` on both changed guides: 0 hard, 0 warnings.
- Dedicated `checkTicketIds()` on both guide files: no findings.
- `git diff --check`: passed.
- Portal route rendered the full article, existing Mermaid, readonly fences, live editor, and adoption exemption at current head.
- Neural Link semantic lookup found the live `Complete next task` button; a simulated click produced no console logs, changed `design.status` from `Ready` to `Done`, and updated provider state to `Completed: Review the design`.
- Physical `drive_drag` moved `queue` from `tabs-queue` to `tabs-summary` and back. The same `neo-dock-pane-3`, `neo-button-25`, provider `neo-state-provider-3`, and Store `neo-state-provider-3__queue` survived.
- The rendered header exposed `unpin`; the resulting vertical rail revealed the same pane; `Pin` restored it. Final topology has `queue` in the right tabs with `autoHidden: false`, `pinned: true`; component consistency is green and console logs are empty.
- Temporary browser bundles and theme output used for the isolated render are ignored and absent from the diff.

## Post-Merge Validation

None deferred. Independent cross-family review must re-grade both changed guides against the whole `guide-authoring` bar.

Origin Session ID: 92f5d790-2865-4f69-b25e-150175745a6d
