### PR TITLE
test(dock): the reveal-wait probe mirrors what it wraps and gives it back on teardown (#18531)

### DIFF
--- a/test/playwright/component/apps/dock-rail-retarget/app.mjs
+++ b/test/playwright/component/apps/dock-rail-retarget/app.mjs
@@ -55,39 +55,89 @@ class RailRetargetWorkspace extends DockWorkspace {
     /** @member {Object|null} revealWaitProbe=null Test observations survive the Rail's teardown. */
     revealWaitProbe = null
 
+    /** @member {String[]} PROBED_METHODS The machine methods the probe wraps, and restores. @static */
+    static PROBED_METHODS = ['registerAsync', 'unregisterAsync', 'timeout']
+
     /**
-     * @summary Observes the existing owner's inherited waits without replacing timer behavior.
+     * @summary Observes the existing owner's waits by wrapping its methods, shaped exactly as they are, for as long as it observes.
+     *
+     * Wrapped, not read, because the machine exposes no seam for either fact this fixture reports:
+     * `core/Base` keeps async registrations in a private field, and a wait's outcome lives only in the
+     * promise `transitionAfter` awaits and drops — the machine fires no event, and its state is a plain
+     * field. Each wrapper mirrors the signature it wraps and forwards through the original, so a call
+     * production makes cannot fail here and pass there; `false` puts the originals back.
      * @param {Boolean} value
      */
     afterSetObserveRevealWaits(value) {
-        if (!value || this.revealWaitProbe) return;
-        const rail     = this.down({dockNodeType: 'edge-rail', dockEdge: 'right'}),
-              owner    = rail.revealMachine, timeout = owner.timeout,
-              register = owner.registerAsync, unregister = owner.unregisterAsync,
-              probe    = this.revealWaitProbe = {
-                  railId    : rail.id, ownerId: owner.id, owner,
-                  registered: 0, pending: new Set(), waits: []
+        const me = this;
+
+        if (!value) {
+            me.restoreRevealWaitProbe();
+            return
+        }
+
+        if (me.revealWaitProbe && !me.revealWaitProbe.restored) return;
+
+        const rail      = me.down({dockNodeType: 'edge-rail', dockEdge: 'right'}),
+              owner     = rail.revealMachine,
+              originals = Object.fromEntries(RailRetargetWorkspace.PROBED_METHODS.map(key => [key, {
+                  own: Object.hasOwn(owner, key), value: owner[key]
+              }])),
+              probe     = me.revealWaitProbe = {
+                  railId    : rail.id, ownerId: owner.id, owner, originals,
+                  registered: 0, pending: new Set(), restored: false, waits: []
               };
 
+        // Registrations: the engine keeps them in a private field, so they are counted here or nowhere.
         owner.registerAsync = (id, reject) => {
             probe.registered++;
             probe.pending.add(id);
-            return register.call(owner, id, reject)
+            return originals.registerAsync.value.call(owner, id, reject)
         };
         owner.unregisterAsync = id => {
             probe.pending.delete(id);
-            return unregister.call(owner, id)
+            return originals.unregisterAsync.value.call(owner, id)
         };
-        owner.timeout = (delay, options) => {
-            const receipt = {delay, itemId: owner.pendingItemId ?? owner.revealedItemId, state: owner.state, status: 'pending'},
-                  wait    = timeout.call(owner, delay, options);
+        // Outcomes: the wait's promise is awaited and dropped inside the machine, so elapsed, aborted
+        // and destroyed are told apart here or nowhere — a state observer sees the same abort on all three.
+        owner.timeout = (time, options = {}) => {
+            const receipt = {delay: time, itemId: owner.pendingItemId ?? owner.revealedItemId, state: owner.state, status: 'pending'},
+                  wait    = originals.timeout.value.call(owner, time, options);
+
             probe.waits.push(receipt);
             wait.then(() => {receipt.status = 'elapsed'}, error => {
                 receipt.status = error === Neo.isDestroyed ? 'destroyed' :
-                    options.signal.aborted && error === options.signal.reason ? 'aborted' : `error:${String(error)}`
+                    options.signal?.aborted && error === options.signal.reason ? 'aborted' : `error:${String(error)}`
             });
             return wait
         }
+    }
+
+    /**
+     * @summary Puts the machine's own methods back; what the probe observed stays readable.
+     * @returns {Boolean} Whether anything was restored.
+     */
+    restoreRevealWaitProbe() {
+        const probe = this.revealWaitProbe, owner = probe?.owner;
+
+        if (!owner || probe.restored) return false;
+
+        probe.restored = true;
+
+        Object.entries(probe.originals).forEach(([key, {own, value}]) => {
+            if (own) owner[key] = value;
+            else delete owner[key]
+        });
+
+        return true
+    }
+
+    /**
+     * @param {...*} args
+     */
+    destroy(...args) {
+        this.restoreRevealWaitProbe();
+        super.destroy(...args)
     }
 
     /** @summary Returns serializable observations of the real reveal owner and its async lifetime. @returns {Object|null} */
@@ -103,8 +153,11 @@ class RailRetargetWorkspace extends DockWorkspace {
             pendingWaits   : probe.pending.size,
             ownerDestroyed : probe.owner.isDestroyed === true,
             ownerRegistered: !!Neo.get(probe.ownerId),
-            waits          : probe.waits.map(receipt => ({...receipt})),
-            documentJson   : JSON.stringify(this.dockModel)
+            // Read off the instance, not off the probe's own bookkeeping: whether the machine carries
+            // the wrappers as own properties right now.
+            wrapped     : RailRetargetWorkspace.PROBED_METHODS.some(key => Object.hasOwn(probe.owner, key)),
+            waits       : probe.waits.map(receipt => ({...receipt})),
+            documentJson: JSON.stringify(this.dockModel)
         }
     }
 

--- a/test/playwright/component/dashboard/DockRailRevealRetarget.spec.mjs
+++ b/test/playwright/component/dashboard/DockRailRevealRetarget.spec.mjs
@@ -92,7 +92,15 @@ test.describe('Neo.dashboard.dock.interaction.RevealOverlay — a retarget slide
         expect(dismissed.waits.at(-1)).toEqual({delay: 1000, itemId: 'alpha', state: 'dismiss-pending', status: 'elapsed'});
         expect(dismissed.state).toBe('idle');
         expect(dismissed.pendingWaits).toBe(0);
-        expect(dismissed.documentJson).toBe(initial.documentJson)
+        expect(dismissed.documentJson).toBe(initial.documentJson);
+
+        // The probe borrows the machine's methods only while it observes: switching it off gives the
+        // instance its own methods back, and what was observed stays readable afterwards.
+        expect(dismissed.wrapped, 'the machine carries the probe\'s wrappers while observed').toBe(true);
+        await neo.setConfig('dock-rail-retarget-workspace', {observeRevealWaits: false});
+        const released = await readReveal(neo);
+        expect(released.wrapped, 'and its own methods once the probe is off').toBe(false);
+        expect(released.waits, 'without losing the receipts').toEqual(dismissed.waits)
     });
 
     test('hover retarget cancels the obsolete dwell and Rail teardown cancels its pending Base wait', async ({page, neo}) => {


### PR DESCRIPTION
Resolves #18531

🌿 The probe that witnesses the reveal machine's waits can no longer fail a call the machine is allowed to make, nor keep the machine's methods after it stops watching.

The reveal-retarget component fixture observes the machine by wrapping three of its methods on the live instance, and one wrapper was stricter than what it replaced: `timeout(delay, options)` with no default and `options.signal.aborted` unguarded, so a bare `timeout(delay)` — which the engine's own signature permits — would throw only under the fixture. None of the three was ever restored. This keeps the wrappers, because the ticket's amended measurement table shows no non-replacing observation point exists (the registry is a private field, the wait's promise is awaited and dropped inside the machine, it fires no event, its state is a plain field, and neither the adapter nor the Rail exposes a class seam), and makes them honest: each mirrors the signature it wraps and forwards through the original, each carries the reason it exists, switching the probe off or destroying the fixture puts the originals back, and the state getter reports whether the machine currently carries them so the spec asserts the restoration rather than assuming it.

Evidence: L3 (the component tier drives the real Rail and its real reveal machine in Chromium; the on/off assertion and the mutation receipt both read the rendered fixture) → L3 required (AC-4 names the component spec going red). Residual: none.

`agent-preflight: not hosted here; baseline pr-body + substrate-size run in CI`. Change class: **test** — fixture instrumentation and its spec; no engine file.

## AC Evidence

| AC | Evidence |
|---|---|
| AC-1 wraps only where the ticket's table shows no non-replacing observation point, and names the reason beside each wrapper | the three wrappers stand; the method's docblock names the private registry and the dropped promise, and each wrapper group carries a one-line reason at its site (registrations: private field; outcomes: the promise the machine awaits and drops, which a state observer cannot separate into elapsed/aborted because `transition` aborts the old controller on both paths) |
| AC-2 no wrapper stricter than the wrapped method | `timeout(time, options = {})` with `options.signal?.aborted`, forwarding `options` untouched; `registerAsync(id, reject)` and `unregisterAsync(id)` unchanged in shape |
| AC-3 wrappers restored on teardown | `restoreRevealWaitProbe()` runs on `observeRevealWaits = false` and on the fixture workspace's `destroy`; it restores an own property or deletes the wrapper so the prototype method is back; the getter's `wrapped` reads `Object.hasOwn` on the instance for the three names. Spec: *hover dwell reveals…* now asserts `wrapped: true` while observing, `wrapped: false` after switching the probe off, and the receipts unchanged across the switch |
| AC-4 the spec still reds when the machine regresses, by mutation | receipt under Test Evidence |

## Deltas from ticket

- **The ticket's Fix premise was amended by its author at intake** (`IC_kwDODSospM8AAAABUJaIYg`): "the engine already exposes the registration pair" was false — `#asyncRejects` is private — and AC-1 now stands on the measurement table ported into the body instead of on "no longer replaces `timeout`". The five routes measured, none open: private registry; promise awaited and dropped in `transitionAfter`; zero `fire(` calls and a single Rail-owned `onChange_`; `state` / `pendingItemId` / `revealedItemId` plain fields; `Rail#createRevealMachine` and `LayoutAdapter.createEdgeRail` both hardcoding their class.
- **A class or factory seam on `Rail` would retire these wrappers entirely.** Declined for this PR by the ticket's author and by me for the same reason: engine API added for a fixture, and the machine's refactor is out of the ticket's scope. Named under Post-Merge Validation as the successor that would retire this fixture.
- **The getter reads the instance, not the probe's bookkeeping.** `wrapped` is `Object.hasOwn(owner, key)` over the three names, so a restoration that forgot one would show.

## Test Evidence

- `npx playwright test dashboard/DockRailRevealRetarget -c test/playwright/playwright.config.component.mjs --workers=1` → 5 passed, at the repaired fixture and again after the per-wrapper comments.
- Mutant (AC-4), applied to the machine at the committed head and restored from it: `me.transitionController?.abort()` removed from `RevealStateMachine#transition`, so a new transition no longer cancels the previous wait. 2 failed / 3 passed — *hover dwell reveals…* on the rescued grace (`{…, state: 'dismiss-pending', status: 'aborted'}` expected, `'pending'` received) and *hover retarget cancels the obsolete dwell…* on alpha's dwell (`'aborted'` expected, `'elapsed'` received); the three motion arms, which never read the probe, stay green. The receipts that reddened are the ones the repaired wrappers produce, so the spec still measures the machine through them.
- Not run: a receipt that the OLD fixture throws on a bare `timeout(delay)` — the machine never makes that call today (`RevealStateMachine.mjs:234` always passes `{signal}`), so the strictness was latent; AC-2 is met by the wrapper's shape, which the diff shows.

## Post-Merge Validation

- [ ] Successor, if wanted: a class or factory seam on `Rail` for its reveal machine, so a fixture can supply a recording subclass and these wrappers retire. Its own leaf; not filed with this PR.

## Commits

- 1931fed6ca — exact-signature wrappers, restoration on off and on destroy, the `wrapped` flag, the reason beside each wrapper, and the spec's on/off assertions (one commit; the reasons were folded in before the PR opened)

Authored by Vega (Fable 5.1, Claude Code). Session c4a95308-109e-4761-a8a0-50f84debf222.
