### PR TITLE
feat(dock): select and replay declared perspectives (#18607)

### DIFF
--- a/buildScripts/util/file-size-baseline.json
+++ b/buildScripts/util/file-size-baseline.json
@@ -1,6 +1,6 @@
 {
     "apps/workstation/view/Workspace.mjs": 1252,
     "examples/dashboard/crossWindow/DemoBWorkspace.mjs": 2546,
-    "src/dashboard/dock/Workspace.mjs": 1137,
+    "src/dashboard/dock/Workspace.mjs": 1140,
     "src/main/addon/DragDrop.mjs": 1267
 }

--- a/buildScripts/util/file-size-baseline.json
+++ b/buildScripts/util/file-size-baseline.json
@@ -1,6 +1,6 @@
 {
     "apps/workstation/view/Workspace.mjs": 1252,
     "examples/dashboard/crossWindow/DemoBWorkspace.mjs": 2546,
-    "src/dashboard/dock/Workspace.mjs": 1106,
+    "src/dashboard/dock/Workspace.mjs": 1137,
     "src/main/addon/DragDrop.mjs": 1267
 }

--- a/docs/output/class-hierarchy.json
+++ b/docs/output/class-hierarchy.json
@@ -225,6 +225,7 @@
  "Neo.dashboard.dock.interaction.DockSplitter": "Neo.component.Splitter",
  "Neo.dashboard.dock.interaction.DragAffordances": "Neo.core.Base",
  "Neo.dashboard.dock.interaction.DropIndicators": "Neo.container.Base",
+ "Neo.dashboard.dock.interaction.PerspectiveSelection": "Neo.core.Base",
  "Neo.dashboard.dock.interaction.Preview": "Neo.component.Base",
  "Neo.dashboard.dock.interaction.PreviewProducer": "Neo.core.Base",
  "Neo.dashboard.dock.interaction.Rail": "Neo.container.Base",

--- a/src/dashboard/dock/Workspace.mjs
+++ b/src/dashboard/dock/Workspace.mjs
@@ -651,7 +651,10 @@ class Workspace extends Container {
             if (!supplied) me.dockModel = document
         }
 
-        if (me.perspectiveSelection) me.perspectiveSelection.initialized = true;
+        if (me.perspectiveSelection) {
+            me.perspectiveSelection.initialized = true;
+            me.perspectiveSelection.connect()
+        }
 
         super.onAfterConstructed()
     }

--- a/src/dashboard/dock/Workspace.mjs
+++ b/src/dashboard/dock/Workspace.mjs
@@ -9,6 +9,7 @@ import LayoutAdapter               from './projection/LayoutAdapter.mjs';
 import Maximize                    from './plugin/Maximize.mjs';
 import MotionSignal                from './projection/MotionSignal.mjs';
 import PreviewProducer             from './interaction/PreviewProducer.mjs';
+import PerspectiveSelection        from './interaction/PerspectiveSelection.mjs';
 import Reconciler                  from './projection/Reconciler.mjs';
 import StateProvider               from '../../state/Provider.mjs';
 import {createDockTearOutHandlers} from './window/TearOut.mjs';
