### PR TITLE
feat(dock): perspective names come from the declared list, and a snapshot carries its origin (#18609)

### DIFF
--- a/buildScripts/util/file-size-baseline.json
+++ b/buildScripts/util/file-size-baseline.json
@@ -1,6 +1,6 @@
 {
     "apps/workstation/view/Workspace.mjs": 1345,
     "examples/dashboard/crossWindow/DemoBWorkspace.mjs": 2546,
-    "src/dashboard/dock/Workspace.mjs": 1146,
+    "src/dashboard/dock/Workspace.mjs": 1155,
     "src/main/addon/DragDrop.mjs": 1267
 }

--- a/src/ai/client/DockService.mjs
+++ b/src/ai/client/DockService.mjs
@@ -283,7 +283,9 @@ class DockService extends Service {
         const holder   = this.resolveHolder(componentId),
               metadata = {
                   layoutId,
-                  metadata: {source: 'neural-link-capture'},
+                  // the declared origin rides the accepted-write identity, so a capture taken
+                  // before a projection still names the perspective it was taken under
+                  metadata: {source: 'neural-link-capture', ...holder.perspectiveProvenance?.()},
                   // the wrapper requires a display title; a capture must not refuse over a
                   // missing label — the name (or id) is the honest default
                   title   : title ?? perspectiveName ?? layoutId,

--- a/src/dashboard/dock/Workspace.mjs
+++ b/src/dashboard/dock/Workspace.mjs
@@ -546,6 +546,35 @@ class Workspace extends Container {
     }
 
     /**
+     * @summary The declared perspective names: what a saved record may equal but never take. The
+     * persistence libraries take this through their `declaredPerspectives` wiring.
+     * @returns {String[]} Empty when nothing is declared.
+     */
+    declaredPerspectives() {
+        return this.perspectiveSelection?.names ?? []
+    }
+
+    /**
+     * @summary The origin a captured snapshot carries: the accepted-write identity, never a published
+     * leaf, so an auto-save that captures before projection still records the right name.
+     * @returns {Object} `{declaredPerspective}`, or an empty object when nothing is declared.
+     */
+    perspectiveProvenance() {
+        return this.perspectiveSelection?.provenance() ?? {}
+    }
+
+    /**
+     * @summary The identity change a Group write adopts beside a restored snapshot's document, or null
+     * when the snapshot carries no origin this workspace declares — the selection then retains its
+     * last committed or initialized declared baseline.
+     * @param {Object|null} metadata The snapshot's `metadata`
+     * @returns {{workspaceKey: String, input: {name: String}}|null}
+     */
+    perspectiveOriginChange(metadata) {
+        return this.perspectiveSelection?.originChange(metadata) ?? null
+    }
+
+    /**
      * @summary Initializes dock-owned services and arms geometry only when already window-bound.
      * @param {Object} config
      */

--- a/src/dashboard/dock/interaction/PerspectiveSelection.mjs
+++ b/src/dashboard/dock/interaction/PerspectiveSelection.mjs
@@ -49,6 +49,30 @@ class PerspectiveSelection extends Base {
     /** @summary Reads semantic identity independently of observer delivery. @member {String|null} committedName */
     get committedName() { return this.#entry?.capture().value.name ?? this.#directName }
 
+    /** @summary The declared names: what a saved record may equal but never take. @member {String[]} names */
+    get names() { return [...this.#documents.keys()] }
+
+    /**
+     * @summary The origin a snapshot carries: the accepted-write identity, never a published leaf.
+     * An auto-save captures before projection, and the identity participant adopts with the document.
+     * @returns {{declaredPerspective: String}}
+     */
+    provenance() { return {declaredPerspective: this.committedName} }
+
+    /**
+     * @summary The identity change a Group write adopts beside a restored snapshot's document: its
+     * declared origin when this workspace declares it, else nothing — an originless snapshot, or one
+     * captured under a name this workspace does not declare, retains the last committed or
+     * initialized declared baseline.
+     * @param {Object|null} metadata The snapshot's `metadata`
+     * @returns {{workspaceKey: String, input: {name: String}}|null}
+     */
+    originChange(metadata) {
+        const name = metadata?.declaredPerspective;
+
+        return this.#documents.has(name) ? {workspaceKey: this.identityKey(), input: {name}} : null
+    }
+
     /** @summary Captures declarations after the host's complete construction chain. @returns {Object} Initial zones. */
     capture() {
         const host     = this.workspace, supplied = host.dockModel !== null,
@@ -172,8 +196,11 @@ class PerspectiveSelection extends Base {
         const replay = context.cursorAction === 'undo' || context.cursorAction === 'redo',
               entry  = replay ? context.replayRow ?? context.row : context.descriptor,
               name   = context.cursorAction === 'undo' ? entry?.before : entry?.after;
-        return entry?.operation === 'restorePerspective' && entry.workspaceKey === this.workspaceKey() && this.#documents.has(name)
-            ? name : null
+        if (entry?.operation === 'restorePerspective' && entry.workspaceKey === this.workspaceKey() && this.#documents.has(name)) return name;
+        // A snapshot restore carries its declared origin in the descriptor. Under a Group the identity
+        // participant adopted that origin with the document, so committedName already reads it.
+        const origin = replay ? undefined : context.descriptor?.declaredPerspective;
+        return this.#documents.has(origin) ? origin : null
     }
 
     /** @summary Public synchronization preserves Effects and two-way bindings. @param {String} name */
@@ -185,8 +212,11 @@ class PerspectiveSelection extends Base {
 
     /** @summary Projects carried identity without overwriting a newer pending request. @param {Object} context */
     project(context) {
-        const name = this.identity(context);
+        // Under a Group the adopted identity participant is the truth for every projection, so a
+        // hydrate that changed it publishes, and one that did not retains the baseline.
+        const name = this.identity(context) ?? (this.#entry ? this.committedName : null);
         if (name === null) return;
+        if (!this.#entry) this.#directName = name;
         this.publishedName = name;
         if (this.pendingName === null || this.pendingName === name) this.sync(name)
     }

--- a/src/dashboard/dock/model/Persistence.mjs
+++ b/src/dashboard/dock/model/Persistence.mjs
@@ -89,6 +89,53 @@ class Persistence extends Base {
     static unsafeRecordKeys = new Set(['__proto__', 'constructor', 'prototype'])
 
     /**
+     * Names beginning with this prefix are engine-reserved: the zones-only declaration's `$default`
+     * and the Group's `$perspective:<workspaceKey>` identity slots. A saved record may never take
+     * one, on either persisted key.
+     * @member {String} RESERVED_NAME_PREFIX='$'
+     * @static
+     */
+    static RESERVED_NAME_PREFIX = '$'
+
+    /**
+     * @summary The write-boundary refusal beside the unsafe-key refusal: a persisted key may neither be
+     * engine-reserved nor name a declared perspective — a saved record may equal a declared
+     * perspective, but never define or impersonate one.
+     * @param {Array<String|undefined>} keys The candidate `layoutId` / `perspectiveName` values.
+     * @param {Function|Iterable<String>|null} [declared=null] The workspace's declared names, or a
+     *     function returning them; null when no declaration set is wired.
+     * @returns {String[]} Errors, empty when every key is usable.
+     * @static
+     */
+    static reservedNameErrors(keys, declared=null) {
+        const names = new Set(typeof declared === 'function' ? declared() ?? [] : declared ?? []);
+
+        return keys.filter(key => typeof key === 'string').flatMap(key => {
+            if (key.startsWith(Persistence.RESERVED_NAME_PREFIX)) {
+                return [`"${key}" is an engine-reserved perspective name`]
+            }
+
+            return names.has(key) ? [`"${key}" names a declared perspective; a saved record may equal one but never take its name`] : []
+        })
+    }
+
+    /**
+     * @summary Validates the origin a snapshot may carry: `metadata.declaredPerspective` names the
+     * declared perspective it was captured under, written from the accepted-write identity.
+     * @param {Object|null} metadata The record's `metadata`
+     * @param {String} path The record path for the error message
+     * @returns {String[]}
+     * @static
+     */
+    static validateDeclaredOrigin(metadata, path) {
+        const origin = metadata?.declaredPerspective;
+
+        return origin === undefined || (typeof origin === 'string' && origin.trim())
+            ? []
+            : [`${path}.declaredPerspective must be a non-empty string when present`]
+    }
+
+    /**
      * @summary Validates the perspective fields shared by the create and restore paths.
      *
      * `windowFingerprint` describes one workspace's topology SHAPE and must be a JSON object or
@@ -407,6 +454,8 @@ class Persistence extends Base {
             errors.push('metadata must be a JSON object')
         }
 
+        errors.push(...Persistence.validateDeclaredOrigin(savedLayout.metadata, 'savedLayout.metadata'));
+
         let secretKey = Object.hasOwn(savedLayout, 'metadata')
             ? WorkspaceDocument.findSecretMetadataKey(savedLayout.metadata, 'savedLayout.metadata')
             : null;
@@ -509,6 +558,8 @@ class Persistence extends Base {
         if (Object.hasOwn(topology, 'metadata') && !WorkspaceDocument.isJsonRecord(topology.metadata)) {
             errors.push('metadata must be a JSON object')
         }
+
+        errors.push(...Persistence.validateDeclaredOrigin(topology.metadata, 'topology.metadata'));
 
         let unexpected = WorkspaceDocument.findUnexpectedKey(topology, Persistence.topologyKeys, 'topology');
 

--- a/src/dashboard/dock/persistence/PerspectiveLibrary.mjs
+++ b/src/dashboard/dock/persistence/PerspectiveLibrary.mjs
@@ -35,7 +35,9 @@ const UNSAFE_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
  *   resolution namespace: a save whose layoutId an OTHER record's perspectiveName would shadow
  *   (or vice versa) is a collision, so every stored record stays addressable through both
  *   documented paths. Prototype-shaped keys (`__proto__`, `constructor`, `prototype`) are
- *   rejected at the write boundary.
+ *   rejected at the write boundary, and so are engine-reserved names (`$`-prefixed) and the
+ *   owning workspace's declared perspective names ({@link #declaredPerspectives}): a saved record
+ *   may equal a declared perspective, never define or impersonate one.
  * - **Removing the active perspective repoints, never dangles.** With siblings present the
  *   successor is the caller's `replacementName` or the first remaining record (insertion
  *   order), reusing the landed `removeSavedLayout` invariant; removing the last record clears
@@ -95,7 +97,15 @@ class PerspectiveLibrary extends Base {
          * non-reactive config: the adapter is wiring, not state.
          * @member {Object|null} persistenceAdapter=null
          */
-        persistenceAdapter: null
+        persistenceAdapter: null,
+        /**
+         * The names a saved record may equal but never take: the owning workspace's declared
+         * perspectives, as an iterable or a function returning one. Wiring, not state: a consumer
+         * passes `() => workspace.declaredPerspectives()`; null skips the declared-name refusal.
+         * Engine-reserved names (`$`-prefixed) are refused either way.
+         * @member {Function|Iterable<String>|null} declaredPerspectives=null
+         */
+        declaredPerspectives: null
     }
     /**
      * The saved layout collection schema for named layout perspectives. One greenfield
@@ -524,6 +534,13 @@ class PerspectiveLibrary extends Base {
             return {collision: null, errors, layoutId: null, saved: false}
         }
 
+        let reserved = Persistence.reservedNameErrors([record.layoutId, record.perspectiveName], me.declaredPerspectives);
+
+        if (reserved.length) {
+            me.lastErrors = reserved;
+            return {collision: null, errors: reserved, layoutId: null, saved: false}
+        }
+
         let name     = record.perspectiveName ?? record.layoutId,
             existing = me.resolveEntry(name),
             // the technical id must STAY reachable after the save: another record's
@@ -636,6 +653,13 @@ class PerspectiveLibrary extends Base {
             let errors = [`"${to}" is not a usable perspective key`];
             me.lastErrors = errors;
             return {collision: null, errors, renamed: false}
+        }
+
+        let reserved = Persistence.reservedNameErrors([to], me.declaredPerspectives);
+
+        if (reserved.length) {
+            me.lastErrors = reserved;
+            return {collision: null, errors: reserved, renamed: false}
         }
 
         let holder = me.resolveEntry(to);

--- a/src/dashboard/dock/persistence/TopologyLibrary.mjs
+++ b/src/dashboard/dock/persistence/TopologyLibrary.mjs
@@ -81,7 +81,14 @@ class TopologyLibrary extends Base {
          * those bytes by resolving and reports failure by rejecting. Only plain JSON crosses it.
          * @member {Object|null} persistenceAdapter=null
          */
-        persistenceAdapter: null
+        persistenceAdapter: null,
+        /**
+         * The names a stored topology may equal but never take: the owning workspace's declared
+         * perspectives, as an iterable or a function returning one. Wiring, not state; null skips the
+         * declared-name refusal. Engine-reserved names (`$`-prefixed) are refused either way.
+         * @member {Function|Iterable<String>|null} declaredPerspectives=null
+         */
+        declaredPerspectives: null
     }
 
     /** @member {String[]} lastErrors=[] */
@@ -347,7 +354,13 @@ class TopologyLibrary extends Base {
 
         const record    = result.topology,
               layoutId  = record.layoutId,
-              candidate = this.collection ?? Persistence.createTopologyCollection([], {activeLayoutId: null}).collection;
+              candidate = this.collection ?? Persistence.createTopologyCollection([], {activeLayoutId: null}).collection,
+              reserved  = Persistence.reservedNameErrors([layoutId, record.perspectiveName], this.declaredPerspectives);
+
+        if (reserved.length) {
+            this.lastErrors = reserved;
+            return {saved: false, layoutId, collision: null, errors: reserved}
+        }
 
         if (Object.hasOwn(candidate.topologies, layoutId) && replace !== true) {
             const errors = [`topology "${layoutId}" already exists; replacement must be explicit`];

--- a/test/playwright/unit/dashboard/DockPerspectiveNameSources.spec.mjs
+++ b/test/playwright/unit/dashboard/DockPerspectiveNameSources.spec.mjs
@@ -1,0 +1,243 @@
+import {setup}        from '../../setup.mjs';
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../src/Neo.mjs';
+import * as core      from '../../../../src/core/_export.mjs';
+import '../../../../src/manager/Instance.mjs';
+import '../../../../src/tab/Container.mjs';
+import Workspace          from '../../../../src/dashboard/dock/Workspace.mjs';
+import WorkspaceSet       from '../../../../src/dashboard/dock/window/WorkspaceSet.mjs';
+import Document           from '../../../../src/dashboard/dock/model/WorkspaceDocument.mjs';
+import Persistence        from '../../../../src/dashboard/dock/model/Persistence.mjs';
+import Authoring          from '../../../../src/dashboard/dock/model/Authoring.mjs';
+import PerspectiveLibrary from '../../../../src/dashboard/dock/persistence/PerspectiveLibrary.mjs';
+import TopologyLibrary    from '../../../../src/dashboard/dock/persistence/TopologyLibrary.mjs';
+import Transaction        from '../../../../src/manager/Transaction.mjs';
+
+setup({appConfig: {name: 'DockPerspectiveNameSourcesTest'}});
+
+const PANES        = {editor: {ntype: 'component'}, preview: {ntype: 'component'}},
+      PERSPECTIVES = {operator: {center: ['editor', 'preview']}, review: {center: ['preview', 'editor']}};
+
+/**
+ * A real declarative workspace, optionally registered in a Group. `zonesOnly` declares no
+ * perspectives, so the single arrangement lowers under the engine-reserved name.
+ */
+function fixture({group = false, zonesOnly = false, active = 'operator'} = {}) {
+    const windowId  = `names-${Neo.getId('test')}`,
+          binding   = group && Transaction.bind({windowId, workspaceKey: 'main'}),
+          workspace = Neo.create(Workspace, {
+              windowId,
+              enableDockMaximizeAction: false,
+              panes                   : PANES,
+              ...(zonesOnly ? {zones: {center: ['editor', 'preview']}} : {perspectives: PERSPECTIVES, activePerspective: active})
+          }),
+          set = group && Neo.create(WorkspaceSet, {manager: Transaction, getGroupId: () => binding.groupId, documentModel: Document});
+
+    if (group) {
+        Transaction.setHistoryDepth({groupId: binding.groupId, depth: 5});
+        workspace.workspaceKey = 'main';
+        workspace.workspaceSet = set;
+        set.register('main', {
+            componentId: workspace.id,
+            getDocument: () => workspace.dockModel,
+            setDocument: value => workspace.dockModel = value,
+            project    : context => workspace.projectDockCommit(context)
+        })
+    }
+
+    return {
+        workspace, set, groupId: binding?.groupId,
+        async settle() {await workspace.perspectiveSelection?.pending; await workspace.refreshPromise},
+        destroy() {
+            set && set.destroy();
+            if (!workspace.isDestroyed) workspace.destroy();
+            binding && Transaction.retireGroup(binding.groupId)
+        }
+    }
+}
+
+const layoutFor = (document, options) => Persistence.capturePerspective(document, options);
+
+test.describe('Neo.dashboard.dock — perspective names come from the declared list; snapshots never define one', () => {
+    test('a layout store refuses a declared name and an engine-reserved name on both persisted keys, on save and on rename', () => {
+        const f     = fixture(), {workspace} = f,
+              store = Neo.create(PerspectiveLibrary, {declaredPerspectives: () => workspace.declaredPerspectives()});
+
+        try {
+            const byName = layoutFor(workspace.dockModel, {layoutId: 'snap-1', perspectiveName: 'review'});
+            expect(byName.errors).toEqual([]);
+
+            let result = store.savePerspective(byName.layout);
+            expect(result.saved).toBe(false);
+            expect(result.errors.join()).toContain('"review" names a declared perspective');
+
+            result = store.savePerspective(layoutFor(workspace.dockModel, {layoutId: 'review', perspectiveName: 'Mine'}).layout);
+            expect(result.saved, 'the technical key is refused as well').toBe(false);
+            expect(result.errors.join()).toContain('"review" names a declared perspective');
+
+            result = store.savePerspective(layoutFor(workspace.dockModel, {layoutId: 'snap-2', perspectiveName: Authoring.defaultPerspectiveName}).layout);
+            expect(result.saved).toBe(false);
+            expect(result.errors.join()).toContain('engine-reserved');
+
+            expect(store.savePerspective(layoutFor(workspace.dockModel, {layoutId: 'snap-3', perspectiveName: 'Mine'}).layout).saved).toBe(true);
+
+            const renamed = store.renamePerspective('Mine', 'operator');
+            expect(renamed.renamed).toBe(false);
+            expect(renamed.errors.join()).toContain('names a declared perspective');
+            expect(store.renamePerspective('Mine', '$snapshot').errors.join()).toContain('engine-reserved');
+            expect(store.renamePerspective('Mine', 'Yours').renamed).toBe(true);
+
+            // Nothing a refused save does reaches the selection.
+            expect(workspace.perspectiveSelection.committedName).toBe('operator');
+            expect(workspace.activePerspective).toBe('operator');
+        } finally {
+            store.destroy();
+            f.destroy()
+        }
+    });
+
+    test('a store without declared wiring still refuses engine-reserved names and accepts the rest', () => {
+        const f = fixture(), {workspace} = f, store = Neo.create(PerspectiveLibrary, {});
+
+        try {
+            expect(store.savePerspective(layoutFor(workspace.dockModel, {layoutId: 'snap-1', perspectiveName: 'review'}).layout).saved).toBe(true);
+            expect(store.savePerspective(layoutFor(workspace.dockModel, {layoutId: '$default'}).layout).errors.join()).toContain('engine-reserved');
+        } finally {
+            store.destroy();
+            f.destroy()
+        }
+    });
+
+    test('a topology store refuses declared and engine-reserved layout ids while the plain "default" record stays usable', () => {
+        const f       = fixture(), {workspace} = f,
+              library = Neo.create(TopologyLibrary, {declaredPerspectives: () => workspace.declaredPerspectives()}),
+              capture = layoutId => Persistence.captureTopologyPerspective({main: workspace.dockModel}, {layoutId});
+
+        try {
+            expect(capture('review').errors).toEqual([]);
+            expect(library.save(capture('review').topology, {activate: true}).errors.join()).toContain('names a declared perspective');
+            expect(library.save(capture('$default').topology, {activate: true}).errors.join()).toContain('engine-reserved');
+            expect(library.save(capture('default').topology, {activate: true}).saved).toBe(true);
+            expect(library.collection.activeLayoutId).toBe('default');
+        } finally {
+            library.destroy();
+            f.destroy()
+        }
+    });
+
+    test('a capture carries the declared origin from the accepted-write identity, including inside a commit listener before projection', async () => {
+        const f      = fixture({group: true}), {workspace, groupId} = f, seen = [],
+              commit = data => {data.groupId === groupId && seen.push(workspace.perspectiveProvenance().declaredPerspective)};
+
+        Transaction.on({commit});
+
+        try {
+            expect(workspace.perspectiveProvenance()).toEqual({declaredPerspective: 'operator'});
+
+            workspace.activePerspective = 'review';
+            await f.settle();
+
+            // Auto-save captures here, before the projection has synchronized anything public.
+            expect(seen).toEqual(['review']);
+
+            const {layout, errors} = Persistence.capturePerspective(workspace.dockModel, {layoutId: 'snap', metadata: workspace.perspectiveProvenance()});
+            expect(errors).toEqual([]);
+            expect(layout.metadata).toEqual({declaredPerspective: 'review'});
+            expect(Persistence.restoreSavedLayout(layout).errors).toEqual([]);
+            expect(Persistence.restoreSavedLayout({...layout, metadata: {declaredPerspective: 42}}).errors.join()).toContain('declaredPerspective');
+
+            const topology = Persistence.captureTopologyPerspective({main: workspace.dockModel}, {layoutId: 'topo', metadata: workspace.perspectiveProvenance()});
+            expect(topology.errors).toEqual([]);
+            expect(topology.topology.metadata).toEqual({declaredPerspective: 'review'});
+            expect(Persistence.restoreTopology({...topology.topology, metadata: {declaredPerspective: ''}}).errors.join()).toContain('declaredPerspective');
+        } finally {
+            Transaction.un({commit});
+            f.destroy()
+        }
+    });
+
+    test('under a Group a known-origin hydrate adopts the declared origin and an originless one retains the baseline, with no history row either way', async () => {
+        const f = fixture({group: true}), {workspace, groupId} = f, errors = [], original = console.error;
+
+        console.error = (...args) => errors.push(args);
+
+        try {
+            await workspace.perspectiveSelection.pending;
+
+            const selection = workspace.perspectiveSelection,
+                  reviewDoc = selection.document('review'),
+                  hydrate   = (document, metadata) => Transaction.write({
+                      groupId,
+                      cause       : 'cold-hydrate',
+                      cursorAction: 'preserve',
+                      descriptor  : {operation: 'hydrateTopology', layoutId: 'snap'},
+                      changes     : [{workspaceKey: 'main', input: document}, workspace.perspectiveOriginChange(metadata)].filter(Boolean)
+                  });
+
+            await hydrate(reviewDoc, {declaredPerspective: 'review'});
+            await workspace.refreshPromise;
+            expect(selection.committedName).toBe('review');
+            expect(workspace.activePerspective).toBe('review');
+            expect(Transaction.get(groupId).history?.count ?? 0, 'a preserve write appends no row').toBe(0);
+
+            await hydrate(selection.document('operator'), {});
+            await workspace.refreshPromise;
+            expect(selection.committedName, 'an originless snapshot changes no selection').toBe('review');
+            expect(workspace.activePerspective).toBe('review');
+
+            expect(workspace.perspectiveOriginChange({declaredPerspective: 'stranger'}), 'an origin this workspace does not declare is originless').toBeNull();
+
+            workspace.activePerspective = 'missing';
+            expect(workspace.activePerspective, 'a refused selection round-trips without null').toBe('review');
+            expect(errors).toHaveLength(1);
+
+            expect((await workspace.resetPerspective()).errors).toEqual([]);
+            await workspace.refreshPromise;
+            expect(workspace.dockModel, 'reset re-applies the committed baseline').toEqual(reviewDoc);
+        } finally {
+            console.error = original;
+            f.destroy()
+        }
+    });
+
+    test('on the direct branch a snapshot restore adopts the origin its descriptor carries and retains the baseline without one', async () => {
+        const f = fixture(), {workspace} = f, selection = workspace.perspectiveSelection;
+
+        try {
+            const {layout} = Persistence.capturePerspective(selection.document('review'), {layoutId: 'snap', metadata: {declaredPerspective: 'review'}}),
+                  restored = Persistence.restoreSavedLayout(layout);
+
+            expect(restored.errors).toEqual([]);
+            await workspace.onDockZoneDocumentChange(restored.document, {operation: 'restoreSavedLayout', layoutId: 'snap', ...layout.metadata}, workspace);
+            await workspace.refreshPromise;
+            expect(workspace.activePerspective).toBe('review');
+            expect(selection.committedName).toBe('review');
+
+            const originless = Persistence.capturePerspective(selection.document('operator'), {layoutId: 'snap-2'});
+            await workspace.onDockZoneDocumentChange(Persistence.restoreSavedLayout(originless.layout).document, {operation: 'restoreSavedLayout', layoutId: 'snap-2'}, workspace);
+            await workspace.refreshPromise;
+            expect(workspace.activePerspective).toBe('review');
+            expect(selection.committedName).toBe('review');
+        } finally {
+            f.destroy()
+        }
+    });
+
+    test('a zones-only workspace declares the engine-reserved name, and a host without declarations reports nothing', () => {
+        const f = fixture({zonesOnly: true}), {workspace} = f, bare = Neo.create(Workspace, {enableDockMaximizeAction: false});
+
+        try {
+            expect(workspace.declaredPerspectives()).toEqual([Authoring.defaultPerspectiveName]);
+            expect(workspace.activePerspective).toBe(Authoring.defaultPerspectiveName);
+            expect(workspace.perspectiveProvenance()).toEqual({declaredPerspective: Authoring.defaultPerspectiveName});
+            expect(Authoring.defaultPerspectiveName.startsWith(Persistence.RESERVED_NAME_PREFIX)).toBe(true);
+
+            expect(bare.declaredPerspectives()).toEqual([]);
+            expect(bare.perspectiveProvenance()).toEqual({});
+            expect(bare.perspectiveOriginChange({declaredPerspective: 'operator'})).toBeNull();
+        } finally {
+            bare.destroy();
+            f.destroy()
+        }
+    });
+});


### PR DESCRIPTION
Resolves #18609

Refs #18605

Perspective names now come from one list. A saved record may equal a declared perspective but never define or impersonate one: both persistence libraries refuse an engine-reserved name (`$`-prefixed, which covers the zones-only `$default` and the Group's `$perspective:<workspaceKey>` identity slots) and, when a consumer wires `declaredPerspectives`, any name the workspace declares — on `layoutId` and `perspectiveName` alike, on save and on rename, beside the existing unsafe-key refusal. A snapshot carries its origin as `metadata.declaredPerspective`, written from the accepted-write identity through `Workspace#perspectiveProvenance()`, never from a published leaf, so an auto-save that captures inside the commit listener still names the perspective it was taken under. Restoring a snapshot adopts a declared origin — under a Group through the identity participant's change that `Workspace#perspectiveOriginChange(metadata)` supplies beside the document, on the direct branch through the descriptor's `declaredPerspective` — and an originless snapshot, or one captured under a name the workspace does not declare, retains the last committed or initialized declared baseline. `null` never enters the enum. The Neural Link capture writes the origin as well.

`Decision Record impact: aligned-with ADR 0029 (as amended by #18606: §2.2 sentences 2–4 of the selection contract)`.

size-guard-growth: src/dashboard/dock/Workspace.mjs — 1140 → 1149 code lines: three consumer-facing facades over the selection owner (`declaredPerspectives()`, `perspectiveProvenance()`, `perspectiveOriginChange()`), so consumers and the Neural Link client never reach into the owner instance; the stateful implementation stays in `interaction/PerspectiveSelection.mjs`. Consumer deletions remain #18610–#18612.

Evidence: unit tier (real Workspace, Provider, Group and WorkspaceSet in the single-thread unit runtime; a cold-hydrate-shaped `preserve` write on the Group queue) → unit tier required for this engine leaf. Residual: the Workstation's first-observable cold-boot value — #18609's Workstation half of F12 is transferred to #18612's "Cold boot after one user commit" AC (recorded in both bodies), because the Workstation's capture (`WorkspaceController.captureTopology`) and hydrate (`ViewportController`'s `hydrateTopology` write) entry points are that leaf's consumer change and are absent from this diff; `modified` is #18608's.

## AC Evidence
| AC | Evidence |
|---|---|
| F8 — save a snapshot under a declared name: refused, on both keys; the same under the reserved name; the selection unchanged | `DockPerspectiveNameSources.spec.mjs`: layout store arms (declared `perspectiveName`, declared `layoutId`, `$default`, rename to a declared and to a `$` name) and the topology store arm (declared and `$default` ids refused, plain `default` saved). `dock.perspective.active` publishing the same answer is #18608's leaf; here `committedName` and `activePerspective` are asserted unchanged |
| F12 known origin — a hydrate of a snapshot whose metadata names a declared perspective publishes that name | Group arm: a `preserve` write with `{operation: 'hydrateTopology', layoutId}` plus the origin change adopts `review` into the identity participant; `committedName` and `activePerspective` read `review`; direct-branch arm: the descriptor's `declaredPerspective` does the same on a standalone workspace |
| F12 missing origin — `metadata: {}` keeps the initialized declared baseline; reset re-applies it; a refused selection round-trips without `null` | Same two arms: an originless hydrate leaves `committedName` unchanged; `perspectiveOriginChange({declaredPerspective: 'stranger'})` is `null`; `activePerspective = 'missing'` round-trips; `resetPerspective()` re-applies the committed baseline. `modified` is #18608's |
| Provenance spec — an auto-saved capture after a declared switch stores the switch's after-name, not the lagging published name; a `preserve` write with no row still yields correct provenance | The commit-listener arm reads `perspectiveProvenance()` inside `Transaction.on({commit})` after a switch to `review` and sees `review`; the hydrate arms run with `history` null (no row ever appended) |
| Legacy records with `metadata: {}` load without errors or warnings | Both origin arms hydrate `{}` records; `validateDeclaredOrigin` accepts an absent field and refuses a non-string or empty one on layouts and topologies |
| F12 cold-boot on the Workstation (owner @neo-opus-grace) — transferred to #18612 by this PR's review (RA-1): the reserved declared name, `modified` true, the Neural Link id mistaken for neither | Engine half here: the zones-only arm pins `$default` as the declared name, its provenance and the enum. The rendered Workstation receipt is #18612's "Cold boot after one user commit" AC; `modified` is #18608's |
| Cross-family review (GPT seat); `Refs #18605`, `Resolves` this leaf only | GPT primary requested at CI green |

## Deltas from ticket
- The refusal rule is a prefix, not one literal: every `$`-prefixed name is engine-reserved, so the identity slots are covered with the same line as `$default`.
- Declared names reach a library through a `declaredPerspectives` wiring config (iterable or function) rather than a workspace reference, because the libraries are consumer-owned and the engine never instantiates them; without the wiring only the prefix rule applies. The wiring is an instance config: #18611 and #18612 hold library instances and wire `() => workspace.declaredPerspectives()`. The dock example (#18610, PR #18631) saves through the static collection helpers (`createSavedLayoutCollection` / `restoreActiveSavedLayout`), which carry neither the prefix nor the declared-name refusal — its follow-through is a consumer decision of its own shape (route saves through an instance, or a reservation seam on the static helpers as a follow-up), not this config.
- The projection owner now treats the adopted identity participant as the truth for every Group projection (`project` falls back to `committedName`), which is what lets a hydrate that changed the identity publish and one that did not retain the baseline without a second signal.
- The Neural Link capture spreads `holder.perspectiveProvenance()` into its metadata; enumerating declared names in the tools stays #18613.

## Test Evidence
Negative control outside CI: the new spec run against the previous engine (the six source files stashed) reds all seven arms. With the change, 7 of 7 pass, and `unit/dashboard`, `unit/manager` and `unit/ai/client` pass locally at the head.

## Post-Merge Validation
- [ ] #18612 wires `declaredPerspectives` and `perspectiveProvenance()` / `perspectiveOriginChange()` into the Workstation's libraries, capture and cold hydrate, and carries the transferred F12 rendered receipt; #18611 does the same for Demo B's instance library; the example's static-helper path (#18610 / #18631) decides its own reservation seam.

## Commits
Rebased onto dev@7e8b32e421 (after #18628 landed): the owner and the host auto-merged; only the size-baseline line conflicted and now carries the measured 1155.
- 78c18c637a — the contract: refusals, provenance, origin adoption, the spec
- 6988fd39a3 — the size baseline follows the three facades (the guard's required bump)

Authored by Mnemosyne (Claude Fable 5.1, Claude Code). Session c42870ab-3721-40f0-a1f8-f385786ffc3c.

