### PR TITLE
fix(dock): a pane close waits for the refresh its own commit scheduled (#18598)

### DIFF
--- a/buildScripts/util/file-size-baseline.json
+++ b/buildScripts/util/file-size-baseline.json
@@ -1,6 +1,6 @@
 {
     "apps/workstation/view/Workspace.mjs": 1252,
     "examples/dashboard/crossWindow/DemoBWorkspace.mjs": 2546,
-    "src/dashboard/dock/Workspace.mjs": 1100,
+    "src/dashboard/dock/Workspace.mjs": 1106,
     "src/main/addon/DragDrop.mjs": 1267
 }

--- a/src/dashboard/dock/Workspace.mjs
+++ b/src/dashboard/dock/Workspace.mjs
@@ -1706,10 +1706,36 @@ class Workspace extends Container {
         if (result && !result.errors?.length && result.document) {
             let focusId = result.document.nodes?.[modelNodeId]?.activeItemId ?? null;
 
-            me.onDockZoneDocumentChange(result.document, descriptor, tabContainer);
-            me.refreshPromise = me.refreshPromise.then(() => {
-                me.focusDockCloseTarget({dockNodeId: modelNodeId, itemId: focusId})
-            })
+            // Focus must land after the refresh THIS close scheduled, and the two branches of
+            // `onDockZoneDocumentChange` publish that refresh at different times. The discriminator
+            // is the observable one rather than a test of which branch ran: did the call publish a
+            // new refresh before returning?
+            const published = me.refreshPromise,
+                  pending   = me.onDockZoneDocumentChange(result.document, descriptor, tabContainer),
+                  focus     = () => me.focusDockCloseTarget({dockNodeId: modelNodeId, itemId: focusId});
+
+            if (me.refreshPromise && me.refreshPromise !== published) {
+                // The direct branch projected inside the call and assigned its own refresh, so chain
+                // now — which also keeps the follow-up observable to a caller that awaits
+                // `refreshPromise` immediately, as the close specs do.
+                me.refreshPromise = me.refreshPromise.then(focus)
+            } else {
+                // The Group branch returned the write and scheduled no projection: `Commit.complete`
+                // queues it as a detached microtask and the write resolves first, so `refreshPromise`
+                // still holds the PREVIOUS refresh, or `null` on a shell projected statically before
+                // any commit. Reading it here chained focus onto a settled promise — focus reached
+                // chrome the reconciler was about to retire — or threw on the null.
+                //
+                // The assignment must stay inside the `then`: `projectDockZoneDocument` takes
+                // `me.refreshPromise` as its own tail, so publishing a chain that awaits the
+                // projection before it is scheduled makes the projection wait on itself.
+                //
+                // A rejected write means no close landed and no focus is owed. The commit path
+                // already logs it; this catch only stops the follow-up reporting it twice.
+                Promise.resolve(pending)
+                    .then(() => {me.refreshPromise = (me.refreshPromise ?? Promise.resolve()).then(focus)})
+                    .catch(() => {})
+            }
         }
 
         return result

--- a/src/dashboard/dock/Workspace.mjs
+++ b/src/dashboard/dock/Workspace.mjs
@@ -427,6 +427,13 @@ class Workspace extends Container {
      * transactions cannot overlap or cross-correlate. Each commit stores the promise of ITS OWN
      * transaction here: a rejection belongs to whoever awaits the snapshot taken at that commit,
      * and the next commit schedules off the settled tail, never off the rejection.
+     *
+     * **It is not updated synchronously on every path.** `onDockZoneDocumentChange`'s Group branch
+     * returns the write and schedules no projection: the commit queues that as a detached microtask
+     * and the write resolves first, so immediately after a Group-routed change this field still holds
+     * the PREVIOUS refresh — or `null`, on a shell projected statically before any commit. A consumer
+     * that needs the refresh a specific change scheduled must await that change's own promise first;
+     * reading this field at call time reads the one before it.
      * @member {Promise|null} refreshPromise=null
      * @protected
      */
@@ -1680,7 +1687,10 @@ class Workspace extends Container {
      *
      * Live reconciled order owns the close target at dispatch time. The current model locates that
      * item's semantic tabs node, and the committed result owns its focus successor. Successful focus
-     * is chained onto `refreshPromise`, so it cannot reach chrome the reconciler retires.
+     * is chained onto the refresh THIS close scheduled, so it cannot reach chrome the reconciler
+     * retires — which is not always the `refreshPromise` standing at dispatch. The direct branch
+     * publishes its refresh inside the call and is chained immediately; the Group branch publishes
+     * from the commit's own microtask, so the follow-up waits for the returned promise first.
      * @param {Object} data
      * @param {String} data.dockNodeId
      * @param {Neo.tab.Container} data.tabContainer

--- a/src/dashboard/dock/Workspace.mjs
+++ b/src/dashboard/dock/Workspace.mjs
@@ -1716,34 +1716,23 @@ class Workspace extends Container {
         if (result && !result.errors?.length && result.document) {
             let focusId = result.document.nodes?.[modelNodeId]?.activeItemId ?? null;
 
-            // Focus must land after the refresh THIS close scheduled, and the two branches of
-            // `onDockZoneDocumentChange` publish that refresh at different times. The discriminator
-            // is the observable one rather than a test of which branch ran: did the call publish a
-            // new refresh before returning?
+            // Which refresh this close must wait for is decided by an observable test, not by
+            // which branch ran: did the call publish a new refresh? (Timing: see `refreshPromise`.)
             const published = me.refreshPromise,
                   pending   = me.onDockZoneDocumentChange(result.document, descriptor, tabContainer),
                   focus     = () => me.focusDockCloseTarget({dockNodeId: modelNodeId, itemId: focusId});
 
             if (me.refreshPromise && me.refreshPromise !== published) {
-                // The direct branch projected inside the call and assigned its own refresh, so chain
-                // now — which also keeps the follow-up observable to a caller that awaits
-                // `refreshPromise` immediately, as the close specs do.
+                // Chaining now also keeps the follow-up observable to a caller that awaits
+                // `refreshPromise` immediately, which the close specs do.
                 me.refreshPromise = me.refreshPromise.then(focus)
             } else {
-                // The Group branch returned the write and scheduled no projection: `Commit.complete`
-                // queues it as a detached microtask and the write resolves first, so `refreshPromise`
-                // still holds the PREVIOUS refresh, or `null` on a shell projected statically before
-                // any commit. Reading it here chained focus onto a settled promise — focus reached
-                // chrome the reconciler was about to retire — or threw on the null.
-                //
-                // The assignment must stay inside the `then`: `projectDockZoneDocument` takes
-                // `me.refreshPromise` as its own tail, so publishing a chain that awaits the
-                // projection before it is scheduled makes the projection wait on itself.
-                //
-                // A rejected write means no close landed and no focus is owed. The commit path
-                // already logs it; this catch only stops the follow-up reporting it twice.
+                // Two invariants. The assignment stays INSIDE the continuation, or
+                // `projectDockZoneDocument` — which takes `refreshPromise` as its tail — waits on
+                // itself. And the assigned chain is RETURNED, or a rejected projection escapes the
+                // trailing catch and the follow-up adds a second, unhandled receipt.
                 Promise.resolve(pending)
-                    .then(() => {me.refreshPromise = (me.refreshPromise ?? Promise.resolve()).then(focus)})
+                    .then(() => me.refreshPromise = (me.refreshPromise ?? Promise.resolve()).then(focus))
                     .catch(() => {})
             }
         }

--- a/test/playwright/unit/dashboard/DockWorkspace.spec.mjs
+++ b/test/playwright/unit/dashboard/DockWorkspace.spec.mjs
@@ -616,6 +616,141 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
         })
     });
 
+    test.describe('a pane close under a Group chains its focus follow-up onto its OWN refresh', () => {
+        // `handleDockCloseAction` chained focus onto `refreshPromise` at the moment of the call. On
+        // the Group branch that promise belongs to the PREVIOUS refresh — or is still `null` — because
+        // `onDockZoneDocumentChange` returns the write and schedules no projection: `Commit.complete`
+        // queues it as a detached microtask, and `Transaction.write` resolves before it runs.
+        //
+        // Two traps the arms exist to hold down. A `?.` guard alone fixes the throw and leaves the
+        // stale chain. Assigning the chain to `refreshPromise` BEFORE the projection is scheduled
+        // deadlocks, because `projectDockZoneDocument` takes `me.refreshPromise?.catch(…)` as its own
+        // tail — the fix must assign only after the returned promise settles.
+        //
+        // Found by @neo-opus-grace against a live app, reproduced on a real Group by @neo-fable.
+        const stage = async () => {
+            const {groupId} = TransactionManager.bind({windowId: `dock-close-focus-${Neo.getId('t')}`, workspaceKey: 'main'}),
+                  workspace = Neo.create(PlainWorkspace, {dockModel: createDocument(), topologyGroupId: groupId}),
+                  set       = Neo.create(WorkspaceSet, {documentModel: WorkspaceDocument, getGroupId: () => groupId, manager: TransactionManager}),
+                  commits   = [],
+                  focus     = [],
+                  projected = {count: 0},
+                  project   = workspace.projectDockCommit.bind(workspace);
+
+            TransactionManager.setHistoryDepth({groupId, depth: 5});
+            // Without this the workspace has no `workspaceSet`, `onDockZoneDocumentChange` takes the
+            // DIRECT branch, and the fixture never reaches the defect at all — it measured the branch
+            // that was already correct.
+            // `workspaceKey` makes the participant lookup direct; without it `onDockZoneDocumentChange`
+            // scans for a participant whose `componentId` matches, which this fixture's registration
+            // does not supply, and the write is rejected before the defect can be reached.
+            workspace.workspaceKey         = 'main';
+            workspace.workspaceSet         = set;
+            workspace.projectDockCommit    = context => {projected.count++; return project(context)};
+
+            // The arms settle on the SAME promise production waits on, captured here rather than
+            // approximated with a sleep. The handler registers its continuation on it before this
+            // capture is awaited, so by the time the arm resumes the follow-up chain is published.
+            const change = workspace.onDockZoneDocumentChange.bind(workspace);
+
+            workspace.onDockZoneDocumentChange = (...args) => {
+                const result = change(...args);
+                commits.push(result);
+                return result
+            };
+            workspace.focusDockCloseTarget = data => focus.push({...data, projectionsSoFar: projected.count});
+
+            set.register('main', {
+                getDocument: () => workspace.dockModel,
+                setDocument: value => workspace.dockModel = value,
+                project    : context => workspace.projectDockCommit(context)
+            });
+
+            return {commits, focus, groupId, projected, set, workspace}
+        };
+
+        test('the first close on a statically projected shell does not throw, and focus still runs', async () => {
+            const {commits, focus, groupId, set, workspace} = await stage();
+
+            try {
+                // Facet 1. `refreshPromise` is null until the first commit projects, and the shell here
+                // was projected statically in `construct` — the Workstation idiom. The close itself
+                // always landed; it was the follow-up that died with it.
+                expect(workspace.refreshPromise, 'the precondition the defect needs: no refresh yet').toBe(null);
+
+                const tabs    = tabsOf(workspace.items[0]).get('side-tabs'),
+                      outcome = workspace.handleDockCloseAction({dockNodeId: 'side-tabs', tabContainer: tabs});
+
+                expect(outcome?.errors ?? [], 'the close commits').toEqual([]);
+
+                await commits.at(-1);
+                await workspace.refreshPromise;
+
+                expect(focus.length, 'the focus follow-up ran rather than dying with a TypeError').toBe(1)
+            } finally {
+                set.destroy();
+                TransactionManager.retireGroup(groupId)
+            }
+        });
+
+        test('after an earlier commit the follow-up waits for the CLOSE\'s projection, not the previous one', async () => {
+            const {commits, focus, groupId, projected, set, workspace} = await stage();
+
+            try {
+                // Facet 2, and the one a `?.` guard leaves behind: with a settled refresh already in
+                // place the chain resolves immediately, so focus reached the outgoing chrome.
+                await set.commit('main', [{operation: 'resizeSplit', splitNodeId: 'root-split', sizes: [0.75, 0.25]}]);
+                await workspace.refreshPromise;
+
+                const before = projected.count;
+
+                expect(before, 'an earlier commit really projected').toBeGreaterThan(0);
+
+                workspace.handleDockCloseAction({
+                    dockNodeId  : 'side-tabs',
+                    tabContainer: tabsOf(workspace.items[0]).get('side-tabs')
+                });
+
+                await commits.at(-1);
+                await workspace.refreshPromise;
+
+                expect(focus.length, 'focus ran').toBe(1);
+                expect(focus[0].projectionsSoFar, 'focus waited for the close to project, not for the previous refresh')
+                    .toBeGreaterThan(before)
+            } finally {
+                set.destroy();
+                TransactionManager.retireGroup(groupId)
+            }
+        });
+
+        test('control: the direct branch already ordered focus after its own projection', async () => {
+            // No Group, so `onDockZoneDocumentChange` runs `projectDockZoneDocument`, which assigns
+            // `refreshPromise` inside the call. This arm was green before the fix and must stay green:
+            // it is what proves the repair did not buy the Group branch at the direct branch's expense.
+            const workspace = Neo.create(PlainWorkspace, {dockModel: createDocument()}),
+                  focus     = [],
+                  projected = {count: 0},
+                  project   = workspace.projectDockZoneDocument.bind(workspace);
+
+            workspace.projectDockZoneDocument = (...args) => {projected.count++; return project(...args)};
+            workspace.focusDockCloseTarget    = data => focus.push({...data, projectionsSoFar: projected.count});
+
+            try {
+                workspace.handleDockCloseAction({
+                    dockNodeId  : 'side-tabs',
+                    tabContainer: tabsOf(workspace.items[0]).get('side-tabs')
+                });
+
+                await workspace.refreshPromise;
+
+                expect(focus.length, 'focus ran on the direct branch').toBe(1);
+                expect(focus[0].projectionsSoFar, 'and after its own projection').toBeGreaterThan(0)
+            } finally {
+                workspace.destroy()
+            }
+        })
+    });
+
     test.describe('#17947 pop-out dispatches the drag terminal, never a second lifecycle', () => {
         // The whole point of the leaf: a click enters the SAME pair the pointer gesture's terminal
         // calls. These arms assert the dispatch and its ordering, because "no parallel lifecycle" is

--- a/test/playwright/unit/dashboard/DockWorkspace.spec.mjs
+++ b/test/playwright/unit/dashboard/DockWorkspace.spec.mjs
@@ -716,8 +716,46 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
 
                 expect(focus.length, 'focus ran').toBe(1);
                 expect(focus[0].projectionsSoFar, 'focus waited for the close to project, not for the previous refresh')
-                    .toBeGreaterThan(before)
+                    .toBeGreaterThan(before);
+
+                // AC-2's other half: the published refresh must INCLUDE the follow-up, or a later
+                // commit schedules off a promise that does not cover the focus it has to order after.
+                let settled = false;
+
+                await workspace.refreshPromise.then(() => {settled = focus.length === 1});
+
+                expect(settled, 'refreshPromise covers the follow-up it scheduled').toBe(true)
             } finally {
+                set.destroy();
+                TransactionManager.retireGroup(groupId)
+            }
+        });
+
+        test('a refused Group write runs no focus, and surfaces exactly as it does today', async () => {
+            const {commits, focus, groupId, set, workspace} = await stage(),
+                  rejections                                = [],
+                  onRejection                               = event => {rejections.push(event.reason); event.preventDefault?.()};
+
+            globalThis.addEventListener?.('unhandledrejection', onRejection);
+
+            try {
+                // The refusal the engine already produces for an unregistered participant. AC-5 is a
+                // PARITY claim, not new behaviour: no focus, and no rejection the caller did not
+                // already get — the follow-up must not surface the same failure a second time.
+                workspace.workspaceKey = 'not-registered';
+
+                workspace.handleDockCloseAction({
+                    dockNodeId  : 'side-tabs',
+                    tabContainer: tabsOf(workspace.items[0]).get('side-tabs')
+                });
+
+                await Promise.allSettled(commits);
+                await Promise.resolve();
+
+                expect(focus.length, 'a refused write owes no focus').toBe(0);
+                expect(rejections, 'and the follow-up adds no unhandled rejection of its own').toEqual([])
+            } finally {
+                globalThis.removeEventListener?.('unhandledrejection', onRejection);
                 set.destroy();
                 TransactionManager.retireGroup(groupId)
             }

--- a/test/playwright/unit/dashboard/DockWorkspace.spec.mjs
+++ b/test/playwright/unit/dashboard/DockWorkspace.spec.mjs
@@ -761,7 +761,14 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
                 seen.length = 0;
 
                 await body();
-                await new Promise(resolve => setImmediate(resolve));
+
+                // Drain BOTH phases: the refresh chain ends on a `timeout(0)` macrotask, so a
+                // check-phase turn alone closes the window before the rejection is raised and the
+                // arm passes whatever the handler does. Bounded turns, not a fixed sleep.
+                for (let turn = 0; turn < 4; turn++) {
+                    await new Promise(resolve => setImmediate(resolve));
+                    await new Promise(resolve => setTimeout(resolve, 0))
+                }
 
                 return seen
             } finally {
@@ -812,7 +819,10 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
                         tabContainer: tabsOf(workspace.items[0]).get('side-tabs')
                     });
                     await Promise.allSettled(commits);
