### PR TITLE
feat(dock): the WorkspaceSet publishes its membership, and the topology bar follows it warm (#18622)

### DIFF
--- a/apps/workstation/view/PopupWorkspace.mjs
+++ b/apps/workstation/view/PopupWorkspace.mjs
@@ -43,6 +43,8 @@ class PopupWorkspace extends DockWorkspace {
 
     /**
      * Presentation and connection references owned by this popup; membership lives in its Group.
+     * Supplied at creation by the root's `createPopupWorkspace`, so the Group registration in
+     * {@link #construct} already finds it — a reader reacting to that membership must resolve it.
      * @member {Object|null} runtimeState=null
      */
     runtimeState = null

--- a/apps/workstation/view/Workspace.mjs
+++ b/apps/workstation/view/Workspace.mjs
@@ -745,21 +745,7 @@ class Workspace extends DockWorkspace {
 
         for (const [workspaceId, document] of Object.entries(me.initialTopology?.workspaces ?? {})) {
             if (workspaceId === Workspace.MAIN_WORKSPACE_ID) continue;
-            const host = Neo.create(PopupWorkspace, {
-                dockModel      : WorkspaceDocument.clone(document), flex: 1, rootWorkspace: me,
-                topologyGroupId: me.topologyGroupId, workspaceKey: workspaceId, workspaceSet: me.workspaceSet,
-                stateProvider  : {module: StateProvider, parent: me.stateProvider}
-            });
-            const state = {
-                committed   : true,
-                disconnected: true,
-                host,
-                get document() { return host.dockModel },
-                set document(value) { host.dockModel = value },
-                windowId    : null,
-                workspaceId
-            };
-            host.runtimeState = state
+            me.createPopupWorkspace(workspaceId, WorkspaceDocument.clone(document), {committed: true, windowId: null})
         }
 
         me.registerMainWorkspace();
@@ -1332,6 +1318,35 @@ class Workspace extends DockWorkspace {
      */
     getPopupStates() {
         return this.workspaceSet?.ids().map(key => this.getPopupState(key)).filter(Boolean) ?? []
+    }
+
+    /**
+     * @summary Creates the owner of one popup workspace with its runtime state already in place.
+     *
+     * The state is handed to the owner at creation, so the Group registration the owner performs in
+     * its own `construct` — and everything that reacts to that membership, the topology bar included —
+     * already resolves the workspace through {@link #getPopupState}. Assigning the state afterwards
+     * left a gap in which the membership had changed and the workspace was visible to no reader.
+     * @param {String} workspaceId
+     * @param {Object} dockModel The workspace's document.
+     * @param {Object} fields The state's ownership facts: `committed`, and `itemId` or `windowId` as the site knows them.
+     * @returns {Object} The runtime state; its `host` is the new owner.
+     */
+    createPopupWorkspace(workspaceId, dockModel, fields) {
+        const me    = this,
+              state = {
+                  ...fields, disconnected: true, host: null, workspaceId,
+                  get document() { return state.host.dockModel },
+                  set document(value) { state.host.dockModel = value }
+              };
+
+        state.host = Neo.create(PopupWorkspace, {
+            dockModel, flex: 1, rootWorkspace: me, runtimeState: state,
+            stateProvider  : {module: StateProvider, parent: me.stateProvider},
+            topologyGroupId: me.topologyGroupId, workspaceKey: workspaceId, workspaceSet: me.workspaceSet
+        });
+
+        return state
     }
 
     /**
@@ -2419,16 +2434,7 @@ class Workspace extends DockWorkspace {
         try {
             if (!me.tearOutHandlers.capturePane(itemId)) throw new Error(`No live pane for ${itemId}`);
             if (!state) {
-                const host = Neo.create(PopupWorkspace, {
-                    dockModel    : me.createVesselWorkspaceDocument(itemId), flex: 1,
-                    rootWorkspace: me, topologyGroupId: me.topologyGroupId,
-                    workspaceKey : workspaceId, workspaceSet: me.workspaceSet,
-                    stateProvider: {module: StateProvider, parent: me.stateProvider}
-                });
-                state = {host, itemId, workspaceId, committed: false, disconnected: true,
-                    get document() { return host.dockModel },
-                    set document(value) { host.dockModel = value }};
-                host.runtimeState = state
+                state = me.createPopupWorkspace(workspaceId, me.createVesselWorkspaceDocument(itemId), {committed: false, itemId})
             }
             await me.workspaceSet.transfer({
                 operation        : 'transferItem', itemId, sourceWorkspaceId: Workspace.MAIN_WORKSPACE_ID,

--- a/apps/workstation/view/WorkspaceController.mjs
+++ b/apps/workstation/view/WorkspaceController.mjs
@@ -188,7 +188,13 @@ class WorkspaceController extends Controller {
      * itself over to be finished.
      */
     onComponentConstructed() {
-        this.syncTopologyBar()
+        const me = this, set = me.component.workspaceSet;
+
+        me.syncTopologyBar();
+
+        // Membership arrives after boot too — a pane torn into its own window, a saved window reopened —
+        // and the bar follows it. The subscription is the observer's: it dies with this controller.
+        set && me.observeConfig(set, 'memberIds', () => me.syncTopologyBar())
     }
 
     /**
@@ -197,10 +203,9 @@ class WorkspaceController extends Controller {
      * The bar itself is declared by the view, which owns its structure; this reaches it through
      * its reference and supplies only the part that depends on live Group membership.
      *
-     * Idempotent and re-callable, but wired to {@link #onComponentConstructed} alone — the same
-     * single population the previous shape performed. `WorkspaceSet` publishes no membership
-     * signal, so a participant registered after boot still gains no buttons until a reload; that
-     * is unchanged here and needs a signal in the engine, not a second reader in this file.
+     * Idempotent and re-callable: it runs once at {@link #onComponentConstructed} for the first paint,
+     * and again whenever the `WorkspaceSet` republishes its `memberIds`, so a participant registered
+     * after boot gains its buttons — and one unregistered loses them — without a reload.
      * @returns {Boolean} Whether the bar was reachable.
      */
     syncTopologyBar() {

--- a/buildScripts/util/file-size-baseline.json
+++ b/buildScripts/util/file-size-baseline.json
@@ -1,5 +1,5 @@
 {
-    "apps/workstation/view/Workspace.mjs": 1345,
+    "apps/workstation/view/Workspace.mjs": 1336,
     "examples/dashboard/crossWindow/DemoBWorkspace.mjs": 2546,
     "src/dashboard/dock/Workspace.mjs": 1146,
     "src/main/addon/DragDrop.mjs": 1267

--- a/src/dashboard/dock/window/WorkspaceSet.mjs
+++ b/src/dashboard/dock/window/WorkspaceSet.mjs
@@ -25,7 +25,16 @@ class WorkspaceSet extends Base {
         /** @member {Function|null} getGroupId=null Resolves the host's current Group identity. */
         getGroupId: null,
         /** @member {Neo.manager.Transaction|null} manager=null Worker-wide transaction authority. */
-        manager: null
+        manager: null,
+        /**
+         * The registered workspace ids, republished by {@link #register} and {@link #unregister} so a
+         * consumer can OBSERVE membership instead of reading it once: `observeConfig(set, 'memberIds', fn)`
+         * ties the subscription to the observer's own lifetime. Replacing a registration under the same
+         * id changes nothing here — the membership is the same set.
+         * @member {String[]} memberIds_=[]
+         * @reactive
+         */
+        memberIds_: []
     }
 
     /**
@@ -322,6 +331,8 @@ class WorkspaceSet extends Base {
             workspaceKey: workspaceId
         });
         if (registered && componentId) Neo.get(componentId)?.perspectiveSelection?.connect();
+        if (registered) this.memberIds = this.ids();
+
         return registered
     }
 
@@ -383,9 +394,12 @@ class WorkspaceSet extends Base {
      * @returns {Boolean} true when a participant was removed
      */
     unregister(workspaceId) {
-        const id = this.resolveGroupId();
+        const id      = this.resolveGroupId(),
+              removed = id ? this.manager.unregisterParticipant({groupId: id, workspaceKey: workspaceId}) : false;
 
-        return id ? this.manager.unregisterParticipant({groupId: id, workspaceKey: workspaceId}) : false
+        if (removed) this.memberIds = this.ids();
+
+        return removed
     }
 }
 

--- a/test/playwright/unit/apps/workstation/WorkspaceController.spec.mjs
+++ b/test/playwright/unit/apps/workstation/WorkspaceController.spec.mjs
@@ -18,8 +18,6 @@ import WorkspaceController from '../../../../../apps/workstation/view/WorkspaceC
 import ViewportController  from '../../../../../apps/workstation/view/ViewportController.mjs';
 import PopupWorkspace      from '../../../../../apps/workstation/view/PopupWorkspace.mjs';
 import Workspace           from '../../../../../apps/workstation/view/Workspace.mjs';
-import WorkspaceDocument   from '../../../../../src/dashboard/dock/model/WorkspaceDocument.mjs';
-import WorkspaceSet        from '../../../../../src/dashboard/dock/window/WorkspaceSet.mjs';
 
 /**
  * @summary The controller under test with its bar syncs counted, so an arm can tell "re-synced" from
@@ -268,55 +266,56 @@ test.describe('Workstation topology save and close coordination', () => {
         controller.destroy()
     });
 
-    test('the bar follows membership: a participant registered after boot gains its buttons, an unregistered one loses them, and a destroyed controller stops listening', () => {
-        const binding = Transaction.bind({windowId: 'controller-membership-root'}),
-              set     = Neo.create(WorkspaceSet, {documentModel: WorkspaceDocument, manager: Transaction, getGroupId: () => binding.groupId}),
-              bar     = Neo.create(Toolbar, Workspace.prototype.createTopologyBar.call({topologyGroupId: binding.groupId})),
-              seams   = key => ({getDocument: () => ({
+    test('the bar follows membership through the production path: a popup workspace created after boot gains its buttons, a destroyed one loses them, and a destroyed controller stops listening', () => {
+        const windowId = 'controller-membership-root',
+              binding  = Transaction.bind({windowId, workspaceKey: 'main'}),
+              document = key => ({
                   schema: 'neo.dock.zone.v1', root: 'tabs',
                   items : {[key]: {reference: key}},
                   nodes : {tabs: {type: 'tabs', items: [key], activeItemId: key}}
-              })}),
+              });
+
+        RecordingWorkspaceController.syncs = 0;
+
+        // The real root, its real registry, its real bar and its real popup-state lookup: the arm drives
+        // the one production seam both creation sites call, so it measures the order in which a popup
+        // workspace registers and becomes resolvable — not a stand-in for that order.
+        const root          = Neo.create(Workspace, {controller: RecordingWorkspaceController, windowId}),
+              bar           = root.controller.getReference('topology-toolbar'),
               ordinaryTexts = () => bar.items
                   .filter(item => item.isToolbarAction !== true && item.isToolbarActionSpacer !== true)
                   .map(item => item.text);
 
-        RecordingWorkspaceController.syncs = 0;
-
-        // The real registry, and the real seam the Workstation derives its recovery buttons from:
-        // one popup state per registered id. Nothing here calls `syncTopologyBar` after construction.
-        const controller = Neo.create(RecordingWorkspaceController, {
-            component: {
-                down          : () => bar,
-                getPopupStates: () => set.ids().map(workspaceId => ({workspaceId})),
-                isConstructed : true,
-                workspaceSet  : set
-            }
-        });
-
         try {
-            // Control: the first paint is the construction-time population, with nothing registered.
+            // Control: the construction-time population, with no popup workspace registered.
             expect(RecordingWorkspaceController.syncs, 'constructed once').toBe(1);
             expect(ordinaryTexts()).toEqual(['Save workspace', 'Close workspace']);
 
-            expect(set.register('alpha', seams('alpha')), 'a participant arrives after boot').toBe(true);
-            // The affordance first: this is the assertion a broken publication must fail on.
+            const alpha = root.createPopupWorkspace('alpha', document('alpha'), {committed: true, windowId: null});
+
+            // The affordance first: this is the assertion a broken publication — or a registration that
+            // outruns its state — must fail on. Nothing here calls the controller.
             expect(ordinaryTexts(), 'the bar offers the new workspace without a reload').toEqual([
                 'Save workspace', 'Close workspace', 'Open alpha as window', 'Show alpha here'
             ]);
             expect(RecordingWorkspaceController.syncs, 'through exactly one more sync').toBe(2);
+            expect(root.getPopupState('alpha'), 'and the state the buttons address is the one created').toBe(alpha);
 
-            expect(set.unregister('alpha')).toBe(true);
+            alpha.host.destroy();
+
             expect(RecordingWorkspaceController.syncs, 'the removal re-synced it too').toBe(3);
             expect(ordinaryTexts(), 'a gone workspace offers nothing').toEqual(['Save workspace', 'Close workspace']);
 
-            controller.destroy();
+            // The component drops its controller the way its own destroy does: the config write destroys
+            // the old instance, and with it the subscription that instance owned.
+            root.controller = null;
 
-            expect(set.register('beta', seams('beta'))).toBe(true);
-            expect(RecordingWorkspaceController.syncs, 'a destroyed controller is not notified').toBe(3)
+            const beta = root.createPopupWorkspace('beta', document('beta'), {committed: true, windowId: null});
+
+            expect(RecordingWorkspaceController.syncs, 'a destroyed controller is not notified').toBe(3);
+            beta.host.destroy()
         } finally {
-            bar.destroy();
-            set.destroy();
+            root.destroy();
             Transaction.retireGroup(binding.groupId)
         }
     })

--- a/test/playwright/unit/apps/workstation/WorkspaceController.spec.mjs
+++ b/test/playwright/unit/apps/workstation/WorkspaceController.spec.mjs
@@ -280,31 +280,39 @@ test.describe('Workstation topology save and close coordination', () => {
         // The real root, its real registry, its real bar and its real popup-state lookup: the arm drives
         // the one production seam both creation sites call, so it measures the order in which a popup
         // workspace registers and becomes resolvable — not a stand-in for that order.
-        const root          = Neo.create(Workspace, {controller: RecordingWorkspaceController, windowId}),
-              bar           = root.controller.getReference('topology-toolbar'),
-              ordinaryTexts = () => bar.items
-                  .filter(item => item.isToolbarAction !== true && item.isToolbarActionSpacer !== true)
-                  .map(item => item.text);
+        const root = Neo.create(Workspace, {controller: RecordingWorkspaceController, windowId}),
+              bar  = root.controller.getReference('topology-toolbar'),
+              // The derived buttons are read by what they ARE — each carries the participant it
+              // addresses — never by where the authored list ends: `createTopologyBar`'s contract is
+              // that the authored items are free to grow, so a pinned head reds on the next readout
+              // the view adds and says nothing about membership.
+              recoveryTexts = () => bar.items.filter(item => item.workspaceKey !== undefined).map(item => item.text),
+              authoredCount = () => bar.items.filter(item =>
+                  item.isToolbarAction !== true && item.isToolbarActionSpacer !== true && item.workspaceKey === undefined).length,
+              authored      = authoredCount();
 
         try {
             // Control: the construction-time population, with no popup workspace registered.
             expect(RecordingWorkspaceController.syncs, 'constructed once').toBe(1);
-            expect(ordinaryTexts()).toEqual(['Save workspace', 'Close workspace']);
+            expect(authored, 'the view authored its own items').toBeGreaterThan(0);
+            expect(recoveryTexts()).toEqual([]);
 
             const alpha = root.createPopupWorkspace('alpha', document('alpha'), {committed: true, windowId: null});
 
             // The affordance first: this is the assertion a broken publication — or a registration that
             // outruns its state — must fail on. Nothing here calls the controller.
-            expect(ordinaryTexts(), 'the bar offers the new workspace without a reload').toEqual([
-                'Save workspace', 'Close workspace', 'Open alpha as window', 'Show alpha here'
+            expect(recoveryTexts(), 'the bar offers the new workspace without a reload').toEqual([
+                'Open alpha as window', 'Show alpha here'
             ]);
             expect(RecordingWorkspaceController.syncs, 'through exactly one more sync').toBe(2);
             expect(root.getPopupState('alpha'), 'and the state the buttons address is the one created').toBe(alpha);
+            expect(authoredCount(), 'the authored items are untouched by the sync').toBe(authored);
 
             alpha.host.destroy();
 
             expect(RecordingWorkspaceController.syncs, 'the removal re-synced it too').toBe(3);
-            expect(ordinaryTexts(), 'a gone workspace offers nothing').toEqual(['Save workspace', 'Close workspace']);
+            expect(recoveryTexts(), 'a gone workspace offers nothing').toEqual([]);
+            expect(authoredCount(), 'and the authored items survive the removal').toBe(authored);
 
             // The component drops its controller the way its own destroy does: the config write destroys
             // the old instance, and with it the subscription that instance owned.

--- a/test/playwright/unit/apps/workstation/WorkspaceController.spec.mjs
+++ b/test/playwright/unit/apps/workstation/WorkspaceController.spec.mjs
@@ -18,6 +18,36 @@ import WorkspaceController from '../../../../../apps/workstation/view/WorkspaceC
 import ViewportController  from '../../../../../apps/workstation/view/ViewportController.mjs';
 import PopupWorkspace      from '../../../../../apps/workstation/view/PopupWorkspace.mjs';
 import Workspace           from '../../../../../apps/workstation/view/Workspace.mjs';
+import WorkspaceDocument   from '../../../../../src/dashboard/dock/model/WorkspaceDocument.mjs';
+import WorkspaceSet        from '../../../../../src/dashboard/dock/window/WorkspaceSet.mjs';
+
+/**
+ * @summary The controller under test with its bar syncs counted, so an arm can tell "re-synced" from
+ * "the bar happens to read right" — and, after destroy, "not notified" from "notified and harmless".
+ */
+class RecordingWorkspaceController extends WorkspaceController {
+    static config = {
+        className: 'Test.Workstation.RecordingWorkspaceController'
+    }
+
+    /**
+     * Class-level on purpose: `destroy` clears an instance's fields, and the arm reads the count after
+     * destroying the controller to prove it was not notified.
+     * @member {Number} syncs=0
+     * @static
+     */
+    static syncs = 0
+
+    /**
+     * @returns {Boolean}
+     */
+    syncTopologyBar() {
+        RecordingWorkspaceController.syncs++;
+        return super.syncTopologyBar()
+    }
+}
+
+Neo.setupClass(RecordingWorkspaceController);
 
 /**
  * @summary An event-driven storage boundary for a write already in flight.
@@ -236,6 +266,59 @@ test.describe('Workstation topology save and close coordination', () => {
         expect(controller.syncTopologyBar(), 'a destroyed bar is not a synced bar').toBe(false);
 
         controller.destroy()
+    });
+
+    test('the bar follows membership: a participant registered after boot gains its buttons, an unregistered one loses them, and a destroyed controller stops listening', () => {
+        const binding = Transaction.bind({windowId: 'controller-membership-root'}),
+              set     = Neo.create(WorkspaceSet, {documentModel: WorkspaceDocument, manager: Transaction, getGroupId: () => binding.groupId}),
+              bar     = Neo.create(Toolbar, Workspace.prototype.createTopologyBar.call({topologyGroupId: binding.groupId})),
+              seams   = key => ({getDocument: () => ({
+                  schema: 'neo.dock.zone.v1', root: 'tabs',
+                  items : {[key]: {reference: key}},
+                  nodes : {tabs: {type: 'tabs', items: [key], activeItemId: key}}
+              })}),
+              ordinaryTexts = () => bar.items
+                  .filter(item => item.isToolbarAction !== true && item.isToolbarActionSpacer !== true)
+                  .map(item => item.text);
+
+        RecordingWorkspaceController.syncs = 0;
+
+        // The real registry, and the real seam the Workstation derives its recovery buttons from:
+        // one popup state per registered id. Nothing here calls `syncTopologyBar` after construction.
+        const controller = Neo.create(RecordingWorkspaceController, {
+            component: {
+                down          : () => bar,
+                getPopupStates: () => set.ids().map(workspaceId => ({workspaceId})),
+                isConstructed : true,
+                workspaceSet  : set
+            }
+        });
+
+        try {
+            // Control: the first paint is the construction-time population, with nothing registered.
+            expect(RecordingWorkspaceController.syncs, 'constructed once').toBe(1);
+            expect(ordinaryTexts()).toEqual(['Save workspace', 'Close workspace']);
+
+            expect(set.register('alpha', seams('alpha')), 'a participant arrives after boot').toBe(true);
+            // The affordance first: this is the assertion a broken publication must fail on.
+            expect(ordinaryTexts(), 'the bar offers the new workspace without a reload').toEqual([
+                'Save workspace', 'Close workspace', 'Open alpha as window', 'Show alpha here'
+            ]);
+            expect(RecordingWorkspaceController.syncs, 'through exactly one more sync').toBe(2);
+
+            expect(set.unregister('alpha')).toBe(true);
+            expect(RecordingWorkspaceController.syncs, 'the removal re-synced it too').toBe(3);
+            expect(ordinaryTexts(), 'a gone workspace offers nothing').toEqual(['Save workspace', 'Close workspace']);
+
+            controller.destroy();
+
+            expect(set.register('beta', seams('beta'))).toBe(true);
+            expect(RecordingWorkspaceController.syncs, 'a destroyed controller is not notified').toBe(3)
+        } finally {
+            bar.destroy();
+            set.destroy();
+            Transaction.retireGroup(binding.groupId)
+        }
     })
 });
 

--- a/test/playwright/unit/dashboard/DockWorkspaceSetTransaction.spec.mjs
+++ b/test/playwright/unit/dashboard/DockWorkspaceSetTransaction.spec.mjs
@@ -548,5 +548,38 @@ test.describe.serial('Dock WorkspaceSet transaction participants', () => {
         expect(main.document.items.main.title).toBe('synchronous');
         expect(main.writes).toHaveLength(1);
         legacy.destroy()
+    });
+
+    test('membership is a reactive config: register and unregister each publish once, a same-id replacement publishes nothing, a destroyed observer hears nothing', () => {
+        const observer = Neo.create(core.Base), seen = [];
+
+        try {
+            observer.observeConfig(set, 'memberIds', value => seen.push([...value]));
+            expect(set.memberIds, 'nothing registered yet').toEqual([]);
+
+            // `holder` registers as it builds, so the first publication is its registration.
+            const main = holder('main');
+
+            expect(seen, 'a registration publishes the new membership').toEqual([['main']]);
+
+            expect(set.register('main', main.seams), 'replacing the same id is a registration').toBe(true);
+            expect(seen, 'and not a membership change — the set is equal').toHaveLength(1);
+
+            const popup = holder('popup');
+
+            expect(seen.at(-1)).toEqual(['main', 'popup']);
+
+            expect(set.unregister('popup')).toBe(true);
+            expect(seen.at(-1), 'a removal publishes too').toEqual(['main']);
+            expect(seen).toHaveLength(3);
+
+            observer.destroy();
+
+            expect(set.register('popup', popup.seams)).toBe(true);
+            expect(seen, 'a destroyed observer hears nothing').toHaveLength(3);
+            expect(set.memberIds, 'while the set itself moved on').toEqual(['main', 'popup'])
+        } finally {
+            observer.isDestroyed || observer.destroy()
+        }
     })
 });

--- a/test/playwright/unit/dashboard/DockWorkspaceSetTransaction.spec.mjs
+++ b/test/playwright/unit/dashboard/DockWorkspaceSetTransaction.spec.mjs
@@ -377,6 +377,7 @@ test.describe.serial('Dock WorkspaceSet transaction participants', () => {
             workspaceSet                 : set, topologyGroupId: groupId,
             getPopupState                : WorkstationWorkspace.prototype.getPopupState,
             getPopupStates               : WorkstationWorkspace.prototype.getPopupStates,
+            createPopupWorkspace         : WorkstationWorkspace.prototype.createPopupWorkspace,
             stateProvider                : TransactionManager.getProvider(groupId),
             resolvePane                  : () => ({ntype: 'component'}),
             createVesselWorkspaceDocument: WorkstationWorkspace.prototype.createVesselWorkspaceDocument,


### PR DESCRIPTION
Resolves #18622

🌿 A workspace that joins the Group after boot can no longer be one the bar has never heard of.

`WorkspaceSet` owned membership and published nothing about it: `register` and `unregister` changed the manager's participant set, and the one reader — the Workstation topology bar's recovery buttons — read that set once, at `onComponentConstructed`, because there was nothing to subscribe to. A pane torn into its own window after boot therefore had no `Open … as window` button for the rest of the session; a reload fixed it, which is the tell that the data was right and only the notification was absent. Now the set republishes its `memberIds` as a reactive config on every registration and removal, and the controller observes it, so the bar follows membership warm. The subscription is the observer's own: `observeConfig` ties its cleanup to the controller's destroy, which is what keeps a controller from outliving its component.

Round 1 (Euclid) found the consumer still missing a warm popup through the real creation path: `PopupWorkspace.construct` registers with the Group before the root had assigned `host.runtimeState`, so the synchronous observer read that gap, resolved no popup state, and never retried. The root now builds the state first and hands it to the owner at creation through one factory, `Workspace#createPopupWorkspace`, which both creation sites — initial topology and tear-out — call; the two inline copies are gone. Nothing about routing, adoption or vessel lifecycle changes.

Evidence: L2 (unit tier — every AC is a statement about the registry's publication and the controller's reaction to it, both reachable in the single-thread harness with the real `WorkspaceSet`, the real `Transaction` manager, the real Workstation root and its real topology bar) → L2 required (no AC names a rendered surface). Residual: none.

`agent-preflight: not hosted here; baseline pr-body + substrate-size run in CI`. Change class: **feat** — a new observable surface on the registry, additive; no existing consumer read membership reactively. The round-1 repair is a **fix** inside it: a popup's state now exists before its registration.

## AC Evidence

| AC | Evidence |
|---|---|
| AC-1 `register` and `unregister` make membership observable, both directions counted | `DockWorkspaceSetTransaction.spec.mjs` › *membership is a reactive config…*: an observer subscribed through `observeConfig` sees `[['main']]` after the first registration, `['main', 'popup']` after the second, `['main']` after the removal — three publications for three changes |
| AC-2 a participant registered after boot gains its recovery button, asserted through the controller | `WorkspaceController.spec.mjs` › *the bar follows membership through the production path…*: a real root (`Neo.create(Workspace, …)` on a bound window) with its real set, real bar and real `getPopupState` lookup; `root.createPopupWorkspace('alpha', …)` alone — no call into the controller — puts `Open alpha as window` / `Show alpha here` on the bar, adds one sync to the counter, and `getPopupState('alpha')` returns the very state the buttons address |
| AC-3 an unregistered participant loses its button | same arm: `alpha.host.destroy()` — the popup's own unregistration — re-syncs once more and the ordinary items are back to `Save workspace`, `Close workspace` |
| AC-4 the subscription is torn down with its subscriber, asserted directly | same arm: `root.controller = null` — the write the component's own destroy performs; `beforeSetController` destroys the old instance — then a further `createPopupWorkspace('beta', …)` leaves the sync count where it was; the set spec's observer arm asserts the same from the publisher's side (a destroyed observer hears nothing while `memberIds` moves on). The mechanism is `core/Base#observeConfig` pushing its cleanup onto the observer's own subscription cleanups, run at destroy |
| AC-5 the docblock's limitation paragraph is removed with its cause | `WorkspaceController.mjs`, `syncTopologyBar`: the paragraph that asked the engine for a signal now states the two triggers — construction and `memberIds` republication |
| AC-6 mutation-verified, the red on the affordance assertion | two receipts under Test Evidence: the publication removed, and the pre-repair creation order restored |
| AC-7 construction-time population still happens | the existing arm *the controller fills only its own buttons…* is unchanged and green; the new arm's first assertions are the control (one sync at construction, the authored items present) |

## Deltas from ticket

- **Same-id replacement publishes nothing, by construction rather than by guard.** `register` is documented as register-or-replace for a re-embodied vessel; a replacement leaves `ids()` equal, and `Config` compares with `Neo.isEqual`, which walks arrays, so the config does not notify. The set spec pins it, so a later change to the equality descriptor would show up here.
- **The popup carries its runtime state from creation (round 1).** The ticket asked for the signal; the signal exposed that the Workstation assigned a popup's `runtimeState` after `Neo.create` returned, while the popup registers inside its own `construct`. `createPopupWorkspace(workspaceId, dockModel, fields)` builds the state, passes it as `runtimeState` in the popup's creation config — a plain field assigned during Base construct, the way `workspaceSet` already arrives — and both creation sites call it: a deduplication as much as a fix. The `PopupWorkspace#runtimeState` docblock names the supplier and why.
- **The regression arm drives the production seam, not a stand-in.** Round 1's arm fed the controller one popup state per registered id; it measured the publication and hid the ordering. The arm now constructs the real root and creates the popup the way the app does, so the assertion holds only where registration and resolvability agree. The popup-birth arm in the set spec, whose stand-in root borrows Workstation prototype methods, borrows the factory too.
- **Decision Record: aligned-with ADR 0029.** The config is an implementation detail of the registry the ADR already places in the App worker; it names no new normative contract, so no amendment.

## Test Evidence

- `npx playwright test -c test/playwright/playwright.config.unit.mjs workstation/WorkspaceController dashboard/DockWorkspaceSetTransaction --workers=1` → 32 passed at the head (26 before the rebase brought #18596's six arms into the same spec).
- Wider folders at the head, `unit/apps/workstation` and `unit/dashboard`, `--workers=1` → 1224 passed, 2 skipped (pre-existing `describe.skip` blocks), 0 failed.
- Mutant 1 (AC-6, publication), applied at the pre-rebase head 9c82e97279 — the same diff — and restored from it: the republication removed from `register`. 2 failed / 24 passed — the controller arm reds on *the bar offers the new workspace without a reload* (expected the two `alpha` buttons, received none) and the set arm on *a registration publishes the new membership* (expected `[['main']]`, received `[]`); every other arm, the construction-time control included, stays green.
- Mutant 2 (round 1, ordering), same head and discipline: `createPopupWorkspace` reverted to assign `runtimeState` after `Neo.create` returns. 1 failed / 25 passed — the controller arm reds on the same affordance assertion and nothing else moves; the popup-birth arm, which reads the state only after creation, stays green, which is exactly why it never saw the gap.
- Size guard, CI's argv against `origin/dev`: 7 paths evaluated, 0 violations — after lowering the ratchet baseline for `apps/workstation/view/Workspace.mjs` from 1252 to the measured 1243 code lines; the factory took nine code lines out of the file and the base-to-HEAD ratchet only moves down.

## Post-Merge Validation

- [x] Pre-merge receipt on this head (9b38e150b5, headed, real popup through the pop-out action, then a real window close — the #18621 isolation rig): with no reload, the root bar offers both `Open workstation-vessel:feed as window` and `Show workstation-vessel:feed here` after the vessel window closed, in every arm (six runs). The Brain-free component arm reusing `tearOutFeed` from `WorkstationBoot.spec.mjs` remains the post-merge form of the same read.
- [ ] Retiring an emptied vessel on reset stays where the ticket left it — earned, not exercised.

## Commits

- 5bd8418015 — the reactive `memberIds`, the observing controller, the two docblocks, and both specs' arms
- 915eb5173a — round 1: `createPopupWorkspace` hands the popup its state at creation; the controller arm through the production path; the popup-birth stand-in borrows the factory
- 9b38e150b5 — the size ratchet's baseline for `Workspace.mjs` follows the file down to 1243

Authored by Vega (Fable 5.1, Claude Code). Session c4a95308-109e-4761-a8a0-50f84debf222.
