### PR TITLE
fix(ai): highlight_component clears its outline and box-shadow after the duration (#18603)

### DIFF
--- a/src/ai/client/ComponentService.mjs
+++ b/src/ai/client/ComponentService.mjs
@@ -261,14 +261,16 @@ class ComponentService extends Service {
     }
 
     /**
+     * Paints the highlight for `duration`, then restores exactly the keys it wrote — by value,
+     * `null` where the component had none. A style key leaves the vdom root only through `null`
+     * (`Neo.component.Base#style_`); assigning the pre-highlight object keeps it painted.
      * @param {Object} params
      * @param {String} params.componentId
      * @param {Object} [params.options]
      * @returns {Object}
      */
     highlightComponent({componentId, options}) {
-        let component = Neo.getComponent(componentId),
-            originalStyle;
+        let component = Neo.getComponent(componentId);
 
         if (!component) {
             throw new Error(`Component not found: ${componentId}`)
@@ -277,25 +279,19 @@ class ComponentService extends Service {
         options = options || {};
 
         const
-            color    = options.color    || 'red',
-            duration = options.duration || 2000,
-            mode     = options.style    || 'outline'; // 'outline' or 'box-shadow'
+            color     = options.color    || 'red',
+            duration  = options.duration || 2000,
+            mode      = options.style    || 'outline', // 'outline' or 'box-shadow'
+            original  = component.style || {},
+            highlight = mode === 'outline' ?
+                {outline: `2px solid ${color}`, outlineOffset: '-2px'} :
+                {boxShadow: `0 0 10px ${color}, inset 0 0 10px ${color}`},
+            restore   = Object.fromEntries(Object.keys(highlight).map(key => [key, original[key] ?? null]));
 
-        originalStyle = component.style || {};
-
-        let highlightStyle = {};
-
-        if (mode === 'outline') {
-            highlightStyle.outline       = `2px solid ${color}`;
-            highlightStyle.outlineOffset = '-2px'
-        } else {
-            highlightStyle.boxShadow = `0 0 10px ${color}, inset 0 0 10px ${color}`
-        }
-
-        component.style = {...originalStyle, ...highlightStyle};
+        component.style = {...original, ...highlight};
 
         this.timeout(duration).then(() => {
-            component.style = originalStyle
+            !component.isDestroyed && (component.style = {...original, ...restore})
         });
 
         return {success: true}

--- a/test/playwright/unit/ai/client/highlightComponent.spec.mjs
+++ b/test/playwright/unit/ai/client/highlightComponent.spec.mjs
@@ -1,0 +1,93 @@
+import {setup} from '../../../setup.mjs';
+
+setup({
+    appConfig: {
+        name: 'HighlightComponentTest'
+    }
+});
+
+import {test, expect}   from '@playwright/test';
+import Neo              from '../../../../../src/Neo.mjs';
+import * as core        from '../../../../../src/core/_export.mjs';
+import Component        from '../../../../../src/component/Base.mjs';
+import ComponentService from '../../../../../src/ai/client/ComponentService.mjs';
+
+const appName = 'HighlightComponentTest';
+
+/**
+ * `highlight_component` paints for `duration` and then restores exactly the keys it wrote — by
+ * value, `null` where the component had none. `Neo.component.Base#style_` merges shallow: an
+ * object that lacks a key never removes it, so a restore that assigns the pre-highlight object
+ * leaves the outline or box-shadow on the component and its vdom root for the life of the
+ * instance — the stuck frame an operator sees minutes after a demo highlight.
+ */
+test.describe('Neo.ai.client.ComponentService#highlightComponent — the restore removes what the highlight wrote', () => {
+    let component = null,
+        service   = null;
+
+    test.beforeEach(() => {
+        service = Neo.create(ComponentService)
+    });
+
+    test.afterEach(() => {
+        component?.destroy();
+        component = null;
+        service.destroy();
+        service = null
+    });
+
+    test('outline mode: after the duration, neither the component style nor the vdom root carries the outline', async () => {
+        component = Neo.create(Component, {appName, style: {color: 'rgb(1, 2, 3)'}});
+
+        expect(service.highlightComponent({componentId: component.id, options: {color: 'blue', duration: 5}})).toEqual({success: true});
+        expect(component.style.outline, 'the highlight is painted').toBe('2px solid blue');
+        expect(component.vdom.style.outlineOffset, 'the vdom root carries the highlight').toBe('-2px');
+
+        await service.timeout(30);
+
+        expect(component.style.outline ?? null, 'the component style carries no outline').toBeNull();
+        expect(component.style.outlineOffset ?? null).toBeNull();
+        expect(component.vdom.style.outline ?? null, 'the vdom root carries no outline').toBeNull();
+        expect(component.vdom.style.outlineOffset ?? null).toBeNull();
+        expect(component.style.color, 'an unrelated key survives the highlight and the restore').toBe('rgb(1, 2, 3)')
+    });
+
+    test('box-shadow mode: after the duration, neither the component style nor the vdom root carries the box-shadow', async () => {
+        component = Neo.create(Component, {appName});
+
+        service.highlightComponent({componentId: component.id, options: {duration: 5, style: 'box-shadow'}});
+        expect(component.style.boxShadow, 'the highlight is painted').toBe('0 0 10px red, inset 0 0 10px red');
+
+        await service.timeout(30);
+
+        expect(component.style.boxShadow ?? null, 'the component style carries no box-shadow').toBeNull();
+        expect(component.vdom.style.boxShadow ?? null, 'the vdom root carries no box-shadow').toBeNull()
+    });
+
+    test('a pre-existing value of a highlighted key is restored, not nulled', async () => {
+        component = Neo.create(Component, {appName, style: {outline: '1px dotted green'}});
+
+        service.highlightComponent({componentId: component.id, options: {duration: 5}});
+        expect(component.style.outline, 'the highlight replaces the value for the duration').toBe('2px solid red');
+
+        await service.timeout(30);
+
+        expect(component.style.outline, 'the original value is back').toBe('1px dotted green');
+        expect(component.vdom.style.outline).toBe('1px dotted green');
+        expect(component.style.outlineOffset ?? null, 'the key the component never had is gone').toBeNull()
+    });
+
+    test('a component destroyed during the highlight does not throw on restore', async () => {
+        component = Neo.create(Component, {appName});
+
+        const {id} = component;
+
+        service.highlightComponent({componentId: id, options: {duration: 5}});
+        component.destroy();
+        component = null;
+
+        await service.timeout(30);
+
+        expect(Neo.getComponent(id) ?? null, 'the component stays gone and the restore raised nothing').toBeNull()
+    })
+});


### PR DESCRIPTION
Resolves #18603

Related: neomjs/neo-agent-institution#125 (the live Fleet Manager demo that surfaced it — three highlights still painted minutes later, read by the operator as a stuck focus outline) · #8323 (the `highlight_component` tool mapping)

`highlight_component` painted for its duration and then assigned the pre-highlight style object back — and an object that lacks a key never removes it. `Neo.component.Base#style_` removes a key only through `null`, and the `wrapperStyle` getter folds the current `vdom.style` back into every update, so the outline (or box-shadow) stayed on the vdom root and the DOM for the life of the component; the config getter alone looked clean, which is why the residue was invisible from the worker side. `highlightComponent` now snapshots the original values of exactly the keys its mode writes and restores them by value, `null` where the component had none; a component destroyed during the highlight is left alone. The four-line docblock names the contract so the next `src/ai/client` writer does not rely on key absence again.

Evidence: L2 (unit — a red-first arm per mode at the vdom root, the value-restore guard, the destroyed-component guard) → L2 required. Residual: none.

## AC Evidence
| AC-1 | `highlightComponent.spec.mjs` outline arm: after the duration, `component.style` and `component.vdom.style` carry no `outline` / `outlineOffset` (`?? null` → `null`), an unrelated key survives; box-shadow arm: no `boxShadow` on either — both RED on the old code at the vdom root (`"2px solid blue"`, `"0 0 10px red, inset 0 0 10px red"` received) |
| AC-2 | "a pre-existing value of a highlighted key is restored, not nulled": `outline: '1px dotted green'` is back on the config and the vdom root; the key the component never had (`outlineOffset`) is gone |
| AC-3 | "a component destroyed during the highlight does not throw on restore": destroy before the timeout lands, the component stays unregistered, nothing raised |
| AC-4 | the two mode arms are the red-first pair (receipts above); the value-restore and destroyed arms were green on the old code and stay green — regression guards, named as such |

## Deltas from ticket
The ticket's premise ("the restore object does not carry the highlight keys, and assigning it never removes them") holds, with one sharpened mechanism: a runtime `style` set REPLACES the config value (the merge-shallow descriptor applies at class-default time), so `component.style` read clean after the old restore — the residue lives in the vdom root because `wrapperStyle` folds `vdom.style` into every `updateStyle()`; the spec asserts the vdom root, where the residue is. The highlight write spreads the original alongside the highlight keys for the same reason (a runtime set replaces).

## Test Evidence
Outside CI, at the commit below: `npx playwright test -c test/playwright/playwright.config.unit.mjs ai/` 218 passed (the four new arms included; the outline and box-shadow arms red-first on the old code, one run each, receipts in AC-1); `npm run check-file-sizes`: 1321 paths, 0 violations; `neo-agent-skills-ticket-archaeology --base origin/dev`: 2 files, 0 violations (the pre-commit hook's own checker, whitespace, shorthand, JSDoc types, block alignment, parse, derived-domain, fixed-sleeps and the engine/brain boundary all passed at commit time).

## Commits
- 44eaa1a7c5 fix(ai): highlight_component clears its outline and box-shadow after the duration (#18603) — `src/ai/client/ComponentService.mjs` + `test/playwright/unit/ai/client/highlightComponent.spec.mjs`

## Post-Merge Validation
- [ ] The next Institution engine pin carries it: a Neural Link `highlight_component` on a live cockpit clears after its duration (computed `outline: none`, no `box-shadow` in the vnode style). Residual-Owner: neomjs/neo-agent-institution#10.

Authored by Clio (Claude Fable 5.1, Claude Code). Session 46156fd3-ef37-410c-a3fa-f843df795597.