@@ -29,7 +30,9 @@ import TopologySeams               from './window/TopologySeams.mjs';
  * that hands the surviving live panes into the next projection instead of recreating them
  * ({@link #refreshDockWorkspace} over {@link Neo.dashboard.dock.projection.Reconciler}, bracketed by
  * the FLIP motion signal). Before this class, each consumer wrote that loop by hand; this class owns
- * it once. A basic consumer declares initial {@link #panes} and {@link #zones}; advanced consumers
+ * it once. A basic consumer declares initial {@link #panes} and {@link #zones}. Named arrangements
+ * use {@link #perspectives} and {@link #activePerspective}; {@link #resetPerspective} re-applies
+ * the committed baseline. Advanced consumers
  * specialize the existing template hooks:
  *
  * - {@link #resolvePane} — custom live component or config resolution beyond declared panes;
@@ -383,6 +386,14 @@ class Workspace extends Container {
          * @member {Object|null} panes=null
          */
         panes: null,
+        /** @member {Object|null} perspectives=null Named zones captured once at construction. */
+        perspectives: null,
+        /**
+         * @member {String|null} activePerspective_=null Accepted declared selection intent, not completion.
+         * Unknown names retain committed identity; equal assignments are no-ops. Use resetPerspective to restore again.
+         * @reactive
+         */
+        activePerspective_: null,
 
         /**
          * Initial nested dock arrangement. Strings/arrays name tabs; objects describe splits
@@ -495,6 +506,33 @@ class Workspace extends Container {
      */
     observedWindowGeometryId = null
 
+    /** @member {Neo.dashboard.dock.interaction.PerspectiveSelection|null} perspectiveSelection=null Selection owner. */
+    perspectiveSelection = null
+
+    /** @summary Validates runtime intent against the captured declarations. @param {String} value @returns {String} */
+    beforeSetActivePerspective(value) {
+        const selection = this.perspectiveSelection;
+        if (selection?.initialized) return selection.accept(value);
+        if (this.isConstructed && !selection && value !== null) {
+            console.error('No declared perspectives are available');
+            return null
+        }
+        return value
+    }
+
+    /** @summary Routes accepted intent and publishes public synchronization. @param {String} value @param {String} oldValue */
+    afterSetActivePerspective(value, oldValue) {
+        if (this.perspectiveSelection?.initialized) {
+            this.perspectiveSelection.onIntent(value);
+            this.fire('activePerspectiveChange', {value, oldValue})
+        }
+    }
+
+    /** @summary Re-applies the committed declared baseline as an explicit write. @returns {Promise<Object>} */
+    resetPerspective() {
+        return this.perspectiveSelection?.restore() ?? Promise.resolve({document: this.dockModel, errors: ['no declared perspective']})
+    }
+
     /**
      * @summary Initializes dock-owned services and arms geometry only when already window-bound.
      * @param {Object} config
@@ -591,8 +629,13 @@ class Workspace extends Container {
         if (supplied) Authoring.validateDocument(me.dockModel, errors);
         if (errors.length) throw new Error(`dockModel: ${errors.join('; ')}`);
 
-        if (me.panes !== null || me.zones !== null) {
-            const {document, errors} = Authoring.fromZones(me.panes ?? {}, supplied ? {type: 'edge-zone'} : me.zones ?? {type: 'edge-zone'});
+        if (me.perspectives !== null || me.zones !== null || me.panes !== null || me.activePerspective !== null) {
+            me.perspectiveSelection = Neo.create(PerspectiveSelection, {workspace: me})
+        }
+        const zones = me.perspectiveSelection?.capture() ?? me.zones;
+
+        if (me.panes !== null || me.zones !== null || me.perspectives !== null) {
+            const {document, errors} = Authoring.fromZones(me.panes ?? {}, supplied ? {type: 'edge-zone'} : zones ?? {type: 'edge-zone'});
             if (errors.length) throw new Error(errors.join('; '));
 
             const declarations = Neo.clone(me.panes ?? {}, true, true), ids = new Set();
@@ -607,6 +650,8 @@ class Workspace extends Container {
             me.declaredPaneItems = document.items;
             if (!supplied) me.dockModel = document
         }
+
+        if (me.perspectiveSelection) me.perspectiveSelection.initialized = true;
 
         super.onAfterConstructed()
     }
@@ -1266,6 +1311,8 @@ class Workspace extends Container {
      */
     destroy(...args) {
         const me = this;
+        me.perspectiveSelection?.destroy();
+        me.perspectiveSelection = null;
         me.releaseDeclaredPanes(null);
         me.transactionManager?.un({bind: me.onTopologyGroupBinding, scope: me});
         me.nativeWindows?.unregisterSource(me.id);
@@ -2348,9 +2395,10 @@ class Workspace extends Container {
      */
     projectDockCommit(context) {
         return this.projectDockZoneDocument(context.snapshot.participants[context.workspaceKey], context.descriptor, this, {
-            preserveItemIds : context.preserveItemIds,
-            previousDocument: context.captured.value,
-            workspaceKey    : context.workspaceKey
+            perspectiveContext: context,
+            preserveItemIds   : context.preserveItemIds,
+            previousDocument  : context.captured.value,
+            workspaceKey      : context.workspaceKey
         })
     }
 
@@ -2366,7 +2414,7 @@ class Workspace extends Container {
      */
     projectDockZoneDocument(document, descriptor=null, source=null, projectionOptions={}) {
         let me = this,
-            {previousDocument=me.dockModel, workspaceKey, ...viewOptions} = projectionOptions,
+            {previousDocument=me.dockModel, workspaceKey, perspectiveContext, ...viewOptions} = projectionOptions,
             commitOptions, preserved, tabInsertDescriptor, refreshOptions, tail;
 
         // Presentation owners release transient state before the outgoing shell is reconciled.
@@ -2391,6 +2439,7 @@ class Workspace extends Container {
         // whose inputs this commit changed re-evaluate now — a lock reaches its header, its pane and
         // a revealed rail pane here, as it always did — and nothing else moves. Optional because a
         // test may drive this hook with a hand-built `this`.
+        me.perspectiveSelection?.project(perspectiveContext ?? {descriptor});
         me.dockHeaderActionPolicy?.publishDocument(document);
 
         me.refreshPromise = tail

--- a/src/dashboard/dock/interaction/PerspectiveSelection.mjs
+++ b/src/dashboard/dock/interaction/PerspectiveSelection.mjs
@@ -101,9 +101,17 @@ class PerspectiveSelection extends Base {
         return host.workspaceKey ?? set?.ids().find(key => set.getParticipant(key)?.componentId === host.id)
     }
 
+    /** @summary Attaches a registered document owner without admitting a selection write. @returns {void} */
+    connect() {
+        if (!this.initialized || !this.workspace.workspaceSet?.has(this.workspaceKey())) return;
+        const pending = this.attachGroup().then(() => ({errors: []}), error => ({errors: [error.message]}));
+        if (this.pendingName === null) this.pending = pending
+    }
+
     /**
      * @summary Registers auxiliary identity on the Group queue without admitting a nested write.
-     * Its captured name survives view replacement; it is not a workspace document or persisted wire.
+     * A replacement retains a name it declares, otherwise captures its initialized baseline.
+     * The live owner supplies validation; the Group retains identity independently of view lifetime.
      * @returns {Promise<void>}
      */
     attachGroup() {
@@ -119,17 +127,21 @@ class PerspectiveSelection extends Base {
         if (!group || !key) return Promise.reject(new Error('dock participant not registered'));
         this.#registration = manager.enqueue(group, () => {
             if (this.isDestroyed || host.isDestroyed) throw new Error('perspective workspace destroyed');
+            const participant = manager.getParticipant(groupId, key);
+            if (!participant || participant.componentId && participant.componentId !== host.id) {
+                throw new Error('perspective workspace replaced')
+            }
             let entry = manager.getParticipant(groupId, identityKey);
             if (entry && entry.perspectiveSelection !== true) throw new Error('perspective participant key already in use');
             if (!entry) {
-                const state = {value: Object.freeze({name: this.#directName}), revision: 0},
-                      names = new Set(this.#documents.keys());
+                const state = {value: Object.freeze({name: this.#directName}), revision: 0};
                 entry = {
                     domain : 'dock', perspectiveSelection: true,
-                    capture: () => ({value: state.value, revision: state.revision,
+                    capture: () => ({value: entry.owner && !entry.owner.#documents.has(state.value.name)
+                        ? {name: entry.owner.#directName} : state.value, revision: state.revision,
                         generation: manager.getBinding(groupId, key)?.generation ?? 0}),
                     prepare: value => {
-                        if (!value || !names.has(value.name)) throw new Error('unknown declared perspective');
+                        if (!value || !entry.owner?.#documents.has(value.name)) throw new Error('unknown declared perspective');
                         return {name: value.name}
                     },
                     adopt     : value => {state.value = value; state.revision++},
@@ -139,7 +151,10 @@ class PerspectiveSelection extends Base {
                     throw new Error('perspective participant could not register')
                 }
             }
-            this.#entry = entry
+            entry.owner = this;
+            this.#entry = entry;
+            this.publishedName = this.committedName;
+            if (this.pendingName === null) this.sync(this.committedName)
         }).catch(error => {
             this.#registration = null;
             throw error
@@ -197,6 +212,7 @@ class PerspectiveSelection extends Base {
                     descriptor       : {operation: 'restorePerspective', workspaceKey: key, after: name},
                     prepareDescriptor: ({descriptor}) => {
                         if (this.isDestroyed || host.isDestroyed) throw new Error('perspective workspace destroyed');
+                        if (this.#entry.owner !== this) throw new Error('perspective workspace replaced');
                         for (const sibling of set.ids().filter(id => id !== key)) {
                             if (Object.keys(set.getDocument(sibling)?.items ?? {}).some(id => Object.hasOwn(document.items, id))) {
                                 throw new Error(`perspective restore would duplicate a pane owned by "${sibling}"`)
@@ -231,6 +247,7 @@ class PerspectiveSelection extends Base {
 
     /** @summary Releases the view's reference; the Group retains its identity participant. @param {...*} args */
     destroy(...args) {
+        if (this.#entry?.owner === this) this.#entry.owner = null;
         super.destroy(...args)
     }
 }

--- a/src/dashboard/dock/interaction/PerspectiveSelection.mjs
+++ b/src/dashboard/dock/interaction/PerspectiveSelection.mjs
@@ -1,0 +1,232 @@
+import Base      from '../../../core/Base.mjs';
+import Authoring from '../model/Authoring.mjs';
+import Document  from '../model/WorkspaceDocument.mjs';
+
+/**
+ * @summary Owns captured perspective declarations and the lifetime of one Workspace's selection requests.
+ * A Group retains identity as an auxiliary participant in the document's atomic write.
+ * Projection synchronizes the public config without restoring again; pending newer intent survives.
+ * Documents remain with the Workspace and its Group. This owner imports no transaction machinery.
+ * @class Neo.dashboard.dock.interaction.PerspectiveSelection
+ * @extends Neo.core.Base
+ */
+class PerspectiveSelection extends Base {
+    static config = {
+        /** @member {String} className='Neo.dashboard.dock.interaction.PerspectiveSelection' */
+        className: 'Neo.dashboard.dock.interaction.PerspectiveSelection',
+        /** @member {Neo.dashboard.dock.Workspace|null} workspace=null The declaring host. */
+        workspace: null
+    }
+
+    /** @member {Boolean} initialized=false Whether declarations have been captured. */
+    initialized = false
+    /** @member {String|null} publishedName=null Identity observed by the latest projection. */
+    publishedName = null
+    /** @member {String|null} pendingName=null Latest unresolved request, independent of projection. */
+    pendingName = null
+    /** @member {Promise} pending Settlement of the latest request. */
+    pending = Promise.resolve({errors: []})
+    /** @member {Map<String,Object>} #documents Captured lowered baselines. @private */
+    #documents = new Map()
+    /** @member {Number} #serial=0 Request generation. @private */
+    #serial = 0
+    /** @member {Boolean} #sync=false Suppresses restoration during public synchronization. @private */
+    #sync = false
+    /** @member {Object|null} #manager=null Borrowed Group authority. @private */
+    #manager = null
+    /** @member {String|null} #groupId=null Observed Group. @private */
+    #groupId = null
+    /** @member {String|null} #directName=null Identity for the standalone document path. @private */
+    #directName = null
+    /** @member {Object|null} #entry=null Group-owned identity participant. @private */
+    #entry = null
+    /** @member {Promise|null} #registration=null Queue-ordered identity registration. @private */
+    #registration = null
+
+    /** @summary Reads semantic identity independently of observer delivery. @member {String|null} committedName */
+    get committedName() { return this.#entry?.capture().value.name ?? this.#directName }
+
+    /** @summary Captures declarations after the host's complete construction chain. @returns {Object} Initial zones. */
+    capture() {
+        const host     = this.workspace, supplied = host.dockModel !== null,
+              declared = host.perspectives === null
+                  ? {[Authoring.defaultPerspectiveName]: host.zones ?? {type: 'edge-zone'}}
+                  : Neo.clone(host.perspectives, true, true);
+        if (!declared || typeof declared !== 'object' || Array.isArray(declared) || !Object.keys(declared).length) {
+            throw new TypeError('perspectives must be a nonempty map of names to zones')
+        }
+        for (const [name, zones] of Object.entries(declared)) {
+            if (!name.trim()) throw new TypeError('perspective names must not be empty');
+            const result = supplied && host.perspectives === null
+                ? {document: Document.clone(host.dockModel), errors: []}
+                : Authoring.fromZones(host.panes ?? {}, zones);
+            if (result.errors.length) throw new TypeError(`perspectives.${name}: ${result.errors.join('; ')}`);
+            this.#documents.set(name, Document.clone(result.document))
+        }
+        const first = this.#documents.keys().next().value;
+        let   name  = host.activePerspective ?? first;
+        if (!this.#documents.has(name)) {
+            console.error('Supported values for activePerspective are:', ...this.#documents.keys());
+            name = first
+        }
+        this.#directName = this.publishedName = name;
+        host.activePerspective = name;
+        return declared[name]
+    }
+
+    /** @summary Reads a fresh copy of a captured baseline. @param {String} name @returns {Object|null} */
+    document(name) { return this.#documents.has(name) ? Document.clone(this.#documents.get(name)) : null }
+
+    /** @summary Refuses unknown names against the captured set. @param {String} value @returns {String} */
+    accept(value) {
+        if (this.#documents.has(value)) return value;
+        console.error('Supported values for activePerspective are:', ...this.#documents.keys());
+        return this.committedName
+    }
+
+    /** @summary A config write admits intent unless it is synchronization from accepted truth. @param {String} value */
+    onIntent(value) {
+        if (!this.#sync && value !== this.committedName) this.restore(value)
+    }
+
+    /** @summary Resolves the host's document participant without owning a registry. @returns {String|undefined} */
+    workspaceKey() {
+        const host = this.workspace, set = host.workspaceSet;
+        return host.workspaceKey ?? set?.ids().find(key => set.getParticipant(key)?.componentId === host.id)
+    }
+
+    /**
+     * @summary Registers auxiliary identity on the Group queue without admitting a nested write.
+     * Its captured name survives view replacement; it is not a workspace document or persisted wire.
+     * @returns {Promise<void>}
+     */
+    attachGroup() {
+        const host    = this.workspace, manager = host.workspaceSet?.manager ?? host.transactionManager ?? Neo.manager?.Transaction,
+              groupId = host.topologyGroupId;
+        if (this.#manager === manager && this.#groupId === groupId && this.#registration) return this.#registration;
+        this.#directName = this.committedName;
+        this.#entry = null;
+        this.#manager = manager;
+        this.#groupId = groupId;
+        if (!groupId || !manager) return Promise.resolve();
+        const group = manager.get(groupId), key = this.workspaceKey(), identityKey = this.identityKey();
+        if (!group || !key) return Promise.reject(new Error('dock participant not registered'));
+        this.#registration = manager.enqueue(group, () => {
+            if (this.isDestroyed || host.isDestroyed) throw new Error('perspective workspace destroyed');
+            let entry = manager.getParticipant(groupId, identityKey);
+            if (entry && entry.perspectiveSelection !== true) throw new Error('perspective participant key already in use');
+            if (!entry) {
+                const state = {value: Object.freeze({name: this.#directName}), revision: 0},
+                      names = new Set(this.#documents.keys());
+                entry = {
+                    domain : 'dock', perspectiveSelection: true,
+                    capture: () => ({value: state.value, revision: state.revision,
+                        generation: manager.getBinding(groupId, key)?.generation ?? 0}),
+                    prepare: value => {
+                        if (!value || !names.has(value.name)) throw new Error('unknown declared perspective');
+                        return {name: value.name}
+                    },
+                    adopt     : value => {state.value = value; state.revision++},
+                    compensate: captured => {state.value = captured.value; state.revision = captured.revision}
+                };
+                if (!manager.registerParticipant({groupId, workspaceKey: identityKey, participant: entry})) {
+                    throw new Error('perspective participant could not register')
+                }
+            }
+            this.#entry = entry
+        }).catch(error => {
+            this.#registration = null;
+            throw error
+        });
+        return this.#registration
+    }
+
+    /** @summary Names this document's auxiliary identity slot. @returns {String} */
+    identityKey() { return `$perspective:${this.workspaceKey()}` }
+
+    /** @summary Reads selection metadata only for this participant. @param {Object} context @returns {String|null} */
+    identity(context) {
+        const replay = context.cursorAction === 'undo' || context.cursorAction === 'redo',
+              entry  = replay ? context.replayRow ?? context.row : context.descriptor,
+              name   = context.cursorAction === 'undo' ? entry?.before : entry?.after;
+        return entry?.operation === 'restorePerspective' && entry.workspaceKey === this.workspaceKey() && this.#documents.has(name)
+            ? name : null
+    }
+
+    /** @summary Public synchronization preserves Effects and two-way bindings. @param {String} name */
+    sync(name) {
+        if (this.isDestroyed || this.workspace.isDestroyed) return;
+        this.#sync = true;
+        try { this.workspace.activePerspective = name } finally { this.#sync = false }
+    }
+
+    /** @summary Projects carried identity without overwriting a newer pending request. @param {Object} context */
+    project(context) {
+        const name = this.identity(context);
+        if (name === null) return;
+        this.publishedName = name;
+        if (this.pendingName === null || this.pendingName === name) this.sync(name)
+    }
+
+    /**
+     * @summary Restores a captured document; foreign-owned panes refuse before any adoption.
+     * The callback captures the before-name inside the existing Group queue. It admits no write itself.
+     * @param {String} name
+     * @returns {Promise<{document:Object,errors:String[]}>}
+     */
+    restore(name = this.committedName) {
+        const host = this.workspace, document = this.document(name), serial = ++this.#serial;
+        this.pendingName = name;
+        let pending;
+        try {
+            if (!document) throw new Error(`unknown declared perspective "${name}"`);
+            const key = this.workspaceKey(), set = host.workspaceSet;
+            if (set && host.topologyGroupId) {
+                if (!key) throw new Error('dock participant not registered');
+                pending = this.attachGroup().then(() => this.#manager.write({
+                    groupId: host.topologyGroupId,
+                    cause  : 'perspective',
+                    changes: [{workspaceKey: key, input: document},
+                        {workspaceKey: this.identityKey(), input: {name}}],
+                    descriptor       : {operation: 'restorePerspective', workspaceKey: key, after: name},
+                    prepareDescriptor: ({descriptor}) => {
+                        if (this.isDestroyed || host.isDestroyed) throw new Error('perspective workspace destroyed');
+                        for (const sibling of set.ids().filter(id => id !== key)) {
+                            if (Object.keys(set.getDocument(sibling)?.items ?? {}).some(id => Object.hasOwn(document.items, id))) {
+                                throw new Error(`perspective restore would duplicate a pane owned by "${sibling}"`)
+                            }
+                        }
+                        return {...descriptor, before: this.committedName}
+                    }
+                }))
+            } else {
+                pending = host.onDockZoneDocumentChange(document, {
+                    operation: 'restorePerspective', workspaceKey: key,
+                    before   : this.committedName, after: name
+                }, host);
+                this.#directName = name
+            }
+        } catch (error) { pending = Promise.reject(error) }
+        this.pending = Promise.resolve(pending).then(() => {
+            if (!this.isDestroyed && !host.isDestroyed && serial === this.#serial) {
+                this.pendingName = null;
+                this.sync(this.committedName)
+            }
+            return {document: host.dockModel, errors: []}
+        }, error => {
+            if (!this.isDestroyed && !host.isDestroyed && serial === this.#serial) {
+                this.pendingName = null;
+                this.sync(this.committedName)
+            }
+            return {document: host.dockModel, errors: [error.message]}
+        });
+        return this.pending
+    }
+
+    /** @summary Releases the view's reference; the Group retains its identity participant. @param {...*} args */
+    destroy(...args) {
+        super.destroy(...args)
+    }
+}
+
+export default Neo.setupClass(PerspectiveSelection);

--- a/src/dashboard/dock/interaction/PerspectiveSelection.mjs
+++ b/src/dashboard/dock/interaction/PerspectiveSelection.mjs
@@ -32,6 +32,8 @@ class PerspectiveSelection extends Base {
     #serial = 0
     /** @member {Boolean} #sync=false Suppresses restoration during public synchronization. @private */
     #sync = false
+    /** @member {Boolean} #rejected=false Marks enum compensation rather than accepted intent. @private */
+    #rejected = false
     /** @member {Object|null} #manager=null Borrowed Group authority. @private */
     #manager = null
     /** @member {String|null} #groupId=null Observed Group. @private */
@@ -79,14 +81,18 @@ class PerspectiveSelection extends Base {
 
     /** @summary Refuses unknown names against the captured set. @param {String} value @returns {String} */
     accept(value) {
+        this.#rejected = false;
         if (this.#documents.has(value)) return value;
+        this.#rejected = true;
         console.error('Supported values for activePerspective are:', ...this.#documents.keys());
         return this.committedName
     }
 
     /** @summary A config write admits intent unless it is synchronization from accepted truth. @param {String} value */
     onIntent(value) {
-        if (!this.#sync && value !== this.committedName) this.restore(value)
+        const rejected = this.#rejected;
+        this.#rejected = false;
+        if (!this.#sync && !rejected) this.restore(value)
     }
 
     /** @summary Resolves the host's document participant without owning a registry. @returns {String|undefined} */

--- a/src/dashboard/dock/model/Authoring.mjs
+++ b/src/dashboard/dock/model/Authoring.mjs
@@ -14,6 +14,9 @@ import WorkspaceDocument from './WorkspaceDocument.mjs';
  * input that omitted a title. No component construction or host lifecycle lives here.
  */
 class Authoring extends Base {
+    /** @member {String} defaultPerspectiveName='$default' Name of a zones-only declaration. @static */
+    static defaultPerspectiveName = '$default'
+
     /**
      * Valid values for a split node's orientation.
      * @member {String[]} orientations=['horizontal','vertical']

--- a/src/dashboard/dock/window/WorkspaceSet.mjs
+++ b/src/dashboard/dock/window/WorkspaceSet.mjs
@@ -218,7 +218,8 @@ class WorkspaceSet extends Base {
      * @summary Registers-or-replaces one workspace participant in the host's Group. Replacement is
      * deliberate: a re-embodied vessel re-registers the SAME stable workspace id with fresh
      * accessor seams, and the stale seams must not survive it. Refused while the host has no
-     * Group — there is no membership to join yet.
+     * Group — there is no membership to join yet. A declaring owner's selection attaches on the
+     * Group queue; its pending promise includes synchronization of retained identity.
      * @param {String} workspaceId Stable semantic identity — never a `windowId`.
      * @param {Object} seams
      * @param {Function} seams.getDocument `()` → the workspace's current committed document.
@@ -315,11 +316,13 @@ class WorkspaceSet extends Base {
         if (componentId !== undefined) entry.componentId = componentId;
         if (typeof dispose === 'function') entry.dispose = dispose;
 
-        return manager.registerParticipant({
+        const registered = manager.registerParticipant({
             groupId     : id,
             participant : entry,
             workspaceKey: workspaceId
-        })
+        });
+        if (registered && componentId) Neo.get(componentId)?.perspectiveSelection?.connect();
+        return registered
     }
 
     /**

--- a/src/manager/Transaction.mjs
+++ b/src/manager/Transaction.mjs
@@ -696,6 +696,8 @@ class Transaction extends Manager {
      * @param {String} request.cause Explicit reason for this write, separate from cursorAction.
      * @param {Object} [request.provenance={}] Plain origin metadata.
      * @param {Object} [request.descriptor={}] Plain transaction metadata.
+     * @param {Function} [request.prepareDescriptor] Pure synchronous `({descriptor, snapshot})` metadata resolver
+     *     at the Group queue head. Must not mutate participants or enqueue another write.
      * @param {Object[]} [request.changes=[]] Unique {workspaceKey, input} entries.
      * @param {String} [request.cursorAction='append'] append, preserve, undo or redo.
      * @param {Object[]} [request.effects=[]] {effectId, run} callbacks, invoked after semantic commit.
@@ -711,6 +713,9 @@ class Transaction extends Manager {
         }
 
         try {
+            if (request.prepareDescriptor !== undefined && typeof request.prepareDescriptor !== 'function') {
+                throw new TypeError('prepareDescriptor must be a function')
+            }
             request = Object.freeze({
                 ...request,
                 changes   : Commit.copy(request.changes ?? []),

--- a/src/manager/transaction/Commit.mjs
+++ b/src/manager/transaction/Commit.mjs
@@ -68,7 +68,6 @@ class Commit extends Base {
         const {
             cause,
             cursorAction = 'append',
-            descriptor = {},
             provenance = {},
             effects = []
         } = request;
@@ -83,7 +82,18 @@ class Commit extends Base {
         if ((cursorAction === 'undo' || cursorAction === 'redo') && !priorRow) {
             return {row: null, snapshot: group.snapshot ?? null, transactionId, participants: [], notificationErrors: [], plans: [], effects: []}
         }
-        const changes = priorRow
+        const resolvedDescriptor = request.prepareDescriptor
+            ? request.prepareDescriptor({descriptor: request.descriptor, snapshot: group.snapshot})
+            : request.descriptor ?? {};
+        if (typeof resolvedDescriptor?.then === 'function') {
+            Promise.resolve(resolvedDescriptor).catch(() => {});
+            throw new TypeError('a descriptor resolver must synchronously return plain metadata')
+        }
+        if (!resolvedDescriptor || typeof resolvedDescriptor !== 'object' || Array.isArray(resolvedDescriptor)) {
+            throw new TypeError('a descriptor resolver must synchronously return plain metadata')
+        }
+        const descriptor = this.copy(resolvedDescriptor);
+        const changes    = priorRow
             ? priorRow.participants.map(entry => ({workspaceKey: entry.workspaceKey, input: entry[cursorAction === 'undo' ? 'before' : 'after']}))
             : request.changes ?? [];
         if (!Array.isArray(changes) || !Array.isArray(effects)) throw new TypeError('changes and effects must be arrays');
@@ -107,10 +117,10 @@ class Commit extends Base {
         if (changes.some(change => ['adopt', 'compensate'].some(key =>
             Object.prototype.toString.call(byKey.get(change.workspaceKey)[key]) === '[object AsyncFunction]'
         ))) throw new TypeError('participant adoption and compensation must be synchronous');
-        const captures = new Map(members.map(([key, entry]) => [key, this.capture(entry)]));
+        const captures     = new Map(members.map(([key, entry]) => [key, this.capture(entry)]));
         const valuesBefore = Object.freeze(Object.fromEntries([...captures].map(([key, capture]) => [key, capture.value])));
-        const metadata = this.copy({cause, provenance, descriptor});
-        const plans    = [];
+        const metadata     = this.copy({cause, provenance, descriptor, ...(priorRow ? {replayRow: priorRow} : {})});
+        const plans        = [];
         for (const change of [...changes].sort((a, b) => a.workspaceKey.localeCompare(b.workspaceKey))) {
             const participant = byKey.get(change.workspaceKey), captured = captures.get(change.workspaceKey);
             const context     = Object.freeze({transactionId, cursorAction, ...metadata, workspaceKey: change.workspaceKey, captured, valuesBefore});

--- a/src/manager/transaction/Commit.mjs
+++ b/src/manager/transaction/Commit.mjs
@@ -58,6 +58,7 @@ class Commit extends Base {
     /**
      * @summary Runs at the Group queue head; no awaited work occurs inside adoption/rollback.
      * Transaction id, cause, provenance and participant endpoints override descriptor fields in the retained row.
+     * Replay projection contexts carry the frozen source row as replayRow, independently of new request metadata.
      * @param {Neo.manager.Transaction} manager
      * @param {Object} group
      * @param {Object} request

--- a/test/playwright/unit/dashboard/DockPerspectiveSelection.spec.mjs
+++ b/test/playwright/unit/dashboard/DockPerspectiveSelection.spec.mjs
@@ -342,3 +342,15 @@ test('a host without declarations refuses a runtime selection rather than silent
         expect(errors).toHaveLength(1);
     } finally {console.error = original; workspace.destroy()}
 });
+
+test('a newer intent returning to the committed name supersedes a pending switch', async () => {
+    const f = fixture({group: true}), {workspace, groupId} = f;
+    try {
+        workspace.activePerspective = 'review';
+        workspace.activePerspective = 'operator';
+        await f.settle();
+        expect(workspace.activePerspective).toBe('operator');
+        expect(workspace.stateProvider.getData('chosen')).toBe('operator');
+        expect(Transaction.get(groupId).history.current).toMatchObject({before: 'review', after: 'operator'});
+    } finally {f.destroy()}
+});

--- a/test/playwright/unit/dashboard/DockPerspectiveSelection.spec.mjs
+++ b/test/playwright/unit/dashboard/DockPerspectiveSelection.spec.mjs
@@ -302,6 +302,99 @@ test('accepted identity works without retained history and remains outside docum
     } finally {f.destroy()}
 });
 
+class ConstructedPerspectiveWorkspace extends Workspace {
+    static config = {
+        className   : 'Test.Unit.Dashboard.ConstructedPerspectiveWorkspace',
+        workspaceSet: null,
+        workspaceKey: 'main'
+    }
+
+    /** @summary Exercises the host registration seam before declaration capture. */
+    onConstructed(...args) {
+        super.onConstructed(...args);
+        this.workspaceSet.register(this.workspaceKey, {
+            componentId: this.id, getDocument: () => this.dockModel,
+            setDocument: value => this.dockModel = value,
+            project    : context => this.projectDockCommit(context)
+        })
+    }
+}
+Neo.setupClass(ConstructedPerspectiveWorkspace);
+
+for (const early of [true, false]) for (const retainsName of [true, false]) {
+    test(`a replacement owner registered ${early ? 'during' : 'after'} construction ${retainsName ? 'retains a declared identity' : 'uses its baseline for an undeclared identity'} and accepts new names`, async () => {
+        const f = fixture({group: true}), {workspace, groupId, set} = f;
+        let second;
+        try {
+            workspace.activePerspective = 'review';
+            await f.settle();
+            const identity = Transaction.getParticipant(groupId, '$perspective:main'),
+                  windowId = workspace.windowId, document = Document.clone(workspace.dockModel);
+            workspace.destroy();
+            second = Neo.create(early ? ConstructedPerspectiveWorkspace : Workspace, {
+                windowId, dockModel: document, enableDockMaximizeAction: false,
+                ...(early ? {workspaceSet: set} : {}),
+                panes       : {editor: {ntype: 'component'}, preview: {ntype: 'component'}},
+                perspectives: {
+                    operator: {center: ['editor', 'preview']},
+                    ...(retainsName ? {review: {center: ['editor', 'preview']}} : {}),
+                    extra: {center: ['editor', 'preview']}
+                },
+                activePerspective: 'operator',
+                stateProvider    : {data: {chosen: 'operator'}},
+                bind             : {activePerspective: {key: 'chosen', twoWay: true}}
+            });
+            if (!early) {
+                second.workspaceKey = 'main';
+                second.workspaceSet = set;
+                expect(set.register('main', {
+                    componentId: second.id, getDocument: () => second.dockModel,
+                    setDocument: value => second.dockModel = value,
+                    project    : context => second.projectDockCommit(context)
+                })).toBe(true)
+            }
+            await second.perspectiveSelection.pending;
+            const baseline = retainsName ? 'review' : 'operator';
+            expect.soft(second.perspectiveSelection.committedName).toBe(baseline);
+            expect.soft(second.activePerspective).toBe(baseline);
+            expect.soft(second.stateProvider.getData('chosen')).toBe(baseline);
+            expect(Transaction.getParticipant(groupId, '$perspective:main')).toBe(identity);
+            expect(second.dockModel).toEqual(document);
+            expect(Transaction.get(groupId).history.count).toBe(1);
+
+            second.activePerspective = 'extra';
+            expect((await second.perspectiveSelection.pending).errors).toEqual([]);
+            expect(second.activePerspective).toBe('extra');
+            expect(identity.capture().value.name).toBe('extra');
+            expect(Transaction.get(groupId).history.current).toMatchObject({before: baseline, after: 'extra'});
+            await Transaction.undo({groupId});
+            expect(second.activePerspective).toBe(baseline);
+            expect(second.perspectiveSelection.committedName).toBe(baseline);
+        } finally {second?.destroy(); f.destroy()}
+    });
+}
+
+for (const attached of [false, true]) test(`a replaced owner cannot ${attached ? 'write through its successor' : 'attach late'}`, async () => {
+    const f               = fixture({group: true}), {workspace, set, groupId} = f,
+          firstAttachment = workspace.perspectiveSelection.pending;
+    if (attached) expect((await firstAttachment).errors).toEqual([]);
+    const second = Neo.create(ConstructedPerspectiveWorkspace, {
+              windowId                : workspace.windowId, workspaceSet: set,
+              enableDockMaximizeAction: false,
+              panes                   : {editor: {ntype: 'component'}},
+              perspectives            : {operator: {center: 'editor'}, extra: {center: 'editor'}}
+          });
+    try {
+        if (!attached) expect((await firstAttachment).errors).toEqual(['perspective workspace replaced']);
+        expect((await second.perspectiveSelection.pending).errors).toEqual([]);
+        const document = Document.clone(second.dockModel);
+        expect((await workspace.perspectiveSelection.restore('review')).errors).toEqual(['perspective workspace replaced']);
+        expect(second.dockModel).toEqual(document);
+        expect(second.activePerspective).toBe('operator');
+        expect(Transaction.get(groupId).history).toBeNull();
+    } finally {second.destroy(); f.destroy()}
+});
+
 test('public selection events and two-way synchronization occur once per effective name', async () => {
     const f = fixture({group: true}), {workspace, groupId} = f, events = [];
     workspace.on('activePerspectiveChange', ({value}) => events.push(value));

--- a/test/playwright/unit/dashboard/DockPerspectiveSelection.spec.mjs
+++ b/test/playwright/unit/dashboard/DockPerspectiveSelection.spec.mjs
@@ -1,0 +1,344 @@
+import {setup}        from '../../setup.mjs';
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../src/Neo.mjs';
+import * as core      from '../../../../src/core/_export.mjs';
+import '../../../../src/manager/Instance.mjs';
+import '../../../../src/tab/Container.mjs';
+import Workspace    from '../../../../src/dashboard/dock/Workspace.mjs';
+import WorkspaceSet from '../../../../src/dashboard/dock/window/WorkspaceSet.mjs';
+import Document     from '../../../../src/dashboard/dock/model/WorkspaceDocument.mjs';
+import Transaction  from '../../../../src/manager/Transaction.mjs';
+import Provider     from '../../../../src/state/Provider.mjs';
+import Persistence  from '../../../../src/dashboard/dock/model/Persistence.mjs';
+import Placement    from '../../../../src/dashboard/dock/window/Placement.mjs';
+
+setup({appConfig: {name: 'DockPerspectiveSelectionTest'}});
+
+/** @summary Creates a real declarative workspace and optionally registers it in a Group. */
+function fixture({group = false, depth = 5, active = 'operator', perspectives, stateProvider} = {}) {
+    const windowId  = `perspective-${Neo.getId('test')}`,
+          binding   = group && Transaction.bind({windowId, workspaceKey: 'main'}),
+          workspace = Neo.create(Workspace, {
+              windowId,
+              enableDockMaximizeAction: false,
+              panes                   : {editor: {ntype: 'component'}, preview: {ntype: 'component'}},
+              perspectives            : perspectives ?? {
+                  operator: {center: ['editor', 'preview']},
+                  review  : {center: ['editor', 'preview']},
+                  triage  : {center: ['editor', 'preview']}
+              },
+              activePerspective: active,
+              stateProvider    : stateProvider ?? {data: {chosen: active}},
+              bind             : {activePerspective: {key: 'chosen', twoWay: true}}
+          }),
+          set = group && Neo.create(WorkspaceSet, {
+              manager: Transaction, getGroupId: () => binding.groupId, documentModel: Document
+          });
+
+    if (group) {
+        Transaction.setHistoryDepth({groupId: binding.groupId, depth});
+        workspace.workspaceKey = 'main';
+        workspace.workspaceSet = set;
+        set.register('main', {
+            componentId: workspace.id,
+            getDocument: () => workspace.dockModel,
+            setDocument: value => workspace.dockModel = value,
+            project    : context => workspace.projectDockCommit(context)
+        });
+    }
+
+    return {workspace, set, groupId: binding?.groupId,
+        async settle() {await workspace.perspectiveSelection?.pending; await workspace.refreshPromise},
+        destroy() {
+            set && set.destroy();
+            if (!workspace.isDestroyed) workspace.destroy();
+            binding && Transaction.retireGroup(binding.groupId)
+        }}
+}
+
+test('a construction binding chooses the initial declaration and runtime writes select once', async () => {
+    const f = fixture({active: 'review', perspectives: {
+        operator: {center: 'editor'}, review: {center: 'preview'}
+    }}), {workspace} = f;
+    try {
+        expect(Document.findContainingTabsId(workspace.dockModel, 'preview')).toBeTruthy();
+        expect(Document.findContainingTabsId(workspace.dockModel, 'editor')).toBeNull();
+        workspace.stateProvider.setData('chosen', 'operator');
+        await f.settle();
+        expect(workspace.activePerspective).toBe('operator');
+        expect(Document.findContainingTabsId(workspace.dockModel, 'editor')).toBeTruthy();
+    } finally {f.destroy()}
+});
+
+/** @summary A deterministic gate for a participant's asynchronous preparation. @returns {Object} */
+function gate() {
+    let resolve;
+    const promise = new Promise(done => resolve = done);
+    return {promise, resolve}
+}
+
+test('F1: an older refusal leaves the newer accepted intent intact', async () => {
+    const f           = fixture({group: true}), {workspace, groupId} = f,
+          entered     = gate(), release = gate(),
+          participant = Transaction.getParticipant(groupId, 'main'), prepare = participant.prepare;
+    let first = true;
+    participant.prepare = async (...args) => {
+        if (first) {
+            first = false;
+            entered.resolve();
+            await release.promise;
+            throw new Error('first selection refused')
+        }
+        return prepare(...args)
+    };
+    try {
+        workspace.activePerspective = 'review';
+        await entered.promise;
+        workspace.activePerspective = 'triage';
+        expect(workspace.activePerspective).toBe('triage');
+        expect(workspace.perspectiveSelection.publishedName).toBe('operator');
+        expect(workspace.perspectiveSelection.pendingName).toBe('triage');
+        release.resolve();
+        await f.settle();
+        expect(workspace.activePerspective).toBe('triage');
+        expect(workspace.stateProvider.getData('chosen')).toBe('triage');
+        expect(Transaction.get(groupId).history.current).toMatchObject({before: 'operator', after: 'triage'});
+        expect(Transaction.get(groupId).history.count).toBe(1);
+    } finally {release.resolve(); f.destroy()}
+});
+
+test('F1: committed projection reads its carried name while a newer prepare is held', async () => {
+    const f           = fixture({group: true}), {workspace, groupId} = f,
+          entered     = gate(), release = gate(), projected = gate(),
+          participant = Transaction.getParticipant(groupId, 'main'), prepare = participant.prepare,
+          project     = workspace.projectDockCommit.bind(workspace);
+    let count = 0;
+    participant.prepare = async (...args) => {
+        if (++count === 2) {entered.resolve(); await release.promise}
+        return prepare(...args)
+    };
+    workspace.projectDockCommit = context => {
+        const result = project(context);
+        if (context.descriptor.after === 'review') projected.resolve();
+        return result
+    };
+    try {
+        workspace.activePerspective = 'review';
+        workspace.activePerspective = 'triage';
+        await entered.promise;
+        await projected.promise;
+        expect(workspace.perspectiveSelection.committedName).toBe('review');
+        expect(workspace.perspectiveSelection.publishedName).toBe('review');
+        expect(workspace.activePerspective).toBe('triage');
+        expect(workspace.perspectiveSelection.pendingName).toBe('triage');
+        release.resolve();
+        await f.settle();
+        expect(workspace.perspectiveSelection.publishedName).toBe('triage');
+    } finally {release.resolve(); f.destroy()}
+});
+
+test('unknown names are refused and captured declarations survive later mutations', async () => {
+    const f      = fixture({group: true}), {workspace, groupId} = f,
+          errors = [], originalError = console.error;
+    console.error = (...args) => errors.push(args);
+    try {
+        workspace.activePerspective = 'missing';
+        expect(workspace.activePerspective).toBe('operator');
+        expect(errors).toHaveLength(1);
+        expect(Transaction.get(groupId).history).toBeNull();
+        delete workspace.perspectives.review;
+        workspace.perspectives.operator.center.length = 0;
+        workspace.activePerspective = 'review';
+        await f.settle();
+        expect(workspace.activePerspective).toBe('review');
+        expect(Document.findContainingTabsId(workspace.dockModel, 'editor')).toBeTruthy();
+        expect(errors).toHaveLength(1);
+    } finally {console.error = originalError; f.destroy()}
+});
+
+test('an equal assignment does not reset; the explicit reset restores the captured document', async () => {
+    const f = fixture({group: true}), {workspace, groupId} = f;
+    try {
+        const initial    = Document.clone(workspace.dockModel),
+              descriptor = {operation: 'moveItem', itemId: 'editor', targetNodeId: Document.findContainingTabsId(initial, 'editor'), index: 1},
+              changed    = workspace.applyDockZoneOperation(descriptor);
+        expect(changed.errors).toEqual([]);
+        await workspace.onDockZoneDocumentChange(changed.document, descriptor);
+        await workspace.refreshPromise;
+        expect(workspace.dockModel).not.toEqual(initial);
+        workspace.activePerspective = 'operator';
+        expect(Transaction.get(groupId).history.count).toBe(1);
+        expect((await workspace.resetPerspective()).errors).toEqual([]);
+        await workspace.refreshPromise;
+        expect(workspace.dockModel).toEqual(initial);
+        expect(Transaction.get(groupId).history.count).toBe(2);
+    } finally {f.destroy()}
+});
+
+test('F3: re-parenting the provider switches selection and two-way writes target the new parent', async () => {
+    const first  = Neo.create(Provider, {data: {chosen: 'review'}}),
+          second = Neo.create(Provider, {data: {chosen: 'operator'}}),
+          f      = fixture({stateProvider: {parent: first, data: {}}}), {workspace} = f;
+    try {
+        expect(workspace.activePerspective).toBe('review');
+        workspace.stateProvider.parent = second;
+        await f.settle();
+        expect(workspace.activePerspective).toBe('operator');
+        workspace.activePerspective = 'triage';
+        await f.settle();
+        expect(second.getData('chosen')).toBe('triage');
+        expect(first.getData('chosen')).toBe('review');
+    } finally {f.destroy(); first.destroy(); second.destroy()}
+});
+
+test('F5: destroying a host during preparation settles without a later selection event', async () => {
+    const f           = fixture({group: true}), {workspace, groupId} = f,
+          entered     = gate(), release = gate(), events = [],
+          participant = Transaction.getParticipant(groupId, 'main'), prepare = participant.prepare;
+    participant.prepare = async (...args) => {entered.resolve(); await release.promise; return prepare(...args)};
+    workspace.on('activePerspectiveChange', event => events.push(event.value));
+    try {
+        workspace.activePerspective = 'review';
+        const pending = workspace.perspectiveSelection.pending;
+        await entered.promise;
+        workspace.destroy();
+        const count = events.length;
+        release.resolve();
+        await pending;
+        expect(events).toHaveLength(count);
+    } finally {release.resolve(); f.destroy()}
+});
+
+test('F11: a restore refuses a pane held by a sibling without changing either document', async () => {
+    const f     = fixture({group: true}), {workspace, groupId, set} = f;
+    let   popup = {schema: 'neo.dock.zone.v1', root: 'root', items: {}, nodes: {
+        root        : {type: 'edge-zone', zones: {center: {nodeId: 'popup-tabs'}}},
+        'popup-tabs': {type: 'tabs', items: []}
+    }};
+    set.register('popup', {getDocument: () => popup, setDocument: value => popup = value});
+    try {
+        await set.transfer({operation: 'transferItem', itemId: 'preview', sourceWorkspaceId: 'main',
+            targetWorkspaceId: 'popup', target: {operation: 'addTab', tabsNodeId: 'popup-tabs', index: 0}});
+        await workspace.refreshPromise;
+        const before = Document.clone(workspace.dockModel), popupBefore = Document.clone(popup);
+        workspace.activePerspective = 'review';
+        const result = await workspace.perspectiveSelection.pending;
+        expect(result.errors.join()).toContain('duplicate a pane');
+        expect(workspace.activePerspective).toBe('operator');
+        expect(workspace.stateProvider.getData('chosen')).toBe('operator');
+        expect(workspace.dockModel).toEqual(before);
+        expect(popup).toEqual(popupBefore);
+        expect(Transaction.get(groupId).history.count).toBe(1);
+        expect(Persistence.captureTopologyPerspective({main: workspace.dockModel, popup}, {layoutId: 'refused'}).errors).toEqual([]);
+    } finally {f.destroy()}
+});
+
+test('F10: queued alias selections retain accepted before-names and undo restores the preceding name', async () => {
+    const f = fixture({group: true}), {workspace, groupId} = f;
+    try {
+        const initial = Document.clone(workspace.dockModel);
+        workspace.activePerspective = 'review';
+        workspace.activePerspective = 'triage';
+        await f.settle();
+        const history = Transaction.get(groupId).history;
+        expect(history?.count ?? 0).toBe(2);
+        expect(history.current).toMatchObject({workspaceKey: 'main', before: 'review', after: 'triage'});
+        expect(workspace.dockModel).toEqual(initial);
+        await Transaction.undo({groupId});
+        await workspace.refreshPromise;
+        expect(workspace.activePerspective).toBe('review');
+        expect(workspace.stateProvider.getData('chosen')).toBe('review');
+        await Transaction.redo({groupId});
+        await workspace.refreshPromise;
+        expect(workspace.activePerspective).toBe('triage');
+        expect(workspace.stateProvider.getData('chosen')).toBe('triage');
+        expect(history.count).toBe(2);
+    } finally {f.destroy()}
+});
+
+test('a failing commit observer cannot change an accepted selection or its next before-name', async () => {
+    const f        = fixture({group: true}), {workspace, groupId} = f,
+          observer = () => {throw new Error('observer failed')};
+    Transaction.on({commit: observer});
+    try {
+        workspace.activePerspective = 'review';
+        await f.settle();
+        expect(workspace.activePerspective).toBe('review');
+        workspace.activePerspective = 'triage';
+        await f.settle();
+        expect(Transaction.get(groupId).history.current.before).toBe('review');
+    } finally {Transaction.un({commit: observer}); f.destroy()}
+});
+
+test('adoption failure compensates the identity and document together', async () => {
+    const f                    = fixture({group: true, perspectives: {operator: {center: 'editor'}, review: {center: 'preview'}}}),
+          {workspace, groupId} = f,
+          participant          = Transaction.getParticipant(groupId, 'main'), adopt = participant.adopt,
+          initial              = Document.clone(workspace.dockModel);
+    participant.adopt = (...args) => {adopt(...args); throw new Error('adoption refused')};
+    try {
+        workspace.activePerspective = 'review';
+        const result = await workspace.perspectiveSelection.pending;
+        expect(result.errors).toEqual(['adoption refused']);
+        expect(workspace.dockModel).toEqual(initial);
+        expect(workspace.perspectiveSelection.committedName).toBe('operator');
+        expect(workspace.perspectiveSelection.publishedName).toBe('operator');
+        expect(workspace.activePerspective).toBe('operator');
+        expect(Transaction.get(groupId).history.count).toBe(0);
+    } finally {f.destroy()}
+});
+
+test('accepted identity works without retained history and remains outside document membership', async () => {
+    const f = fixture({group: true, depth: 0}), {workspace, groupId, set} = f;
+    try {
+        workspace.activePerspective = 'review';
+        workspace.activePerspective = 'triage';
+        await f.settle();
+        expect(workspace.activePerspective).toBe('triage');
+        expect(workspace.perspectiveSelection.committedName).toBe('triage');
+        expect(Transaction.get(groupId).history).toBeNull();
+        expect(set.ids()).toEqual(['main']);
+        expect(Persistence.captureTopologyPerspective({main: workspace.dockModel}, {layoutId: 'no-history'}).errors).toEqual([]);
+    } finally {f.destroy()}
+});
+
+test('public selection events and two-way synchronization occur once per effective name', async () => {
+    const f = fixture({group: true}), {workspace, groupId} = f, events = [];
+    workspace.on('activePerspectiveChange', ({value}) => events.push(value));
+    try {
+        workspace.activePerspective = 'review';
+        await f.settle();
+        workspace.activePerspective = 'review';
+        await Transaction.undo({groupId});
+        await workspace.refreshPromise;
+        await Transaction.redo({groupId});
+        await workspace.refreshPromise;
+        expect(events).toEqual(['review', 'operator', 'review']);
+        expect(Transaction.get(groupId).history.count).toBe(1);
+        expect(workspace.items).toHaveLength(1);
+    } finally {f.destroy()}
+});
+
+test('Placement projection ignores selection metadata and the replay envelope', async () => {
+    const observed = [], host = {participantKey: 'placementHints',
+        applyHint: async (key, hint) => observed.push({key, hint})},
+          context = {cursorAction: 'undo', cause: 'history', captured: {value: {popup: {dx: 0, dy: 0}}},
+              snapshot: {participants: {placementHints: {popup: {dx: 20, dy: 30}}}}};
+    await Placement.prototype.project.call(host, context);
+    const control = observed.splice(0);
+    await Placement.prototype.project.call(host, {...context,
+        descriptor: {operation: 'restorePerspective', workspaceKey: 'main', before: 'operator', after: 'review'},
+        replayRow : {operation: 'restorePerspective', workspaceKey: 'main', before: 'operator', after: 'review'}});
+    expect(observed).toEqual(control);
+    expect(observed).toEqual([{key: 'popup', hint: {dx: 20, dy: 30}}]);
+});
+
+test('a host without declarations refuses a runtime selection rather than silently accepting it', () => {
+    const workspace = Neo.create(Workspace, {enableDockMaximizeAction: false}), errors = [], original = console.error;
+    console.error = (...args) => errors.push(args);
+    try {
+        workspace.activePerspective = 'unknown';
+        expect(workspace.activePerspective).toBeNull();
+        expect(errors).toHaveLength(1);
+    } finally {console.error = original; workspace.destroy()}
+});

--- a/test/playwright/unit/manager/TransactionWrite.spec.mjs
+++ b/test/playwright/unit/manager/TransactionWrite.spec.mjs
@@ -232,6 +232,27 @@ test.describe.serial('Neo.manager.Transaction — history admission, the queue a
         expect(provider.getData('historyLength')).toBe(2)
     });
 
+    test('queue-head metadata sees the preceding accepted value and is frozen before preparation', async () => {
+        const {groupId} = Transaction.bind({windowId: 'descriptor-queue'}), state = registerValue(groupId), seen = [];
+        Transaction.setHistoryDepth({groupId, depth: 5});
+        const send = kind => write({groupId, descriptor: {kind},
+            prepareDescriptor: ({descriptor}) => ({...descriptor, before: state.value.kind}),
+            changes          : [{workspaceKey: 'main', input: {kind}}]});
+        const first = send('first'), second = send('second');
+        seen.push(await first, await second);
+        expect(seen.map(result => result.row.before)).toEqual(['initial', 'first']);
+        expect(Object.isFrozen(seen[1].row)).toBe(true);
+    });
+
+    test('a metadata resolver cannot make adoption asynchronous or admit non-JSON metadata', async () => {
+        const {groupId} = Transaction.bind({windowId: 'descriptor-refusal'}), state = registerValue(groupId);
+        for (const prepareDescriptor of [async () => ({}), () => ({callback() {}}), () => {throw new Error('refused')}]) {
+            await expect(write({groupId, prepareDescriptor, changes: [{workspaceKey: 'main', input: {kind: 'bad'}}]})).rejects.toThrow();
+            expect(state.value).toEqual({kind: 'initial'});
+        }
+        await expect(write({groupId, prepareDescriptor: 'not-a-function'})).rejects.toThrow('prepareDescriptor');
+    });
+
     test('a descriptor that cannot become immutable data is refused before participant adoption', async () => {
         Transaction.historyDepth = 5;
 


### PR DESCRIPTION
Resolves #18607

Refs #18605

A Workspace can declare named `perspectives`, select through the reactive `activePerspective_` config, and explicitly reset its committed baseline. Construction bindings choose the initial arrangement; runtime bindings, public events and two-way synchronization preserve intent while Group writes are pending. Alias names survive undo/redo even when their documents are identical.

The selection owner lives in `interaction/PerspectiveSelection.mjs`. Under a Group, a small auxiliary identity participant changes atomically with the document: a failing observer or compensated adoption cannot corrupt the next selection's before-name. A pure queue-head descriptor resolver supplies the retained before/after metadata, and replay contexts carry the immutable source row. Standalone workspaces import no Group module through this owner. A restore that would duplicate a sibling-owned pane is refused before adoption; both documents and native ownership remain intact.

Evidence: L2 (real Workspace, Provider, Group and WorkspaceSet in the single-thread unit runtime; real document projection, controlled platform seams) → L2 required for this selection/transport leaf. Provider publication belongs to #18608; snapshot-origin storage to #18609; rendered consumer receipts to #18610–#18612. This PR tests the identity observed at the owner's projection boundary and does not claim those later provider/UI surfaces are delivered.

size-guard-growth: src/dashboard/dock/Workspace.mjs — 1106 → 1140 code lines expose the selection config and order capture, attachment, projection and teardown. The stateful implementation is in its own owner. This is the engine capability leaf; consumer deletions remain #18610–#18612.

## AC Evidence

| AC | Evidence |
|---|---|
| F1: held prepare and supersession | `DockPerspectiveSelection.spec.mjs`: an older refusal preserves newer intent; a held second prepare exposes the first committed name; returning to the committed name supersedes a pending switch |
| F2: alias-name undo/redo | Same spec: identical documents, two accepted names, public config and two-way source restored without a second restore |
| F10: queued before-name | Same spec: operator → review → triage records triage's before-name as review; undo returns review |
| F3: provider topology | Real provider re-parent switches selection; later two-way writes reach the new parent |
| F5: destruction | Held prepare released after host destruction emits no later selection event and settles without an unhandled rejection |
| F11: sibling-owned pane | Real transfer precedes restore; refusal leaves both documents unchanged, no extra history row, valid topology capture |
| Unknown name and equal assignment | Unknown values are refused; captured declarations survive later mutation; equal assignment creates no write, explicit reset restores the baseline |
| Placement | Actual `Placement.project` makes the same geometry decision with and without selection/replay metadata |
| Committed regression coverage | Dedicated dashboard spec covers the former scratch cases; auxiliary identity is excluded from document membership, works without history, and compensates with the document. Replacement owners retain declared identity or use their initialized baseline, accept their own captured names, and fence stale owners; both registration timings and undo are covered |
| Review / close target | One cross-family primary will be requested at CI green; this PR closes the leaf only |

## Deltas from ticket

- The illustrative reducer route was corrected during intake: `restorePerspective` is document-write metadata, not a reducer operation.
- Committed identity is an auxiliary participant (`$perspective:<workspaceKey>`, value `{name}`, no `getDocument`). It uses the existing capture/prepare/adopt/compensate protocol in the same write as the document. A commit-observer implementation failed the injected-observer test and was removed.
- `Transaction.write` accepts optional `prepareDescriptor({descriptor, snapshot})`: synchronous, pure metadata resolution at queue head; absent means the existing static descriptor path. Non-JSON or asynchronous results refuse before adoption. `project(context).replayRow` is present on undo/redo and absent on ordinary writes. Neither changes the commit-event payload.
- The shared zones-only name is `Authoring.defaultPerspectiveName = '$default'`; persisted-name enforcement stays with #18609.
- A private synchronization guard distinguishes replay/refusal synchronization from a newer valid intent that happens to equal the committed baseline. The latter must still supersede a pending switch.
- No provider namespace or modification predicate is introduced here. #18608 consumes the owner's committed/projected/request state.

## Test Evidence

Two mutations were applied to committed code and restored before the final run:

| Mutation | Result |
|---|---|
| Read the original standalone name instead of Group-owned accepted identity for before-name | F10 fails: before operator instead of review |
| Remove `replayRow` transport | F10 fails on undo: triage instead of review |

Red-first checks also caught the missing construction selection, missing history rows, observer-dependent identity, and a newer return-to-baseline intent being ignored. These are unit-runtime receipts; no native-window outcome is inferred from them.

`agent-preflight` is not hosted in this checkout (verified missing script); change class is **capability**. Repository staged checks, generated hierarchy and size guard were run; hosted baseline jobs will validate the handoff.

## Signal Ledger

Source Discussion #18594, fold 8 at `DC_kwDODSospM4BGPTF`:

- Claude: AUTHOR_SIGNAL by Mnemosyne at that anchor.
- GPT: APPROVED by Euclid (`DC_kwDODSospM4BGPTh`) and Emmy (`DC_kwDODSospM4BGPTz`).
- The current PR author is GPT; its formal reviewer must be from another family.

## Unresolved Dissent

None at graduation. The source deferrals were resolved at `DC_kwDODSospM4BGPR-`, `DC_kwDODSospM4BGPTh` and `DC_kwDODSospM4BGPTz`. The implementation choices above are explicit review surfaces.

## Unresolved Liveness

The source record retains benched Gemini/Kimi and active, no-signal `unknown` (@neo-preview) as liveness entries, not consent. No additional approval floor is inferred.

## Post-Merge Validation

- #18608 wires the provider leaves to these selection boundaries.
- #18609 enforces the reserved name and stores accepted-write origin metadata.
- Consumer leaves exercise the selected foreign-pane refusal policy in their rendered applications.

Authored by Emmy (GPT-6 Astra, Codex). Session 4212db71-578a-43de-9a2a-36ac3eb6cb17.
Design provenance: Mnemosyne (Claude Fable 5.1, Claude Code), D#18594 and #18607, session c42870ab-3721-40f0-a1f8-f385786ffc3c.