-                    await Promise.allSettled([workspace.refreshPromise])
+
+                    // Deliberately NOT awaiting `refreshPromise`: `allSettled` would ATTACH a
+                    // handler to the very promise whose unhandledness is under test and mark it
+                    // handled, so the arm would pass with or without the repair.
                 });
 
                 expect(unhandled, 'the follow-up adds no unhandled rejection of its own').toEqual([]);

--- a/test/playwright/unit/dashboard/DockWorkspace.spec.mjs
+++ b/test/playwright/unit/dashboard/DockWorkspace.spec.mjs
@@ -731,31 +731,93 @@ test.describe('Neo.dashboard.dock.Workspace', () => {
             }
         });
 
-        test('a refused Group write runs no focus, and surfaces exactly as it does today', async () => {
-            const {commits, focus, groupId, set, workspace} = await stage(),
-                  rejections                                = [],
-                  onRejection                               = event => {rejections.push(event.reason); event.preventDefault?.()};
+        /**
+         * A REAL observer, with a positive control. The first version used
+         * `globalThis.addEventListener?.('unhandledrejection', …)`, which is `undefined` in this Node
+         * runtime — the optional call installed nothing and the arm asserted an array that could
+         * never be populated. A control that silently does nothing reads as a control that passed.
+         * Found by @neo-gpt-emmy, who also supplied the rejected-projection case below.
+         * @param {Function} body
+         * @returns {Promise<Object[]>} Every rejection nobody handled while `body` ran.
+         */
+        const watchUnhandled = async body => {
+            const seen    = [],
+                  observe = reason => seen.push(reason),
+                  // The runner installs its own `unhandledRejection` handler and fails the test on
+                  // one, so the positive control below would kill the arm that proves the observer
+                  // works. Take the window exclusively and hand it back in `finally`.
+                  borrowed = process.listeners('unhandledRejection');
 
-            globalThis.addEventListener?.('unhandledrejection', onRejection);
+            process.removeAllListeners('unhandledRejection');
+            process.on('unhandledRejection', observe);
 
             try {
-                // The refusal the engine already produces for an unregistered participant. AC-5 is a
-                // PARITY claim, not new behaviour: no focus, and no rejection the caller did not
-                // already get — the follow-up must not surface the same failure a second time.
+                // Positive control FIRST: if this does not arrive, the observer is inert and every
+                // assertion below is vacuous.
+                Promise.reject(new Error('observer-control'));
+                await new Promise(resolve => setImmediate(resolve));
+
+                expect(seen.map(String), 'the observer itself works').toEqual(['Error: observer-control']);
+                seen.length = 0;
+
+                await body();
+                await new Promise(resolve => setImmediate(resolve));
+
+                return seen
+            } finally {
+                process.off('unhandledRejection', observe);
+                borrowed.forEach(listener => process.on('unhandledRejection', listener))
+            }
+        };
+
+        test('a refused Group write runs no focus and adds no unhandled rejection', async () => {
+            const {commits, focus, groupId, set, workspace} = await stage();
+
+            try {
                 workspace.workspaceKey = 'not-registered';
 
-                workspace.handleDockCloseAction({
-                    dockNodeId  : 'side-tabs',
-                    tabContainer: tabsOf(workspace.items[0]).get('side-tabs')
+                const unhandled = await watchUnhandled(async () => {
+                    workspace.handleDockCloseAction({
+                        dockNodeId  : 'side-tabs',
+                        tabContainer: tabsOf(workspace.items[0]).get('side-tabs')
+                    });
+                    await Promise.allSettled(commits)
                 });
 
-                await Promise.allSettled(commits);
-                await Promise.resolve();
-
                 expect(focus.length, 'a refused write owes no focus').toBe(0);
-                expect(rejections, 'and the follow-up adds no unhandled rejection of its own').toEqual([])
+                expect(unhandled, 'and the follow-up adds none of its own').toEqual([])
             } finally {
-                globalThis.removeEventListener?.('unhandledrejection', onRejection);
+                set.destroy();
+                TransactionManager.retireGroup(groupId)
+            }
+        });
+
+        test('a rejected projection keeps the Group receipt and adds no SECOND, unhandled one', async () => {
+            const {commits, focus, groupId, set, workspace} = await stage();
+
+            try {
+                // Reach the state the defect needs: an earlier commit, so the follow-up takes the
+                // Group branch with a published refresh behind it.
+                await set.commit('main', [{operation: 'resizeSplit', splitNodeId: 'root-split', sizes: [0.75, 0.25]}]);
+                await workspace.refreshPromise;
+
+                // The projection this close will schedule now fails. Before the repair the assigned
+                // chain was created inside the continuation and never returned, so the trailing catch
+                // did not cover it and this produced a rejection nobody handled.
+                workspace.refreshDockWorkspace = () => Promise.reject(new Error('projection rejected'));
+
+                const unhandled = await watchUnhandled(async () => {
+                    workspace.handleDockCloseAction({
+                        dockNodeId  : 'side-tabs',
+                        tabContainer: tabsOf(workspace.items[0]).get('side-tabs')
+                    });
+                    await Promise.allSettled(commits);
+                    await Promise.allSettled([workspace.refreshPromise])
+                });
+
+                expect(unhandled, 'the follow-up adds no unhandled rejection of its own').toEqual([]);
+                expect(focus.length, 'and a failed projection focuses nothing').toBe(0)
+            } finally {
                 set.destroy();
                 TransactionManager.retireGroup(groupId)
             }


### PR DESCRIPTION
Resolves #18598

Closing a pane chained its focus follow-up onto whatever `refreshPromise` held at the moment of the call. On the Group branch that is the wrong promise, and on a shell projected statically before any commit it is not a promise at all — so the first close threw and focus never moved, and every close after an earlier commit ran focus against the outgoing chrome.

Evidence: L2 (a real `Transaction` Group and `WorkspaceSet` on a real `Workspace` subclass in the unit runtime; both facets reproduced red before the fix, both mutations red after) → L2 required (every AC here is Group/commit ordering, reachable in-process). Residual: the Post-Merge worker-console receipt the ticket already flags as out of unit reach per #18554.

size-guard-growth: src/dashboard/dock/Workspace.mjs — 1100 → 1106, six lines on an over-target file and I deleted nothing to pay for them. Five are the branch the repair needs; one is the guard against re-reading a field the Group branch has not published yet. The alternative that adds no lines is the ticket's uniform defer, and M2 shows it costs three documented specs — so the six lines buy back a contract rather than adding surface. This file's decomposition is #18304's subject.

## AC Evidence

| AC | Evidence |
|---|---|
| AC-1 | *"the first close on a statically projected shell does not throw, and focus still runs"* — asserts `refreshPromise === null` as the precondition the defect needs, then a clean close with `focus.length === 1`. Red before the fix with the production `TypeError: Cannot read properties of null (reading 'then')` |
| AC-2 | *"after an earlier commit the follow-up waits for the CLOSE's projection, not the previous one"* — focus records the projection count at its own call time and asserts it exceeds the count before the close. Plus AC-2's second half: awaiting the published `refreshPromise` afterwards observes the follow-up already run, so a later commit schedules off a promise that covers it |
| AC-3 | *"control: the direct branch already ordered focus after its own projection"* — green before the fix and after. It is the arm that proves the Group branch was not bought at the direct branch's expense, and **M2 below shows it is load-bearing** |
| AC-4 | The arms live in `test/playwright/unit/dashboard/DockWorkspace.spec.mjs` against a real `TransactionManager.bind` Group, a real `WorkspaceSet` with a registered participant, and the real projected tabs node — no stubbed branch. `@neo-fable`'s scratch arms lifted into the engine spec, as the ticket asked |
| AC-5 | Two arms, both through a **working** observer that proves itself before it is trusted: a deliberate unhandled rejection must arrive first or the arm fails. A refused write owes no focus and adds no rejection; **a rejected projection** keeps the Group's receipt and adds no second, unhandled one. The first version of this arm installed nothing and asserted an unpopulatable array — found by @neo-gpt-emmy |
| AC-6 | Both docblocks corrected. The `refreshPromise` member now states that the Group branch does not publish it synchronously; `handleDockCloseAction`'s comment now names the refresh *this close* scheduled rather than the field standing at dispatch, and says how each branch reaches it |

## Deltas from ticket

**The prescribed fix regressed three pre-existing specs, so the shipped shape differs from the ticket's.** The ticket prescribes deferring the follow-up behind the returned promise on both branches. Applied uniformly that breaks `the opt-in close action … focuses after refresh`, `a model-ahead close targets live chrome but focuses the model-selected successor`, and `closing a node's only item focuses the surviving DockWorkspace root …` — all three close the pane and then `await workspace.refreshPromise` to observe focus. On the direct branch that ordering is documented contract, not incidental timing.

So the fix discriminates, and on the **observable** fact rather than on which branch ran: *did the call publish a new refresh before returning?* If it did — the direct branch, which projects inside the call — chain now, keeping the follow-up visible to a caller that awaits `refreshPromise` immediately. If it did not — the Group branch — wait for the returned promise first, by which point the commit's microtask has published the close's own refresh.

That is a genuine amendment to the prescription rather than a preference: **M2 in the matrix below is the ticket's own shape, and it reds four arms.**

**Both of the ticket's named traps hold and are why the shape is what it is.** A `?.` guard alone leaves facet 2 (M1 reds the ordering arm as well as the throw arm). Assigning the chain to `refreshPromise` before the projection is scheduled deadlocks, because `projectDockZoneDocument` takes that field as its own tail — so the assignment stays inside the continuation.

**The handler's synchronous `{document, errors}` return is unchanged**, per the third trap: the action router depends on it.

## Test Evidence

**Mutation matrix — three mutations, and they red *different* arms, which is the point:**

| mutation | red |
|---|---|
| **M1** read `refreshPromise` at call time (the shipped defect) | **2** — the facet-1 throw arm *and* the facet-2 ordering arm. Control stays green |
| **M2** drop the discriminator, defer uniformly (the ticket's prescription) | **4** — the control *and* the three pre-existing close specs |
| **M7** drop the `return` on the assigned chain (the reviewed defect) | 1 — *a rejected projection … adds no SECOND, unhandled one* |

M1 and M2 reddening disjoint sets is the evidence that the discriminator is load-bearing in both directions: without it the Group branch is broken, and with it applied everywhere the direct branch is.

Red-first receipts, before the fix: arm 1 failed with the exact production `TypeError: Cannot read properties of null (reading 'then')`; arm 2 failed with focus at projection count 1 where >1 was required. Two fixture corrections were needed before those reds were honest — the first version named a node the document does not have, and the second never assigned `workspaceSet`, so it exercised the direct branch and could not reach the defect at all.

Unit tier: **1110 passed** for `test/playwright/unit/dashboard/`.

The arms settle on the promise production itself waits on, captured through the seam, rather than on a fixed sleep — which `check-fixed-sleeps` bans and which would have been flaky regardless.

## Post-Merge Validation

- [ ] Closing a tab in the Workstation logs no App Worker error — a headed or Neural Link receipt on the flagship. The unit tier cannot assert the worker console (#18554), which is why the ticket flagged it rather than making it an AC.

Authored by Grace (Claude Opus 5, Claude Code), consuming @neo-fable's reproduction and prescription — session 53e15593-07f9-43f5-a64d-679ed05d549b, author session c42870ab-3721-40f0-a1f8-f385786ffc3c.
