### PR TITLE
fix(deps): bound gray-matter empty-merge parsing (#18600)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4940,9 +4940,9 @@
             }
         },
         "node_modules/gray-matter/node_modules/js-yaml": {
-            "version": "3.15.1",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
-            "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
+            "version": "3.15.2",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.2.tgz",
+            "integrity": "sha512-6EuL879VkRA+1Cz578mKMiKvjPNEuk6+r1JaFzoSWejZmtf7xWbIyw1e3KkxlkzTIt9Taw6JBhEppG7utc1P+w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -136,7 +136,7 @@
     },
     "overrides": {
         "gray-matter": {
-            "js-yaml": "^3.15.1"
+            "js-yaml": "^3.15.2"
         }
     },
     "funding": {


### PR DESCRIPTION
Resolves #18600

Raise the existing gray-matter override to `^3.15.2` and replace only that package's locked version, URL and integrity. This removes [GHSA-2883-xcg3-v3hh](https://github.com/advisories/GHSA-2883-xcg3-v3hh) while retaining gray-matter's 3.x safeLoad/safeDump API and direct js-yaml 5.4.1.

Change class: restoration.
Decision Record impact: none.
Evidence: L2 — clean installation, real gray-matter parse/stringify and bounded vulnerable-version control. Default-branch alert closure is post-merge.

agent-preflight: not hosted here; shared PR-body and baseline jobs are the CI gates.

## AC Evidence

| AC | Evidence |
|---|---|
| AC-1 | `npm ci --ignore-scripts --no-audit --no-fund` on Node 24.21.0 succeeds; gray-matter resolves js-yaml 3.15.2. |
| AC-2 | `npm audit --package-lock-only --json` contains no js-yaml finding. Residuals below. |
| AC-3 | Real gray-matter roundtrip preserves title, boolean, tags and body; ordinary YAML merge succeeds; direct js-yaml 5.4.1 still parses correctly. |
| AC-4 | Exactly two files: one manifest floor and three lock fields. `git diff --check` passes. Repository CI is required before review routing. |

## Deltas from ticket

None. Out of scope, noted in [Engine #18354](https://github.com/neomjs/neo/issues/18354): Monaco/DOMPurify leaves npm's two affected package entries (one low, one moderate).

## Test Evidence

The default-limit witness below uses 101 mappings of 100 empty sources each (about 80 KB). Node 24.21.0: gray-matter with 3.15.1 accepts it; both patched installs reject it with `merge keys exceeded maxTotalMergeKeys (10000)` in 3 ms. The initial single-large-sequence probe hit 3.15.2's additional sequence-size guard; splitting the batches isolates aggregate-budget enforcement.

```js
const matter = require('gray-matter');
const batch = Array(100).fill('*empty').join(', ');
const input = '---\nempty: &empty {}\n' +
    Array.from({length: 101}, (_, i) =>
        `merged${i}: { <<: [${batch}] }`).join('\n') + '\n---\n';
require('node:assert/strict').throws(() => matter(input),
    /merge keys exceeded maxTotalMergeKeys \(10000\)/);
```

## Post-Merge Validation

No implementation deferred. GitHub's default-branch alert closure is observable only after human merge and a rescan; the repaired lock and audit are verified above.

Authored by Euclid (OpenAI GPT, Codex). Session 92f5d790-2865-4f69-b25e-150175745a6d.
