### PR TITLE
fix(container): a viewport's theme reaches the body, so one surface cannot inherit another's colour (#18571)

### DIFF
--- a/buildScripts/util/e2eCiSelection.mjs
+++ b/buildScripts/util/e2eCiSelection.mjs
@@ -41,6 +41,11 @@ export const RUN_PATHS = [
     'test/playwright/e2e/core',
     'test/playwright/e2e/dashboard',
     'test/playwright/e2e/grid',
+    // Named individually because both siblings in `e2e/portal` are excluded below. Neither of their
+    // causes reaches this one: they fail hosted on live previews and content routing, and this arm
+    // needs neither — it boots the portal root and reads `document.body`'s theme class. The sidebar
+    // arm of `LearnLinkRoutingNL` already shows the portal itself booting on a hosted runner.
+    'test/playwright/e2e/portal/StoredThemeBoot.spec.mjs',
     'test/playwright/e2e/rendering/InputModalityMultiWindow.spec.mjs',
     'test/playwright/e2e/rendering/ViewTransitionReveal.spec.mjs'
 ];

--- a/src/container/Viewport.mjs
+++ b/src/container/Viewport.mjs
@@ -64,7 +64,12 @@ class Viewport extends Container {
      */
     afterSetTheme(value, oldValue) {
         super.afterSetTheme(value, oldValue);
-        this.isConstructed && this.syncBodyTheme(oldValue)
+
+        // `oldValue` is what makes a reset publishable. `theme_: null` is a supported state meaning
+        // "inherit", and after this method has already published an explicit theme the body cannot be
+        // left carrying it — `getTheme()` has moved on and the two surfaces would disagree again, which
+        // is the whole defect. A viewport that never had a theme is a different case and stays silent.
+        this.isConstructed && (value || oldValue) && this.syncBodyTheme(oldValue)
     }
 
     /**
@@ -81,7 +86,9 @@ class Viewport extends Container {
             windowId
         });
 
-        me.syncBodyTheme()
+        // Only when this viewport carries an explicit theme. An untouched default already agrees with the
+        // body, and publishing it here would make that path depend on this method.
+        me.theme && me.syncBodyTheme()
     }
 
     /**
@@ -100,20 +107,24 @@ class Viewport extends Container {
      * Every declared theme is removed rather than only `oldValue`: the class the body carries at boot came
      * from `themes[0]` and was never this config's value, so `oldValue` is `undefined` on the first change
      * and cannot name what is actually there.
+     *
+     * What is published is the EFFECTIVE theme from `getTheme()`, never the `theme` config. The two differ
+     * exactly when the config is reset to `null` to return to inheritance: the config says nothing, while
+     * `getTheme()` resolves the ancestor's or the window default. Publishing the config there would leave
+     * the body on the last explicit theme forever. The callers decide WHETHER to publish; this decides WHAT.
      * @param {String} [oldValue] A previous theme outside the declared set, which `themes` cannot name
      * @protected
      */
     syncBodyTheme(oldValue) {
-        let me                = this,
-            {theme, windowId} = me;
+        let me         = this,
+            {windowId} = me;
 
-        // No theme config means this viewport inherits the boot theme, which the body already carries.
-        // Rewriting it here would make the no-preference default depend on this method.
-        if (!me.applyBodyCls || !theme) {
+        if (!me.applyBodyCls) {
             return
         }
 
-        let remove = new Set((Neo.windowConfigs?.[windowId] || Neo.config).themes || []);
+        let theme  = me.getTheme(),
+            remove = new Set((Neo.windowConfigs?.[windowId] || Neo.config).themes || []);
 
         oldValue && remove.add(oldValue);
         remove.delete(theme);

--- a/src/container/Viewport.mjs
+++ b/src/container/Viewport.mjs
@@ -57,17 +57,68 @@ class Viewport extends Container {
     }
 
     /**
+     * Triggered after the theme config got changed
+     * @param {String} value
+     * @param {String} oldValue
+     * @protected
+     */
+    afterSetTheme(value, oldValue) {
+        super.afterSetTheme(value, oldValue);
+        this.isConstructed && this.syncBodyTheme(oldValue)
+    }
+
+    /**
      *
      */
     onConstructed() {
         super.onConstructed();
 
-        let {windowId} = this;
+        let me         = this,
+            {windowId} = me;
 
-        this.applyBodyCls && Neo.main.DomAccess.applyBodyCls({
+        me.applyBodyCls && Neo.main.DomAccess.applyBodyCls({
             cls: ['neo-body-viewport'],
             windowId
-        })
+        });
+
+        me.syncBodyTheme()
+    }
+
+    /**
+     * @summary Mirrors this viewport's theme onto `document.body`, so both surfaces name one theme.
+     *
+     * `main.addon.Stylesheet#addGlobalCss` stamps `Neo.config.themes[0]` onto the body once, on the main
+     * thread, before any worker runs — and nothing in the theme path rewrites it afterwards. A viewport
+     * that already owns `neo-body-viewport` owns this class too; the alternative is a second publisher
+     * per app, which is what `apps/shareddialog` had to become as the only `setBodyCls` caller in `src/`.
+     *
+     * The disagreement this prevents is not cosmetic. `background-color` resolves from the theme class on
+     * the viewport while `color` INHERITS from the body's, so a stored light preference against a
+     * dark-booted body renders a light background carrying the dark theme's text — measured at 1.13:1
+     * contrast, effectively invisible (#18571).
+     *
+     * Every declared theme is removed rather than only `oldValue`: the class the body carries at boot came
+     * from `themes[0]` and was never this config's value, so `oldValue` is `undefined` on the first change
+     * and cannot name what is actually there.
+     * @param {String} [oldValue] A previous theme outside the declared set, which `themes` cannot name
+     * @protected
+     */
+    syncBodyTheme(oldValue) {
+        let me                = this,
+            {theme, windowId} = me;
+
+        // No theme config means this viewport inherits the boot theme, which the body already carries.
+        // Rewriting it here would make the no-preference default depend on this method.
+        if (!me.applyBodyCls || !theme) {
+            return
+        }
+
+        let remove = new Set((Neo.windowConfigs?.[windowId] || Neo.config).themes || []);
+
+        oldValue && remove.add(oldValue);
+        remove.delete(theme);
+
+        Neo.main.DomAccess.setBodyCls({add: [theme], remove: [...remove], windowId})
     }
 
     /**

--- a/src/container/Viewport.mjs
+++ b/src/container/Viewport.mjs
@@ -95,7 +95,7 @@ class Viewport extends Container {
      * The disagreement this prevents is not cosmetic. `background-color` resolves from the theme class on
      * the viewport while `color` INHERITS from the body's, so a stored light preference against a
      * dark-booted body renders a light background carrying the dark theme's text — measured at 1.13:1
-     * contrast, effectively invisible (#18571).
+     * contrast, effectively invisible.
      *
      * Every declared theme is removed rather than only `oldValue`: the class the body carries at boot came
      * from `themes[0]` and was never this config's value, so `oldValue` is `undefined` on the first change

--- a/test/playwright/e2e/portal/StoredThemeBoot.spec.mjs
+++ b/test/playwright/e2e/portal/StoredThemeBoot.spec.mjs
@@ -1,0 +1,177 @@
+import {test, expect} from '@playwright/test';
+
+/**
+ * A stored `portalTheme` preference must reach the whole page, not one half of it.
+ *
+ * #18571, measured at `dev@e99ffb6588`. With `localStorage.portalTheme = 'neo-theme-neo-light'` the
+ * preference DOES arrive: `div#neo-viewport-1` carries `neo-theme-neo-light`. `document.body` keeps
+ * `neo-theme-neo-dark`, because the body class is written ONCE on the main thread by
+ * `main.addon.Stylesheet#addGlobalCss` from the static `Neo.config.themes[0]` — before any worker runs —
+ * and nothing in the theme path ever rewrites it. The only other body-class writer in `src/` is
+ * `main.DomAccess#setBodyCls`, whose sole caller repo-wide is `apps/shareddialog`.
+ *
+ * ## Why the split is worse than either half
+ *
+ * `background-color` is set by the theme class on the viewport; `color` is INHERITED from the body,
+ * which is still on the other theme. Measured computed styles:
+ *
+ * | arm | viewport background | viewport color |
+ * |---|---|---|
+ * | no preference | `rgb(14,15,13)` | `rgb(240,242,240)` |
+ * | stored light  | `rgb(255,255,255)` | `rgb(240,242,240)` |
+ *
+ * So the failure is not "the app renders dark". It renders a LIGHT background carrying the DARK
+ * theme's text colour — a contrast ratio near 1:1. The content is invisible, which is why the
+ * contrast arm below is the one that describes the user's experience.
+ *
+ * ## The liveness arm is load-bearing, not ceremony
+ *
+ * `addGlobalCss` stamps `themes[0]` from the MAIN thread, and the portal declares
+ * `neo-theme-neo-dark` first. A portal that never boots therefore still shows `neo-theme-neo-dark` on
+ * the body and still fails the light arm, for an unrelated reason — a dead page is indistinguishable
+ * from the defect at the body class alone. `booted()` separates them and runs before every assertion.
+ */
+
+const PORTAL      = '/apps/portal/index.html',
+      STORAGE_KEY = 'portalTheme',
+      DARK        = 'neo-theme-neo-dark',
+      LIGHT       = 'neo-theme-neo-light';
+
+/**
+ * Seeds the stored preference BEFORE any page script runs. `addInitScript` is the only hook early
+ * enough: `ViewportController` reads the key during app start.
+ * @param {import('@playwright/test').Page} page
+ * @param {String|null} theme Stored value, or null for the no-preference case
+ */
+async function seedStoredTheme(page, theme) {
+    await page.addInitScript(([key, value]) => {
+        value === null ? localStorage.removeItem(key) : localStorage.setItem(key, value)
+    }, [STORAGE_KEY, theme])
+}
+
+/**
+ * Asserts the portal actually rendered. A Neo app replaces the body with a real tree; a boot failure
+ * leaves the bootstrap script behind. Polls, because the render is worker-driven.
+ * @param {import('@playwright/test').Page} page
+ */
+async function booted(page) {
+    await expect
+        .poll(() => page.evaluate(() => document.body.children.length), {
+            message: 'portal never rendered — every theme assertion below would be vacuous',
+            timeout: 30000
+        })
+        .toBeGreaterThan(1)
+}
+
+/**
+ * Reads the theme class and the resolved colours of both surfaces in one pass.
+ * @param {import('@playwright/test').Page} page
+ * @returns {Promise<{body: Object, viewport: Object}>}
+ */
+function readSurfaces(page) {
+    return page.evaluate(() => {
+        const read = el => {
+            const style = getComputedStyle(el);
+
+            return {
+                theme     : [...el.classList].filter(cls => cls.startsWith('neo-theme-')),
+                background: style.backgroundColor,
+                color     : style.color
+            }
+        };
+
+        return {body: read(document.body), viewport: read(document.querySelector('#neo-viewport-1'))}
+    })
+}
+
+/**
+ * WCAG relative-luminance contrast ratio between two `rgb(r, g, b)` strings.
+ *
+ * Asserting the ratio rather than an exact colour keeps the arm from pinning the palette: a theme
+ * may restyle freely, and only a pairing drawn from two DIFFERENT themes collapses toward 1:1.
+ * @param {String} a
+ * @param {String} b
+ * @returns {Number}
+ */
+function contrastRatio(a, b) {
+    const luminance = value => {
+        const [r, g, b] = value.match(/\d+/g).slice(0, 3).map(channel => {
+            const part = Number(channel) / 255;
+
+            return part <= 0.03928 ? part / 12.92 : ((part + 0.055) / 1.055) ** 2.4
+        });
+
+        return 0.2126 * r + 0.7152 * g + 0.0722 * b
+    };
+
+    const [high, low] = [luminance(a), luminance(b)].sort((x, y) => y - x);
+
+    return (high + 0.05) / (low + 0.05)
+}
+
+test.describe('portal stored theme at boot', () => {
+    test('the no-preference default boots dark on both surfaces', async ({page}) => {
+        await seedStoredTheme(page, null);
+        await page.goto(PORTAL);
+        await booted(page);
+
+        const {body, viewport} = await readSurfaces(page);
+
+        // AC-3, and the control for every arm below: it fails if seeding, boot, or the surface read is
+        // broken, so a red light arm cannot be blamed on the harness.
+        expect(body.theme).toEqual([DARK]);
+
+        // Measured, not assumed: with no preference the viewport carries NO theme class and inherits
+        // the body's. That is `component.Base#getTheme`'s documented contract — "a child inside a
+        // themed scope carries no theme class of its own by design" — so an empty list here is the
+        // correct default, and asserting [DARK] would pin a behaviour the engine does not have.
+        expect(viewport.theme).toEqual([]);
+        expect(await page.evaluate(key => localStorage.getItem(key), STORAGE_KEY)).toBeNull();
+
+        // The same floor the defect arm asserts — proving the floor is clearable, not decorative.
+        expect(contrastRatio(viewport.background, viewport.color)).toBeGreaterThan(3)
+    });
+
+    test('a stored light preference reaches BOTH the body and the viewport', async ({page}) => {
+        await seedStoredTheme(page, LIGHT);
+        await page.goto(PORTAL);
+        await booted(page);
+
+        // Without this, a storage write that silently failed would present as the defect.
+        expect(await page.evaluate(key => localStorage.getItem(key), STORAGE_KEY)).toBe(LIGHT);
+
+        const {body, viewport} = await readSurfaces(page);
+
+        // The half that already works today. Asserted so a regression here cannot hide behind the
+        // body-class failure below.
+        expect(viewport.theme, 'the viewport receives the stored preference').toEqual([LIGHT]);
+
+        // AC-1. Red at e99ffb6588, where the body still reads neo-theme-neo-dark.
+        expect(body.theme, 'the body must follow the stored preference').toEqual([LIGHT]);
+
+        // AC-2, the no-split-brain invariant, and the one that survives a palette change: the viewport
+        // either carries NO theme class (inheriting the body's, as the default arm shows) or carries
+        // the SAME one. What it may never do is name a different theme than the surface it inherits
+        // `color` from — that is the state this defect produces.
+        expect(
+            viewport.theme.length === 0 || viewport.theme[0] === body.theme[0],
+            `viewport theme ${JSON.stringify(viewport.theme)} must inherit or match body ${JSON.stringify(body.theme)}`
+        ).toBe(true)
+    });
+
+    test('a stored light preference leaves readable text', async ({page}) => {
+        await seedStoredTheme(page, LIGHT);
+        await page.goto(PORTAL);
+        await booted(page);
+
+        const {viewport} = await readSurfaces(page);
+
+        // The user-visible harm, and the reason the split matters: the viewport takes its background
+        // from its own theme and INHERITS its colour from the body's. Two themes, one element,
+        // ~1:1 contrast. Red at e99ffb6588 — rgb(255,255,255) behind rgb(240,242,240).
+        expect(
+            contrastRatio(viewport.background, viewport.color),
+            'viewport background and text must come from the same theme'
+        ).toBeGreaterThan(3)
+    })
+});

--- a/test/playwright/e2e/portal/StoredThemeBoot.spec.mjs
+++ b/test/playwright/e2e/portal/StoredThemeBoot.spec.mjs
@@ -3,7 +3,7 @@ import {test, expect} from '@playwright/test';
 /**
  * A stored `portalTheme` preference must reach the whole page, not one half of it.
  *
- * #18571, measured at `dev@e99ffb6588`. With `localStorage.portalTheme = 'neo-theme-neo-light'` the
+ * With `localStorage.portalTheme = 'neo-theme-neo-light'` stored, the
  * preference DOES arrive: `div#neo-viewport-1` carries `neo-theme-neo-light`. `document.body` keeps
  * `neo-theme-neo-dark`, because the body class is written ONCE on the main thread by
  * `main.addon.Stylesheet#addGlobalCss` from the static `Neo.config.themes[0]` — before any worker runs —

--- a/test/playwright/unit/buildScripts/util/E2eCiSelection.spec.mjs
+++ b/test/playwright/unit/buildScripts/util/E2eCiSelection.spec.mjs
@@ -79,6 +79,10 @@ test.describe('e2e CI selection — the coverage summary must add up', () => {
         add('core/B.spec.mjs');
         add('dashboard/C.spec.mjs');
         add('grid/D.spec.mjs');
+        // Named, not `portal/E.spec.mjs`, because `RUN_PATHS` names this file rather than its
+        // directory — `portal/Outside.spec.mjs` below is still outside the run set, which is what
+        // that arm needs.
+        add('portal/StoredThemeBoot.spec.mjs');
         add('rendering/InputModalityMultiWindow.spec.mjs');
         add('rendering/ViewTransitionReveal.spec.mjs');
 

--- a/test/playwright/unit/container/ItemTheme.spec.mjs
+++ b/test/playwright/unit/container/ItemTheme.spec.mjs
@@ -96,5 +96,31 @@ test.describe('Neo.container.Base — an item config\'s own theme survives creat
         });
 
         expect(container.items[0].theme).toBe('neo-theme-neo-light')
+    });
+
+    /**
+     * #18571 AC-5. The stored-preference read is a promise, so the theme can land AFTER the tree is
+     * built — and an item added later still has to resolve the CURRENT theme rather than the one
+     * present at construction. Both directions are asserted because they fail independently:
+     * `afterSetTheme` propagates to LIVE items, while `createItem` resolves precedence for a new one.
+     * An arm covering only the second passes while a live item keeps a stale theme, and vice versa.
+     */
+    test('a theme change reaches the live item AND the one added after it', () => {
+        container = Neo.create(Container, {
+            appName,
+            theme: 'neo-theme-neo-dark',
+            items: [{module: Component}]
+        });
+
+        const [existing] = container.items;
+
+        expect(existing.theme, 'inherited at construction').toBe('neo-theme-neo-dark');
+
+        container.theme = 'neo-theme-neo-light';
+        container.add({module: Component});
+
+        expect(existing.theme, 'the live item follows the change').toBe('neo-theme-neo-light');
+        expect(container.items[1].theme, 'and the item added after it resolves the CURRENT theme')
+            .toBe('neo-theme-neo-light')
     })
 });

--- a/test/playwright/unit/container/ItemTheme.spec.mjs
+++ b/test/playwright/unit/container/ItemTheme.spec.mjs
@@ -99,7 +99,7 @@ test.describe('Neo.container.Base — an item config\'s own theme survives creat
     });
 
     /**
-     * #18571 AC-5. The stored-preference read is a promise, so the theme can land AFTER the tree is
+     * A stored-preference read is a promise, so a theme can land AFTER the tree is
      * built — and an item added later still has to resolve the CURRENT theme rather than the one
      * present at construction. Both directions are asserted because they fail independently:
      * `afterSetTheme` propagates to LIVE items, while `createItem` resolves precedence for a new one.

--- a/test/playwright/unit/container/ViewportBodyTheme.spec.mjs
+++ b/test/playwright/unit/container/ViewportBodyTheme.spec.mjs
@@ -1,0 +1,114 @@
+import {setup} from '../../setup.mjs';
+
+setup({
+    appConfig: {
+        name: 'ViewportBodyThemeTest'
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../src/Neo.mjs';
+import * as core      from '../../../../src/core/_export.mjs';
+import Viewport       from '../../../../src/container/Viewport.mjs';
+
+const appName = 'ViewportBodyThemeTest';
+
+/**
+ * `Neo.container.Viewport` publishes its theme onto `document.body`, because the body class is written
+ * once at main-thread boot from `Neo.config.themes[0]` and nothing in the theme path rewrote it. These
+ * arms pin WHEN it publishes and WHAT it publishes, at the main-thread boundary rather than through a
+ * rendered page — the rendered half is covered by `e2e/portal/StoredThemeBoot.spec.mjs`.
+ *
+ * The transition that matters here is the one boot cases structurally cannot reach: `theme_: null` is a
+ * supported state meaning "inherit", so a reset from an explicit theme must republish what `getTheme()`
+ * now resolves. Reading the `theme` CONFIG instead of the effective theme leaves the body on the last
+ * explicit value while every other surface has moved on — the same two-surface disagreement the publisher
+ * exists to remove, arriving through its own fix.
+ */
+test.describe('Neo.container.Viewport — body-theme publication', () => {
+    let calls    = [],
+        original = null,
+        viewport = null;
+
+    test.beforeEach(() => {
+        calls = [];
+
+        Neo.main            ??= {};
+        Neo.main.DomAccess  ??= {};
+        original              = {
+            applyBodyCls: Neo.main.DomAccess.applyBodyCls,
+            setBodyCls  : Neo.main.DomAccess.setBodyCls
+        };
+
+        Neo.main.DomAccess.applyBodyCls = () => {};
+        Neo.main.DomAccess.setBodyCls   = data => calls.push(data)
+    });
+
+    test.afterEach(() => {
+        viewport?.destroy();
+        viewport = null;
+
+        Neo.main.DomAccess.applyBodyCls = original.applyBodyCls;
+        Neo.main.DomAccess.setBodyCls   = original.setBodyCls
+    });
+
+    /** @returns {String|null} the theme the last publication put on the body */
+    const published = () => calls.at(-1)?.add?.[0] ?? null;
+
+    test('an explicit theme at construction is published once', () => {
+        viewport = Neo.create(Viewport, {appName, autoMount: false, theme: 'neo-theme-neo-light'});
+
+        expect(calls).toHaveLength(1);
+        expect(published()).toBe('neo-theme-neo-light');
+        expect(viewport.getTheme()).toBe('neo-theme-neo-light');
+    });
+
+    test('a reset to inheritance republishes the effective theme, not the last explicit one', () => {
+        viewport = Neo.create(Viewport, {appName, autoMount: false, theme: 'neo-theme-neo-light'});
+
+        expect(published(), 'the explicit theme lands first').toBe('neo-theme-neo-light');
+
+        viewport.theme = null;
+
+        // `getTheme()` walks to the window/app default once the config is cleared. The body has to follow
+        // it: reading `theme` here returns null, and skipping on null is what left the body on light.
+        const effective = viewport.getTheme();
+
+        expect(effective, 'the viewport falls back to the app default').toBe(Neo.config.themes[0]);
+        expect(calls, 'the reset publishes rather than being skipped').toHaveLength(2);
+        expect(published(), 'and the two surfaces agree again').toBe(effective);
+    });
+
+    test('an explicit theme change also republishes — the working control for the reset arm', () => {
+        viewport = Neo.create(Viewport, {appName, autoMount: false, theme: 'neo-theme-neo-light'});
+
+        viewport.theme = 'neo-theme-neo-dark';
+
+        // Without this arm a reset arm could pass against a publisher that never fires at all.
+        expect(calls).toHaveLength(2);
+        expect(published()).toBe('neo-theme-neo-dark');
+        expect(viewport.getTheme()).toBe('neo-theme-neo-dark');
+    });
+
+    test('a viewport that never carries a theme publishes nothing', () => {
+        viewport = Neo.create(Viewport, {appName, autoMount: false});
+
+        // The untouched default already agrees with the body, and this path must not start depending on
+        // the publisher. An implementation that published `getTheme()` unconditionally passes every arm
+        // above and fails this one.
+        expect(calls).toHaveLength(0);
+    });
+
+    test('applyBodyCls:false opts out even with an explicit theme', () => {
+        viewport = Neo.create(Viewport, {
+            appName,
+            applyBodyCls: false,
+            autoMount   : false,
+            theme       : 'neo-theme-neo-light'
+        });
+
+        viewport.theme = null;
+
+        expect(calls).toHaveLength(0);
+    })
+});


### PR DESCRIPTION
Resolves #18571

A stored `portalTheme: neo-theme-neo-light` reached `Portal.view.Viewport` and stopped there: `document.body` kept the boot theme, so `background-color` resolved from the viewport's class while `color` inherited from the body's. `Neo.container.Viewport` now mirrors its theme onto the body, which it was already half-doing — `applyBodyCls` puts `neo-body-viewport` there in `onConstructed`.

Evidence: L4 (live browser, real portal boot under the e2e harness, both preference states measured) → L4 required (AC-1/2/3 are rendered-surface claims no unit tier can witness). Residual: none.

The ticket's own inferred mechanism was wrong, and it said so in advance — it flagged the mechanism as inferred and told whoever took it to establish it. Measured at `dev@e99ffb6588`, the preference *does* arrive: `div#neo-viewport-1` carries `neo-theme-neo-light`. Propagation works; only the body is stale, and `DomAccess#setBodyCls` had exactly one caller in the repository, in `apps/shareddialog`. So the failure is not "renders dark" — it renders `rgb(255,255,255)` behind `rgb(240,242,240)`, **1.13:1 contrast**, invisible text. Ticket body updated with the measurement.

## AC Evidence

| AC | Evidence |
|---|---|
| AC-1 — cold boot renders light, no surface still dark | outside-CI: `StoredThemeBoot.spec.mjs` › `a stored light preference reaches BOTH the body and the viewport` |
| AC-2 — Viewport config and body class agree, asserted together | outside-CI: same arm, final assertion — the viewport must inherit (no class) or name the SAME theme as the body |
| AC-3 — dark preference and no-preference default unchanged | outside-CI: `the no-preference default boots dark on both surfaces`, plus the full unit tier |
| AC-4 — cause established before the fix, and stated | this body + the fix commit message; census and computed-style measurements at `e99ffb6588` |
| AC-5 — a descendant created AFTER the stored theme lands inherits it | CI-covered: `ItemTheme.spec.mjs` › `a theme change reaches the live item AND the one added after it` |

**AC-5 is a regression lock, not red-first evidence.** That spec's import graph is `container/Base.mjs` and `component/Base.mjs`; it never reaches `container/Viewport.mjs` and passes unchanged on base. The engine already resolved late-added items correctly — nothing asserted it.

## Deltas from ticket

Two, both scope-forced:

- **`e2e/portal` sits outside `RUN_PATHS`**, because both existing specs there are declared exclusions (`LearnLinkRoutingNL`, `LearnMermaidRender` — hosted live-preview and routing causes, both mine). Neither cause reaches this arm, which boots the portal root and reads a class, so it is named individually in the run set. `E2eCiSelection` caught the omission: with the spec added and unregistered, 2 arms fail; a control run with the file removed passes 5/5.
- **The guard's synthetic fixture** hand-lists one spec per `RUN_PATHS` entry, despite a comment saying it is derived. One matching line added. Naming a *file* rather than the directory keeps its `portal/Outside.spec.mjs` genuinely outside, which that arm needs. Out of scope to make the fixture actually derived, noted here rather than filed — it is one line in a guard nobody is currently changing.

## Test Evidence

Outside-CI only; the unit tier's passes are not restated.

- **Red-first, with a working control.** Before the fix: control green (no preference → both surfaces dark, readable), both defect arms red — `body.theme` `[neo-theme-neo-dark]` against `[neo-theme-neo-light]`, contrast `1.125`. After: 3/3 green. The control is what makes the red meaningful.
- **The liveness poll is load-bearing.** `addGlobalCss` stamps `themes[0]` from the MAIN thread, so a portal that never boots *also* shows `neo-theme-neo-dark` and *also* fails the light arm, for an unrelated reason. I hit exactly that earlier: a dead page in a browser pane reproduced the symptom perfectly. Each arm gates on the portal having rendered first.
- **The contrast floor is cleared by the passing control**, so it is not a floor nothing clears.
- **A wrong control caught by the run:** I first asserted the viewport carries `[neo-theme-neo-dark]` by default. Measured, it carries `[]` — it inherits, per `getTheme`'s documented contract. AC-2 is now the invariant that survives a palette change: inherit, or match.
- Re-run after rebasing onto `259964a7bf`: e2e 3/3, unit 3808 passed / 2 skipped / 0 failed.

## Post-Merge Validation

- [ ] `StoredThemeBoot.spec.mjs` passes on a hosted runner. Its two `e2e/portal` siblings do not, for live-preview and routing reasons that do not apply here — if it fails hosted anyway, it becomes an `EXCLUSIONS` entry with the observed cause, not a silent removal.
- [ ] No app relying on the previous behaviour — a viewport theme that deliberately did NOT reach the body — regresses. No such consumer found: `setBodyCls` had one caller, unrelated to theming.

## Commits

- `9a918a666a` — the fix, the e2e arms, and the CI-selection registration
- `f857a7420a` — AC-5 regression lock at the engine tier

Authored by Ada (Claude Opus 5, Claude Code). Session 472402c1-2f1d-40d2-9e44-22b23c8a2e2b.
