### PR TITLE
fix(state): an effect that read an absent data key re-runs once the key exists (#18616)

### DIFF
--- a/src/dashboard/dock/projection/HeaderActionPolicy.mjs
+++ b/src/dashboard/dock/projection/HeaderActionPolicy.mjs
@@ -196,11 +196,11 @@ class HeaderActionPolicy extends Base {
      * {@link #publishDocument} rewrites it from the committed document on every commit, so a
      * consumer write there would survive until the next commit and then vanish.
      *
-     * ⚠️ The key must be DECLARED, not assigned later. An `Effect` reading an absent key touches no
-     * `Config` and so registers no dependency on it, and `state.Provider#setConfigValue` re-runs
-     * only the owner provider's bindings when a new key appears. A late key is therefore latent
-     * rather than rejected: it applies at the next evaluation some other leaf triggers. The same
-     * hazard is why {@link #publishDocument} seeds the leaves a formatter reads before its first run.
+     * The key may be declared up front or assigned later. An `Effect` reading an absent key touches
+     * no `Config`, so `state.Provider` lets that miss depend on the key set of every provider it
+     * looked in: creating the key re-runs exactly the formatters that read it while it was absent,
+     * on the owner or on a descendant, and a late veto lands at once. {@link #publishDocument} still
+     * seeds the leaves a formatter reads, so the first run computes from a value, not from `undefined`.
      *
      * ⚠️ Clear a veto per LEAF, never by re-assigning the namespace object. Writing a partial object
      * MERGES: present keys update and omitted keys persist, so `{close: true}` meant as "close
@@ -312,8 +312,7 @@ class HeaderActionPolicy extends Base {
                 pinnable: item?.pinnable !== false
             };
 
-            // A leaf a binding reads must exist before the binding's first run: a formatter
-            // registers the configs it read, and a key created later is not one of them. The
+            // Seeded so a binding's first run computes from a value rather than `undefined`. The
             // flight is owned by the workspace's reload path, so an existing value is never touched.
             !provider.getDataConfig(`dock.flights.${itemId}`) && (flights[itemId] = null)
         });

--- a/src/state/Provider.mjs
+++ b/src/state/Provider.mjs
@@ -119,6 +119,8 @@ class Provider extends Base {
          * Each formula is a function that receives a `data` argument, which is a hierarchical proxy
          * allowing access to data from the current provider and all its parent providers.
          * Changes to dependencies (accessed via `data.propertyName`) will automatically re-run the formula.
+         * A formula that reads a key which does not exist yet re-runs once that key gets created on this
+         * provider or on one of its parents.
          * @member {Object|null} formulas_=null
          * @example
          *     data: {
@@ -202,6 +204,20 @@ class Provider extends Base {
      * @private
      */
     #dataConfigs = {}
+    /**
+     * Counts the data properties created on this provider: the plain mirror of `#dataKeyVersion`,
+     * so that a bump never registers a read.
+     * @member {Number} #dataKeyCount=0
+     * @private
+     */
+    #dataKeyCount = 0
+    /**
+     * Changes whenever a data property gets created on this provider. An effect that looked a path
+     * up here while it was absent depends on it and re-runs once the key exists (see `#findDataOwner`).
+     * @member {Neo.core.Config} #dataKeyVersion=new Config(0)
+     * @private
+     */
+    #dataKeyVersion = new Config(0)
     /**
      * @member {Map} #formulaEffects=new Map()
      * @private
@@ -594,19 +610,48 @@ class Provider extends Base {
      * @returns {{owner: Neo.state.Provider, propertyName: String}|null}
      */
     getOwnerOfDataProperty(path) {
-        let me = this;
+        return this.#findDataOwner(path, true)
+    }
+
+    /**
+     * Walks the parent chain for the provider owning a data path.
+     * A miss at a level reads that provider's `#dataKeyVersion`: an active effect which read a path
+     * that does not exist yet depends on the key set of every provider it looked in, so it re-runs
+     * when the key gets created on any of them (see `#createDataConfig`).
+     * @param {String}  path
+     * @param {Boolean} track `false` on the write path: a write's owner lookup is not a read
+     * @returns {{owner: Neo.state.Provider, propertyName: String}|null}
+     * @private
+     */
+    #findDataOwner(path, track) {
+        const me = this;
 
         if (me.#dataConfigs[path]) {
             return {owner: me, propertyName: path}
         }
 
-        // Check for parent ownership
-        const parent = me.getParent();
-        if (parent) {
-            return parent.getOwnerOfDataProperty(path)
-        }
+        track && me.#dataKeyVersion.get();
 
-        return null
+        const parent = me.getParent();
+
+        return parent ? parent.#findDataOwner(path, track) : null
+    }
+
+    /**
+     * The single creation point for a data property's Config. Bumping `#dataKeyVersion` re-runs
+     * exactly the effects that read this provider's key set while the path was absent.
+     * @param {String} path
+     * @param {*}      value
+     * @returns {Neo.core.Config}
+     * @private
+     */
+    #createDataConfig(path, value) {
+        const config = new Config(value);
+
+        this.#dataConfigs[path] = config;
+        this.#dataKeyVersion.set(++this.#dataKeyCount);
+
+        return config
     }
 
     /**
@@ -682,6 +727,9 @@ class Provider extends Base {
             keys       = new Set(),
             pathPrefix = path ? `${path}.` : '';
 
+        // An enumeration depends on this provider's key set
+        this.#dataKeyVersion.get();
+
         for (const fullPath in this.#dataConfigs) {
             if (fullPath.startsWith(pathPrefix)) {
                 const
@@ -736,7 +784,7 @@ class Provider extends Base {
         }
 
         const
-            ownerDetails   = originStateProvider && me.getOwnerOfDataProperty(key),
+            ownerDetails   = originStateProvider && me.#findDataOwner(key, false),
             targetProvider = ownerDetails ? ownerDetails.owner : (originStateProvider || me);
 
         me.#setConfigValue(targetProvider, key, value, null);
@@ -823,7 +871,7 @@ class Provider extends Base {
             if (me.#dataConfigs[fullPath]) {
                 me.#dataConfigs[fullPath].set(value)
             } else {
-                me.#dataConfigs[fullPath] = new Config(value)
+                me.#createDataConfig(fullPath, value)
             }
 
             me.#syncRecordDataValue(fullPath, value);
@@ -869,10 +917,7 @@ class Provider extends Base {
             oldValue  = currentConfig.get();
             hasChange = currentConfig.set(newValue)
         } else {
-            currentConfig = new Config(newValue);
-            provider.#dataConfigs[path] = currentConfig;
-            // Trigger all binding effects to re-evaluate their dependencies
-            provider.#bindingEffects.forEach(effect => effect.run())
+            currentConfig = provider.#createDataConfig(path, newValue)
         }
 
         if (hasChange) {

--- a/test/playwright/unit/dashboard/DockHeaderState.spec.mjs
+++ b/test/playwright/unit/dashboard/DockHeaderState.spec.mjs
@@ -589,27 +589,24 @@ test.describe('Neo.dashboard.dock.Workspace — the consumer\'s header-action ve
         }
     });
 
-    test('⚠️ a veto published AFTER the first run does not land, and lands silently on the next unrelated re-evaluation', async () => {
-        // The documented limitation, asserted rather than described. An Effect reading an ABSENT key
-        // touches no Config and so registers no dependency on it, and `setConfigValue` re-runs only
-        // the OWNER provider's bindings when a new key appears, so the veto is latent, not rejected.
+    test('a veto published AFTER the first run lands at once, and an unrelated re-evaluation keeps it', async () => {
+        // A formatter that read the ABSENT `dockActionPolicy` at its first run touched no Config,
+        // so the provider lets that miss depend on its key set: creating the key re-runs exactly the
+        // formatters that missed it, and the veto lands immediately instead of staying latent.
         const center = hostWith({}),
               close  = center.getAction('close');
 
         expect(close.hidden, 'alpha is closable and nothing is vetoed').toBe(false);
 
         host.stateProvider.setData('dockActionPolicy.close', false);
-        expect(close.hidden, 'the late key is invisible to a formatter that never depended on it').toBe(false);
+        expect(close.hidden, 'the late key reaches the formatter that read it while it was absent').toBe(true);
 
-        // Worse than inert, and the reason the declared path is the contract: the veto is not
-        // rejected, it is LATENT. Any later change to a leaf the formula does depend on applies it.
-        //
         // The RETURN to index 0 is load-bearing and the arm is theatre without it: beta declares
         // `closable: false`, so a `close.hidden` of true there proves nothing — the per-item policy
         // produces it whether or not the veto works. Alpha IS closable, so only a working veto can
         // hide close on it.
         await center.set({activeIndex: 1});
         await center.set({activeIndex: 0});
-        expect(close.hidden, 'an unrelated re-evaluation now applies a veto set two steps ago').toBe(true)
+        expect(close.hidden, 'an unrelated re-evaluation keeps the veto').toBe(true)
     })
 });

--- a/test/playwright/unit/state/ProviderAbsentKeyReads.spec.mjs
+++ b/test/playwright/unit/state/ProviderAbsentKeyReads.spec.mjs
@@ -1,0 +1,185 @@
+import {setup} from '../../setup.mjs';
+
+const appName = 'StateProviderAbsentKeyReadsTest';
+
+setup({
+    neoConfig: {
+        allowVdomUpdatesInTests: true,
+        useDomApiRenderer      : true
+    },
+    appConfig: {
+        name: appName
+    }
+});
+
+import {test, expect}  from '@playwright/test';
+import Neo             from '../../../../src/Neo.mjs';
+import * as core       from '../../../../src/core/_export.mjs';
+import Component       from '../../../../src/component/Base.mjs';
+import InstanceManager from '../../../../src/manager/Instance.mjs';
+import StateProvider   from '../../../../src/state/Provider.mjs';
+
+class MockComponent extends Component {
+    static config = {
+        className  : 'Mock.AbsentKeyReads.Component',
+        appName,
+        testConfig_: null,
+        userObject_: null
+    }
+}
+MockComponent = Neo.setupClass(MockComponent);
+
+/**
+ * A formula or binding that reads a data path which does not exist yet has no Config to depend on.
+ * The provider therefore lets every lookup miss depend on the key set of the provider it looked in,
+ * so exactly the effects that missed a key re-run once that key gets created, on the same provider
+ * or on a parent, and nothing else re-runs.
+ */
+test.describe('Neo.state.Provider reads of absent keys', () => {
+    test('a formula that read an absent top-level key at its first run re-runs when the key gets created', () => {
+        let runs = 0;
+
+        const component = Neo.create(MockComponent, {
+            stateProvider: {
+                data    : {},
+                formulas: {
+                    greeting: data => {
+                        runs++;
+                        return data.user ? `hi ${data.user.name}` : 'nobody'
+                    }
+                }
+            }
+        });
+        const provider = component.getStateProvider();
+
+        expect(runs).toBe(1);
+        expect(provider.getData('greeting')).toBe('nobody');
+
+        // The missed key appears: one re-run, and the leaf is tracked from now on.
+        provider.setData('user', {name: 'Ada'});
+        expect(runs).toBe(2);
+        expect(provider.getData('greeting')).toBe('hi Ada');
+
+        provider.setData('user.name', 'Grace');
+        expect(runs).toBe(3);
+        expect(provider.getData('greeting')).toBe('hi Grace');
+
+        // Every read resolves now, so an unrelated new key does not re-run it.
+        provider.setData('unrelated', 1);
+        expect(runs).toBe(3);
+
+        component.destroy();
+    });
+
+    test('a dotted path created under an absent parent reaches a formula, and a formula creating its own result key neither loops nor re-runs on unrelated keys', () => {
+        let doubledRuns = 0;
+
+        const component = Neo.create(MockComponent, {
+            stateProvider: {
+                data    : {a: 1},
+                formulas: {
+                    doubled: data => {
+                        doubledRuns++;
+                        return data.a * 2
+                    },
+                    late: data => data.nested?.leaf ?? -1
+                }
+            }
+        });
+        const provider = component.getStateProvider();
+
+        // The first run wrote the result key 'doubled' itself: that creation must not re-enter the formula.
+        expect(doubledRuns).toBe(1);
+        expect(provider.getData('doubled')).toBe(2);
+        expect(provider.getData('late')).toBe(-1);
+
+        provider.setData('nested.leaf', 5);
+        expect(provider.getData('late')).toBe(5);
+
+        // 'doubled' missed nothing, so the new keys did not re-run it.
+        expect(doubledRuns).toBe(1);
+
+        provider.setData('a', 4);
+        expect(provider.getData('doubled')).toBe(8);
+        expect(doubledRuns).toBe(2);
+
+        component.destroy();
+    });
+
+    test('a child formula that missed a key picks it up when a parent creates it, and again when the child shadows it', () => {
+        const parentComponent = Neo.create(MockComponent, {stateProvider: {data: {}}});
+        const childComponent  = Neo.create(MockComponent, {
+            parentComponent,
+
+            stateProvider: {
+                data    : {},
+                formulas: {
+                    label: data => data.shared === undefined ? 'unset' : `shared:${data.shared}`
+                }
+            }
+        });
+
+        const
+            parentProvider = parentComponent.getStateProvider(),
+            childProvider  = childComponent.getStateProvider();
+
+        expect(childProvider.getData('label')).toBe('unset');
+
+        parentProvider.setData('shared', 7);
+        expect(childProvider.getData('label')).toBe('shared:7');
+
+        childProvider.setDataAtSameLevel('shared', 8);
+        expect(childProvider.getData('label')).toBe('shared:8');
+
+        childComponent.destroy();
+        parentComponent.destroy();
+    });
+
+    test('creating a key re-runs only the bindings that read it while it was absent', () => {
+        const component = Neo.create(MockComponent, {stateProvider: {data: {known: 'k'}}});
+        const provider  = component.getStateProvider();
+
+        let readerRuns    = 0,
+            bystanderRuns = 0;
+
+        provider.createBinding(component.id, 'testConfig', data => {
+            readerRuns++;
+            return data.later ?? null
+        });
+
+        provider.createBinding(component.id, 'userObject', data => {
+            bystanderRuns++;
+            return data.known
+        });
+
+        expect([readerRuns, bystanderRuns]).toEqual([1, 1]);
+        expect(component.testConfig).toBe(null);
+
+        component.setState('later', 'now');
+        expect([readerRuns, bystanderRuns]).toEqual([2, 1]);
+        expect(component.testConfig).toBe('now');
+
+        component.destroy();
+    });
+
+    test('getData of an absent key inside a binding formatter is a tracked read as well', () => {
+        const component = Neo.create(MockComponent, {stateProvider: {data: {}}});
+        const provider  = component.getStateProvider();
+
+        let runs = 0;
+
+        provider.createBinding(component.id, 'testConfig', function() {
+            runs++;
+            return this.getData('flag') ?? 'absent'
+        });
+
+        expect(runs).toBe(1);
+        expect(component.testConfig).toBe('absent');
+
+        provider.setData('flag', 'present');
+        expect(runs).toBe(2);
+        expect(component.testConfig).toBe('present');
+
+        component.destroy();
+    });
+});


### PR DESCRIPTION
Resolves #18616

Refs #18605

An effect that read a data path which did not exist yet had no Config to depend on, so a formula stayed at its first value forever and only bindings were rescued, by re-running every binding on the provider whenever any key was created. Now each lookup miss reads the key-set version of the provider it looked in, and the single Config-creation point bumps that version: exactly the effects that missed a key re-run once the key exists, on the same provider or on a parent, and nothing else re-runs. The blanket re-run of all bindings is gone; a write's owner lookup no longer registers a read, so a formula creating its own result key neither re-enters nor picks up a spurious dependency. `getData` of an absent key and key enumeration through the proxy are tracked reads as well.

`Decision Record impact: none`.

Evidence: unit tier (the `unit-engine` project, which boots Neo in Node and exercises providers, bindings and formulas directly) → unit tier required (every close-target AC is observable there). Residual: none.

## AC Evidence
| AC-1 | `test/playwright/unit/state/ProviderAbsentKeyReads.spec.mjs` — a formula reading an absent top-level key re-runs on `setData('user', {...})` and then tracks the leaf; a dotted `setData('nested.leaf', 5)` under an absent parent reaches a formula; a child formula picks up a key the parent creates and again when the child shadows it |
| AC-2 | The full unit tier passes on this head; the same spec pins that a formula creating its own result key runs once, that an unrelated new key does not re-run a formula whose reads all resolve, and that an ordinary leaf write re-runs a formula exactly once |
| AC-3 | The `formulas_` docblock states the re-run rule; `#findDataOwner`, `#createDataConfig`, `#dataKeyVersion` and `#dataKeyCount` carry their own |

## Deltas from ticket
The ticket offered a one-line variant (re-run all formula effects on new-key creation, mirroring the bindings) and a missed-read variant. This is the missed-read variant, made cheap by a per-provider version Config instead of a per-effect set, and it replaces the bindings' blanket re-run rather than adding a second one: creating a key now re-runs only the bindings that read it while it was absent (a new arm pins the bystander at one run). A parent-created key reaching a descendant's formula was not in the ticket; the same mechanism covers it and an arm pins it.

One consumer pinned the old behaviour as a documented limitation: the dock header-action veto (#18574). Its warning-marked arm in `test/playwright/unit/dashboard/DockHeaderState.spec.mjs` asserted that a veto published after a formatter's first run stays latent until an unrelated re-evaluation; it now asserts that the veto lands at once and survives that re-evaluation. The matching docblock in `src/dashboard/dock/projection/HeaderActionPolicy.mjs` no longer says the key must be declared up front, and its seeding comment states the remaining reason for the seed (a first-run value rather than `undefined`). Second commit, cd9199f031.

## Test Evidence
Negative control outside CI: the new spec run in isolation against the previous `Provider.mjs` (stashed) reds four of five arms — the formula stays at one run (expected 2, received 1), the dotted path is never reached (expected 5, received -1), the child stays `unset`, and the bystander binding re-runs (expected `[2, 1]`, received `[2, 2]`). The fifth arm, a `getData` read of an absent key inside a binding formatter, is green before and after: the retired blanket re-run rescued it by accident, the tracked read keeps it deliberately, so the arm pins parity.

Correction of an earlier claim in this body: at c9df22c759 it said the full unit tier passed locally. CI showed one failure in 3794 on that head, the veto arm above, which reds locally as well; the local pass had been read from a last-run record a narrower run had overwritten. At cd9199f031 the spec passes in isolation, `unit/state` passes 49 of 49, `unit/dashboard/DockHeaderState` passes 16 of 16, and the local full-tier record reports passed; CI is the arbiter. The e2e-engine run on the previous head also failed one grid header-drag geometry arm (`HeaderCellRectSync`, "no cell under header Total" mid-drag), untouched by this diff and green on every `dev` run today; the new head re-runs it, and a second failure there is treated as this PR's, not a flake.

## Post-Merge Validation
- [ ] None: no post-merge-only effect; the epic's published-truth leaf (#18608) can rely on the rule when it seeds `dock.perspective`.

Authored by Mnemosyne (Claude Fable 5.1, Claude Code). Session c42870ab-3721-40f0-a1f8-f385786ffc3c.
