### PR TITLE
feat(dock): publish committed perspective state (#18608)

### DIFF
--- a/buildScripts/util/file-size-baseline.json
+++ b/buildScripts/util/file-size-baseline.json
@@ -1,6 +1,6 @@
 {
     "apps/workstation/view/Workspace.mjs": 1252,
     "examples/dashboard/crossWindow/DemoBWorkspace.mjs": 2546,
-    "src/dashboard/dock/Workspace.mjs": 1140,
+    "src/dashboard/dock/Workspace.mjs": 1146,
     "src/main/addon/DragDrop.mjs": 1267
 }

--- a/docs/output/class-hierarchy.json
+++ b/docs/output/class-hierarchy.json
@@ -248,6 +248,7 @@
  "Neo.dashboard.dock.projection.HeaderActionPolicy": "Neo.core.Base",
  "Neo.dashboard.dock.projection.LayoutAdapter": "Neo.core.Base",
  "Neo.dashboard.dock.projection.MotionSignal": "Neo.core.Base",
+ "Neo.dashboard.dock.projection.PerspectiveState": "Neo.core.Base",
  "Neo.dashboard.dock.projection.Reconciler": "Neo.core.Base",
  "Neo.dashboard.dock.window.DragTarget": "Neo.core.Base",
  "Neo.dashboard.dock.window.NativeVesselTransaction": "Neo.core.Base",

--- a/src/dashboard/dock/Workspace.mjs
+++ b/src/dashboard/dock/Workspace.mjs
@@ -10,6 +10,7 @@ import Maximize                    from './plugin/Maximize.mjs';
 import MotionSignal                from './projection/MotionSignal.mjs';
 import PreviewProducer             from './interaction/PreviewProducer.mjs';
 import PerspectiveSelection        from './interaction/PerspectiveSelection.mjs';
+import PerspectiveState            from './projection/PerspectiveState.mjs';
 import Reconciler                  from './projection/Reconciler.mjs';
 import StateProvider               from '../../state/Provider.mjs';
 import {createDockTearOutHandlers} from './window/TearOut.mjs';
@@ -509,6 +510,17 @@ class Workspace extends Container {
     /** @member {Neo.dashboard.dock.interaction.PerspectiveSelection|null} perspectiveSelection=null Selection owner. */
     perspectiveSelection = null
 
+    /**
+     * @summary Seeds perspective data before the received provider's formulas first execute.
+     * @param {Object|Neo.state.Provider|null} value
+     * @param {Neo.state.Provider|null} oldValue
+     * @returns {Neo.state.Provider|null}
+     * @protected
+     */
+    beforeSetStateProvider(value, oldValue) {
+        return super.beforeSetStateProvider(PerspectiveState.seedProvider(this, value), oldValue)
+    }
+
     /** @summary Validates runtime intent against the captured declarations. @param {String} value @returns {String} */
     beforeSetActivePerspective(value) {
         const selection = this.perspectiveSelection;
@@ -653,7 +665,8 @@ class Workspace extends Container {
 
         if (me.perspectiveSelection) {
             me.perspectiveSelection.initialized = true;
-            me.perspectiveSelection.connect()
+            me.perspectiveSelection.connect();
+            PerspectiveState.publishDocument(me, me.dockModel)
         }
 
         super.onAfterConstructed()
@@ -2443,6 +2456,7 @@ class Workspace extends Container {
         // a revealed rail pane here, as it always did — and nothing else moves. Optional because a
         // test may drive this hook with a hand-built `this`.
         me.perspectiveSelection?.project(perspectiveContext ?? {descriptor});
+        PerspectiveState.publishDocument(me, document);
         me.dockHeaderActionPolicy?.publishDocument(document);
 
         me.refreshPromise = tail

--- a/src/dashboard/dock/interaction/PerspectiveSelection.mjs
+++ b/src/dashboard/dock/interaction/PerspectiveSelection.mjs
@@ -1,6 +1,7 @@
-import Base      from '../../../core/Base.mjs';
-import Authoring from '../model/Authoring.mjs';
-import Document  from '../model/WorkspaceDocument.mjs';
+import Base             from '../../../core/Base.mjs';
+import Authoring        from '../model/Authoring.mjs';
+import Document         from '../model/WorkspaceDocument.mjs';
+import PerspectiveState from '../projection/PerspectiveState.mjs';
 
 /**
  * @summary Owns captured perspective declarations and the lifetime of one Workspace's selection requests.
@@ -154,7 +155,8 @@ class PerspectiveSelection extends Base {
             entry.owner = this;
             this.#entry = entry;
             this.publishedName = this.committedName;
-            if (this.pendingName === null) this.sync(this.committedName)
+            if (this.pendingName === null) this.sync(this.committedName);
+            PerspectiveState.publishDocument(host, host.dockModel)
         }).catch(error => {
             this.#registration = null;
             throw error
@@ -198,6 +200,7 @@ class PerspectiveSelection extends Base {
     restore(name = this.committedName) {
         const host = this.workspace, document = this.document(name), serial = ++this.#serial;
         this.pendingName = name;
+        PerspectiveState.publishPending(host, name);
         let pending;
         try {
             if (!document) throw new Error(`unknown declared perspective "${name}"`);
@@ -232,12 +235,14 @@ class PerspectiveSelection extends Base {
         this.pending = Promise.resolve(pending).then(() => {
             if (!this.isDestroyed && !host.isDestroyed && serial === this.#serial) {
                 this.pendingName = null;
+                PerspectiveState.publishPending(host, null);
                 this.sync(this.committedName)
             }
             return {document: host.dockModel, errors: []}
         }, error => {
             if (!this.isDestroyed && !host.isDestroyed && serial === this.#serial) {
                 this.pendingName = null;
+                PerspectiveState.publishPending(host, null);
                 this.sync(this.committedName)
             }
             return {document: host.dockModel, errors: [error.message]}

--- a/src/dashboard/dock/projection/PerspectiveState.mjs
+++ b/src/dashboard/dock/projection/PerspectiveState.mjs
@@ -1,0 +1,110 @@
+import Base         from '../../../core/Base.mjs';
+import Authoring    from '../model/Authoring.mjs';
+import Document     from '../model/WorkspaceDocument.mjs';
+import TopologyDiff from '../model/TopologyDiff.mjs';
+
+/**
+ * @summary Projects declared-perspective truth onto the Workspace's existing provider.
+ * Selection owns names and request serials; this helper owns only the provider representation.
+ * Committed leaves are published beside header truth, while pending is written by request lifecycle.
+ * @class Neo.dashboard.dock.projection.PerspectiveState
+ * @extends Neo.core.Base
+ */
+class PerspectiveState extends Base {
+    static config = {
+        /** @member {String} className='Neo.dashboard.dock.projection.PerspectiveState' @protected */
+        className: 'Neo.dashboard.dock.projection.PerspectiveState'
+    }
+
+    /**
+     * @summary Compares documents under the perspective modification contract, without planner semantics.
+     * Only edge resizability is excluded. Missing extents differ from present extents; finite edge
+     * extents and split fractions within the size tolerance compare equal. Inputs remain untouched.
+     * @param {Object|null} document
+     * @param {Object|null} baseline
+     * @param {Number} sizeEpsilon=TopologyDiff.SIZE_EPSILON
+     * @returns {Boolean}
+     */
+    static isModified(document, baseline, sizeEpsilon=TopologyDiff.SIZE_EPSILON) {
+        if (!baseline) return false;
+        const before = Document.clone(baseline), after = Document.clone(document);
+        for (const source of [before, after]) {
+            for (const node of Object.values(source?.nodes ?? {})) {
+                if (node.type === 'edge-zone') {
+                    for (const zone of Object.values(node.zones)) delete zone.resizable
+                }
+            }
+        }
+        for (const [id, node] of Object.entries(before.nodes)) {
+            const other = after?.nodes?.[id];
+            if (node.type !== other?.type) continue;
+            if (node.type === 'edge-zone') {
+                for (const [edge, zone] of Object.entries(node.zones)) {
+                    const target = other.zones[edge];
+                    if (Number.isFinite(zone.extent) && Number.isFinite(target?.extent) &&
+                        Math.abs(zone.extent - target.extent) <= sizeEpsilon) target.extent = zone.extent
+                }
+            } else if (node.type === 'split' && node.sizes.length === other.sizes.length) {
+                other.sizes = other.sizes.map((size, index) =>
+                    Math.abs(size - node.sizes[index]) <= sizeEpsilon ? node.sizes[index] : size)
+            }
+        }
+        return !Neo.isEqual(before, after)
+    }
+
+    /**
+     * @summary Reads the name carried into projection, never inferring identity from document equality.
+     * Before declaration capture, the initial config or first declared name supplies the seed.
+     * @param {Neo.dashboard.dock.Workspace} workspace
+     * @param {Object|null} document=workspace.dockModel
+     * @returns {{active:(String|null), modified:Boolean, pending:(String|null)}}
+     */
+    static read(workspace, document=workspace.dockModel) {
+        const selection = workspace.perspectiveSelection,
+              names     = Object.keys(workspace.perspectives ??
+                  (workspace.panes != null || workspace.zones != null ? {[Authoring.defaultPerspectiveName]: null} : {})),
+              active = selection?.publishedName ?? (names.includes(workspace.activePerspective)
+                  ? workspace.activePerspective : names[0] ?? null);
+        return {active, modified: this.isModified(document, selection?.document(active)), pending: selection?.pendingName ?? null}
+    }
+
+    /**
+     * @summary Seeds the owned namespace before a configured provider runs formulas, retaining consumer data.
+     * A supplied instance has already constructed; it receives the same local namespace immediately.
+     * @param {Neo.dashboard.dock.Workspace} workspace
+     * @param {Object|Neo.state.Provider|Neo.core.Base|null} value
+     * @returns {Object|Neo.state.Provider|null}
+     */
+    static seedProvider(workspace, value) {
+        if (!value) return value;
+        const state = this.read(workspace), type = Neo.typeOf(value);
+        if (type === 'NeoInstance') {
+            value.setDataAtSameLevel('dock.perspective', state);
+            return value
+        }
+        if (type === 'NeoClass') value = {module: value};
+        const data = value.data ?? {}, dock = data.dock ?? {};
+        return {...value, data: {...data, dock: {...dock, perspective: {...dock.perspective, ...state}}}}
+    }
+
+    /**
+     * @summary Publishes committed leaves together; request state is never derived from projection completion.
+     * @param {Neo.dashboard.dock.Workspace} workspace
+     * @param {Object|null} document
+     */
+    static publishDocument(workspace, document) {
+        const {active, modified} = this.read(workspace, document);
+        workspace.stateProvider?.setDataAtSameLevel('dock.perspective', {active, modified})
+    }
+
+    /**
+     * @summary Publishes the request owner's already-fenced pending name at its lifecycle boundary.
+     * @param {Neo.dashboard.dock.Workspace} workspace
+     * @param {String|null} name
+     */
+    static publishPending(workspace, name) {
+        workspace.stateProvider?.setDataAtSameLevel('dock.perspective.pending', name)
+    }
+}
+
+export default Neo.setupClass(PerspectiveState);

--- a/test/playwright/unit/dashboard/DockPerspectiveState.spec.mjs
+++ b/test/playwright/unit/dashboard/DockPerspectiveState.spec.mjs
@@ -1,0 +1,297 @@
+import {setup}        from '../../setup.mjs';
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../src/Neo.mjs';
+import * as core      from '../../../../src/core/_export.mjs';
+import '../../../../src/manager/Instance.mjs';
+import '../../../../src/tab/Container.mjs';
+import Workspace        from '../../../../src/dashboard/dock/Workspace.mjs';
+import WorkspaceSet     from '../../../../src/dashboard/dock/window/WorkspaceSet.mjs';
+import Document         from '../../../../src/dashboard/dock/model/WorkspaceDocument.mjs';
+import TopologyDiff     from '../../../../src/dashboard/dock/model/TopologyDiff.mjs';
+import PerspectiveState from '../../../../src/dashboard/dock/projection/PerspectiveState.mjs';
+import Transaction      from '../../../../src/manager/Transaction.mjs';
+import Provider         from '../../../../src/state/Provider.mjs';
+
+setup({appConfig: {name: 'DockPerspectiveStateTest'}});
+
+/** @summary A consumer-owned Provider class with its own data and formula defaults. */
+class ConsumerProvider extends Provider {
+    static config = {
+        className: 'Test.Unit.DockPerspectiveState.ConsumerProvider',
+        data     : {fromClass: 'retained'},
+        formulas : {caption: data => data.dock?.perspective?.active ?? 'absent'}
+    }
+}
+ConsumerProvider = Neo.setupClass(ConsumerProvider);
+
+/** @summary Creates real selection and publication owners, optionally joined to a Group. */
+function fixture({group = false, stateProvider, ...config} = {}) {
+    const windowId  = `perspective-state-${Neo.getId('test')}`,
+          binding   = group && Transaction.bind({windowId, workspaceKey: 'main'}),
+          workspace = Neo.create(Workspace, {
+              windowId,
+              enableDockMaximizeAction: false,
+              panes                   : {editor: {ntype: 'component'}, preview: {ntype: 'component'}, inspector: {ntype: 'component'}},
+              perspectives            : {
+                  operator: {center: ['editor', 'preview'], right: {items: ['inspector'], resizable: true}},
+                  review  : {center: ['editor', 'preview', 'inspector']}
+              },
+              activePerspective: 'operator',
+              stateProvider    : stateProvider ?? {data: {custom: 'kept', dock: {other: 7}}},
+              ...config
+          }),
+          set = group && Neo.create(WorkspaceSet, {
+              manager: Transaction, getGroupId: () => binding.groupId, documentModel: Document
+          });
+    if (group) {
+        Transaction.setHistoryDepth({groupId: binding.groupId, depth: 10});
+        workspace.workspaceKey = 'main';
+        workspace.workspaceSet = set;
+        set.register('main', {
+            componentId: workspace.id,
+            getDocument: () => workspace.dockModel,
+            setDocument: value => workspace.dockModel = value,
+            project    : context => workspace.projectDockCommit(context)
+        })
+    }
+    return {workspace, set, groupId: binding?.groupId,
+        state: () => workspace.stateProvider.getData('dock.perspective'),
+        async select(name) {workspace.activePerspective = name; return workspace.perspectiveSelection.pending},
+        async write(document) {return workspace.onDockZoneDocumentChange(document)},
+        destroy() {
+            if (!workspace.isDestroyed) workspace.destroy();
+            set && set.destroy();
+            binding && Transaction.retireGroup(binding.groupId)
+        }
+    }
+}
+
+/** @summary Makes asynchronous preparation controllable without timers. */
+function gate() {
+    let resolve;
+    const promise = new Promise(done => resolve = done);
+    return {promise, resolve}
+}
+
+test('a received provider is seeded for its first formula and owns every later publication', async () => {
+    const seen = [], f = fixture({stateProvider: {data: {custom: 'kept', dock: {other: 7}}, formulas: {
+        label: data => {seen.push(data.dock?.perspective?.active); return data.dock?.perspective?.active}
+    }}});
+    try {
+        expect(f.state()).toEqual({active: 'operator', modified: false, pending: null});
+        expect(seen[0]).toBe('operator');
+        expect(f.workspace.stateProvider.getData('custom')).toBe('kept');
+        expect(f.workspace.stateProvider.getData('dock.other')).toBe(7);
+        await f.select('review');
+        expect(f.state()).toEqual({active: 'review', modified: false, pending: null});
+        expect(f.workspace.stateProvider.getData('label')).toBe('review');
+        expect(seen).toContain('review')
+    } finally {f.destroy()}
+});
+
+test('one-sided edge extent changes count; policy and sub-epsilon changes do not', async () => {
+    const f = fixture();
+    try {
+        const baseline   = Document.clone(f.workspace.dockModel),
+              descriptor = {operation: 'resizeEdgeZone', edgeZoneId: 'root', edge: 'right', extent: 0.3},
+              resized    = f.workspace.applyDockZoneOperation(descriptor);
+        expect(resized.errors).toEqual([]);
+        await f.workspace.onDockZoneDocumentChange(resized.document, descriptor);
+        expect(f.state().modified, 'an absent-to-present extent differs').toBe(true);
+        await f.workspace.resetPerspective();
+        expect(f.state().modified).toBe(false);
+
+        const policy = Document.clone(baseline);
+        policy.nodes.root.zones.right.resizable = false;
+        await f.write(policy);
+        expect(f.state().modified, 'resizable is not user-modification truth').toBe(false)
+    } finally {f.destroy()}
+
+    const sized = fixture({perspectives: {operator: {
+        center: ['editor', 'preview'], right: {items: ['inspector'], extent: 0.3}
+    }}});
+    try {
+        const document = Document.clone(sized.workspace.dockModel);
+        document.nodes.root.zones.right.extent += TopologyDiff.SIZE_EPSILON / 2;
+        await sized.write(document);
+        expect(sized.state().modified).toBe(false)
+    } finally {sized.destroy()}
+});
+
+test('captured names and baselines survive edits to the initial declaration object', async () => {
+    const f = fixture();
+    try {
+        delete f.workspace.perspectives.operator;
+        await f.select('review');
+        await f.select('operator');
+        expect(f.state()).toEqual({active: 'operator', modified: false, pending: null});
+        const tabs       = Document.findContainingTabsId(f.workspace.dockModel, 'editor');
+        const descriptor = {operation: 'moveItem', itemId: 'preview', targetNodeId: tabs, index: 0},
+              result = f.workspace.applyDockZoneOperation(descriptor);
+        expect(result.errors ?? []).toEqual([]);
+        await f.workspace.onDockZoneDocumentChange(result.document, descriptor);
+        expect(f.state().modified).toBe(true)
+    } finally {f.destroy()}
+});
+
+test('held acceptance publishes pending separately and a stale refusal cannot clear its successor', async () => {
+    const f           = fixture({group: true}), first = gate(), releaseFirst = gate(), second = gate(), releaseSecond = gate(),
+          participant = Transaction.getParticipant(f.groupId, 'main'), prepare = participant.prepare;
+    const project = participant.project;
+    let   calls   = 0, projections = 0;
+    participant.project = context => {projections++; return project(context)};
+    participant.prepare = async (...args) => {
+        if (++calls === 1) {
+            first.resolve(); await releaseFirst.promise; throw new Error('first refused')
+        }
+        second.resolve(); await releaseSecond.promise; return prepare(...args)
+    };
+    try {
+        const rejected = f.select('review');
+        await first.promise;
+        expect(f.state()).toEqual({active: 'operator', modified: false, pending: 'review'});
+        expect(Transaction.get(f.groupId).history?.count ?? 0).toBe(0);
+        expect(projections).toBe(0);
+        const accepted = f.select('operator');
+        expect(f.state().pending).toBe('operator');
+        releaseFirst.resolve();
+        await second.promise;
+        expect((await rejected).errors).toContain('first refused');
+        expect(f.state().pending, 'stale rejection did not clear the new pending name').toBe('operator');
+        releaseSecond.resolve(); await accepted;
+        expect(projections).toBe(1);
+        expect(f.state()).toEqual({active: 'operator', modified: false, pending: null})
+    } finally {releaseFirst.resolve(); releaseSecond.resolve(); f.destroy()}
+});
+
+test('the modification predicate tolerates split fractions, counts removals, and never mutates its inputs', () => {
+    const before = {schema: Document.SCHEMA, root: 'split', items: {a: {}, b: {}}, nodes: {
+        split: {type: 'split', orientation: 'horizontal', children: ['a', 'b'], sizes: [0.4, 0.6]},
+        a    : {type: 'tabs', items: ['a'], activeItemId: 'a'},
+        b    : {type: 'tabs', items: ['b'], activeItemId: 'b'}
+    }}, after = Document.clone(before), snapshot = JSON.stringify(before);
+    after.nodes.split.sizes = [0.4005, 0.5995];
+    const afterSnapshot = JSON.stringify(after);
+    expect(PerspectiveState.isModified(after, before)).toBe(false);
+    expect(JSON.stringify(before)).toBe(snapshot);
+    expect(JSON.stringify(after)).toBe(afterSnapshot);
+    after.nodes.split.sizes = [0.41, 0.59];
+    expect(PerspectiveState.isModified(after, before)).toBe(true);
+    const f = fixture({perspectives: {operator: {center: ['editor', 'preview'], right: {items: ['inspector'], extent: 0.3}}}});
+    try {
+        const original = f.workspace.dockModel, removed = Document.clone(original);
+        delete removed.nodes.root.zones.right.extent;
+        expect(PerspectiveState.isModified(removed, original)).toBe(true)
+    } finally {f.destroy()}
+});
+
+test('acceptance updates committed leaves, refusal clears pending, and undo publishes the carried name', async () => {
+    const f = fixture({group: true});
+    try {
+        await f.select('review');
+        expect(f.state()).toEqual({active: 'review', modified: false, pending: null});
+        await Transaction.undo({groupId: f.groupId});
+        expect(f.state()).toEqual({active: 'operator', modified: false, pending: null});
+        const participant = Transaction.getParticipant(f.groupId, 'main');
+        participant.prepare = () => {throw new Error('refused')};
+        expect((await f.select('review')).errors).toContain('refused');
+        expect(f.state()).toEqual({active: 'operator', modified: false, pending: null})
+    } finally {f.destroy()}
+});
+
+test('identical document aliases publish distinct names through selection, undo and redo', async () => {
+    const zones = {center: ['editor', 'preview', 'inspector']},
+          f     = fixture({group: true, perspectives: {operator: zones, review: zones}});
+    try {
+        await f.select('review');
+        expect(f.state()).toEqual({active: 'review', modified: false, pending: null});
+        await Transaction.undo({groupId: f.groupId});
+        expect(f.state()).toEqual({active: 'operator', modified: false, pending: null});
+        await Transaction.redo({groupId: f.groupId});
+        expect(f.state()).toEqual({active: 'review', modified: false, pending: null})
+    } finally {f.destroy()}
+});
+
+test('a failed projection after acceptance is one handled receipt and does not revert published truth', async () => {
+    const f         = fixture({group: true}), received = gate(), receipts = [],
+          onReceipt = ({groupId, receipt}) => {
+              if (groupId === f.groupId) {receipts.push(receipt); received.resolve()}
+          };
+    Transaction.on('effectReceipt', onReceipt);
+    try {
+        f.workspace.refreshDockWorkspace = async () => {throw new Error('projection failed')};
+        const result = await f.select('review');
+        expect(result.errors).toEqual([]);
+        await received.promise;
+        expect(receipts).toEqual([expect.objectContaining({kind: 'projection', error: 'projection failed'})]);
+        expect(Transaction.get(f.groupId).history.count).toBe(1);
+        expect(f.state()).toEqual({active: 'review', modified: false, pending: null})
+    } finally {Transaction.un('effectReceipt', onReceipt); f.destroy()}
+});
+
+test('provider instances and replacement keep consumer data while receiving current perspective truth', async () => {
+    const provider = Neo.create(Provider, {data: {custom: 9}}), f = fixture({stateProvider: provider});
+    try {
+        expect(f.state().active).toBe('operator');
+        expect(provider.getData('custom')).toBe(9);
+        await f.select('review');
+        f.workspace.stateProvider = {data: {next: true}};
+        expect(f.state()).toEqual({active: 'review', modified: false, pending: null});
+        expect(f.workspace.stateProvider.getData('next')).toBe(true)
+    } finally {f.destroy()}
+});
+
+test('consumer Provider classes and descriptors retain their defaults and construction bindings settle the initial name', async () => {
+    for (const stateProvider of [ConsumerProvider, {module: ConsumerProvider, data: {chosen: 'review'}}]) {
+        const f = fixture({stateProvider, ...(stateProvider === ConsumerProvider ? {} : {bind: {activePerspective: 'chosen'}})});
+        try {
+            const name = stateProvider === ConsumerProvider ? 'operator' : 'review';
+            expect(f.state()).toEqual({active: name, modified: false, pending: null});
+            expect(f.workspace.stateProvider.getData('fromClass')).toBe('retained');
+            expect(f.workspace.stateProvider.getData('caption')).toBe(name)
+        } finally {f.destroy()}
+    }
+});
+
+test('a replacement publishes the retained Group identity when attachment completes', async () => {
+    const f = fixture({group: true});
+    let replacement;
+    try {
+        await f.select('review');
+        const document = Document.clone(f.workspace.dockModel), windowId = f.workspace.windowId;
+        f.workspace.destroy();
+        replacement = fixture({windowId, dockModel: document});
+        const workspace = replacement.workspace;
+        workspace.workspaceKey = 'main';
+        workspace.workspaceSet = f.set;
+        f.set.register('main', {
+            componentId: workspace.id, getDocument: () => workspace.dockModel,
+            setDocument: value => workspace.dockModel = value,
+            project    : context => workspace.projectDockCommit(context)
+        });
+        await workspace.perspectiveSelection.pending;
+        expect(replacement.state()).toEqual({active: 'review', modified: false, pending: null});
+        expect(Transaction.get(f.groupId).history.count).toBe(1)
+    } finally {replacement?.destroy(); f.destroy()}
+});
+
+test('a selection-free write queued at commit keeps the accepted name', async () => {
+    const f = fixture({group: true}), queued = gate();
+    let successor;
+    const onCommit = ({groupId, row, snapshot}) => {
+        if (groupId !== f.groupId || row?.operation !== 'restorePerspective') return;
+        const document = Document.clone(snapshot.participants.main);
+        document.items.editor.locked = true;
+        successor = f.set.write({main: document}, {cause: 'lock-after-selection'});
+        queued.resolve()
+    };
+    Transaction.on('commit', onCommit);
+    try {
+        await f.select('review');
+        await queued.promise;
+        await successor;
+        await f.workspace.refreshPromise;
+        expect(f.workspace.perspectiveSelection.committedName).toBe('review');
+        expect(f.state()).toEqual({active: 'review', modified: true, pending: null})
+    } finally {Transaction.un('commit', onCommit); f.destroy()}
+});


### PR DESCRIPTION
Resolves #18608

Refs #18605

A Workspace publishes `dock.perspective.active`, `modified`, and `pending` on its existing state provider. The projection helper writes the committed name and modification flag together; the selection owner's serial-fenced request lifecycle writes pending separately. Provider configs are seeded before formulas run without discarding consumer data. Captured declarations remain the baseline even if the caller later edits its initial map, and a replacement view publishes the Group's retained identity when attachment completes.

`PerspectiveState` is a static projection helper beside `LayoutAdapter` and `HeaderActionPolicy`; it owns no selection state, history, or registry. Its comparison excludes only edge resizability, counts one-sided extents, and applies the existing size epsilon to finite edge extents and split fractions. The document stays a field and the six action opt-ins are unchanged. This capability leaf enables the consumer deletions owned by #18610–#18612; it does not claim those migrations.

Evidence: L2 (real Workspace, Provider, Group, WorkspaceSet, document projection and effect receipts in the unit runtime) → L2 required for this publication leaf. Residual: none in this leaf; native consumer and cold-origin receipts remain their owning leaves.

size-guard-growth: src/dashboard/dock/Workspace.mjs — 1140 → 1146 code lines for the provider-construction seam and initialization/commit publication calls. Comparison and provider shaping stay in the projection helper, not the host.

## AC Evidence
| AC-1 | `DockPerspectiveState.spec.mjs`: real `resizeEdgeZone` from absent extent marks modified; sub-epsilon geometry does not. |
| AC-2 | Deleting the initial declared entry does not remove the captured name or baseline; restore and subsequent move remain truthful. |
| AC-3 | A real held Group prepare leaves active/modified unchanged and history/projection empty; newer pending replaces older pending; stale refusal cannot clear it; acceptance, refusal and undo have direct controls. |
| AC-4 | Resizability is ignored; missing/present extents differ in both directions; split tolerance and input immutability are checked; reset clears modified and move sets it. |
| AC-5 | A consumer formula sees the seeded active name and later publications. Provider class, descriptor, instance and replacement paths preserve consumer data. |
| AC-6 | An accepted write whose projection rejects emits exactly one `effectReceipt`; the returned projection chain is consumed by the existing Commit owner, not left unhandled. Semantic acceptance remains successful. |
| AC-7 | No `dockModel_` or action-opt-in delta. |
| AC-8 | Claude-family review is requested at green CI, following the actual GPT author family. |

## Deltas from ticket
The standalone absent-key Provider defect has already merged; engine-owned namespace seeding remains explicit. Retained Group attachment is an initialization boundary too, so a replacement provider sees accepted identity without requiring another document write. Projection failure retains the existing successful-semantic-write/error-receipt split; this leaf does not redefine Group write promises to reject after commitment. The ticket's original “GPT seat” wording follows its anticipated author family; this GPT-authored implementation instead requests Ada or Grace, as directed by the operator.

## Test Evidence
The pre-implementation provider controls failed on absent `dock.perspective` state. Removing only post-commit publication, with seeding still present, produced two targeted failures: an absent-to-present extent left `modified: false`, and accepted selection left `active: operator` rather than `review`. Restoring publication clears both. The final full-suite run and ordinary unit controls execute through the repository's custom unit configuration; CI is the exact-head gate.

Change class: capability. `agent-preflight` is not hosted in this Engine checkout (missing script verified); staged repository guards, generated class hierarchy and the size guard are run locally, with the hosted baseline jobs validating the PR body.

## Post-Merge Validation
- Consumer switcher migrations exercise these leaves in their rendered applications; snapshot provenance and the cold-origin first-observation matrix remain #18609.

## Signal Ledger
Source: D#18594 fold 8 at `DC_kwDODSospM4BGPTF`. Claude author signal: Mnemosyne; GPT graduation approvals: Euclid `DC_kwDODSospM4BGPTh`, Emmy `DC_kwDODSospM4BGPTz`. The normative ADR amendment merged through #18618; the selection implementation merged through #18625. Independent epic entry review: `IC_kwDODSospM8AAAABUJUhtQ`.

## Unresolved Dissent
None on this leaf's graduated two-writer contract.

## Unresolved Liveness
The source Discussion retains benched Gemini/Kimi and the active no-signal unknown family as liveness entries, not additional endorsements.

Authored by Euclid (GPT, Codex Desktop). Session 92f5d790-2865-4f69-b25e-150175745a6d.
